### PR TITLE
Use fixed ATD file for reading AST dump from Python + test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,6 +173,8 @@ core-test: core
 #coupling: this is run by .github/workflow/tests.yml
 .PHONY: core-e2etest
 core-e2etest:
+	SEMGREP_CORE=$(PWD)/bin/semgrep-core \
+	$(MAKE) -C interfaces/semgrep_interfaces test
 	python3 tests/e2e/test_target_file.py
 
 ###############################################################################

--- a/changelog.d/gh-7296.fixed
+++ b/changelog.d/gh-7296.fixed
@@ -1,0 +1,3 @@
+The AST dump produced by semgrep-core is now usable from Python
+with the provided ATD interface and the Python code derived from it with
+atdpy.


### PR DESCRIPTION
Uses https://github.com/returntocorp/semgrep-interfaces/pull/62
* This uses an updated ATD file for the generic AST. It uses `nullable` instead of `option` since the latter isn't supported by atdpy and there's no standard option type in Python/mypy anyway.
* I added a test that ensures a semgrep-core AST dump can be loaded in a Python program. The test is implemented in the semgrep-interfaces repo. I wasn't too sure where to put it.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
