### PR TITLE
fix(SSC): Maven comparison bug

### DIFF
--- a/changelog.d/sc-maven-cmp-bug.fixed
+++ b/changelog.d/sc-maven-cmp-bug.fixed
@@ -1,0 +1,1 @@
+Fixed bug in comparison of Maven versions where multi digit versions would cause a default to raw string comparison

--- a/cli/src/semdep/maven_version.py
+++ b/cli/src/semdep/maven_version.py
@@ -22,18 +22,20 @@ MavenVersion = Union[ParsedMavenVersion, str]
 
 
 def parse_maven_version(version: str) -> MavenVersion:
-    m = re.compile(r"(\d+)\.(\d+)(?:\.(\d+))?(.*)").match(version)
+    m = re.compile(
+        r"(?P<major>\d+)\.(?P<minor>\d+)(?:\.(?P<incremental>\d+))?(?P<qualifier>.*)"
+    ).match(version)
     # "If you do not follow Maven versioning standards in your project versioning scheme,
     # then for version comparison, Maven interprets the entire version as a simple string."
     if not m:
         return version
-    if "." in m.group(4):
+    if "." in m.group("qualifier"):
         return version
     return ParsedMavenVersion(
-        major=int(m.group(1)),
-        minor=int(m.group(2)),
-        incremental=int(m.group(3)) if m.group(3) else 0,
-        qualifer=m.group(4),
+        major=int(m.group("major")),
+        minor=int(m.group("minor")),
+        incremental=int(m.group("incremental")) if m.group("incremental") else 0,
+        qualifer=m.group("qualifier"),
         raw_version=m.group(0),
     )
 

--- a/cli/src/semdep/maven_version.py
+++ b/cli/src/semdep/maven_version.py
@@ -22,7 +22,7 @@ MavenVersion = Union[ParsedMavenVersion, str]
 
 
 def parse_maven_version(version: str) -> MavenVersion:
-    m = re.compile(r"(\d)\.(\d)(?:\.(\d))?(.*)").match(version)
+    m = re.compile(r"(\d+)\.(\d+)(?:\.(\d+))?(.*)").match(version)
     # "If you do not follow Maven versioning standards in your project versioning scheme,
     # then for version comparison, Maven interprets the entire version as a simple string."
     if not m:

--- a/cli/tests/e2e/test_dependency_aware_rules.py
+++ b/cli/tests/e2e/test_dependency_aware_rules.py
@@ -115,6 +115,9 @@ def test_dependency_aware_rules(run_semgrep_on_copied_files, snapshot, rule, tar
         ("1.0-SNAPSHOT", "> 1.0-alpha", True),
         ("2.17.2", "< 2.3.1", False),
         ("2.0", "< 1.0", False),
+        ("2.0.0", "< 10.0.0", True),
+        ("0.2.0", "0.10.0", True),
+        ("0.0.2", "< 0.0.10", True),
     ],
 )
 def test_maven_version_comparison(version, specifier, outcome):

--- a/cli/tests/e2e/test_dependency_aware_rules.py
+++ b/cli/tests/e2e/test_dependency_aware_rules.py
@@ -105,18 +105,20 @@ def test_dependency_aware_rules(run_semgrep_on_copied_files, snapshot, rule, tar
 
 
 @pytest.mark.parametrize(
-    "version,specifier",
+    "version,specifier,outcome",
     [
-        ("1.2-beta-2", "> 1.0, < 1.2"),
-        ("1.2-beta-2", "> 1.2-alpha-6, < 1.2-beta-3"),
-        ("1.0.10.1", "< 1.0.10.2"),
-        ("1.0.10.2", "> 1.0.10.1, < 1.0.9.3"),  # Yes, seriously
-        ("1.3.4-SNAPSHOT", "< 1.3.4"),
-        ("1.0-SNAPSHOT", "> 1.0-alpha"),
+        ("1.2-beta-2", "> 1.0, < 1.2", True),
+        ("1.2-beta-2", "> 1.2-alpha-6, < 1.2-beta-3", True),
+        ("1.0.10.1", "< 1.0.10.2", True),
+        ("1.0.10.2", "> 1.0.10.1, < 1.0.9.3", True),  # Yes, seriously
+        ("1.3.4-SNAPSHOT", "< 1.3.4", True),
+        ("1.0-SNAPSHOT", "> 1.0-alpha", True),
+        ("2.17.2", "< 2.3.1", False),
+        ("2.0", "< 1.0", False),
     ],
 )
-def test_maven_version_comparison(version, specifier):
-    assert is_in_range(Ecosystem(Maven()), specifier, version)
+def test_maven_version_comparison(version, specifier, outcome):
+    assert is_in_range(Ecosystem(Maven()), specifier, version) == outcome
 
 
 @pytest.mark.parametrize(

--- a/cli/tests/e2e/test_dependency_aware_rules.py
+++ b/cli/tests/e2e/test_dependency_aware_rules.py
@@ -116,7 +116,7 @@ def test_dependency_aware_rules(run_semgrep_on_copied_files, snapshot, rule, tar
         ("2.17.2", "< 2.3.1", False),
         ("2.0", "< 1.0", False),
         ("2.0.0", "< 10.0.0", True),
-        ("0.2.0", "0.10.0", True),
+        ("0.2.0", "< 0.10.0", True),
         ("0.0.2", "< 0.0.10", True),
     ],
 )


### PR DESCRIPTION
The regex for parsing versions incorrectly allowed only single digit numbers for major/minor/incremental versions.


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
