### PR TITLE
[RFC]: allow regex capture group metavariables

### DIFF
--- a/changelog.d/pa-2514.fixed
+++ b/changelog.d/pa-2514.fixed
@@ -1,0 +1,2 @@
+Fixed a bug where sometimes metavariables from regex capture groups could not be
+`focus-metavariable`d, `metavariable-regex`d, or would otherwise disappear.

--- a/src/core/Metavariable.ml
+++ b/src/core/Metavariable.ml
@@ -207,7 +207,7 @@ type bindings = (mvar * mvalue) list (* = Common.assoc *)
  * cases below in is_metavar_name.
  * coupling: AST_generic.is_metavar_name
  *)
-let metavar_regexp_string = "^\\(\\$[A-Z_][A-Z_0-9]*\\)$"
+let metavar_regexp_string = "^\\(\\$[A-Z_0-9]+\\)$"
 
 (*
  * Hacks abusing existing constructs to encode extra constructions.
@@ -237,7 +237,7 @@ let is_metavar_name s =
 (* $...XXX multivariadic metavariables. Note that I initially chose
  * $X... but this leads to parsing conflicts in Javascript.
  *)
-let metavar_ellipsis_regexp_string = "^\\(\\$\\.\\.\\.[A-Z_][A-Z_0-9]*\\)$"
+let metavar_ellipsis_regexp_string = "^\\(\\$\\.\\.\\.[A-Z_0-9]+\\)$"
 let is_metavar_ellipsis s = s =~ metavar_ellipsis_regexp_string
 
 module Structural = struct

--- a/tests/rules/capture_group_metavar.py
+++ b/tests/rules/capture_group_metavar.py
@@ -1,0 +1,3 @@
+
+# MATCH:
+x = foo

--- a/tests/rules/capture_group_metavar.yaml
+++ b/tests/rules/capture_group_metavar.yaml
@@ -1,0 +1,10 @@
+rules:
+  - id: capture-group-metavar 
+    patterns: 
+      - pattern-regex: "x = (.*)"
+      - metavariable-regex:
+          metavariable: $1
+          regex: ".*"
+    message: Semgrep found a match $1
+    languages: [python] 
+    severity: WARNING


### PR DESCRIPTION
## What:
This PR makes it so metavariables can start with numerals.

## Why:
Currently, regex matches can use capture groups to introduce metavariables with names like `$1`, `$2`, which do not currently pass our `is_metavar` checks. This means they cannot be inspected with `metavariable-regex`, meaning they are produced, and appear in the interpolated message, but are otherwise invisible to the engine.

this causes issues in stuff like https://returntocorp.slack.com/archives/C01NXGX2EHZ/p1675903424282459

from the thread: 
> im sure this solution causes a litany of other issues (which others can enlighten me on), so im putting it up as RFC. open to other ideas (like renaming the produced metavars, perhaps)

PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
