### PR TITLE
tainting: Make identification of sinks more precise

### DIFF
--- a/changelog.d/pa-2509.fixed
+++ b/changelog.d/pa-2509.fixed
@@ -1,0 +1,3 @@
+taint-mode: Code such as `sink(sanitizer(source) if source else ok)` will not be
+incorrectly reported as a tainted sink. This follows a previous attempt at fixing
+these issues in version 1.1.0.

--- a/src/tainting/Dataflow_tainting.ml
+++ b/src/tainting/Dataflow_tainting.ml
@@ -174,11 +174,16 @@ module Top_sinks = struct
         else
           (* We found a better (larger) match! *)
           (* There may be several matches in `sinks` that are subsumed by `m'`.
-           * E.g. we could have sinks (1,5) and (5,10), and then add `(1,10)`
-           * as a match. Before we try adding `m'` to `sinks` we need to make
-           * sure that there is no other match `m` that is included in `m'`.
+           * E.g. we could have found sinks at ranges (1,5) and (6,10), and then
+           * we find that there is better sink match at range (1,10). This
+           * new larger match subsumes both (1,5) and (6, 10) matches.
+           * Thus, before we try adding `m'` to `sinks`, we need to make sure
+           * that there is no other match `m` that is included in `m'`.
            * Otherwise `m'` would be considered a duplicate and it would not
-           * be added. *)
+           * be added (e.g., if we try adding the range (1,10) to a set that
+           * still contains the range (6,10), given our `compare` function above
+           * the (1,10) range will be considered a duplicate), hence the
+           * recursive call to `add` here. *)
           add m' (S.remove m sinks)
 
   let is_best_match sinks m' =

--- a/src/tainting/Dataflow_tainting.ml
+++ b/src/tainting/Dataflow_tainting.ml
@@ -137,9 +137,12 @@ type fun_env = (var, Taints.t) Hashtbl.t
  * because we know there is a better match.
  *)
 module Top_sinks = struct
+  (* For m, m' in S.t, not (m.range $<=$ m'.range) && not (m'.range $<=$ m.range) *)
   module S = Set.Make (struct
     type t = R.taint_sink tmatch
 
+    (* This compare function is subtle but it allows both `add` and `is_best_match`
+     * to be simple and quite efficient. *)
     let compare m1 m2 =
       let sink_id_cmp = String.compare m1.spec.R.sink_id m2.spec.R.sink_id in
       if sink_id_cmp <> 0 then sink_id_cmp
@@ -155,7 +158,7 @@ module Top_sinks = struct
 
   let empty = S.empty
 
-  let add m' sinks =
+  let rec add m' sinks =
     (* We check if we have another match for the *same* sink specification
      * (i.e., same 'sink_id'), and if so we must keep the best match and drop
      * the other one. *)
@@ -168,8 +171,15 @@ module Top_sinks = struct
         if r'.start > r.start || r'.end_ < r.end_ then
           (* The new match is a worse fit so we keep the current one. *)
           sinks
-        else (* We found a better (larger) match! *)
-          S.add m' (S.remove m sinks)
+        else
+          (* We found a better (larger) match! *)
+          (* There may be several matches in `sinks` that are subsumed by `m'`.
+           * E.g. we could have sinks (1,5) and (5,10), and then add `(1,10)`
+           * as a match. Before we try adding `m'` to `sinks` we need to make
+           * sure that there is no other match `m` that is included in `m'`.
+           * Otherwise `m'` would be considered a duplicate and it would not
+           * be added. *)
+          add m' (S.remove m sinks)
 
   let is_best_match sinks m' =
     match S.find_opt m' sinks with

--- a/tests/rules/taint_best_fit_sink1.php
+++ b/tests/rules/taint_best_fit_sink1.php
@@ -1,0 +1,26 @@
+<?php
+
+ // ok:taint-regression-1.6.0
+sink(isset($source) ? 'something' : 'b');
+
+$a = (isset($source) ? 'something' : 'c');
+// ok:taint-regression-1.6.0
+sink($a);
+
+if (isset($source)) {
+    $b = 'sonething';
+} else {
+    $b = 'd';
+}
+// ok:taint-regression-1.6.0
+sink($b);
+
+// ok:taint-regression-1.6.0
+sink(isset($source) ? sanitizer($source) : '');
+
+$c = isset($source) ? sanitizer($source) : '';
+// ok:taint-regression-1.6.0
+sink($c);
+
+// ruleid:taint-regression-1.6.0
+sink(isset($source) ? $source : '');

--- a/tests/rules/taint_best_fit_sink1.yaml
+++ b/tests/rules/taint_best_fit_sink1.yaml
@@ -1,0 +1,13 @@
+rules:
+  - id: taint-regression-1.6.0
+    languages:
+      - php
+    message: Match Found!
+    mode: taint
+    pattern-sanitizers:
+      - pattern: sanitizer(...)
+    pattern-sinks:
+      - pattern: sink(...)
+    pattern-sources:
+      - pattern: $source
+    severity: WARNING

--- a/tests/rules/taint_best_fit_sink2.py
+++ b/tests/rules/taint_best_fit_sink2.py
@@ -1,0 +1,13 @@
+
+# ok: test
+sink(sanitizer(source) if isset(source) else '')
+
+# ok: test
+sink(sanitizer(source) if isset(safe) else '')
+
+# ok: test
+sink(sanitizer(safe) if isset(source) else '')
+
+# ok: test
+sink(safe if isset(source) else '')
+

--- a/tests/rules/taint_best_fit_sink2.yaml
+++ b/tests/rules/taint_best_fit_sink2.yaml
@@ -1,0 +1,14 @@
+rules:
+  - id: test
+    languages:
+      - python
+    message: Match Found!
+    mode: taint
+    pattern-sanitizers:
+      - pattern: sanitizer(...)
+    pattern-sinks:
+      - pattern: sink(...)
+    pattern-sources:
+      - pattern: source
+    severity: WARNING
+


### PR DESCRIPTION
Previously in 1eb330d6887 we did not consider that when adding a better sink range to Top_sinks, there could be not just one but several ranges that were subsumed by the new one.

Closes PA-2509

Fixes: 1eb330d6887 ("tainting: Make identification of sinks more precise (#6640)")

test plan:
make test # added two more tests

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
