### PR TITLE
fix(taint): uninitialized taint sink error

### DIFF
--- a/changelog.d/pa-2625.fixed
+++ b/changelog.d/pa-2625.fixed
@@ -1,0 +1,2 @@
+Taint: Fixed an issue where an error could be thrown if semgrep-core's output
+contained a dataflow trace without a sink.

--- a/cli/src/semgrep/rule_match.py
+++ b/cli/src/semgrep/rule_match.py
@@ -394,6 +394,7 @@ class RuleMatch:
         if dataflow_trace:
             taint_source = None
             intermediate_vars = None
+            taint_sink = None
             if dataflow_trace.taint_source:
                 taint_source = translate_core_match_call_trace(
                     dataflow_trace.taint_source


### PR DESCRIPTION
Closes #7288

## What:
This PR always initializes a local variable `taint_sink`, making it impossible to use it without it being initialized.

## Why:
This can very rarely cause a crash in Semgrep CLI, if `core` does not return a taint sink in the JSON output.

## How:
Initialized the sink to `None`.

I really wish `mypy` warned about this sort of thing.

No test plan, but I think this is pretty self-explanatory.

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
