### PR TITLE
ask git for remote origin url if repo_url not provided

### DIFF
--- a/changelog.d/gh-7144.fixed
+++ b/changelog.d/gh-7144.fixed
@@ -1,0 +1,1 @@
+Fix local scan hyperlinks by asking git for remote.origin.url if repo_url not provided

--- a/cli/src/semgrep/meta.py
+++ b/cli/src/semgrep/meta.py
@@ -104,17 +104,17 @@ class GitMeta:
         if not repo_url:
             # if the repo URL was not explicitly provided, try getting it from git
             # nosem: use-git-check-output-helper
-            rev_parse = subprocess.run(
+            git_parse = subprocess.run(
                 ["git", "remote", "get-url", "origin"],
                 capture_output=True,
                 encoding="utf-8",
                 timeout=env.git_command_timeout,
             )
-            if rev_parse.returncode != 0:
-                raise Exception(
-                    "Unable to infer repo_url. Set SEMGREP_REPO_URL environment variable or run in a valid git project"
+            if git_parse.returncode != 0:
+                logger.warn(
+                    f"Unable to infer repo_url. Set SEMGREP_REPO_URL environment variable or run in a valid git project with remote origin defined"
                 )
-            repo_url = rev_parse.stdout.strip()
+            repo_url = git_parse.stdout.strip()
 
         return get_url_from_sstp_url(repo_url)
 

--- a/cli/src/semgrep/meta.py
+++ b/cli/src/semgrep/meta.py
@@ -112,6 +112,7 @@ class GitMeta:
                 raise Exception(
                     "Unable to infer repo_url. Set SEMGREP_REPO_URL environment variable or run in a valid git project"
                 )
+            repo_url = rev_parse.stdout.strip()
 
         return get_url_from_sstp_url(repo_url)
 

--- a/cli/src/semgrep/meta.py
+++ b/cli/src/semgrep/meta.py
@@ -99,9 +99,11 @@ class GitMeta:
 
     @property
     def repo_url(self) -> Optional[str]:
+        env = get_state().env
         repo_url = os.getenv("SEMGREP_REPO_URL")
         if not repo_url:
             # if the repo URL was not explicitly provided, try getting it from git
+            # nosem: use-git-check-output-helper
             rev_parse = subprocess.run(
                 ["git", "config", "--get", "remote.origin.url"],
                 capture_output=True,
@@ -309,7 +311,14 @@ class GithubMeta(GitMeta):
             f"head branch ({head_branch_name}) has latest commit {commit}, fetching that commit now."
         )
         git_check_output(
-            ["git", "fetch", "origin", "--force", "--depth=1", commit,]
+            [
+                "git",
+                "fetch",
+                "origin",
+                "--force",
+                "--depth=1",
+                commit,
+            ]
         )
         return str(commit)
 
@@ -350,10 +359,10 @@ class GithubMeta(GitMeta):
         env = get_state().env
 
         # fetch 0, 4, 16, 64, 256, 1024, ...
-        fetch_depth = 4 ** attempt_count if attempt_count else 0
+        fetch_depth = 4**attempt_count if attempt_count else 0
         fetch_depth += get_state().env.min_fetch_depth
         if attempt_count > self.MAX_FETCH_ATTEMPT_COUNT:  # get all commits on last try
-            fetch_depth = 2 ** 31 - 1  # git expects a signed 32-bit integer
+            fetch_depth = 2**31 - 1  # git expects a signed 32-bit integer
 
         logger.debug(
             f"Attempting to find merge base, attempt_count={attempt_count}, fetch_depth={fetch_depth}"

--- a/cli/src/semgrep/meta.py
+++ b/cli/src/semgrep/meta.py
@@ -105,7 +105,7 @@ class GitMeta:
             # if the repo URL was not explicitly provided, try getting it from git
             # nosem: use-git-check-output-helper
             rev_parse = subprocess.run(
-                ["git", "config", "--get", "remote.origin.url"],
+                ["git", "remote", "get-url", "origin"],
                 capture_output=True,
                 encoding="utf-8",
                 timeout=env.git_command_timeout,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/meta.json
@@ -2,7 +2,7 @@
   "meta": {
     "semgrep_version": "<sanitized version>",
     "repository": "checkout_project_name",
-    "repo_url": null,
+    "repo_url": "https://pytest-0/popen-gw1/test_full_run_autofix_local_0/project_name",
     "branch": "some/branch-name",
     "ci_job_url": null,
     "commit": "sanitized",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/meta.json
@@ -2,7 +2,7 @@
   "meta": {
     "semgrep_version": "<sanitized version>",
     "repository": "checkout_project_name",
-    "repo_url": "https://pytest-0/popen-gw1/test_full_run_autofix_local_0/project_name",
+    "repo_url": "git@github.com:example/fake.git",
     "branch": "some/branch-name",
     "ci_job_url": null,
     "commit": "sanitized",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/meta.json
@@ -2,7 +2,7 @@
   "meta": {
     "semgrep_version": "<sanitized version>",
     "repository": "checkout_project_name",
-    "repo_url": "git@github.com:example/fake.git",
+    "repo_url": "https://github.com/example/fake",
     "branch": "some/branch-name",
     "ci_job_url": null,
     "commit": "sanitized",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/results.txt
@@ -1,5 +1,5 @@
 === command
-SEMGREP_APP_TOKEN="fake-key-from-tests" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERSION_CACHE_PATH="<MASKED>" SEMGREP_ENABLE_VERSION_CHECK="0" SEMGREP_SEND_METRICS="off" semgrep ci --no-suppress-errors
+SEMGREP_APP_TOKEN="fake-key-from-tests" SEMGREP_REPO_URL="git@github.com:example/fake.git" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERSION_CACHE_PATH="<MASKED>" SEMGREP_ENABLE_VERSION_CHECK="0" SEMGREP_SEND_METRICS="off" semgrep ci --no-suppress-errors
 === end of command
 
 === exit code

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/meta.json
@@ -2,7 +2,7 @@
   "meta": {
     "semgrep_version": "<sanitized version>",
     "repository": "checkout_project_name",
-    "repo_url": "https://pytest-0/popen-gw1/test_full_run_noautofix_local_0/project_name",
+    "repo_url": "git@github.com:example/fake.git",
     "branch": "some/branch-name",
     "ci_job_url": null,
     "commit": "sanitized",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/meta.json
@@ -2,7 +2,7 @@
   "meta": {
     "semgrep_version": "<sanitized version>",
     "repository": "checkout_project_name",
-    "repo_url": null,
+    "repo_url": "https://pytest-0/popen-gw1/test_full_run_noautofix_local_0/project_name",
     "branch": "some/branch-name",
     "ci_job_url": null,
     "commit": "sanitized",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/meta.json
@@ -2,7 +2,7 @@
   "meta": {
     "semgrep_version": "<sanitized version>",
     "repository": "checkout_project_name",
-    "repo_url": "git@github.com:example/fake.git",
+    "repo_url": "https://github.com/example/fake",
     "branch": "some/branch-name",
     "ci_job_url": null,
     "commit": "sanitized",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/results.txt
@@ -1,5 +1,5 @@
 === command
-SEMGREP_APP_TOKEN="fake-key-from-tests" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERSION_CACHE_PATH="<MASKED>" SEMGREP_ENABLE_VERSION_CHECK="0" SEMGREP_SEND_METRICS="off" semgrep ci --no-suppress-errors
+SEMGREP_APP_TOKEN="fake-key-from-tests" SEMGREP_REPO_URL="git@github.com:example/fake.git" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERSION_CACHE_PATH="<MASKED>" SEMGREP_ENABLE_VERSION_CHECK="0" SEMGREP_SEND_METRICS="off" semgrep ci --no-suppress-errors
 === end of command
 
 === exit code

--- a/cli/tests/e2e/test_ci.py
+++ b/cli/tests/e2e/test_ci.py
@@ -31,7 +31,7 @@ BRANCH_NAME = "some/branch-name"
 MAIN_BRANCH_NAME = "main"
 COMMIT_MESSAGE = "some: commit message! foo"
 COMMIT_MESSAGE_2 = "Some other commit/ message"
-REMOTE_REPO_URL = 'git@github.com:example/fake.git'
+REMOTE_REPO_URL = "git@github.com:example/fake.git"
 DEPLOYMENT_ID = 33
 BAD_CONFIG = dedent(
     """

--- a/cli/tests/e2e/test_ci.py
+++ b/cli/tests/e2e/test_ci.py
@@ -31,6 +31,7 @@ BRANCH_NAME = "some/branch-name"
 MAIN_BRANCH_NAME = "main"
 COMMIT_MESSAGE = "some: commit message! foo"
 COMMIT_MESSAGE_2 = "Some other commit/ message"
+REMOTE_REPO_URL = 'git@github.com:example/fake.git'
 DEPLOYMENT_ID = 33
 BAD_CONFIG = dedent(
     """
@@ -150,7 +151,7 @@ def git_tmp_path_with_commit(monkeypatch, tmp_path, mocker):
     monkeypatch.chdir(repo_copy_base)
     subprocess.run(["git", "init"], check=True, capture_output=True)
     subprocess.run(
-        ["git", "remote", "add", "origin", repo_base],
+        ["git", "remote", "add", "origin", REMOTE_REPO_URL],
         check=True,
         capture_output=True,
     )

--- a/cli/tests/e2e/test_ci.py
+++ b/cli/tests/e2e/test_ci.py
@@ -151,7 +151,7 @@ def git_tmp_path_with_commit(monkeypatch, tmp_path, mocker):
     monkeypatch.chdir(repo_copy_base)
     subprocess.run(["git", "init"], check=True, capture_output=True)
     subprocess.run(
-        ["git", "remote", "add", "origin", REMOTE_REPO_URL],
+        ["git", "remote", "add", "origin", repo_base],
         check=True,
         capture_output=True,
     )
@@ -252,6 +252,7 @@ def automocks(mocker):
 
 @pytest.fixture(params=[True, False], ids=["autofix", "noautofix"])
 def mock_autofix(request, mocker):
+    mocker.patch.object(GitMeta, "repo_url", REMOTE_REPO_URL)
     mocker.patch.object(ScanHandler, "autofix", request.param)
 
 

--- a/cli/tests/e2e/test_ci.py
+++ b/cli/tests/e2e/test_ci.py
@@ -252,14 +252,16 @@ def automocks(mocker):
 
 @pytest.fixture(params=[True, False], ids=["autofix", "noautofix"])
 def mock_autofix(request, mocker):
-    mocker.patch.object(GitMeta, "repo_url", REMOTE_REPO_URL)
     mocker.patch.object(ScanHandler, "autofix", request.param)
 
 
 @pytest.mark.parametrize(
     "env",
     [
-        {"SEMGREP_APP_TOKEN": "dummy"},  # Local run with no CI env vars
+        {  # Local run with no CI env vars
+            "SEMGREP_APP_TOKEN": "dummy",
+            "SEMGREP_REPO_URL": REMOTE_REPO_URL,
+        },
         {  # Github full scan
             "CI": "true",
             "GITHUB_ACTIONS": "true",
@@ -535,6 +537,7 @@ def test_full_run(
     snapshot,
     env,
     run_semgrep,
+    mocker,
     mock_autofix,
 ):
     repo_copy_base, base_commit, head_commit = git_tmp_path_with_commit


### PR DESCRIPTION
Should fix https://linear.app/r2c/issue/PA-2540/missing-hyperlinks-after-local-scan

Testing situation is not ideal. Testing is not using the `git` subprocess command, because if it does, the output will be non-deterministic as pytest is creating a new directory for the repo every time and thus the origin will be different. We could change the origin, but other tests actually rely on it being clonable. 

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
