### PR TITLE
tainting: Make identification of sinks more precise

### DIFF
--- a/changelog.d/pa-2477.changed
+++ b/changelog.d/pa-2477.changed
@@ -1,0 +1,15 @@
+taint-mode: Historically, the matching of taint sinks has been somewhat imprecise.
+For example, `sink(ok if tainted else ok)` was flagged. Recently, we made sink-
+matching more precise for sinks like `sink(...)` declaring that any argument of
+a given function is a sink. Now we make it more precise when specific arguments of
+a function are sinks, like:
+
+```yaml
+pattern-sinks:
+- patterns:
+  - pattern: sink($X, ...)
+  - focus-metavariable: $X
+```
+
+So `sink(ok1 if tainted else ok2)`, `sink(not_a_propagator(tainted))`, and
+`sink(some_array[tainted])`, will not be reported as findings.

--- a/src/tainting/Dataflow_tainting.ml
+++ b/src/tainting/Dataflow_tainting.ml
@@ -158,6 +158,11 @@ module Top_sinks = struct
 
   let empty = S.empty
 
+  let _debug sinks =
+    sinks |> S.elements
+    |> Common.map (fun m -> Range.content_at_range m.spec_pm.file m.range)
+    |> String.concat " ; "
+
   let rec add m' sinks =
     (* We check if we have another match for the *same* sink specification
      * (i.e., same 'sink_id'), and if so we must keep the best match and drop
@@ -251,7 +256,7 @@ let orig_is_source config orig = config.is_source (any_of_orig orig)
 let orig_is_sanitized config orig = config.is_sanitizer (any_of_orig orig)
 let orig_is_sink config orig = config.is_sink (any_of_orig orig)
 
-let orig_is_best_sink env orig =
+let orig_is_best_sink env orig : R.taint_sink tmatch list =
   orig_is_sink env.config orig
   |> List.filter (Top_sinks.is_best_match env.top_sinks)
 
@@ -279,9 +284,24 @@ let report_findings env findings =
 let top_level_sinks_in_nodes config flow =
   flow.CFG.reachable |> CFG.NodeiSet.to_seq
   |> Stdcompat.Seq.concat_map (fun ni ->
+         let origs_of_args args =
+           Seq.map (fun a -> (IL_helpers.exp_of_arg a).eorig) (List.to_seq args)
+         in
          let node = flow.CFG.graph#nodes#assoc ni in
          match node.n with
-         | NInstr instr -> orig_is_sink config instr.iorig |> List.to_seq
+         | NInstr instr ->
+             let origs : orig Seq.t =
+               Seq.cons instr.iorig
+                 (match instr.i with
+                 | Call (_, c, args) -> Seq.cons c.eorig (origs_of_args args)
+                 | CallSpecial (_, _, args) -> origs_of_args args
+                 | Assign (_, e) -> List.to_seq [ e.eorig ]
+                 | AssignAnon _
+                 | FixmeInstr _ ->
+                     Seq.empty)
+             in
+             origs
+             |> Seq.concat_map (fun o -> orig_is_sink config o |> List.to_seq)
          | NCond (_, exp)
          | NReturn (_, exp)
          | NThrow (_, exp) ->
@@ -297,6 +317,27 @@ let top_level_sinks_in_nodes config flow =
          | NTodo _ ->
              Seq.empty)
   |> Seq.fold_left (fun s x -> Top_sinks.add x s) Top_sinks.empty
+
+(* Checks whether the sink corresponds has the shape
+ *
+ *     patterns:
+ *     - pattern: <func>(<args>)
+ *     - focus-metavariable: $MVAR
+ *
+ * In which case we know that the function call itself is not the sink, but
+ * either the <func> or one (or more) of the <args>.
+ *)
+let is_func_sink_with_focus taint_sink =
+  match taint_sink.Rule.sink_formula with
+  | Rule.And
+      ( _,
+        {
+          conjuncts = [ P { pat = Sem (E { e = Call _; _ }, _); _ } ];
+          focus = [ _focus ];
+          _;
+        } ) ->
+      true
+  | __else__ -> false
 
 let unify_mvars_sets mvars1 mvars2 =
   let xs =
@@ -421,6 +462,17 @@ let findings_of_tainted_return taints return_tok : T.finding list =
          match taint.orig with
          | T.Arg i -> T.ArgToReturn (i, tokens, return_tok)
          | T.Src src -> T.SrcToReturn (src, tokens, return_tok))
+
+let check_orig_if_sink env ?filter_sinks orig taints =
+  let sinks = orig_is_best_sink env orig in
+  let sinks =
+    match filter_sinks with
+    | None -> sinks
+    | Some sink_pred -> sinks |> List.filter sink_pred
+  in
+  let sinks = sinks |> Common.map trace_of_match in
+  let findings = findings_of_tainted_sinks env taints sinks in
+  report_findings env findings
 
 let filter_taints_by_labels labels taints =
   Taints.fold
@@ -779,9 +831,6 @@ and check_tainted_expr env exp : Taints.t * Lval_env.t =
       (* TODO: We should check that taint and sanitizer(s) are unifiable. *)
       (Taints.empty, lval_env)
   | None ->
-      let sinks =
-        orig_is_best_sink env exp.eorig |> Common.map trace_of_match
-      in
       let taints_sources =
         orig_is_source env.config exp.eorig |> taints_of_matches
       in
@@ -793,8 +842,7 @@ and check_tainted_expr env exp : Taints.t * Lval_env.t =
         handle_taint_propagators { env with lval_env } (`Exp exp) taints
       in
       let taints = Taints.union taints taints_propagated in
-      let findings = findings_of_tainted_sinks env taints sinks in
-      report_findings env findings;
+      check_orig_if_sink env exp.eorig taints;
       (taints, var_env)
 
 let check_tainted_var env (var : IL.name) : Taints.t * Lval_env.t =
@@ -849,11 +897,6 @@ let check_function_signature env fun_exp args_taints =
   | Some _, _ ->
       None
 
-let check_orig_if_sink env orig taints =
-  let sinks = orig_is_best_sink env orig |> Common.map trace_of_match in
-  let findings = findings_of_tainted_sinks env taints sinks in
-  report_findings env findings
-
 (* Test whether an instruction is tainted, and if it is also a sink,
  * report the finding too (by side effect). *)
 (* TODO: This should return a new var_env rather than just taint, it
@@ -884,9 +927,13 @@ let check_tainted_instr env instr : Taints.t * Lval_env.t =
           List.fold_left Taints.union Taints.empty all_taints
         in
         let opt_taint_sig = check_function_signature env e args_taints in
-        (* If the function is a sink, then we consider that all its parameters
-           * are sinks. *)
-        check_orig_if_sink env instr.iorig all_args_taints;
+        (* After we introduced Top_sinks, we need to explicitly support sinks like
+         * `sink(...)` by considering that all of the parameters are sinks. To make
+         * sure that we are backwards compatible, we do this for any sink that does
+         * not match the `is_func_sink_with_focus` pattern.
+         *)
+        check_orig_if_sink env instr.iorig all_args_taints
+          ~filter_sinks:(fun m -> not (is_func_sink_with_focus m.spec));
         let call_taints =
           match opt_taint_sig with
           | Some call_taints -> call_taints
@@ -915,9 +962,6 @@ let check_tainted_instr env instr : Taints.t * Lval_env.t =
       (* TODO: We should check that taint and sanitizer(s) are unifiable. *)
       (Taints.empty, env.lval_env)
   | [] ->
-      let sinks =
-        orig_is_best_sink env instr.iorig |> Common.map trace_of_match
-      in
       let taint_sources =
         orig_is_source env.config instr.iorig |> taints_of_matches
       in
@@ -931,8 +975,7 @@ let check_tainted_instr env instr : Taints.t * Lval_env.t =
           (`Ins instr) taints
       in
       let taints = Taints.union taints taints_propagated in
-      let findings = findings_of_tainted_sinks env taints sinks in
-      report_findings env findings;
+      check_orig_if_sink env instr.iorig taints;
       (taints, lval_env')
 
 (* Test whether a `return' is tainted, and if it is also a sink,

--- a/tests/rules/taint_best_fit_sink3.py
+++ b/tests/rules/taint_best_fit_sink3.py
@@ -1,0 +1,11 @@
+#ruleid: test
+sink(tainted())
+
+# ok:test
+sink(ok1 if tainted() else ok2)
+
+#ok:test
+sink(not_a_propagator(tainted()))
+
+#ok:test
+sink(some_array[tainted()])

--- a/tests/rules/taint_best_fit_sink3.yaml
+++ b/tests/rules/taint_best_fit_sink3.yaml
@@ -1,0 +1,17 @@
+rules:
+  - id: test
+    languages:
+      - python
+    message: Match
+    mode: taint
+    options:
+      taint_assume_safe_functions: true
+      taint_assume_safe_indexes: true
+    pattern-sinks:
+      - patterns:
+        - pattern: sink($X)
+        - focus-metavariable: $X
+    pattern-sources:
+      - pattern: tainted(...)
+    severity: WARNING
+

--- a/tests/rules/taint_best_fit_sink4.php
+++ b/tests/rules/taint_best_fit_sink4.php
@@ -1,0 +1,32 @@
+<?php
+
+// ok:taint-regression-1.6.0
+sink(isset($source) ? 'something' : 'b');
+
+$a = (isset($source) ? 'something' : 'c');
+// ok:taint-regression-1.6.0
+sink($a);
+
+if (isset($source)) {
+    $b = 'sonething';
+} else {
+    $b = 'd';
+}
+// ok:taint-regression-1.6.0
+sink($b);
+
+// ok:taint-regression-1.6.0
+sink(isset($source) ? sanitizer($source) : '');
+
+$c = isset($source) ? sanitizer($source) : '';
+// ok:taint-regression-1.6.0
+sink($c);
+
+// ruleid:taint-regression-1.6.0
+sink(isset($source) ? $source : '');
+
+// ok:taint-regression-1.6.0
+sink(isset($source) ? 'aa' . $source : 'bb');
+
+// ruleid:taint-regression-1.6.0
+sink(isset($source) ? $source : 'bb');

--- a/tests/rules/taint_best_fit_sink4.yaml
+++ b/tests/rules/taint_best_fit_sink4.yaml
@@ -1,0 +1,18 @@
+rules:
+  - id: taint-regression-1.6.0
+    languages:
+      - php
+    message: Match Found!
+    mode: taint
+    pattern-sanitizers:
+      - pattern: sanitizer(...)
+      - patterns:
+          - pattern: $S
+          - pattern: $ANY . $S
+    pattern-sinks:
+      - patterns:
+          - focus-metavariable: $SOURCE
+          - pattern: sink($SOURCE, ...)
+    pattern-sources:
+      - pattern: $source
+    severity: WARNING


### PR DESCRIPTION
Folllows: 4020470dd7c ("tainting: Make identification of sinks more precise (#7215)")

Closes PA-2477
Closes PA-2571

test plan:
make test # tests added
Run p/default on django, redash, mypy, angular.js, and bootstrap, and check that perf and number of findings don't change. 

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
