### PR TITLE
chore: fix wrong isinstance

### DIFF
--- a/cli/src/semgrep/formatter/text.py
+++ b/cli/src/semgrep/formatter/text.py
@@ -745,7 +745,7 @@ class TextFormatter(BaseFormatter):
         oss_rules = [
             with_color(Colors.foreground, rule.value[0].value, bold=True)
             for rule in rules_by_engine
-            if isinstance(rule.value[1], out.OSS)
+            if isinstance(rule.value[1].value, out.OSS)
         ]
 
         rules_output = []


### PR DESCRIPTION
## What:
#7068 introduced a check that, if our requested engine is non-OSS, and we have run rules with the OSS engine, we complain. There is a small typo, however, in that it's not comparing the correct engine value. This PR fixes that, and will enable separate rules to work.

Testp lan:
![image](https://user-images.githubusercontent.com/49291449/218192614-380f32c5-662d-4710-b468-1c0c84868afb.png)


PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
