### PR TITLE
osemgrep: Fix realpath test to also work on Fedora

### DIFF
--- a/src/osemgrep/targeting/Realpath.ml
+++ b/src/osemgrep/targeting/Realpath.ml
@@ -105,8 +105,10 @@ let test () =
     [
       Symlink ("loop_a", "loop_b");
       Symlink ("loop_b", "loop_a");
-      (* Previously we used /tmp for testing, but in OSX /tmp is a symlink to /private/tmp. *)
-      Symlink ("link-to-bin", "/bin");
+      (* Previously we used /tmp for testing, but in OSX /tmp is a symlink to
+       * /private/tmp. After that we used /bin for testing, but on Fedora, /bin
+       * is a symlink to /usr/bin. *)
+      Symlink ("link-to-usr", "/usr");
       File ("regfile", "");
       Dir ("sub", [ Symlink ("link-to-reg", "..//regfile///") ]);
     ]
@@ -121,15 +123,15 @@ let test () =
       List.iter check
         [
           ("/", "/");
-          ("/bin", "/bin");
-          ("/bin/.", "/bin");
-          ("/bin/..", "/");
-          ("/bin/", "/bin");
+          ("/usr", "/usr");
+          ("/usr/.", "/usr");
+          ("/usr/..", "/");
+          ("/usr/", "/usr");
           (root_s, root_s);
           (* not sure why Fpath considers an extra leading slash to be
              a volume, which we preserve like a Windows volume. *)
-          ("//bin", "//bin");
-          ("/////bin", "//bin");
+          ("//usr", "//usr");
+          ("/////usr", "//usr");
           (sprintf "%s//sub" root_s, sprintf "%s/sub" root_s);
           (sprintf "%s/sub/link-to-reg" root_s, sprintf "%s/regfile" root_s);
         ];
@@ -145,7 +147,7 @@ let test () =
             [
               (".", sprintf "%s/sub" root_s);
               ("..", root_s);
-              ("../link-to-bin", "/bin");
+              ("../link-to-usr", "/usr");
             ]))
 
 let () =


### PR DESCRIPTION
#7277 made this work on macOS, but `/bin` is a symlink to `/usr/bin` on Fedora so the test fails there.

Looks like `/usr` exists and is not a symlink on both my Fedora machine and macOS. Maybe at some point we should make a test that's less dependent on the specifics of the environment, though.

Test plan: Automated tests

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
