### PR TITLE
chore: allow negative patterns in new syntax for `metavariable-pattern`

### DIFF
--- a/cli/tests/e2e/rules/syntax/good_new_syntax.yaml
+++ b/cli/tests/e2e/rules/syntax/good_new_syntax.yaml
@@ -1,0 +1,21 @@
+rules:
+- id: new-syntax
+  match:
+    all:
+      - foo(...) 
+      - any:
+        - foo(1, ...)
+        - foo(1, 2, ...)
+      - not: |
+          foo(1, 2, 4, ...)
+      - inside: |
+          def $NAME(...):
+            ...
+    where:
+      - metavariable: $NAME
+        all:
+          - not: |
+              bar 
+  message: xxx
+  languages: [python]
+  severity: WARNING

--- a/src/parsing/Parse_rule.ml
+++ b/src/parsing/Parse_rule.ml
@@ -984,6 +984,7 @@ and produce_constraint env dict tok indicator =
             (env', Some xlang)
         | ___else___ -> (env, None)
       in
+      let env' = { env' with in_metavariable_pattern = true } in
       let formula = parse_pair env' (find_formula env dict) in
       match formula with
       | R.P { pat = Xpattern.Regexp regexp; _ } ->


### PR DESCRIPTION
## What:
This PR fixes a bug where the new syntax would reject rules that had a negative `all` pattern, in a `metavariable-pattern`.

## Why:
This is actually allowed in the old syntax, but I forgot a flag. The equivalent old syntax rule is accepted.

## How:
Set `in_metavariable_pattern`.

## Test plan:
`make test`

Closes PA-2499

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
