### PR TITLE
fix(pro): report semgrep pro errors nicely

### DIFF
--- a/changelog.d/gh-7028.fixed
+++ b/changelog.d/gh-7028.fixed
@@ -1,1 +1,2 @@
-Fix: Semgrep Pro previously reported a crash for normal errors. This fixes that
+Fix: Semgrep Pro previously reported a crash for user errors such as
+invalid patterns. It will now give a good error message.

--- a/changelog.d/gh-7028.fixed
+++ b/changelog.d/gh-7028.fixed
@@ -1,0 +1,1 @@
+Fix: Semgrep Pro previously reported a crash for normal errors. This fixes that

--- a/cli/src/semgrep/core_runner.py
+++ b/cli/src/semgrep/core_runner.py
@@ -992,7 +992,11 @@ class CoreRunner:
             return self._run_rules_direct_to_semgrep_core_helper(
                 rules, target_manager, dump_command_for_core, engine
             )
+        except SemgrepError as e:
+            # Handle Semgrep errors normally
+            raise e
         except Exception as e:
+            # Unexpected error, output a warning that the engine might be out of date
             if engine.is_pro:
                 logger.error(
                     f"""


### PR DESCRIPTION
Closes https://github.com/returntocorp/semgrep/issues/7028

Previously reported crashes for routine errors (including user errors) due to how errors were caught. This is now fixed

Test plan: pull changes from PR 580 in semgrep-pro. Then create a file with a pattern parse error. Run from anywhere

`semgrep --config <config> . --pro`

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
