### PR TITLE
refactor: Use generated visitors for src/parsing

### DIFF
--- a/src/parsing/Check_pattern.ml
+++ b/src/parsing/Check_pattern.ml
@@ -42,22 +42,28 @@ let lang_has_no_dollar_ids =
     | Solidity ->
         false)
 
+class ['self] metavar_checker =
+  object (_self : 'self)
+    inherit [_] AST_generic.iter_no_id_info as super
+
+    method! visit_ident (error, lang) id =
+      let str, _tok = id in
+      if
+        str.[0] = '$'
+        && (not (Metavariable.is_metavar_name str))
+        && not (Metavariable.is_metavar_ellipsis str)
+      then
+        error
+          (Common.spf
+             "`%s' is neither a valid identifier in %s nor a valid \
+              meta-variable"
+             str (Lang.to_string lang));
+      super#visit_ident (error, lang) id
+  end
+
 let check_pattern_metavars error lang ast =
-  let kident_metavar (k, _out) ((str, _tok) as ident) =
-    if
-      str.[0] = '$'
-      && (not (Metavariable.is_metavar_name str))
-      && not (Metavariable.is_metavar_ellipsis str)
-    then
-      error
-        (Common.spf
-           "`%s' is neither a valid identifier in %s nor a valid meta-variable"
-           str (Lang.to_string lang));
-    k ident
-  in
   if lang_has_no_dollar_ids lang then
-    Visitor_AST.(
-      mk_visitor { default_visitor with kident = kident_metavar } ast)
+    (new metavar_checker)#visit_any (error, lang) ast
 
 let check lang ast =
   let error s = failwith s in


### PR DESCRIPTION
Aside from AST_stat.ml, which deserved its own PR (#7224)

Test plan: Automated tests

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
