### PR TITLE
fix: remove event id from data sent to app

### DIFF
--- a/cli/src/semgrep/app/scans.py
+++ b/cli/src/semgrep/app/scans.py
@@ -311,7 +311,6 @@ class ScanHandler:
                     }
                     for (lang, data) in parse_rate.get_errors_by_lang().items()
                 },
-                "event_id": str(state.metrics.payload["event_id"]),
                 "engine_requested": engine_requested.name,
             },
         }

--- a/cli/tests/e2e/snapshots/test_ci/test_dryrun/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_dryrun/results.txt
@@ -474,7 +474,6 @@ Would have sent complete blob: {
                 "num_bytes": 366
             }
         },
-        "event_id": <MASKED>
         "engine_requested": "OSS"
     }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines-overwrite-autodetected-variables/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines-overwrite-autodetected-variables/complete.json
@@ -16,7 +16,6 @@
         "num_bytes": 366
       }
     },
-    "event_id": "xxxxxxxxxx",
     "engine_requested": "OSS"
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines/complete.json
@@ -16,7 +16,6 @@
         "num_bytes": 366
       }
     },
-    "event_id": "xxxxxxxxxx",
     "engine_requested": "OSS"
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket-overwrite-autodetected-variables/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket-overwrite-autodetected-variables/complete.json
@@ -16,7 +16,6 @@
         "num_bytes": 366
       }
     },
-    "event_id": "xxxxxxxxxx",
     "engine_requested": "OSS"
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket/complete.json
@@ -16,7 +16,6 @@
         "num_bytes": 366
       }
     },
-    "event_id": "xxxxxxxxxx",
     "engine_requested": "OSS"
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite-overwrite-autodetected-variables/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite-overwrite-autodetected-variables/complete.json
@@ -16,7 +16,6 @@
         "num_bytes": 366
       }
     },
-    "event_id": "xxxxxxxxxx",
     "engine_requested": "OSS"
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite/complete.json
@@ -16,7 +16,6 @@
         "num_bytes": 366
       }
     },
-    "event_id": "xxxxxxxxxx",
     "engine_requested": "OSS"
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci-overwrite-autodetected-variables/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci-overwrite-autodetected-variables/complete.json
@@ -16,7 +16,6 @@
         "num_bytes": 366
       }
     },
-    "event_id": "xxxxxxxxxx",
     "engine_requested": "OSS"
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci/complete.json
@@ -16,7 +16,6 @@
         "num_bytes": 366
       }
     },
-    "event_id": "xxxxxxxxxx",
     "engine_requested": "OSS"
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/complete.json
@@ -16,7 +16,6 @@
         "num_bytes": 366
       }
     },
-    "event_id": "xxxxxxxxxx",
     "engine_requested": "OSS"
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr-semgrepconfig/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr-semgrepconfig/complete.json
@@ -14,7 +14,6 @@
         "num_bytes": 366
       }
     },
-    "event_id": "xxxxxxxxxx",
     "engine_requested": "OSS"
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr/complete.json
@@ -14,7 +14,6 @@
         "num_bytes": 366
       }
     },
-    "event_id": "xxxxxxxxxx",
     "engine_requested": "OSS"
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/complete.json
@@ -16,7 +16,6 @@
         "num_bytes": 366
       }
     },
-    "event_id": "xxxxxxxxxx",
     "engine_requested": "OSS"
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-push/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-push/complete.json
@@ -16,7 +16,6 @@
         "num_bytes": 366
       }
     },
-    "event_id": "xxxxxxxxxx",
     "engine_requested": "OSS"
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab/complete.json
@@ -14,7 +14,6 @@
         "num_bytes": 366
       }
     },
-    "event_id": "xxxxxxxxxx",
     "engine_requested": "OSS"
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/complete.json
@@ -16,7 +16,6 @@
         "num_bytes": 366
       }
     },
-    "event_id": "xxxxxxxxxx",
     "engine_requested": "OSS"
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-overwrite-autodetected-variables/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-overwrite-autodetected-variables/complete.json
@@ -16,7 +16,6 @@
         "num_bytes": 366
       }
     },
-    "event_id": "xxxxxxxxxx",
     "engine_requested": "OSS"
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins/complete.json
@@ -16,7 +16,6 @@
         "num_bytes": 366
       }
     },
-    "event_id": "xxxxxxxxxx",
     "engine_requested": "OSS"
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/complete.json
@@ -16,7 +16,6 @@
         "num_bytes": 366
       }
     },
-    "event_id": "xxxxxxxxxx",
     "engine_requested": "OSS"
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-self-hosted/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-self-hosted/complete.json
@@ -16,7 +16,6 @@
         "num_bytes": 366
       }
     },
-    "event_id": "xxxxxxxxxx",
     "engine_requested": "OSS"
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis-overwrite-autodetected-variables/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis-overwrite-autodetected-variables/complete.json
@@ -16,7 +16,6 @@
         "num_bytes": 366
       }
     },
-    "event_id": "xxxxxxxxxx",
     "engine_requested": "OSS"
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis/complete.json
@@ -16,7 +16,6 @@
         "num_bytes": 366
       }
     },
-    "event_id": "xxxxxxxxxx",
     "engine_requested": "OSS"
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-unparsable_url/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-unparsable_url/complete.json
@@ -16,7 +16,6 @@
         "num_bytes": 366
       }
     },
-    "event_id": "xxxxxxxxxx",
     "engine_requested": "OSS"
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines-overwrite-autodetected-variables/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines-overwrite-autodetected-variables/complete.json
@@ -16,7 +16,6 @@
         "num_bytes": 366
       }
     },
-    "event_id": "xxxxxxxxxx",
     "engine_requested": "OSS"
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines/complete.json
@@ -16,7 +16,6 @@
         "num_bytes": 366
       }
     },
-    "event_id": "xxxxxxxxxx",
     "engine_requested": "OSS"
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket-overwrite-autodetected-variables/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket-overwrite-autodetected-variables/complete.json
@@ -16,7 +16,6 @@
         "num_bytes": 366
       }
     },
-    "event_id": "xxxxxxxxxx",
     "engine_requested": "OSS"
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket/complete.json
@@ -16,7 +16,6 @@
         "num_bytes": 366
       }
     },
-    "event_id": "xxxxxxxxxx",
     "engine_requested": "OSS"
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite-overwrite-autodetected-variables/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite-overwrite-autodetected-variables/complete.json
@@ -16,7 +16,6 @@
         "num_bytes": 366
       }
     },
-    "event_id": "xxxxxxxxxx",
     "engine_requested": "OSS"
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite/complete.json
@@ -16,7 +16,6 @@
         "num_bytes": 366
       }
     },
-    "event_id": "xxxxxxxxxx",
     "engine_requested": "OSS"
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci-overwrite-autodetected-variables/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci-overwrite-autodetected-variables/complete.json
@@ -16,7 +16,6 @@
         "num_bytes": 366
       }
     },
-    "event_id": "xxxxxxxxxx",
     "engine_requested": "OSS"
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci/complete.json
@@ -16,7 +16,6 @@
         "num_bytes": 366
       }
     },
-    "event_id": "xxxxxxxxxx",
     "engine_requested": "OSS"
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/complete.json
@@ -16,7 +16,6 @@
         "num_bytes": 366
       }
     },
-    "event_id": "xxxxxxxxxx",
     "engine_requested": "OSS"
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr-semgrepconfig/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr-semgrepconfig/complete.json
@@ -14,7 +14,6 @@
         "num_bytes": 366
       }
     },
-    "event_id": "xxxxxxxxxx",
     "engine_requested": "OSS"
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr/complete.json
@@ -14,7 +14,6 @@
         "num_bytes": 366
       }
     },
-    "event_id": "xxxxxxxxxx",
     "engine_requested": "OSS"
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/complete.json
@@ -16,7 +16,6 @@
         "num_bytes": 366
       }
     },
-    "event_id": "xxxxxxxxxx",
     "engine_requested": "OSS"
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-push/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-push/complete.json
@@ -16,7 +16,6 @@
         "num_bytes": 366
       }
     },
-    "event_id": "xxxxxxxxxx",
     "engine_requested": "OSS"
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab/complete.json
@@ -14,7 +14,6 @@
         "num_bytes": 366
       }
     },
-    "event_id": "xxxxxxxxxx",
     "engine_requested": "OSS"
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/complete.json
@@ -16,7 +16,6 @@
         "num_bytes": 366
       }
     },
-    "event_id": "xxxxxxxxxx",
     "engine_requested": "OSS"
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-overwrite-autodetected-variables/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-overwrite-autodetected-variables/complete.json
@@ -16,7 +16,6 @@
         "num_bytes": 366
       }
     },
-    "event_id": "xxxxxxxxxx",
     "engine_requested": "OSS"
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins/complete.json
@@ -16,7 +16,6 @@
         "num_bytes": 366
       }
     },
-    "event_id": "xxxxxxxxxx",
     "engine_requested": "OSS"
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/complete.json
@@ -16,7 +16,6 @@
         "num_bytes": 366
       }
     },
-    "event_id": "xxxxxxxxxx",
     "engine_requested": "OSS"
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-self-hosted/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-self-hosted/complete.json
@@ -16,7 +16,6 @@
         "num_bytes": 366
       }
     },
-    "event_id": "xxxxxxxxxx",
     "engine_requested": "OSS"
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis-overwrite-autodetected-variables/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis-overwrite-autodetected-variables/complete.json
@@ -16,7 +16,6 @@
         "num_bytes": 366
       }
     },
-    "event_id": "xxxxxxxxxx",
     "engine_requested": "OSS"
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis/complete.json
@@ -16,7 +16,6 @@
         "num_bytes": 366
       }
     },
-    "event_id": "xxxxxxxxxx",
     "engine_requested": "OSS"
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-unparsable_url/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-unparsable_url/complete.json
@@ -16,7 +16,6 @@
         "num_bytes": 366
       }
     },
-    "event_id": "xxxxxxxxxx",
     "engine_requested": "OSS"
   }
 }

--- a/cli/tests/e2e/test_ci.py
+++ b/cli/tests/e2e/test_ci.py
@@ -648,9 +648,6 @@ def test_full_run(
 
     complete_json = post_calls[2].kwargs["json"]
     complete_json["stats"]["total_time"] = 0.5  # Sanitize time for comparison
-    complete_json["stats"][
-        "event_id"
-    ] = "xxxxxxxxxx"  # Sanitize event_id for comparison
     # TODO: flaky tests (on Linux at least)
     # see https://linear.app/r2c/issue/PA-2461/restore-flaky-e2e-tests for more info
     complete_json["stats"]["lockfile_scan_info"] = {}


### PR DESCRIPTION
This partially reverts https://github.com/returntocorp/semgrep/pull/7088

There are circumstances where the event id could make it possible to guess user ids from the app data so, to prevent that, we will remove it and remove all collected event ids.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
