### PR TITLE
chore: fix parsing of go grouped parameters

### DIFF
--- a/changelog.d/pa-2558.fixed
+++ b/changelog.d/pa-2558.fixed
@@ -1,2 +1,4 @@
-Go: Fixed a bug where function arguments in a group that share the same type, after the first, would parse as
-having the name ","
+Go: Fixed a bug where function arguments in a group that share the same type,
+such as "func foo(x, y, z int)", would parse all arguments after the first as
+having the name ",". For instance, "y" and "z" here would not have the correct
+names.

--- a/changelog.d/pa-2558.fixed
+++ b/changelog.d/pa-2558.fixed
@@ -1,0 +1,2 @@
+Go: Fixed a bug where function arguments in a group that share the same type, after the first, would parse as
+having the name ","

--- a/languages/go/tree-sitter/Parse_go_tree_sitter.ml
+++ b/languages/go/tree-sitter/Parse_go_tree_sitter.ml
@@ -150,9 +150,9 @@ let field_name_list (env : env) ((v1, v2) : CST.field_name_list) : ident list =
   let v2 =
     Common.map
       (fun (v1, v2) ->
-        let v1 = identifier env v1 (* "," *) in
-        let _v2 = token env v2 (* identifier *) in
-        v1)
+        let _v1 = token env v1 (* "," *) in
+        let v2 = identifier env v2 (* identifier *) in
+        v2)
       v2
   in
   v1 :: v2

--- a/tests/rules/go_grouped_arguments.go
+++ b/tests/rules/go_grouped_arguments.go
@@ -1,0 +1,2 @@
+
+func foo (x, y, z int) { }

--- a/tests/rules/go_grouped_arguments.go
+++ b/tests/rules/go_grouped_arguments.go
@@ -1,2 +1,3 @@
 
+// ruleid: go-grouped-arguments
 func foo (x, y, z int) { }

--- a/tests/rules/go_grouped_arguments.go
+++ b/tests/rules/go_grouped_arguments.go
@@ -1,3 +1,3 @@
 
 // ruleid: go-grouped-arguments
-func foo (x, y, z int) { }
+func foo (a, b, c int) { }

--- a/tests/rules/go_grouped_arguments.yaml
+++ b/tests/rules/go_grouped_arguments.yaml
@@ -9,4 +9,8 @@ rules:
       func $FOO($ARG1, $ARG2, $ARG3 int) { }
     where:
       - metavariable: $ARG1
-        regex: "x"
+        regex: "a"
+      - metavariable: $ARG2
+        regex: "b"
+      - metavariable: $ARG3
+        regex: "c"

--- a/tests/rules/go_grouped_arguments.yaml
+++ b/tests/rules/go_grouped_arguments.yaml
@@ -1,0 +1,12 @@
+rules:
+- id: go-grouped-arguments 
+  message: |
+    Consecutive Go arguments should parse as having their real names
+  severity: ERROR
+  languages: [go]
+  match:
+    pattern: |
+      func $FOO($ARG1, $ARG2, $ARG3 int) { }
+    where:
+      - metavariable: $ARG1
+        regex: "x"

--- a/tests/rules/metavar_ellipsis_param.go
+++ b/tests/rules/metavar_ellipsis_param.go
@@ -27,7 +27,7 @@ func qux(int) { }
 // ruleid: metavar_ellipsis_param
 func qux(x int) { }
 
-// todo: metavar_ellipsis_param
+// ruleid: metavar_ellipsis_param
 func qux(string, x int) { }
 
 func qux(string, x int, string) { }


### PR DESCRIPTION
This PR fixes a bug where Go parameters that shared a common type, would parse all but the first to have the name `,`

## Test plan:
![image](https://user-images.githubusercontent.com/49291449/220417995-38142761-1e7b-42c7-8e97-b45e74cc6b65.png)


PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
