### PR TITLE
feat!: code path for simultaneous tainting

### DIFF
--- a/src/core_cli/Core_CLI.ml
+++ b/src/core_cli/Core_CLI.ml
@@ -111,6 +111,7 @@ let use_parsing_cache = ref Runner_config.default.parsing_cache_dir
 (* similar to filter_irrelevant_patterns, but use the whole rule to extract
  * the regexp *)
 let filter_irrelevant_rules = ref Runner_config.default.filter_irrelevant_rules
+let simultaneous_taint = ref Runner_config.default.simultaneous_taint
 
 (* ------------------------------------------------------------------------- *)
 (* flags used by the semgrep-python wrapper *)
@@ -350,6 +351,7 @@ let mk_config () =
     rule_source = !rule_source;
     lang_job = None;
     filter_irrelevant_rules = !filter_irrelevant_rules;
+    simultaneous_taint = !simultaneous_taint;
     (* not part of CLI *)
     equivalences_file = !equivalences_file;
     lang = !lang;
@@ -615,6 +617,9 @@ let options actions =
     ( "-fast",
       Arg.Set filter_irrelevant_rules,
       " filter rules not containing any strings in target file" );
+    ( "-simultaneous_taint",
+      Arg.Set simultaneous_taint,
+      " run taint rules at the same time (calling dataflow once)" );
     ( "-bloom_filter",
       Arg.Set Flag.use_bloom_filter,
       " use a bloom filter to only attempt matches when strings in the pattern \

--- a/src/engine/Match_env.ml
+++ b/src/engine/Match_env.ml
@@ -50,6 +50,7 @@ type xconfig = {
    *)
   matching_explanations : bool;
   filter_irrelevant_rules : bool;
+  simultaneous_taint : bool;
 }
 
 type env = {
@@ -105,4 +106,5 @@ let default_xconfig =
      * true when running as part of the regular code path (not testing code)
      *)
     filter_irrelevant_rules = false;
+    simultaneous_taint = false;
   }

--- a/src/engine/Match_rules.ml
+++ b/src/engine/Match_rules.ml
@@ -132,6 +132,9 @@ let check ~match_hook ~timeout ~timeout_threshold (xconf : Match_env.xconfig)
   let res_rules =
     relevant_rules
     |> Common.map (fun r ->
+           let xconf =
+             Match_env.adjust_xconfig_with_rule_options xconf r.R.options
+           in
            let rule_id = fst r.R.id in
            Rule.last_matched_rule := Some rule_id;
            let match_result =

--- a/src/engine/Simultaneous_tainting.ml
+++ b/src/engine/Simultaneous_tainting.ml
@@ -1,0 +1,23 @@
+(* Brandon Wu
+ *
+ * Copyright (C) 2019-2022 r2c
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * version 2.1 as published by the Free Software Foundation, with the
+ * special exception on linking described in file LICENSE.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
+ * LICENSE for more details.
+ *)
+
+(*****************************************************************************)
+(* Prelude *)
+(*****************************************************************************)
+(* A separate code path for running many taint rules on the same target,
+ * simultaneously.
+ *)
+
+let run_simultaneous_taint ~match_hook:_ _rules _xconf _target = ()

--- a/src/engine/Simultaneous_tainting.mli
+++ b/src/engine/Simultaneous_tainting.mli
@@ -1,0 +1,6 @@
+val run_simultaneous_taint :
+  match_hook:(string -> Pattern_match.t -> unit) ->
+  Rule.taint_mode Rule.rule_info list ->
+  Match_env.xconfig ->
+  Xtarget.t ->
+  unit

--- a/src/runner/Run_semgrep.ml
+++ b/src/runner/Run_semgrep.ml
@@ -672,6 +672,7 @@ let semgrep_with_rules config ((rules, invalid_rules), rules_parse_time) =
                nested_formula = false;
                matching_explanations = config.matching_explanations;
                filter_irrelevant_rules = config.filter_irrelevant_rules;
+               simultaneous_taint = config.simultaneous_taint;
              }
            in
            let matches =

--- a/src/runner/Runner_config.ml
+++ b/src/runner/Runner_config.ml
@@ -67,6 +67,7 @@ type t = {
   ncores : int;
   parsing_cache_dir : Common.dirname; (* "" means no cache *)
   filter_irrelevant_rules : bool;
+  simultaneous_taint : bool;
   (* Flag used by the semgrep-python wrapper *)
   target_source : target_source option;
   (* Common.ml action for the -dump_xxx *)
@@ -120,6 +121,7 @@ let default =
     ncores = 1;
     parsing_cache_dir = "";
     filter_irrelevant_rules = true;
+    simultaneous_taint = false;
     (* -fast by default *)
     (* "" means no cache *)
     (* Flag used by the semgrep-python wrapper *)


### PR DESCRIPTION
## What:
This PR adds in the beginnings of what I am calling "simultaneous tainting", which is when you run multiple taint rules on a single target at the same time. 

This is Step 1 in the plan of my scope doc for running multiple taint rules at the same time: https://www.notion.so/r2cdev/Taint-Mode-for-Multiple-Rules-bd0b2eb571ae4e3aa2b8661bba8b2edc?pvs=4

## Why:
This is as opposed to how we currently do it, where we invoke the taint engine once on an xtarget for every single taint rule. This causes us to run the dataflow engine on a control flow graph many times, when we really don't have to. This is seen in taint labels, which allow us to invoke dataflow analysis once within a single rule, but for "multiple taint rules".

Preliminary results have showed that taking a number of taint rules and reinterpreting them as a single taint rule with multiple taint labels have had good implications for runtime.

## How:
Just added an alternate codepath, and a tentative new file. Current behavior should be unchanged.

## Test plan:
`make test`

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
