### PR TITLE
fix(pro): Override toggle with requested engine

### DIFF
--- a/changelog.d/pa-2587.fixed
+++ b/changelog.d/pa-2587.fixed
@@ -1,0 +1,3 @@
+`--oss-only` previously required `--oss-only true` to be passed. This PR fixes
+it so that `--oss-only` will invoke the oss engine. Note that `--oss-only true`
+will no longer be supported

--- a/cli/src/semgrep/engine.py
+++ b/cli/src/semgrep/engine.py
@@ -30,11 +30,11 @@ class EngineType(Enum):
         Considers settings from Semgrep Cloud Platform and version control state.
         """
         if git_meta and scan_handler:
+            if scan_handler.deepsemgrep and requested_engine is None:
+                requested_engine = cls.PRO_INTERFILE
+
             if requested_engine == cls.PRO_INTERFILE and not git_meta.is_full_scan:
                 requested_engine = cls.PRO_LANG
-
-            if scan_handler.deepsemgrep:
-                return cls.PRO_INTERFILE if git_meta.is_full_scan else cls.PRO_LANG
 
         return requested_engine or cls.OSS
 


### PR DESCRIPTION
This fixes `--oss-only`.

Test plan:
Toggle on:

semgrep ci --oss-only
semgrep ci

Toggle off:
semgrep ci --oss-only
semgrep ci
semgrep ci --pro

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
