### PR TITLE
fix: infra-1105 issues with homebrew PR opening

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,7 +149,6 @@ jobs:
     name: Upload Wheels to PyPI
     runs-on: ubuntu-latest
     needs: [wait-for-build-test, dry-run]
-    if: ${{ !contains(github.ref, '-test-release') && needs.dry-run.outputs.dry-run != 'true' }}
     steps:
       - name: Download Artifact
         uses: actions/download-artifact@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -351,7 +351,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.HOMEBREW_PR_TOKEN }}
           R2C_HOMEBREW_CORE_FORK_HTTPS_URL: https://github.com/returntocorp/homebrew-core.git
         run: |
-          cd $(brew --repository)/Library/Taps/homebrew/homebrew-core
+          cd "$(brew --repository)/Library/Taps/homebrew/homebrew-core"
           git status
           git diff
 
@@ -359,7 +359,7 @@ jobs:
           git config user.email ${{ github.actor }}@users.noreply.github.com
 
           gh auth setup-git
-          git remote add r2c ${R2C_HOMEBREW_CORE_FORK_HTTPS_URL}
+          git remote add r2c "${R2C_HOMEBREW_CORE_FORK_HTTPS_URL}"
 
           git checkout -b bump-semgrep-${{ steps.get-version.outputs.VERSION }}
           git add Formula/semgrep.rb
@@ -369,8 +369,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.HOMEBREW_PR_TOKEN }}
         if: ${{ !contains(github.ref, '-test-release') && needs.dry-run.outputs.dry-run != 'true' }}
         run: |
-          cd $(brew --repository)/Library/Taps/homebrew/homebrew-core
-          git push --set-upstream r2c --force bump-semgrep-${{ steps.get-version.outputs.VERSION }}
+          cd "$(brew --repository)/Library/Taps/homebrew/homebrew-core"
+          git push --set-upstream r2c --force "bump-semgrep-${{ steps.get-version.outputs.VERSION }}"
       - name: Push to Fork
         env:
           GITHUB_TOKEN: ${{ secrets.HOMEBREW_PR_TOKEN }}
@@ -378,6 +378,6 @@ jobs:
         if: ${{ !contains(github.ref, '-test-release') && needs.dry-run.outputs.dry-run != 'true' }}
         run: |
           gh pr create --repo homebrew/homebrew-core \
-            --base master --head ${R2C_HOMEBREW_CORE_OWNER}:bump-semgrep-${{ steps.get-version.outputs.VERSION }} \
+            --base master --head "${R2C_HOMEBREW_CORE_OWNER}:bump-semgrep-${{ steps.get-version.outputs.VERSION }}" \
             --title="semgrep ${{ steps.get-version.outputs.VERSION }}" \
             --body "Bump semgrep to version ${{ steps.get-version.outputs.VERSION }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,18 +176,10 @@ jobs:
         run: unzip ./m1-wheel/dist.zip "*.whl"
       - name: Publish to Pypi
         uses: pypa/gh-action-pypi-publish@master
-        if: ${{ !contains(github.ref,'-test-release') }}
+        if: ${{ !contains(github.ref, '-test-release') && needs.dry-run.outputs.dry-run != 'true' }}
         with:
           user: __token__
           password: ${{ secrets.pypi_upload_token }}
-          skip_existing: true
-      - name: Publish to test Pypi
-        uses: pypa/gh-action-pypi-publish@master
-        if: ${{ contains(github.ref,'-test-release') }}
-        with:
-          repository_url: https://test.pypi.org/legacy/
-          user: __token__
-          password: ${{ secrets.test_pypi_upload_token }}
           skip_existing: true
 
   create-release:
@@ -311,16 +303,15 @@ jobs:
     # Need to wait for pypi to propagate ssince pipgrip relies on it being published on pypi
     needs: [dry-run, upload-wheels]
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.ref, '-test-release') && needs.dry-run.outputs.dry-run != 'true' }}
     steps:
       - name: Sleep 10 min
+        if: ${{ !contains(github.ref, '-test-release') && needs.dry-run.outputs.dry-run != 'true' }}
         run: sleep 10m
 
   homebrew-core-pr:
     name: Update on Homebrew-Core
     needs: [dry-run, sleep-before-homebrew] # Needs to run after pypi released so brew can update pypi dependency hashes
     runs-on: macos-12
-    if: ${{ !contains(github.ref, '-test-release') && needs.dry-run.outputs.dry-run != 'true' }}
     steps:
       - name: Get the version
         id: get-version
@@ -338,10 +329,56 @@ jobs:
         run: brew install --overwrite python@3.11
       - name: Install pipgrip
         run: brew install --overwrite pipgrip
-      - name: Open Brew PR on homebrew/homebrew-core
+      - name: Dry Run Brew PR
+        # This step does some brew oddities (setting a fake version, and setting a revision) to allow the brew PR prep to succeed
+        # The `brew bump-formula-pr` does checks to ensure your PR is legit, but we want to do a phony PR (or at least prep it) for Dry Run only
+        env:
+          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.HOMEBREW_PR_TOKEN }}
+        if: ${{ contains(github.ref, '-test-release') || needs.dry-run.outputs.dry-run == 'true' }}
+        run: |
+          brew bump-formula-pr --force --no-audit --no-browse --write-only \
+            --message="Bump semgrep to version ${{ steps.get-version.outputs.VERSION }}" \
+            --fork-org=returntocorp --tag="${{ steps.get-version.outputs.VERSION }}" --revision="${GITHUB_SHA}" semgrep --python-exclude-packages semgrep
+      - name: Prepare Brew PR
+        if: ${{ !contains(github.ref, '-test-release') && needs.dry-run.outputs.dry-run != 'true' }}
         env:
           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.HOMEBREW_PR_TOKEN }}
         run: |
-          brew bump-formula-pr --force --no-audit --no-browse \
+          brew bump-formula-pr --force --no-audit --no-browse --write-only \
             --message="Bump semgrep to version ${{ steps.get-version.outputs.VERSION }}" \
             --fork-org=returntocorp --tag="${{ steps.get-version.outputs.VERSION }}" semgrep
+      - name: Prepare Branch
+        env:
+          GITHUB_TOKEN: ${{ secrets.HOMEBREW_PR_TOKEN }}
+          R2C_HOMEBREW_CORE_FORK_HTTPS_URL: https://github.com/returntocorp/homebrew-core.git
+        run: |
+          cd $(brew --repository)/Library/Taps/homebrew/homebrew-core
+          git status
+          git diff
+
+          git config user.name ${{ github.actor }}
+          git config user.email ${{ github.actor }}@users.noreply.github.com
+
+          gh auth setup-git
+          git remote add r2c ${R2C_HOMEBREW_CORE_FORK_HTTPS_URL}
+
+          git checkout -b bump-semgrep-${{ steps.get-version.outputs.VERSION }}
+          git add Formula/semgrep.rb
+          git commit -m "Bump semgrep to version ${{ steps.get-version.outputs.VERSION }}"
+      - name: Push Branch to Fork
+        env:
+          GITHUB_TOKEN: ${{ secrets.HOMEBREW_PR_TOKEN }}
+        if: ${{ !contains(github.ref, '-test-release') && needs.dry-run.outputs.dry-run != 'true' }}
+        run: |
+          cd $(brew --repository)/Library/Taps/homebrew/homebrew-core
+          git push --set-upstream r2c --force bump-semgrep-${{ steps.get-version.outputs.VERSION }}
+      - name: Push to Fork
+        env:
+          GITHUB_TOKEN: ${{ secrets.HOMEBREW_PR_TOKEN }}
+          R2C_HOMEBREW_CORE_OWNER: returntocorp
+        if: ${{ !contains(github.ref, '-test-release') && needs.dry-run.outputs.dry-run != 'true' }}
+        run: |
+          gh pr create --repo homebrew/homebrew-core \
+            --base master --head ${R2C_HOMEBREW_CORE_OWNER}:bump-semgrep-${{ steps.get-version.outputs.VERSION }} \
+            --title="semgrep ${{ steps.get-version.outputs.VERSION }}" \
+            --body "Bump semgrep to version ${{ steps.get-version.outputs.VERSION }}"


### PR DESCRIPTION
Brew PR opening in release flow has been failing for some time - we've been taking manual action to open the PR once it's been set up. Debugging was unable to determine the cause for the failures. 

This PR does two things:
- Sets up a new process of letting brew perform only the Formula updates and allowing us to open the PR manually
- Allows us to start dry-running this process nightly, so we can inspect these diffs. 

Testing:
- https://github.com/returntocorp/test-gh-actions/actions/runs/4238546907 - this workflow job was tested here against our own fork at `returntocorp/homebrew-core`
- https://github.com/returntocorp/semgrep/actions/runs/4238828072/jobs/7366505561 - this a dry-run of this job, which will also run on our nightly checks.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
