### PR TITLE
fix(validate): treat regex metavariables correctly

### DIFF
--- a/changelog.d/validate-regex-mvar.fix
+++ b/changelog.d/validate-regex-mvar.fix
@@ -1,0 +1,2 @@
+Fixed bug with validate for metavariables like $1, $2. Previously,
+it blocked rules that it shouldn't.

--- a/changelog.d/validate-regex-mvar.fix
+++ b/changelog.d/validate-regex-mvar.fix
@@ -1,2 +1,2 @@
-CLI: Fixed bug with `semgrep --validate` for metavariables like $1, $2. 
+CLI: Fixed bug with `semgrep --validate` for metavariables like $1, $2.
 Previously, it blocked rules that it shouldn't.

--- a/changelog.d/validate-regex-mvar.fix
+++ b/changelog.d/validate-regex-mvar.fix
@@ -1,2 +1,2 @@
-Fixed bug with validate for metavariables like $1, $2. Previously,
-it blocked rules that it shouldn't.
+CLI: Fixed bug with `semgrep --validate` for metavariables like $1, $2. 
+Previously, it blocked rules that it shouldn't.

--- a/src/core/Metavariable.ml
+++ b/src/core/Metavariable.ml
@@ -239,6 +239,8 @@ let is_metavar_name s =
  *)
 let metavar_ellipsis_regexp_string = "^\\(\\$\\.\\.\\.[A-Z_][A-Z_0-9]*\\)$"
 let is_metavar_ellipsis s = s =~ metavar_ellipsis_regexp_string
+let metavar_for_capture_group = "^\\(\\$[0-9]+\\)$"
+let is_metavar_for_capture_group s = s =~ metavar_for_capture_group
 
 module Structural = struct
   let equal_mvalue = AST_utils.with_structural_equal equal_mvalue


### PR DESCRIPTION
The current validate behavior doesn't work for $1, $2, etc. See: https://semgrep.dev/playground/s/W5qZ

The problem is that $1 appears in the `metavariable-regex` but does not appear in the pattern string by name (it's bound by the capture group).

Test plan: `semgrep --config lewis_rule.yaml lewis_code.txt --validate`

TODO will add tests after launch, should have a while ago

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
