### PR TITLE
AST_to_IL: Fix translation of side-effects in Bool exprs

### DIFF
--- a/changelog.d/gh-7199.fixed
+++ b/changelog.d/gh-7199.fixed
@@ -1,0 +1,4 @@
+Dataflow: Fixed incorrect translation of side-effects inside Boolean expressions,
+this was (for example) causing `if (cond && x = 42) S1; S2` to be interpreted as
+`x = 42; if (cond && x) S1; S2`, thus incorrectly flagging `x` as a constant
+inside S2.

--- a/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awarelog4shell.yaml-dependency_awarelog4j/results.txt
+++ b/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awarelog4shell.yaml-dependency_awarelog4j/results.txt
@@ -39,19 +39,6 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
               "line": 33,
               "offset": 1035
             },
-            "propagated_value": {
-              "svalue_abstract_content": "req.getParameter(\"uname\")",
-              "svalue_end": {
-                "col": 52,
-                "line": 19,
-                "offset": 562
-              },
-              "svalue_start": {
-                "col": 27,
-                "line": 19,
-                "offset": 537
-              }
-            },
             "start": {
               "col": 26,
               "line": 33,

--- a/src/analyzing/AST_to_IL.ml
+++ b/src/analyzing/AST_to_IL.ml
@@ -190,6 +190,14 @@ let pop_stmts env =
   env.stmts := [];
   xs
 
+let with_pre_stmts env f =
+  let saved_stmts = !(env.stmts) in
+  env.stmts := [];
+  let r = f env in
+  let f_stmts = pop_stmts env in
+  env.stmts := saved_stmts;
+  (f_stmts, r)
+
 let bracket_keep f (t1, x, t2) = (t1, f x, t2)
 
 let ident_of_entity_opt ent =
@@ -445,8 +453,14 @@ and assign env lhs tok rhs_exp e_gen =
 and expr_aux env ?(void = false) e_gen =
   let eorig = SameAs e_gen in
   match e_gen.G.e with
+  | G.Call
+      ( { e = G.IdSpecial (G.Op ((G.And | G.Or) as op), tok); _ },
+        (_, arg0 :: args, _) )
+    when not void ->
+      expr_lazy_op env op tok arg0 args eorig
+  (* args_with_pre_stmts *)
   | G.Call ({ e = G.IdSpecial (G.Op op, tok); _ }, args) -> (
-      let args = arguments env args in
+      let args = arguments env (PI.unbracket args) in
       if not void then mk_e (Operator ((op, tok), args)) eorig
       else
         (* The operation's result is not being used, so it may have side-effects.
@@ -521,7 +535,7 @@ and expr_aux env ?(void = false) e_gen =
       (* obj.concat(args) *)
       (* NOTE: Often this will be string concatenation but not necessarily! *)
       let obj_arg' = Unnamed (expr env obj) in
-      let args' = arguments env args in
+      let args' = arguments env (PI.unbracket args) in
       let res =
         match env.lang with
         (* Ruby's concat method is side-effectful and updates the object. *)
@@ -546,7 +560,7 @@ and expr_aux env ?(void = false) e_gen =
         args ) ->
       let lval = fresh_lval env tok in
       let special = (Eval, tok) in
-      let args = arguments env args in
+      let args = arguments env (PI.unbracket args) in
       add_instr env (mk_i (CallSpecial (Some lval, special, args)) eorig);
       mk_e (Fetch lval) (related_tok tok)
   | G.Call
@@ -560,12 +574,12 @@ and expr_aux env ?(void = false) e_gen =
       (* TODO: lift up New in IL like we did in AST_generic *)
       let special = (New, tok) in
       let arg = G.ArgType ty in
-      let args = arguments env args in
+      let args = arguments env (PI.unbracket args) in
       add_call env tok eorig ~void (fun res ->
           CallSpecial (res, special, argument env arg :: args))
   | G.Call ({ e = G.IdSpecial spec; _ }, args) -> (
       let tok = snd spec in
-      let args = arguments env args in
+      let args = arguments env (PI.unbracket args) in
       try
         let special = call_special env spec in
         add_call env tok eorig ~void (fun res ->
@@ -762,6 +776,25 @@ and expr_opt env = function
       mk_e (Literal void) NoOrig
   | Some e -> expr env e
 
+and expr_lazy_op env op tok arg0 args eorig =
+  let arg0' = argument env arg0 in
+  let args' : exp argument list =
+    (* Consider A && B && C, side-effects in B must only take effect `if A`,
+       * and side-effects in C must only take effect `if A && B`. *)
+    args
+    |> List.fold_left_map
+         (fun cond argi ->
+           let ssi, argi' = arg_with_pre_stmts env argi in
+           if ssi <> [] then add_stmt env (mk_s @@ If (tok, cond, ssi, []));
+           let condi =
+             mk_e (Operator ((op, tok), [ Unnamed cond; argi' ])) eorig
+           in
+           (condi, argi'))
+         (IL_helpers.exp_of_arg arg0')
+    |> snd
+  in
+  mk_e (Operator ((op, tok), arg0' :: args')) eorig
+
 and call_generic env ?(void = false) tok e args =
   let eorig = SameAs (G.Call (e, args) |> G.e) in
   let e = expr env e in
@@ -774,7 +807,7 @@ and call_generic env ?(void = false) tok e args =
    * to return in expr multiple arguments and thread things around; Not
    * worth it.
    *)
-  let args = arguments env args in
+  let args = arguments env (PI.unbracket args) in
   add_call env tok eorig ~void (fun res -> Call (res, e, args))
 
 and call_special _env (x, tok) =
@@ -811,7 +844,7 @@ and composite_kind = function
   | G.Tuple -> CTuple
 
 (* TODO: dependency of order between arguments for instr? *)
-and arguments env xs = xs |> PI.unbracket |> Common.map (argument env)
+and arguments env xs = xs |> Common.map (argument env)
 
 and argument env arg =
   match arg with
@@ -987,28 +1020,23 @@ and lval_of_ent env ent =
       | x :: _ -> fresh_lval env x)
 
 and expr_with_pre_stmts env ?void e =
-  let e = expr env ?void e in
-  let xs = pop_stmts env in
-  (xs, e)
+  with_pre_stmts env (fun env -> expr env ?void e)
 
 (* alt: could use H.cond_to_expr and reuse expr_with_pre_stmts *)
 and cond_with_pre_stmts env ?void cond =
-  match cond with
-  | G.Cond e ->
-      let e = expr env ?void e in
-      let xs = pop_stmts env in
-      (xs, e)
-  | G.OtherCond (categ, xs) ->
-      let e = G.OtherExpr (categ, xs) |> G.e in
-      log_fixme ToDo (G.E e);
-      let e = expr env ?void e in
-      let xs = pop_stmts env in
-      (xs, e)
+  with_pre_stmts env (fun env ->
+      match cond with
+      | G.Cond e -> expr env ?void e
+      | G.OtherCond (categ, xs) ->
+          let e = G.OtherExpr (categ, xs) |> G.e in
+          log_fixme ToDo (G.E e);
+          expr env ?void e)
+
+and arg_with_pre_stmts env arg =
+  with_pre_stmts env (fun env -> argument env arg)
 
 and args_with_pre_stmts env args =
-  let args = arguments env args in
-  let xs = pop_stmts env in
-  (xs, args)
+  with_pre_stmts env (fun env -> arguments env args)
 
 and expr_with_pre_stmts_opt env eopt =
   match eopt with
@@ -1218,7 +1246,7 @@ and stmt_aux env st =
       let ss, e = expr_with_pre_stmts_opt env eopt in
       ss @ [ mk_s (Return (tok, e)) ]
   | G.Assert (tok, args, _) ->
-      let ss, args = args_with_pre_stmts env args in
+      let ss, args = args_with_pre_stmts env (PI.unbracket args) in
       let special = (Assert, tok) in
       (* less: wrong e? would not be able to match on Assert, or
        * need add sorig:

--- a/src/analyzing/AST_to_IL.ml
+++ b/src/analyzing/AST_to_IL.ml
@@ -450,6 +450,9 @@ and assign env lhs tok rhs_exp e_gen =
 (* less: we could pass in an optional lval that we know the caller want
  * to assign into, which would avoid creating useless fresh_var intermediates.
  *)
+(* We set `void` to `true` when the value of the expression is being discarded, in
+ * which case, for certain expressions and in certain languages, we assume that the
+ * expression has side-effects. See translation of operators below. *)
 and expr_aux env ?(void = false) e_gen =
   let eorig = SameAs e_gen in
   match e_gen.G.e with

--- a/tests/patterns/java/cp_is_must_analysis.java
+++ b/tests/patterns/java/cp_is_must_analysis.java
@@ -1,0 +1,37 @@
+class A {
+    String str;
+    public void method1(boolean condition){
+        str = "hello";
+        //ERROR: test
+        X.test(str);
+    }
+    public void method2(boolean condition){
+        if(condition){
+            str = "hello"
+        }
+        //OK: test
+        X.test(str);
+    }
+    public void method3(boolean condition){
+        if(condition && str = "hello"){
+        }
+        //OK: test
+        X.test(str);
+    }
+    public void method4(boolean condition){
+        if(condition || str = "hello"){
+        }
+        //OK: test
+        X.test(str);
+    }
+    public void method5(boolean condition){
+        if(condition){
+            str = "hello"
+        }
+        else {
+            str = "hello"
+        }
+        //ERROR: test
+        X.test(str);
+    }
+}

--- a/tests/patterns/java/cp_is_must_analysis.sgrep
+++ b/tests/patterns/java/cp_is_must_analysis.sgrep
@@ -1,0 +1,1 @@
+X.test("hello")

--- a/tests/patterns/java/cp_is_must_analysis1.java
+++ b/tests/patterns/java/cp_is_must_analysis1.java
@@ -1,0 +1,25 @@
+// https://github.com/returntocorp/semgrep/issues/7199
+class A {
+    
+    public void method(boolean condition){
+      var str = "hello";
+      if(condition){
+        if("goodbye".equals(str = "goodbye"))
+            // OK: test
+            X.test(str);
+      }
+      // OK: test
+      X.test(str);
+    }
+
+    public void method2(boolean condition){
+      var str = "hello";
+      if(condition && "goodbye".equals(str = "goodbye")){
+        // OK: test
+        X.test(str);
+      }
+      // OK: test
+      X.test(str);
+    }
+
+}

--- a/tests/patterns/java/cp_is_must_analysis1.sgrep
+++ b/tests/patterns/java/cp_is_must_analysis1.sgrep
@@ -1,0 +1,1 @@
+X.test("hello")

--- a/tests/patterns/java/cp_is_must_analysis2.java
+++ b/tests/patterns/java/cp_is_must_analysis2.java
@@ -1,0 +1,36 @@
+// https://github.com/returntocorp/semgrep/issues/7199
+class A {
+    
+    public void method(boolean condition){
+      var str = "hello";
+      if(condition){
+        if("goodbye".equals(str = "goodbye"))
+            // ERROR: test
+            X.test(str);
+      }
+      // OK: test
+      X.test(str);
+    }
+
+    public void method2(boolean condition){
+      var str = "hello";
+      /*
+      In the IL this will be viewed as:
+
+      if (condition)
+        str = "goodbye";
+      if(condition && "goodbye".equals(str)) {
+        X.test(str);
+      }
+
+      And const-prop is a path-insensitive analysis.
+      */
+      if(condition && "goodbye".equals(str = "goodbye")){
+        // TODO: test
+        X.test(str);
+      }
+      // OK: test
+      X.test(str);
+    }
+
+}

--- a/tests/patterns/java/cp_is_must_analysis2.sgrep
+++ b/tests/patterns/java/cp_is_must_analysis2.sgrep
@@ -1,0 +1,1 @@
+X.test("goodbye")

--- a/tests/rules/sym_prop_no_merge3.java
+++ b/tests/rules/sym_prop_no_merge3.java
@@ -1,0 +1,19 @@
+package com.example.log4shell;
+
+public class LoginServlet extends HttpServlet {
+    @Override
+    protected void doPost(HttpServletRequest req) {
+
+        String userName = req.xyz;
+
+        if(foo && bar) {
+            //ruleid: test
+            baz(userName);
+        }
+        // TODO: Right now we kill all sym-prop values at JOIN points (i.e. after if-
+        //       or loop statements). In principle we would not have to do this when
+        //       all the branches arriving at the JOIN carry the same sym-prop value.
+        //todoruleid: test
+        baz(userName);
+    }
+}

--- a/tests/rules/sym_prop_no_merge3.yaml
+++ b/tests/rules/sym_prop_no_merge3.yaml
@@ -1,0 +1,9 @@
+rules:
+  - id: test
+    languages:
+      - java
+    message: Test
+    severity: INFO
+    options:
+      symbolic_propagation: true
+    pattern: baz(req.xyz)

--- a/tests/rules/sym_prop_no_merge4.java
+++ b/tests/rules/sym_prop_no_merge4.java
@@ -1,0 +1,18 @@
+package com.example.log4shell;
+
+public class LoginServlet extends HttpServlet {
+    @Override
+    protected void doPost(HttpServletRequest req) {
+
+        String userName = req.xyz;
+
+        if(foo && x = 42) {
+            //TODO: Since `x = 42` has side-effects, an `if (foo) x = 42` statement
+            //      is added in the Dataflow IL before this if-statement. And because
+            //      sym-prop values are killed at JOIN points, here we no longer have
+            //      a sym-prop value for userName.
+            //todoruleid: test
+            baz(userName);
+        }
+    }
+}

--- a/tests/rules/sym_prop_no_merge4.yaml
+++ b/tests/rules/sym_prop_no_merge4.yaml
@@ -1,0 +1,9 @@
+rules:
+  - id: test
+    languages:
+      - java
+    message: Test
+    severity: INFO
+    options:
+      symbolic_propagation: true
+    pattern: baz(req.xyz)


### PR DESCRIPTION
We were interpreting `A && x = 42` as `x = 42; A && x`, but the side-effects of `x = 42` only take effect if `A` holds.

We fix this by guarding these side-effects, e.g. interpreting `A && x = 42` as `if (A) x = 42; A && x`.
    
Unfortunately, this will have some side-effects on sym-prop, because we kill sym-prop values at JOIN points, so any sym-prop values are lost after an if-statement. Sym-prop is experimental so that's OK.

Closes #7199

test plan:
make test # tests added

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
