### PR TITLE
CI: remove use of a dune cache

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,6 +1,7 @@
 # This workflow dogfoods Semgrep Code and Supply Chain.
 
 name: semgrep
+
 on:
   # This workflow runs on 'pull_request_target' so that PRs from forks are able
   # to run an action that uses the SEMGREP_APP_TOKEN secret
@@ -15,14 +16,15 @@ on:
   schedule:
     # random HH:MM to avoid a load spike on GitHub Actions at 00:00
     - cron: "50 15 * * *"
+
 jobs:
   semgrep:
     name: semgrep ci
     runs-on: ubuntu-20.04
-    env:
-      SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
     container:
       image: returntocorp/semgrep
+    env:
+      SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
     if: (github.actor != 'dependabot[bot]')
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,22 +30,8 @@ jobs:
         with:
           submodules: true
           persist-credentials: false
-      - name: Cache OCaml build files
-        uses: actions/cache@v3
-        with:
-          path: |
-            /root/.dune
-            /root/.opam/download-cache
-            /root/.opam/*/.opam-switch/packages
-            /root/.opam/*/.opam-switch/sources
-          key: ${{ runner.os }}-ocamlbuild
       - name: Build semgrep-core
         run: ./scripts/install-alpine-semgrep-core
-        env:
-          DUNE_CACHE: enabled
-          DUNE_CACHE_STORAGE_MODE: copy
-          DUNE_CACHE_ROOT: /root/.dune
-          DUNE_CACHE_TRANSPORT: direct
       - name: Test semgrep-core
         run: |
           eval $(opam env)


### PR DESCRIPTION
Not sure what was the purpose of this caching code. I think
Bence added the code a long time ago. Maybe when chris
removed some of the semgrep-core caching code bence wrote
he forgot also to remove this bit.

Maybe this is useful when ocaml-layer lags behind,
but this step currently takes 1m, so seems simpler
to just rely on ocaml-layer for caching the needed packages
and just faster too.

test plan:
wait for CI to kick in, look at the time for the Test semgrep-core
job and look if less than 10min51s


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)