### PR TITLE
feat: allow string literal metavariables in julia

### DIFF
--- a/changelog.d/pa-2630.fixed
+++ b/changelog.d/pa-2630.fixed
@@ -1,0 +1,1 @@
+Julia: Properly allow string literal metavariables like "$A" to be patterns.

--- a/languages/julia/generic/Parse_julia_tree_sitter.ml
+++ b/languages/julia/generic/Parse_julia_tree_sitter.ml
@@ -670,12 +670,16 @@ and map_anon_choice_str_content_838a78d (env : env)
   match x with
   | `Str_content tok -> (* string_content *) Left3 (str env tok)
   | `Str_interp (v1, v2) ->
-      let _v1 = (* "$" *) token env v1 in
+      let dollar_s, dollar_t = (* "$" *) str env v1 in
       let v2 =
         match v2 with
-        | `Id tok ->
-            let id = map_identifier env tok in
-            Middle3 (N (H2.name_of_id id) |> G.e)
+        | `Id tok -> (
+            let s, t = map_identifier env tok in
+            match env.extra with
+            | Pattern ->
+                let mvar_id = (dollar_s ^ s, PI.combine_infos dollar_t [ t ]) in
+                Left3 mvar_id
+            | Program -> Middle3 (N (H2.name_of_id (s, t)) |> G.e))
         | `Imme_paren_LPAR_choice_exp_RPAR (v1, v2, v3, v4) ->
             let _v1 = (* immediate_paren *) token env v1 in
             let v2 = (* "(" *) token env v2 in

--- a/tests/rules/string_mvar_julia.jl
+++ b/tests/rules/string_mvar_julia.jl
@@ -1,0 +1,11 @@
+
+# ruleid: string-mvar-julia
+x = "hi"
+
+y = hi
+
+z = "i said hi to someone"
+
+z = "i said hi"
+
+z = "hi to someone"

--- a/tests/rules/string_mvar_julia.yaml
+++ b/tests/rules/string_mvar_julia.yaml
@@ -1,0 +1,12 @@
+rules:
+- id: string-mvar-julia 
+  patterns:
+    - pattern: |
+        "$A"
+    - metavariable-regex:
+        metavariable: $A
+        regex: "^hi$"
+  message: Test
+  languages:
+  - julia 
+  severity: WARNING


### PR DESCRIPTION
## What:
This PR adds in the ability to properly parse string literal metavariables like `"$A"` in Julia.

## Why:
These were previously being confused with interpolated variables in a string.

## How:
Special-cased it in the parser.

This can probably also happen in the future if you did something like `"foo $A bar"`, but this is kind of a weird pattern and I find it highly unlikely anyone will try that.

## Test plan:
`make test`

Closes #7280 
Closes PA-2630

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
