### PR TITLE
refactor: Remove weird visitor code

### DIFF
--- a/libs/ast_generic/Visitor_AST.ml
+++ b/libs/ast_generic/Visitor_AST.ml
@@ -411,13 +411,9 @@ class ['self] matching_visitor =
       env.vin.kentity (k, env.vout) x
 
     method! visit_function_definition env x =
-      let k x' =
-        (* TODO: This partial node is created using `x`, i.e. the original node
-         * passed in to this method. It does not use `x'` which is passed in to
-         * the `k` function. This is probably a mistake, but for now I am
-         * mimicking the behavior of the previous visitor. *)
+      let k x =
         self#v_partial ~recurse:false env (PartialLambdaOrFuncDef x);
-        super#visit_function_definition env x'
+        super#visit_function_definition env x
       in
       env.vin.kfunction_definition (k, env.vout) x
 
@@ -489,31 +485,6 @@ class ['self] matching_visitor =
 
     method! visit_program env v1 = self#v_stmts env v1
     method! visit_Ss env v1 = self#v_stmts env v1
-
-    (* Overrides to skip visiting nodes. TODO These should probably all be
-     * deleted but are here for now to keep the behavior the same as the old
-     * handcoded visitor. *)
-
-    method! visit_concat_string_kind _ _ = ()
-    method! visit_incr_decr _ _ = ()
-    method! visit_prefix_postfix _ _ = ()
-    method! visit_operator _ _ = ()
-    method! visit_variance _ _ = ()
-    method! visit_keyword_attribute _ _ = ()
-
-    method! visit_OtherAttribute env _v1 v2 =
-      self#visit_list self#visit_any env v2
-
-    method! visit_other_stmt_with_stmt_operator _ _ = ()
-    method! visit_other_stmt_operator _ _ = ()
-    method! visit_OtherPat env _v1 v2 = self#visit_list self#visit_any env v2
-    method! visit_OtherDef env _v1 v2 = self#visit_list self#visit_any env v2
-
-    method! visit_OtherTypeKind env _v1 v2 =
-      self#visit_list self#visit_any env v2
-
-    method! visit_class_kind _ _ = ()
-    method! visit_OtherModule env _v1 v2 = self#visit_list self#visit_any env v2
   end
 
 let visitor_instance = lazy (new matching_visitor)


### PR DESCRIPTION
In #7186 I kept this in so as to preserve the existing behavior as much as possible. I wanted to do this cleanup separately so that we would minimize the amount of code we might have to revert if this caused a regression that tests didn't catch.

The deleted comments explain what this code was for.

Test plan: Automated tests

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
