### PR TITLE
fix: update dry-run message

### DIFF
--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -23,7 +23,7 @@ on:
       dry-run:
         required: true
         type: boolean
-        description: Whether a dry-run or real release should be done. No external state (PRs, branches, tags, etc) will be created on dry-run.
+        description: Check the box for a dry-run - A dry-run will not push any external state (branches, tags, images, or PyPI packages).
         default: true
 
 jobs:


### PR DESCRIPTION
Unless specifically requested, I assume that we want to leave dry-run as the default for safety.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
