### PR TITLE
chore(tests): Add a unit test for decide_engine_type

### DIFF
--- a/cli/tests/unit/test_decide_engine_type.py
+++ b/cli/tests/unit/test_decide_engine_type.py
@@ -1,0 +1,67 @@
+import pytest
+
+from semgrep.app.scans import ScanHandler
+from semgrep.engine import EngineType
+from semgrep.meta import GitMeta
+
+
+# Alias the function that's being called to make the test lines shorter
+def decide_type(a, b, c):
+    return EngineType.decide_engine_type(a, b, c)
+
+
+@pytest.mark.quick
+def test_code_hash_independent_of_filepath(mocker):
+    mocker.patch.object(ScanHandler, "deepsemgrep")
+    mocker.patch.object(GitMeta, "is_full_scan")
+    msh = ScanHandler(False)
+    mgm = GitMeta()
+
+    # semgrep scan
+    assert decide_type(None, None, None) == EngineType.OSS
+    assert decide_type(EngineType.OSS, None, None) == EngineType.OSS
+    assert decide_type(EngineType.PRO_LANG, None, None) == EngineType.PRO_LANG
+    assert decide_type(EngineType.PRO_INTRAFILE, None, None) == EngineType.PRO_INTRAFILE
+    assert decide_type(EngineType.PRO_INTERFILE, None, None) == EngineType.PRO_INTERFILE
+
+    # semgrep ci with toggle on, full scan
+    msh.deepsemgrep = True
+    mgm.is_full_scan = True
+    assert decide_type(None, msh, mgm) == EngineType.PRO_INTERFILE
+    assert decide_type(EngineType.OSS, msh, mgm) == EngineType.OSS
+    assert decide_type(EngineType.PRO_LANG, msh, mgm) == EngineType.PRO_LANG
+    assert decide_type(EngineType.PRO_INTRAFILE, msh, mgm) == EngineType.PRO_INTRAFILE
+    assert decide_type(EngineType.PRO_INTERFILE, msh, mgm) == EngineType.PRO_INTERFILE
+
+    # semgrep ci with toggle on, diff scan
+    msh.deepsemgrep = True
+    mgm.is_full_scan = False
+    assert decide_type(None, msh, mgm) == EngineType.PRO_LANG
+    assert decide_type(EngineType.OSS, msh, mgm) == EngineType.OSS
+    assert decide_type(EngineType.PRO_LANG, msh, mgm) == EngineType.PRO_LANG
+    assert decide_type(EngineType.PRO_INTRAFILE, msh, mgm) == EngineType.PRO_INTRAFILE
+    assert decide_type(EngineType.PRO_INTERFILE, msh, mgm) == EngineType.PRO_LANG
+
+    # semgrep ci with toggle off, full scan
+    msh.deepsemgrep = False
+    mgm.is_full_scan = True
+    assert decide_type(None, msh, mgm) == EngineType.OSS
+    assert decide_type(EngineType.OSS, msh, mgm) == EngineType.OSS
+    assert decide_type(EngineType.PRO_LANG, msh, mgm) == EngineType.PRO_LANG
+    assert decide_type(EngineType.PRO_INTRAFILE, msh, mgm) == EngineType.PRO_INTRAFILE
+    assert decide_type(EngineType.PRO_INTERFILE, msh, mgm) == EngineType.PRO_INTERFILE
+
+    # semgrep ci with toggle off, diff scan
+    msh.deepsemgrep = False
+    mgm.is_full_scan = False
+    assert decide_type(None, msh, mgm) == EngineType.OSS
+    assert decide_type(EngineType.OSS, msh, mgm) == EngineType.OSS
+    assert decide_type(EngineType.PRO_LANG, msh, mgm) == EngineType.PRO_LANG
+    assert decide_type(EngineType.PRO_INTRAFILE, msh, mgm) == EngineType.PRO_INTRAFILE
+    assert decide_type(EngineType.PRO_INTERFILE, msh, mgm) == EngineType.PRO_LANG
+
+    """
+     requested_engine: Optional["EngineType"] = None,
+     scan_handler: Optional[ScanHandler] = None,
+     git_meta: Optional[GitMeta] = None,
+    """

--- a/cli/tests/unit/test_decide_engine_type.py
+++ b/cli/tests/unit/test_decide_engine_type.py
@@ -59,9 +59,3 @@ def test_code_hash_independent_of_filepath(mocker):
     assert decide_type(EngineType.PRO_LANG, msh, mgm) == EngineType.PRO_LANG
     assert decide_type(EngineType.PRO_INTRAFILE, msh, mgm) == EngineType.PRO_INTRAFILE
     assert decide_type(EngineType.PRO_INTERFILE, msh, mgm) == EngineType.PRO_LANG
-
-    """
-     requested_engine: Optional["EngineType"] = None,
-     scan_handler: Optional[ScanHandler] = None,
-     git_meta: Optional[GitMeta] = None,
-    """

--- a/cli/tests/unit/test_decide_engine_type.py
+++ b/cli/tests/unit/test_decide_engine_type.py
@@ -11,7 +11,7 @@ def decide_type(a, b, c):
 
 
 @pytest.mark.quick
-def test_code_hash_independent_of_filepath(mocker):
+def test_engine_type_deciding_logic(mocker):
     mocker.patch.object(ScanHandler, "deepsemgrep")
     mocker.patch.object(GitMeta, "is_full_scan")
     msh = ScanHandler(False)


### PR DESCRIPTION
The logic for choosing an engine is too complicated. Add a unit test for the relevant function to catch errors if we make changes.

Test plan: see test

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
