### PR TITLE
Fix semgrep-jsonnet in pre-commit on arm macs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -190,7 +190,7 @@ repos:
         # 'docker_image' to run semgrep, but for now jsonnet support
         # is not available via setup.py and only (unofficially)
         # available in docker.
-        entry: -e SEMGREP_LOG_FILE=/tmp/out.log -e SEMGREP_VERSION_CACHE_PATH=/tmp/cache returntocorp/semgrep:develop semgrep
+        entry: -e SEMGREP_LOG_FILE=/tmp/out.log -e SEMGREP_VERSION_CACHE_PATH=/tmp/cache --platform linux/amd64 returntocorp/semgrep:develop semgrep
 
         # Both the .semgrepignore file and the --exclude option
         # do nothing because the target files are passed


### PR DESCRIPTION
Without this change it always fails with

```
semgrep jsonnet..........................................................Failed
- hook id: semgrep-jsonnet
- exit code: 125

WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
docker: Error response from daemon: platform linux/arm64/v8 not supported.
```


PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
