### PR TITLE
revert changes to the generic AST that cause a segfault when updating semgrep-pro

### DIFF
--- a/languages/bash/ast/AST_bash.ml
+++ b/languages/bash/ast/AST_bash.ml
@@ -388,7 +388,7 @@ and declaration_attribute =
 
 (* 'unsetenv' *)
 and expression =
-  | Word of (* unquoted string *) string wrap (* TODO: bracket *)
+  | Word of (* unquoted string *) string wrap
   | Special_character of (* unquoted string *) string wrap
   | String of (* "..." *) string_fragment list bracket
   | String_fragment of (* $x ${...} $(...) `...` ... *) loc * string_fragment

--- a/languages/bash/generic/Bash_to_generic.ml
+++ b/languages/bash/generic/Bash_to_generic.ml
@@ -414,7 +414,7 @@ and command (env : env) (cmd : command) : stmt_or_expr =
         G.FuncDef
           {
             G.fkind = (G.Function, first_tok);
-            fparams = Parse_info.unsafe_fake_bracket [];
+            fparams = [];
             frettype = None;
             fbody = G.FBStmt (command env def.body |> as_stmt);
           }

--- a/languages/c/ast/ast_c.ml
+++ b/languages/c/ast/ast_c.ml
@@ -129,12 +129,12 @@ and struct_kind = Struct | Union
 and expr =
   | Int of int option wrap
   | Float of float option wrap
-  | String of string wrap (* TODO: bracket *)
+  | String of string wrap
   | Char of string wrap
   (* c-ext:? *)
   | Null of tok
   | Bool of bool wrap
-  | ConcatString of string wrap list (* TODO: bracket *)
+  | ConcatString of string wrap list
   (* can be a cpp or enum constant (e.g. FOO), or a local/global/parameter
    * variable, or a function name.
    *)

--- a/languages/c/ast/ast_c.ml
+++ b/languages/c/ast/ast_c.ml
@@ -108,7 +108,7 @@ type type_ =
   (* tree-sitter-c: kind of poor's man generic via cpp *)
   | TMacroApply of name * type_ bracket
 
-and function_type = type_ * parameter list (* TODO bracket *)
+and function_type = type_ * parameter list
 
 and parameter =
   | ParamClassic of parameter_classic

--- a/languages/c/generic/c_to_generic.ml
+++ b/languages/c/generic/c_to_generic.ml
@@ -177,7 +177,7 @@ and expr e =
       G.L (G.Bool v1) |> G.e
   | String v1 ->
       let v1 = wrap string v1 in
-      G.L (G.String (fb v1)) |> G.e
+      G.L (G.String v1) |> G.e
   | Char v1 ->
       let v1 = wrap string v1 in
       G.L (G.Char v1) |> G.e
@@ -185,8 +185,7 @@ and expr e =
   | ConcatString xs ->
       G.Call
         ( G.IdSpecial (G.ConcatString G.SequenceConcat, unsafe_fake " ") |> G.e,
-          fb (xs |> Common.map (fun x -> G.Arg (G.L (G.String (fb x)) |> G.e)))
-        )
+          fb (xs |> Common.map (fun x -> G.Arg (G.L (G.String x) |> G.e))) )
       |> G.e
   | Defined (t, id) ->
       let e = G.N (G.Id (id, G.empty_id_info ())) |> G.e in
@@ -463,7 +462,7 @@ and directive = function
       let v2 =
         match v2 with
         | None -> []
-        | Some s -> [ G.E (G.L (G.String (fb s)) |> G.e) ]
+        | Some s -> [ G.E (G.L (G.String s) |> G.e) ]
       in
       G.DirectiveStmt (G.Pragma (v1, v2) |> G.d)
 

--- a/languages/c/generic/c_to_generic.ml
+++ b/languages/c/generic/c_to_generic.ml
@@ -391,7 +391,7 @@ and func_def { f_name; f_type; f_body; f_static } =
   ( entity,
     G.FuncDef
       {
-        G.fparams = fb params;
+        G.fparams = params;
         frettype = Some ret;
         fbody = G.FBStmt (G.s (G.Block v3));
         fkind = (G.Function, G.fake "");

--- a/languages/cpp/ast/ast_cpp.ml
+++ b/languages/cpp/ast/ast_cpp.ml
@@ -316,10 +316,8 @@ and constant =
   | Float of float option wrap
   | Char of string wrap (* normally it is equivalent to Int *)
   (* the wrap can contain the L/u/U/u8 prefix *)
-  | String of string wrap (* TODO: bracket *)
-  | MultiString of string wrap list
-  (* can contain MacroString *)
-  (* TODO: bracket *)
+  | String of string wrap
+  | MultiString of string wrap list (* can contain MacroString *)
   (* c++ext: *)
   | Bool of bool wrap
   | Nullptr of tok

--- a/languages/cpp/generic/cpp_to_generic.ml
+++ b/languages/cpp/generic/cpp_to_generic.ml
@@ -562,7 +562,7 @@ and map_constant env x : G.literal =
       G.Char v1
   | String v1 ->
       let v1 = map_wrap env map_of_string v1 in
-      G.String (fb v1)
+      G.String v1
   | MultiString v1 ->
       let v1 = map_of_list (map_wrap env map_of_string) v1 in
       let s = v1 |> Common.map fst |> String.concat "" in
@@ -571,7 +571,7 @@ and map_constant env x : G.literal =
         | [] -> raise Impossible
         | x :: xs -> PI.combine_infos x xs
       in
-      G.String (fb (s, t))
+      G.String (s, t)
   | Bool v1 ->
       let v1 = map_wrap env map_of_bool v1 in
       G.Bool v1

--- a/languages/cpp/generic/cpp_to_generic.ml
+++ b/languages/cpp/generic/cpp_to_generic.ml
@@ -52,7 +52,6 @@ let error_unless_partial_error _env t s =
 
 let empty_stmt tk = Compound (tk, [], tk)
 let _id x = x
-let fb = Parse_info.unsafe_fake_bracket
 
 let map_either _env f g x =
   match x with
@@ -245,7 +244,7 @@ and map_typeC env x : G.type_ =
       and v2 = map_type_ env v2 in
       G.TyArray (v1, v2) |> G.t
   | TFunction v1 ->
-      let (_, ps, _), tret = map_functionType env v1 in
+      let ps, tret = map_functionType env v1 in
       G.TyFun (ps, tret) |> G.t
   | TypeName v1 ->
       let v1 = map_a_ident_name env v1 in
@@ -1297,7 +1296,7 @@ and map_function_definition env
   let fparams, fret = map_functionType env v_f_type in
   { G.fkind = (G.Function, G.fake ""); fparams; frettype = Some fret; fbody }
 
-and map_functionType env x : G.parameters * G.type_ =
+and map_functionType env x : G.parameter list * G.type_ =
   match x with
   | {
    ft_ret = v_ft_ret;
@@ -1309,7 +1308,7 @@ and map_functionType env x : G.parameters * G.type_ =
       let _v_ft_throwTODO = map_of_list (map_exn_spec env) v_ft_throw in
       let _v_ft_constTODO = map_of_option (map_tok env) v_ft_const in
       let _v_ft_specsTODO = map_of_list (map_specifier env) v_ft_specs in
-      let params =
+      let _, params, _ =
         map_paren env (map_of_list (map_parameter env)) v_ft_params
       in
       let tret = map_type_ env v_ft_ret in
@@ -1454,7 +1453,7 @@ and map_class_definition_bis env
     cextends = v_c_inherit;
     cimplements = [];
     cmixins = [];
-    cparams = fb [];
+    cparams = [];
     cbody = (l, fields, r);
   }
 

--- a/languages/csharp/generic/Parse_csharp_tree_sitter.ml
+++ b/languages/csharp/generic/Parse_csharp_tree_sitter.ml
@@ -110,9 +110,7 @@ let param_from_lambda_params lambda_params =
 
 (* create lambda lambda_params -> expr *)
 let create_lambda lambda_params expr =
-  let fparams =
-    PI.unsafe_fake_bracket [ param_from_lambda_params lambda_params ]
-  in
+  let fparams = [ param_from_lambda_params lambda_params ] in
   Lambda
     {
       fkind = (Arrow, fake "=>");
@@ -126,7 +124,7 @@ let create_lambda lambda_params expr =
 let create_join_result_lambda lambda_params ident =
   let p1 = param_from_lambda_params lambda_params in
   let p2 = Param (param_of_id ident) in
-  let fparams = fb [ p1; p2 ] in
+  let fparams = [ p1; p2 ] in
   let ids =
     lambda_params @ [ ident ]
     |> Common.map (fun id -> N (Id (id, empty_id_info ())) |> G.e)
@@ -1194,17 +1192,17 @@ and expression (env : env) (x : CST.expression) : G.expr =
         | Some tok -> [ KeywordAttr (Async, token env tok) ] (* "async" *)
         | None -> []
       in
-      let tdelegate = token env v2 (* "delegate" *) in
-      let fparams =
+      let v2 = token env v2 (* "delegate" *) in
+      let v3 =
         match v3 with
         | Some x -> parameter_list env x
-        | None -> fb []
+        | None -> []
       in
       let v4 = block env v4 in
       Lambda
         {
-          fkind = (LambdaKind, tdelegate);
-          fparams;
+          fkind = (LambdaKind, v2);
+          fparams = v3;
           frettype = None;
           fbody = G.FBStmt v4;
         }
@@ -1235,7 +1233,7 @@ and expression (env : env) (x : CST.expression) : G.expr =
           cextends = [];
           cimplements = [];
           cmixins = [];
-          cparams = fb [];
+          cparams = [];
           cbody = (v2, v3, v5);
         }
       |> G.e
@@ -1357,7 +1355,7 @@ and expression (env : env) (x : CST.expression) : G.expr =
         | `Id tok ->
             let id = identifier env tok in
             let p = param_of_id id in
-            fb [ Param p ]
+            [ Param p ]
         (* identifier *)
       in
       let v3 = token env v3 (* "=>" *) in
@@ -2370,16 +2368,16 @@ and type_parameter_constraints_clause (env : env)
   in
   (v2, v4 :: v5)
 
-and parameter_list (env : env) ((v1, v2, v3) : CST.parameter_list) : parameters
-    =
-  let lp = token env v1 (* "(" *) in
-  let xs =
+and parameter_list (env : env) ((v1, v2, v3) : CST.parameter_list) :
+    parameter list =
+  let _v1 = token env v1 (* "(" *) in
+  let v2 =
     match v2 with
     | Some x -> formal_parameter_list env x
     | None -> []
   in
-  let rp = token env v3 (* ")" *) in
-  (lp, xs, rp)
+  let _v3 = token env v3 (* ")" *) in
+  v2
 
 and attribute_argument_list (env : env)
     ((v1, v2, v3) : CST.attribute_argument_list) : arguments =
@@ -2463,11 +2461,11 @@ let accessor_declaration (env : env)
   ((attr :: v1) @ v2, id, v4)
 
 let bracketed_parameter_list (env : env)
-    ((v1, v2, v3) : CST.bracketed_parameter_list) : G.parameters =
-  let lbra = token env v1 (* "[" *) in
+    ((v1, v2, v3) : CST.bracketed_parameter_list) =
+  let _lbra = token env v1 (* "[" *) in
   let params = formal_parameter_list env v2 in
-  let rbra = token env v3 (* "]" *) in
-  (lbra, params, rbra)
+  let _rbra = token env v3 (* "]" *) in
+  params
 
 let constructor_initializer (env : env)
     ((v1, v2, v3) : CST.constructor_initializer) =
@@ -2701,7 +2699,7 @@ and class_interface_struct (env : env) class_kind
           cextends = v6;
           cimplements = [];
           cmixins = [];
-          cparams = fb [];
+          cparams = [];
           cbody = (open_bra, fields, close_bra);
         } )
   |> G.s
@@ -2733,11 +2731,11 @@ and delegate_declaration env (v1, v2, v3, v4, v5, v6, v7, v8, v9) =
     | Some x -> type_parameter_list env x
     | None -> []
   in
-  let _, params, _ = parameter_list env v7 in
+  let v7 = parameter_list env v7 in
   let v8 = Common.map (type_parameter_constraints_clause env) v8 in
   let _v9 = token env v9 (* ";" *) in
   let tparams = type_parameters_with_constraints v6 v8 in
-  let func = TyFun (params, v4) |> G.t in
+  let func = TyFun (v7, v4) |> G.t in
   let idinfo = empty_id_info () in
   let ent = { name = EN (Id (v5, idinfo)); attrs = v1 @ v2; tparams } in
   DefStmt (ent, TypeDef { tbody = NewType func }) |> G.s
@@ -2864,7 +2862,7 @@ and declaration (env : env) (x : CST.declaration) : stmt =
                        FuncDef
                          {
                            fkind = (Method, itok);
-                           fparams = fb [ valparam ];
+                           fparams = [ valparam ];
                            frettype = None;
                            fbody;
                          }
@@ -2901,7 +2899,7 @@ and declaration (env : env) (x : CST.declaration) : stmt =
       let v3 = type_constraint env v3 in
       let _v4TODO = Option.map (explicit_interface_specifier env) v4 in
       let _v5 = token env v5 (* "this" *) in
-      let lbra, params, rbra = bracketed_parameter_list env v6 in
+      let v6 = bracketed_parameter_list env v6 in
       let indexer_attrs = v1 @ v2 in
       match v7 with
       | `Acce_list x ->
@@ -2917,7 +2915,7 @@ and declaration (env : env) (x : CST.declaration) : stmt =
                          FuncDef
                            {
                              fkind = (Method, itok);
-                             fparams = (lbra, params, rbra);
+                             fparams = v6;
                              frettype = Some v3;
                              fbody;
                            }
@@ -2939,7 +2937,7 @@ and declaration (env : env) (x : CST.declaration) : stmt =
                          FuncDef
                            {
                              fkind = (Method, itok);
-                             fparams = (lbra, params @ [ valparam ], rbra);
+                             fparams = v6 @ [ valparam ];
                              frettype = None;
                              fbody;
                            }
@@ -2958,7 +2956,7 @@ and declaration (env : env) (x : CST.declaration) : stmt =
             FuncDef
               {
                 fkind = (Arrow, arrow);
-                fparams = (lbra, params, rbra);
+                fparams = v6;
                 frettype = Some v3;
                 fbody;
               }
@@ -3056,19 +3054,18 @@ and declaration (env : env) (x : CST.declaration) : stmt =
                       {
                         fkind = (Method, itok);
                         fparams =
-                          fb
-                            (if has_params then
-                             [
-                               Param
-                                 {
-                                   pname = Some ("value", fake "value");
-                                   ptype = Some v3;
-                                   pdefault = None;
-                                   pattrs = [];
-                                   pinfo = empty_id_info ();
-                                 };
-                             ]
-                            else []);
+                          (if has_params then
+                           [
+                             Param
+                               {
+                                 pname = Some ("value", fake "value");
+                                 ptype = Some v3;
+                                 pdefault = None;
+                                 pattrs = [];
+                                 pinfo = empty_id_info ();
+                               };
+                           ]
+                          else []);
                         frettype = (if has_return then Some v3 else None);
                         (* TODO Should this be "void"? *)
                         fbody;
@@ -3090,7 +3087,7 @@ and declaration (env : env) (x : CST.declaration) : stmt =
               FuncDef
                 {
                   fkind = (Arrow, arrow);
-                  fparams = fb [];
+                  fparams = [];
                   frettype = Some v3;
                   fbody = G.FBStmt (ExprStmt (expr, v2) |> G.s);
                 }

--- a/languages/csharp/generic/Parse_csharp_tree_sitter.ml
+++ b/languages/csharp/generic/Parse_csharp_tree_sitter.ml
@@ -301,7 +301,7 @@ let _TODOparameter_modifier (env : env) (x : CST.parameter_modifier) =
 let escape_sequence (env : env) (tok : CST.escape_sequence) =
   let s = str env tok in
   (* escape_sequence *)
-  String (fb s)
+  String s
 
 let assignment_operator (env : env) (x : CST.assignment_operator) :
     operator wrap =
@@ -332,7 +332,7 @@ let predefined_type (env : env) (tok : CST.predefined_type) =
   G.ty_builtin (str env tok)
 
 let verbatim_string_literal (env : env) (tok : CST.verbatim_string_literal) =
-  G.String (fb (str env tok))
+  G.String (str env tok)
 
 (* verbatim_string_literal *)
 
@@ -436,7 +436,7 @@ let interpolated_verbatim_string_text (env : env)
     | `DQUOTDQUOT tok -> str env tok
     (* "\"\"" *)
   in
-  String (fb x)
+  String x
 
 let real_literal (env : env) (tok : CST.real_literal) =
   let s, t = str env tok (* real_literal *) in
@@ -487,9 +487,9 @@ let _preproc_directive_end (env : env) (tok : CST.preproc_directive_end) =
 
 let interpolated_string_text (env : env) (x : CST.interpolated_string_text) =
   match x with
-  | `LCURLLCURL tok -> String (fb (str env tok)) (* "{{" *)
+  | `LCURLLCURL tok -> String (str env tok) (* "{{" *)
   | `Inte_str_text_frag tok ->
-      String (fb (str env tok)) (* pattern "[^{\"\\\\\\n]+" *)
+      String (str env tok) (* pattern "[^{\"\\\\\\n]+" *)
   | `Esc_seq tok -> escape_sequence env tok
 
 (* escape_sequence *)
@@ -592,8 +592,8 @@ let literal (env : env) (x : CST.literal) : literal =
   | `Real_lit tok -> real_literal env tok (* real_literal *)
   | `Int_lit tok -> integer_literal env tok (* integer_literal *)
   | `Str_lit (v1, v2, v3) ->
-      let l = token env v1 (* "\"" *) in
-      let xs =
+      let v1 = token env v1 (* "\"" *) in
+      let v2 =
         Common.map
           (fun x ->
             match x with
@@ -602,13 +602,16 @@ let literal (env : env) (x : CST.literal) : literal =
             (* escape_sequence *))
           v2
       in
-      let r =
+      let v3 =
         match v3 with
         | `DQUOT tok -> (* "\"" *) token env tok
         | `DQUOTU8 tok -> (* "\"U8" *) token env tok
         | `DQUOTu8 tok -> (* "\"u8" *) token env tok
       in
-      G.String (G.string_ (l, xs, r))
+      let str = v2 |> Common.map fst |> String.concat "" in
+      let toks = v2 |> Common.map snd in
+      let toks = PI.combine_infos v1 (toks @ [ v3 ]) in
+      G.String (str, toks)
   | `Verb_str_lit tok -> verbatim_string_literal env tok
 
 (* verbatim_string_literal *)

--- a/languages/dockerfile/generic/Dockerfile_to_generic.ml
+++ b/languages/dockerfile/generic/Dockerfile_to_generic.ml
@@ -8,7 +8,6 @@ open AST_dockerfile
 
 type env = AST_bash.input_kind
 
-let fb = Parse_info.unsafe_fake_bracket
 let stmt_of_expr loc (e : G.expr) : G.stmt = G.s (G.ExprStmt (e, fst loc))
 
 let call ((orig_name, name_tok) : string wrap) ((args_start, args_end) : Loc.t)
@@ -56,7 +55,7 @@ let expr_of_stmt (st : G.stmt) : G.expr = G.stmt_to_expr st
 let expr_of_stmts loc (stmts : G.stmt list) : G.expr =
   G.Block (bracket loc stmts) |> G.s |> expr_of_stmt
 
-let string_expr s : G.expr = G.L (G.String (fb s)) |> G.e
+let string_expr s : G.expr = G.L (G.String s) |> G.e
 
 let id_expr (x : string wrap) : G.expr =
   G.N (G.Id (x, G.empty_id_info ())) |> G.e

--- a/languages/elixir/generic/Parse_elixir_tree_sitter.ml
+++ b/languages/elixir/generic/Parse_elixir_tree_sitter.ml
@@ -108,8 +108,6 @@ type block = body_or_clauses bracket
 (*****************************************************************************)
 (* Intermediate AST constructs to AST_generic *)
 (*****************************************************************************)
-
-let fb = PI.unsafe_fake_bracket
 let keyval_of_kwd (k, v) = G.keyval k (G.fake "=>") v
 let kwd_of_id (id : ident) : keyword = N (H2.name_of_id id) |> G.e
 let body_to_stmts es = es |> Common.map G.exprstmt
@@ -148,7 +146,7 @@ let stab_clauses_to_function_definition tk (xs : stab_clause list) :
     G.Switch (tk, Some (G.Cond (G.N (H2.name_of_id id) |> G.e)), xs) |> G.s
   in
   {
-    G.fparams = fb params;
+    G.fparams = PI.unsafe_fake_bracket params;
     frettype = None;
     fkind = (G.Function, tk);
     fbody = G.FBStmt body_stmt;
@@ -157,7 +155,7 @@ let stab_clauses_to_function_definition tk (xs : stab_clause list) :
 (* following Elixir semantic (unsugaring pairs) *)
 let list_container_of_kwds xs =
   let es = xs |> Common.map keyval_of_kwd in
-  Container (List, fb es) |> G.e
+  Container (List, PI.unsafe_fake_bracket es) |> G.e
 
 let args_of_exprs_and_keywords (es : expr list) (kwds : pair list) :
     argument list =
@@ -179,7 +177,7 @@ let expr_of_body_or_clauses tk (x : body_or_clauses) : expr =
       let stmts = body_to_stmts xs in
       (* less: use G.stmt1 instead? or get rid of fake_bracket here
        * passed down from caller? *)
-      let block = Block (fb stmts) |> G.s in
+      let block = Block (PI.unsafe_fake_bracket stmts) |> G.s in
       G.stmt_to_expr block
   | Right clauses ->
       let fdef = stab_clauses_to_function_definition tk clauses in
@@ -216,7 +214,7 @@ let args_of_do_block_opt (blopt : do_block option) : argument list =
 
 let mk_call_no_parens (e : expr) (args : argument list)
     (blopt : do_block option) : call =
-  Call (e, fb (args @ args_of_do_block_opt blopt)) |> G.e
+  Call (e, PI.unsafe_fake_bracket (args @ args_of_do_block_opt blopt)) |> G.e
 
 let mk_call_parens (e : expr) (args : argument list bracket)
     (blopt : do_block option) : call =
@@ -227,7 +225,7 @@ let binary_call (e1 : expr) op_either (e2 : expr) : expr =
   match op_either with
   | Left id ->
       let n = N (H2.name_of_id id) |> G.e in
-      Call (n, fb ([ e1; e2 ] |> Common.map G.arg)) |> G.e
+      Call (n, PI.unsafe_fake_bracket ([ e1; e2 ] |> Common.map G.arg)) |> G.e
   | Right op -> G.opcall op [ e1; e2 ]
 
 let expr_of_e_or_kwds (x : (expr, pair list) either) : expr =
@@ -318,9 +316,9 @@ let map_identifier_or_ellipsis (env : env) (x : CST.identifier) : expr =
       let id = str env tok in
       N (H2.name_of_id id) |> G.e
 
-let map_quoted_xxx (env : env) (v1, v2, v3) : string wrap bracket =
-  let l = (* "/" or another one *) token env v1 in
-  let xs =
+let map_quoted_xxx (env : env) (v1, v2, v3) : string wrap =
+  let v1 = (* "/" or another one *) token env v1 in
+  let v2 =
     Common.map
       (fun x ->
         match x with
@@ -338,8 +336,10 @@ let map_quoted_xxx (env : env) (v1, v2, v3) : string wrap bracket =
         | `Esc_seq tok -> (* escape_sequence *) str env tok)
       v2
   in
-  let r = (* "/" or another one *) token env v3 in
-  G.string_ (l, xs, r)
+  let v3 = (* "/" or another one *) token env v3 in
+  let str = v2 |> Common.map fst |> String.concat "" in
+  let toks = (v2 |> Common.map snd) @ [ v3 ] in
+  (str, PI.combine_infos v1 toks)
 
 let map_quoted_i_xxx map_interpolation (env : env) (v1, v2, v3) : expr =
   let v1 = (* "<" or another one *) token env v1 in
@@ -1138,7 +1138,7 @@ and map_keyword (env : env) (x : CST.keyword) : keyword =
   | `Kw_ tok ->
       (* todo: remove suffix ':' *)
       let x = (* keyword_ *) str env tok in
-      L (String (fb x)) |> G.e
+      L (String x) |> G.e
   | `Quoted_kw (v1, v2) ->
       let v1 = map_anon_choice_quoted_i_double_d7d5f65 env v1 in
       let _v2TODO = (* pattern :\s *) token env v2 in

--- a/languages/elixir/generic/Parse_elixir_tree_sitter.ml
+++ b/languages/elixir/generic/Parse_elixir_tree_sitter.ml
@@ -146,7 +146,7 @@ let stab_clauses_to_function_definition tk (xs : stab_clause list) :
     G.Switch (tk, Some (G.Cond (G.N (H2.name_of_id id) |> G.e)), xs) |> G.s
   in
   {
-    G.fparams = PI.unsafe_fake_bracket params;
+    G.fparams = params;
     frettype = None;
     fkind = (G.Function, tk);
     fbody = G.FBStmt body_stmt;

--- a/languages/go/ast/ast_go.ml
+++ b/languages/go/ast/ast_go.ml
@@ -190,9 +190,7 @@ and literal =
   | Float of float option wrap
   | Imag of string wrap
   | Rune of string wrap (* unicode char *)
-  | String of string wrap
-(* unicode string *)
-(* TODO: bracket *)
+  | String of string wrap (* unicode string *)
 
 and index = expr
 and arguments = argument list

--- a/languages/go/generic/go_to_generic.ml
+++ b/languages/go/generic/go_to_generic.ml
@@ -159,7 +159,7 @@ let top_func () =
     | TBidirectional ->
         G.TyN (G.Id (unsafe_fake_id "bidirectional", G.empty_id_info ())) |> G.t
   and func_type { ftok; fparams = l, params, r; fresults } :
-      G.tok * G.parameters * G.type_ option =
+      G.tok * G.parameters bracket * G.type_ option =
     let fparams = list parameter_binding params in
     let fresults = list parameter_binding fresults in
     (ftok, (l, fparams, r), return_type_of_results fresults)
@@ -204,7 +204,7 @@ let top_func () =
   and interface_field = function
     | Method (v1, v2) ->
         let v1 = ident v1 in
-        let ftok, params, ret = func_type v2 in
+        let ftok, (_l, params, _r), ret = func_type v2 in
         let ent = G.basic_entity v1 in
         let fdef =
           G.FuncDef (mk_func_def (G.Method, ftok) params ret (G.FBDecl G.sc))
@@ -297,7 +297,7 @@ let top_func () =
         let v3 = type_ v3 in
         G.TypedMetavar (v1, v2, v3)
     | FuncLit (v1, v2) ->
-        let ftok, params, ret = func_type v1 and v2 = stmt v2 in
+        let ftok, (_l, params, _r), ret = func_type v1 and v2 = stmt v2 in
         G.Lambda (mk_func_def (G.LambdaKind, ftok) params ret (G.FBStmt v2))
     | Receive (v1, v2) ->
         let v1 = tok v1 and v2 = expr v2 in
@@ -607,7 +607,7 @@ let top_func () =
     | DFunc (v1, v2, (v3, v4)) ->
         let v1 = ident v1 in
         let tparams = option type_parameters v2 |> Common.optlist_to_list in
-        let ftok, params, ret = func_type v3 in
+        let ftok, (_l, params, _r), ret = func_type v3 in
         let body = stmt v4 in
         let ent = G.basic_entity v1 ~tparams in
         G.DefStmt
@@ -618,14 +618,14 @@ let top_func () =
     | DMethod (v1, v2, (v3, v4)) ->
         let v1 = ident v1
         and v2 = parameter v2
-        and ftok, params, ret = func_type v3
+        and ftok, (_l, params, _r), ret = func_type v3
         and v4 = stmt v4 in
         let ent = G.basic_entity v1 in
         let def = mk_func_def (G.Method, ftok) params ret (G.FBStmt v4) in
         let receiver = G.OtherParam (("Receiver", snd v1), [ G.Pa v2 ]) in
-        let l, params, r = def.G.fparams in
-        let fparams = (l, receiver :: params, r) in
-        G.DefStmt (ent, G.FuncDef { def with G.fparams }) |> G.s
+        G.DefStmt
+          (ent, G.FuncDef { def with G.fparams = receiver :: def.G.fparams })
+        |> G.s
     | DTop v1 ->
         let v1 = decl v1 in
         v1

--- a/languages/go/generic/go_to_generic.ml
+++ b/languages/go/generic/go_to_generic.ml
@@ -329,7 +329,7 @@ let top_func () =
         G.Char v1
     | String v1 ->
         let v1 = wrap string v1 in
-        G.String (fb v1)
+        G.String v1
   and index v = expr v
   and arguments v = list argument v
   and argument = function

--- a/languages/java/ast/ast_java.ml
+++ b/languages/java/ast/ast_java.ml
@@ -244,13 +244,13 @@ and expr =
 and literal =
   | Int of int option wrap
   | Float of float option wrap
-  | String of string wrap (* TODO: bracket *)
+  | String of string wrap
   | Char of string wrap
   | Bool of bool wrap
   | Null of tok
   (* alt: merge with String? Java 15 *)
   (* TODO? the string contains the enclosing triple quotes for now *)
-  | TextBlock of string wrap (* TODO bracket *)
+  | TextBlock of string wrap
 
 and arguments = expr list bracket
 and expr_or_type = (expr, typ) Common.either

--- a/languages/java/generic/java_to_generic.ml
+++ b/languages/java/generic/java_to_generic.ml
@@ -232,11 +232,11 @@ and literal = function
       G.Float v1
   | String v1 ->
       let v1 = wrap string v1 in
-      G.String (fb v1)
+      G.String v1
   | TextBlock v1 ->
       (* TODO: remove enclosing triple quotes? or do that in ast_java.ml? *)
       let v1 = wrap string v1 in
-      G.String (fb v1)
+      G.String v1
   | Char v1 ->
       let v1 = wrap string v1 in
       G.Char v1

--- a/languages/java/generic/java_to_generic.ml
+++ b/languages/java/generic/java_to_generic.ml
@@ -284,7 +284,7 @@ and expr e =
                 cextends = [ (v1, None) ];
                 cimplements = [];
                 cmixins = [];
-                cparams = fb [];
+                cparams = [];
                 cbody = decls |> bracket (Common.map (fun x -> G.F x));
               }
             |> G.e
@@ -373,11 +373,11 @@ and expr e =
       let v2 = typ v2 in
       G.TypedMetavar (v1, Parse_info.fake_info (snd v1) " ", v2)
   | Lambda (v1, t, v2) ->
-      let fparams = parameters v1 in
+      let v1 = parameters v1 in
       let v2 = stmt v2 in
       G.Lambda
         {
-          G.fparams = fb fparams;
+          G.fparams = v1;
           frettype = None;
           fbody = G.FBStmt v2;
           fkind = (G.Arrow, t);
@@ -589,7 +589,7 @@ and init = function
       let v1 = bracket (list init) v1 in
       G.Container (G.Array, v1) |> G.e
 
-and parameters v : G.parameter list = Common.map parameter_binding v
+and parameters v = Common.map parameter_binding v
 
 and parameter_binding = function
   | ParamClassic v
@@ -604,7 +604,7 @@ and parameter_binding = function
 
 and method_decl ?(cl_kind = None) { m_var; m_formals; m_throws; m_body } =
   let ent, rett = var m_var in
-  let fparams = parameters m_formals in
+  let v2 = parameters m_formals in
   let v3 = list typ m_throws in
   let v4 = stmt m_body in
   (* TODO: use fthrow field instead *)
@@ -618,12 +618,7 @@ and method_decl ?(cl_kind = None) { m_var; m_formals; m_throws; m_body } =
     | _ -> FBStmt v4
   in
   ( { ent with G.attrs = ent.G.attrs @ throws },
-    {
-      G.fparams = fb fparams;
-      frettype = rett;
-      fbody;
-      fkind = (G.Method, G.fake "");
-    } )
+    { G.fparams = v2; frettype = rett; fbody; fkind = (G.Method, G.fake "") } )
 
 and field v = var_with_init v
 
@@ -642,7 +637,7 @@ and enum_decl { en_name; en_mods; en_impls; en_body } =
       cextends = v3;
       cmixins = [];
       cimplements = [];
-      cparams = fb [];
+      cparams = [];
       cbody;
     }
   in
@@ -686,7 +681,7 @@ and class_decl
       cextends = Option.to_list v5;
       cimplements = v6;
       cmixins = [];
-      cparams = fb cparams;
+      cparams;
       cbody = fields;
     }
   in

--- a/languages/javascript/ast/ast_js.ml
+++ b/languages/javascript/ast/ast_js.ml
@@ -229,7 +229,7 @@ and expr =
 and literal =
   | Bool of bool wrap
   | Num of float option wrap
-  | String of string wrap (* TODO: bracket, like for Regexp below *)
+  | String of string wrap
   | Regexp of string wrap bracket (* // *) * string wrap option (* modifier *)
 
 and a_arguments = a_argument list bracket

--- a/languages/javascript/ast/ast_js.ml
+++ b/languages/javascript/ast/ast_js.ml
@@ -433,7 +433,7 @@ and function_definition = {
   f_kind : AST_generic.function_kind wrap;
   (* less: move that in entity? but some anon func have attributes too *)
   f_attrs : attribute list;
-  f_params : parameter list; (* TODO: bracket *)
+  f_params : parameter list;
   (* typescript-ext: *)
   f_rettype : type_ option;
   f_body : stmt;

--- a/languages/javascript/generic/js_to_generic.ml
+++ b/languages/javascript/generic/js_to_generic.ml
@@ -557,7 +557,7 @@ and fun_ { f_kind; f_attrs = f_props; f_params; f_body; f_rettype } =
   let v2 = list parameter_binding f_params in
   let v3 = stmt f_body |> as_block in
   let frettype = option type_ f_rettype in
-  ({ G.fparams = fb v2; frettype; fbody = G.FBStmt v3; fkind = f_kind }, v1)
+  ({ G.fparams = v2; frettype; fbody = G.FBStmt v3; fkind = f_kind }, v1)
 
 and parameter_binding = function
   | ParamClassic x -> parameter x
@@ -640,7 +640,7 @@ and class_ { c_extends; c_implements; c_body; c_kind; c_attrs } =
       cextends;
       cimplements;
       cmixins = [];
-      cparams = fb [];
+      cparams = [];
       cbody = v2;
     },
     attrs )

--- a/languages/javascript/generic/js_to_generic.ml
+++ b/languages/javascript/generic/js_to_generic.ml
@@ -216,7 +216,7 @@ and literal x : G.literal =
       G.Float v1
   | String v1 ->
       let v1 = wrap string v1 in
-      G.String (fb v1)
+      G.String v1
   | Regexp (v1, v2) ->
       let v1 = bracket (wrap string) v1 in
       let v2 = option (wrap string) v2 in
@@ -709,7 +709,7 @@ and module_directive x =
   match x with
   | ReExportNamespace (v1, _v2, _opt_alias, _v3, v4) ->
       let v4 = filename v4 in
-      G.OtherDirective (("ReExportNamespace", v1), [ G.Str (fb v4) ])
+      G.OtherDirective (("ReExportNamespace", v1), [ G.Str v4 ])
   | Import (t, v1, v2) ->
       let v1 =
         Common.map

--- a/languages/json/generic/json_to_generic.ml
+++ b/languages/json/generic/json_to_generic.ml
@@ -18,8 +18,6 @@ module PI = Parse_info
 module M = Map_AST
 module G = AST_generic
 
-let fb = Parse_info.unsafe_fake_bracket
-
 let parse_json_string json =
   try
     Some
@@ -74,7 +72,7 @@ let expr ?(unescape_strings = false) x =
                               * anything in Semgrep (this may change though) *)
                              if AST_generic.is_metavar_name (fst id) then
                                G.N (G.Id (id, G.empty_id_info ())) |> G.e
-                             else G.L (G.String (fb id)) |> G.e
+                             else G.L (G.String id) |> G.e
                            in
                            G.Container
                              (G.Tuple, PI.unsafe_fake_bracket [ key; e ])
@@ -82,7 +80,7 @@ let expr ?(unescape_strings = false) x =
                        | Right t -> G.Ellipsis t |> G.e)
                 in
                 G.Container (G.Dict, (lp, zs, rp)) |> G.e
-            | G.L (G.String (_, (escaped, t), _)) when unescape_strings ->
+            | G.L (G.String (escaped, t)) when unescape_strings ->
                 let unescaped =
                   match unescape_json_string_contents escaped with
                   | Some s -> s
@@ -92,7 +90,7 @@ let expr ?(unescape_strings = false) x =
                          Compare with: assert false *)
                       escaped
                 in
-                G.L (G.String (fb (unescaped, t))) |> G.e
+                G.L (G.String (unescaped, t)) |> G.e
             | _ -> e);
       }
   in
@@ -113,6 +111,6 @@ let any x =
       let key =
         if AST_generic.is_metavar_name (fst v1) then
           G.N (G.Id (v1, G.empty_id_info ())) |> G.e
-        else G.L (G.String (fb v1)) |> G.e
+        else G.L (G.String v1) |> G.e
       in
       G.E (G.Container (G.Tuple, PI.unsafe_fake_bracket [ key; expr v3 ]) |> G.e)

--- a/languages/jsonnet/ast/AST_jsonnet.ml
+++ b/languages/jsonnet/ast/AST_jsonnet.ml
@@ -278,7 +278,9 @@ type any = E of expr
 (* Helpers *)
 (*****************************************************************************)
 
-let mk_string_ (l, (str, tk), r) = (None, DoubleQuote, (l, [ (str, tk) ], r))
+let mk_string_ (str, tk) =
+  let fk = Parse_info.unsafe_fake_info "" in
+  (None, DoubleQuote, (fk, [ (str, tk) ], fk))
 
 let string_of_string_ (x : string_) : string wrap =
   let _verbatimTODO, _kindTODO, (l, xs, r) = x in

--- a/languages/jsonnet/generic/Jsonnet_to_generic.ml
+++ b/languages/jsonnet/generic/Jsonnet_to_generic.ml
@@ -170,11 +170,14 @@ and map_literal env v : G.literal =
       let v = map_string_ env v in
       G.String v
 
-and map_string_ env (v1, v2, v3) : string G.wrap G.bracket =
+and map_string_ env (v1, v2, v3) : string G.wrap =
   let _v1 = (map_option map_verbatim) env v1 in
   let _v2 = map_string_kind env v2 in
   let l, xs, r = (map_bracket map_string_content) env v3 in
-  G.string_ (l, xs, r)
+  let s = xs |> Common.map fst |> String.concat "" in
+  let toks = xs |> Common.map snd in
+  let tk = PI.combine_infos l (toks @ [ r ]) in
+  (s, tk)
 
 and map_verbatim env v = map_tok env v
 
@@ -367,7 +370,7 @@ and map_field_name env v : G.entity_name =
       let id = map_ident env v in
       G.EN (G.Id (id, G.empty_id_info ()))
   | FStr v ->
-      let _, (s, tk), _ = map_string_ env v in
+      let s, tk = map_string_ env v in
       G.EN (G.Id ((s, tk), G.empty_id_info ()))
   | FDynamic v ->
       let l, e, r = (map_bracket map_expr) env v in

--- a/languages/jsonnet/generic/Jsonnet_to_generic.ml
+++ b/languages/jsonnet/generic/Jsonnet_to_generic.ml
@@ -304,7 +304,7 @@ and map_bind env v : G.definition =
 and map_function_definition env v : G.function_definition =
   let { f_tok; f_params; f_body } = v in
   let f_tok = map_tok env f_tok in
-  let fparams = (map_bracket (map_list map_parameter)) env f_params in
+  let _l, fparams, _r = (map_bracket (map_list map_parameter)) env f_params in
   let f_body = map_expr env f_body in
   {
     fkind = (G.LambdaKind, f_tok);

--- a/languages/kotlin/generic/Parse_kotlin_tree_sitter.ml
+++ b/languages/kotlin/generic/Parse_kotlin_tree_sitter.ml
@@ -623,7 +623,7 @@ and class_declaration (env : env) (x : CST.class_declaration) :
   | `Opt_modifs_choice_class_simple_id_opt_type_params_opt_prim_cons_opt_COLON_dele_specis_opt_type_consts_opt_class_body
       (v1, v2, v3, v4, v5, v6, v7, v8) ->
       let v1 = modifiers_opt env v1 in
-      let ckind =
+      let v2 =
         match v2 with
         | `Class tok -> (Class, token env tok) (* "class" *)
         | `Inte tok -> (Interface, token env tok)
@@ -635,12 +635,12 @@ and class_declaration (env : env) (x : CST.class_declaration) :
         | Some x -> type_parameters env x
         | None -> []
       in
-      let cparams =
+      let v5 =
         match v5 with
         | Some x -> primary_constructor env x
-        | None -> fb []
+        | None -> []
       in
-      let cextends =
+      let v6 =
         match v6 with
         | Some (v1, v2) ->
             let _v1 = token env v1 (* ":" *) in
@@ -653,33 +653,40 @@ and class_declaration (env : env) (x : CST.class_declaration) :
         | Some x -> type_constraints env x
         | None -> []
       in
-      let cbody =
+      let v8 =
         match v8 with
         | Some x -> class_body env x
         | None -> fb []
       in
       let ent = G.basic_entity v3 ~attrs:v1 ~tparams:v4 in
       let cdef =
-        { ckind; cextends; cimplements = []; cmixins = []; cparams; cbody }
+        {
+          ckind = v2;
+          cextends = v6;
+          cimplements = [];
+          cmixins = [];
+          cparams = v5;
+          cbody = v8;
+        }
       in
       (ent, cdef)
   | `Opt_modifs_enum_class_simple_id_opt_type_params_opt_prim_cons_opt_COLON_dele_specis_opt_type_consts_opt_enum_class_body
       (v1, v2, v3, v4, v5, v6, v7, v8, v9) ->
       let v1 = modifiers_opt env v1 in
       let v2 = token env v2 (* "enum" *) in
-      let tclass = token env v3 (* "class" *) in
+      let v3 = token env v3 (* "class" *) in
       let v4 = simple_identifier env v4 in
       let v5 =
         match v5 with
         | Some x -> type_parameters env x
         | None -> []
       in
-      let cparams =
+      let v6 =
         match v6 with
         | Some x -> primary_constructor env x
-        | None -> fb []
+        | None -> []
       in
-      let cextends =
+      let v7 =
         match v7 with
         | Some (v1, v2) ->
             let _v1 = token env v1 (* ":" *) in
@@ -692,7 +699,7 @@ and class_declaration (env : env) (x : CST.class_declaration) :
         | Some x -> type_constraints env x
         | None -> []
       in
-      let cbody =
+      let v9 =
         match v9 with
         | Some x -> enum_class_body env x
         | None -> fb []
@@ -702,12 +709,12 @@ and class_declaration (env : env) (x : CST.class_declaration) :
       in
       let cdef =
         {
-          ckind = (Class, tclass);
-          cextends;
+          ckind = (Class, v3);
+          cextends = v7;
           cimplements = [];
           cmixins = [];
-          cparams;
-          cbody;
+          cparams = v6;
+          cbody = v9;
         }
       in
       (ent, cdef)
@@ -749,7 +756,7 @@ and class_member_declaration (env : env) (x : CST.class_member_declaration) :
               cextends = v5;
               cimplements = [];
               cmixins = [];
-              cparams = fb [];
+              cparams = [];
               cbody = v6;
             }
           in
@@ -761,7 +768,7 @@ and class_member_declaration (env : env) (x : CST.class_member_declaration) :
       | `Seco_cons (v1, v2, v3, v4, v5) ->
           let v1 = modifiers_opt env v1 in
           let v2 = str env v2 (* "constructor" *) in
-          let fparams = function_value_parameters env v3 in
+          let v3 = function_value_parameters env v3 in
           let _v4TODO =
             match v4 with
             | Some (v1, v2) ->
@@ -770,14 +777,19 @@ and class_member_declaration (env : env) (x : CST.class_member_declaration) :
                 Some (v1, v2)
             | None -> None
           in
-          let fbody =
+          let v5 =
             match v5 with
             | Some x -> G.FBStmt (block env x)
             | None -> G.FBDecl G.sc
           in
           let ent = G.basic_entity v2 ~attrs:v1 in
           let def =
-            { fkind = (Method, snd v2); fparams; frettype = None; fbody }
+            {
+              fkind = (Method, snd v2);
+              fparams = v3;
+              frettype = None;
+              fbody = v5;
+            }
           in
           (ent, FuncDef def) |> G.fld)
   | `Ellips x ->
@@ -823,8 +835,8 @@ and class_parameter (env : env) (x : CST.class_parameter) : G.parameter =
 
 and class_parameters (env : env) ((v1, v2, v3, v4) : CST.class_parameters) :
     parameters =
-  let l = token env v1 (* "(" *) in
-  let params =
+  let _v1 = token env v1 (* "(" *) in
+  let v2 =
     match v2 with
     | Some (v1, v2) ->
         let v1 = class_parameter env v1 in
@@ -845,8 +857,8 @@ and class_parameters (env : env) ((v1, v2, v3, v4) : CST.class_parameters) :
     | Some v3 -> Some (token env v3)
     (* , *)
   in
-  let r = token env v4 (* ")" *) in
-  (l, params, r)
+  let _v4 = token env v4 (* ")" *) in
+  v2
 
 and constructor_delegation_call (env : env)
     ((v1, v2) : CST.constructor_delegation_call) : expr =
@@ -950,7 +962,7 @@ and declaration (env : env) (x : CST.declaration) : definition =
           cextends = v4;
           cimplements = [];
           cmixins = [];
-          cparams = fb [];
+          cparams = [];
           cbody = v5;
         }
       in
@@ -1268,9 +1280,9 @@ and function_value_parameter (env : env) (x : CST.function_value_parameter) =
       ParamEllipsis t
 
 and function_value_parameters (env : env)
-    ((v1, v2, _v3, v4) : CST.function_value_parameters) : G.parameters =
-  let l = token env v1 (* "(" *) in
-  let params =
+    ((v1, v2, _v3, v4) : CST.function_value_parameters) : G.parameter list =
+  let _v1 = token env v1 (* "(" *) in
+  let v2 =
     match v2 with
     | Some (v1, v2) ->
         let v1 = function_value_parameter env v1 in
@@ -1285,8 +1297,8 @@ and function_value_parameters (env : env)
         v1 :: v2
     | None -> []
   in
-  let r = token env v4 (* ")" *) in
-  (l, params, r)
+  let _v4 = token env v4 (* ")" *) in
+  v2
 
 and getter (env : env) ((v0, v1, v2) : CST.getter) =
   let mods = modifiers_opt env v0 in
@@ -1424,9 +1436,7 @@ and lambda_literal (env : env) ((v1, v2, v3, v4) : CST.lambda_literal) =
   let v4 = token env v4 (* "}" *) in
   let fbody = G.FBStmt (Block (lbracket_block_start, v3, v4) |> G.s) in
   let kind = (LambdaKind, v1) in
-  let func_def =
-    { fkind = kind; fparams = fb params; frettype = None; fbody }
-  in
+  let func_def = { fkind = kind; fparams = params; frettype = None; fbody } in
   Lambda func_def |> G.e
 
 and var_or_multivar (env : env) (x : CST.lambda_parameter) =
@@ -1629,7 +1639,7 @@ and parenthesized_type (env : env) ((v1, v2, v3) : CST.parenthesized_type) =
   v2
 
 and primary_constructor (env : env) ((v1, v2) : CST.primary_constructor) :
-    parameters =
+    parameter list =
   let _v1TODO =
     match v1 with
     | Some (v1, v2) ->
@@ -1697,7 +1707,7 @@ and primary_expression (env : env) (x : CST.primary_expression) : expr =
           cextends = v2;
           cimplements = [];
           cmixins = [];
-          cparams = fb [];
+          cparams = [];
           cbody = v3;
         }
       |> G.e

--- a/languages/lua/generic/Parse_lua_tree_sitter.ml
+++ b/languages/lua/generic/Parse_lua_tree_sitter.ml
@@ -116,8 +116,8 @@ let map_field_sep (env : env) (x : CST.field_sep) =
  *   token env tok (\* string *\) *)
 
 let map_parameters (env : env) ((v1, v2, v3) : CST.parameters) : G.parameters =
-  let lp = token env v1 (* "(" *) in
-  let params =
+  let _v1 = token env v1 (* "(" *) in
+  let v2 =
     match v2 with
     | Some (v1, v2, v3) ->
         let v1 =
@@ -147,8 +147,8 @@ let map_parameters (env : env) ((v1, v2, v3) : CST.parameters) : G.parameters =
         deoptionalize (List.concat [ [ Some v1 ]; v2; [ v3 ] ])
     | None -> []
   in
-  let rp = token env v3 (* ")" *) in
-  (lp, params, rp)
+  let _v3 = token env v3 (* ")" *) in
+  v2
 
 let map_local_variable_declarator (env : env)
     ((v1, v2) : CST.local_variable_declarator) local : G.entity list =

--- a/languages/lua/generic/Parse_lua_tree_sitter.ml
+++ b/languages/lua/generic/Parse_lua_tree_sitter.ml
@@ -97,7 +97,7 @@ let string_literal (env : env) (tok : CST.identifier) =
         logger#warning "weird string literal: %s" s;
         s
   in
-  G.L (G.String (fb (s, t))) |> G.e
+  G.L (G.String (s, t)) |> G.e
 
 let map_field_sep (env : env) (x : CST.field_sep) =
   match x with

--- a/languages/ocaml/ast/ast_ml.ml
+++ b/languages/ocaml/ast/ast_ml.ml
@@ -163,7 +163,7 @@ and literal =
   | Int of int option wrap
   | Float of float option wrap
   | Char of string wrap
-  | String of string wrap (* TODO bracket *)
+  | String of string wrap
   | Bool of bool wrap
   | Unit of tok * tok (* () or begin/end *)
 

--- a/languages/ocaml/generic/ml_to_generic.ml
+++ b/languages/ocaml/generic/ml_to_generic.ml
@@ -402,7 +402,7 @@ and literal = function
       G.Char v1
   | String v1 ->
       let v1 = wrap string v1 in
-      G.String (fb v1)
+      G.String v1
   | Bool v1 ->
       let v1 = wrap bool v1 in
       G.Bool v1

--- a/languages/ocaml/generic/ml_to_generic.ml
+++ b/languages/ocaml/generic/ml_to_generic.ml
@@ -60,7 +60,7 @@ let mk_var_or_func tlet params tret body =
   | _ :: _, _body ->
       G.FuncDef
         {
-          G.fparams = fb params;
+          G.fparams = params;
           frettype = tret;
           fkind = (G.Function, tlet);
           (* TODO? maybe generate FBExpr when we can? *)
@@ -352,7 +352,7 @@ and expr e =
       let v1 = list parameter v1 and v2 = expr v2 in
       let def =
         {
-          G.fparams = fb v1;
+          G.fparams = v1;
           frettype = None;
           fkind = (G.Function, t);
           fbody = G.FBExpr v2;
@@ -370,7 +370,7 @@ and expr e =
       in
       G.Lambda
         {
-          G.fparams = fb params;
+          G.fparams = params;
           frettype = None;
           fkind = (G.Function, t);
           fbody = G.FBStmt body_stmt;

--- a/languages/php/ast/ast_php.ml
+++ b/languages/php/ast/ast_php.ml
@@ -336,7 +336,7 @@ and func_def = {
   (* TODO: "_lambda" when used for lambda, see also AnonLambda for f_kind below *)
   f_name : ident;
   f_kind : function_kind wrap;
-  f_params : parameter list; (* TODO bracket *)
+  f_params : parameter list;
   f_return_type : hint_type option;
   (* functions returning a ref are rare *)
   f_ref : bool;

--- a/languages/php/ast/ast_php.ml
+++ b/languages/php/ast/ast_php.ml
@@ -147,7 +147,7 @@ type expr =
    * 'Id name' sometimes. Some magic functions like param_post() also
    * introduce entities (variables) via strings.
    *)
-  | String of string wrap (* TODO: bracket *)
+  | String of string wrap
   (* Id is valid for "entities" (functions, classes, constants). Id is also
    * used for class methods/fields/constants. It can also contain
    * "self/parent" or "static", "class". It can be "true", "false", "null"

--- a/languages/php/generic/php_to_generic.ml
+++ b/languages/php/generic/php_to_generic.ml
@@ -255,7 +255,7 @@ and expr e : G.expr =
       G.L (G.Float v1) |> G.e
   | String v1 ->
       let v1 = wrap string v1 in
-      G.L (G.String (fb v1)) |> G.e
+      G.L (G.String v1) |> G.e
   | Id v1 ->
       let v1 = name_of_qualified_ident v1 in
       G.N v1 |> G.e
@@ -382,7 +382,7 @@ and expr e : G.expr =
        * generate an InterpolatedConcat because it's actually not an
        * interpolation ($VAR is interpreted as a metavar, not a PHP var)
        *)
-      | [ ({ e = G.L (G.String (_, (str, _), _)); _ } as e) ]
+      | [ ({ e = G.L (G.String (str, _)); _ } as e) ]
         when AST_generic.is_metavar_name str ->
           e
       | _else_ ->

--- a/languages/php/generic/php_to_generic.ml
+++ b/languages/php/generic/php_to_generic.ml
@@ -431,7 +431,7 @@ and expr e : G.expr =
           (* TODO: transform l_uses in UseOuterDecl preceding body *)
           G.Lambda
             {
-              G.fparams = fb ps;
+              G.fparams = ps;
               frettype = rett;
               fbody = G.FBStmt body;
               fkind = (lambdakind, t);
@@ -542,7 +542,7 @@ and func_def
   let body = stmt f_body in
   let ent = G.basic_entity id ~attrs:(modifiers @ attrs) in
   let def =
-    { G.fparams = fb params; frettype = fret; fbody = G.FBStmt body; fkind }
+    { G.fparams = params; frettype = fret; fbody = G.FBStmt body; fkind }
   in
   (ent, def)
 
@@ -554,7 +554,7 @@ and function_kind (kind, t) =
     | Method -> G.Method),
     t )
 
-and parameters x : G.parameter list = list parameter x
+and parameters x = list parameter x
 
 and parameter x =
   match x with
@@ -654,7 +654,7 @@ and class_def
       cextends = extends |> Option.to_list;
       cimplements = implements;
       cmixins = uses;
-      cparams = fb [];
+      cparams = [];
       cbody = (t1, fields |> Common.map (fun def -> G.fld def), t2);
     }
   in

--- a/languages/python/ast/AST_python.ml
+++ b/languages/python/ast/AST_python.ml
@@ -110,9 +110,7 @@ type expr =
    * content is string wrap bracket where bracket are enclosing
    * quote/double-quote/triple-quotes
    *)
-  | Str of string wrap
-  (* s *)
-  (* TODO bracket *)
+  | Str of string wrap (* s *)
   (* TODO: we should split the token in r'foo' in two, one string wrap
    * for the prefix and a string wrap for the string itself. *)
   | EncodedStr of string wrap * string (* prefix *)

--- a/languages/python/ast/AST_python.ml
+++ b/languages/python/ast/AST_python.ml
@@ -255,7 +255,6 @@ and argument =
 (* ------------------------------------------------------------------------- *)
 (* Parameters (used for Lambda above and function_definition below) *)
 (* ------------------------------------------------------------------------- *)
-(* TODO: add bracket *)
 and parameters = parameter list
 
 and parameter =

--- a/languages/python/generic/Python_to_generic.ml
+++ b/languages/python/generic/Python_to_generic.ml
@@ -290,7 +290,7 @@ let rec expr env (x : expr) =
       let v1 = parameters env v1 and v2 = expr env v2 in
       G.Lambda
         {
-          G.fparams = fb v1;
+          G.fparams = v1;
           fbody = G.FBExpr v2;
           frettype = None;
           fkind = (G.LambdaKind, t0);
@@ -445,7 +445,7 @@ and param_pattern env = function
       let t = list (param_pattern env) t in
       G.PatTuple (PI.unsafe_fake_bracket t)
 
-and parameters env xs : G.parameter list =
+and parameters env xs =
   xs
   |> Common.map (function
        | ParamDefault ((n, topt), e) ->
@@ -562,7 +562,7 @@ and stmt_aux env x =
       let ent = G.basic_entity v1 ~attrs:v5 in
       let def =
         {
-          G.fparams = fb v2;
+          G.fparams = v2;
           frettype = v3;
           fbody = G.FBStmt v4;
           fkind = (G.Function, t);
@@ -582,7 +582,7 @@ and stmt_aux env x =
           cextends = v2;
           cimplements = [];
           cmixins = [];
-          cparams = fb [];
+          cparams = [];
           cbody = fb (v3 |> Common.map (fun x -> fieldstmt x));
         }
       in

--- a/languages/python/generic/Python_to_generic.ml
+++ b/languages/python/generic/Python_to_generic.ml
@@ -157,7 +157,7 @@ let rec expr env (x : expr) =
       G.L v1 |> G.e
   | Str v1 ->
       let v1 = wrap string v1 in
-      G.L (G.String (fb v1)) |> G.e
+      G.L (G.String v1) |> G.e
   | EncodedStr (v1, pre) ->
       let v1 = wrap string v1 in
       (* bugfix: do not reuse the same tok! otherwise in semgrep
@@ -168,7 +168,7 @@ let rec expr env (x : expr) =
        *)
       G.Call
         ( G.IdSpecial (G.EncodedString pre, fake (snd v1) "") |> G.e,
-          fb [ G.Arg (G.L (G.String (fb v1)) |> G.e) ] )
+          fb [ G.Arg (G.L (G.String v1) |> G.e) ] )
       |> G.e
   | InterpolatedString (v1, xs, v3) ->
       G.Call

--- a/languages/python/generic/Python_to_generic.mli
+++ b/languages/python/generic/Python_to_generic.mli
@@ -3,7 +3,7 @@ val program :
 
 val any : AST_python.any -> AST_generic.any
 val type_for_lsif : AST_python.type_ -> AST_generic.type_
-val parameters_for_lsif : AST_python.parameters -> AST_generic.parameter list
+val parameters_for_lsif : AST_python.parameters -> AST_generic.parameters
 
 (* exception Error of string * Parse_info.info *)
 (* may raise Error *)

--- a/languages/r/generic/Parse_r_tree_sitter.ml
+++ b/languages/r/generic/Parse_r_tree_sitter.ml
@@ -98,13 +98,13 @@ let map_identifier (env : env) (x : CST.identifier) : G.ident =
           combine_str_and_infos l xs r)
   | `Semg_meta tok -> (* semgrep_metavariable *) str env tok
 
-let map_string_ (env : env) (x : CST.string_) : string G.wrap G.bracket =
+let map_string_ (env : env) (x : CST.string_) : string G.wrap =
   match x with
   (* TODO: need to remove the enclosing quotes *)
-  | `Raw_str_lit tok -> (* raw_string_literal *) fb (str env tok)
+  | `Raw_str_lit tok -> (* raw_string_literal *) str env tok
   | `DQUOT_rep_choice_pat_de5d470_DQUOT (v1, v2, v3) ->
-      let l = (* "\"" *) token env v1 in
-      let xs =
+      let v1 = (* "\"" *) token env v1 in
+      let v2 =
         Common.map
           (fun x ->
             match x with
@@ -112,11 +112,11 @@ let map_string_ (env : env) (x : CST.string_) : string G.wrap G.bracket =
             | `Esc_seq tok -> (* escape_sequence *) str env tok)
           v2
       in
-      let r = (* "\"" *) token env v3 in
-      G.string_ (l, xs, r)
+      let v3 = (* "\"" *) token env v3 in
+      combine_str_and_infos v1 v2 v3
   | `SQUOT_rep_choice_pat_3e57880_SQUOT (v1, v2, v3) ->
-      let l = (* "'" *) token env v1 in
-      let xs =
+      let v1 = (* "'" *) token env v1 in
+      let v2 =
         Common.map
           (fun x ->
             match x with
@@ -124,8 +124,8 @@ let map_string_ (env : env) (x : CST.string_) : string G.wrap G.bracket =
             | `Esc_seq tok -> (* escape_sequence *) str env tok)
           v2
       in
-      let r = (* "'" *) token env v3 in
-      G.string_ (l, xs, r)
+      let v3 = (* "'" *) token env v3 in
+      combine_str_and_infos v1 v2 v3
 
 let rec map_argument (env : env) (x : CST.argument) : G.argument =
   match x with
@@ -253,23 +253,24 @@ and map_binary (env : env) (x : CST.binary) : G.expr =
 
 and map_default_argument (env : env) ((v1, v2, v3) : CST.default_argument) :
     G.argument =
-  let id =
+  let v1 =
     match v1 with
     | `Id x -> map_identifier env x
-    | `Str x ->
-        let _, x, _ = map_string_ env x in
-        x
+    | `Str x -> map_string_ env x
     (* TODO ?? not semgrep! *)
     | `Dots tok ->
         let x = (* "..." *) str env tok in
         x
   in
-  let teq = (* "=" *) token env v2 in
-  match v3 with
-  | Some x ->
-      let e = map_expression env x in
-      ArgKwd (id, e)
-  | None -> OtherArg (("Empty =", teq), [ I id ])
+  let v2 = (* "=" *) token env v2 in
+  let v3 =
+    match v3 with
+    | Some x ->
+        let e = map_expression env x in
+        ArgKwd (v1, e)
+    | None -> OtherArg (("Empty =", v2), [ I v1 ])
+  in
+  v3
 
 and map_expression (env : env) (x : CST.expression) : G.expr =
   match x with
@@ -348,7 +349,7 @@ and map_expression (env : env) (x : CST.expression) : G.expr =
       let id =
         match v3 with
         | `Id x -> map_identifier env x
-        | `Str x -> map_string_ env x |> Parse_info.unbracket
+        | `Str x -> map_string_ env x
       in
       DotAccess (e, t, FN (H2.name_of_id id)) |> G.e
   | `Slot (v1, v2, v3) ->

--- a/languages/r/generic/Parse_r_tree_sitter.ml
+++ b/languages/r/generic/Parse_r_tree_sitter.ml
@@ -478,8 +478,8 @@ and map_formal_parameter (env : env) (x : CST.formal_parameter) : G.parameter =
       G.ParamEllipsis t
 
 and map_formal_parameters (env : env) ((v1, v2, v3) : CST.formal_parameters) :
-    G.parameters =
-  let l = (* "(" *) token env v1 in
+    G.parameter list =
+  let _l = (* "(" *) token env v1 in
   let xs =
     match v2 with
     | Some (v1, v2, v3) ->
@@ -500,15 +500,20 @@ and map_formal_parameters (env : env) ((v1, v2, v3) : CST.formal_parameters) :
         e :: xs
     | None -> []
   in
-  let r = (* ")" *) token env v3 in
-  (l, xs, r)
+  let _r = (* ")" *) token env v3 in
+  xs
 
 and map_function_definition (env : env) ((v1, v2, v3) : CST.function_definition)
     : G.function_definition =
   let tk = (* "function" *) token env v1 in
-  let fparams = map_formal_parameters env v2 in
+  let params = map_formal_parameters env v2 in
   let body = map_expression env v3 in
-  { G.fkind = (LambdaKind, tk); fparams; frettype = None; fbody = FBExpr body }
+  {
+    G.fkind = (LambdaKind, tk);
+    fparams = params;
+    frettype = None;
+    fbody = FBExpr body;
+  }
 
 and map_lambda_function (env : env) ((v1, v2, v3) : CST.lambda_function) :
     G.function_definition =

--- a/languages/ruby/ast/ast_ruby.ml
+++ b/languages/ruby/ast/ast_ruby.ml
@@ -272,7 +272,7 @@ and atom_kind =
   | AtomFromString of interp list bracket (* '' or "" or %i() *)
 
 and string_kind =
-  | Single of string wrap (* TODO: bracket *)
+  | Single of string wrap
   | Double of interp list bracket
   | Tick of interp list bracket
 

--- a/languages/ruby/generic/ruby_to_generic.ml
+++ b/languages/ruby/generic/ruby_to_generic.ml
@@ -342,7 +342,7 @@ and interpolated_string (t1, xs, t2) : G.expr_kind =
       (t1, xs |> Common.map (fun e -> G.Arg e), t2) )
 
 and string_contents tok = function
-  | StrChars s -> G.L (G.String (fb s)) |> G.e
+  | StrChars s -> G.L (G.String s) |> G.e
   | StrExpr (l, e, r) ->
       G.Call
         ( G.IdSpecial (G.InterpolatedElement, tok) |> G.e,
@@ -455,9 +455,13 @@ and literal x =
   | Nil t -> G.L (G.Null (tok t))
   | String skind -> (
       match skind with
-      | Single x -> G.L (G.String (fb x))
-      | Double (l, [], r) -> G.L (G.String (l, ("", l), r))
-      | Double (l, [ StrChars (s, t) ], r) -> G.L (G.String (l, (s, t), r))
+      | Single x -> G.L (G.String x)
+      | Double (l, [], r) ->
+          let t = PI.combine_infos l [ r ] in
+          G.L (G.String ("", t))
+      | Double (l, [ StrChars (s, t2) ], r) ->
+          let t = PI.combine_infos l [ t2; r ] in
+          G.L (G.String (s, t))
       | Double x -> interpolated_string x
       | Tick (l, xs, r) ->
           G.OtherExpr
@@ -486,7 +490,7 @@ and expr_special_cases e =
   | G.Call ({ G.e = G.N (G.Id (("require", t), _)); _ }, args)
   | G.Call ({ G.e = G.N (G.Id (("load", t), _)); _ }, args) -> (
       match args with
-      | _, [ G.Arg { G.e = G.L (G.String (_, str, _)); _ } ], _
+      | _, [ G.Arg { G.e = G.L (G.String str); _ } ], _
       | _, [ G.Arg { G.e = G.N (G.Id (str, _)); _ } ], _ ->
           let s =
             G.DirectiveStmt

--- a/languages/ruby/generic/ruby_to_generic.ml
+++ b/languages/ruby/generic/ruby_to_generic.ml
@@ -141,7 +141,7 @@ let rec expr e =
       let st = G.Block (t1, list_stmts xs, t2) |> G.s in
       let def =
         {
-          G.fparams = fb params;
+          G.fparams = params;
           frettype = None;
           fbody = G.FBStmt st;
           fkind = (G.LambdaKind, t1);
@@ -158,7 +158,7 @@ let rec expr e =
       let st = G.Block (tok, list_stmts xs, tok) |> G.s in
       let def =
         {
-          G.fparams = fb params;
+          G.fparams = params;
           frettype = None;
           fbody = G.FBStmt st;
           fkind = (G.LambdaKind, tok);
@@ -643,7 +643,7 @@ and definition def =
       let body = body_exn body in
       let funcdef =
         {
-          G.fparams = fb params;
+          G.fparams = params;
           frettype = None;
           fbody = G.FBStmt body;
           fkind = (G.Method, t);
@@ -689,7 +689,7 @@ and definition def =
               (* TODO: this is done by special include/require builtins *)
               cimplements = [];
               cmixins = [];
-              cparams = fb [];
+              cparams = [];
               cbody = fb [ G.F body ];
             }
           in

--- a/languages/rust/generic/Parse_rust_tree_sitter.ml
+++ b/languages/rust/generic/Parse_rust_tree_sitter.ml
@@ -260,8 +260,10 @@ let map_string_literal (env : env) ((v1, v2, v3) : CST.string_literal) :
         (* string_content *))
       v2
   in
-  let rdquote = token env v3 in
-  G.String (G.string_ (ldquote, strs, rdquote))
+  let rdquote = token env v3 (* "\"" *) in
+  let str = strs |> Common.map fst |> String.concat "" in
+  let toks = (strs |> Common.map snd) @ [ rdquote ] in
+  G.String (str, PI.combine_infos ldquote toks)
 
 let integer_literal env tok =
   let s, t = str env tok in
@@ -274,7 +276,7 @@ let float_literal env tok =
 let map_literal (env : env) (x : CST.literal) : G.literal =
   match x with
   | `Str_lit x -> map_string_literal env x
-  | `Raw_str_lit tok -> G.String (fb (str env tok)) (* raw_string_literal *)
+  | `Raw_str_lit tok -> G.String (str env tok) (* raw_string_literal *)
   | `Char_lit tok -> G.Char (str env tok) (* char_literal *)
   | `Bool_lit x -> map_boolean_literal env x
   | `Int_lit tok -> G.Int (integer_literal env tok) (* integer_literal *)
@@ -286,7 +288,7 @@ let map_literal_pattern (env : env) (x : CST.literal_pattern) : G.pattern =
   match x with
   | `Str_lit x -> G.PatLiteral (map_string_literal env x)
   | `Raw_str_lit tok ->
-      G.PatLiteral (G.String (fb (str env tok))) (* raw_string_literal *)
+      G.PatLiteral (G.String (str env tok)) (* raw_string_literal *)
   | `Char_lit tok -> G.PatLiteral (G.Char (str env tok)) (* char_literal *)
   | `Bool_lit x -> G.PatLiteral (map_boolean_literal env x)
   | `Int_lit tok ->

--- a/languages/rust/generic/Parse_rust_tree_sitter.ml
+++ b/languages/rust/generic/Parse_rust_tree_sitter.ml
@@ -57,7 +57,7 @@ let deoptionalize l =
 type function_declaration_rs = {
   name : G.entity_name;
   type_params : G.type_parameter list;
-  params : G.parameters;
+  params : G.parameter list;
   retval : G.type_ option;
 }
 
@@ -1005,8 +1005,8 @@ and map_bracketed_type (env : env) ((v1, v2, v3) : CST.bracketed_type) =
   (lthan, ty, gthan)
 
 and map_closure_parameters (env : env) ((v1, v2, v3) : CST.closure_parameters) :
-    G.parameters =
-  let lpipe = token env v1 (* "|" *) in
+    G.parameter list =
+  let _lpipe = token env v1 (* "|" *) in
   let params =
     match v2 with
     | Some (v1, v2) ->
@@ -1022,8 +1022,8 @@ and map_closure_parameters (env : env) ((v1, v2, v3) : CST.closure_parameters) :
         param_first :: param_rest
     | None -> []
   in
-  let rpipe = token env v3 (* "|" *) in
-  (lpipe, params, rpipe)
+  let _rpipe = token env v3 (* "|" *) in
+  params
 
 and map_const_block (env : env) ((v1, v2) : CST.const_block) : G.expr =
   let tconst = token env v1 (* "const" *) in
@@ -1843,7 +1843,7 @@ and map_function_type (env : env) ((v1, v2, v3, v4) : CST.function_type) :
         let _fnTODO = token env v2 (* "fn" *) in
         (None, modifiers)
   in
-  let _, params, _ = map_parameters env v3 in
+  let params = map_parameters env v3 in
   let ret_type =
     match v4 with
     | Some (v1, v2) ->
@@ -2243,8 +2243,8 @@ and map_parameter (env : env) ((v1, v2, v3, v4) : CST.parameter) : G.parameter =
       G.Param param
 
 and map_parameters (env : env) ((v1, v2, v3, v4) : CST.parameters) :
-    G.parameters =
-  let lparen = token env v1 (* "(" *) in
+    G.parameter list =
+  let _lparen = token env v1 (* "(" *) in
   let params =
     match v2 with
     | Some (v1, v2, v3) ->
@@ -2266,8 +2266,8 @@ and map_parameters (env : env) ((v1, v2, v3, v4) : CST.parameters) :
     | None -> []
   in
   let _comma = Option.map (fun tok -> token env tok) v3 in
-  let rparen = token env v4 (* ")" *) in
-  (lparen, params, rparen)
+  let _rparen = token env v4 (* ")" *) in
+  params
 
 and map_path_name (env : env) (x : CST.path) : G.name =
   match x with
@@ -3106,7 +3106,7 @@ and map_declaration_statement_bis (env : env) (*_outer_attrs _visibility*) x :
           G.cextends = [];
           G.cimplements = [];
           G.cmixins = [];
-          G.cparams = fb [];
+          G.cparams = [];
           G.cbody = fields;
         }
       in
@@ -3282,7 +3282,7 @@ and map_declaration_statement_bis (env : env) (*_outer_attrs _visibility*) x :
           G.cextends = [];
           G.cimplements = [];
           G.cmixins = [];
-          G.cparams = fb [];
+          G.cparams = [];
           G.cbody = (l, fields |> Common.map (fun x -> G.F x), r);
         }
       in

--- a/languages/scala/ast/AST_scala.ml
+++ b/languages/scala/ast/AST_scala.ml
@@ -137,13 +137,14 @@ type literal =
   | Int of int option wrap
   | Float of float option wrap
   | Char of string wrap
-  | String of string wrap (* TODO: bracket *)
+  | String of string wrap
   | Bool of bool wrap
   | Symbol of tok (* "'" *) * string wrap
   (* scala3: not in simple_literal *)
   | Null of tok
   (* this forces to define type_ and pattern and expr as mutually recursive*)
-  | Interpolated of ident (* e.g., s"..." *) * encaps list * tok (* " or """ *)
+  | Interpolated of
+      ident (* e.g., s"..." *) * encaps list * tok (* '"' or '""""' *)
 
 and encaps =
   | EncapsStr of string wrap

--- a/languages/scala/generic/scala_to_generic.ml
+++ b/languages/scala/generic/scala_to_generic.ml
@@ -54,7 +54,7 @@ let cases_to_lambda lb cases : G.function_definition =
   {
     fkind = (G.BlockCases, lb);
     frettype = None;
-    fparams = fb [ param ];
+    fparams = [ param ];
     fbody = G.FBStmt body;
   }
 
@@ -430,7 +430,7 @@ and v_expr e : G.expr =
       match v2 with
       | {
        cextends = [ (tp, args) ];
-       cparams = _, [], _;
+       cparams = [];
        cmixins = [];
        cbody = _, [], _;
        cimplements = [];
@@ -810,7 +810,7 @@ and v_function_definition
   let fbody = v_option v_fbody vfbody in
   {
     fkind = kind;
-    fparams = fb (List.flatten params);
+    fparams = List.flatten params;
     (* TODO? *)
     frettype = tret;
     fbody =
@@ -882,7 +882,7 @@ and v_template_definition
     } : G.class_definition =
   let ckind = v_wrap v_template_kind v_ckind in
   (* TODO? flatten? *)
-  let cparams = fb (v_list v_bindings v_cparams |> List.flatten) in
+  let cparams = v_list v_bindings v_cparams |> List.flatten in
   let cextends, cmixins = v_template_parents v_cparents in
   let body = v_option v_template_body v_cbody in
   let cbody =

--- a/languages/scala/generic/scala_to_generic.ml
+++ b/languages/scala/generic/scala_to_generic.ml
@@ -174,7 +174,7 @@ let rec v_literal = function
       Left (G.Char v1)
   | String v1 ->
       let v1 = v_wrap v_string v1 in
-      Left (G.String (fb v1))
+      Left (G.String v1)
   | Bool v1 ->
       let v1 = v_wrap v_bool v1 in
       Left (G.Bool v1)
@@ -201,7 +201,7 @@ let rec v_literal = function
 and v_encaps = function
   | EncapsStr v1 ->
       let v1 = v_wrap v_string v1 in
-      Left (G.String (fb v1))
+      Left (G.String v1)
   | EncapsDollarIdent v1 ->
       let v1 = v_ident v1 in
       let name = H.name_of_id v1 in

--- a/languages/solidity/generic/Parse_solidity_tree_sitter.ml
+++ b/languages/solidity/generic/Parse_solidity_tree_sitter.ml
@@ -1296,7 +1296,7 @@ and map_parameter (env : env) (x : CST.parameter) : parameter =
 
 and map_parameter_list (env : env) ((v1, v2, v3) : CST.parameter_list) :
     parameters =
-  let lp = (* "(" *) token env v1 in
+  let _lp = (* "(" *) token env v1 in
   let params =
     match v2 with
     | Some (v1, v2, v3) ->
@@ -1313,8 +1313,8 @@ and map_parameter_list (env : env) ((v1, v2, v3) : CST.parameter_list) :
         v1 :: v2
     | None -> []
   in
-  let rp = (* ")" *) token env v3 in
-  (lp, params, rp)
+  let _rp = (* ")" *) token env v3 in
+  params
 
 and map_parenthesized_expression (env : env)
     ((v1, v2, v3) : CST.parenthesized_expression) : expr =
@@ -1477,7 +1477,7 @@ and map_type_name (env : env) (x : CST.type_name) : type_ =
       TyArray ((lb, eopt, rb), t) |> G.t
   | `Func_type (v1, v2, v3, v4) ->
       let tfunc = (* "function" *) token env v1 in
-      let _, params, _ = map_parameter_list env v2 in
+      let params = map_parameter_list env v2 in
       let _v3TODO =
         Common.map
           (fun x ->
@@ -1642,7 +1642,7 @@ and map_yul_statement (env : env) (x : CST.yul_statement) : stmt =
       let def =
         {
           fkind = (Function, tfunc);
-          fparams = fb params;
+          fparams = params;
           frettype = tret;
           fbody = FBStmt body;
         }
@@ -1800,7 +1800,7 @@ let map_struct_declaration (env : env)
       cextends = [];
       cimplements = [];
       cmixins = [];
-      cparams = fb [];
+      cparams = [];
       cbody = (lb, flds, rb);
     }
   in
@@ -1964,7 +1964,7 @@ and map_catch_clause (env : env) ((v1, v2, v3) : CST.catch_clause) : catch =
               (* pattern [a-zA-Z$_][a-zA-Z0-9$_]* *) [ I (str env tok) ]
           | None -> []
         in
-        let _l, params, _r = map_parameter_list env v2 in
+        let params = map_parameter_list env v2 in
         let anys = idopt @ (params |> Common.map (fun p -> Pa p)) in
         OtherCatch (("CatchParams", tcatch), anys)
     | None -> OtherCatch (("CatchEmpty", tcatch), [])
@@ -2037,7 +2037,7 @@ and map_statement (env : env) (x : CST.statement) : stmt =
         | Some x ->
             let _treturn, params = map_return_type_definition env x in
             params
-        | None -> fb []
+        | None -> []
       in
       let st = map_block_statement env v4 in
       let fun_ =
@@ -2251,7 +2251,7 @@ let map_modifier_definition (env : env)
   let params =
     match v3 with
     | Some x -> map_parameter_list env x
-    | None -> fb []
+    | None -> []
   in
   let attrs =
     Common.map
@@ -2369,7 +2369,7 @@ let map_declaration (env : env) (x : CST.declaration) : definition =
           cextends = parents;
           cmixins = [];
           cimplements = [];
-          cparams = fb [];
+          cparams = [];
           cbody = (l, flds, r);
         }
       in
@@ -2393,7 +2393,7 @@ let map_declaration (env : env) (x : CST.declaration) : definition =
           cextends = parents;
           cmixins = [];
           cimplements = [];
-          cparams = fb [];
+          cparams = [];
           cbody = (l, flds, r);
         }
       in

--- a/languages/terraform/ast/AST_terraform.ml
+++ b/languages/terraform/ast/AST_terraform.ml
@@ -107,11 +107,7 @@ and block_type =
   | Terraform
   | OtherBlockType of string
 
-and block_label =
-  | LblStr of string wrap
-  (* TODO bracket? *)
-  | LblId of ident
-
+and block_label = LblStr of string wrap | LblId of ident
 and block_body = block_body_element list bracket
 
 and block_body_element =

--- a/languages/terraform/generic/Terraform_to_generic.ml
+++ b/languages/terraform/generic/Terraform_to_generic.ml
@@ -25,8 +25,6 @@ module H2 = AST_generic_helpers
 (* Helpers *)
 (*****************************************************************************)
 
-let fb = Parse_info.unsafe_fake_bracket
-
 let map_argument (arg : argument) : G.definition =
   let id, _teq, e = arg in
   let ent = G.basic_entity id in
@@ -55,7 +53,7 @@ and map_block ({ btype = _kind, tk; blabels; bbody = lb, body, rb } : block) :
   let labels_id =
     blabels
     |> Common.map (function
-         | LblStr x -> G.L (G.String (fb x)) |> G.e
+         | LblStr x -> G.L (G.String x) |> G.e
          | LblId id ->
              let n = H2.name_of_id id in
              G.N n |> G.e)

--- a/languages/terraform/tree-sitter/Parse_terraform_tree_sitter.ml
+++ b/languages/terraform/tree-sitter/Parse_terraform_tree_sitter.ml
@@ -137,12 +137,13 @@ let map_identifier (env : env) (x : CST.identifier) : ident =
       (* tok_choice_pat_3e8fcfc_rep_choice_pat_71519dc *) str env tok
   | `Semg_meta tok -> (* semgrep_metavariable *) str env tok
 
-let map_string_lit (env : env) ((v1, v2, v3) : CST.string_lit) :
-    string wrap bracket =
-  let l = (* quoted_template_start *) token env v1 in
-  let xs = map_template_literal env v2 |> Option.to_list in
-  let r = (* quoted_template_end *) token env v3 in
-  G.string_ (l, xs, r)
+let map_string_lit (env : env) ((v1, v2, v3) : CST.string_lit) : string wrap =
+  let v1 = (* quoted_template_start *) token env v1 in
+  let v2 = map_template_literal env v2 in
+  let v3 = (* quoted_template_end *) token env v3 in
+  match v2 with
+  | Some (s, t) -> (s, PI.combine_infos v1 [ t; v3 ])
+  | None -> ("", PI.combine_infos v1 [ v3 ])
 
 let map_variable_expr (env : env) (x : CST.variable_expr) = map_identifier env x
 
@@ -572,7 +573,7 @@ let rec map_block (env : env) ((v1, v2, v3, v4, v5) : CST.block) : block =
       (fun x ->
         match x with
         | `Str_lit x ->
-            let _, x, _ = map_string_lit env x in
+            let x = map_string_lit env x in
             LblStr x
         | `Id tok ->
             let id = (* identifier *) map_identifier env tok in

--- a/languages/tree-sitter-to-generic/Parse_hack_tree_sitter.ml
+++ b/languages/tree-sitter-to-generic/Parse_hack_tree_sitter.ml
@@ -38,7 +38,6 @@ let logger = Logging.get_logger [ __MODULE__ ]
 let token = H.token
 let str = H.str
 let fk tok = Parse_info.fake_info tok ""
-let fb = Parse_info.unsafe_fake_bracket
 
 (* Remove this function when everything is done *)
 let todo (_env : env) _ = failwith "not implemented"
@@ -1118,7 +1117,7 @@ and declaration (env : env) (x : CST.declaration) =
           cextends = v8;
           cimplements = v9;
           cmixins = v10;
-          cparams = fb [];
+          cparams = [];
           cbody = v11;
         }
       in
@@ -1154,7 +1153,7 @@ and declaration (env : env) (x : CST.declaration) =
           cextends = v5;
           cimplements = [];
           cmixins = v6;
-          cparams = fb [];
+          cparams = [];
           cbody = v7;
         }
       in
@@ -1190,7 +1189,7 @@ and declaration (env : env) (x : CST.declaration) =
           cextends = [];
           cimplements = v5;
           cmixins = v6;
-          cparams = fb [];
+          cparams = [];
           cbody = v7;
         }
       in
@@ -1555,11 +1554,11 @@ and expression (env : env) (x : CST.expression) : G.expr =
                 (* "async" *) [ G.KeywordAttr (G.Async, token env tok) ]
             | None -> []
           in
-          let fparams, return_type =
+          let v3, return_type =
             match v3 with
             | `Single_param_params tok ->
                 (* variable *)
-                (fb [ G.Param (G.param_of_id (str env tok)) ], None)
+                ([ G.Param (G.param_of_id (str env tok)) ], None)
             | `Params_opt_COLON_choice_type_spec (v1, v2) ->
                 let v1 = parameters env v1 in
                 let v2 =
@@ -1582,7 +1581,7 @@ and expression (env : env) (x : CST.expression) : G.expr =
             {
               fkind = (G.LambdaKind, v4);
               (* Q: Is the arrow the token here? Arrow vs LambdaKind? *)
-              fparams;
+              fparams = v3;
               frettype = return_type;
               fbody = v5;
             }
@@ -1860,8 +1859,8 @@ and parameter (env : env) (x : CST.parameter) : G.parameter =
       | None -> G.Param param)
   | `Ellips tok -> (* "..." *) G.ParamEllipsis (token env tok)
 
-and parameters (env : env) ((v1, v2, v3) : CST.parameters) : G.parameters =
-  let lp = (* "(" *) token env v1 in
+and parameters (env : env) ((v1, v2, v3) : CST.parameters) =
+  let _v1 = (* "(" *) token env v1 in
   let v2 =
     match v2 with
     | Some x -> (
@@ -1898,8 +1897,8 @@ and parameters (env : env) ((v1, v2, v3) : CST.parameters) : G.parameters =
             v1 :: v2)
     | None -> []
   in
-  let rp = (* ")" *) token env v3 in
-  (lp, v2, rp)
+  let _v3 = (* ")" *) token env v3 in
+  v2
 
 and parenthesized_expression (env : env)
     ((v1, v2, v3) : CST.parenthesized_expression) =

--- a/languages/tree-sitter-to-generic/Parse_hack_tree_sitter.ml
+++ b/languages/tree-sitter-to-generic/Parse_hack_tree_sitter.ml
@@ -68,7 +68,7 @@ let stringify_without_quotes str =
         logger#warning "weird string literal: %s" s;
         s
   in
-  G.String (fb (s, t))
+  G.String (s, t)
 
 (*****************************************************************************)
 (* Boilerplate converter *)
@@ -1365,8 +1365,7 @@ and expression (env : env) (x : CST.expression) : G.expr =
                 G.Arg
                   (match x with
                   | `Here_body tok ->
-                      (* heredoc_body *)
-                      G.L (G.String (fb (str env tok))) |> G.e
+                      (* heredoc_body *) G.L (G.String (str env tok)) |> G.e
                   | `Var tok ->
                       (* variable *)
                       G.N (Id (str env tok, G.empty_id_info ())) |> G.e

--- a/libs/ast_generic/AST_generic.ml
+++ b/libs/ast_generic/AST_generic.ml
@@ -1536,7 +1536,8 @@ and function_kind =
   (* for Scala *)
   | BlockCases
 
-and parameters = parameter list bracket
+(* TODO bracket *)
+and parameters = parameter list
 
 (* newvar: *)
 and parameter =

--- a/libs/ast_generic/AST_generic_to_v1.ml
+++ b/libs/ast_generic/AST_generic_to_v1.ml
@@ -1117,7 +1117,7 @@ and map_function_body = function
       `FBDecl v1
   | FBNothing -> `FBNothing
 
-and map_parameters (_, v, _) = map_of_list map_parameter v
+and map_parameters v = map_of_list map_parameter v
 
 and map_parameter = function
   | Param v1 ->

--- a/libs/ast_generic/AST_generic_to_v1.ml
+++ b/libs/ast_generic/AST_generic_to_v1.ml
@@ -251,11 +251,10 @@ and map_expr x : B.expr =
          like /hello #{name}/ *)
       `L
         (match v1 with
-        | { e = G.L (G.String (l, x, r)); _ } ->
-            let l = map_tok l in
-            let r = map_tok r in
+        | { e = G.L (G.String x); _ } ->
+            let fk' = map_tok fk in
             let static_regexp = map_wrap map_of_string x in
-            `Regexp ((l, static_regexp, r), None)
+            `Regexp ((fk', static_regexp, fk'), None)
         | _dropped_template ->
             let fk' = map_tok fk in
             `Regexp ((fk', ("", map_tok l), fk'), None))
@@ -413,7 +412,7 @@ and map_literal = function
       let v1 = map_wrap map_of_string v1 in
       `Char v1
   | String v1 ->
-      let _, v1, _ = map_bracket (map_wrap map_of_string) v1 in
+      let v1 = map_wrap map_of_string v1 in
       `String v1
   | Regexp (v1, v2) ->
       let v1 = map_bracket (map_wrap map_of_string) v1 in
@@ -1346,7 +1345,7 @@ and map_any x : B.any =
       let v1 = map_ident v1 in
       `I v1
   | Str v1 ->
-      let _, v1, _ = map_bracket (map_wrap map_of_string) v1 in
+      let v1 = map_wrap map_of_string v1 in
       `Str v1
   | Tk v1 ->
       let v1 = map_tok v1 in

--- a/libs/ast_generic/Map_AST.ml
+++ b/libs/ast_generic/Map_AST.ml
@@ -977,7 +977,7 @@ let (mk_visitor : visitor_in -> visitor_out) =
     let v_frettype = map_of_option map_type_ v_frettype in
     let v_fparams = map_parameters v_fparams in
     { fkind; fparams = v_fparams; frettype = v_frettype; fbody = v_fbody }
-  and map_parameters v = map_bracket (map_of_list map_parameter) v
+  and map_parameters v = map_of_list map_parameter v
   and map_parameter = function
     | Param v1 ->
         let v1 = map_parameter_classic v1 in

--- a/libs/ast_generic/Map_AST.ml
+++ b/libs/ast_generic/Map_AST.ml
@@ -418,7 +418,7 @@ let (mk_visitor : visitor_in -> visitor_out) =
           let v1 = map_wrap map_of_string v1 in
           Char v1
       | String v1 ->
-          let v1 = map_bracket (map_wrap map_of_string) v1 in
+          let v1 = map_wrap map_of_string v1 in
           String v1
       | Regexp (v1, v2) ->
           let v1 = map_bracket (map_wrap map_of_string) v1 in
@@ -1204,7 +1204,7 @@ let (mk_visitor : visitor_in -> visitor_out) =
         let v1 = map_of_list map_any v1 in
         Anys v1
     | Str v1 ->
-        let v1 = map_bracket (map_wrap map_of_string) v1 in
+        let v1 = map_wrap map_of_string v1 in
         Str v1
     | Args v1 ->
         let v1 = map_of_list map_argument v1 in

--- a/libs/ast_generic/Meta_AST.ml
+++ b/libs/ast_generic/Meta_AST.ml
@@ -1152,7 +1152,7 @@ and vof_function_definition
   let bnds = bnd :: bnds in
   OCaml.VDict bnds
 
-and vof_parameters v = vof_bracket (OCaml.vof_list vof_parameter) v
+and vof_parameters v = OCaml.vof_list vof_parameter v
 
 and vof_parameter = function
   | Param v1 ->

--- a/libs/ast_generic/Meta_AST.ml
+++ b/libs/ast_generic/Meta_AST.ml
@@ -365,7 +365,7 @@ and vof_literal = function
       let v1 = vof_wrap OCaml.vof_string v1 in
       OCaml.VSum ("Char", [ v1 ])
   | String v1 ->
-      let v1 = vof_bracket (vof_wrap OCaml.vof_string) v1 in
+      let v1 = vof_wrap OCaml.vof_string v1 in
       OCaml.VSum ("String", [ v1 ])
   | Regexp (v1, v2) ->
       let v1 = vof_bracket (vof_wrap OCaml.vof_string) v1 in
@@ -1422,7 +1422,7 @@ and vof_any = function
       let v1 = vof_case v1 in
       OCaml.VSum ("Cs", [ v1 ])
   | Str v1 ->
-      let v1 = vof_bracket (vof_wrap OCaml.vof_string) v1 in
+      let v1 = vof_wrap OCaml.vof_string v1 in
       OCaml.VSum ("Str", [ v1 ])
   | Args v1 ->
       let v1 = OCaml.vof_list vof_argument v1 in

--- a/libs/ast_generic/Visitor_AST.ml
+++ b/libs/ast_generic/Visitor_AST.ml
@@ -1109,7 +1109,7 @@ let (mk_visitor :
       ()
     in
     vin.kfunction_definition (k, all_functions) x
-  and v_parameters v = v_bracket (v_list v_parameter) v
+  and v_parameters v = v_list v_parameter v
   and v_parameter x =
     let k x =
       match x with

--- a/libs/ast_generic/Visitor_AST.ml
+++ b/libs/ast_generic/Visitor_AST.ml
@@ -298,9 +298,7 @@ let (mk_visitor :
               |> List.iter (fun e ->
                      match e.e with
                      | Container
-                         ( Tuple,
-                           (tok, [ { e = L (String (_, id, _)); _ }; e ], _) )
-                       ->
+                         (Tuple, (tok, [ { e = L (String id); _ }; e ], _)) ->
                          let t = PI.fake_info tok ":" in
                          v_partial ~recurse:false
                            (PartialSingleField (id, t, e))
@@ -463,7 +461,7 @@ let (mk_visitor :
           let v1 = v_wrap v_string v1 in
           ()
       | String v1 ->
-          let v1 = v_bracket (v_wrap v_string) v1 in
+          let v1 = v_wrap v_string v1 in
           ()
       | Regexp (v1, v2) ->
           let v1 = v_bracket (v_wrap v_string) v1 in
@@ -1331,7 +1329,7 @@ let (mk_visitor :
     | Tp v1 -> v_type_parameter v1
     | Ta v1 -> v_type_argument v1
     | Cs v1 -> v_case v1
-    | Str v1 -> v_bracket (v_wrap v_string) v1
+    | Str v1 -> v_wrap v_string v1
     | Args v1 -> v_list v_argument v1
     | Params v1 -> v_list v_parameter v1
     | Flds v1 -> v_fields v1
@@ -1452,7 +1450,6 @@ let ii_of_any any = extract_info_visitor (fun visitor -> visitor any)
 
 let first_info_of_any any =
   let xs = ii_of_any any in
-  let xs = List.filter Parse_info.is_origintok xs in
   let min, _max = Parse_info.min_max_ii_by_pos xs in
   min
 

--- a/libs/lib_parsing/Parse_info.ml
+++ b/libs/lib_parsing/Parse_info.ml
@@ -160,11 +160,9 @@ let is_fake tok =
   | _ -> false
 
 (* TODO: the use of unsafe_fake_xxx is usually because the token
- * does not exist in the original file. It's better then to generate
+ * does not exist in the original file. It's better than to generate
  * an empty string in the FakeTokStr so that pretty printer will
- * not generate those brackets or semicolons. Moreover
- * we use unsafe_fake_bracket not only for () but also for [], {}, and
- * now even for "", so better again to put an empty string in it.
+ * not generate those brackets or semicolons.
  *)
 
 (* used to be in AST_generic.ml *)
@@ -393,9 +391,6 @@ let compare_pos ii1 ii2 =
       | 1 -> 1
       | _ -> raise Impossible)
 
-(* TODO: we should filter with is_origintok() first, to avoid having
- * the caller to do it.
- *)
 let min_max_ii_by_pos xs =
   match xs with
   | [] ->

--- a/libs/lib_parsing/Parse_info.ml
+++ b/libs/lib_parsing/Parse_info.ml
@@ -159,12 +159,6 @@ let is_fake tok =
   | FakeTokStr _ -> true
   | _ -> false
 
-(* TODO: the use of unsafe_fake_xxx is usually because the token
- * does not exist in the original file. It's better than to generate
- * an empty string in the FakeTokStr so that pretty printer will
- * not generate those brackets or semicolons.
- *)
-
 (* used to be in AST_generic.ml *)
 let unsafe_fake_bracket x = (unsafe_fake_info "(", x, unsafe_fake_info ")")
 

--- a/src/analyzing/AST_to_IL.ml
+++ b/src/analyzing/AST_to_IL.ml
@@ -1035,8 +1035,8 @@ and for_var_or_expr_list env xs =
 (*****************************************************************************)
 (* Parameters *)
 (*****************************************************************************)
-and parameters _env params : name list =
-  params |> Parse_info.unbracket
+and parameters _env params =
+  params
   |> List.filter_map (function
        | G.Param { pname = Some i; pinfo; _ } -> Some (var_of_id_info i pinfo)
        | ___else___ -> None (* TODO *))

--- a/src/analyzing/Constant_propagation.ml
+++ b/src/analyzing/Constant_propagation.ml
@@ -90,7 +90,6 @@ type var_stats = (var, lr_stats) Hashtbl.t
 (* Helpers *)
 (*****************************************************************************)
 
-let fb = Parse_info.unsafe_fake_bracket
 let ( let* ) o f = Option.bind o f
 let ( let/ ) o f = Option.iter f o
 
@@ -220,8 +219,8 @@ let binop_bool_cst op b1 b2 =
 
 let concat_string_cst s1 s2 =
   match (s1, s2) with
-  | Some (Lit (String (l, (s1, t1), r))), Some (Lit (String (_, (s2, _), _))) ->
-      Some (Lit (String (l, (s1 ^ s2, t1), r)))
+  | Some (Lit (String (s1, t1))), Some (Lit (String (s2, _))) ->
+      Some (Lit (String (s1 ^ s2, t1)))
   | Some (Lit (String _)), Some (Cst Cstr)
   | Some (Cst Cstr), Some (Lit (String _))
   | Some (Cst Cstr), Some (Cst Cstr) ->
@@ -260,15 +259,11 @@ let rec eval env x : svalue option =
       Some (Dataflow_svalue.union v2 v3)
   | Call
       ( { e = IdSpecial (EncodedString str_kind, _); _ },
-        (_, [ Arg { e = L (String (_, (str, str_tok), _) as str_lit); _ } ], _)
-      ) -> (
+        (_, [ Arg { e = L (String (str, str_tok) as str_lit); _ } ], _) ) -> (
       match str_kind with
       | "r" ->
           let str = String.escaped str in
-          (* TODO? reuse l/r from the Call instead of using fb below? or
-           * from the String above?
-           *)
-          Some (Lit (String (fb (str, str_tok))))
+          Some (Lit (String (str, str_tok)))
       | _else ->
           (* THINK: is this good enough for "b" and "u"? *)
           Some (Lit str_lit))
@@ -470,7 +465,7 @@ let (terraform_stmt_to_vardefs : item -> (ident * expr) list) =
               ( { e = N (Id (("variable", _), _)); _ },
                 ( _,
                   [
-                    Arg { e = L (String (_, id, _)); _ };
+                    Arg { e = L (String id); _ };
                     Arg { e = Record (_, xs, _); _ };
                   ],
                   _ ) );

--- a/src/analyzing/Dataflow_svalue.ml
+++ b/src/analyzing/Dataflow_svalue.ml
@@ -54,7 +54,6 @@ let warning _tok s =
 (*****************************************************************************)
 
 let str_of_name name = spf "%s:%s" (fst name.ident) (G.SId.show name.sid)
-let fb = Parse_info.unsafe_fake_bracket
 
 (*****************************************************************************)
 (* Constness *)
@@ -200,7 +199,7 @@ let int_of_literal = function
   | G.Int (x, _) -> x
   | ___else___ -> None
 
-let literal_of_string ?tok s : G.literal =
+let literal_of_string ?tok s =
   let tok =
     match tok with
     | None -> Parse_info.unsafe_fake_info s
@@ -213,7 +212,7 @@ let literal_of_string ?tok s : G.literal =
          * an $MVAR always has a source location. *)
         tok
   in
-  G.String (fb (s, tok))
+  G.String (s, tok)
 
 let eval_unop_bool op b =
   match op with
@@ -327,8 +326,7 @@ and eval_op env wop args =
       eval_binop_bool op b1 b2
   | op, [ G.Lit (G.Int _ as li1); G.Lit (G.Int _ as li2) ] ->
       eval_binop_int tok op (int_of_literal li1) (int_of_literal li2)
-  | op, [ G.Lit (G.String (_, (s1, _), _)); G.Lit (G.String (_, (s2, _), _)) ]
-    ->
+  | op, [ G.Lit (G.String (s1, _)); G.Lit (G.String (s2, _)) ] ->
       eval_binop_string ~tok op s1 s2
   | _op, [ (G.Cst _ as c1) ] -> c1
   | _op, [ G.Cst t1; G.Cst t2 ] -> G.Cst (union_ctype t1 t2)
@@ -341,14 +339,12 @@ and eval_op env wop args =
 and eval_concat env args =
   match Common.map (eval env) args with
   | [] -> G.Lit (literal_of_string "")
-  | G.Lit (G.String (_, (r, tok), _)) :: args' ->
+  | G.Lit (G.String (r, tok)) :: args' ->
       List.fold_left
         (fun res e ->
           match (res, e) with
-          | G.Lit (G.String (_l, (x, tok), _r)), G.Lit (G.String (_, (s, _), _))
-            ->
-              (* should reuse l/r? *)
-              G.Lit (literal_of_string ~tok (x ^ s))
+          | G.Lit (G.String (r, tok)), G.Lit (G.String (s, _)) ->
+              G.Lit (literal_of_string ~tok (r ^ s))
           | (G.Lit _ | G.Cst _), G.Cst G.Cstr -> G.Cst G.Cstr
           | _____else_____ -> G.NotCst)
         (G.Lit (literal_of_string ~tok r))

--- a/src/core/Metavariable.ml
+++ b/src/core/Metavariable.ml
@@ -106,8 +106,7 @@ let mvalue_to_any = function
   | Xmls x -> G.Xmls x
   | T x -> G.T x
   | P x -> G.P x
-  | Text (s, info, _) ->
-      G.E (G.L (G.String (Parse_info.unsafe_fake_bracket (s, info))) |> G.e)
+  | Text (s, info, _) -> G.E (G.L (G.String (s, info)) |> G.e)
 
 (* coupling: this function should be an inverse to the function above! *)
 let mvalue_of_any = function
@@ -115,8 +114,7 @@ let mvalue_of_any = function
   | E { e = RawExpr x; _ }
   | Raw x ->
       Some (Raw x)
-  | E { e = L (String (_, (s, info), _)); _ } ->
-      Some (Text (s, info, G.fake ""))
+  | E { e = L (String (s, info)); _ } -> Some (Text (s, info, G.fake ""))
   | E e -> Some (E e)
   | S s -> Some (S s)
   | Name x -> Some (N x)

--- a/src/engine/Eval_generic.ml
+++ b/src/engine/Eval_generic.ml
@@ -133,7 +133,7 @@ let print_result xopt =
 let value_of_lit ~code x =
   match x with
   | G.Bool (b, _t) -> Bool b
-  | G.String (_, (s, _t), _) -> String s
+  | G.String (s, _t) -> String s
   (* big integers or floats can't be evaluated (Int (None, ...)) *)
   | G.Int (Some i, _t) -> Int i
   | G.Float (Some f, _t) -> Float f
@@ -212,8 +212,7 @@ let rec eval env code =
                 FN (Id (("match", _), _)) );
           _;
         },
-        (_, [ G.Arg { e = G.L (G.String (_, (re, _), _)); _ }; G.Arg e2 ], _) )
-    -> (
+        (_, [ G.Arg { e = G.L (G.String (re, _)); _ }; G.Arg e2 ], _) ) -> (
       (* alt: take the text range of the metavariable in the original file,
        * and enforce e1 can only be an Id metavariable.
        * alt: let s = value_to_string v in

--- a/src/engine/Match_search_mode.ml
+++ b/src/engine/Match_search_mode.ml
@@ -145,7 +145,6 @@ let error_with_rule_id rule_id (error : E.error) =
   | _ -> { error with rule_id = Some rule_id }
 
 let lazy_force x = Lazy.force x [@@profiling]
-let fb = Parse_info.unsafe_fake_bracket
 
 (*****************************************************************************)
 (* Adapters *)
@@ -555,7 +554,7 @@ let rec filter_ranges (env : env) (xs : (RM.t * MV.bindings list) list)
                 * but too many possible escaping problems, so easier to build
                 * an expression manually.
                 *)
-               let re_exp = G.L (G.String (fb (re_str, fk))) |> G.e in
+               let re_exp = G.L (G.String (re_str, fk)) |> G.e in
                let mvar_exp = G.N (G.Id ((mvar, fk), fki)) |> G.e in
                let call_re_match re_exp str_exp =
                  G.Call

--- a/src/engine/Match_tainting_mode.ml
+++ b/src/engine/Match_tainting_mode.ml
@@ -550,8 +550,7 @@ let check_fundef lang options taint_config opt_ent fdef =
         | G.ParamEllipsis _
         | G.OtherParam (_, _) ->
             env)
-      Lval_env.empty
-      (Parse_info.unbracket fdef.G.fparams)
+      Lval_env.empty fdef.G.fparams
   in
   let _, xs = AST_to_IL.function_definition lang fdef in
   let flow = CFG_build.cfg_of_stmts xs in

--- a/src/engine/Metavariable_analysis.ml
+++ b/src/engine/Metavariable_analysis.ml
@@ -46,7 +46,7 @@ let analyze_string_metavar env bindings mvar (analyzer : string -> bool) =
   analyze_metavar env bindings mvar (function
     (* We don't use Eval_generic.text_of_binding on string literals because
        it returns the quoted string but we want it unquoted. *)
-    | E { G.e = G.L (G.String (_, (escaped, _tok), _)); _ } ->
+    | E { G.e = G.L (G.String (escaped, _tok)); _ } ->
         escaped |> String_literal.approximate_unescape |> analyzer
     | other_mval -> (
         match Eval_generic.text_of_binding mvar other_mval with

--- a/src/engine/Metavariable_pattern.ml
+++ b/src/engine/Metavariable_pattern.ml
@@ -228,7 +228,7 @@ let get_nested_metavar_pattern_bindings get_nested_formula_matches env r mvar
                 match (xlang, mval) with
                 | _, MV.Text (content, _tok, _)
                 | _, MV.Xmls [ XmlText (content, _tok) ]
-                | _, MV.E { e = G.L (G.String (_, (content, _tok), _)); _ } ->
+                | _, MV.E { e = G.L (G.String (content, _tok)); _ } ->
                     Some content
                 | Xlang.LGeneric, _else_ ->
                     Some (Range.content_at_range mval_file mval_range)

--- a/src/engine/Xpattern_matcher.ml
+++ b/src/engine/Xpattern_matcher.ml
@@ -116,6 +116,6 @@ let mval_of_string str t =
     match int_of_string_opt str with
     | Some i -> G.Int (Some i, t)
     (* TODO? could try float_of_string_opt? *)
-    | None -> G.String (PI.unsafe_fake_bracket (str, t))
+    | None -> G.String (str, t)
   in
   MV.E (G.L literal |> G.e)

--- a/src/experiments/synthesizing/Pattern_from_Code.ml
+++ b/src/experiments/synthesizing/Pattern_from_Code.ml
@@ -107,13 +107,11 @@ let get_id ?(with_type = false) env e =
               match !id_type with
               | None -> (notype_id, has_type)
               | Some t -> (default_tyvar (count_to_id env.count) t, true))
-          | L (String (l, (_, tag), r)) ->
-              (L (String (l, ("...", tag), r)) |> G.e, false)
+          | L (String (_, tag)) -> (L (String ("...", tag)) |> G.e, false)
           | _ -> (notype_id, has_type)
         else
           match e.e with
-          | L (String (l, (_, tag), r)) ->
-              (L (String (l, ("...", tag), r)) |> G.e, false)
+          | L (String (_, tag)) -> (L (String ("...", tag)) |> G.e, false)
           | _ -> (notype_id, has_type)
       in
       let env' =

--- a/src/experiments/synthesizing/Pattern_from_Targets.ml
+++ b/src/experiments/synthesizing/Pattern_from_Targets.ml
@@ -295,15 +295,15 @@ let pattern_from_call env (e', (lp, args, rp)) : pattern_instrs =
        [ (ANY (E e'), replace_name); (ANY (Args args), replace_args) ] ));
   ]
 
-let pattern_from_literal env lit : pattern_instrs =
-  match lit with
-  | String (l, (_, tok), r) ->
+let pattern_from_literal env l : pattern_instrs =
+  match l with
+  | String (_, tok) ->
       [
         ( env,
-          E (L (String (l, ("...", tok), r)) |> G.e),
-          [ (LN (E (L lit |> G.e)), fun f any -> f any) ] );
+          E (L (String ("...", tok)) |> G.e),
+          [ (LN (E (L l |> G.e)), fun f any -> f any) ] );
       ]
-  | _ -> [ (env, E (L lit |> G.e), [ (DONE, fun f e -> f e) ]) ]
+  | _ -> [ (env, E (L l |> G.e), [ (DONE, fun f e -> f e) ]) ]
 
 type side = Left | Right
 

--- a/src/fixing/Autofix_metavar_replacement.ml
+++ b/src/fixing/Autofix_metavar_replacement.ml
@@ -18,18 +18,11 @@ open Common
 module MV = Metavariable
 module G = AST_generic
 
-(*****************************************************************************)
-(* Prelude *)
-(*****************************************************************************)
+(******************************************************************************)
 (* Module responsible for traversing a fix pattern AST and replacing
  * metavariables within it with the AST nodes from the target file to which the
- * metavariables are bound.
- *)
-
-(*****************************************************************************)
-(* Helpers *)
-(*****************************************************************************)
-let fb = Parse_info.unsafe_fake_bracket
+ * metavariables are bound. *)
+(******************************************************************************)
 
 let replace metavar_tbl pattern_ast =
   (* Use a mapper to traverse the AST. For each metavar, look up what it is
@@ -113,15 +106,14 @@ let replace metavar_tbl pattern_ast =
           klit =
             (fun (k, _) lit ->
               match lit with
-              | String (_l, (str, _), _r) -> (
+              | String (str, _) -> (
                   (* TODO handle the case where the metavar appears within the
                    * string but is not the entire contents of the string *)
                   match Hashtbl.find_opt metavar_tbl str with
                   | Some (MV.Text (str, _info, originfo)) ->
                       (* Don't use `Metavariable.mvalue_to_any` here. It uses
                        * the modified token info, which drops the quotes. *)
-                      (* TODO? reuse l and r from String above? *)
-                      String (fb (str, originfo))
+                      String (str, originfo)
                   | _ -> k lit)
               | _ -> k lit);
           kname =
@@ -183,7 +175,7 @@ let find_remaining_metavars metavar_tbl ast =
           klit =
             (fun (k, _) lit ->
               (match lit with
-              | String (_, (str, _), _) ->
+              | String (str, _) ->
                   (* Textual autofix allows metavars to appear anywhere within
                    * string literals. This is useful when the pattern is
                    * something like `foo("$X")` and you'd like the fix to modify

--- a/src/matching/Generic_vs_generic.ml
+++ b/src/matching/Generic_vs_generic.ml
@@ -2003,7 +2003,7 @@ and m_type_ a b =
   | G.TyEllipsis _, _ -> return ()
   (* boilerplate *)
   | G.TyFun (a1, a2), B.TyFun (b1, b2) ->
-      m_parameter_list a1 b1 >>= fun () -> m_type_ a2 b2
+      m_parameters a1 b1 >>= fun () -> m_type_ a2 b2
   | G.TyArray (a1, a2), B.TyArray (b1, b2) ->
       m_bracket (m_option m_expr) a1 b1 >>= fun () -> m_type_ a2 b2
   | G.TyTuple a1, B.TyTuple b1 ->
@@ -2854,9 +2854,7 @@ and m_function_body a b =
   | G.FBNothing, _ ->
       fail ()
 
-and m_parameters a b = m_bracket m_parameter_list a b
-
-and m_parameter_list a b =
+and m_parameters a b =
   m_list_with_dots_and_metavar_ellipsis ~f:m_parameter
     ~is_dots:(function
       | G.ParamEllipsis _ -> true

--- a/src/matching/Generic_vs_generic.ml
+++ b/src/matching/Generic_vs_generic.ml
@@ -1183,16 +1183,16 @@ and m_literal a b =
            sides of the trees.
         *)
         match (a, b) with
-        | G.Int (a1, a2), B.String (_, (b1, b2), _) ->
+        | G.Int (a1, a2), B.String (b1, b2) ->
             let i = Option.map Int.to_string a1 in
             m_wrap_m_string_opt (i, a2) (Some b1, b2)
-        | G.String (_, (a1, a2), _), B.Int (b1, b2) ->
+        | G.String (a1, a2), B.Int (b1, b2) ->
             let i = Option.map Int.to_string b1 in
             m_wrap_m_string_opt (Some a1, a2) (i, b2)
-        | G.Bool (a1, a2), B.String (_, (b1, b2), _) ->
+        | G.Bool (a1, a2), B.String (b1, b2) ->
             let b = Bool.to_string a1 in
             m_wrap m_string (b, a2) (b1, b2)
-        | G.String (_, (a1, a2), _), B.Bool (b1, b2) ->
+        | G.String (a1, a2), B.Bool (b1, b2) ->
             let b = Bool.to_string b1 in
             m_wrap m_string (a1, a2) (b, b2)
         (* For the float case, we coerce from string to float, rather
@@ -1200,10 +1200,10 @@ and m_literal a b =
            While this is not strictly what Hcl does, this is because we
            may have inconsistency in how floats are represented, as strings.
         *)
-        | G.Float (a1, a2), B.String (_, (b1, b2), _) ->
+        | G.Float (a1, a2), B.String (b1, b2) ->
             let f = Float.of_string_opt b1 in
             m_wrap_m_float_opt (a1, a2) (f, b2)
-        | G.String (_, (a1, a2), _), B.Float (b1, b2) ->
+        | G.String (a1, a2), B.Float (b1, b2) ->
             let f = Float.of_string_opt a1 in
             m_wrap_m_float_opt (f, a2) (b1, b2)
         | __else__ -> m_literal_inner a b
@@ -1213,9 +1213,7 @@ and m_literal_inner a b =
   Trace_matching.(if on then print_literal_pair a b);
   match (a, b) with
   (* dots: metavar: '...' and metavars on string/regexps/atoms *)
-  | G.String (_, a, _), B.String (_, b, _) ->
-      (* iso? don't care about the kind of quotes used? *)
-      m_string_ellipsis_or_metavar_or_default a b
+  | G.String a, B.String b -> m_string_ellipsis_or_metavar_or_default a b
   | G.Atom (_, a), B.Atom (_, b) -> m_ellipsis_or_metavar_or_string a b
   | G.Regexp (a1, a2), B.Regexp (b1, b2) -> (
       let* () = m_bracket m_ellipsis_or_metavar_or_string a1 b1 in
@@ -1286,7 +1284,7 @@ and m_literal_svalue a b =
   | B.Lit b1 -> m_literal a b1
   | B.Cst B.Cstr -> (
       match a with
-      | G.String (_, ("...", _), _) -> return ()
+      | G.String ("...", _) -> return ()
       | ___else___ -> fail ())
   | B.Cst _
   | B.Sym _
@@ -1744,12 +1742,11 @@ and m_arguments_concat a b =
     | _ -> m_argument xa xb
   in
   let is_dots = function
-    | G.Arg { e = G.L (G.String (_, ("...", _), _)); _ } -> true
+    | G.Arg { e = G.L (G.String ("...", _)); _ } -> true
     | _else_ -> false
   in
   let is_metavar_ellipsis = function
-    | G.Arg { e = G.L (G.String (_, (s, tok), _)); _ }
-      when MV.is_metavar_ellipsis s ->
+    | G.Arg { e = G.L (G.String (s, tok)); _ } when MV.is_metavar_ellipsis s ->
         Some ((s, tok), fun xs -> MV.Args xs)
     | _else_ -> None
   in
@@ -3285,9 +3282,7 @@ and m_directive_vs_def a b =
                     e =
                       B.Call
                         ( { e = B.IdSpecial (B.Require, _); _ },
-                          ( _,
-                            [ B.Arg { e = B.L (B.String (_, fileb, _)); _ } ],
-                            _ ) );
+                          (_, [ B.Arg { e = B.L (B.String fileb); _ } ], _) );
                     _;
                   };
               vtype = _;
@@ -3313,10 +3308,7 @@ and m_directive_vs_def a b =
                               B.Call
                                 ( { e = B.IdSpecial (Require, _); _ },
                                   ( _,
-                                    [
-                                      B.Arg
-                                        { e = B.L (B.String (_, fileb, _)); _ };
-                                    ],
+                                    [ B.Arg { e = B.L (B.String fileb); _ } ],
                                     _ ) );
                             _;
                           } );
@@ -3469,8 +3461,7 @@ and m_partial a b =
 and m_any a b =
   match (a, b) with
   | G.Raw a1, B.Raw b1 -> m_raw_tree a1 b1
-  | G.Str (_, a1, _), B.Str (_, b1, _) ->
-      m_string_ellipsis_or_metavar_or_default a1 b1
+  | G.Str a1, B.Str b1 -> m_string_ellipsis_or_metavar_or_default a1 b1
   | G.Ss a1, B.Ss b1 -> m_stmts_deep ~inside:false ~less_is_ok:true a1 b1
   | G.Flds a1, B.Flds b1 -> m_fields a1 b1
   | G.E a1, B.E b1 -> m_expr a1 b1

--- a/src/naming/Naming_AST.ml
+++ b/src/naming/Naming_AST.ml
@@ -393,8 +393,8 @@ let resolved_name_kind env lang =
       | _ -> raise Impossible)
 
 (* !also set the id_info of the parameter as a side effect! *)
-let params_of_parameters env params : scope =
-  params |> Parse_info.unbracket
+let params_of_parameters env xs =
+  xs
   |> Common.map_filter (function
        | Param { pname = Some id; pinfo = id_info; ptype = typ; _ } ->
            let sid = SId.mk () in

--- a/src/naming/Naming_AST.ml
+++ b/src/naming/Naming_AST.ml
@@ -329,7 +329,7 @@ let get_resolved_type lang (vinit, vtype) =
       | Some { e = L (Int (_, tok)); _ } -> make_type "int" tok
       | Some { e = L (Float (_, tok)); _ } -> make_type "float" tok
       | Some { e = L (Char (_, tok)); _ } -> make_type "char" tok
-      | Some { e = L (String (_, (_, tok), _)); _ } ->
+      | Some { e = L (String (_, tok)); _ } ->
           let string_str =
             match lang with
             | Lang.Go -> "str"
@@ -528,8 +528,7 @@ let resolve lang prog =
                         e =
                           Call
                             ( { e = IdSpecial (Require, _); _ },
-                              (_, [ Arg { e = L (String (_, file, _)); _ } ], _)
-                            );
+                              (_, [ Arg { e = L (String file); _ } ], _) );
                         _;
                       };
                   vtype = _;
@@ -558,11 +557,8 @@ let resolve lang prog =
                                 e =
                                   Call
                                     ( { e = IdSpecial (Require, _); _ },
-                                      ( _,
-                                        [
-                                          Arg { e = L (String (_, file, _)); _ };
-                                        ],
-                                        _ ) );
+                                      (_, [ Arg { e = L (String file); _ } ], _)
+                                    );
                                 _;
                               } );
                         _;

--- a/src/optimizing/Analyze_pattern.ml
+++ b/src/optimizing/Analyze_pattern.ml
@@ -101,7 +101,7 @@ let extract_strings_and_mvars ?lang any =
              * We do now semantic equivance on integers between values so
              * 1000 is now equivalent to 1_000 so we can't "regexpize" it.
              *)
-            | L (String (_, (str, _tok), _)) ->
+            | L (String (str, _tok)) ->
                 if not (Pattern.is_special_string_literal str) then
                   Common.push str strings
             | IdSpecial (Eval, t) ->

--- a/src/optimizing/Bloom_annotation.ml
+++ b/src/optimizing/Bloom_annotation.ml
@@ -110,13 +110,13 @@ let rec statement_strings stmt =
             (* less: we could extract strings for the other literals too?
              * atoms, chars, even int?
              *)
-            | L (String (_, (str, _tok), _)) -> push str res
+            | L (String (str, _tok)) -> push str res
             | IdSpecial (_, tok) -> push (Parse_info.str_of_info tok) res
             | __else__ -> k x);
         V.ksvalue =
           (fun (_k, _) x ->
             match x with
-            | Lit (String (_, (str, _tok), _)) ->
+            | Lit (String (str, _tok)) ->
                 if not (Pattern.is_special_string_literal str) then push str res
             | Lit _
             | Cst _

--- a/src/osemgrep/cli_scan/AST_generic_to_jsonnet.ml
+++ b/src/osemgrep/cli_scan/AST_generic_to_jsonnet.ml
@@ -30,11 +30,10 @@ module G = AST_generic
  *)
 
 (*****************************************************************************)
-(* Helpers *)
+(* Types *)
 (*****************************************************************************)
 
 let error tk s = raise (Parse_info.Other_error (s, tk))
-let fb = Parse_info.unsafe_fake_bracket
 
 (*****************************************************************************)
 (* Expr to expr *)
@@ -53,7 +52,7 @@ let rec expr_to_expr (e : G.expr) : A.expr =
       | G.Bool (b, tk) -> A.L (A.Bool (b, tk))
       | G.Int (Some i, tk) -> A.L (A.Number (string_of_int i, tk))
       | G.Float (Some f, tk) -> A.L (A.Number (string_of_float f, tk))
-      | G.String x -> A.L (A.Str (A.mk_string_ x))
+      | G.String (s, tk) -> A.L (A.Str (A.mk_string_ (s, tk)))
       | _else_ -> error ())
   (* in some YAML constructs like
    *   - metavariable-regex:
@@ -61,7 +60,7 @@ let rec expr_to_expr (e : G.expr) : A.expr =
    * the $EXN is actually passed as an Id, not a String
    * TODO? double check is_metavariable str?
    *)
-  | G.N (G.Id ((str, tk), _idinfo)) -> A.L (A.Str (A.mk_string_ (fb (str, tk))))
+  | G.N (G.Id ((str, tk), _idinfo)) -> A.L (A.Str (A.mk_string_ (str, tk)))
   | G.Container (kind, (l, xs, r)) -> (
       match kind with
       | G.Array ->
@@ -75,7 +74,8 @@ let rec expr_to_expr (e : G.expr) : A.expr =
                    | G.Container (G.Tuple, (l, [ k; v ], _)) ->
                        let fld_name =
                          match k.G.e with
-                         | G.L (G.String x) -> A.FStr (A.mk_string_ x)
+                         | G.L (G.String (s, tk)) ->
+                             A.FStr (A.mk_string_ (s, tk))
                          | _else_ -> error ()
                        in
                        A.OField

--- a/src/parsing/Manifest_jsonnet_to_AST_generic.ml
+++ b/src/parsing/Manifest_jsonnet_to_AST_generic.ml
@@ -28,7 +28,6 @@ module A = AST_jsonnet
 (*****************************************************************************)
 
 let error tk s = raise (Parse_info.Other_error (s, tk))
-let fb = Parse_info.unsafe_fake_bracket
 
 (*****************************************************************************)
 (* Entry point *)
@@ -42,7 +41,7 @@ let rec value_to_expr (v : V.value_) : G.expr =
         | V.Null tk -> G.Null tk
         | V.Bool (b, tk) -> G.Bool (b, tk)
         | V.Double (f, tk) -> G.Float (Some f, tk)
-        | V.Str (s, tk) -> G.String (fb (s, tk))
+        | V.Str (s, tk) -> G.String (s, tk)
       in
       G.L literal |> G.e
   | V.Function { f_tok = tk; _ } -> error tk "Function value"
@@ -65,7 +64,7 @@ let rec value_to_expr (v : V.value_) : G.expr =
                | A.ForcedVisible ->
                    let v = Lazy.force fld_value.v in
                    let e = value_to_expr v in
-                   let k = G.L (G.String (fb fld_name)) |> G.e in
+                   let k = G.L (G.String fld_name) |> G.e in
                    Some (G.keyval k (snd fld_name) e))
       in
       G.Container (G.Dict, (l, xs, r)) |> G.e

--- a/src/parsing/yaml_to_generic.ml
+++ b/src/parsing/yaml_to_generic.ml
@@ -151,7 +151,6 @@ let mk_bracket
     tok (e_index', e_line, e_column) ")" env )
 
 let mk_id str pos env = G.Id ((str, mk_tok pos "" env), G.empty_id_info ())
-let fb = Parse_info.unsafe_fake_bracket
 
 (*****************************************************************************)
 (* Error management *)
@@ -268,7 +267,7 @@ let scalar (_tag, pos, value, style) env : G.expr * E.pos =
           G.L (G.Float (Some nan, token))
       | _ -> (
           try G.L (G.Float (Some (float_of_string value), token)) with
-          | _ -> G.L (G.String (fb (value, token)))))
+          | _ -> G.L (G.String (value, token))))
       |> G.e
     in
     (expr, pos)
@@ -373,7 +372,7 @@ let parse (env : env) : G.expr list =
           let _mappings, end_pos = read_mappings [] in
           ( G.OtherExpr
               ( ("Mapping", mk_tok start_pos "" env),
-                [ G.Str (fb ("", mk_tok end_pos "" env)) ] )
+                [ G.Str ("", mk_tok end_pos "" env) ] )
             |> G.e,
             end_pos )
       | v, pos -> error "Expected a valid scalar, got" v pos env

--- a/src/printing/Pretty_print_AST.ml
+++ b/src/printing/Pretty_print_AST.ml
@@ -642,7 +642,7 @@ and literal _env l =
    * we will be able to print correctly whether '' or "" was used
    * to contain the string
    *)
-  | String (_l, (s, _), _r) -> "\"" ^ s ^ "\""
+  | String (s, _) -> "\"" ^ s ^ "\""
   | Regexp ((_, (s, _), _), rmod) -> (
       "/" ^ s ^ "/"
       ^

--- a/src/tainting/Dataflow_tainting.ml
+++ b/src/tainting/Dataflow_tainting.ml
@@ -457,8 +457,7 @@ let find_args_taints args_taints fdef =
                 (* Otherwise, it has not been consumed, so keep it in the remaining parameters.*)
             | None -> param :: acc (* Same as above. *))
         | __else__ -> param :: acc)
-      (Parse_info.unbracket fdef.G.fparams)
-      []
+      fdef.G.fparams []
   in
   let _ =
     (* We then process all of the positional arguments in order of the remaining parameters.


### PR DESCRIPTION
See https://github.com/returntocorp/semgrep-proprietary/pull/555 


PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)