### PR TITLE
GHA: update to returntocorp/ocaml:alpine-2023-03-03

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,8 +3,8 @@
 ###############################################################################
 # The main goals of this pipeline are to:
 # - dogfood Semgrep by running it on each semgrep PRs.
-# - check that Semgrep can run in alternate CI platforms like Circle CI
-#   (and not just in Github actions).
+# - check that Semgrep can run in an alternate CI platform like Circle CI
+#   (and not just in Github Actions).
 # - have a cron that update our parsing statistics as well as some benchmarks,
 #   which are then accessible at https://dashboard.semgrep.dev/metrics
 #   and also at https://metabase.corp.r2c.dev/collection/59-semgrep
@@ -26,7 +26,7 @@ jobs:
       - checkout
       # Dogfooding on the bleeding edge by using jsonnet and the new syntax!
       # coupling: see also 'make check'
-      - run: semgrep --config semgrep.jsonnet --error --verbose --exclude tests --exclude pfff
+      - run: semgrep --config semgrep.jsonnet --error --verbose --exclude tests
 
   # For the benchmarks below, we had two alternatives:
   # A. run semgrep container from existing container: requires mounting
@@ -66,7 +66,7 @@ jobs:
       - store_artifacts:
           path: stats/parsing-stats/results.txt
 
-  # Run parsing stats and publish them to the semgrep dashboard.
+  # Run autofix parsing stats and publish them to the semgrep dashboard.
   autofix-printing-stats:
     docker:
       # The returntocorp/semgrep-dev:develop image doesn't have OCaml, so

--- a/.github/workflows/build-test-core-x86.yaml
+++ b/.github/workflows/build-test-core-x86.yaml
@@ -8,7 +8,7 @@ jobs:
   build-test-core-x86:
     name: Build Test Semgrep Core
     runs-on: ubuntu-latest
-    container: returntocorp/ocaml:alpine-2022-09-24
+    container: returntocorp/ocaml:alpine-2023-03-03
     # We need this hack because GHA tampers with the HOME in container
     # and this does not play well with 'opam' installed in /root
     env:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,7 +1,7 @@
-# The goal of this workflow is mostly to run pre-commit on every pull requests.
+# The main goal of this workflow is to run pre-commit on every pull requests.
+# It also runs some Github Actions (GHA) lint checks
+# TODO: we should port those GHA checks to semgrep and add then in semgrep-rules
 
-#TODO? we could rename to 'pre-commit' really. We used to run another "lint-style" command
-# for the changelog, but we don't anymore, so all that remains is just pre-commit stuff
 name: lint
 
 on:
@@ -71,7 +71,7 @@ jobs:
     # This custom image provides 'ocamlformat' with a specific version needed to check
     # OCaml code (must be the same than the one in dev/dev.opam)
     # See https://github.com/returntocorp/ocaml-layer/blob/master/configs/ubuntu.sh
-    container: returntocorp/ocaml:ubuntu-2022-09-24
+    container: returntocorp/ocaml:ubuntu-2023-03-03
     # HOME in the container is tampered by GHA and modified from /root to /home/github
     # which then confuses opam below which can not find its ~/.opam (which is at /root/.opam)
     # hence the ugly use of 'env: HOME ...' below.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
     # TODO: why not use the artifact of build-semgrep-core in this job instead?
     name: test semgrep-core
     runs-on: ubuntu-22.04
-    container: returntocorp/ocaml:alpine-2022-09-24
+    container: returntocorp/ocaml:alpine-2023-03-03
     env:
       HOME: /root
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -83,7 +83,7 @@ repos:
     rev: v1.0.0
     hooks:
       - id: mypy
-        exclude: ^cli/tests/.+$|^setup.py$|^cli/src/semdep/external/packaging/.*$|^cli/src/semdep/external/parsy/.*$|^cli/scripts/.*$|^scripts/.+$|^stats/parsing-stats/.+$|pfff|^perf/.+$$
+        exclude: ^cli/tests/.+$|^setup.py$|^cli/src/semdep/external/packaging/.*$|^cli/src/semdep/external/parsy/.*$|^cli/scripts/.*$|^scripts/.+$|^stats/parsing-stats/.+$|^perf/.+$$
         args: [--config, mypy.ini, --show-error-codes]
         additional_dependencies: &mypy-deps
           # versions must be manually synced:
@@ -150,7 +150,6 @@ repos:
         language: docker_image
         entry: koalaman/shellcheck:v0.8.0
         files: "[.]sh$"
-        exclude: "pfff"
       - id: hadolint
         name: hadolint
         language: docker_image
@@ -197,7 +196,7 @@ repos:
         # explicitly on the command line by pre-commit!
         # TODO: remove once file targeting is revamped and supports
         # filtering for explicit targets (a command-line flag should do)
-        exclude: "^semgrep-core/src/pfff|Realpath.ml"
+        exclude: "Realpath.ml"
 
         #coupling: 'make check' and the SEMGREP_ARGS variable
         args: [

--- a/Makefile
+++ b/Makefile
@@ -219,6 +219,7 @@ ALPINE_APK_DEPS=pcre-dev python3 python3-dev gmp-dev
 
 # We pin to a specific version just to prevent things from breaking randomly.
 # We could update to a more recent version.
+# coupling: if you modify the version, please modify also .github/workflows/*
 PIPENV='pipenv==2022.6.7'
 
 # This target is used in our Dockerfile and a few GHA workflows.
@@ -383,7 +384,7 @@ report-perf-matching:
 
 
 #coupling: see also .circleci/config.yml and its 'semgrep' job
-SEMGREP_ARGS=--config semgrep.jsonnet --error --exclude tests --exclude pfff
+SEMGREP_ARGS=--config semgrep.jsonnet --error --exclude tests
 # you can add --verbose for debugging
 
 DOCKER_IMAGE=returntocorp/semgrep:develop


### PR DESCRIPTION
This should speedup a bit the build in CI

test plan:
check the details of the CI build check and make sure
we don't install OPAM packages (they should all be already
installed in returntocorp/ocaml:alpine-2023-03-03) so
the make install-deps-XXX step should be a noop mostly.


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)