### PR TITLE
New semgrep-core -raja flags, for quick experiments

### DIFF
--- a/cli/src/semgrep/core_output.py
+++ b/cli/src/semgrep/core_output.py
@@ -112,7 +112,7 @@ def core_matches_to_rule_matches(
     Convert core_match objects into RuleMatch objects that the rest of the codebase
     interacts with.
 
-    For now assumes that all matches encapsulated by this object are from the same rulee
+    For now assumes that all matches encapsulated by this object are from the same rule
     """
     rule_table = {rule.id: rule for rule in rules}
 

--- a/cli/src/semgrep/formatter/json.py
+++ b/cli/src/semgrep/formatter/json.py
@@ -43,6 +43,8 @@ class JsonFormatter(BaseFormatter):
             extra.fix_regex = rule_match.fix_regex
         if rule_match.is_ignored is not None:
             extra.is_ignored = rule_match.is_ignored
+        if rule_match.extra.get("extra_extra"):
+            extra.extra_extra = out.RawJson(rule_match.extra.get("extra_extra"))
 
         return out.CliMatch(
             check_id=out.RuleId(rule_match.rule_id),

--- a/src/configuring/Flag_semgrep.ml
+++ b/src/configuring/Flag_semgrep.ml
@@ -68,3 +68,6 @@ let equivalence_mode = ref false
 (* Note that an important flag used during parsing is actually in pfff in
  * Flag_parsing.sgrep_mode
  *)
+
+(* One-off experiment for Raja. Delete at some point (March 2023). *)
+let raja = ref false

--- a/src/configuring/Flag_semgrep.ml
+++ b/src/configuring/Flag_semgrep.ml
@@ -69,5 +69,5 @@ let equivalence_mode = ref false
  * Flag_parsing.sgrep_mode
  *)
 
-(* One-off experiment for Raja. Delete at some point (March 2023). *)
+(* One-off experiment for Raja (See Raja_experiment.ml) *)
 let raja = ref false

--- a/src/core_cli/Core_CLI.ml
+++ b/src/core_cli/Core_CLI.ml
@@ -658,6 +658,7 @@ let options actions =
       " <file> log debugging info to file" );
     ("-test", Arg.Set test, " (internal) set test context");
     ("-lsp", Arg.Set lsp, " connect to LSP lang server to get type information");
+    ("-raja", Arg.Set Flag_semgrep.raja, " undocumented");
   ]
   @ Flag_parsing_cpp.cmdline_flags_macrofile ()
   (* inlining of: Common2.cmdline_flags_devel () @ *)

--- a/src/experiments/misc/Raja_experiment.ml
+++ b/src/experiments/misc/Raja_experiment.ml
@@ -1,0 +1,41 @@
+module Out = Output_from_core_j
+
+(*****************************************************************************)
+(* Prelude *)
+(*****************************************************************************)
+(* One-off experiment for Raja.
+ *
+ * This experiment consists in returning the enclosing function name
+ * and function body in the extra_extra JSON field for each match
+ * results. This code path is triggered when passing --core-opts='-raja'
+ * to the Semgrep CLI.
+ *)
+
+(*****************************************************************************)
+(* Helpers *)
+(*****************************************************************************)
+
+(*****************************************************************************)
+(* Entry point *)
+(*****************************************************************************)
+
+let adjust_core_match_results (x : Out.core_match_results) :
+    Out.core_match_results =
+  let matches =
+    x.matches
+    |> Common.map (fun (m : Out.core_match) ->
+           let extra =
+             {
+               m.extra with
+               extra_extra =
+                 Some
+                   (`Assoc
+                     [
+                       ("function_name", `String "TODO: funcname");
+                       ("function_body", `String "TODO: body text or range?");
+                     ]);
+             }
+           in
+           { m with extra })
+  in
+  { x with matches }

--- a/src/experiments/misc/Raja_experiment.mli
+++ b/src/experiments/misc/Raja_experiment.mli
@@ -1,0 +1,2 @@
+val adjust_core_match_results :
+  Output_from_core_j.core_match_results -> Output_from_core_j.core_match_results

--- a/src/experiments/misc/dune
+++ b/src/experiments/misc/dune
@@ -7,7 +7,8 @@
    lib_parsing
    pfff-lang_GENERIC-analyze
 
-   semgrep_core
+   semgrep.core
+   semgrep.reporting
  )
  (preprocess (pps ppx_profiling))
 )

--- a/src/osemgrep/cli_scan/Cli_json_output.ml
+++ b/src/osemgrep/cli_scan/Cli_json_output.ml
@@ -317,9 +317,10 @@ let cli_match_of_core_match (env : env) (x : Out.core_match) : Out.cli_match =
        message;
        metavars;
        rendered_fix;
+       engine_kind;
+       extra_extra;
        (* LATER *)
        dataflow_trace = _;
-       engine_kind;
      };
   } ->
       let rule =
@@ -382,6 +383,7 @@ let cli_match_of_core_match (env : env) (x : Out.core_match) : Out.cli_match =
             (* It's optional in the CLI output, but not in the core match results!
              *)
             engine_kind = Some engine_kind;
+            extra_extra;
           };
       }
 

--- a/src/reporting/JSON_report.ml
+++ b/src/reporting/JSON_report.ml
@@ -256,6 +256,7 @@ let unsafe_match_to_match render_fix_opt (x : Pattern_match.t) : Out.core_match
         dataflow_trace;
         rendered_fix;
         engine_kind = convert_engine_kind x.engine_kind;
+        extra_extra = None;
       };
   }
 

--- a/src/runner/Run_semgrep.ml
+++ b/src/runner/Run_semgrep.ml
@@ -849,6 +849,11 @@ let semgrep_with_rules_and_formatted_output config =
         JSON_report.match_results_of_matches_and_errors
           (Some Autofix.render_fix) (List.length files) res
       in
+      (* one-off experiment, delete it at some point (March 2023) *)
+      let res =
+        if !Flag_semgrep.raja then Raja_experiment.adjust_core_match_results res
+        else res
+      in
       (*
         Not pretty-printing the json output (Yojson.Safe.prettify)
         because it kills performance, adding an extra 50% time on our


### PR DESCRIPTION
test plan:
```
$ semgrep --core-opts="-raja" -l ocaml --config ~/test.yaml ~/test.ml --json | jq
Ran 1 rule on 1 file: 1 finding.
{
  "errors": [],
  "paths": {
    "_comment": "<add --verbose for a list of skipped paths>",
    "scanned": [
      "/home/pad/test.ml"
    ]
  },
  "results": [
    {
      "check_id": "home.pad.stupid-eq",
      "end": {
        "col": 8,
        "line": 5,
        "offset": 36
      },
      "extra": {
        "engine_kind": "OSS",
        "extra_extra": {
          "function_body": "TODO: body text or range?",
          "function_name": "TODO: funcname"
        },
        "fingerprint": "873b52c00b5b7d8a14d66330ffc767cfacb2b64ff075c4294a67264235c166324bc3f1e0f540853bef4d997a22d43e661d452ffa0a0d8ba93c9fbef2543808a1_0",
        "is_ignored": false,
        "lines": "  n = n",
        "message": "Found it",
        "metadata": {
          "reference": "wikipedia",
          "type": "XSS"
        },
        "metavars": {
          "$X": {
            "abstract_content": "n",
            "end": {
              "col": 4,
              "line": 5,
              "offset": 32
            },
            "start": {
              "col": 3,
              "line": 5,
              "offset": 31
            }
          }
        },
        "severity": "ERROR"
      },
      "path": "/home/pad/test.ml",
      "start": {
        "col": 3,
        "line": 5,
        "offset": 31
      }
    }
  ],
  "version": "1.14.0"
}
```


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)