### PR TITLE
docker: Remove custom entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -98,7 +98,7 @@ RUN apk update &&\
 
 
 # Here is why we need the apk packages below:
-# - bash: for entrypoint.sh (see below) and probably many other things
+# - bash: previously for entrypoint.sh (but no longer) and probably (?) many other things
 # - git, git-lfs, openssh: so that the semgrep docker image can be used in
 #   Github actions (GHA) and get git submodules and use ssh to get those submodules
 # - libstdc++: for the Python jsonnet binding now used in the semgrep CLI
@@ -131,10 +131,6 @@ RUN apk add --no-cache --virtual=.build-deps build-base make g++ &&\
      apk del .build-deps &&\
      mkdir -p /tmp/.cache
 
-# TODO: we should remove this (we were supposed to get rid of it in June 2022)
-COPY entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
-
 # Let the user know how their container was built
 COPY Dockerfile /Dockerfile
 
@@ -166,6 +162,5 @@ RUN rm -rf /semgrep
 # In case of problems, if you need to debug the docker image, run 'docker build .',
 # identify the SHA of the build image and run 'docker run -it <sha> /bin/bash'
 # to interactively explore the docker image.
-ENTRYPOINT ["/entrypoint.sh"]
 CMD ["semgrep", "--help"]
 LABEL maintainer="support@r2c.dev"

--- a/changelog.d/pa-2642.changed
+++ b/changelog.d/pa-2642.changed
@@ -1,0 +1,5 @@
+Remove custom entry point for returntocorp/semgrep Docker image's, now you must
+explicitly call semgrep.
+
+This won't work now:   `docker run -v $(pwd):/src returntocorp/semgrep scan ...`
+Must do this instead:  `docker run -v $(pwd):/src returntocorp/semgrep semgrep scan ...`

--- a/changelog.d/pa-2642.changed
+++ b/changelog.d/pa-2642.changed
@@ -1,4 +1,4 @@
-Remove custom entry point for returntocorp/semgrep Docker image's, now you must
+Remove custom _entrypoint_ for returntocorp/semgrep Docker images, now you must
 explicitly call semgrep.
 
 This won't work now:   `docker run -v $(pwd):/src returntocorp/semgrep scan ...`

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-set -e
-
-exec "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,22 +1,4 @@
 #!/usr/bin/env bash
 set -e
 
-if [[ "$1" != "semgrep" && ("$*" =~ "--config" || "$*" == "--help" || "$1" == "publish" || "$1" == "ci") ]]; then
-  # 1) --config is a required semgrep scan argument,
-  #    so if it's present, we assume the user meant to call semgrep.
-  #
-  #    -f is a valid --config alias,
-  #    but that could also be part of many shell commands used by e.g. GitLab CI,
-  #    and our docs always type out the full --config flag anyway,
-  #    so we don't assume user meant to call semgrep in those cases.
-  #
-  # 2) if a known subcommand is used, we also assume the user meant to call semgrep.
-  >&2 echo "======= DEPRECATION WARNING ======="
-  >&2 echo "The returntocorp/semgrep Docker image's custom entrypoint will be removed by June 2022."
-  >&2 echo "Please update your command to explicitly call semgrep."
-  >&2 echo "Change from:  docker run -v \$(pwd):/src returntocorp/semgrep $*"
-  >&2 echo "Change to:    docker run -v \$(pwd):/src returntocorp/semgrep semgrep $*"
-  exec semgrep "$@"
-fi
-
 exec "$@"

--- a/scripts/validate-docker-build.sh
+++ b/scripts/validate-docker-build.sh
@@ -45,14 +45,14 @@ docker run "$image"
 docker run "$image" echo -l -a -t -r -v -e -f
 
 # Semgrep should run when a config is passed
-docker run "$image" --config=p/ci --help
+docker run "$image" semgrep --config=p/ci --help
 
 # Semgrep should run when just help is requested
-docker run "$image" --help
+docker run "$image" semgrep --help
 
 # Semgrep should run when a subcommand is passed
-docker run "$image" ci --help
-docker run "$image" publish --help
+docker run "$image" semgrep ci --help
+docker run "$image" semgrep publish --help
 
 # Semgrep should be able to return findings
 echo "if 1 == 1: pass" \


### PR DESCRIPTION
test plan:
% docker run -v \$(pwd):/src returntocorp/semgrep scan -c p/default .
 #^ should no longer work
% docker run -v \$(pwd):/src returntocorp/semgrep semgrep scan -c p/default .
 #^ should work

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
