### PR TITLE
fix(metrics): Send metrics for app scans

### DIFF
--- a/cli/src/semgrep/app/session.py
+++ b/cli/src/semgrep/app/session.py
@@ -163,6 +163,7 @@ class AppSession(requests.Session):
         metrics = get_state().metrics
         metrics.add_token(self.token)
 
+    @property
     def is_authenticated(self) -> bool:
         return self.token is not None
 

--- a/cli/src/semgrep/app/session.py
+++ b/cli/src/semgrep/app/session.py
@@ -163,6 +163,9 @@ class AppSession(requests.Session):
         metrics = get_state().metrics
         metrics.add_token(self.token)
 
+    def is_authenticated(self) -> bool:
+        return self.token is not None
+
     def request(self, *args: Any, **kwargs: Any) -> requests.Response:
         kwargs.setdefault("timeout", 60)
         kwargs.setdefault("headers", {})

--- a/cli/src/semgrep/cli.py
+++ b/cli/src/semgrep/cli.py
@@ -82,6 +82,7 @@ def cli(ctx: click.Context) -> None:
     state.app_session.authenticate()
     state.app_session.user_agent.tags.add(f"command/{subcommand}")
     state.metrics.add_feature("subcommand", subcommand)
+    state.command.set_subcommand(subcommand)
 
     maybe_set_git_safe_directories()
 

--- a/cli/src/semgrep/command.py
+++ b/cli/src/semgrep/command.py
@@ -1,0 +1,26 @@
+"""
+Save information about the command
+"""
+from attr import define
+from typing_extensions import Literal
+from typing_extensions import TypedDict
+
+
+class CommandSchema(TypedDict, total=False):
+    subcommand: str
+
+
+CommandKeys = Literal["subcommand"]
+
+DEFAULT_SETTINGS: CommandSchema = {"subcommand": "unset"}
+
+
+@define
+class Command:
+    _contents: CommandSchema = DEFAULT_SETTINGS
+
+    def set_subcommand(self, subcommand: str) -> None:
+        self._contents["subcommand"] = subcommand
+
+    def get_subcommand(self) -> str:
+        return self._contents["subcommand"]

--- a/cli/src/semgrep/commands/ci.py
+++ b/cli/src/semgrep/commands/ci.py
@@ -219,7 +219,7 @@ def ci(
         output_format=output_format,
     )
 
-    state.metrics.configure(metrics, metrics)
+    state.metrics.configure(metrics, metrics_legacy)
     state.error_handler.configure(suppress_errors)
     scan_handler = None
 

--- a/cli/src/semgrep/commands/ci.py
+++ b/cli/src/semgrep/commands/ci.py
@@ -219,15 +219,6 @@ def ci(
         output_format=output_format,
     )
 
-    # Metrics are always on for CI scans. It doesn't make sense for them to
-    # be off, since CI scans have to connect to the Cloud Platform
-    # (For reviewers: is this explanation below clear?)
-    if metrics == MetricsState.OFF or metrics_legacy == MetricsState.OFF:
-        raise click.BadParameter(
-            "--metrics cannot be turned off for ci scans since ci scans require access to the Cloud Platform"
-        )
-    metrics = MetricsState.ON
-
     state.metrics.configure(metrics, metrics)
     state.error_handler.configure(suppress_errors)
     scan_handler = None

--- a/cli/src/semgrep/commands/ci.py
+++ b/cli/src/semgrep/commands/ci.py
@@ -219,7 +219,16 @@ def ci(
         output_format=output_format,
     )
 
-    state.metrics.configure(metrics, metrics_legacy)
+    # Metrics are always on for CI scans. It doesn't make sense for them to
+    # be off, since CI scans have to connect to the Cloud Platform
+    # (For reviewers: is this explanation below clear?)
+    if metrics == MetricsState.OFF or metrics_legacy == MetricsState.OFF:
+        raise click.BadParameter(
+            "--metrics cannot be turned off for ci scans since ci scans require access to the Cloud Platform"
+        )
+    metrics = MetricsState.ON
+
+    state.metrics.configure(metrics, metrics)
     state.error_handler.configure(suppress_errors)
     scan_handler = None
 

--- a/cli/src/semgrep/metrics.py
+++ b/cli/src/semgrep/metrics.py
@@ -410,6 +410,7 @@ class Metrics:
           - on, sends
           - off, doesn't send
         """
+        # import here to prevent circular import
         from semgrep.state import get_state
 
         state = get_state()

--- a/cli/src/semgrep/metrics.py
+++ b/cli/src/semgrep/metrics.py
@@ -420,7 +420,7 @@ class Metrics:
             # However, these scans are still pulling from the registry
             using_app = (
                 state.command.get_subcommand() == "ci"
-                and state.app_session.is_authenticated()
+                and state.app_session.is_authenticated
             )
             return self.is_using_registry or using_app
         return self.metrics_state == MetricsState.ON
@@ -439,6 +439,10 @@ class Metrics:
             if source == click.core.ParameterSource.PROMPT:
                 self.add_feature("cli-prompt", param)
 
+    # Posting the metrics is separated out so that our tests can check
+    # for it
+    # TODO it's a bit unfortunate that our tests are going to post
+    # metrics...
     def _post_metrics(self, user_agent: str) -> None:
         r = requests.post(
             METRICS_ENDPOINT,

--- a/cli/src/semgrep/state.py
+++ b/cli/src/semgrep/state.py
@@ -3,6 +3,7 @@ from attrs import Factory
 from attrs import frozen
 
 from semgrep.app.session import AppSession
+from semgrep.command import Command
 from semgrep.env import Env
 from semgrep.error_handler import ErrorHandler
 from semgrep.metrics import Metrics
@@ -24,6 +25,7 @@ class SemgrepState:
     error_handler: ErrorHandler = Factory(ErrorHandler)
     settings: Settings = Factory(Settings)
     terminal: Terminal = Factory(Terminal)
+    command: Command = Factory(Command)
 
 
 def get_state() -> SemgrepState:

--- a/cli/tests/e2e/test_ci.py
+++ b/cli/tests/e2e/test_ci.py
@@ -21,6 +21,7 @@ from semgrep.error_handler import ErrorHandler
 from semgrep.meta import GithubMeta
 from semgrep.meta import GitlabMeta
 from semgrep.meta import GitMeta
+from semgrep.metrics import Metrics
 
 pytestmark = pytest.mark.kinda_slow
 
@@ -1262,3 +1263,16 @@ def test_git_failure_error_handler(
         env={"SEMGREP_APP_TOKEN": "fake-key-from-tests"},
     )
     mock_send.assert_called_once_with(mocker.ANY, 2)
+
+
+def test_metrics_enabled(run_semgrep: RunSemgrep, mocker):
+    mock_send = mocker.patch.object(Metrics, "_post_metrics")
+    run_semgrep(
+        options=["ci"],
+        target_name=None,
+        strict=False,
+        assert_exit_code=1,
+        force_metrics_off=False,
+        env={"SEMGREP_APP_TOKEN": "fake-key-from-tests"},
+    )
+    mock_send.assert_called_once()


### PR DESCRIPTION
We currently do not send metrics for most scans triggered by semgrep ci due to an error in the logic. This makes it harder for us to debug issues for our customers, since there may be useful information in the metrics that we don't have access to. This PR fixes the bug

Test plan: I tested this by running `semgrep ci` and printing out whether metrics were enabled. Also see e2e tests

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
