### PR TITLE
feat(perf): share matches for taint formulas

### DIFF
--- a/src/core/Lang.ml.j2
+++ b/src/core/Lang.ml.j2
@@ -47,7 +47,7 @@ type t =
 {% for item in langs %}  | {{ item.id }}
 {% endfor %}
 
-[@@deriving show { with_path = false }, eq]
+[@@deriving show { with_path = false }, eq, hash]
 
 let is_js = function
 {% for item in langs %}{% if "is_js" in item.tags %}  | {{ item.id }}

--- a/src/core/Lang.mli.j2
+++ b/src/core/Lang.mli.j2
@@ -1,7 +1,7 @@
 type t =
 {% for item in langs %}  | {{ item.id }}
 {% endfor %}
-[@@deriving show, eq]
+[@@deriving show, eq, hash]
 
 (* unsupported_language_message [lang] takes the language as a string and
  * returns an error message.

--- a/src/core/Rule.ml
+++ b/src/core/Rule.ml
@@ -18,6 +18,8 @@ module MV = Metavariable
 
 let logger = Logging.get_logger [ __MODULE__ ]
 
+open Ppx_hash_lib.Std.Hash.Builtin
+
 (*****************************************************************************)
 (* Prelude *)
 (*****************************************************************************)
@@ -107,7 +109,8 @@ and metavar_cond =
   | CondAnalysis of MV.mvar * metavar_analysis_kind
   | CondNestedFormula of MV.mvar * Xlang.t option * formula
 
-and metavar_analysis_kind = CondEntropy | CondReDoS [@@deriving show, eq]
+and metavar_analysis_kind = CondEntropy | CondReDoS
+[@@deriving show, eq, hash]
 
 (*****************************************************************************)
 (* Taint-specific types *)

--- a/src/core/Xlang.ml
+++ b/src/core/Xlang.ml
@@ -2,6 +2,8 @@
    Extended languages: everything from Lang.t + spacegrep (generic) and regex.
 *)
 
+open Ppx_hash_lib.Std.Hash.Builtin
+
 (* eXtended language, stored in the languages: field in the rule.
  * less: merge with xpattern_kind? *)
 type t =
@@ -11,7 +13,7 @@ type t =
   | LRegex
   (* for spacegrep *)
   | LGeneric
-[@@deriving show, eq]
+[@@deriving show, eq, hash]
 
 exception InternalInvalidLanguage of string (* rule id *) * string (* msg *)
 

--- a/src/core/Xlang.mli
+++ b/src/core/Xlang.mli
@@ -12,7 +12,7 @@ type t =
   | LRegex
   (* for spacegrep *)
   | LGeneric
-[@@deriving show, eq]
+[@@deriving show, eq, hash]
 
 exception InternalInvalidLanguage of string (* rule id *) * string (* msg *)
 

--- a/src/core/Xpattern.ml
+++ b/src/core/Xpattern.ml
@@ -55,6 +55,14 @@ type xpattern_kind =
 (* eXtended pattern *)
 type t = {
   pat : xpattern_kind; [@hash.ignore]
+  (* w.r.t. hashing, these are just Generic ASTs, which can be rather large.
+     Whereas `Hashtbl.hash` will hash only to a certain depth, because it
+     is polymorphic, it will be sensitive to things like tokens, which should
+     be ignored by the hash function.
+     The generated hash function for Generic ASTs will be rather hefty though,
+     for the above reasoning. So we will choose to just decline to hash
+     the generic AST.
+  *)
   (* Regarding @equal below, even if two patterns have different indentation,
    * we still consider them equal in the metachecker context.
    * We rely only on the equality on pat, which will
@@ -71,8 +79,7 @@ type t = {
   pid : pattern_id; [@equal fun _ _ -> true] [@hash.ignore]
 }
 [@@deriving show, eq, hash]
-(* Patterns are just Generic ASTs, which are not easy to hash.
-   So for hashing patterns, let's just hash the originating string. It's
+(* For hashing patterns, let's just hash the originating string. It's
    a good enough proxy.
 *)
 

--- a/src/core/Xpattern.ml
+++ b/src/core/Xpattern.ml
@@ -13,6 +13,8 @@
  * LICENSE for more details.
  *)
 
+open Ppx_hash_lib.Std.Hash.Builtin
+
 (*****************************************************************************)
 (* Prelude *)
 (*****************************************************************************)
@@ -22,7 +24,7 @@
 (*****************************************************************************)
 
 type compiled_regexp = Regexp_engine.t [@@deriving show, eq]
-type regexp_string = string [@@deriving show, eq]
+type regexp_string = string [@@deriving show, eq, hash]
 (* see the NOTE "Regexp" below for the need to have this type *)
 
 (* used in the engine for rule->mini_rule and match_result gymnastic *)
@@ -52,7 +54,7 @@ type xpattern_kind =
 
 (* eXtended pattern *)
 type t = {
-  pat : xpattern_kind;
+  pat : xpattern_kind; [@hash.ignore]
   (* Regarding @equal below, even if two patterns have different indentation,
    * we still consider them equal in the metachecker context.
    * We rely only on the equality on pat, which will
@@ -66,9 +68,13 @@ type t = {
    * This is used to run the patterns in a formula in a batch all-at-once
    * and remember what was the matching results for a certain pattern id.
    *)
-  pid : pattern_id; [@equal fun _ _ -> true]
+  pid : pattern_id; [@equal fun _ _ -> true] [@hash.ignore]
 }
-[@@deriving show, eq]
+[@@deriving show, eq, hash]
+(* Patterns are just Generic ASTs, which are not easy to hash.
+   So for hashing patterns, let's just hash the originating string. It's
+   a good enough proxy.
+*)
 
 (*****************************************************************************)
 (* Helpers *)

--- a/src/engine/Match_tainting_mode.ml
+++ b/src/engine/Match_tainting_mode.ml
@@ -162,7 +162,7 @@ module Formula_tbl = struct
           (* if there's only 1 more use left, there's no point
              in caching it
           *)
-          ranges, expls
+          (ranges, expls)
         else (
           (* otherwise, this is the first time we've seen this
              formula, and we should cache it

--- a/src/engine/Match_tainting_mode.ml
+++ b/src/engine/Match_tainting_mode.ml
@@ -156,34 +156,6 @@ module Formula_tbl = struct
     | Some (ranges, expls) -> (ranges, expls)
 end
 
-(*
-let identify_sharing (rules : Rule.taint_rule list) =
-  let count_tbl = Formula_tbl.create 128 in
-  let flat_formulas =
-    rules |> List.concat_map (fun rule ->
-      let `Taint (spec : R.taint_spec) = rule.R.mode in
-      Common.map (fun source -> source.R.source_formula) (snd spec.sources)
-      @ Common.map (fun sanitizer -> sanitizer.R.sanitizer_formula) spec.sanitizers
-      @ Common.map (fun sink -> sink.R.sink_formula) (snd spec.sinks)
-      @ Common.map (fun propagator -> propagator.R.propagator_formula) spec.propagators
-    )
-  in
-  flat_formulas |> List.iter (fun formula ->
-    match Formula_tbl.find_opt formula_tbl formula with
-    | None -> Formula_tbl.add formula_tbl formula 1
-    | Some x -> Formula_tbl.replace formula_tbl formula (1 + x)
-  );
-  let
-  Formula_tbl.iter (fun k v ->
-    (* if there's only one occurrence, take it out *)
-    if v <= 1 then
-      None
-    else
-      Some v
-  ) formula_tbl;
-  formula_tbl
-  *)
-
 (*****************************************************************************)
 (* Finding matches for taint specs *)
 (*****************************************************************************)

--- a/src/engine/Match_tainting_mode.ml
+++ b/src/engine/Match_tainting_mode.ml
@@ -147,11 +147,11 @@ module Formula_tbl = struct
     let hash = Rule.hash_formula
   end)
 
-  let cached_find_opt formula_cache formula cont =
+  let cached_find_opt formula_cache formula compute_matches_fn =
     match find_opt formula_cache formula with
     | None ->
-        let ranges, expls = cont () in
-        replace formula_cache formula (ranges, expls);
+        let ranges, expls = compute_matches_fn () in
+        add formula_cache formula (ranges, expls);
         (ranges, expls)
     | Some (ranges, expls) -> (ranges, expls)
 end

--- a/src/engine/Match_tainting_mode.mli
+++ b/src/engine/Match_tainting_mode.mli
@@ -47,7 +47,7 @@ val hook_setup_hook_function_taint_signature :
    [taint_config_of_rule] is used on the same file!
 *)
 val taint_config_of_rule :
-  formula_cache:formula_cache ->
+  per_file_formula_cache:formula_cache ->
   Match_env.xconfig ->
   Common.filename ->
   AST_generic.program * Parse_info.token_location list ->

--- a/src/engine/Match_tainting_mode.mli
+++ b/src/engine/Match_tainting_mode.mli
@@ -32,6 +32,11 @@ val hook_setup_hook_function_taint_signature :
 
 module Formula_tbl : Hashtbl.S with type key = Rule.formula
 
+val mk_specialized_formula_cache :
+  Rule.taint_rule list ->
+  (Range_with_metavars.ranges * Matching_explanation.t list) option
+  Formula_tbl.t
+
 (* It could be a private function, but it is also used by Deep Semgrep. *)
 (* This [formula_cache] argument is exposed here because this function is also
    a subroutine but the cache itself should be created outside of the any main
@@ -40,7 +45,8 @@ module Formula_tbl : Hashtbl.S with type key = Rule.formula
 *)
 val taint_config_of_rule :
   formula_cache:
-    (Range_with_metavars.ranges * Matching_explanation.t list) Formula_tbl.t ->
+    (Range_with_metavars.ranges * Matching_explanation.t list) option
+    Formula_tbl.t ->
   Match_env.xconfig ->
   Common.filename ->
   AST_generic.program * Parse_info.token_location list ->

--- a/src/engine/Match_tainting_mode.mli
+++ b/src/engine/Match_tainting_mode.mli
@@ -8,6 +8,16 @@ type debug_taint = {
 }
 (** To facilitate debugging of taint rules. *)
 
+(* The type of the specialized formual cache used for inter-rule
+   match sharing.
+*)
+type formula_cache
+
+(* These formula caches are only safe to use to share results between
+   runs of rules on the same target! It is consumed by [taint_config_of_rule].
+*)
+val mk_specialized_formula_cache : Rule.taint_rule list -> formula_cache
+
 val hook_setup_hook_function_taint_signature :
   (Match_env.xconfig ->
   Rule.taint_rule ->
@@ -30,13 +40,6 @@ val hook_setup_hook_function_taint_signature :
   *   (or we could infer a signature for them too...).
   *)
 
-module Formula_tbl : Hashtbl.S with type key = Rule.formula
-
-val mk_specialized_formula_cache :
-  Rule.taint_rule list ->
-  (Range_with_metavars.ranges * Matching_explanation.t list) option
-  Formula_tbl.t
-
 (* It could be a private function, but it is also used by Deep Semgrep. *)
 (* This [formula_cache] argument is exposed here because this function is also
    a subroutine but the cache itself should be created outside of the any main
@@ -44,9 +47,7 @@ val mk_specialized_formula_cache :
    [taint_config_of_rule] is used on the same file!
 *)
 val taint_config_of_rule :
-  formula_cache:
-    (Range_with_metavars.ranges * Matching_explanation.t list) option
-    Formula_tbl.t ->
+  formula_cache:formula_cache ->
   Match_env.xconfig ->
   Common.filename ->
   AST_generic.program * Parse_info.token_location list ->

--- a/src/engine/Match_tainting_mode.mli
+++ b/src/engine/Match_tainting_mode.mli
@@ -30,8 +30,11 @@ val hook_setup_hook_function_taint_signature :
   *   (or we could infer a signature for them too...).
   *)
 
+module Formula_tbl : Hashtbl.S with type key = Rule.formula
+
 (* It could be a private function, but it is also used by Deep Semgrep. *)
 val taint_config_of_rule :
+  (Range_with_metavars.ranges * Matching_explanation.t list ) Formula_tbl.t ->
   Match_env.xconfig ->
   Common.filename ->
   AST_generic.program * Parse_info.token_location list ->

--- a/src/engine/Match_tainting_mode.mli
+++ b/src/engine/Match_tainting_mode.mli
@@ -33,8 +33,14 @@ val hook_setup_hook_function_taint_signature :
 module Formula_tbl : Hashtbl.S with type key = Rule.formula
 
 (* It could be a private function, but it is also used by Deep Semgrep. *)
+(* This [formula_cache] argument is exposed here because this function is also
+   a subroutine but the cache itself should be created outside of the any main
+   loop which runs over rules. This cache is only safe to share with if
+   [taint_config_of_rule] is used on the same file!
+*)
 val taint_config_of_rule :
-  (Range_with_metavars.ranges * Matching_explanation.t list ) Formula_tbl.t ->
+  formula_cache:
+    (Range_with_metavars.ranges * Matching_explanation.t list) Formula_tbl.t ->
   Match_env.xconfig ->
   Common.filename ->
   AST_generic.program * Parse_info.token_location list ->

--- a/src/engine/Test_dataflow_tainting.ml
+++ b/src/engine/Test_dataflow_tainting.ml
@@ -75,8 +75,8 @@ let test_dfg_tainting rules_file file =
   *)
   let tbl = Match_tainting_mode.mk_specialized_formula_cache [] in
   let config, debug_taint, _exps =
-    Match_tainting_mode.taint_config_of_rule tbl xconf file (ast, []) rule
-      handle_findings
+    Match_tainting_mode.taint_config_of_rule ~per_file_formula_cache:tbl xconf
+      file (ast, []) rule handle_findings
   in
   Common.pr2 "\nSources";
   Common.pr2 "-------";

--- a/src/engine/Test_dataflow_tainting.ml
+++ b/src/engine/Test_dataflow_tainting.ml
@@ -70,7 +70,10 @@ let test_dfg_tainting rules_file file =
   let handle_findings _ _ _ = () in
   let xconf = Match_env.default_xconfig in
   let xconf = Match_env.adjust_xconfig_with_rule_options xconf rule.options in
-  let tbl = Match_tainting_mode.Formula_tbl.create 128 in
+  (* this won't cache anything. but that's fine, we don't need it
+     for test purposes.
+  *)
+  let tbl = Match_tainting_mode.mk_specialized_formula_cache [] in
   let config, debug_taint, _exps =
     Match_tainting_mode.taint_config_of_rule tbl xconf file (ast, []) rule
       handle_findings

--- a/src/engine/Test_dataflow_tainting.ml
+++ b/src/engine/Test_dataflow_tainting.ml
@@ -70,8 +70,9 @@ let test_dfg_tainting rules_file file =
   let handle_findings _ _ _ = () in
   let xconf = Match_env.default_xconfig in
   let xconf = Match_env.adjust_xconfig_with_rule_options xconf rule.options in
+  let tbl = Match_tainting_mode.Formula_tbl.create 128 in
   let config, debug_taint, _exps =
-    Match_tainting_mode.taint_config_of_rule xconf file (ast, []) rule
+    Match_tainting_mode.taint_config_of_rule tbl xconf file (ast, []) rule
       handle_findings
   in
   Common.pr2 "\nSources";


### PR DESCRIPTION
## What:
This PR adds the ability to share matches between taint rules running on a different file. In particular, if there is a source, sink, propagator, or sanitizer that is used more than once between multiple rules (or even a single rule), we will cache and share the pre-computed matches.

## Why:
This may have marginal effects on OSS engine. In particular, hardcoded propagators also fall under this category, so we expect to see significant gains for Pro Engine.

## How:
I made a `Formula_tbl` module which allows mapping from rule formulas to things (in this case, matches and match explanations). This module uses structural equality on ASTs to compare formulae, and a newly-derived hash on rule formula. Hashing the Generic AST is possible, but might be kind of hefty, so I've opted to just hash the literal string that the pattern originally came from, in the hopes that it will serve as a "good enough" proxy that still permits equality to behave normally.

We also factor out a lot of `Match_tainting_mode` by a `formula_cache` argument, which must be created prior to running on a bunch of rules. `check_rules` does this for you automatically, behind the scenes, but it must be created manually if you call `taint_config_of_rule` a bunch of times, as Pro Engine does.

## Alternatives considered:

I considered factoring out `taint_config_of_rule` to take in multiple rules, and then hide the taint config creation. `handle_findings` and `xconf` are both different when invoked by Pro Engine, for each taint config, however, so that logic would need to be ported too, and I thought at that point creating an external cache was sufficiently uncumbersome that it would be cleaner to just keep it the way it is (also because I expect `Match_tainting_mode.taint_config_of_rule` to need no more call-sites.

For `Formula_tbl`, I considered caching only things which are literally xpatterns (which would subsume the propagators case), but I didn't want to make it too specialized to the hardcoded propagators. That being said, having the exact same formula is probably pretty rare outside of hardcoded propagators (though it does happen)



## Test plan:
`make test`

I conducted benchmarks via `deepsemgrep-sqli-rules.yaml` on `android`.

On `develop`, we get the following trace:
<img width="492" alt="image" src="https://user-images.githubusercontent.com/49291449/220785335-aebabfa0-18e1-4d68-a8d5-6fb231800072.png">

With these sharing changes, we get:
<img width="486" alt="image" src="https://user-images.githubusercontent.com/49291449/220785365-372e2d13-afce-4601-8c99-34bd7591f9ae.png">

Memory usage went up very slightly, which I did not actually anticipate. But time elapsed went down, by 2x in this case.

We actually see elsewhere in the memtrace that memory usage _in total_ goes from 342G to 154G, so we did save on memory (from not recomputing propagators). But for some reason, it seems that the excess propagators are not actually the source of the _maximal_ memory usage.

Closes PA-2553

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
