### PR TITLE
Fix logging of headers to stderr when --quiet is on

### DIFF
--- a/changelog.d/quiet-please.fix
+++ b/changelog.d/quiet-please.fix
@@ -1,0 +1,3 @@
+The 1.11.0 release started printing log lines to stderr even when --quiet was on,
+making it impossible to get well-formed JSON output when mixing stdout and stderr.
+These lines are now gone, and output is again restricted to just scan results.

--- a/cli/src/semgrep/terminal.py
+++ b/cli/src/semgrep/terminal.py
@@ -4,6 +4,7 @@ import sys
 
 from attr import define
 
+from semgrep.console import console
 from semgrep.env import Env
 
 
@@ -35,7 +36,12 @@ class Terminal:
         quiet: bool = True,
         force_color: bool = False,
     ) -> None:
-        """Set the relevant logging levels"""
+        """Set the relevant logging levels.
+
+        Affects also the configuration of the rich console."""
+
+        console.quiet = quiet
+
         # Assumes only one of verbose, debug, quiet is True
         logger = logging.getLogger("semgrep")
         logger.handlers = []  # Reset to no handlers

--- a/cli/tests/e2e/snapshots/test_check/test_terminal_output_quiet/results.txt
+++ b/cli/tests/e2e/snapshots/test_check/test_terminal_output_quiet/results.txt
@@ -26,18 +26,6 @@ Findings:
 === end of stdout - plain
 
 === stderr - plain
-                                                                                
-                                                                                
-╭─────────╮                                                                     
-│ Results │                                                                     
-╰─────────╯                                                                     
-                                                                                
-                                                                                
-                                                                                
-╭──────────────╮                                                                
-│ Scan Summary │                                                                
-╰──────────────╯                                                                
-                                                                                
 
 === end of stderr - plain
 
@@ -61,17 +49,5 @@ Findings:
 === end of stdout - color
 
 === stderr - color
-                                                                                
-                                                                                
-╭─────────╮                                                                     
-│ Results │                                                                     
-╰─────────╯                                                                     
-                                                                                
-                                                                                
-                                                                                
-╭──────────────╮                                                                
-│ Scan Summary │                                                                
-╰──────────────╯                                                                
-                                                                                
 
 === end of stderr - color

--- a/cli/tests/e2e/test_output.py
+++ b/cli/tests/e2e/test_output.py
@@ -120,6 +120,24 @@ def test_yaml_metavariables(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(stdout, "report.json")
 
 
+@pytest.mark.quick
+def test_quiet_mode_has_empty_stderr(run_semgrep_in_tmp, snapshot):
+    """
+    Test that quiet mode doesn't print anything to stderr.
+
+    This is because some contexts e.g. Kubernetes jobs force-mix stdout and stderr,
+    and --quiet is the only way to get valid JSON output in that case.
+    """
+    stdout, stderr = run_semgrep_in_tmp(
+        "rules/yaml_key.yaml",
+        target_name="yaml/target.yaml",
+        output_format=OutputFormat.JSON,
+        options=["--quiet"],
+    )
+    assert stderr == ""
+    json.loads(stdout)  # stdout must be parseable JSON
+
+
 # junit-xml is tested in a test_junit_xml_output due to ambiguous XML attribute ordering
 @pytest.mark.kinda_slow
 @pytest.mark.parametrize(
@@ -261,7 +279,6 @@ def test_sarif_output_with_nosemgrep_and_error(run_semgrep_in_tmp, snapshot):
 
 @pytest.mark.kinda_slow
 def test_sarif_output_with_autofix(run_semgrep_in_tmp, snapshot):
-
     snapshot.assert_match(
         run_semgrep_in_tmp(
             "rules/autofix/autofix.yaml",


### PR DESCRIPTION
PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
