### PR TITLE
fix: allow metavar ellipsis params in Go

### DIFF
--- a/changelog.d/pa-2545.fixed
+++ b/changelog.d/pa-2545.fixed
@@ -1,0 +1,1 @@
+Golang: Fixed a bug where metavariable ellipses as parameters to functions were not working properly

--- a/languages/go/ast/ast_go.ml
+++ b/languages/go/ast/ast_go.ml
@@ -92,6 +92,7 @@ and func_type = {
 
 and parameter_binding =
   | ParamClassic of parameter
+  | ParamMetavarEllipsis of ident
   (* sgrep-ext: *)
   | ParamEllipsis of tok
 

--- a/languages/go/ast/ast_go.ml
+++ b/languages/go/ast/ast_go.ml
@@ -92,8 +92,8 @@ and func_type = {
 
 and parameter_binding =
   | ParamClassic of parameter
-  | ParamMetavarEllipsis of ident
   (* sgrep-ext: *)
+  | ParamMetavarEllipsis of ident
   | ParamEllipsis of tok
 
 and parameter = {

--- a/languages/go/ast/ast_go.ml
+++ b/languages/go/ast/ast_go.ml
@@ -93,6 +93,11 @@ and func_type = {
 and parameter_binding =
   | ParamClassic of parameter
   (* sgrep-ext: *)
+  (* For metavariable ellipsis identifier (like $...ARGS), we don't
+     usually separate this out at the AST level. However, single
+     identifiers as parameters are parsed as types in Go, so we can't
+     reuse the ordinary identifier construct. So we use this.
+  *)
   | ParamMetavarEllipsis of ident
   | ParamEllipsis of tok
 

--- a/languages/go/generic/go_to_generic.ml
+++ b/languages/go/generic/go_to_generic.ml
@@ -167,6 +167,7 @@ let top_func () =
     match x with
     | ParamClassic x -> parameter x
     | ParamEllipsis t -> G.ParamEllipsis t
+    | ParamMetavarEllipsis id -> G.Param (G.param_of_id id)
   and parameter x =
     match x with
     | { pname; ptype; pdots } -> (

--- a/languages/go/menhir/parser_go.mly
+++ b/languages/go/menhir/parser_go.mly
@@ -1025,6 +1025,17 @@ fnlitdcl: fntype { $1 }
 arg_type:
 |       name_or_type {
     (match $1 with
+    (* This means a param of the form $...<ID>.
+     * Ordinarily, in Golang, a singular identifier is interpreted as an
+     * anonymous argument of the type of that identifier.
+     * So func foo(int) is allowed.
+
+     * When we see a metavariable ellipsis, it's a little silly to consider that
+     * as a type. If someone writes func foo ($...ARGS), they probably just meant to
+     * capture all of the args of the function, and an anonymous argument of type $...ARGS.
+
+     * So we parse it as such here.
+     *)
     | TName [ (s, _) as id ] when AST_generic.is_metavar_ellipsis s ->
         ParamMetavarEllipsis id
     | __else__ ->

--- a/languages/go/menhir/parser_go.mly
+++ b/languages/go/menhir/parser_go.mly
@@ -118,6 +118,7 @@ let adjust_signatures params =
             let id = type_to_id id_typ in
             aux (id::acc) xs
           | ParamEllipsis t -> (ParamEllipsis t):: aux [] xs
+          | ParamMetavarEllipsis id -> (ParamMetavarEllipsis id) :: aux [] xs
         )
     in
     aux [] params
@@ -1007,6 +1008,7 @@ fndcl:
             DMethod ($4, x, ({ ftok; fparams = ($5, $6, $7); fresults = $8 }, body))
         | [] -> error $1 "method has no receiver"
         | [ParamEllipsis _] -> error $1 "method has ... for receiver"
+        | [ParamMetavarEllipsis _] -> error $1 "method has metavar ellipsis for receiver"
         | _::_::_ -> error $1 "method has multiple receivers"
     }
 
@@ -1021,7 +1023,14 @@ fnliteral: fnlitdcl lbrace listsc(stmt) "}"
 fnlitdcl: fntype { $1 }
 
 arg_type:
-|       name_or_type { ParamClassic { pname= None; ptype = $1; pdots = None } }
+|       name_or_type {
+    (match $1 with
+    | TName [ (s, _) as id ] when AST_generic.is_metavar_ellipsis s ->
+        ParamMetavarEllipsis id
+    | __else__ ->
+     ParamClassic { pname= None; ptype = $1; pdots = None }
+     )
+    }
 |   sym name_or_type { ParamClassic { pname= Some $1; ptype = $2; pdots = None } }
 |   sym dotdotdot    { ParamClassic { pname= Some $1; ptype = snd $2; pdots = Some (fst $2)}}
 |       dotdotdot    { ParamClassic { pname= None; ptype = snd $1; pdots = Some (fst $1)} }

--- a/languages/go/menhir/parser_go.mly
+++ b/languages/go/menhir/parser_go.mly
@@ -1032,7 +1032,7 @@ arg_type:
 
      * When we see a metavariable ellipsis, it's a little silly to consider that
      * as a type. If someone writes func foo ($...ARGS), they probably just meant to
-     * capture all of the args of the function, and an anonymous argument of type $...ARGS.
+     * capture all of the args of the function, and not an anonymous argument of type $...ARGS.
 
      * So we parse it as such here.
      *)

--- a/languages/go/menhir/parser_go.mly
+++ b/languages/go/menhir/parser_go.mly
@@ -95,6 +95,7 @@ let adjust_signatures params =
       | ParamClassic {pname = None; _} -> true
       (* sgrep-ext: ellipsis count as a type *)
       | ParamEllipsis _ -> true
+      | ParamMetavarEllipsis _ -> true
       | _ ->false) in
   if all_types
   then params
@@ -1037,7 +1038,7 @@ arg_type:
      * So we parse it as such here.
      *)
     | TName [ (s, _) as id ] when AST_generic.is_metavar_ellipsis s ->
-        ParamMetavarEllipsis id
+        Flag_parsing.sgrep_guard (ParamMetavarEllipsis id)
     | __else__ ->
      ParamClassic { pname= None; ptype = $1; pdots = None }
      )

--- a/tests/rules/metavar_ellipsis_param.go
+++ b/tests/rules/metavar_ellipsis_param.go
@@ -1,0 +1,32 @@
+
+// ERROR: match
+func foo(int) { }
+
+// ERROR: match
+func foo(x int) { }
+
+// ERROR: match
+func foo(x, y int) { }
+
+// ERROR: match
+func foo(int, string, bool) { }
+
+// ERROR: match
+func bar(int, string, bool) { }
+
+func bar(x int, string, bool) { }
+
+func bar(string, string, bool) { }
+
+func bar(string, int, string, bool) { }
+
+func qux() { }
+
+func qux(int) { }
+
+func qux(x int) { }
+
+// ERROR: match
+func qux(string, x int) { }
+
+func qux(string, x int, string) { }

--- a/tests/rules/metavar_ellipsis_param.go
+++ b/tests/rules/metavar_ellipsis_param.go
@@ -24,6 +24,7 @@ func qux() { }
 
 func qux(int) { }
 
+// ERROR: match
 func qux(x int) { }
 
 // ERROR: match

--- a/tests/rules/metavar_ellipsis_param.go
+++ b/tests/rules/metavar_ellipsis_param.go
@@ -1,17 +1,17 @@
 
-// ERROR: match
+// ruleid: metavar_ellipsis_param
 func foo(int) { }
 
-// ERROR: match
+// ruleid: metavar_ellipsis_param
 func foo(x int) { }
 
-// ERROR: match
+// ruleid: metavar_ellipsis_param
 func foo(x, y int) { }
 
-// ERROR: match
+// ruleid: metavar_ellipsis_param
 func foo(int, string, bool) { }
 
-// ERROR: match
+// ruleid: metavar_ellipsis_param
 func bar(int, string, bool) { }
 
 func bar(x int, string, bool) { }
@@ -24,10 +24,10 @@ func qux() { }
 
 func qux(int) { }
 
-// ERROR: match
+// ruleid: metavar_ellipsis_param
 func qux(x int) { }
 
-// ERROR: match
+// todo: metavar_ellipsis_param
 func qux(string, x int) { }
 
 func qux(string, x int, string) { }

--- a/tests/rules/metavar_ellipsis_param.yaml
+++ b/tests/rules/metavar_ellipsis_param.yaml
@@ -1,0 +1,13 @@
+rules:
+  - id: test
+    languages:
+      - go
+    message: javascript inside html working!
+    patterns:
+      - pattern: |
+          func foo($...ARG) { ... }
+      - pattern: |
+          func bar(int, $...ARG) { ... }
+      - pattern: |
+          func qux($...ARG, x int) { ... }
+    severity: WARNING

--- a/tests/rules/metavar_ellipsis_param.yaml
+++ b/tests/rules/metavar_ellipsis_param.yaml
@@ -4,11 +4,12 @@ rules:
       - go
     message: |
       Metavariable ellipses should be able to match arguments in Go! 
-    patterns:
-      - pattern: |
-          func foo($...ARG) { ... }
-      - pattern: |
-          func bar(int, $...ARG) { ... }
-      - pattern: |
-          func qux($...ARG, x int) { ... }
+    match:
+      any:
+        - |
+            func foo($...ARG) { ... }
+        - |
+            func bar(int, $...ARG) { ... }
+        - |
+            func qux($...ARG, x int) { ... }
     severity: WARNING

--- a/tests/rules/metavar_ellipsis_param.yaml
+++ b/tests/rules/metavar_ellipsis_param.yaml
@@ -2,7 +2,8 @@ rules:
   - id: test
     languages:
       - go
-    message: javascript inside html working!
+    message: |
+      Metavariable ellipses should be able to match arguments in Go! 
     patterns:
       - pattern: |
           func foo($...ARG) { ... }


### PR DESCRIPTION
## What:
This PR adds in support for metavariable ellipses as parameters in Golang.

## Why:
c.f. [this thread](https://returntocorp.slack.com/archives/C01NXGX2EHZ/p1676405651489119), they were not working properly to capture arguments. [This playground example](https://semgrep.dev/s/wb4P), for instance, does not properly produce a match as expected.

This ended up being because single identifier arguments in Golang are interpreted as types, so something like `func foo($...ARGS)` was interpreted as a function with a single argument of type `$....ARGS`. This is kind of silly, and it's a safe bet if anyone writes that, they don't mean a type which is an ellipsis metavariable (what does that even mean?)

## How:
Special-cased it in the pattern parser.

Note I had to add in logic for signatures in `adjust_signatures`, because there's some logic for distributing types across identifiers. I followed the same logic as for `...`, which is to not try and distribute types over it (that wouldn't really make sense anyways).

Due to the special cases for ellipses, I felt it was better to add it as a variant to the Go AST.

## Test plan:
`make test`

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
