### PR TITLE
cleaning Pretty_print_AST.ml

### DIFF
--- a/libs/lib_parsing/Parse_info.ml
+++ b/libs/lib_parsing/Parse_info.ml
@@ -60,6 +60,8 @@ type token_origin =
          * origin tokens. This can be useful when have to give an error
          * message that involves a fakeToken. The int is a kind of
          * virtual position, an offset. See compare_pos below.
+         * Those are called "safe" fake tokens (in contrast to the
+         * regular/unsafe one which have no position information at all).
          *)
       (token_location * int) option
   (* In the case of a XHP file, we could preprocess it and incorporate
@@ -140,6 +142,7 @@ let unsafe_token_location_of_info ii =
 let unsafe_fake_info str : token_mutable =
   { token = FakeTokStr (str, None); transfo = NoTransfo }
 
+(* "safe" fake token *)
 let fake_info_loc next_to_loc str : token_mutable =
   (* TODO: offset seems to have no use right now (?) *)
   { token = FakeTokStr (str, Some (next_to_loc, -1)); transfo = NoTransfo }

--- a/src/experiments/synthesizing/Unit_synthesizer.ml
+++ b/src/experiments/synthesizing/Unit_synthesizer.ml
@@ -23,10 +23,10 @@ let python_tests =
     ( "arrays_and_funcs.py",
       "4:9-4:29",
       [
-        ("exact match", "metrics.send('my-report-id')");
+        ("exact match", "metrics.send(\"my-report-id\")");
         ("dots", "metrics.send(...)");
-        ("metavars", "metrics.send('...', ...)");
-        ("exact metavars", "metrics.send('...')");
+        ("metavars", "metrics.send(\"...\", ...)");
+        ("exact metavars", "metrics.send(\"...\")");
       ] );
     (* TODO: adjust range, this changed after we added parens for tuples
        ("arrays_and_funcs.py", "5:4-5:11", [ ("exact match", "(hi, my)") ]);
@@ -52,7 +52,7 @@ let python_tests =
       [ ("exact match", "self.data"); ("metavar", "$X") ] );
     ( "arrays_and_funcs.py",
       "17:3-17:36",
-      [ ("exact match", "'nice' if is_nice else 'not nice'") ] );
+      [ ("exact match", "\"nice\" if is_nice else \"not nice\"") ] );
     ( "arrays_and_funcs.py",
       "18:3-18:34",
       [
@@ -70,13 +70,13 @@ let python_tests =
       "5:10-7:35",
       [
         ( "exact match",
-          "flask.response.set_cookie('sessionid', \
-           generate_cookie_value('RANDOM-UUID'), secure=True)" );
+          "flask.response.set_cookie(\"sessionid\", \
+           generate_cookie_value(\"RANDOM-UUID\"), secure=True)" );
         ("dots", "flask.response.set_cookie(...)");
-        ("metavars", "flask.response.set_cookie('...', $Y, secure=$Z, ...)");
-        ("exact metavars", "flask.response.set_cookie('...', $Y, secure=$Z)");
+        ("metavars", "flask.response.set_cookie(\"...\", $Y, secure=$Z, ...)");
+        ("exact metavars", "flask.response.set_cookie(\"...\", $Y, secure=$Z)");
         ( "deep metavars",
-          "flask.response.set_cookie('...', generate_cookie_value('...'), \
+          "flask.response.set_cookie(\"...\", generate_cookie_value(\"...\"), \
            secure=$Z)" );
       ] );
     ( "set_cookie.py",

--- a/src/experiments/synthesizing/Unit_synthesizer_targets.ml
+++ b/src/experiments/synthesizing/Unit_synthesizer_targets.ml
@@ -12,9 +12,11 @@ let stmt_tests =
     (* Motivating example. *)
     ("hello.py", [ "2:0-2:5"; "5:0-5:8" ], "$X(3, ...)");
     (* Single statement. *)
-    ("string_ellipsis.py", [ "2:0-2:13"; "5:0-5:13" ], "foo('...')");
+    ("string_ellipsis.py", [ "2:0-2:13"; "5:0-5:13" ], "foo(\"...\")");
     (* Three targets. *)
-    ("string_ellipsis.py", [ "2:0-2:13"; "5:0-5:13"; "8:0-8:13" ], "foo('...')");
+    ( "string_ellipsis.py",
+      [ "2:0-2:13"; "5:0-5:13"; "8:0-8:13" ],
+      "foo(\"...\")" );
   ]
 
 let statement_list_tests =

--- a/src/printing/Pretty_print_AST.mli
+++ b/src/printing/Pretty_print_AST.mli
@@ -1,6 +1,6 @@
-(* old: This module used to be part of semgrep_synthesizing under the name of
- * Pretty_print_generic. We moved it to semgrep_core so that it could be used
- * by -dfg_svalue (Test_analyze_generic). *)
+(* This module is currently deprecated. You probably should rely
+ * on Ugly_print_AST.ml instead.
+ *)
 
 val expr_to_string : Lang.t -> AST_generic.expr -> string
 val svalue_to_string : Lang.t -> AST_generic.svalue -> string

--- a/tests/synthesizing/arrays_and_funcs.py
+++ b/tests/synthesizing/arrays_and_funcs.py
@@ -1,7 +1,7 @@
 from metrics import send
 def foo():
    a.bar(f(x), y==f(x))
-   bar + send('my-report-id') + bar()
+   bar + send("my-report-id") + bar()
    (hi, my)
    (hi, my, bye)
    A[1]


### PR DESCRIPTION
My main motivation was to reduce the number of places where we match
over lang, which is annoying because each time we add a new language,
we have to add boilerplate at many places in this file.

test plan:
make core-test


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)