### PR TITLE
feat!: pro latest testing workflow

### DIFF
--- a/.github/workflows/test-semgrep-pro-latest.yaml
+++ b/.github/workflows/test-semgrep-pro-latest.yaml
@@ -1,9 +1,9 @@
 # The goal of this workflow is to offer a validation step before releasing
-# Semgrep, to ensure that the to-be-released version of Semgrep is not 
+# Semgrep, to ensure that the to-be-released version of Semgrep is not
 # incompatible with the currently released version of Semgrep Pro.
 #
 # If this workflow succeeds, then it should be safe to release Semgrep and
-# not immediately be incompatible with Semgrep Pro. 
+# not immediately be incompatible with Semgrep Pro.
 
 name: test-semgrep-pro-latest
 

--- a/.github/workflows/test-semgrep-pro-latest.yaml
+++ b/.github/workflows/test-semgrep-pro-latest.yaml
@@ -2,6 +2,7 @@ name: test-semgrep-pro-latest
 
 on:
   workflow_dispatch:
+  pull_request:
 jobs:
   test-semgrep-pro-latest:
     name: Test Semgrep Pro Engine (latest release)

--- a/.github/workflows/test-semgrep-pro-latest.yaml
+++ b/.github/workflows/test-semgrep-pro-latest.yaml
@@ -1,0 +1,35 @@
+name: test-semgrep-pro-latest
+
+on:
+  workflow_dispatch:
+jobs:
+  test-semgrep-pro-latest:
+    name: Test Semgrep Pro Engine (latest release)
+    runs-on: ubuntu-22.04
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: arn:aws:iam::338683922796:role/returntocorp-semgrep-deploy-role
+          role-duration-seconds: 900
+          role-session-name: "semgrep-deploy"
+          aws-region: us-west-2
+      # This is the `latest` binary, which is the most recent officially released
+      # binar of `semgrep-core-proprietary`.
+      # We test with this so that we can see whether this proposed release will break with the
+      # currently released version of Semgrep Pro Engine.
+      - name: Download Semgrep Pro `develop` binary
+        run: |
+          aws s3 cp s3://web-assets.r2c.dev/assets/semgrep-core-proprietary-manylinux-develop ./semgrep-core-proprietary
+      - name: Run Semgrep Pro Engine!
+        run: |
+          docker run --rm -v "$(pwd):/root" -e SEMGREP_APP_TOKEN=${{ secrets.SEMGREP_APP_TOKEN }} --entrypoint=bash "returntocorp/semgrep:develop" /root/scripts/test-pro.sh

--- a/.github/workflows/test-semgrep-pro-latest.yaml
+++ b/.github/workflows/test-semgrep-pro-latest.yaml
@@ -1,3 +1,10 @@
+# The goal of this workflow is to offer a validation step before releasing
+# Semgrep, to ensure that the to-be-released version of Semgrep is not 
+# incompatible with the currently released version of Semgrep Pro.
+#
+# If this workflow succeeds, then it should be safe to release Semgrep and
+# not immediately be incompatible with Semgrep Pro. 
+
 name: test-semgrep-pro-latest
 
 on:


### PR DESCRIPTION
## What:
This PR sets up a workflow, intended to be dispatched manually, to check whether the current `develop` version of Semgrep is incompatible with the latest released version of Semgrep Pro Engine.

## Why:
Ideally, if we make a breaking change to `semgrep` that necessitates a `semgrep-proprietary` change, we will release both at the same time. Sometimes, however, we will have hotfixes which necessitate releasing just one of them individually, without the other. If we are releasing Semgrep, for instance, we want to be sure that it is not incompatible with Semgrep Pro Engine's last released version, or the latest released version for both will be incompatible with each other, and we'll look bad.

This PR just adds in a manual step to verify that they work together.

## How:
It's pretty similar to the `test-semgrep-pro` workflow I set up for testing the `develop` `proprietary` binary, but instead of using the `develop` binary, it uses the latest released one. It also uses the `returntocorp/semgrep:develop` Docker image, which should be updated per PR to Semgrep, and thus correspond to the `develop` branch currently on `semgrep`.

## Test plan:
See the corresponding check in CI.

Closes PA-2522

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
