### PR TITLE
Docker: update to returntocorp/ocaml:alpine-2023-03-03

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,9 +52,9 @@
 # - doc/SEMGREP_CORE_CONTRIBUTING.md
 # - https://github.com/Homebrew/homebrew-core/blob/master/Formula/semgrep.rb
 #
-# Note that some .github/workflows/ use returntocorp/ocaml:alpine, which should
-# be the latest, but may differ from this one.
-FROM returntocorp/ocaml:alpine-2022-09-24 as semgrep-core-container
+# coupling: if you modify this FROM below, you probably need to modify also
+# a few .github/workflows/ files. grep for returntocorp/ocaml there.
+FROM returntocorp/ocaml:alpine-2023-03-03 as semgrep-core-container
 
 WORKDIR /src/semgrep
 COPY . .

--- a/Makefile
+++ b/Makefile
@@ -217,7 +217,8 @@ install-deps: install-deps-for-semgrep-core
 # - gmp-dev: for osemgrep and its use of cohttp
 ALPINE_APK_DEPS=pcre-dev python3 python3-dev gmp-dev
 
-#TODO why this one?
+# We pin to a specific version just to prevent things from breaking randomly.
+# We could update to a more recent version.
 PIPENV='pipenv==2022.6.7'
 
 # This target is used in our Dockerfile and a few GHA workflows.
@@ -231,9 +232,11 @@ PIPENV='pipenv==2022.6.7'
 #    container with many things pre-installed.
 # pro:
 #  - it avoids repeating yourself everywhere
+# For '--ignore-installed distlib' below see
+# https://stackoverflow.com/questions/63515454/why-does-pip3-install-pipenv-give-error-error-cannot-uninstall-distlib
 install-deps-ALPINE-for-semgrep-core:
 	apk add --no-cache $(ALPINE_APK_DEPS)
-	pip install --no-cache-dir $(PIPENV)
+	pip install --no-cache-dir --ignore-installed distlib $(PIPENV)
 
 #TODO: deprecate scripts/install-alpine-xxx in favor of that
 install-deps-and-build-ALPINE-semgrep-core:


### PR DESCRIPTION
This currently fails to build ... I get weird errors early about
distlib:
```
(1/1) Installing python3-dev (3.8.10-r0)
Executing busybox-1.31.1-r16.trigger
OK: 705 MiB in 128 packages
pip install --no-cache-dir pipenv
Requirement already satisfied: pipenv in /usr/lib/python3.8/site-packages (2023.2.18)
Requirement already satisfied: certifi in /usr/lib/python3.8/site-packages (from pipenv) (2020.4.5.1)
Collecting setuptools>=67.0.0
  Downloading setuptools-67.6.0-py3-none-any.whl (1.1 MB)
Requirement already satisfied: virtualenv-clone>=0.2.5 in /usr/lib/python3.8/site-packages (from pipenv) (0.5.7)
Requirement already satisfied: virtualenv>=20.17.1 in /usr/lib/python3.8/site-packages (from pipenv) (20.20.0)
Collecting distlib<1,>=0.3.6
  Downloading distlib-0.3.6-py2.py3-none-any.whl (468 kB)
Requirement already satisfied: filelock<4,>=3.4.1 in /usr/lib/python3.8/site-packages (from virtualenv>=20.17.1->pipenv) (3.9.0)
Requirement already satisfied: platformdirs<4,>=2.4 in /usr/lib/python3.8/site-packages (from virtualenv>=20.17.1->pipenv) (3.1.0)
Installing collected packages: setuptools, distlib
  Attempting uninstall: setuptools
    Found existing installation: setuptools 47.0.0
    Uninstalling setuptools-47.0.0:
      Successfully uninstalled setuptools-47.0.0
  Attempting uninstall: distlib
    Found existing installation: distlib 0.3.0
ERROR: Cannot uninstall 'distlib'. It is a distutils installed project and thus we cannot accurately determine which files belong to it which would lead to only a partial uninstall.
make: *** [Makefile:233: install-deps-ALPINE-for-semgrep-core] Error 1
The command '/bin/sh -c make install-deps-ALPINE-for-semgrep-core &&    make install-deps-for-semgrep-core' returned a non-zero code: 2
make: *** [Makefile:105: build-docker] Error 2
```

test plan:
make build-docker


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)