### PR TITLE
tainting: Add `by-side-effect` option for taint propagators

### DIFF
--- a/changelog.d/pa-2400.added
+++ b/changelog.d/pa-2400.added
@@ -1,0 +1,19 @@
+taint-mode: Taint propagators can now specify `by-side-effect`, just like sources and
+sanitizers. However, the default value of `by-side-effect` for propagators is `true`
+(unlike for sources or sanitizers). When using rule option
+`taint_assume_safe_functions: true`, this allows to specify functions that must
+propagate taint, for example:
+```yaml
+    pattern-propagators:
+      - by-side-effect: false
+        patterns:
+          - pattern-inside: $F(..., $X, ...)
+          - focus-metavariable: $F
+          - pattern-either:
+              - pattern: unsafe_function
+        from: $X
+        to: $F
+```
+Without `by-side-effect: true`, `unsafe_function` itself would be tainted by side-
+effect, and subsequent invokations of this function, even if the arguments were safe,
+would be tainted.

--- a/src/core/Rule.ml
+++ b/src/core/Rule.ml
@@ -188,6 +188,7 @@ and taint_sink = {
  *)
 and taint_propagator = {
   propagator_formula : formula;
+  propagator_by_side_effect : bool;
   from : MV.mvar wrap;
   to_ : MV.mvar wrap;
 }

--- a/src/parsing/Parse_rule.ml
+++ b/src/parsing/Parse_rule.ml
@@ -1115,10 +1115,14 @@ let parse_taint_propagator ~(is_old : bool) env (key : key) (value : G.expr) :
     if is_old then parse_formula_old_from_dict else parse_formula_from_dict
   in
   let parse_from_dict dict f =
+    let propagator_by_side_effect =
+      take_opt dict env parse_bool "by-side-effect"
+      |> Option.value ~default:true
+    in
     let from = take dict env parse_string_wrap "from" in
     let to_ = take dict env parse_string_wrap "to" in
     let propagator_formula = f env dict in
-    { R.propagator_formula; from; to_ }
+    { R.propagator_formula; propagator_by_side_effect; from; to_ }
   in
   let dict = yaml_to_dict env key value in
   parse_from_dict dict f

--- a/src/tainting/Dataflow_tainting.ml
+++ b/src/tainting/Dataflow_tainting.ml
@@ -550,29 +550,31 @@ let handle_taint_propagators env thing taints =
       (fun lval_env prop -> Lval_env.propagate_to prop.spec.var taints lval_env)
       lval_env propagate_froms
   in
-  let taints_propagated =
+  let taints_propagated, lval_env =
     (* `thing` is the destination (the "to") of propagation. we collect all the
      * incoming taints by looking for the propagator ids in the environment. *)
     List.fold_left
-      (fun taints_in_acc prop ->
-        let taints_strid =
+      (fun (taints_in_acc, lval_env) prop ->
+        let taints_from_prop =
           match Lval_env.propagate_from prop.spec.var lval_env with
           | None -> Taints.empty
           | Some taints -> taints
         in
-        Taints.union taints_in_acc taints_strid)
-      Taints.empty propagate_tos
-  in
-  let lval_env =
-    match thing with
-    (* If `thing` is an l-value of the form `x.a.b.c`, then taint can be propagated
-     * by side-effect. A pattern-propagator may use this to e.g. propagate taint
-     * from `x` to `y` in `f(x,y)`, so that subsequent uses of `y` are tainted
-     * if `x` was previously tainted. *)
-    | `Lval lval -> Lval_env.add lval_env lval taints_propagated
-    | `Exp _
-    | `Ins _ ->
-        lval_env
+        let lval_env =
+          if prop.spec.prop.propagator_by_side_effect then
+            match thing with
+            (* If `thing` is an l-value of the form `x.a.b.c`, then taint can be propagated
+               * by side-effect. A pattern-propagator may use this to e.g. propagate taint
+               * from `x` to `y` in `f(x,y)`, so that subsequent uses of `y` are tainted
+               * if `x` was previously tainted. *)
+            | `Lval lval -> Lval_env.add lval_env lval taints_from_prop
+            | `Exp _
+            | `Ins _ ->
+                lval_env
+          else lval_env
+        in
+        (Taints.union taints_in_acc taints_from_prop, lval_env))
+      (Taints.empty, lval_env) propagate_tos
   in
   (taints_propagated, lval_env)
 

--- a/tests/rules/taint_propagator_by_side_effect_false.php
+++ b/tests/rules/taint_propagator_by_side_effect_false.php
@@ -1,0 +1,47 @@
+<?php
+
+// ruleid:match
+echo $_GET['a'];
+// ok:match
+echo 'nop';
+
+// ruleid:match
+echo foo($_GET['a']);
+
+// ok:match
+echo foo('a');
+
+// ruleid:match
+print_r($_GET);
+
+// ruleid:match
+print_r($_GET, false);
+
+// ruleid:match
+echo print_r($_GET, true);
+
+// ok:match
+print_r($_GET, true);
+
+// ok:match
+print_r('a');
+
+// ok:match
+printf('a');
+
+hook('action', function() {
+    // ruleid:match
+    echo $_GET['b'];
+
+    // ruleid:match
+    echo foo($_GET['b']);
+
+    // ok:match
+    echo foo('a');
+
+    // ok:match
+    echo bar($_GET['b']);
+
+    // ok:match
+    echo 'nop';
+});

--- a/tests/rules/taint_propagator_by_side_effect_false.yaml
+++ b/tests/rules/taint_propagator_by_side_effect_false.yaml
@@ -1,0 +1,33 @@
+rules:
+  - id: match
+    message: Semgrep found a match
+    languages:
+      - php
+    severity: WARNING
+    mode: taint
+    options:
+      taint_assume_safe_functions: true
+    pattern-sources:
+      - pattern: $_GET
+    pattern-propagators:
+      - by-side-effect: false
+        patterns:
+          - pattern-inside: $F(..., $X, ...)
+          - focus-metavariable: $F
+          - pattern-either:
+              - pattern: foo
+        from: $X
+        to: $F
+      - by-side-effect: false
+        patterns:
+          - pattern-inside: $F($X, true)
+          - focus-metavariable: $F
+          - pattern-either:
+              - pattern: print_r
+        from: $X
+        to: $F
+    pattern-sinks:
+      - pattern: echo ...;
+      - pattern: print_r($SOURCE)
+      - pattern: print_r($SOURCE, false)
+

--- a/tests/rules/taint_propagator_by_side_effect_false1.php
+++ b/tests/rules/taint_propagator_by_side_effect_false1.php
@@ -1,0 +1,23 @@
+<?php
+
+// ruleid:match
+echo $_GET['a'];
+// ok:match
+echo 'nop';
+
+hook('action', function() {
+    // ruleid:match
+    echo $_GET['b'];
+
+    // ruleid:match
+    echo foo($_GET['b']);
+
+    // ok:match
+    echo foo('a');
+
+    // ok:match
+    echo bar($_GET['b']);
+
+    // ok:match
+    echo 'nop';
+});

--- a/tests/rules/taint_propagator_by_side_effect_false1.yaml
+++ b/tests/rules/taint_propagator_by_side_effect_false1.yaml
@@ -1,0 +1,23 @@
+rules:
+  - id: match
+    message: Semgrep found a match
+    languages:
+      - php
+    severity: WARNING
+    mode: taint
+    options:
+      taint_assume_safe_functions: true
+    pattern-sources:
+      - pattern: $_GET
+    pattern-propagators:
+      - by-side-effect: false
+        patterns:
+          - pattern-inside: $F(..., $X, ...)
+          - focus-metavariable: $F
+          - pattern-either:
+              - pattern: foo
+        from: $X
+        to: $F
+    pattern-sinks:
+      - pattern: echo ...;
+


### PR DESCRIPTION
When using `taint_assume_safe_functions: true`, this enables the use of propagators to specify functions that must propagate taint.

Closes PA-2400

test plan:
make test # added two tests

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
