### PR TITLE
fix(extract): Run all rules of dest language on extracted target

### DIFF
--- a/changelog.d/pa-2591.fixed
+++ b/changelog.d/pa-2591.fixed
@@ -1,0 +1,5 @@
+Fix an error with rule targeting for extract mode. Previously, if a ruleset had
+two rules, the first being the extract rule, the second being the rule to run,
+no rules would run on the extracted targets. Additionally, with multiple rules
+the wrong rule might be run on the extracted target, causing errors. Now, in
+extract mode all the rules for the destination language will be run.

--- a/cli/tests/e2e/rules/extract_rules/js_html_concat.yaml
+++ b/cli/tests/e2e/rules/extract_rules/js_html_concat.yaml
@@ -1,0 +1,33 @@
+rules:
+  - id: extract-javascript-from-html
+    mode: extract
+    pattern: |
+        <script>$...BODY</script>
+    extract: $...BODY
+    languages:
+      - html
+    paths:
+      include:
+        - '*.html'
+    # Typescript files run Javascript rules but
+    # Javascript files do not run Typescript rules
+    # This exercises the language detection logic
+    dest-language: typescript
+    reduce: concat
+  - id: get-elem-id
+    mode: search
+    pattern: document.getElementById(...)
+    languages:
+      - javascript
+    message: "Found match"
+    severity: ERROR
+  - id: cross-tag-taint
+    mode: taint
+    pattern-sources:
+      - pattern: foo()
+    pattern-sinks:
+      - pattern: bar($X)
+    languages:
+      - typescript
+    message: "Taint match"
+    severity: ERROR

--- a/cli/tests/e2e/snapshots/test_check/test_extract/results.json
+++ b/cli/tests/e2e/snapshots/test_check/test_extract/results.json
@@ -1,0 +1,326 @@
+{
+  "errors": [],
+  "paths": {
+    "_comment": "<add --verbose for a list of skipped paths>",
+    "scanned": [
+      "targets/extract/js_html_concat.html"
+    ]
+  },
+  "results": [
+    {
+      "check_id": "rules.extract_rules.get-elem-id",
+      "end": {
+        "col": 64,
+        "line": 5,
+        "offset": 130
+      },
+      "extra": {
+        "engine_kind": "OSS",
+        "fingerprint": "0x42",
+        "is_ignored": false,
+        "lines": "        function myFunction() { document.getElementById(\"demo\").innerHTML = \"Paragraph changed.\"; }",
+        "message": "Found match",
+        "metadata": {},
+        "metavars": {},
+        "severity": "ERROR"
+      },
+      "path": "targets/extract/js_html_concat.html",
+      "start": {
+        "col": 33,
+        "line": 5,
+        "offset": 99
+      }
+    },
+    {
+      "check_id": "rules.extract_rules.get-elem-id",
+      "end": {
+        "col": 64,
+        "line": 8,
+        "offset": 284
+      },
+      "extra": {
+        "engine_kind": "OSS",
+        "fingerprint": "0x42",
+        "is_ignored": false,
+        "lines": "        function myFunction() { document.getElementById(\"demo\").innerHTML = \"Paragraph changed.\"; }",
+        "message": "Found match",
+        "metadata": {},
+        "metavars": {},
+        "severity": "ERROR"
+      },
+      "path": "targets/extract/js_html_concat.html",
+      "start": {
+        "col": 33,
+        "line": 8,
+        "offset": 253
+      }
+    },
+    {
+      "check_id": "rules.extract_rules.get-elem-id",
+      "end": {
+        "col": 68,
+        "line": 22,
+        "offset": 667
+      },
+      "extra": {
+        "engine_kind": "OSS",
+        "fingerprint": "0x42",
+        "is_ignored": false,
+        "lines": "            function myFunction() { document.getElementById(\"demo\").innerHTML = \"Paragraph changed.\"; }",
+        "message": "Found match",
+        "metadata": {},
+        "metavars": {},
+        "severity": "ERROR"
+      },
+      "path": "targets/extract/js_html_concat.html",
+      "start": {
+        "col": 37,
+        "line": 22,
+        "offset": 636
+      }
+    },
+    {
+      "check_id": "rules.extract_rules.get-elem-id",
+      "end": {
+        "col": 68,
+        "line": 24,
+        "offset": 806
+      },
+      "extra": {
+        "engine_kind": "OSS",
+        "fingerprint": "0x42",
+        "is_ignored": false,
+        "lines": "            function myFunction() { document.getElementById(\"demo\").innerHTML = \"Paragraph changed.\"; }",
+        "message": "Found match",
+        "metadata": {},
+        "metavars": {},
+        "severity": "ERROR"
+      },
+      "path": "targets/extract/js_html_concat.html",
+      "start": {
+        "col": 37,
+        "line": 24,
+        "offset": 775
+      }
+    },
+    {
+      "check_id": "rules.extract_rules.cross-tag-taint",
+      "end": {
+        "col": 15,
+        "line": 10,
+        "offset": 370
+      },
+      "extra": {
+        "dataflow_trace": {
+          "intermediate_vars": [
+            {
+              "content": "x",
+              "location": {
+                "end": {
+                  "col": 14,
+                  "line": 6,
+                  "offset": 180
+                },
+                "path": "targets/extract/js_html_concat.html",
+                "start": {
+                  "col": 13,
+                  "line": 6,
+                  "offset": 179
+                }
+              }
+            }
+          ],
+          "taint_sink": [
+            "CliLoc",
+            [
+              {
+                "end": {
+                  "col": 15,
+                  "line": 10,
+                  "offset": 370
+                },
+                "path": "targets/extract/js_html_concat.html",
+                "start": {
+                  "col": 9,
+                  "line": 10,
+                  "offset": 364
+                }
+              },
+              "bar(x)"
+            ]
+          ],
+          "taint_source": [
+            "CliLoc",
+            [
+              {
+                "end": {
+                  "col": 22,
+                  "line": 6,
+                  "offset": 188
+                },
+                "path": "targets/extract/js_html_concat.html",
+                "start": {
+                  "col": 17,
+                  "line": 6,
+                  "offset": 183
+                }
+              },
+              "foo()"
+            ]
+          ]
+        },
+        "engine_kind": "OSS",
+        "fingerprint": "0x42",
+        "is_ignored": false,
+        "lines": "        bar(x);",
+        "message": "Taint match",
+        "metadata": {},
+        "metavars": {
+          "$X": {
+            "abstract_content": "x",
+            "end": {
+              "col": 14,
+              "line": 7,
+              "offset": 325
+            },
+            "propagated_value": {
+              "svalue_abstract_content": "foo()",
+              "svalue_end": {
+                "col": 22,
+                "line": 3,
+                "offset": 144
+              },
+              "svalue_start": {
+                "col": 17,
+                "line": 3,
+                "offset": 139
+              }
+            },
+            "start": {
+              "col": 13,
+              "line": 7,
+              "offset": 324
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/extract/js_html_concat.html",
+      "start": {
+        "col": 9,
+        "line": 10,
+        "offset": 364
+      }
+    },
+    {
+      "check_id": "rules.extract_rules.cross-tag-taint",
+      "end": {
+        "col": 19,
+        "line": 27,
+        "offset": 901
+      },
+      "extra": {
+        "dataflow_trace": {
+          "intermediate_vars": [
+            {
+              "content": "x",
+              "location": {
+                "end": {
+                  "col": 14,
+                  "line": 6,
+                  "offset": 180
+                },
+                "path": "targets/extract/js_html_concat.html",
+                "start": {
+                  "col": 13,
+                  "line": 6,
+                  "offset": 179
+                }
+              }
+            }
+          ],
+          "taint_sink": [
+            "CliLoc",
+            [
+              {
+                "end": {
+                  "col": 19,
+                  "line": 27,
+                  "offset": 901
+                },
+                "path": "targets/extract/js_html_concat.html",
+                "start": {
+                  "col": 13,
+                  "line": 27,
+                  "offset": 895
+                }
+              },
+              "bar(x)"
+            ]
+          ],
+          "taint_source": [
+            "CliLoc",
+            [
+              {
+                "end": {
+                  "col": 22,
+                  "line": 6,
+                  "offset": 188
+                },
+                "path": "targets/extract/js_html_concat.html",
+                "start": {
+                  "col": 17,
+                  "line": 6,
+                  "offset": 183
+                }
+              },
+              "foo()"
+            ]
+          ]
+        },
+        "engine_kind": "OSS",
+        "fingerprint": "0x42",
+        "is_ignored": false,
+        "lines": "            bar(x);",
+        "message": "Taint match",
+        "metadata": {},
+        "metavars": {
+          "$X": {
+            "abstract_content": "x",
+            "end": {
+              "col": 18,
+              "line": 14,
+              "offset": 655
+            },
+            "propagated_value": {
+              "svalue_abstract_content": "foo()",
+              "svalue_end": {
+                "col": 22,
+                "line": 3,
+                "offset": 144
+              },
+              "svalue_start": {
+                "col": 17,
+                "line": 3,
+                "offset": 139
+              }
+            },
+            "start": {
+              "col": 17,
+              "line": 14,
+              "offset": 654
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/extract/js_html_concat.html",
+      "start": {
+        "col": 13,
+        "line": 27,
+        "offset": 895
+      }
+    }
+  ],
+  "version": "0.42"
+}

--- a/cli/tests/e2e/targets/extract/js_html_concat.html
+++ b/cli/tests/e2e/targets/extract/js_html_concat.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+    <script>
+        // ruleid: get-elem-id
+        function myFunction() { document.getElementById("demo").innerHTML = "Paragraph changed."; }
+        var x = foo();
+        // ruleid: get-elem-id
+        function myFunction() { document.getElementById("demo").innerHTML = "Paragraph changed."; }
+        // ruleid: cross-tag-taint
+        bar(x);
+    </script>
+
+    <body>
+        <h2>Demo JavaScript in Body</h2>
+
+        <p id="demo">A Paragraph</p>
+
+        <button type="button" onclick="myFunction()">Try it</button>
+
+        <script>
+            // ruleid: get-elem-id
+            function myFunction() { document.getElementById("demo").innerHTML = "Paragraph changed."; }
+            // ruleid: get-elem-id
+            function myFunction() { document.getElementById("demo").innerHTML = "Paragraph changed."; }
+
+            // ruleid: cross-tag-taint
+            bar(x);
+        </script>
+
+    </body>
+</html>

--- a/cli/tests/e2e/test_check.py
+++ b/cli/tests/e2e/test_check.py
@@ -113,6 +113,20 @@ def test_script(run_semgrep_in_tmp: RunSemgrep, snapshot):
 
 
 @pytest.mark.kinda_slow
+def test_extract(run_semgrep_in_tmp: RunSemgrep, snapshot):
+    """
+    Validates that Semgrep works with extract mode
+    """
+    snapshot.assert_match(
+        run_semgrep_in_tmp(
+            "rules/extract_rules/js_html_concat.yaml",
+            target_name="extract/js_html_concat.html",
+        ).stdout,
+        "results.json",
+    )
+
+
+@pytest.mark.kinda_slow
 def test_basic_rule__absolute(run_semgrep_in_tmp: RunSemgrep, snapshot):
     snapshot.assert_match(
         run_semgrep_in_tmp(Path.cwd() / "rules" / "eqeq.yaml").stdout,

--- a/src/engine/Match_extract_mode.ml
+++ b/src/engine/Match_extract_mode.ml
@@ -152,8 +152,8 @@ let rules_for_extracted_lang (all_rules : Rule.t list) =
                      List.exists (fun x -> Lang.equal l x) (rl :: rls)
                  | Xlang.LGeneric, Xlang.LGeneric -> true
                  | Xlang.LRegex, Xlang.LRegex -> true
-                 | _else -> false)
-          |> Common.map (fun (i, _r) -> i)
+                 | (Xlang.L _ | Xlang.LGeneric | Xlang.LRegex), _ -> false)
+          |> Common.map fst
         in
         Hashtbl.add rules_for_lang_tbl xlang rule_ids_for_lang;
         rule_ids_for_lang

--- a/src/engine/Match_extract_mode.mli
+++ b/src/engine/Match_extract_mode.mli
@@ -20,5 +20,5 @@ val extract_nested_lang :
   timeout_threshold:int ->
   Rule.extract_rule list ->
   Xtarget.t ->
-  Rule.rule_id list ->
+  Rule.t list ->
   (Input_to_core_t.target * match_result_location_adjuster) list

--- a/src/engine/Test_engine.ml
+++ b/src/engine/Test_engine.ml
@@ -170,11 +170,10 @@ let make_tests ?(unit_testing = false) ?(get_xlang = None) xs =
                    | mode -> Left { r with mode })
                  rules
              in
-             let rule_ids = Common.map (fun r -> fst r.R.id) rules in
              let extracted_ranges =
                Match_extract_mode.extract_nested_lang
                  ~match_hook:(fun _ _ -> ())
-                 ~timeout:0. ~timeout_threshold:0 extract_rules xtarget rule_ids
+                 ~timeout:0. ~timeout_threshold:0 extract_rules xtarget rules
              in
              let extract_targets, extract_result_map =
                (List.fold_right (fun (t, fn) (ts, fn_tbl) ->

--- a/src/runner/Run_semgrep.ml
+++ b/src/runner/Run_semgrep.ml
@@ -559,7 +559,7 @@ let targets_of_config (config : Runner_config.t)
  * the original rules passed via -rules, without the extract-mode rules).
  *)
 let extracted_targets_of_config (config : Runner_config.t)
-    (rule_ids : Rule.rule_id list) (extractors : Rule.extract_rule list) :
+    (extractors : Rule.extract_rule list) (all_rules : Rule.t list) :
     In.target list
     * ( Common.filename,
         Match_extract_mode.match_result_location_adjuster )
@@ -587,7 +587,7 @@ let extracted_targets_of_config (config : Runner_config.t)
              Match_extract_mode.extract_nested_lang ~match_hook
                ~timeout:config.timeout
                ~timeout_threshold:config.timeout_threshold extractors xtarget
-               rule_ids
+               all_rules
            in
            (* Print number of extra targets so Python knows *)
            (match config.output_format with
@@ -614,12 +614,15 @@ let extracted_targets_of_config (config : Runner_config.t)
 let semgrep_with_rules config ((rules, invalid_rules), rules_parse_time) =
   sanity_check_rules_and_invalid_rules config rules invalid_rules;
 
-  let rules, extract_rules =
-    rules
-    |> Common.partition_either (fun r ->
-           match r.Rule.mode with
-           | `Extract _ as e -> Right { r with mode = e }
-           | mode -> Left { r with mode })
+  let extract_rules =
+    List.filter_map
+      (fun r ->
+        match r.Rule.mode with
+        | `Extract _ as e -> Some { r with mode = e }
+        | `Search _
+        | `Taint _ ->
+            None)
+      rules
   in
   let rule_ids = rules |> Common.map (fun r -> fst r.R.id) in
 
@@ -632,7 +635,7 @@ let semgrep_with_rules config ((rules, invalid_rules), rules_parse_time) =
    * our extractors (extract mode rules) on the relevant basic targets.
    *)
   let new_extracted_targets, extract_result_map =
-    extracted_targets_of_config config rule_ids extract_rules
+    extracted_targets_of_config config extract_rules rules
   in
 
   let all_targets = targets @ new_extracted_targets in
@@ -660,6 +663,14 @@ let semgrep_with_rules config ((rules, invalid_rules), rules_parse_time) =
                  is in skipped_rules *)
              target.In.rule_nums
              |> List.filter_map (fun r_num -> Hashtbl.find_opt rule_table r_num)
+             (* Don't run the extract rules
+                Note: we can't filter this out earlier because the rule ids need to be stable *)
+             |> List.filter (fun r ->
+                    match r.R.mode with
+                    | `Extract _ -> false
+                    | `Search _
+                    | `Taint _ ->
+                        true)
            in
 
            let xtarget = xtarget_of_file config xlang file in

--- a/src/runner/Run_semgrep.mli
+++ b/src/runner/Run_semgrep.mli
@@ -172,7 +172,6 @@ val mk_rule_table : Rule.t list -> Rule.rule_id list -> (int, Rule.t) Hashtbl.t
 
 val extracted_targets_of_config :
   Runner_config.t ->
-  Rule.extract_rule list ->
   Rule.t list ->
   Input_to_core_t.target list
   * ( Common.filename,

--- a/src/runner/Run_semgrep.mli
+++ b/src/runner/Run_semgrep.mli
@@ -172,8 +172,8 @@ val mk_rule_table : Rule.t list -> Rule.rule_id list -> (int, Rule.t) Hashtbl.t
 
 val extracted_targets_of_config :
   Runner_config.t ->
-  Rule.rule_id list ->
   Rule.extract_rule list ->
+  Rule.t list ->
   Input_to_core_t.target list
   * ( Common.filename,
       Match_extract_mode.match_result_location_adjuster )

--- a/tests/extract/js_html_concat.yaml
+++ b/tests/extract/js_html_concat.yaml
@@ -9,7 +9,10 @@ rules:
     paths:
       include:
         - '*.html'
-    dest-language: javascript
+    # Typescript files run Javascript rules but
+    # Javascript files do not run Typescript rules
+    # This exercises the language detection logic
+    dest-language: typescript
     reduce: concat
   - id: get-elem-id
     mode: search
@@ -25,7 +28,7 @@ rules:
     pattern-sinks:
       - pattern: bar($X)
     languages:
-      - javascript
+      - typescript
     message: "Taint match"
     severity: ERROR
 


### PR DESCRIPTION
Semgrep file targeting relies on a relatively fragile system of recording the rules that should b e run for each target. This is a consequence of the current split between Python and OCaml.

Previously, the way that extract rules were separated out caused the numbering to become offset. This in turn meant that the wrong rules were being run on targets. Fixed by this PR

Possibly closes some other issues.

Test plan:
```
➜  extract git:(emma/pa-2591-fix-extract-mode) ✗ pwd
/Users/emma/workspace/semgrep/tests/extract
➜  extract git:(emma/pa-2591-fix-extract-mode) ✗ semgrep --config python_jupyter.yaml python_jupyter.ipynb
Scanning 1 file.

┌─────────┐
│ Results │
└─────────┘
Findings:

  python_jupyter.ipynb
     forbid-pickle
        found pickle

         31┆ "    pickle.dump(data, f)"

┌──────────────┐
│ Scan Summary │
└──────────────┘

Ran 2 rules on 1 file: 1 finding.
```
(This previously gave no findings)

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
