### PR TITLE
osemgrep: Fix realpath test to also work in OSX

### DIFF
--- a/src/osemgrep/targeting/Realpath.ml
+++ b/src/osemgrep/targeting/Realpath.ml
@@ -105,24 +105,31 @@ let test () =
     [
       Symlink ("loop_a", "loop_b");
       Symlink ("loop_b", "loop_a");
-      Symlink ("link-to-tmp", "/tmp");
+      (* Previously we used /tmp for testing, but in OSX /tmp is a symlink to /private/tmp. *)
+      Symlink ("link-to-bin", "/bin");
       File ("regfile", "");
       Dir ("sub", [ Symlink ("link-to-reg", "..//regfile///") ]);
     ]
     (fun root ->
-      let root_s = Fpath.to_string root in
+      let root_s =
+        Fpath.to_string root
+        (* In OSX `root` is /var/... and at the same time /var is a symlink
+         * to /private/var, so we need to resolve the symlink here or else all
+         * subsequent tests based on this `root` will fail. *)
+        |> realpath_str
+      in
       List.iter check
         [
           ("/", "/");
-          ("/tmp", "/tmp");
-          ("/tmp/.", "/tmp");
-          ("/tmp/..", "/");
-          ("/tmp/", "/tmp");
+          ("/bin", "/bin");
+          ("/bin/.", "/bin");
+          ("/bin/..", "/");
+          ("/bin/", "/bin");
           (root_s, root_s);
           (* not sure why Fpath considers an extra leading slash to be
              a volume, which we preserve like a Windows volume. *)
-          ("//tmp", "//tmp");
-          ("/////tmp", "//tmp");
+          ("//bin", "//bin");
+          ("/////bin", "//bin");
           (sprintf "%s//sub" root_s, sprintf "%s/sub" root_s);
           (sprintf "%s/sub/link-to-reg" root_s, sprintf "%s/regfile" root_s);
         ];
@@ -138,7 +145,7 @@ let test () =
             [
               (".", sprintf "%s/sub" root_s);
               ("..", root_s);
-              ("../link-to-tmp", "/tmp");
+              ("../link-to-bin", "/bin");
             ]))
 
 let () =


### PR DESCRIPTION
test plan:
make test

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
