### PR TITLE
feat!: use version in download of semgrep pro binary

### DIFF
--- a/changelog.d/pa-2595.added
+++ b/changelog.d/pa-2595.added
@@ -1,0 +1,6 @@
+Pro Engine: Semgrep CLI will now download a version of Semgrep Pro Engine
+compatible with the current version of Semgrep CLI, as opposed to the most
+recently released version.
+
+This behavior is only supported for Semgrep 1.12.1 and later. Previous
+versions will still download the most recently released version, as before.

--- a/cli/src/semgrep/commands/install.py
+++ b/cli/src/semgrep/commands/install.py
@@ -14,6 +14,7 @@ from rich.progress import TextColumn
 from rich.progress import TimeRemainingColumn
 from rich.progress import TransferSpeedColumn
 
+from semgrep import __VERSION__
 from semgrep.commands.wrapper import handle_command_errors
 from semgrep.console import console
 from semgrep.error import FATAL_EXIT_CODE
@@ -70,7 +71,7 @@ def run_install_semgrep_pro() -> None:
             "Running on potentially unsupported platform. Installing linux compatible binary"
         )
 
-    url = f"{state.env.semgrep_url}/api/agent/deployments/deepbinary/{platform_kind}"
+    url = f"{state.env.semgrep_url}/api/agent/deployments/deepbinary/{platform_kind}?version={__VERSION__}"
 
     # Download the binary into a temporary location, check it, then install it.
     # This should prevent bad installations.


### PR DESCRIPTION
## What:
This PR makes it so that the downloaded Pro Engine binary is the latest one compatible with the version of Semgrep that is downloading it.

## Why:
This is a step in the plan to link the versions of Semgrep and Semgrep Pro Engine, as detailed [in this scope doc](https://www.notion.so/r2cdev/Semgrep-Semgrep-Pro-Version-linking-9a8a1c33674743ef9099ea520c30c181?pvs=4). This builds upon https://github.com/returntocorp/semgrep-proprietary/pull/571 and https://github.com/returntocorp/semgrep-app/pull/7448, which set up the necessary information to link the versions of the two.

## How
We simply consult the already-established App endpoint to download the proper binary.

## Test plan:
I installed the Pro Engine binary and then ran `-pro_version` on it three times, amending the `__VERSION__` constant between each run. This was with it set to `1.14.0`, `1.13.0`, and `1.12.1`, which are the only current entries of the versions manifest.

![image](https://user-images.githubusercontent.com/49291449/225135681-6c17f03b-fe36-4294-a29d-7eb555350b8a.png)

Note that, except for the first, all the returned commit hashes line up with the `pro_commit_hash` in the versions manifest (and the first is off by one for reasons @spencerdrak and I already identified).

Closes PA-2595


PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
