### PR TITLE
fix(SSC): Fix maven comparison bug

### DIFF
--- a/changelog.d/sc-656.changed
+++ b/changelog.d/sc-656.changed
@@ -1,0 +1,1 @@
+Changed Maven version comparison to more closely reflect usage, so versions with more than 3 increments will not be treated as plain strings

--- a/cli/src/semdep/parsers/util.py
+++ b/cli/src/semdep/parsers/util.py
@@ -43,6 +43,7 @@ logger = getLogger(__name__)
 
 A = TypeVar("A")
 B = TypeVar("B")
+C = TypeVar("C")
 
 Pos = Tuple[int, int]
 
@@ -93,6 +94,13 @@ def pair(p1: "Parser[A]", p2: "Parser[B]") -> "Parser[Tuple[A,B]]":
     Returns a parser which runs [p1] then [p2] and produces a pair of the results
     """
     return p1.bind(lambda a: p2.bind(lambda b: success((a, b))))
+
+
+def triple(p1: "Parser[A]", p2: "Parser[B]", p3: "Parser[C]") -> "Parser[Tuple[A,B,C]]":
+    """
+    Returns a parser which runs [p1] then [p2] then [p3] and produces a triple of the results
+    """
+    return p1.bind(lambda a: p2.bind(lambda b: p3.bind(lambda c: success((a, b, c)))))
 
 
 def transitivity(manifest_deps: Optional[Set[A]], dep_sources: List[A]) -> Transitivity:
@@ -149,6 +157,8 @@ def quoted(p: "Parser[A]") -> "Parser[A]":
     return string('"') >> p << string('"')
 
 
+integer = regex(r"\d+").map(int)
+any_str = regex(".*")
 word = not_any(" ")
 consume_word = word >> success(None)
 

--- a/cli/tests/e2e/test_dependency_aware_rules.py
+++ b/cli/tests/e2e/test_dependency_aware_rules.py
@@ -116,7 +116,6 @@ def test_dependency_aware_rules(
         ("1.2-beta-2", "> 1.0, < 1.2", True),
         ("1.2-beta-2", "> 1.2-alpha-6, < 1.2-beta-3", True),
         ("1.0.10.1", "< 1.0.10.2", True),
-        ("1.0.10.2", "> 1.0.10.1, < 1.0.9.3", True),  # Yes, seriously
         ("1.3.4-SNAPSHOT", "< 1.3.4", True),
         ("1.0-SNAPSHOT", "> 1.0-alpha", True),
         ("2.17.2", "< 2.3.1", False),
@@ -124,6 +123,9 @@ def test_dependency_aware_rules(
         ("2.0.0", "< 10.0.0", True),
         ("0.2.0", "< 0.10.0", True),
         ("0.0.2", "< 0.0.10", True),
+        ("2.14.0", "< 2.9.10.3", False),
+        ("2.14.0-beta", "< 2.9.10.3", False),
+        ("1.1.1.1-SNAPSHOT", "< 1.1.1.1", True),
     ],
 )
 def test_maven_version_comparison(version, specifier, outcome):


### PR DESCRIPTION
Changes maven version comparison to more closely reflect usage, even though Maven itself might get this wrong. Now we parse a "version core" of at least 2 (and possibly arbitrarily many more) integers separated by dots, as well as a postfix qualifier. The version core is compared in the expected way, and then maven specific rules are used for the qualifiers.

PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
