### PR TITLE
Break dependency cycle between Logging and Common

### DIFF
--- a/libs/commons/Logging.mli
+++ b/libs/commons/Logging.mli
@@ -130,4 +130,4 @@ val add_PID_tag : unit -> unit
    Load a json config file that sets log levels for each logger matching
    specific tags.
 *)
-val load_config_file : Common.filename -> unit
+val load_config_file : string -> unit


### PR DESCRIPTION
Hi,

I am part of the dune dev team. While checking for regressions in the upcoming 3.7 release, I found that the `commons` library does not build with it.

After investigating, there is a dependency cycle in `libs/commons`: `Common.ml` depends on `Logging`, and `logging.mli` depends on `Common`.

Dune used to be OK with that, but the new dependency analysis algorithm in 3.7 makes tighter checks and (correctly) detects it. It's kinda OK in that particular case because `Logging` only uses a type alias from `Common`, but dune can not reliably detect this.

So this PR expands the type alias in a way that splits the cycle and makes it compatible with dune 3.7.

PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
