### PR TITLE
chore: no longer complain about `interfile: true` when `--interfile` not specified

### DIFF
--- a/changelog.d/pa-2528.fixed
+++ b/changelog.d/pa-2528.fixed
@@ -1,0 +1,2 @@
+CLI: No longer reports rules as being run with a lack of `interfile: true` when interfile
+analysis was not requested.

--- a/cli/src/semgrep/formatter/text.py
+++ b/cli/src/semgrep/formatter/text.py
@@ -749,10 +749,7 @@ class TextFormatter(BaseFormatter):
         ]
 
         rules_output = []
-        if (
-            cli_output_extra.engine_requested is None
-            or not isinstance(cli_output_extra.engine_requested.value, out.OSS)
-        ) and oss_rules:
+        if (extra["engine_requested"].is_interfile) and oss_rules:
             rules_output = [
                 "\nSome rules were run as OSS rules because `interfile: true` was not specified.\n"
             ]

--- a/cli/src/semgrep/output.py
+++ b/cli/src/semgrep/output.py
@@ -486,6 +486,9 @@ class OutputHandler:
         if self.settings.output_format == OutputFormat.SARIF:
             extra["dataflow_traces"] = self.settings.dataflow_traces
 
+        # as opposed to below, we need to distinguish the various kinds of pro engine
+        extra["engine_requested"] = self.engine_requested
+
         # the rules are used only by the SARIF formatter
         return self.formatter.output(
             self.rules,
@@ -496,6 +499,7 @@ class OutputHandler:
                 time=cli_timing,
                 explanations=explanations,
                 rules_by_engine=rules_by_engine,
+                # this flattens the information into just distinguishing "pro" and "not-pro"
                 engine_requested=self.engine_requested.to_engine_kind(),
             ),
             extra,


### PR DESCRIPTION
## What:
This PR makes it so that the CLI no longer complains that some rules were run as OSS, even if `--interfile` was not specified.

## Why:
This is a disingenuous error because it's just not relevant to the user, if they specify `--pro-intrafile` or `--pro-languages`. It makes them think there's an error when it's not an error.

## How:
I made it such that we only really report this if `--interfile` was requested.

## Notes:
This is the minimal change to get the behavior correct. There is some redundancy in the CLI code (most introduced by myself), that warrants a refactor. Ultimately, I see a kind of tension between parts of the codebase where we only care about whether the Pro Engine is running (in all three of its forms), and parts where we see fit to dispatch on that information. The existence of both of these makes the code kind of ugly right now.

In addition, we will still report rules run with the intrafile engine and pro languages as "OSS" rules. That is something I'm downscoping to fix for this PR. A more disciplined solution is in order, but later.

We also really need e2e testing for `pro`.

## Test plan:
![image](https://user-images.githubusercontent.com/49291449/218523931-a7e69657-198e-4350-a6d2-676b4bdd0fbf.png)


PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
