### PR TITLE
fix: Improve parse error messages related to metavariable-pattern

### DIFF
--- a/changelog.d/pa-2537.fixed
+++ b/changelog.d/pa-2537.fixed
@@ -1,0 +1,1 @@
+Improve error messages displayed with `--verbose` when the contents of a metavariable fails to parse.

--- a/src/engine/Metavariable_pattern.ml
+++ b/src/engine/Metavariable_pattern.ml
@@ -261,9 +261,14 @@ let get_nested_metavar_pattern_bindings get_nested_formula_matches env r mvar
                               let { Parse_target.ast; skipped_tokens; _ } =
                                 Parse_target.parse_and_resolve_name lang file
                               in
-                              (* TODO: If we wanted to report the parse errors
-                               * then we should fix the parse info with
-                               * Parse_info.adjust_info_wrt_base! *)
+                              (* Reposition the errors to the original source
+                               * text, so that we don't report them to the end
+                               * user as being from the temp file that we
+                               * created. *)
+                              let skipped_tokens =
+                                skipped_tokens
+                                |> Common.map (fun tok -> revert_loc tok)
+                              in
                               if skipped_tokens <> [] then
                                 pr2
                                   (spf


### PR DESCRIPTION
Currently, when there is a nested language in a `metavariable-pattern` and we encounter a parse error when parsing the metavariable's contents, we get something like this (appears when providing the `--verbose` flag to the CLI):

```
[WARN] Syntax error at line /tmp/tmp-3427277-52324a.mvar-pattern:1:
 `<` was unexpected
```

This is totally unactionable, and is a bit scary. There is no way to tell what rule or file led to this result. To improve this situation, I propose two changes in this pull request:

First, when we encounter errors when running a nested pattern in a different language for metavariable-pattern, we annotate the resulting error message with information about the nested target language and the rule ID.

Second, when we get parse errors, we now update their locations so that they point to the original source text rather than to the temp file created for the metavariable pattern.

I'm not completely convinced that we should be even issuing these errors at all. I think it is expected that the contents of a metavariable might not always parse cleanly as another language. But, it's probably better than silently declining to provide results because of a parse error that users don't have any way of finding out about. I'd like to see if this messaging change clears up confusion first and iterate if not.

Test plan:

Rule:

```
rules:
- id: find.really.scary.problems
  patterns:
    - pattern: "$X"
    - metavariable-pattern:
        metavariable: $X
        language: js
        pattern: ...
  message: placeholder message
  languages: [python]
  severity: WARNING
```

test.py:
```
y = 'asdf'

x = '<'
```

Run `semgrep scan -c test.yaml . --verbose` and observe the following lines in the output:

```
[WARN] Syntax error at line test.py:3:
 When parsing a snippet as JavaScript for metavariable-pattern in rule 'find.really.scary.problems', `<` was unexpected
```

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
