### PR TITLE
const-prop: Let Pro engine resolve functions

### DIFF
--- a/src/analyzing/Dataflow_svalue.mli
+++ b/src/analyzing/Dataflow_svalue.mli
@@ -2,13 +2,13 @@
 
 type mapping = AST_generic.svalue Dataflow_var_env.mapping
 
-(* Indicates guarantees on the return value of a function
- * We could also reuse AST_generic.Cst, but this will make it easier
- * to extend if we want function-specific types *)
-type constness_type = Constant | NotAlwaysConstant [@@deriving show]
+(* Indicates guarantees on the return value of a function *)
+(* TODO: This should be AST_generic.svalue, if we need something more complex,
+ * then we build it on top of the svalue type. *)
+type constness = Constant | NotConstant [@@deriving show]
 
-val hook_constness_table_of_functions :
-  (string -> constness_type option) option ref
+val hook_constness_of_function :
+  (AST_generic.expr -> constness option) option ref
 
 val is_symbolic_expr : AST_generic.expr -> bool
 val eq : AST_generic.svalue -> AST_generic.svalue -> bool


### PR DESCRIPTION
In Pro, a function is assigned a unique key used for lookups, and how this key is obtained should not matter to Semgrep OSS. So we pass the entire function expression to the Pro hook and let the Pro Engine do its the magic. This is how taint analysis hook works and const-prop hook should work the same way.

Also do some code/style clean up.

Follows returntocorp/semgrep-proprietary#545

test plan:
make test

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
