### PR TITLE
cli: start scan before fetching config

### DIFF
--- a/cli/src/semgrep/app/auth.py
+++ b/cli/src/semgrep/app/auth.py
@@ -7,9 +7,9 @@ from semgrep.state import get_state
 logger = logging.getLogger(__name__)
 
 
-def is_valid_token(token: str) -> Optional[str]:
+def get_deployment_from_token(token: str) -> Optional[str]:
     """
-    Returns the deployment name the token is for if token is valid
+    Returns the deployment name the token is for, if token is valid
     """
     state = get_state()
     r = state.app_session.get(

--- a/cli/src/semgrep/app/auth.py
+++ b/cli/src/semgrep/app/auth.py
@@ -7,16 +7,20 @@ from semgrep.state import get_state
 logger = logging.getLogger(__name__)
 
 
-def is_valid_token(token: str) -> bool:
+def is_valid_token(token: str) -> Optional[str]:
     """
-    Returns true if token is valid
+    Returns the deployment name the token is for if token is valid
     """
     state = get_state()
     r = state.app_session.get(
         f"{state.env.semgrep_url}/api/agent/deployments/current",
         headers={"Authorization": f"Bearer {token}"},
     )
-    return r.ok
+    if r.ok:
+        data = r.json()
+        return data.get("deployment", {}).get("name")  # type: ignore
+    else:
+        return None
 
 
 def get_deployment_id() -> Optional[int]:

--- a/cli/src/semgrep/app/scans.py
+++ b/cli/src/semgrep/app/scans.py
@@ -35,9 +35,9 @@ logger = getLogger(__name__)
 
 
 class ScanHandler:
-    def __init__(self, dry_run: bool = False) -> None:
+    def __init__(self, dry_run: bool = False, deployment_name: str = "") -> None:
         self._deployment_id: Optional[int] = None
-        self._deployment_name: str = ""
+        self._deployment_name: str = deployment_name
 
         self.scan_id = None
         self.ignore_patterns: List[str] = []
@@ -148,7 +148,13 @@ class ScanHandler:
                 "semgrep_version": meta.get("semgrep_version", "0.0.0"),
             }
         )
-        app_get_config_url = f"{state.env.semgrep_url}/{DEFAULT_SEMGREP_APP_CONFIG_URL}?{self._scan_params}"
+
+        if self.dry_run:
+            app_get_config_url = f"{state.env.semgrep_url}/{DEFAULT_SEMGREP_APP_CONFIG_URL}?{self._scan_params}"
+        else:
+            app_get_config_url = (
+                f"{state.env.semgrep_url}/api/agent/scans/{self.scan_id}/config"
+            )
 
         body = self._get_scan_config_from_app(app_get_config_url)
 

--- a/cli/src/semgrep/app/scans.py
+++ b/cli/src/semgrep/app/scans.py
@@ -190,7 +190,7 @@ class ScanHandler:
         logger.debug("Starting scan")
         response = state.app_session.post(
             f"{state.env.semgrep_url}/api/agent/deployments/scans",
-            json={"meta": meta, "policy_names": self._policy_names},
+            json={"meta": meta},
         )
 
         if response.status_code == 404:

--- a/cli/src/semgrep/commands/ci.py
+++ b/cli/src/semgrep/commands/ci.py
@@ -238,13 +238,13 @@ def ci(
         )
         sys.exit(FATAL_EXIT_CODE)
     elif token:
-        deployment = auth.is_valid_token(token)
-        if not deployment:
+        deployment_name = auth.get_deployment_from_token(token)
+        if not deployment_name:
             logger.info(
                 "API token not valid. Try to run `semgrep logout` and `semgrep login` again.",
             )
             sys.exit(INVALID_API_KEY_EXIT_CODE)
-        scan_handler = ScanHandler(dry_run=dry_run, deployment_name=deployment)
+        scan_handler = ScanHandler(dry_run=dry_run, deployment_name=deployment_name)
     else:  # impossible state… until we break the code above
         raise RuntimeError("The token and/or config are misconfigured")
 

--- a/cli/src/semgrep/commands/ci.py
+++ b/cli/src/semgrep/commands/ci.py
@@ -238,12 +238,13 @@ def ci(
         )
         sys.exit(FATAL_EXIT_CODE)
     elif token:
-        if not auth.is_valid_token(token):
+        deployment = auth.is_valid_token(token)
+        if not deployment:
             logger.info(
                 "API token not valid. Try to run `semgrep logout` and `semgrep login` again.",
             )
             sys.exit(INVALID_API_KEY_EXIT_CODE)
-        scan_handler = ScanHandler(dry_run)
+        scan_handler = ScanHandler(dry_run=dry_run, deployment_name=deployment)
     else:  # impossible state… until we break the code above
         raise RuntimeError("The token and/or config are misconfigured")
 
@@ -296,17 +297,18 @@ def ci(
                     if state.env.semgrep_url != "https://semgrep.dev"
                     else ""
                 )
-                connection_task = progress_bar.add_task(
-                    f"Fetching configuration from Semgrep Cloud Platform{at_url_maybe}"
-                )
-                scan_handler.fetch_and_init_scan_config(metadata_dict)
-                progress_bar.update(connection_task, completed=100)
 
                 start_scan_task = progress_bar.add_task(
                     f"Reporting start of scan for [bold]{scan_handler.deployment_name}[/bold]"
                 )
                 scan_handler.start_scan(metadata_dict)
                 progress_bar.update(start_scan_task, completed=100)
+
+                connection_task = progress_bar.add_task(
+                    f"Fetching configuration from Semgrep Cloud Platform{at_url_maybe}"
+                )
+                scan_handler.fetch_and_init_scan_config(metadata_dict)
+                progress_bar.update(connection_task, completed=100)
 
             config = (scan_handler.rules,)
 

--- a/cli/src/semgrep/commands/login.py
+++ b/cli/src/semgrep/commands/login.py
@@ -97,7 +97,7 @@ def login() -> NoReturn:
 
 def save_token(login_token: Optional[str], echo_token: bool) -> bool:
     state = get_state()
-    if login_token is not None and auth.is_valid_token(login_token):
+    if login_token is not None and auth.get_deployment_from_token(login_token):
         auth.set_token(login_token)
         click.echo(
             f"Saved login token\n\n\t{login_token if echo_token else '<redacted>'}\n\nin {state.settings.path}."

--- a/cli/src/semgrep/lsp/config.py
+++ b/cli/src/semgrep/lsp/config.py
@@ -124,7 +124,7 @@ class LSPConfig:
 
     @property
     def scan_url(self) -> str:
-        scan_handler = ScanHandler(True)
+        scan_handler = ScanHandler(dry_run=True)
         metadata = generate_meta_from_environment(self.baseline_commit)
         state = get_state()
         to_server = (

--- a/cli/tests/e2e/snapshots/test_ci/test_dryrun/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_dryrun/results.txt
@@ -70,8 +70,8 @@ First-Party Blocking Rules Fired:
             
   CONNECTION
 Would have sent POST request to create scan
-  Fetching configuration from Semgrep Cloud Platform  
-  Reporting start of scan for org_name                               
+  Reporting start of scan for r2c                     
+  Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐
 │ Scan Status │

--- a/cli/tests/e2e/snapshots/test_ci/test_dryrun/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_dryrun/results.txt
@@ -70,7 +70,7 @@ First-Party Blocking Rules Fired:
             
   CONNECTION
 Would have sent POST request to create scan
-  Reporting start of scan for r2c                     
+  Reporting start of scan for deployment_name         
   Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines-overwrite-autodetected-variables/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines-overwrite-autodetected-variables/meta.json
@@ -19,10 +19,5 @@
     "scan_environment": "azure-pipelines",
     "is_full_scan": true,
     "is_sca_scan": false
-  },
-  "policy_names": [
-    "audit",
-    "comment",
-    "block"
-  ]
+  }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines-overwrite-autodetected-variables/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines-overwrite-autodetected-variables/results.txt
@@ -70,7 +70,7 @@ First-Party Blocking Rules Fired:
                 pull_request                                                    
             
   CONNECTION
-  Reporting start of scan for r2c                     
+  Reporting start of scan for deployment_name         
   Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines-overwrite-autodetected-variables/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines-overwrite-autodetected-variables/results.txt
@@ -70,8 +70,8 @@ First-Party Blocking Rules Fired:
                 pull_request                                                    
             
   CONNECTION
-  Fetching configuration from Semgrep Cloud Platform  
-  Reporting start of scan for org_name                               
+  Reporting start of scan for r2c                     
+  Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐
 │ Scan Status │

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines/meta.json
@@ -19,10 +19,5 @@
     "scan_environment": "azure-pipelines",
     "is_full_scan": true,
     "is_sca_scan": false
-  },
-  "policy_names": [
-    "audit",
-    "comment",
-    "block"
-  ]
+  }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines/results.txt
@@ -70,7 +70,7 @@ First-Party Blocking Rules Fired:
                 pull_request                                                    
             
   CONNECTION
-  Reporting start of scan for r2c                     
+  Reporting start of scan for deployment_name         
   Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines/results.txt
@@ -70,8 +70,8 @@ First-Party Blocking Rules Fired:
                 pull_request                                                    
             
   CONNECTION
-  Fetching configuration from Semgrep Cloud Platform  
-  Reporting start of scan for org_name                               
+  Reporting start of scan for r2c                     
+  Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐
 │ Scan Status │

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket-overwrite-autodetected-variables/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket-overwrite-autodetected-variables/meta.json
@@ -19,10 +19,5 @@
     "scan_environment": "bitbucket",
     "is_full_scan": true,
     "is_sca_scan": false
-  },
-  "policy_names": [
-    "audit",
-    "comment",
-    "block"
-  ]
+  }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket-overwrite-autodetected-variables/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket-overwrite-autodetected-variables/results.txt
@@ -70,7 +70,7 @@ First-Party Blocking Rules Fired:
                 pull_request                                                    
             
   CONNECTION
-  Reporting start of scan for r2c                     
+  Reporting start of scan for deployment_name         
   Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket-overwrite-autodetected-variables/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket-overwrite-autodetected-variables/results.txt
@@ -70,8 +70,8 @@ First-Party Blocking Rules Fired:
                 pull_request                                                    
             
   CONNECTION
-  Fetching configuration from Semgrep Cloud Platform  
-  Reporting start of scan for org_name                               
+  Reporting start of scan for r2c                     
+  Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐
 │ Scan Status │

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket/meta.json
@@ -19,10 +19,5 @@
     "scan_environment": "bitbucket",
     "is_full_scan": true,
     "is_sca_scan": false
-  },
-  "policy_names": [
-    "audit",
-    "comment",
-    "block"
-  ]
+  }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket/results.txt
@@ -70,7 +70,7 @@ First-Party Blocking Rules Fired:
                 pull_request                                                    
             
   CONNECTION
-  Reporting start of scan for r2c                     
+  Reporting start of scan for deployment_name         
   Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket/results.txt
@@ -70,8 +70,8 @@ First-Party Blocking Rules Fired:
                 pull_request                                                    
             
   CONNECTION
-  Fetching configuration from Semgrep Cloud Platform  
-  Reporting start of scan for org_name                               
+  Reporting start of scan for r2c                     
+  Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐
 │ Scan Status │

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite-overwrite-autodetected-variables/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite-overwrite-autodetected-variables/meta.json
@@ -19,10 +19,5 @@
     "scan_environment": "buildkite",
     "is_full_scan": true,
     "is_sca_scan": false
-  },
-  "policy_names": [
-    "audit",
-    "comment",
-    "block"
-  ]
+  }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite-overwrite-autodetected-variables/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite-overwrite-autodetected-variables/results.txt
@@ -70,7 +70,7 @@ First-Party Blocking Rules Fired:
                 pull_request                                                    
             
   CONNECTION
-  Reporting start of scan for r2c                     
+  Reporting start of scan for deployment_name         
   Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite-overwrite-autodetected-variables/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite-overwrite-autodetected-variables/results.txt
@@ -70,8 +70,8 @@ First-Party Blocking Rules Fired:
                 pull_request                                                    
             
   CONNECTION
-  Fetching configuration from Semgrep Cloud Platform  
-  Reporting start of scan for org_name                               
+  Reporting start of scan for r2c                     
+  Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐
 │ Scan Status │

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite/meta.json
@@ -19,10 +19,5 @@
     "scan_environment": "buildkite",
     "is_full_scan": true,
     "is_sca_scan": false
-  },
-  "policy_names": [
-    "audit",
-    "comment",
-    "block"
-  ]
+  }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite/results.txt
@@ -70,7 +70,7 @@ First-Party Blocking Rules Fired:
                 pull_request                                                    
             
   CONNECTION
-  Reporting start of scan for r2c                     
+  Reporting start of scan for deployment_name         
   Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite/results.txt
@@ -70,8 +70,8 @@ First-Party Blocking Rules Fired:
                 pull_request                                                    
             
   CONNECTION
-  Fetching configuration from Semgrep Cloud Platform  
-  Reporting start of scan for org_name                               
+  Reporting start of scan for r2c                     
+  Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐
 │ Scan Status │

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci-overwrite-autodetected-variables/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci-overwrite-autodetected-variables/meta.json
@@ -19,10 +19,5 @@
     "scan_environment": "circleci",
     "is_full_scan": true,
     "is_sca_scan": false
-  },
-  "policy_names": [
-    "audit",
-    "comment",
-    "block"
-  ]
+  }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci-overwrite-autodetected-variables/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci-overwrite-autodetected-variables/results.txt
@@ -70,7 +70,7 @@ First-Party Blocking Rules Fired:
                 pull_request                                                    
             
   CONNECTION
-  Reporting start of scan for r2c                     
+  Reporting start of scan for deployment_name         
   Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci-overwrite-autodetected-variables/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci-overwrite-autodetected-variables/results.txt
@@ -70,8 +70,8 @@ First-Party Blocking Rules Fired:
                 pull_request                                                    
             
   CONNECTION
-  Fetching configuration from Semgrep Cloud Platform  
-  Reporting start of scan for org_name                               
+  Reporting start of scan for r2c                     
+  Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐
 │ Scan Status │

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci/meta.json
@@ -19,10 +19,5 @@
     "scan_environment": "circleci",
     "is_full_scan": true,
     "is_sca_scan": false
-  },
-  "policy_names": [
-    "audit",
-    "comment",
-    "block"
-  ]
+  }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci/results.txt
@@ -70,7 +70,7 @@ First-Party Blocking Rules Fired:
                 pull_request                                                    
             
   CONNECTION
-  Reporting start of scan for r2c                     
+  Reporting start of scan for deployment_name         
   Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci/results.txt
@@ -70,8 +70,8 @@ First-Party Blocking Rules Fired:
                 pull_request                                                    
             
   CONNECTION
-  Fetching configuration from Semgrep Cloud Platform  
-  Reporting start of scan for org_name                               
+  Reporting start of scan for r2c                     
+  Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐
 │ Scan Status │

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/meta.json
@@ -19,10 +19,5 @@
     "scan_environment": "github-actions",
     "is_full_scan": true,
     "is_sca_scan": false
-  },
-  "policy_names": [
-    "audit",
-    "comment",
-    "block"
-  ]
+  }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/results.txt
@@ -18,7 +18,7 @@ CI="true" GITHUB_ACTIONS="true" GITHUB_EVENT_NAME="push" GITHUB_REPOSITORY="proj
   environment - running in environment github-actions, triggering event is push
             
   CONNECTION
-  Reporting start of scan for r2c                     
+  Reporting start of scan for deployment_name         
   Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/results.txt
@@ -18,8 +18,8 @@ CI="true" GITHUB_ACTIONS="true" GITHUB_EVENT_NAME="push" GITHUB_REPOSITORY="proj
   environment - running in environment github-actions, triggering event is push
             
   CONNECTION
-  Fetching configuration from Semgrep Cloud Platform  
-  Reporting start of scan for org_name                               
+  Reporting start of scan for r2c                     
+  Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐
 │ Scan Status │

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr-semgrepconfig/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr-semgrepconfig/meta.json
@@ -23,10 +23,5 @@
       "tag1",
       "tag_key:tag_val"
     ]
-  },
-  "policy_names": [
-    "audit",
-    "comment",
-    "block"
-  ]
+  }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr-semgrepconfig/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr-semgrepconfig/results.txt
@@ -25,7 +25,7 @@ Not on head ref: <MASKED>; checking that out now.
             
   CONNECTION
 Using <MASKED> as the merge-base of <MASKED> and <MASKED>
-  Reporting start of scan for r2c                     
+  Reporting start of scan for deployment_name         
   Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr-semgrepconfig/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr-semgrepconfig/results.txt
@@ -25,8 +25,8 @@ Not on head ref: <MASKED>; checking that out now.
             
   CONNECTION
 Using <MASKED> as the merge-base of <MASKED> and <MASKED>
-  Fetching configuration from Semgrep Cloud Platform  
-  Reporting start of scan for org_name                               
+  Reporting start of scan for r2c                     
+  Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐
 │ Scan Status │

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr/meta.json
@@ -19,10 +19,5 @@
     "scan_environment": "github-actions",
     "is_full_scan": false,
     "is_sca_scan": false
-  },
-  "policy_names": [
-    "audit",
-    "comment",
-    "block"
-  ]
+  }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr/results.txt
@@ -22,8 +22,8 @@ Not on head ref: <MASKED>; checking that out now.
             
   CONNECTION
 Using <MASKED> as the merge-base of <MASKED> and <MASKED>
-  Fetching configuration from Semgrep Cloud Platform  
-  Reporting start of scan for org_name                               
+  Reporting start of scan for r2c                     
+  Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐
 │ Scan Status │

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr/results.txt
@@ -22,7 +22,7 @@ Not on head ref: <MASKED>; checking that out now.
             
   CONNECTION
 Using <MASKED> as the merge-base of <MASKED> and <MASKED>
-  Reporting start of scan for r2c                     
+  Reporting start of scan for deployment_name         
   Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/meta.json
@@ -19,10 +19,5 @@
     "scan_environment": "github-actions",
     "is_full_scan": true,
     "is_sca_scan": false
-  },
-  "policy_names": [
-    "audit",
-    "comment",
-    "block"
-  ]
+  }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/results.txt
@@ -18,7 +18,7 @@ CI="true" GITHUB_ACTIONS="true" GITHUB_EVENT_NAME="push" GITHUB_REPOSITORY="proj
   environment - running in environment github-actions, triggering event is push
             
   CONNECTION
-  Reporting start of scan for r2c                     
+  Reporting start of scan for deployment_name         
   Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/results.txt
@@ -18,8 +18,8 @@ CI="true" GITHUB_ACTIONS="true" GITHUB_EVENT_NAME="push" GITHUB_REPOSITORY="proj
   environment - running in environment github-actions, triggering event is push
             
   CONNECTION
-  Fetching configuration from Semgrep Cloud Platform  
-  Reporting start of scan for org_name                               
+  Reporting start of scan for r2c                     
+  Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐
 │ Scan Status │

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-push/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-push/meta.json
@@ -21,10 +21,5 @@
     "base_sha": "sanitized",
     "start_sha": null,
     "is_sca_scan": false
-  },
-  "policy_names": [
-    "audit",
-    "comment",
-    "block"
-  ]
+  }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-push/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-push/results.txt
@@ -69,8 +69,8 @@ First-Party Blocking Rules Fired:
   environment - running in environment gitlab-ci, triggering event is push
             
   CONNECTION
-  Fetching configuration from Semgrep Cloud Platform  
-  Reporting start of scan for org_name                               
+  Reporting start of scan for r2c                     
+  Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐
 │ Scan Status │

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-push/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-push/results.txt
@@ -69,7 +69,7 @@ First-Party Blocking Rules Fired:
   environment - running in environment gitlab-ci, triggering event is push
             
   CONNECTION
-  Reporting start of scan for r2c                     
+  Reporting start of scan for deployment_name         
   Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab/meta.json
@@ -21,10 +21,5 @@
     "base_sha": "sanitized",
     "start_sha": "unused-commit-test-placeholder",
     "is_sca_scan": false
-  },
-  "policy_names": [
-    "audit",
-    "comment",
-    "block"
-  ]
+  }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab/results.txt
@@ -60,7 +60,7 @@ Blocking Rules Fired:
                 pull_request                                                    
             
   CONNECTION
-  Reporting start of scan for r2c                     
+  Reporting start of scan for deployment_name         
   Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab/results.txt
@@ -60,8 +60,8 @@ Blocking Rules Fired:
                 pull_request                                                    
             
   CONNECTION
-  Fetching configuration from Semgrep Cloud Platform  
-  Reporting start of scan for org_name                               
+  Reporting start of scan for r2c                     
+  Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐
 │ Scan Status │

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/meta.json
@@ -19,10 +19,5 @@
     "scan_environment": "jenkins",
     "is_full_scan": true,
     "is_sca_scan": false
-  },
-  "policy_names": [
-    "audit",
-    "comment",
-    "block"
-  ]
+  }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/results.txt
@@ -69,8 +69,8 @@ First-Party Blocking Rules Fired:
   environment - running in environment jenkins, triggering event is unknown
             
   CONNECTION
-  Fetching configuration from Semgrep Cloud Platform  
-  Reporting start of scan for org_name                               
+  Reporting start of scan for r2c                     
+  Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐
 │ Scan Status │

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/results.txt
@@ -69,7 +69,7 @@ First-Party Blocking Rules Fired:
   environment - running in environment jenkins, triggering event is unknown
             
   CONNECTION
-  Reporting start of scan for r2c                     
+  Reporting start of scan for deployment_name         
   Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-overwrite-autodetected-variables/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-overwrite-autodetected-variables/meta.json
@@ -19,10 +19,5 @@
     "scan_environment": "jenkins",
     "is_full_scan": true,
     "is_sca_scan": false
-  },
-  "policy_names": [
-    "audit",
-    "comment",
-    "block"
-  ]
+  }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-overwrite-autodetected-variables/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-overwrite-autodetected-variables/results.txt
@@ -69,8 +69,8 @@ First-Party Blocking Rules Fired:
   environment - running in environment jenkins, triggering event is unknown
             
   CONNECTION
-  Fetching configuration from Semgrep Cloud Platform  
-  Reporting start of scan for org_name                               
+  Reporting start of scan for r2c                     
+  Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐
 │ Scan Status │

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-overwrite-autodetected-variables/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-overwrite-autodetected-variables/results.txt
@@ -69,7 +69,7 @@ First-Party Blocking Rules Fired:
   environment - running in environment jenkins, triggering event is unknown
             
   CONNECTION
-  Reporting start of scan for r2c                     
+  Reporting start of scan for deployment_name         
   Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins/meta.json
@@ -19,10 +19,5 @@
     "scan_environment": "jenkins",
     "is_full_scan": true,
     "is_sca_scan": false
-  },
-  "policy_names": [
-    "audit",
-    "comment",
-    "block"
-  ]
+  }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins/results.txt
@@ -69,8 +69,8 @@ First-Party Blocking Rules Fired:
   environment - running in environment jenkins, triggering event is unknown
             
   CONNECTION
-  Fetching configuration from Semgrep Cloud Platform  
-  Reporting start of scan for org_name                               
+  Reporting start of scan for r2c                     
+  Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐
 │ Scan Status │

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins/results.txt
@@ -69,7 +69,7 @@ First-Party Blocking Rules Fired:
   environment - running in environment jenkins, triggering event is unknown
             
   CONNECTION
-  Reporting start of scan for r2c                     
+  Reporting start of scan for deployment_name         
   Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/meta.json
@@ -19,10 +19,5 @@
     "scan_environment": "git",
     "is_full_scan": true,
     "is_sca_scan": false
-  },
-  "policy_names": [
-    "audit",
-    "comment",
-    "block"
-  ]
+  }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/results.txt
@@ -69,7 +69,7 @@ First-Party Blocking Rules Fired:
   environment - running in environment git, triggering event is unknown
             
   CONNECTION
-  Reporting start of scan for r2c                     
+  Reporting start of scan for deployment_name         
   Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/results.txt
@@ -69,8 +69,8 @@ First-Party Blocking Rules Fired:
   environment - running in environment git, triggering event is unknown
             
   CONNECTION
-  Fetching configuration from Semgrep Cloud Platform  
-  Reporting start of scan for org_name                               
+  Reporting start of scan for r2c                     
+  Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐
 │ Scan Status │

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-self-hosted/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-self-hosted/meta.json
@@ -19,10 +19,5 @@
     "scan_environment": "git",
     "is_full_scan": true,
     "is_sca_scan": false
-  },
-  "policy_names": [
-    "audit",
-    "comment",
-    "block"
-  ]
+  }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-self-hosted/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-self-hosted/results.txt
@@ -69,8 +69,8 @@ First-Party Blocking Rules Fired:
   environment - running in environment git, triggering event is pull_request
             
   CONNECTION
-  Fetching configuration from Semgrep Cloud Platform  
-  Reporting start of scan for org_name                               
+  Reporting start of scan for r2c                     
+  Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐
 │ Scan Status │

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-self-hosted/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-self-hosted/results.txt
@@ -69,7 +69,7 @@ First-Party Blocking Rules Fired:
   environment - running in environment git, triggering event is pull_request
             
   CONNECTION
-  Reporting start of scan for r2c                     
+  Reporting start of scan for deployment_name         
   Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis-overwrite-autodetected-variables/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis-overwrite-autodetected-variables/meta.json
@@ -19,10 +19,5 @@
     "scan_environment": "travis-ci",
     "is_full_scan": true,
     "is_sca_scan": false
-  },
-  "policy_names": [
-    "audit",
-    "comment",
-    "block"
-  ]
+  }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis-overwrite-autodetected-variables/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis-overwrite-autodetected-variables/results.txt
@@ -70,7 +70,7 @@ First-Party Blocking Rules Fired:
                 pull_request                                                    
             
   CONNECTION
-  Reporting start of scan for r2c                     
+  Reporting start of scan for deployment_name         
   Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis-overwrite-autodetected-variables/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis-overwrite-autodetected-variables/results.txt
@@ -70,8 +70,8 @@ First-Party Blocking Rules Fired:
                 pull_request                                                    
             
   CONNECTION
-  Fetching configuration from Semgrep Cloud Platform  
-  Reporting start of scan for org_name                               
+  Reporting start of scan for r2c                     
+  Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐
 │ Scan Status │

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis/meta.json
@@ -19,10 +19,5 @@
     "scan_environment": "travis-ci",
     "is_full_scan": true,
     "is_sca_scan": false
-  },
-  "policy_names": [
-    "audit",
-    "comment",
-    "block"
-  ]
+  }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis/results.txt
@@ -70,7 +70,7 @@ First-Party Blocking Rules Fired:
                 pull_request                                                    
             
   CONNECTION
-  Reporting start of scan for r2c                     
+  Reporting start of scan for deployment_name         
   Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis/results.txt
@@ -70,8 +70,8 @@ First-Party Blocking Rules Fired:
                 pull_request                                                    
             
   CONNECTION
-  Fetching configuration from Semgrep Cloud Platform  
-  Reporting start of scan for org_name                               
+  Reporting start of scan for r2c                     
+  Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐
 │ Scan Status │

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-unparsable_url/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-unparsable_url/meta.json
@@ -19,10 +19,5 @@
     "scan_environment": "git",
     "is_full_scan": true,
     "is_sca_scan": false
-  },
-  "policy_names": [
-    "audit",
-    "comment",
-    "block"
-  ]
+  }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-unparsable_url/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-unparsable_url/results.txt
@@ -69,8 +69,8 @@ First-Party Blocking Rules Fired:
   environment - running in environment git, triggering event is pull_request
             
   CONNECTION
-  Fetching configuration from Semgrep Cloud Platform  
-  Reporting start of scan for org_name                               
+  Reporting start of scan for r2c                     
+  Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐
 │ Scan Status │

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-unparsable_url/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-unparsable_url/results.txt
@@ -69,7 +69,7 @@ First-Party Blocking Rules Fired:
   environment - running in environment git, triggering event is pull_request
             
   CONNECTION
-  Reporting start of scan for r2c                     
+  Reporting start of scan for deployment_name         
   Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines-overwrite-autodetected-variables/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines-overwrite-autodetected-variables/meta.json
@@ -19,10 +19,5 @@
     "scan_environment": "azure-pipelines",
     "is_full_scan": true,
     "is_sca_scan": false
-  },
-  "policy_names": [
-    "audit",
-    "comment",
-    "block"
-  ]
+  }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines-overwrite-autodetected-variables/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines-overwrite-autodetected-variables/results.txt
@@ -70,7 +70,7 @@ First-Party Blocking Rules Fired:
                 pull_request                                                    
             
   CONNECTION
-  Reporting start of scan for r2c                     
+  Reporting start of scan for deployment_name         
   Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines-overwrite-autodetected-variables/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines-overwrite-autodetected-variables/results.txt
@@ -70,8 +70,8 @@ First-Party Blocking Rules Fired:
                 pull_request                                                    
             
   CONNECTION
-  Fetching configuration from Semgrep Cloud Platform  
-  Reporting start of scan for org_name                               
+  Reporting start of scan for r2c                     
+  Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐
 │ Scan Status │

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines/meta.json
@@ -19,10 +19,5 @@
     "scan_environment": "azure-pipelines",
     "is_full_scan": true,
     "is_sca_scan": false
-  },
-  "policy_names": [
-    "audit",
-    "comment",
-    "block"
-  ]
+  }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines/results.txt
@@ -70,7 +70,7 @@ First-Party Blocking Rules Fired:
                 pull_request                                                    
             
   CONNECTION
-  Reporting start of scan for r2c                     
+  Reporting start of scan for deployment_name         
   Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines/results.txt
@@ -70,8 +70,8 @@ First-Party Blocking Rules Fired:
                 pull_request                                                    
             
   CONNECTION
-  Fetching configuration from Semgrep Cloud Platform  
-  Reporting start of scan for org_name                               
+  Reporting start of scan for r2c                     
+  Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐
 │ Scan Status │

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket-overwrite-autodetected-variables/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket-overwrite-autodetected-variables/meta.json
@@ -19,10 +19,5 @@
     "scan_environment": "bitbucket",
     "is_full_scan": true,
     "is_sca_scan": false
-  },
-  "policy_names": [
-    "audit",
-    "comment",
-    "block"
-  ]
+  }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket-overwrite-autodetected-variables/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket-overwrite-autodetected-variables/results.txt
@@ -70,7 +70,7 @@ First-Party Blocking Rules Fired:
                 pull_request                                                    
             
   CONNECTION
-  Reporting start of scan for r2c                     
+  Reporting start of scan for deployment_name         
   Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket-overwrite-autodetected-variables/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket-overwrite-autodetected-variables/results.txt
@@ -70,8 +70,8 @@ First-Party Blocking Rules Fired:
                 pull_request                                                    
             
   CONNECTION
-  Fetching configuration from Semgrep Cloud Platform  
-  Reporting start of scan for org_name                               
+  Reporting start of scan for r2c                     
+  Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐
 │ Scan Status │

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket/meta.json
@@ -19,10 +19,5 @@
     "scan_environment": "bitbucket",
     "is_full_scan": true,
     "is_sca_scan": false
-  },
-  "policy_names": [
-    "audit",
-    "comment",
-    "block"
-  ]
+  }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket/results.txt
@@ -70,7 +70,7 @@ First-Party Blocking Rules Fired:
                 pull_request                                                    
             
   CONNECTION
-  Reporting start of scan for r2c                     
+  Reporting start of scan for deployment_name         
   Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket/results.txt
@@ -70,8 +70,8 @@ First-Party Blocking Rules Fired:
                 pull_request                                                    
             
   CONNECTION
-  Fetching configuration from Semgrep Cloud Platform  
-  Reporting start of scan for org_name                               
+  Reporting start of scan for r2c                     
+  Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐
 │ Scan Status │

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite-overwrite-autodetected-variables/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite-overwrite-autodetected-variables/meta.json
@@ -19,10 +19,5 @@
     "scan_environment": "buildkite",
     "is_full_scan": true,
     "is_sca_scan": false
-  },
-  "policy_names": [
-    "audit",
-    "comment",
-    "block"
-  ]
+  }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite-overwrite-autodetected-variables/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite-overwrite-autodetected-variables/results.txt
@@ -70,7 +70,7 @@ First-Party Blocking Rules Fired:
                 pull_request                                                    
             
   CONNECTION
-  Reporting start of scan for r2c                     
+  Reporting start of scan for deployment_name         
   Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite-overwrite-autodetected-variables/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite-overwrite-autodetected-variables/results.txt
@@ -70,8 +70,8 @@ First-Party Blocking Rules Fired:
                 pull_request                                                    
             
   CONNECTION
-  Fetching configuration from Semgrep Cloud Platform  
-  Reporting start of scan for org_name                               
+  Reporting start of scan for r2c                     
+  Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐
 │ Scan Status │

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite/meta.json
@@ -19,10 +19,5 @@
     "scan_environment": "buildkite",
     "is_full_scan": true,
     "is_sca_scan": false
-  },
-  "policy_names": [
-    "audit",
-    "comment",
-    "block"
-  ]
+  }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite/results.txt
@@ -70,7 +70,7 @@ First-Party Blocking Rules Fired:
                 pull_request                                                    
             
   CONNECTION
-  Reporting start of scan for r2c                     
+  Reporting start of scan for deployment_name         
   Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite/results.txt
@@ -70,8 +70,8 @@ First-Party Blocking Rules Fired:
                 pull_request                                                    
             
   CONNECTION
-  Fetching configuration from Semgrep Cloud Platform  
-  Reporting start of scan for org_name                               
+  Reporting start of scan for r2c                     
+  Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐
 │ Scan Status │

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci-overwrite-autodetected-variables/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci-overwrite-autodetected-variables/meta.json
@@ -19,10 +19,5 @@
     "scan_environment": "circleci",
     "is_full_scan": true,
     "is_sca_scan": false
-  },
-  "policy_names": [
-    "audit",
-    "comment",
-    "block"
-  ]
+  }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci-overwrite-autodetected-variables/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci-overwrite-autodetected-variables/results.txt
@@ -70,7 +70,7 @@ First-Party Blocking Rules Fired:
                 pull_request                                                    
             
   CONNECTION
-  Reporting start of scan for r2c                     
+  Reporting start of scan for deployment_name         
   Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci-overwrite-autodetected-variables/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci-overwrite-autodetected-variables/results.txt
@@ -70,8 +70,8 @@ First-Party Blocking Rules Fired:
                 pull_request                                                    
             
   CONNECTION
-  Fetching configuration from Semgrep Cloud Platform  
-  Reporting start of scan for org_name                               
+  Reporting start of scan for r2c                     
+  Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐
 │ Scan Status │

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci/meta.json
@@ -19,10 +19,5 @@
     "scan_environment": "circleci",
     "is_full_scan": true,
     "is_sca_scan": false
-  },
-  "policy_names": [
-    "audit",
-    "comment",
-    "block"
-  ]
+  }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci/results.txt
@@ -70,7 +70,7 @@ First-Party Blocking Rules Fired:
                 pull_request                                                    
             
   CONNECTION
-  Reporting start of scan for r2c                     
+  Reporting start of scan for deployment_name         
   Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci/results.txt
@@ -70,8 +70,8 @@ First-Party Blocking Rules Fired:
                 pull_request                                                    
             
   CONNECTION
-  Fetching configuration from Semgrep Cloud Platform  
-  Reporting start of scan for org_name                               
+  Reporting start of scan for r2c                     
+  Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐
 │ Scan Status │

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/meta.json
@@ -19,10 +19,5 @@
     "scan_environment": "github-actions",
     "is_full_scan": true,
     "is_sca_scan": false
-  },
-  "policy_names": [
-    "audit",
-    "comment",
-    "block"
-  ]
+  }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/results.txt
@@ -18,7 +18,7 @@ CI="true" GITHUB_ACTIONS="true" GITHUB_EVENT_NAME="push" GITHUB_REPOSITORY="proj
   environment - running in environment github-actions, triggering event is push
             
   CONNECTION
-  Reporting start of scan for r2c                     
+  Reporting start of scan for deployment_name         
   Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/results.txt
@@ -18,8 +18,8 @@ CI="true" GITHUB_ACTIONS="true" GITHUB_EVENT_NAME="push" GITHUB_REPOSITORY="proj
   environment - running in environment github-actions, triggering event is push
             
   CONNECTION
-  Fetching configuration from Semgrep Cloud Platform  
-  Reporting start of scan for org_name                               
+  Reporting start of scan for r2c                     
+  Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐
 │ Scan Status │

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr-semgrepconfig/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr-semgrepconfig/meta.json
@@ -23,10 +23,5 @@
       "tag1",
       "tag_key:tag_val"
     ]
-  },
-  "policy_names": [
-    "audit",
-    "comment",
-    "block"
-  ]
+  }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr-semgrepconfig/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr-semgrepconfig/results.txt
@@ -25,7 +25,7 @@ Not on head ref: <MASKED>; checking that out now.
             
   CONNECTION
 Using <MASKED> as the merge-base of <MASKED> and <MASKED>
-  Reporting start of scan for r2c                     
+  Reporting start of scan for deployment_name         
   Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr-semgrepconfig/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr-semgrepconfig/results.txt
@@ -25,8 +25,8 @@ Not on head ref: <MASKED>; checking that out now.
             
   CONNECTION
 Using <MASKED> as the merge-base of <MASKED> and <MASKED>
-  Fetching configuration from Semgrep Cloud Platform  
-  Reporting start of scan for org_name                               
+  Reporting start of scan for r2c                     
+  Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐
 │ Scan Status │

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr/meta.json
@@ -19,10 +19,5 @@
     "scan_environment": "github-actions",
     "is_full_scan": false,
     "is_sca_scan": false
-  },
-  "policy_names": [
-    "audit",
-    "comment",
-    "block"
-  ]
+  }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr/results.txt
@@ -22,8 +22,8 @@ Not on head ref: <MASKED>; checking that out now.
             
   CONNECTION
 Using <MASKED> as the merge-base of <MASKED> and <MASKED>
-  Fetching configuration from Semgrep Cloud Platform  
-  Reporting start of scan for org_name                               
+  Reporting start of scan for r2c                     
+  Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐
 │ Scan Status │

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr/results.txt
@@ -22,7 +22,7 @@ Not on head ref: <MASKED>; checking that out now.
             
   CONNECTION
 Using <MASKED> as the merge-base of <MASKED> and <MASKED>
-  Reporting start of scan for r2c                     
+  Reporting start of scan for deployment_name         
   Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/meta.json
@@ -19,10 +19,5 @@
     "scan_environment": "github-actions",
     "is_full_scan": true,
     "is_sca_scan": false
-  },
-  "policy_names": [
-    "audit",
-    "comment",
-    "block"
-  ]
+  }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/results.txt
@@ -18,7 +18,7 @@ CI="true" GITHUB_ACTIONS="true" GITHUB_EVENT_NAME="push" GITHUB_REPOSITORY="proj
   environment - running in environment github-actions, triggering event is push
             
   CONNECTION
-  Reporting start of scan for r2c                     
+  Reporting start of scan for deployment_name         
   Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/results.txt
@@ -18,8 +18,8 @@ CI="true" GITHUB_ACTIONS="true" GITHUB_EVENT_NAME="push" GITHUB_REPOSITORY="proj
   environment - running in environment github-actions, triggering event is push
             
   CONNECTION
-  Fetching configuration from Semgrep Cloud Platform  
-  Reporting start of scan for org_name                               
+  Reporting start of scan for r2c                     
+  Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐
 │ Scan Status │

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-push/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-push/meta.json
@@ -21,10 +21,5 @@
     "base_sha": "sanitized",
     "start_sha": null,
     "is_sca_scan": false
-  },
-  "policy_names": [
-    "audit",
-    "comment",
-    "block"
-  ]
+  }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-push/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-push/results.txt
@@ -69,8 +69,8 @@ First-Party Blocking Rules Fired:
   environment - running in environment gitlab-ci, triggering event is push
             
   CONNECTION
-  Fetching configuration from Semgrep Cloud Platform  
-  Reporting start of scan for org_name                               
+  Reporting start of scan for r2c                     
+  Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐
 │ Scan Status │

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-push/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-push/results.txt
@@ -69,7 +69,7 @@ First-Party Blocking Rules Fired:
   environment - running in environment gitlab-ci, triggering event is push
             
   CONNECTION
-  Reporting start of scan for r2c                     
+  Reporting start of scan for deployment_name         
   Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab/meta.json
@@ -21,10 +21,5 @@
     "base_sha": "sanitized",
     "start_sha": "unused-commit-test-placeholder",
     "is_sca_scan": false
-  },
-  "policy_names": [
-    "audit",
-    "comment",
-    "block"
-  ]
+  }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab/results.txt
@@ -60,7 +60,7 @@ Blocking Rules Fired:
                 pull_request                                                    
             
   CONNECTION
-  Reporting start of scan for r2c                     
+  Reporting start of scan for deployment_name         
   Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab/results.txt
@@ -60,8 +60,8 @@ Blocking Rules Fired:
                 pull_request                                                    
             
   CONNECTION
-  Fetching configuration from Semgrep Cloud Platform  
-  Reporting start of scan for org_name                               
+  Reporting start of scan for r2c                     
+  Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐
 │ Scan Status │

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/meta.json
@@ -19,10 +19,5 @@
     "scan_environment": "jenkins",
     "is_full_scan": true,
     "is_sca_scan": false
-  },
-  "policy_names": [
-    "audit",
-    "comment",
-    "block"
-  ]
+  }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/results.txt
@@ -69,8 +69,8 @@ First-Party Blocking Rules Fired:
   environment - running in environment jenkins, triggering event is unknown
             
   CONNECTION
-  Fetching configuration from Semgrep Cloud Platform  
-  Reporting start of scan for org_name                               
+  Reporting start of scan for r2c                     
+  Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐
 │ Scan Status │

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/results.txt
@@ -69,7 +69,7 @@ First-Party Blocking Rules Fired:
   environment - running in environment jenkins, triggering event is unknown
             
   CONNECTION
-  Reporting start of scan for r2c                     
+  Reporting start of scan for deployment_name         
   Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-overwrite-autodetected-variables/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-overwrite-autodetected-variables/meta.json
@@ -19,10 +19,5 @@
     "scan_environment": "jenkins",
     "is_full_scan": true,
     "is_sca_scan": false
-  },
-  "policy_names": [
-    "audit",
-    "comment",
-    "block"
-  ]
+  }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-overwrite-autodetected-variables/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-overwrite-autodetected-variables/results.txt
@@ -69,8 +69,8 @@ First-Party Blocking Rules Fired:
   environment - running in environment jenkins, triggering event is unknown
             
   CONNECTION
-  Fetching configuration from Semgrep Cloud Platform  
-  Reporting start of scan for org_name                               
+  Reporting start of scan for r2c                     
+  Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐
 │ Scan Status │

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-overwrite-autodetected-variables/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-overwrite-autodetected-variables/results.txt
@@ -69,7 +69,7 @@ First-Party Blocking Rules Fired:
   environment - running in environment jenkins, triggering event is unknown
             
   CONNECTION
-  Reporting start of scan for r2c                     
+  Reporting start of scan for deployment_name         
   Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins/meta.json
@@ -19,10 +19,5 @@
     "scan_environment": "jenkins",
     "is_full_scan": true,
     "is_sca_scan": false
-  },
-  "policy_names": [
-    "audit",
-    "comment",
-    "block"
-  ]
+  }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins/results.txt
@@ -69,8 +69,8 @@ First-Party Blocking Rules Fired:
   environment - running in environment jenkins, triggering event is unknown
             
   CONNECTION
-  Fetching configuration from Semgrep Cloud Platform  
-  Reporting start of scan for org_name                               
+  Reporting start of scan for r2c                     
+  Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐
 │ Scan Status │

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins/results.txt
@@ -69,7 +69,7 @@ First-Party Blocking Rules Fired:
   environment - running in environment jenkins, triggering event is unknown
             
   CONNECTION
-  Reporting start of scan for r2c                     
+  Reporting start of scan for deployment_name         
   Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/meta.json
@@ -19,10 +19,5 @@
     "scan_environment": "git",
     "is_full_scan": true,
     "is_sca_scan": false
-  },
-  "policy_names": [
-    "audit",
-    "comment",
-    "block"
-  ]
+  }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/results.txt
@@ -69,7 +69,7 @@ First-Party Blocking Rules Fired:
   environment - running in environment git, triggering event is unknown
             
   CONNECTION
-  Reporting start of scan for r2c                     
+  Reporting start of scan for deployment_name         
   Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/results.txt
@@ -69,8 +69,8 @@ First-Party Blocking Rules Fired:
   environment - running in environment git, triggering event is unknown
             
   CONNECTION
-  Fetching configuration from Semgrep Cloud Platform  
-  Reporting start of scan for org_name                               
+  Reporting start of scan for r2c                     
+  Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐
 │ Scan Status │

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-self-hosted/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-self-hosted/meta.json
@@ -19,10 +19,5 @@
     "scan_environment": "git",
     "is_full_scan": true,
     "is_sca_scan": false
-  },
-  "policy_names": [
-    "audit",
-    "comment",
-    "block"
-  ]
+  }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-self-hosted/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-self-hosted/results.txt
@@ -69,8 +69,8 @@ First-Party Blocking Rules Fired:
   environment - running in environment git, triggering event is pull_request
             
   CONNECTION
-  Fetching configuration from Semgrep Cloud Platform  
-  Reporting start of scan for org_name                               
+  Reporting start of scan for r2c                     
+  Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐
 │ Scan Status │

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-self-hosted/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-self-hosted/results.txt
@@ -69,7 +69,7 @@ First-Party Blocking Rules Fired:
   environment - running in environment git, triggering event is pull_request
             
   CONNECTION
-  Reporting start of scan for r2c                     
+  Reporting start of scan for deployment_name         
   Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis-overwrite-autodetected-variables/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis-overwrite-autodetected-variables/meta.json
@@ -19,10 +19,5 @@
     "scan_environment": "travis-ci",
     "is_full_scan": true,
     "is_sca_scan": false
-  },
-  "policy_names": [
-    "audit",
-    "comment",
-    "block"
-  ]
+  }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis-overwrite-autodetected-variables/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis-overwrite-autodetected-variables/results.txt
@@ -70,7 +70,7 @@ First-Party Blocking Rules Fired:
                 pull_request                                                    
             
   CONNECTION
-  Reporting start of scan for r2c                     
+  Reporting start of scan for deployment_name         
   Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis-overwrite-autodetected-variables/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis-overwrite-autodetected-variables/results.txt
@@ -70,8 +70,8 @@ First-Party Blocking Rules Fired:
                 pull_request                                                    
             
   CONNECTION
-  Fetching configuration from Semgrep Cloud Platform  
-  Reporting start of scan for org_name                               
+  Reporting start of scan for r2c                     
+  Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐
 │ Scan Status │

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis/meta.json
@@ -19,10 +19,5 @@
     "scan_environment": "travis-ci",
     "is_full_scan": true,
     "is_sca_scan": false
-  },
-  "policy_names": [
-    "audit",
-    "comment",
-    "block"
-  ]
+  }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis/results.txt
@@ -70,7 +70,7 @@ First-Party Blocking Rules Fired:
                 pull_request                                                    
             
   CONNECTION
-  Reporting start of scan for r2c                     
+  Reporting start of scan for deployment_name         
   Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis/results.txt
@@ -70,8 +70,8 @@ First-Party Blocking Rules Fired:
                 pull_request                                                    
             
   CONNECTION
-  Fetching configuration from Semgrep Cloud Platform  
-  Reporting start of scan for org_name                               
+  Reporting start of scan for r2c                     
+  Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐
 │ Scan Status │

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-unparsable_url/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-unparsable_url/meta.json
@@ -19,10 +19,5 @@
     "scan_environment": "git",
     "is_full_scan": true,
     "is_sca_scan": false
-  },
-  "policy_names": [
-    "audit",
-    "comment",
-    "block"
-  ]
+  }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-unparsable_url/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-unparsable_url/results.txt
@@ -69,8 +69,8 @@ First-Party Blocking Rules Fired:
   environment - running in environment git, triggering event is pull_request
             
   CONNECTION
-  Fetching configuration from Semgrep Cloud Platform  
-  Reporting start of scan for org_name                               
+  Reporting start of scan for r2c                     
+  Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐
 │ Scan Status │

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-unparsable_url/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-unparsable_url/results.txt
@@ -69,7 +69,7 @@ First-Party Blocking Rules Fired:
   environment - running in environment git, triggering event is pull_request
             
   CONNECTION
-  Reporting start of scan for r2c                     
+  Reporting start of scan for deployment_name         
   Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---emacs/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---emacs/results.txt
@@ -30,7 +30,7 @@ poetry.lock:0:0:error(supply-chain1)::found a dependency
   environment - running in environment git, triggering event is unknown
             
   CONNECTION
-  Reporting start of scan for r2c                     
+  Reporting start of scan for deployment_name         
   Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---emacs/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---emacs/results.txt
@@ -30,8 +30,8 @@ poetry.lock:0:0:error(supply-chain1)::found a dependency
   environment - running in environment git, triggering event is unknown
             
   CONNECTION
-  Fetching configuration from Semgrep Cloud Platform  
-  Reporting start of scan for org_name                               
+  Reporting start of scan for r2c                     
+  Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐
 │ Scan Status │

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---gitlab-sast/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---gitlab-sast/results.txt
@@ -290,7 +290,7 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
   environment - running in environment git, triggering event is unknown
             
   CONNECTION
-  Reporting start of scan for r2c                     
+  Reporting start of scan for deployment_name         
   Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---gitlab-sast/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---gitlab-sast/results.txt
@@ -290,8 +290,8 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
   environment - running in environment git, triggering event is unknown
             
   CONNECTION
-  Fetching configuration from Semgrep Cloud Platform  
-  Reporting start of scan for org_name                               
+  Reporting start of scan for r2c                     
+  Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐
 │ Scan Status │

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---gitlab-secrets/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---gitlab-secrets/results.txt
@@ -344,7 +344,7 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
   environment - running in environment git, triggering event is unknown
             
   CONNECTION
-  Reporting start of scan for r2c                     
+  Reporting start of scan for deployment_name         
   Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---gitlab-secrets/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---gitlab-secrets/results.txt
@@ -344,8 +344,8 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
   environment - running in environment git, triggering event is unknown
             
   CONNECTION
-  Fetching configuration from Semgrep Cloud Platform  
-  Reporting start of scan for org_name                               
+  Reporting start of scan for r2c                     
+  Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐
 │ Scan Status │

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---json/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---json/results.txt
@@ -432,7 +432,7 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
   environment - running in environment git, triggering event is unknown
             
   CONNECTION
-  Reporting start of scan for r2c                     
+  Reporting start of scan for deployment_name         
   Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---json/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---json/results.txt
@@ -432,8 +432,8 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
   environment - running in environment git, triggering event is unknown
             
   CONNECTION
-  Fetching configuration from Semgrep Cloud Platform  
-  Reporting start of scan for org_name                               
+  Reporting start of scan for r2c                     
+  Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐
 │ Scan Status │

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---sarif/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---sarif/results.txt
@@ -588,7 +588,7 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
   environment - running in environment git, triggering event is unknown
             
   CONNECTION
-  Reporting start of scan for r2c                     
+  Reporting start of scan for deployment_name         
   Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---sarif/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---sarif/results.txt
@@ -588,8 +588,8 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
   environment - running in environment git, triggering event is unknown
             
   CONNECTION
-  Fetching configuration from Semgrep Cloud Platform  
-  Reporting start of scan for org_name                               
+  Reporting start of scan for r2c                     
+  Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐
 │ Scan Status │

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---vim/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---vim/results.txt
@@ -30,7 +30,7 @@ poetry.lock:0:0:E:supply-chain1:found a dependency
   environment - running in environment git, triggering event is unknown
             
   CONNECTION
-  Reporting start of scan for r2c                     
+  Reporting start of scan for deployment_name         
   Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---vim/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---vim/results.txt
@@ -30,8 +30,8 @@ poetry.lock:0:0:E:supply-chain1:found a dependency
   environment - running in environment git, triggering event is unknown
             
   CONNECTION
-  Fetching configuration from Semgrep Cloud Platform  
-  Reporting start of scan for org_name                               
+  Reporting start of scan for r2c                     
+  Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐
 │ Scan Status │

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---emacs/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---emacs/results.txt
@@ -30,7 +30,7 @@ poetry.lock:0:0:error(supply-chain1)::found a dependency
   environment - running in environment git, triggering event is unknown
             
   CONNECTION
-  Reporting start of scan for r2c                     
+  Reporting start of scan for deployment_name         
   Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---emacs/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---emacs/results.txt
@@ -30,8 +30,8 @@ poetry.lock:0:0:error(supply-chain1)::found a dependency
   environment - running in environment git, triggering event is unknown
             
   CONNECTION
-  Fetching configuration from Semgrep Cloud Platform  
-  Reporting start of scan for org_name                               
+  Reporting start of scan for r2c                     
+  Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐
 │ Scan Status │

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---gitlab-sast/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---gitlab-sast/results.txt
@@ -290,7 +290,7 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
   environment - running in environment git, triggering event is unknown
             
   CONNECTION
-  Reporting start of scan for r2c                     
+  Reporting start of scan for deployment_name         
   Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---gitlab-sast/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---gitlab-sast/results.txt
@@ -290,8 +290,8 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
   environment - running in environment git, triggering event is unknown
             
   CONNECTION
-  Fetching configuration from Semgrep Cloud Platform  
-  Reporting start of scan for org_name                               
+  Reporting start of scan for r2c                     
+  Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐
 │ Scan Status │

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---gitlab-secrets/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---gitlab-secrets/results.txt
@@ -344,7 +344,7 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
   environment - running in environment git, triggering event is unknown
             
   CONNECTION
-  Reporting start of scan for r2c                     
+  Reporting start of scan for deployment_name         
   Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---gitlab-secrets/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---gitlab-secrets/results.txt
@@ -344,8 +344,8 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
   environment - running in environment git, triggering event is unknown
             
   CONNECTION
-  Fetching configuration from Semgrep Cloud Platform  
-  Reporting start of scan for org_name                               
+  Reporting start of scan for r2c                     
+  Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐
 │ Scan Status │

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---json/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---json/results.txt
@@ -429,7 +429,7 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
   environment - running in environment git, triggering event is unknown
             
   CONNECTION
-  Reporting start of scan for r2c                     
+  Reporting start of scan for deployment_name         
   Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---json/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---json/results.txt
@@ -429,8 +429,8 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
   environment - running in environment git, triggering event is unknown
             
   CONNECTION
-  Fetching configuration from Semgrep Cloud Platform  
-  Reporting start of scan for org_name                               
+  Reporting start of scan for r2c                     
+  Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐
 │ Scan Status │

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---sarif/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---sarif/results.txt
@@ -534,7 +534,7 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
   environment - running in environment git, triggering event is unknown
             
   CONNECTION
-  Reporting start of scan for r2c                     
+  Reporting start of scan for deployment_name         
   Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---sarif/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---sarif/results.txt
@@ -534,8 +534,8 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
   environment - running in environment git, triggering event is unknown
             
   CONNECTION
-  Fetching configuration from Semgrep Cloud Platform  
-  Reporting start of scan for org_name                               
+  Reporting start of scan for r2c                     
+  Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐
 │ Scan Status │

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---vim/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---vim/results.txt
@@ -30,7 +30,7 @@ poetry.lock:0:0:E:supply-chain1:found a dependency
   environment - running in environment git, triggering event is unknown
             
   CONNECTION
-  Reporting start of scan for r2c                     
+  Reporting start of scan for deployment_name         
   Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---vim/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---vim/results.txt
@@ -30,8 +30,8 @@ poetry.lock:0:0:E:supply-chain1:found a dependency
   environment - running in environment git, triggering event is unknown
             
   CONNECTION
-  Fetching configuration from Semgrep Cloud Platform  
-  Reporting start of scan for org_name                               
+  Reporting start of scan for r2c                     
+  Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐
 │ Scan Status │

--- a/cli/tests/e2e/snapshots/test_ci/test_shallow_wrong_merge_base/bad_results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_shallow_wrong_merge_base/bad_results.txt
@@ -22,8 +22,8 @@ Not on head ref: 7b5cda417c780f1f96c888e1d7bd062f46df236e; checking that out now
             
   CONNECTION
 Using b903231925961ac9d787ae53ee0bd15ec156e689 as the merge-base of 81af3f0c528f4206d48f2f1d1a0ada5fa9e01f38 and 7b5cda417c780f1f96c888e1d7bd062f46df236e
-  Fetching configuration from Semgrep Cloud Platform  
-  Reporting start of scan for org_name                               
+  Reporting start of scan for r2c                     
+  Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐
 │ Scan Status │

--- a/cli/tests/e2e/snapshots/test_ci/test_shallow_wrong_merge_base/bad_results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_shallow_wrong_merge_base/bad_results.txt
@@ -22,7 +22,7 @@ Not on head ref: 7b5cda417c780f1f96c888e1d7bd062f46df236e; checking that out now
             
   CONNECTION
 Using b903231925961ac9d787ae53ee0bd15ec156e689 as the merge-base of 81af3f0c528f4206d48f2f1d1a0ada5fa9e01f38 and 7b5cda417c780f1f96c888e1d7bd062f46df236e
-  Reporting start of scan for r2c                     
+  Reporting start of scan for deployment_name         
   Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐

--- a/cli/tests/e2e/snapshots/test_ci/test_shallow_wrong_merge_base/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_shallow_wrong_merge_base/results.txt
@@ -22,8 +22,8 @@ Not on head ref: 7b5cda417c780f1f96c888e1d7bd062f46df236e; checking that out now
             
   CONNECTION
 Using 5b37988ae28e701bc9fd48d651db9e4e67936bcc as the merge-base of 81af3f0c528f4206d48f2f1d1a0ada5fa9e01f38 and 7b5cda417c780f1f96c888e1d7bd062f46df236e
-  Fetching configuration from Semgrep Cloud Platform  
-  Reporting start of scan for org_name                               
+  Reporting start of scan for r2c                     
+  Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐
 │ Scan Status │

--- a/cli/tests/e2e/snapshots/test_ci/test_shallow_wrong_merge_base/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_shallow_wrong_merge_base/results.txt
@@ -22,7 +22,7 @@ Not on head ref: 7b5cda417c780f1f96c888e1d7bd062f46df236e; checking that out now
             
   CONNECTION
 Using 5b37988ae28e701bc9fd48d651db9e4e67936bcc as the merge-base of 81af3f0c528f4206d48f2f1d1a0ada5fa9e01f38 and 7b5cda417c780f1f96c888e1d7bd062f46df236e
-  Reporting start of scan for r2c                     
+  Reporting start of scan for deployment_name         
   Fetching configuration from Semgrep Cloud Platform                 
                
 ┌─────────────┐

--- a/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awarelog4shell.yaml-dependency_awarelog4j/results.txt
+++ b/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awarelog4shell.yaml-dependency_awarelog4j/results.txt
@@ -39,6 +39,19 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
               "line": 33,
               "offset": 1035
             },
+            "propagated_value": {
+              "svalue_abstract_content": "req.getParameter(\"uname\")",
+              "svalue_end": {
+                "col": 52,
+                "line": 19,
+                "offset": 562
+              },
+              "svalue_start": {
+                "col": 27,
+                "line": 19,
+                "offset": 537
+              }
+            },
             "start": {
               "col": 26,
               "line": 33,

--- a/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awarelog4shell.yaml-dependency_awarelog4j/results.txt
+++ b/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awarelog4shell.yaml-dependency_awarelog4j/results.txt
@@ -39,19 +39,6 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
               "line": 33,
               "offset": 1035
             },
-            "propagated_value": {
-              "svalue_abstract_content": "req.getParameter(\"uname\")",
-              "svalue_end": {
-                "col": 52,
-                "line": 19,
-                "offset": 562
-              },
-              "svalue_start": {
-                "col": 27,
-                "line": 19,
-                "offset": 537
-              }
-            },
             "start": {
               "col": 26,
               "line": 33,

--- a/cli/tests/e2e/snapshots/test_output/test_debug_experimental_rule/results.txt
+++ b/cli/tests/e2e/snapshots/test_output/test_debug_experimental_rule/results.txt
@@ -70,7 +70,6 @@ Running Semgrep engine with command:
 <MASKED>
 <MASKED>
 <MASKED>
-<MASKED>
 --- end semgrep-core stderr ---
 semgrep ran in <MASKED> on 1 files
 findings summary: 2 experiment

--- a/cli/tests/e2e/snapshots/test_output/test_debug_experimental_rule/results.txt
+++ b/cli/tests/e2e/snapshots/test_output/test_debug_experimental_rule/results.txt
@@ -70,6 +70,7 @@ Running Semgrep engine with command:
 <MASKED>
 <MASKED>
 <MASKED>
+<MASKED>
 --- end semgrep-core stderr ---
 semgrep ran in <MASKED> on 1 files
 findings summary: 2 experiment

--- a/cli/tests/e2e/test_ci.py
+++ b/cli/tests/e2e/test_ci.py
@@ -247,7 +247,9 @@ def automocks(mocker):
             "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
         ],
     )
-    mocker.patch("semgrep.app.auth.is_valid_token", return_value="r2c")
+    mocker.patch(
+        "semgrep.app.auth.get_deployment_from_token", return_value="deployment_name"
+    )
     mocker.patch.object(AppSession, "post")
 
 
@@ -1056,7 +1058,7 @@ def test_fail_auth(run_semgrep: RunSemgrep, mocker, git_tmp_path_with_commit):
     """
     Test that failure to authenticate does not have exit code 0 or 1
     """
-    mocker.patch("semgrep.app.auth.is_valid_token", return_value=None)
+    mocker.patch("semgrep.app.auth.get_deployment_from_token", return_value=None)
     run_semgrep(
         options=["ci", "--no-suppress-errors"],
         target_name=None,
@@ -1065,7 +1067,7 @@ def test_fail_auth(run_semgrep: RunSemgrep, mocker, git_tmp_path_with_commit):
         env={"SEMGREP_APP_TOKEN": "fake-key-from-tests"},
     )
 
-    mocker.patch("semgrep.app.auth.is_valid_token", side_effect=Exception)
+    mocker.patch("semgrep.app.auth.get_deployment_from_token", side_effect=Exception)
     run_semgrep(
         options=["ci", "--no-suppress-errors"],
         target_name=None,
@@ -1081,7 +1083,7 @@ def test_fail_auth_error_handler(
     """
     Test that failure to authenticate with --suppres-errors returns exit code 0
     """
-    mocker.patch("semgrep.app.auth.is_valid_token", side_effect=Exception)
+    mocker.patch("semgrep.app.auth.get_deployment_from_token", side_effect=Exception)
     mock_send = mocker.spy(ErrorHandler, "send")
     run_semgrep(
         options=["ci"],

--- a/cli/tests/e2e/test_ci.py
+++ b/cli/tests/e2e/test_ci.py
@@ -247,7 +247,7 @@ def automocks(mocker):
             "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
         ],
     )
-    mocker.patch("semgrep.app.auth.is_valid_token", return_value=True)
+    mocker.patch("semgrep.app.auth.is_valid_token", return_value="r2c")
     mocker.patch.object(AppSession, "post")
 
 
@@ -1056,7 +1056,7 @@ def test_fail_auth(run_semgrep: RunSemgrep, mocker, git_tmp_path_with_commit):
     """
     Test that failure to authenticate does not have exit code 0 or 1
     """
-    mocker.patch("semgrep.app.auth.is_valid_token", return_value=False)
+    mocker.patch("semgrep.app.auth.is_valid_token", return_value=None)
     run_semgrep(
         options=["ci", "--no-suppress-errors"],
         target_name=None,

--- a/cli/tests/e2e/test_login.py
+++ b/cli/tests/e2e/test_login.py
@@ -14,7 +14,7 @@ def test_login(tmp_path, mocker):
     fake_key = "key123"
 
     # Patch Token Validation:
-    mocker.patch("semgrep.app.auth.is_valid_token", return_value=True)
+    mocker.patch("semgrep.app.auth.is_valid_token", return_value="r2c")
 
     # Logout
     result = runner.invoke(

--- a/cli/tests/e2e/test_login.py
+++ b/cli/tests/e2e/test_login.py
@@ -14,7 +14,9 @@ def test_login(tmp_path, mocker):
     fake_key = "key123"
 
     # Patch Token Validation:
-    mocker.patch("semgrep.app.auth.is_valid_token", return_value="r2c")
+    mocker.patch(
+        "semgrep.app.auth.get_deployment_from_token", return_value="deployment_name"
+    )
 
     # Logout
     result = runner.invoke(

--- a/cli/tests/e2e/test_publish.py
+++ b/cli/tests/e2e/test_publish.py
@@ -32,7 +32,7 @@ def test_publish(tmp_path, mocker):
     assert result.exit_code == 2
     assert result.output == "run `semgrep login` before using upload\n"
 
-    mocker.patch("semgrep.app.auth.is_valid_token", return_value=True)
+    mocker.patch("semgrep.app.auth.is_valid_token", return_value="r2c")
 
     # log back in
     result = runner.invoke(cli, ["login"], env={"SEMGREP_APP_TOKEN": "fakeapitoken"})

--- a/cli/tests/e2e/test_publish.py
+++ b/cli/tests/e2e/test_publish.py
@@ -32,7 +32,9 @@ def test_publish(tmp_path, mocker):
     assert result.exit_code == 2
     assert result.output == "run `semgrep login` before using upload\n"
 
-    mocker.patch("semgrep.app.auth.is_valid_token", return_value="r2c")
+    mocker.patch(
+        "semgrep.app.auth.get_deployment_from_token", return_value="deployment_name"
+    )
 
     # log back in
     result = runner.invoke(cli, ["login"], env={"SEMGREP_APP_TOKEN": "fakeapitoken"})


### PR DESCRIPTION
We want to start caching the rules that semgrep runs on a particular scan in our database.

In order to connect a cached config that is generated to the scan that it was generated for (in the even that it was generated for a specific scan), we need to create the scan before generating the rules config.

This PR accomplishes this by separating out the endpoint that is used by scans, which takes a scan_id, from the endpoint that is used by non-scans, which takes a bunch of metadata in order to figure out which rules to run.

After this PR gets merged, for scans we call:
`PUT deployments/scans` to create the scan object in our database
`GET scans/<scan_id>/config` to create the list of rules (and connect them to the scan they were generated for so we can go back later and always have a source of truth for which rules ran on a scan)

For non-scans (dry-run, VS code, etc.) we call:
`GET deployments/scans/config` to create and return the list of rules based on a set of metadata

Fixes APP-3607

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
