### PR TITLE
CI: Run Pro (intrafile) interproc by default in diff scans

### DIFF
--- a/changelog.d/pa-2565.changed
+++ b/changelog.d/pa-2565.changed
@@ -1,0 +1,3 @@
+Pro: `semgrep ci` will run intrafile interprocedural taint analysis by default
+in differential scans (aka PR scans). (Note that interfile analysis is not run
+in differential scans for performance reasons.)

--- a/cli/src/semgrep/engine.py
+++ b/cli/src/semgrep/engine.py
@@ -36,7 +36,7 @@ class EngineType(Enum):
                 requested_engine = cls.PRO_INTERFILE
 
             if requested_engine == cls.PRO_INTERFILE and not git_meta.is_full_scan:
-                requested_engine = cls.PRO_LANG
+                requested_engine = cls.PRO_INTRAFILE
 
         return requested_engine or cls.OSS
 

--- a/cli/tests/unit/test_engine_type.py
+++ b/cli/tests/unit/test_engine_type.py
@@ -22,11 +22,11 @@ from semgrep.meta import GitMeta
         (True, True, ET.PRO_INTRAFILE, ET.PRO_INTRAFILE),
         (True, True, ET.PRO_INTERFILE, ET.PRO_INTERFILE),
         # semgrep ci with toggle on, diff scan
-        (True, False, None, ET.PRO_LANG),
+        (True, False, None, ET.PRO_INTRAFILE),
         (True, False, ET.OSS, ET.OSS),
         (True, False, ET.PRO_LANG, ET.PRO_LANG),
         (True, False, ET.PRO_INTRAFILE, ET.PRO_INTRAFILE),
-        (True, False, ET.PRO_INTERFILE, ET.PRO_LANG),
+        (True, False, ET.PRO_INTERFILE, ET.PRO_INTRAFILE),
         # semgrep ci with toggle off, full scan
         (False, True, None, ET.OSS),
         (False, True, ET.OSS, ET.OSS),
@@ -38,7 +38,7 @@ from semgrep.meta import GitMeta
         (False, False, ET.OSS, ET.OSS),
         (False, False, ET.PRO_LANG, ET.PRO_LANG),
         (False, False, ET.PRO_INTRAFILE, ET.PRO_INTRAFILE),
-        (False, False, ET.PRO_INTERFILE, ET.PRO_LANG),
+        (False, False, ET.PRO_INTERFILE, ET.PRO_INTRAFILE),
     ],
 )
 def test_decide_engine_type(


### PR DESCRIPTION
Helps PA-2565

test plan:
make test # cli/tests/unit/test_engine_type.py
```bash
% semgrep ci --baseline-commit="7c6250fcbeea4fa7a77ecc73bbdf4aae130523f5"
#^ Use `--debug` or `top` to check that this is calling
# semgrep-core-proprietary *and* passing it flag `-deep_intra_file`.
```

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
