### PR TITLE
Partially revert "fix: Reduce logspew with Pro Engine (#7128)"

### DIFF
--- a/src/engine/Match_tainting_mode.ml
+++ b/src/engine/Match_tainting_mode.ml
@@ -242,20 +242,14 @@ let range_of_any any =
    * the AST at some point. *)
   match Visitor_AST.range_of_any_opt any with
   | None ->
-      (match any with
       (* IL.any_of_orig will return `G.Anys []` for `NoOrig`, and there is
        * no point in issuing this warning in that case.
        * TODO: Perhaps we should avoid the call to `any_in_ranges` in the
        * first place? *)
-      | G.Anys []
-      (* An enormous amount of logspew with Semgrep Pro Engine happens with this
-       * case. TODO Figure out why and avoid it? *)
-      | G.Tk _ ->
-          ()
-      | _else_ ->
-          logger#warning
-            "Cannot compute range, there are no real tokens in this AST: %s"
-            (G.show_any any));
+      if any <> G.Anys [] then
+        logger#trace
+          "Cannot compute range, there are no real tokens in this AST: %s"
+          (G.show_any any);
       None
   | Some (tok1, tok2) ->
       let r = Range.range_of_token_locations tok1 tok2 in


### PR DESCRIPTION
This reverts commit c038f4b4f088080fad62d4ede55d05db5f4a088f.

Instead demote the severity from "warning" to "trace".

test plan:
% semgrep -c p/default-v2 example-annotations/repos/java/SQLi/vuln-repos/BenchmarkJava/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest0151*.java --debug

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
