### PR TITLE
feat(sarif): add rule board preference to SARIF output

### DIFF
--- a/changelog.d/pa-2519.added
+++ b/changelog.d/pa-2519.added
@@ -1,0 +1,2 @@
+CLI: SARIF output now includes a tag pertaining to which card of the Rule Board a rule originated from.
+This can be "rule-board-block", "rule-board-audit", or "rule-board-pr-comments".

--- a/cli/src/semgrep/formatter/sarif.py
+++ b/cli/src/semgrep/formatter/sarif.py
@@ -341,6 +341,14 @@ class SarifFormatter(BaseFormatter):
                 if isinstance(owasp, list)
                 else [f"OWASP-{owasp}"]
             )
+        if (
+            "semgrep.policy" in rule.metadata
+            and "slug" in rule.metadata["semgrep.policy"]
+        ):
+            # https://github.com/returntocorp/semgrep-app/blob/8d2e6187b7daa2b20c49839a4fcb67e560202aa8/frontend/src/pages/ruleBoard/constants/constants.tsx#L74
+            # this should be "rule-board-audit", "rule-board-block", or "rule-board-pr-comments"
+            slug = rule.metadata["semgrep.policy"]["slug"]
+            result.append(slug)
 
         for tags in rule.metadata.get("tags", []):
             result.append(tags)

--- a/cli/tests/e2e/rules/rule-board-eqeq.yaml
+++ b/cli/tests/e2e/rules/rule-board-eqeq.yaml
@@ -1,0 +1,9 @@
+rules:
+  - id: rule-board-eqeq-five
+    message: "this rule comes from the rule board!"
+    languages: [python]
+    severity: ERROR
+    pattern: $X == $X
+    metadata:
+      semgrep.policy:
+        slug: "rule-board-block"

--- a/cli/tests/e2e/snapshots/test_output/test_sarif_output_rule_board/results.sarif
+++ b/cli/tests/e2e/snapshots/test_output/test_sarif_output_rule_board/results.sarif
@@ -1,0 +1,127 @@
+{
+  "$schema": "https://docs.oasis-open.org/sarif/sarif/v2.1.0/os/schemas/sarif-schema-2.1.0.json",
+  "runs": [
+    {
+      "invocations": [
+        {
+          "executionSuccessful": true,
+          "toolExecutionNotifications": []
+        }
+      ],
+      "results": [
+        {
+          "fingerprints": {
+            "matchBasedId/v1": "1fa894f43c4fd60b1b0c5e2e9a50311b67b77a7b09f7c45001277b41e41accd87cd8e2931d57e0bf41a0e5086501be1fea611473dd02e1625c49204145464dba_0"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "targets/basic/stupid.py",
+                  "uriBaseId": "%SRCROOT%"
+                },
+                "region": {
+                  "endColumn": 26,
+                  "endLine": 3,
+                  "snippet": {
+                    "text": "    return a + b == a + b"
+                  },
+                  "startColumn": 12,
+                  "startLine": 3
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "this rule comes from the rule board!"
+          },
+          "ruleId": "rules.rule-board-eqeq-five"
+        },
+        {
+          "fingerprints": {
+            "matchBasedId/v1": "79990521677dc96cec634491f9134e8528b49257440a27b8df47582e37668aaf5cb3343fe53b19476b12071b84f58db799c9f7f3d75b09dd3547f283b7036d38_0"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "targets/basic/stupid.py",
+                  "uriBaseId": "%SRCROOT%"
+                },
+                "region": {
+                  "endColumn": 11,
+                  "endLine": 8,
+                  "snippet": {
+                    "text": "    x == x"
+                  },
+                  "startColumn": 5,
+                  "startLine": 8
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "this rule comes from the rule board!"
+          },
+          "ruleId": "rules.rule-board-eqeq-five"
+        },
+        {
+          "fingerprints": {
+            "matchBasedId/v1": "79990521677dc96cec634491f9134e8528b49257440a27b8df47582e37668aaf5cb3343fe53b19476b12071b84f58db799c9f7f3d75b09dd3547f283b7036d38_1"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "targets/basic/stupid.py",
+                  "uriBaseId": "%SRCROOT%"
+                },
+                "region": {
+                  "endColumn": 18,
+                  "endLine": 12,
+                  "snippet": {
+                    "text": "assertTrue(x == x)"
+                  },
+                  "startColumn": 12,
+                  "startLine": 12
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "this rule comes from the rule board!"
+          },
+          "ruleId": "rules.rule-board-eqeq-five"
+        }
+      ],
+      "tool": {
+        "driver": {
+          "name": "semgrep",
+          "rules": [
+            {
+              "defaultConfiguration": {
+                "level": "error"
+              },
+              "fullDescription": {
+                "text": "this rule comes from the rule board!"
+              },
+              "id": "rules.rule-board-eqeq-five",
+              "name": "rules.rule-board-eqeq-five",
+              "properties": {
+                "precision": "very-high",
+                "tags": [
+                  "rule-board-block"
+                ]
+              },
+              "shortDescription": {
+                "text": "this rule comes from the rule board!"
+              }
+            }
+          ],
+          "semanticVersion": "placeholder"
+        }
+      }
+    }
+  ],
+  "version": "2.1.0"
+}

--- a/cli/tests/e2e/test_output.py
+++ b/cli/tests/e2e/test_output.py
@@ -234,6 +234,19 @@ def test_sarif_output_include_nosemgrep(run_semgrep_in_tmp, snapshot):
     )
 
 
+# Test that rule board information makes its way into SARIF output
+@pytest.mark.kinda_slow
+def test_sarif_output_rule_board(run_semgrep_in_tmp, snapshot):
+    snapshot.assert_match(
+        run_semgrep_in_tmp(
+            "rules/rule-board-eqeq.yaml",
+            target_name="basic/stupid.py",
+            output_format=OutputFormat.SARIF,
+        ).stdout,
+        "results.sarif",
+    )
+
+
 @pytest.mark.kinda_slow
 def test_sarif_output_with_source(run_semgrep_in_tmp, snapshot):
     stdout = run_semgrep_in_tmp(


### PR DESCRIPTION
## What:
This PR adds an identifying tag to the SARIF output, when a rule has been run that was extracted from the Rule Board.

## Why:
Customer request, we may want to be able to categorize SARIF results by whether it was specified as monitor, comment, or blocking.

## How:
I ingested the rule information (which should have been piped back via the App, from the user's rule board preferences) and injected it into the SARIF output.

I based the code that I wrote off of the code that I saw modifying the rule in the App code. As far as I know, this should be faithful: see the `tags` I got from this output that I got from running `semgrep ci` with some rules run as monitor, blocking, and comment:
![image](https://user-images.githubusercontent.com/49291449/219096690-ee3dc6cc-f9a6-48e4-80e8-bf81aab9e4c1.png)


## Test plan:
`make test`

See the `tags` in the snapshot output

Closes PA-2519

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
