### PR TITLE
chore: add `taint` to acceptable pattern keys

### DIFF
--- a/cli/src/semgrep/rule_lang.py
+++ b/cli/src/semgrep/rule_lang.py
@@ -439,6 +439,7 @@ class RuleValidation:
     REQUIRE_REGEX = re.compile(r"'(.*)' is a required property")
     PATTERN_KEYS = {
         "match",
+        "taint",  # for new-syntax taint mode rules
         "pattern",
         "pattern-either",
         "pattern-regex",


### PR DESCRIPTION
## What:
This PR adds `taint` as an acceptable key for Semgrep rules in the CLI.

## Why:
#7070 introduced new syntax for taint, but I overlooked that there is CLI code which validates rules. This makes rules which run properly, but just don't produce any findings.

## How:
Added it to the list of allowed keys.

## Test plan:
Observed that these rules now run. I'm pretty sure I did this before too, but maybe I messed something up.
<img width="787" alt="image" src="https://user-images.githubusercontent.com/49291449/218026441-bbd24a5f-9e51-4134-9182-df15ce9b70c2.png">

I tried adding a `test_rule_parser` test, but because these rules still allow Semgrep to run, albeit with no findings produced, it's hard to do. I figured it was fine to test locally and avoid adding a more special-cased test.

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
