### PR TITLE
refactor: Convert AST_stat.ml to use generated visitor

### DIFF
--- a/src/parsing/tests/AST_stat.ml
+++ b/src/parsing/tests/AST_stat.ml
@@ -9,55 +9,54 @@ type t = Parsing_stat.ast_stat
 let stat (ast : G.program) : t =
   let total_node_count = ref 0 in
   let untranslated_node_count = ref 0 in
-  let count_ordinary_node (k, _) node =
+  let count_ordinary_node recurse env node =
     incr total_node_count;
-    k node
+    recurse env node
   in
-  let visit_nodes =
-    Visitor_AST.mk_visitor
-      {
-        kexpr = count_ordinary_node;
-        kstmt = count_ordinary_node;
-        ktype_ = count_ordinary_node;
-        kpattern = count_ordinary_node;
-        kfield = count_ordinary_node;
-        (* Fields are also visited individually *)
-        kfields = (fun (k, _) x -> k x);
-        (* Partial nodes are generated for matching and will lead to
-         * double-counting *)
-        kpartial = (fun _ _ -> ());
-        kdef = count_ordinary_node;
-        kdir = count_ordinary_node;
-        kattr = count_ordinary_node;
-        kparam = count_ordinary_node;
-        ktparam = count_ordinary_node;
-        kcatch = count_ordinary_node;
-        kident = count_ordinary_node;
-        kname = count_ordinary_node;
-        kentity = count_ordinary_node;
-        (* Statements are also visited individually *)
-        kstmts = (fun (k, _) x -> k x);
-        kfunction_definition = count_ordinary_node;
-        kclass_definition = count_ordinary_node;
-        kinfo = count_ordinary_node;
-        (* By default, do not visit the refs in id_info *)
-        kid_info = Visitor_AST.default_visitor.kid_info;
-        ksvalue = count_ordinary_node;
-        kargument = count_ordinary_node;
-        klit = count_ordinary_node;
-        ktodo =
-          (fun (k, _) x ->
-            incr total_node_count;
-            incr untranslated_node_count;
-            k x);
-        kraw =
-          (fun (k, _) raw_node ->
-            incr total_node_count;
-            incr untranslated_node_count;
-            k raw_node);
-      }
+  let visitor =
+    object
+      inherit [_] G.iter_no_id_info as super
+      method! visit_expr = count_ordinary_node super#visit_expr
+      method! visit_stmt = count_ordinary_node super#visit_stmt
+      method! visit_type_ = count_ordinary_node super#visit_type_
+      method! visit_pattern = count_ordinary_node super#visit_pattern
+      method! visit_field = count_ordinary_node super#visit_field
+      method! visit_definition = count_ordinary_node super#visit_definition
+      method! visit_directive = count_ordinary_node super#visit_directive
+      method! visit_attribute = count_ordinary_node super#visit_attribute
+      method! visit_parameter = count_ordinary_node super#visit_parameter
+
+      method! visit_type_parameter =
+        count_ordinary_node super#visit_type_parameter
+
+      method! visit_catch = count_ordinary_node super#visit_catch
+      method! visit_ident = count_ordinary_node super#visit_ident
+      method! visit_name = count_ordinary_node super#visit_name
+      method! visit_entity = count_ordinary_node super#visit_entity
+
+      method! visit_function_definition =
+        count_ordinary_node super#visit_function_definition
+
+      method! visit_class_definition =
+        count_ordinary_node super#visit_class_definition
+
+      method! visit_tok = count_ordinary_node super#visit_tok
+      method! visit_svalue = count_ordinary_node super#visit_svalue
+      method! visit_argument = count_ordinary_node super#visit_argument
+      method! visit_literal = count_ordinary_node super#visit_literal
+
+      method! visit_todo_kind env x =
+        incr total_node_count;
+        incr untranslated_node_count;
+        super#visit_todo_kind env x
+
+      method! visit_raw_tree env raw_node =
+        incr total_node_count;
+        incr untranslated_node_count;
+        super#visit_raw_tree env raw_node
+    end
   in
-  visit_nodes (G.Pr ast);
+  visitor#visit_program () ast;
   {
     total_node_count = !total_node_count;
     untranslated_node_count = !untranslated_node_count;

--- a/src/parsing/tests/AST_stat.ml
+++ b/src/parsing/tests/AST_stat.ml
@@ -21,8 +21,11 @@ let stat (ast : G.program) : t =
         ktype_ = count_ordinary_node;
         kpattern = count_ordinary_node;
         kfield = count_ordinary_node;
-        kfields = count_ordinary_node;
-        kpartial = count_ordinary_node;
+        (* Fields are also visited individually *)
+        kfields = (fun (k, _) x -> k x);
+        (* Partial nodes are generated for matching and will lead to
+         * double-counting *)
+        kpartial = (fun _ _ -> ());
         kdef = count_ordinary_node;
         kdir = count_ordinary_node;
         kattr = count_ordinary_node;
@@ -32,7 +35,8 @@ let stat (ast : G.program) : t =
         kident = count_ordinary_node;
         kname = count_ordinary_node;
         kentity = count_ordinary_node;
-        kstmts = count_ordinary_node;
+        (* Statements are also visited individually *)
+        kstmts = (fun (k, _) x -> k x);
         kfunction_definition = count_ordinary_node;
         kclass_definition = count_ordinary_node;
         kinfo = count_ordinary_node;


### PR DESCRIPTION
This changes the stats somewhat. This is because previously we used the matching visitor which generates various extra nodes for matching purposes. I split this up into two commits so as to demonstrate that this is why the numbers have changed. In the first commit, I change this code to ignore the nodes that are generated just for matching. This causes the numbers to change. In the second commit, I updated this code to use the vanilla autogenerated visitor, and the numbers do not change.

Test plan:

From `stats/parsing-stats`, run `./run-lang julia` (after running `make core && make install` at the repo root).

The untranslated node count is unchanged (149476) but the total node count drops from 9432006 to 9005661

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
