### PR TITLE
feat(rust): allow let patterns to percolate taint

### DIFF
--- a/changelog.d/pa-2605.fixed
+++ b/changelog.d/pa-2605.fixed
@@ -1,0 +1,2 @@
+Rust: Basic let-statement bindings (such as `let x = tainted`) now properly
+carry taint.

--- a/languages/rust/generic/Parse_rust_tree_sitter.ml
+++ b/languages/rust/generic/Parse_rust_tree_sitter.ml
@@ -2944,7 +2944,7 @@ and map_declaration_statement_bis (env : env) (*_outer_attrs _visibility*) x :
   | `Asso_type v1 -> [ map_associated_type env v1 ]
   (* was moved in _statement instead of declaration_statement by ruin *)
   | `Let_decl (v1, v2, v3, v4, v5, v6) ->
-      let let_ = token env v1 (* "let" *) in
+      let _let_ = token env v1 (* "let" *) in
       let mutability =
         Option.map
           (fun tok ->
@@ -2976,8 +2976,7 @@ and map_declaration_statement_bis (env : env) (*_outer_attrs _visibility*) x :
       let ent =
         {
           (* Patterns are difficult to convert to expressions, so wrap it *)
-          G.name =
-            G.EDynamic (G.OtherExpr (("LetPat", let_), [ G.P pattern ]) |> G.e);
+          G.name = G.EPattern pattern;
           G.attrs;
           G.tparams = [];
         }

--- a/src/analyzing/AST_to_IL.ml
+++ b/src/analyzing/AST_to_IL.ml
@@ -1042,6 +1042,7 @@ and lval_of_ent env ent =
   | G.EN (G.Id (id, idinfo)) -> lval_of_id_info env id idinfo
   | G.EN name -> lval env (G.N name |> G.e)
   | G.EDynamic eorig -> lval env eorig
+  | G.EPattern (PatId (id, id_info)) -> lval env (G.N (Id (id, id_info)) |> G.e)
   | G.EPattern _ -> (
       let any = G.En ent in
       log_fixme ToDo any;

--- a/tests/rules/tainted_pattern_lval.rs
+++ b/tests/rules/tainted_pattern_lval.rs
@@ -1,0 +1,17 @@
+
+fn main() {
+  let file = tainted; 
+
+  // ruleid: tainted-pattern-lval
+  sink(file);
+
+  let (file2, arg) = tainted;
+
+  // todo: tainted-pattern-lval
+  sink(file2);
+
+  let file3 : ty = tainted;
+
+  // ruleid: tainted-pattern-lval
+  sink(file3)
+}

--- a/tests/rules/tainted_pattern_lval.yaml
+++ b/tests/rules/tainted_pattern_lval.yaml
@@ -1,0 +1,12 @@
+rules:
+- id: tainted-pattern-lval 
+  mode: taint
+  pattern-sources:
+    - pattern: |
+        tainted 
+  pattern-sinks: 
+    - pattern: |
+        sink(...)
+  message: Working!
+  severity: WARNING
+  languages: [rust]


### PR DESCRIPTION
## What:
This PR lets Rust let patterns be translated into appropriate structures in the IL, such that it can transfer taint.

## Why:
Currently, very simple programs in Rust that look like they should straightforwardly percolate taint do not, such as:
```
fn main() {
  let file = tainted; 

  sink(file);
}
```

## How:
I avoided putting Rust let-patterns into `EDynamic` of a `OtherExpr`, since `OtherExpr` can't be used for any further semantic purpose other than matching. I instead put it into `EPattern`, and allowed any `EPattern` of an identifier to be translated as normal.

Note that this doesn't handle the tuple case. I leave that to @IagoAbal, as I'm not sure I know the proper IL way to treat this.

## Test plan:
`make test`

Closes PA-2605

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
