### PR TITLE
feat(perf): Only parse rules that will actually be run

### DIFF
--- a/src/osemgrep/cli_scan/Rule_fetching.mli
+++ b/src/osemgrep/cli_scan/Rule_fetching.mli
@@ -12,7 +12,7 @@ type rules_source =
 (* output *)
 type rules_and_origin = {
   origin : origin;
-  rules : Rule.rules;
+  rules : Rule.lazy_rule list;
   errors : Rule.invalid_rule_error list;
 }
 
@@ -20,7 +20,7 @@ and origin = Common.filename option (* None for remote files *)
 [@@deriving show]
 
 val partition_rules_and_errors :
-  rules_and_origin list -> Rule.rules * Rule.invalid_rule_error list
+  rules_and_origin list -> Rule.lazy_rule list * Rule.invalid_rule_error list
 
 (* [rules_from_rules_source] returns rules from --config or -e
  * TODO: does it rewrite the rule_id?

--- a/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -140,6 +140,9 @@ let run (conf : Scan_CLI.conf) : Exit_code.t =
       let rules, errors =
         Rule_fetching.partition_rules_and_errors rules_and_origins
       in
+      let rules, errors, _rules_parse_time =
+        Rule.force_and_record_rules rules errors 0.0
+      in
       let filtered_rules =
         Rule_filtering.filter_rules conf.rule_filtering_conf rules
       in

--- a/src/osemgrep/cli_scan/Validate_subcommand.ml
+++ b/src/osemgrep/cli_scan/Validate_subcommand.ml
@@ -94,6 +94,9 @@ let run (conf : conf) : Exit_code.t =
         let metarules, metaerrors =
           Rule_fetching.partition_rules_and_errors metarules_and_origin
         in
+        let metarules, metaerrors, _rules_parse_time =
+          Rule.force_and_record_rules metarules metaerrors 0.0
+        in
         if metaerrors <> [] then
           Error.abort (spf "error in metachecks! please fix %s" metarules_pack);
 

--- a/src/parsing/Parse_rule.mli
+++ b/src/parsing/Parse_rule.mli
@@ -9,7 +9,7 @@
  * (e.g., Rule.InvalidYaml).
  *)
 val parse_and_filter_invalid_rules :
-  Common.filename -> Rule.rules * Rule.invalid_rule_error list
+  Common.filename -> Rule.lazy_rule list * Rule.invalid_rule_error list
 
 (* ex: foo.yaml, foo.yml, but not foo.test.yaml.
  *
@@ -43,4 +43,4 @@ val parse_generic_ast :
   ?error_recovery:bool ->
   Common.filename ->
   AST_generic.program ->
-  Rule.rules * Rule.invalid_rule_error list
+  Rule.lazy_rule list * Rule.invalid_rule_error list

--- a/src/runner/Run_semgrep.mli
+++ b/src/runner/Run_semgrep.mli
@@ -161,7 +161,8 @@ val exn_to_error : Common.filename -> Exception.t -> Semgrep_error_code.error
   See also JSON_report.json_of_exn for non-target related exn handling.
 *)
 
-val mk_rule_table : Rule.t list -> Rule.rule_id list -> (int, Rule.t) Hashtbl.t
+val mk_rule_table :
+  Rule.lazy_rule list -> Rule.rule_id list -> (int, Rule.lazy_rule) Hashtbl.t
 (** Helper to create the table of rules to run for each file **)
 
 val extracted_targets_of_config :


### PR DESCRIPTION
Pattern parsing--specifically, Ruby pattern parsing--can be slow. We currently have over 1000 rules in p/default, many of which are not run depending on the languages in the repo. We can skip the pattern parsing stage for those rules.

In conjunction with https://github.com/returntocorp/semgrep/pull/7188, reduces rule parsing when run on the semgrep repo  to around a second, down from 13 seconds with just 7188. It is very effective because Ruby pattern parsing takes the vast majority of the time. Any repo without Ruby should see a similar result.

Curently not implemented for osemgrep.

Test plan: make test

PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
