### PR TITLE
fix: brew nightly tests failing

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -52,18 +52,18 @@ jobs:
     with:
       dry-run: true
 
-  # notify-failure:
-  #   needs: [brew-build, release-dry-run]
-  #   name: Notify of Failure
-  #   runs-on: ubuntu-20.04
-  #   if: failure()
-  #   steps:
-  #     - name: Notify Failure
-  #       run: |
-  #         curl --request POST \
-  #         --url  ${{ secrets.HOMEBREW_NIGHTLY_NOTIFICATIONS_URL }} \
-  #         --header 'content-type: application/json' \
-  #         --data '{
-  #           "commit_sha": "${{needs.release-setup.outputs.version}}",
-  #           "workflow_url": "https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}"
-  #         }'
+  notify-failure:
+    needs: [brew-build, release-dry-run]
+    name: Notify of Failure
+    runs-on: ubuntu-20.04
+    if: failure()
+    steps:
+      - name: Notify Failure
+        run: |
+          curl --request POST \
+          --url  ${{ secrets.HOMEBREW_NIGHTLY_NOTIFICATIONS_URL }} \
+          --header 'content-type: application/json' \
+          --data '{
+            "commit_sha": "${{needs.release-setup.outputs.version}}",
+            "workflow_url": "https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}"
+          }'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -28,6 +28,8 @@ jobs:
       - name: Cleanup semgrep
         run: brew cleanup --prune=all semgrep
       - name: Brew update
+        env:
+          HOMEBREW_NO_INSTALL_FROM_API: 1
         run: brew update --debug --verbose
       - name: Debug
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -20,6 +20,9 @@ jobs:
   brew-build:
     name: Build Semgrep via Brew from `returntocorp/semgrep:develop`
     runs-on: ["self-hosted", "macOS", "X64"]
+    # We've had issues with this workflow in the past, and needed to ensure that homebrew wouldn't use the API.
+    # See: https://github.com/orgs/Homebrew/discussions/4150, https://github.com/orgs/Homebrew/discussions/4136
+    # There's also much other discussion on this topic available on GH and in the brew discussions.
     steps:
       - name: Uninstall semgrep
         # This is sub-optimal - our workflows shouldn't have to conform to their environment.

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -28,10 +28,18 @@ jobs:
       - name: Cleanup semgrep
         run: brew cleanup --prune=all semgrep
       - name: Brew update
-        run: brew update
+        run: brew update --debug --verbose
+      - name: Debug
+        run: |
+          brew --repository
+          cat /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/semgrep.rb
       - name: Brew Install
-        run: brew install semgrep --HEAD
+        env:
+          HOMEBREW_NO_INSTALL_FROM_API: 1
+        run: brew install semgrep --HEAD --debug
       - name: Check installed correctly
+        env:
+          HOMEBREW_NO_INSTALL_FROM_API: 1
         run: brew test semgrep --HEAD
       - name: Clean up semgrep installation
         run: brew uninstall semgrep
@@ -42,18 +50,18 @@ jobs:
     with:
       dry-run: true
 
-  notify-failure:
-    needs: [brew-build, release-dry-run]
-    name: Notify of Failure
-    runs-on: ubuntu-20.04
-    if: failure()
-    steps:
-      - name: Notify Failure
-        run: |
-          curl --request POST \
-          --url  ${{ secrets.HOMEBREW_NIGHTLY_NOTIFICATIONS_URL }} \
-          --header 'content-type: application/json' \
-          --data '{
-            "commit_sha": "${{needs.release-setup.outputs.version}}",
-            "workflow_url": "https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}"
-          }'
+  # notify-failure:
+  #   needs: [brew-build, release-dry-run]
+  #   name: Notify of Failure
+  #   runs-on: ubuntu-20.04
+  #   if: failure()
+  #   steps:
+  #     - name: Notify Failure
+  #       run: |
+  #         curl --request POST \
+  #         --url  ${{ secrets.HOMEBREW_NIGHTLY_NOTIFICATIONS_URL }} \
+  #         --header 'content-type: application/json' \
+  #         --data '{
+  #           "commit_sha": "${{needs.release-setup.outputs.version}}",
+  #           "workflow_url": "https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}"
+  #         }'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -31,10 +31,6 @@ jobs:
         env:
           HOMEBREW_NO_INSTALL_FROM_API: 1
         run: brew update --debug --verbose
-      - name: Debug
-        run: |
-          brew --repository
-          cat /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/semgrep.rb
       - name: Brew Install
         env:
           HOMEBREW_NO_INSTALL_FROM_API: 1


### PR DESCRIPTION
Nightly homebrew checks began failing due to an unknown error, but this may be related [to changes to the homebrew API discussed here](https://github.com/orgs/Homebrew/discussions/4150) - we set the correct environment variables and then found that `brew update` was not properly updating our formula unless the same env var was set on the `brew update` step. There's been a lot of discussion about this flag/var recently, since it's newly added.

This should resolve issues moving forward, since it will force all updates/installs/tests to use the source and never the homebrew API.

Test Plan:
- successful run here: https://github.com/returntocorp/semgrep/actions/runs/4297155703/jobs/7489775698

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
