### PR TITLE
fix: allow brew nightly to poll API

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -30,12 +30,8 @@ jobs:
       - name: Brew update
         run: brew update
       - name: Brew Install
-        env:
-          HOMEBREW_NO_INSTALL_FROM_API: 1
         run: brew install semgrep --HEAD
       - name: Check installed correctly
-        env:
-          HOMEBREW_NO_INSTALL_FROM_API: 1
         run: brew test semgrep --HEAD
       - name: Clean up semgrep installation
         run: brew uninstall semgrep


### PR DESCRIPTION
There's ongoing discussion and changes in `homebrew/homebrew-core` and `homebrew/brew` about the env variables - I'll link some here shortly. Removal of these envs allows our nightly jobs to pass again.

This does not address the Brew PR release failure - MTF on that. 

Test Plan: 
- wait for [success on this job](https://github.com/returntocorp/semgrep/actions/runs/4146444104)

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
