### PR TITLE
fix: Reduce logspew with Pro Engine

### DIFF
--- a/src/engine/Match_tainting_mode.ml
+++ b/src/engine/Match_tainting_mode.ml
@@ -249,7 +249,7 @@ let range_of_any any =
        * first place? *)
       | G.Anys []
       (* An enormous amount of logspew with Semgrep Pro Engine happens with this
-       * case. TODO Figure out why avoid it? *)
+       * case. TODO Figure out why and avoid it? *)
       | G.Tk _ ->
           ()
       | _else_ ->

--- a/src/engine/Match_tainting_mode.ml
+++ b/src/engine/Match_tainting_mode.ml
@@ -242,14 +242,20 @@ let range_of_any any =
    * the AST at some point. *)
   match Visitor_AST.range_of_any_opt any with
   | None ->
+      (match any with
       (* IL.any_of_orig will return `G.Anys []` for `NoOrig`, and there is
        * no point in issuing this warning in that case.
        * TODO: Perhaps we should avoid the call to `any_in_ranges` in the
        * first place? *)
-      if any <> G.Anys [] then
-        logger#warning
-          "Cannot compute range, there are no real tokens in this AST: %s"
-          (G.show_any any);
+      | G.Anys []
+      (* An enormous amount of logspew with Semgrep Pro Engine happens with this
+       * case. TODO Figure out why avoid it? *)
+      | G.Tk _ ->
+          ()
+      | _else_ ->
+          logger#warning
+            "Cannot compute range, there are no real tokens in this AST: %s"
+            (G.show_any any));
       None
   | Some (tok1, tok2) ->
       let r = Range.range_of_token_locations tok1 tok2 in


### PR DESCRIPTION
I was seeing this a lot with `--debug` and it was drowning out other findings and leading to excessive memory use on the CLI side (which stores up all the output and then prints it at the end).

After this change, the CLI's memory usage with `--debug --pro` is greatly reduced.

Test plan: Manually tested with `--debug --pro` and observed greatly reduced memory usage.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
