### PR TITLE
fix: re-order checks after decomposing

### DIFF
--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -249,7 +249,7 @@ jobs:
     if: ${{ ! inputs.dry-run }}
     name: Create Release Tag
     runs-on: ubuntu-20.04
-    needs: [get-version, check-semgrep-pro, release-setup]
+    needs: [get-version, check-semgrep-pro, release-setup, wait-for-pr-checks]
     steps:
       - name: Get JWT for semgrep-ci GitHub App
         id: jwt
@@ -295,7 +295,7 @@ jobs:
     if: ${{ ! inputs.dry-run }}
     name: Create Draft Release
     runs-on: ubuntu-20.04
-    needs: [get-version, release-setup, create-tag]
+    needs: [get-version, release-setup, create-tag, wait-for-pr-checks]
     steps:
       - name: Download Release Body Artifact
         id: download_body


### PR DESCRIPTION
During recent decomposition, ordering was moved around such that the PR was opened and the release tag were pushed at the same time. This causes issues with the trigger release workflows, as it expects the standard PR checks to run, then the release checks to run. 

This PR restores the ordering. 

Test Plan: 
- Successful dry run confirming ordering: https://github.com/returntocorp/semgrep/actions/runs/4310520485

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
