### PR TITLE
fix(SSC): Handle maven versions with a custom parser and comparator

### DIFF
--- a/changelog.d/sc-maven-versions.fixed
+++ b/changelog.d/sc-maven-versions.fixed
@@ -1,0 +1,1 @@
+Supply Chain rules now correctly understand Maven version strings, as described in https://docs.oracle.com/middleware/1212/core/MAVEN/maven_version.htm#MAVEN8855

--- a/cli/src/semdep/maven_version.py
+++ b/cli/src/semdep/maven_version.py
@@ -23,6 +23,8 @@ MavenVersion = Union[ParsedMavenVersion, str]
 
 def parse_maven_version(version: str) -> MavenVersion:
     m = re.compile(r"(\d)\.(\d)(?:\.(\d))?(.*)").match(version)
+    # "If you do not follow Maven versioning standards in your project versioning scheme,
+    # then for version comparison, Maven interprets the entire version as a simple string."
     if not m:
         return version
     if "." in m.group(4):
@@ -63,6 +65,10 @@ def cmp_maven_versions(first: MavenVersion, second: MavenVersion) -> int:
             return 1
         elif second.qualifer == "" and first.qualifer != "":
             return -1
+
+        # "Maven treats the SNAPSHOT qualifier differently from all others.
+        # If a version number is followed by -SNAPSHOT, then Maven considers it
+        # the "as-yet-unreleased" version of the associated MajorVersion, MinorVersion, or IncrementalVersion."
         elif first.qualifer == "-SNAPSHOT" and second.qualifer != "-SNAPSHOT":
             return 1
         elif second.qualifer == "-SNAPSHOT" and first.qualifer != "-SNAPSHOT":

--- a/cli/src/semdep/maven_version.py
+++ b/cli/src/semdep/maven_version.py
@@ -1,0 +1,122 @@
+"""
+Custom parser and comparator for Maven versions
+Based on https://docs.oracle.com/middleware/1212/core/MAVEN/maven_version.htm#MAVEN400
+"""
+import re
+from dataclasses import dataclass
+from typing import Union
+
+from semgrep.error import SemgrepError
+
+
+@dataclass
+class ParsedMavenVersion:
+    major: int
+    minor: int
+    incremental: int
+    qualifer: str
+    raw_version: str
+
+
+MavenVersion = Union[ParsedMavenVersion, str]
+
+
+def parse_maven_version(version: str) -> MavenVersion:
+    m = re.compile(r"(\d)\.(\d)(?:\.(\d))?(.*)").match(version)
+    if not m:
+        return version
+    if "." in m.group(4):
+        return version
+    return ParsedMavenVersion(
+        major=int(m.group(1)),
+        minor=int(m.group(2)),
+        incremental=int(m.group(3)) if m.group(3) else 0,
+        qualifer=m.group(4),
+        raw_version=m.group(0),
+    )
+
+
+def cmp_str(x: str, y: str) -> int:
+    if x == y:
+        return 0
+    elif x > y:
+        return 1
+    else:
+        return -1
+
+
+def cmp_maven_versions(first: MavenVersion, second: MavenVersion) -> int:
+    """
+    Return less than 0 if first < second
+    0 if ==
+    greater than 0 if first > second
+    """
+    if isinstance(first, ParsedMavenVersion) and isinstance(second, ParsedMavenVersion):
+        if first.major != second.major:
+            return first.major - second.major
+        elif first.minor != second.minor:
+            return first.minor - second.minor
+        elif first.incremental != second.incremental:
+            return first.incremental - second.incremental
+        # "All versions with a qualifier are older than the same version without a qualifier (release version)."
+        elif first.qualifer == "" and second.qualifer != "":
+            return 1
+        elif second.qualifer == "" and first.qualifer != "":
+            return -1
+        elif first.qualifer == "-SNAPSHOT" and second.qualifer != "-SNAPSHOT":
+            return 1
+        elif second.qualifer == "-SNAPSHOT" and first.qualifer != "-SNAPSHOT":
+            return -1
+        else:
+            return cmp_str(first.qualifer, second.qualifer)
+    else:
+        if isinstance(first, ParsedMavenVersion) and isinstance(second, str):
+            first_raw = first.raw_version
+            second_raw = second
+        elif isinstance(second, ParsedMavenVersion) and isinstance(first, str):
+            first_raw = first
+            second_raw = second.raw_version
+        else:
+            assert isinstance(first, str)
+            assert isinstance(second, str)
+            first_raw = first
+            second_raw = second
+        return cmp_str(first_raw, second_raw)
+
+
+def compare_maven_specifier(specifier: str, version: str) -> bool:
+    """
+    Returns if version satisfies specifier requirement
+
+    i.e. specifier: '< 1.0.0', version: 0.1.0 returns true
+
+    See https://docs.oracle.com/middleware/1212/core/MAVEN/maven_version.htm#MAVEN400
+    """
+    specifier_regex = re.compile(
+        r"""(?P<operator>(==|!=|<=|>=|<|>))\s*(?P<version>.*)"""
+    )
+    matched = specifier_regex.match(specifier)
+    if not matched:
+        raise SemgrepError(
+            f"unknown package version comparison expression: {specifier}"
+        )
+    operator = matched.group("operator")
+    specifier_version = parse_maven_version(matched.group("version"))
+    parsed_version = parse_maven_version(version)
+
+    if operator == "==":
+        return cmp_maven_versions(parsed_version, specifier_version) == 0
+    elif operator == "!=":
+        return cmp_maven_versions(parsed_version, specifier_version) != 0
+    elif operator == "<=":
+        return cmp_maven_versions(parsed_version, specifier_version) <= 0
+    elif operator == "<":
+        return cmp_maven_versions(parsed_version, specifier_version) < 0
+    elif operator == ">=":
+        return cmp_maven_versions(parsed_version, specifier_version) >= 0
+    elif operator == ">":
+        return cmp_maven_versions(parsed_version, specifier_version) > 0
+    else:
+        raise SemgrepError(
+            f"unknown package version comparison expression: {specifier}"
+        )

--- a/cli/tests/e2e/rules/dependency_aware/maven-guice.yaml
+++ b/cli/tests/e2e/rules/dependency_aware/maven-guice.yaml
@@ -3,7 +3,7 @@ rules:
     r2c-internal-project-depends-on:
       namespace: maven
       package: com.google.inject:guice
-      version: <= 99.99.99
+      version: <= 4.3.3
     message: got em
     languages: [java]
     severity: WARNING

--- a/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awaremaven-guice.yaml-dependency_awaremaven_dep_tree_optional/results.txt
+++ b/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awaremaven-guice.yaml-dependency_awaremaven_dep_tree_optional/results.txt
@@ -34,7 +34,7 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
             "dependency_pattern": {
               "ecosystem": "maven",
               "package": "com.google.inject:guice",
-              "semver_range": "<= 99.99.99"
+              "semver_range": "<= 4.3.3"
             },
             "found_dependency": {
               "allowed_hashes": {},

--- a/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awaremaven-guice.yaml-dependency_awaremaven_dep_tree_release_version/results.txt
+++ b/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awaremaven-guice.yaml-dependency_awaremaven_dep_tree_release_version/results.txt
@@ -1,5 +1,5 @@
 === command
-SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERSION_CACHE_PATH="<MASKED>" SEMGREP_ENABLE_VERSION_CHECK="0" SEMGREP_SEND_METRICS="off" semgrep --strict --config rules/dependency_aware/maven-guice.yaml --json targets/dependency_aware/maven_dep_tree_extra_field
+SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERSION_CACHE_PATH="<MASKED>" SEMGREP_ENABLE_VERSION_CHECK="0" SEMGREP_SEND_METRICS="off" semgrep --strict --config rules/dependency_aware/maven-guice.yaml --json targets/dependency_aware/maven_dep_tree_release_version
 === end of command
 
 === exit code
@@ -42,9 +42,9 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
               "line_number": 2,
               "package": "com.google.inject:guice",
               "transitivity": "direct",
-              "version": "4.2.2"
+              "version": "4.2.2.RELEASE"
             },
-            "lockfile": "targets/dependency_aware/maven_dep_tree_extra_field/maven_dep_tree.txt"
+            "lockfile": "targets/dependency_aware/maven_dep_tree_release_version/maven_dep_tree.txt"
           },
           "reachability_rule": false,
           "reachable": false,
@@ -52,7 +52,7 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
         },
         "severity": "WARNING"
       },
-      "path": "targets/dependency_aware/maven_dep_tree_extra_field/maven_dep_tree.txt",
+      "path": "targets/dependency_aware/maven_dep_tree_release_version/maven_dep_tree.txt",
       "start": {
         "col": 0,
         "line": 0,

--- a/cli/tests/e2e/targets/dependency_aware/maven_dep_tree_release_version/maven_dep_tree.txt
+++ b/cli/tests/e2e/targets/dependency_aware/maven_dep_tree_release_version/maven_dep_tree.txt
@@ -1,0 +1,2 @@
+com.example.log4j:log4j-examples:jar:1.0-SNAPSHOT
++- com.google.inject:guice:jar:no_aop:4.2.2.RELEASE:test (optional)

--- a/cli/tests/e2e/test_dependency_aware_rules.py
+++ b/cli/tests/e2e/test_dependency_aware_rules.py
@@ -5,6 +5,9 @@ from time import time
 import pytest
 
 from ..conftest import TESTS_PATH
+from semdep.package_restrictions import is_in_range
+from semgrep.semgrep_interfaces.semgrep_output_v1 import Ecosystem
+from semgrep.semgrep_interfaces.semgrep_output_v1 import Maven
 
 pytestmark = pytest.mark.kinda_slow
 
@@ -85,6 +88,10 @@ pytestmark = pytest.mark.kinda_slow
             "dependency_aware/maven_dep_tree_optional",
         ),
         (
+            "rules/dependency_aware/maven-guice.yaml",
+            "dependency_aware/maven_dep_tree_release_version",
+        ),
+        (
             "rules/dependency_aware/js-sca.yaml",
             "dependency_aware/package-lock_resolved_false",
         ),
@@ -95,6 +102,21 @@ def test_dependency_aware_rules(run_semgrep_on_copied_files, snapshot, rule, tar
         run_semgrep_on_copied_files(rule, target_name=target).as_snapshot(),
         "results.txt",
     )
+
+
+@pytest.mark.parametrize(
+    "version,specifier",
+    [
+        ("1.2-beta-2", "> 1.0, < 1.2"),
+        ("1.2-beta-2", "> 1.2-alpha-6, < 1.2-beta-3"),
+        ("1.0.10.1", "< 1.0.10.2"),
+        ("1.0.10.2", "> 1.0.10.1, < 1.0.9.3"),  # Yes, seriously
+        ("1.3.4-SNAPSHOT", "< 1.3.4"),
+        ("1.0-SNAPSHOT", "> 1.0-alpha"),
+    ],
+)
+def test_maven_version_comparison(version, specifier):
+    assert is_in_range(Ecosystem(Maven()), specifier, version)
 
 
 @pytest.mark.parametrize(

--- a/cli/tests/unit/test_semver_matching.py
+++ b/cli/tests/unit/test_semver_matching.py
@@ -1,6 +1,8 @@
 import pytest
 
-from semdep.package_restrictions import semver_matches
+from semdep.package_restrictions import is_in_range
+from semgrep.semgrep_interfaces.semgrep_output_v1 import Ecosystem
+from semgrep.semgrep_interfaces.semgrep_output_v1 import Npm
 
 
 @pytest.mark.quick
@@ -27,4 +29,5 @@ from semdep.package_restrictions import semver_matches
     ],
 )
 def test_matches(expression, candidate, match):
-    assert semver_matches(expression, candidate) == match
+    # Can be any ecosystem except Maven, which has custom version operation
+    assert is_in_range(Ecosystem(Npm()), expression, candidate) == match


### PR DESCRIPTION
Previously we just ignored Maven versions with qualifiers or weird structure. Now we handle them.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
