### PR TITLE
Add versioning to AST_Generic.ml

### DIFF
--- a/libs/ast_generic/AST_generic.ml
+++ b/libs/ast_generic/AST_generic.ml
@@ -19,6 +19,8 @@
 (* A generic AST, to factorize similar analysis in different programming
  * languages (e.g., naming, semantic code highlighting, semgrep matching).
  *
+ * !!!If you modify this file, please adjust the 'version' variable below!!!
+ *
  * Right now this generic AST is mostly the factorized union of:
  *  - Python, Ruby, Lua, Julia, Elixir
  *  - Javascript, Typescript, Vue
@@ -156,6 +158,18 @@
  *    used in a function (instead of having the first Assign play the role
  *    of a VarDef, as done in Python for example).
  *)
+
+(* !! Modify version below each time you modify the generic AST!! There are
+ * now a few places where we cache the generic AST in a marshalled binary
+ * form on disk (e.g., in src/runner/Parsing_with_cache.ml) and reading back
+ * old version of this AST can lead to segfaults in OCaml.
+ * Note that this number below could be independent of the versioning scheme of
+ * Semgrep; we don't have to update version below for each version of
+ * Semgrep, just when we actually modify the generic AST. However it's convenient
+ * to correspond mostly to Semgrep versions. So version below can jump from
+ * "1.12.1" to "1.20.0" and that's fine.
+ *)
+let version = "1.12.1"
 
 (* Provide hash_* and hash_fold_* for the core ocaml types *)
 open Ppx_hash_lib.Std.Hash.Builtin

--- a/src/runner/Run_semgrep.ml
+++ b/src/runner/Run_semgrep.ml
@@ -472,8 +472,7 @@ let xtarget_of_file (config : Runner_config.t) (xlang : Xlang.t)
         lazy
           (Parse_with_caching.parse_and_resolve_name
              ~parsing_cache_dir:config.parsing_cache_dir
-             (* alt: could define a AST_generic.version *)
-             config.version lang file)
+             AST_generic.version lang file)
     | _ -> lazy (failwith "requesting generic AST for LRegex|LGeneric")
   in
 

--- a/src/runner/Run_semgrep.ml
+++ b/src/runner/Run_semgrep.ml
@@ -471,8 +471,8 @@ let xtarget_of_file (config : Runner_config.t) (xlang : Xlang.t)
         assert (other_langs =*= []);
         lazy
           (Parse_with_caching.parse_and_resolve_name
-             ~parsing_cache_dir:config.parsing_cache_dir
-             AST_generic.version lang file)
+             ~parsing_cache_dir:config.parsing_cache_dir AST_generic.version
+             lang file)
     | _ -> lazy (failwith "requesting generic AST for LRegex|LGeneric")
   in
 


### PR DESCRIPTION
test plan:
now make test in semgrep-pro does not generate segfault anymore,
even with the presence of old ast.binary because they
will not be read anymore because the cache key will change
because of the version change


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)