### PR TITLE
feat: Use Semgrep to enforce correct changelog extensions

### DIFF
--- a/semgrep.yml
+++ b/semgrep.yml
@@ -240,3 +240,21 @@ rules:
         - lang_php/analyze/foundation/unit_prolog_php.ml
         - main_db.ml
         - tests/Test.ml
+  - id: bad-changelog-extension
+    pattern-regex: .*
+    message: |
+      This file has an invalid extension. Please choose from one of the allowed
+      extensions: .added, .changed, .fixed, or .infra
+    languages: [generic]
+    severity: WARNING
+    paths:
+      include:
+        - changelog.d/*
+      exclude:
+        - changelog.d/.gitignore
+        - changelog.d/README
+        - changelog.d/gh-1234.example
+        - changelog.d/*.added
+        - changelog.d/*.changed
+        - changelog.d/*.fixed
+        - changelog.d/*.infra


### PR DESCRIPTION
Semgrep doesn't really have support for enforcing standards on path names. The best we can do right now is the workaround described in #2438 to include/exclude paths, and then always match any contents in files that the rule applies to.

Unfortunately, the workaround generates a separate finding for each line, but that's really not a big deal.

Test plan:

Add files `asdf.js` and `asdf.fix` to the `changelog.d` directory. Run `semgrep -c semgrep.yml` and observe findings both when the files are empty and when they are populated. Otherwise, observe no findings.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
