### PR TITLE
Terraform: split Parse_terraform_tree_sitter.ml in 2

### DIFF
--- a/languages/terraform/ast/AST_terraform.ml
+++ b/languages/terraform/ast/AST_terraform.ml
@@ -47,7 +47,6 @@ type 'a wrap = 'a * tok [@@deriving show]
 
 (* round(), square[], curly{}, angle<> brackets *)
 type 'a bracket = tok * 'a * tok [@@deriving show]
-type todo_kind = string wrap
 
 (* ------------------------------------------------------------------------- *)
 (* Names  *)

--- a/languages/terraform/generic/Terraform_to_generic.ml
+++ b/languages/terraform/generic/Terraform_to_generic.ml
@@ -1,4 +1,106 @@
-(* TODO
-   argument -> G.definition
-   ...
-*)
+(* Yoann Padioleau
+ *
+ * Copyright (c) 2023 r2c
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * version 2.1 as published by the Free Software Foundation, with the
+ * special exception on linking described in file LICENSE.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
+ * LICENSE for more details.
+ *)
+open AST_terraform
+module G = AST_generic
+module H2 = AST_generic_helpers
+
+(*****************************************************************************)
+(* Prelude *)
+(*****************************************************************************)
+(* AST_terraform to AST_generic *)
+
+(*****************************************************************************)
+(* Helpers *)
+(*****************************************************************************)
+
+let map_argument (arg : argument) : G.definition =
+  let id, _teq, e = arg in
+  let ent = G.basic_entity id in
+  let def = { G.vinit = Some e; vtype = None } in
+  (ent, G.VarDef def)
+
+(* We convert to a field, to be similar to Parse_terraform_xxx.map_object,
+ * so some patterns like 'a=1 ... b=2' can match block body as well as objects.
+ *)
+let rec map_block_body_element (x : block_body_element) : G.field =
+  match x with
+  | Argument v1 ->
+      let def = map_argument v1 in
+      def |> G.fld
+  | Block blk ->
+      let e = map_block blk in
+      G.F (G.exprstmt e)
+  | BlockEllipsis t -> G.fieldEllipsis t
+
+(* TODO? convert to a definition? a class_def?
+ * coupling: Constant_propagation.terraform_stmt_to_vardefs
+ *)
+and map_block ({ btype = _kind, tk; blabels; bbody = lb, body, rb } : block) :
+    G.expr =
+  let id = (Parse_info.str_of_info tk, tk) in
+  let labels_id =
+    blabels
+    |> Common.map (function
+         | LblStr x -> G.L (G.String x) |> G.e
+         | LblId id ->
+             let n = H2.name_of_id id in
+             G.N n |> G.e)
+  in
+
+  let n = H2.name_of_id id in
+  (* convert in a Record like map_object *)
+  let flds = Common.map map_block_body_element body in
+  let body = Record (lb, flds, rb) |> G.e in
+  let es = labels_id @ [ body ] in
+  let args = es |> Common.map G.arg in
+  (* coupling: if you modify this code, you should adjust
+   * Constant_propagation.terraform_stmt_to_vardefs.
+   * bugfix: I used to transform that in a New (..., TyN n, ...) but
+   * lots of terraform rules are using some
+   *   pattern-inside: resource ... {}
+   *   pattern: resource
+   * and the second pattern is parsed as an expression which would not
+   * match the TyN.
+   * TODO? convert in something else?
+   * TODO: should we use something else than Call since it's already used
+   * for expressions in map_expr_term() above?
+   *)
+  G.Call (N n |> G.e, Parse_info.unsafe_fake_bracket args) |> G.e
+
+(*****************************************************************************)
+(* Entry points *)
+(*****************************************************************************)
+
+(* almost copy-paste of map_block_body_element above, but returning statements
+ * TODO? we should transform the 'locals' and 'variable' blocks
+ * in regular VarDefs instead of doing it later in
+ * Constant_propagation.terraform_stmt_to_vardefs?
+ *)
+let program (xs : config) : G.program =
+  xs
+  |> Common.map (function
+       (* TODO? this should never happen in terraform files at the toplevel *)
+       | Argument e ->
+           let def = map_argument e in
+           G.DefStmt def |> G.s
+       | BlockEllipsis t -> G.exprstmt (G.Ellipsis t |> G.e)
+       | Block blk ->
+           let e = map_block blk in
+           G.exprstmt e)
+
+let any (x : any) : G.any =
+  match x with
+  | E e -> G.E e
+  | Pr config -> G.Pr (program config)

--- a/languages/terraform/generic/Terraform_to_generic.mli
+++ b/languages/terraform/generic/Terraform_to_generic.mli
@@ -1,0 +1,2 @@
+val program : AST_terraform.config -> AST_generic.program
+val any : AST_terraform.any -> AST_generic.any

--- a/languages/terraform/generic/dune
+++ b/languages/terraform/generic/dune
@@ -6,6 +6,7 @@
    commons
    lib_parsing lib_parsing_tree_sitter
    tree-sitter-lang.hcl
+   parser_terraform.ast
    ast_generic
  )
  (preprocess (pps ppx_deriving.show))

--- a/languages/terraform/tree-sitter/Parse_terraform_tree_sitter.mli
+++ b/languages/terraform/tree-sitter/Parse_terraform_tree_sitter.mli
@@ -1,4 +1,4 @@
 val parse :
-  Common.filename -> AST_generic.program Tree_sitter_run.Parsing_result.t
+  Common.filename -> AST_terraform.config Tree_sitter_run.Parsing_result.t
 
-val parse_pattern : string -> AST_generic.any Tree_sitter_run.Parsing_result.t
+val parse_pattern : string -> AST_terraform.any Tree_sitter_run.Parsing_result.t

--- a/src/parsing/Parse_pattern.ml
+++ b/src/parsing/Parse_pattern.ml
@@ -171,7 +171,10 @@ let parse_pattern lang ?(print_errors = false) str =
         extract_pattern_from_tree_sitter_result res print_errors
     | Lang.Terraform ->
         let res = Parse_terraform_tree_sitter.parse_pattern str in
-        extract_pattern_from_tree_sitter_result res print_errors
+        let pattern =
+          extract_pattern_from_tree_sitter_result res print_errors
+        in
+        Terraform_to_generic.any pattern
     (* use pfff *)
     | Lang.Python
     | Lang.Python2

--- a/src/parsing/Parse_target.ml
+++ b/src/parsing/Parse_target.ml
@@ -404,7 +404,9 @@ let rec just_parse_with_lang lang file =
         [ TreeSitter (Parse_vue_tree_sitter.parse parse_embedded_js) ]
         (fun x -> x)
   | Lang.Terraform ->
-      run file [ TreeSitter Parse_terraform_tree_sitter.parse ] (fun x -> x)
+      run file
+        [ TreeSitter Parse_terraform_tree_sitter.parse ]
+        Terraform_to_generic.program
   | Lang.Apex ->
       (* Proprietary. The actual parser needs to register itself for
          parsing to take place. *)


### PR DESCRIPTION
First generate intermediate AST_terraform, then convert
this AST into AST_generic.
Hopefully this will help cleaning up how we currently handle
Terraform.

test plan:
make core-test


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)