### PR TITLE
fix: use a phony tag when doing a brew dry-run that won't change

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -336,8 +336,8 @@ jobs:
         if: ${{ contains(github.ref, '-test-release') || needs.dry-run.outputs.dry-run == 'true' }}
         run: |
           brew bump-formula-pr --force --no-audit --no-browse --write-only \
-            --message="Bump semgrep to version ${{ steps.get-version.outputs.VERSION }}" \
-            --fork-org=returntocorp --tag="${{ steps.get-version.outputs.VERSION }}" --revision="${GITHUB_SHA}" semgrep --python-exclude-packages semgrep
+            --message="Bump semgrep to version v99.99.99" \
+            --fork-org=returntocorp --tag="v99.99.99" --revision="${GITHUB_SHA}" semgrep --python-exclude-packages semgrep
       - name: Prepare Brew PR
         if: ${{ !contains(github.ref, '-test-release') && needs.dry-run.outputs.dry-run != 'true' }}
         env:


### PR DESCRIPTION
Nightly verification was failing to do the dry-run step - it appears that `refs/heads/develop` is not acceptable by the brew command as a tag. This hard-codes a phony version so that manually-triggered runs and cron runs have the same input, and we only rely on `VERSION` when we run for real on a push of a tag.

Note that this won't affect regular release, only the dry-run when fired by a cron.

Test Plan: 
- https://github.com/returntocorp/semgrep/actions/runs/4254971220

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
