### PR TITLE
Revert "Make abstract_content more meaningful (#7017)"

### DIFF
--- a/changelog.d/pa-2510.fixed
+++ b/changelog.d/pa-2510.fixed
@@ -1,0 +1,2 @@
+metavariable-pattern: Fixed regression introduced in version 1.9.0 that broke
+the use of `pattern-not` within `metavariable-pattern` in some cases.

--- a/libs/ast_generic/AST_generic.ml
+++ b/libs/ast_generic/AST_generic.ml
@@ -2099,9 +2099,7 @@ let basic_id_info ?(hidden = false) resolved =
 (* TODO: move AST_generic_helpers.name_of_id and ids here *)
 
 let dotted_to_canonical xs = Common.map fst xs
-
-let canonical_to_dotted tid xs =
-  xs |> Common.map (fun s -> (s, Parse_info.fake_info tid s))
+let canonical_to_dotted tid xs = xs |> Common.map (fun s -> (s, tid))
 
 (* ------------------------------------------------------------------------- *)
 (* Entities *)

--- a/libs/ast_generic/Visitor_AST.ml
+++ b/libs/ast_generic/Visitor_AST.ml
@@ -588,7 +588,7 @@ class ['self] range_visitor =
         ranges := Some (smaller orig_left left, larger orig_right right)
   in
   let incorporate_token ranges tok =
-    if PI.has_origin_loc tok then
+    if PI.is_origintok tok then
       let tok_loc = PI.unsafe_token_location_of_info tok in
       incorporate_tokens ranges (tok_loc, tok_loc)
   in
@@ -637,7 +637,7 @@ let extract_ranges :
     res
 
 let range_of_tokens tokens =
-  List.filter PI.has_origin_loc tokens |> PI.min_max_ii_by_pos
+  List.filter PI.is_origintok tokens |> PI.min_max_ii_by_pos
   [@@profiling]
 
 let range_of_any_opt any =

--- a/libs/lib_parsing/Parse_info.ml
+++ b/libs/lib_parsing/Parse_info.ml
@@ -338,13 +338,6 @@ let is_origintok ii =
   | OriginTok _ -> true
   | _ -> false
 
-let has_origin_loc ii =
-  match ii.token with
-  | OriginTok _
-  | FakeTokStr (_, Some _) ->
-      true
-  | _ -> false
-
 (* info about the current location *)
 
 (* original info *)
@@ -365,9 +358,7 @@ type posrv =
 
 let compare_pos ii1 ii2 =
   let get_pos = function
-    | OriginTok pi
-    | FakeTokStr (_, Some (pi, _)) ->
-        Real pi
+    | OriginTok pi -> Real pi
     (* todo? I have this for lang_php/
         | FakeTokStr (s, Some (pi_orig, offset)) ->
             Virt (pi_orig, offset)

--- a/libs/lib_parsing/Parse_info.mli
+++ b/libs/lib_parsing/Parse_info.mli
@@ -143,9 +143,6 @@ val fake_token_location : token_location
 val is_fake : t -> bool
 val is_origintok : t -> bool
 
-val has_origin_loc : t -> bool
-(** Either an OriginTok or a FakeTokStr associated with a real location. *)
-
 (* NOTE: These functions introduce unsafe fake tokens, prefer safe functions
  * below, use these only as a last resort! *)
 val unsafe_fake_info : string -> t

--- a/src/core/Range.ml
+++ b/src/core/Range.ml
@@ -110,7 +110,7 @@ let range_of_token_locations (start_loc : PI.token_location)
 
 let range_of_tokens xs =
   try
-    let xs = List.filter PI.has_origin_loc xs in
+    let xs = List.filter PI.is_origintok xs in
     let mini, maxi = PI.min_max_ii_by_pos xs in
     let start = PI.pos_of_info mini in
     let end_ =

--- a/src/reporting/JSON_report.ml
+++ b/src/reporting/JSON_report.ml
@@ -119,7 +119,7 @@ let metavar_string_of_any any =
      we have y = 2 but there is no source location for 2.
      Handle such cases *)
   any |> V.ii_of_any
-  |> List.filter PI.has_origin_loc
+  |> List.filter PI.is_origintok
   |> List.sort Parse_info.compare_pos
   |> Common.map PI.str_of_info |> Matching_report.join_with_space_if_needed
 
@@ -187,7 +187,7 @@ let tokens_to_single_loc toks =
    * taint rule finding but it shouldn't happen in practice. *)
   let locations =
     tokens_to_locations
-      (List.filter PI.has_origin_loc toks |> List.sort PI.compare_pos)
+      (List.filter PI.is_origintok toks |> List.sort PI.compare_pos)
   in
   let* first_loc, last_loc = first_and_last locations in
   Some

--- a/tests/rules/metavar_pattern_fake_toks.php
+++ b/tests/rules/metavar_pattern_fake_toks.php
@@ -1,0 +1,46 @@
+<?php
+
+// ruleid:regression-1.9.0
+if ( ! something( $a ) ) {
+    echo 'failed';
+}
+
+// ok:regression-1.9.0
+if ( ! something( $a ) ) {
+    die('ok');
+}
+
+// ok:regression-1.9.0
+if ( ! something( $aa ) ) {
+    $s = 3;
+    die('ok');
+}
+
+// ruleid:regression-1.9.0
+if ( isset( $b ) && something( $b ) ) {
+    echo 'failed';
+}
+
+// ok:regression-1.9.0
+if ( isset( $b ) && something( $b ) ) {
+    die('ok');
+}
+
+// ok:regression-1.9.0
+if ( isset( $b ) && something( $b ) ) {
+    $s = 5;
+    die('ok');
+}
+
+// ok:regression-1.9.0
+if ( something( $c ) ) {
+    break;
+}
+
+// ok:regression-1.9.0
+if ( something( $cc ) ) {
+    $s = 3;
+    break;
+}
+
+

--- a/tests/rules/metavar_pattern_fake_toks.yaml
+++ b/tests/rules/metavar_pattern_fake_toks.yaml
@@ -1,0 +1,17 @@
+rules:
+  - id: regression-1.9.0
+    message: Match!
+    languages:
+      - php
+    severity: WARNING
+    patterns:
+      - pattern: |
+          if (<... something($VAR, ...) ...>) {
+            $NO_DIE_EXIT_RETURN;
+          }
+      - metavariable-pattern:
+          metavariable: $NO_DIE_EXIT_RETURN
+          patterns:
+            - pattern-not: die(...);
+            - pattern-not: exit(...);
+            - pattern-not: break;

--- a/tests/rules/metavar_pattern_fake_toks1.php
+++ b/tests/rules/metavar_pattern_fake_toks1.php
@@ -1,0 +1,7 @@
+<?php
+
+// ok:regression-1.9.0
+if (cond) {
+    die('ok');
+}
+

--- a/tests/rules/metavar_pattern_fake_toks1.yaml
+++ b/tests/rules/metavar_pattern_fake_toks1.yaml
@@ -1,0 +1,16 @@
+rules:
+  - id: regression-1.9.0
+    message: Match!
+    languages:
+      - php
+    severity: WARNING
+    patterns:
+      - pattern: |
+          if (cond) {
+            $NO_DIE_EXIT_RETURN;
+          }
+      - metavariable-pattern:
+          metavariable: $NO_DIE_EXIT_RETURN
+          patterns:
+            - pattern-not: die(...);
+


### PR DESCRIPTION
This reverts (most of) commit d571780cd2c3bc87eed5b6d0c8cf31c26fb316e1.

d571780cd2c makes safe fake-tokens count to compute ranges but these safe fake-tokens were not being "fixed" by metavariable-pattern via `Parsing_helpers.fix_token_location`. This could result in bad ranges when matching a nested metavariable-pattern formula.

It should be fixable but for now we just revert.

Closes PA-2510

test plan:
make test # tests added

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
