### PR TITLE
refactor: Migrate ii_of_any to generated visitor

### DIFF
--- a/libs/ast_generic/AST_generic.ml
+++ b/libs/ast_generic/AST_generic.ml
@@ -2006,6 +2006,16 @@ and raw_tree = (any Raw_tree.t[@name "raw_tree_t"])
      * otherwise be assigned a visitor method named `visit_t`. *)
     visitors { variety = "iter"; ancestors = [ "iter_parent" ] }]
 
+(* Most clients should use this instead of the default `iter`. In many cases,
+ * it's not desirable to recurse into id_info since it contains resolved names
+ * and svalues which often contain nodes that are already present elsewhere in
+ * the AST. This matches the default behavior of the old mk_visitor. *)
+class virtual ['self] iter_no_id_info =
+  object (_self : 'self)
+    inherit ['self] iter
+    method! visit_id_info _env _info = ()
+  end
+
 (*****************************************************************************)
 (* Error *)
 (*****************************************************************************)


### PR DESCRIPTION
It was already using the generated visitor through `mk_visitor`, but it's simpler to use it directly.

As part of this I added the `iter_no_id_info` class which avoids visiting `id_info` like `mk_visitor` does by default. Most callsites use that default behavior.

Test plan: Automated tests

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
