### PR TITLE
Small experiment for Raja

### DIFF
--- a/libs/ast_generic/Visitor_AST.mli
+++ b/libs/ast_generic/Visitor_AST.mli
@@ -59,7 +59,7 @@ val ii_of_any : AST_generic.any -> Parse_info.t list
 
 (* may raise NoTokenLocation *)
 val first_info_of_any : AST_generic.any -> Parse_info.t
-val range_of_tokens : Parse_info.t list -> Parse_info.t * Parse_info.t
+val range_of_tokens : Parse_info.t list -> Loc.t
 
 val range_of_any_opt :
   AST_generic.any ->

--- a/libs/lib_parsing/Loc.ml
+++ b/libs/lib_parsing/Loc.ml
@@ -4,8 +4,8 @@
    This is used so far in intermediate, language-specific ASTs.
 *)
 
-type tok = Parse_info.t
-type t = tok * tok
+type tok = Parse_info.t [@@deriving show]
+type t = tok * tok [@@deriving show]
 
 let fix ((left, right) as loc) =
   if Parse_info.is_fake left then (right, right)

--- a/libs/lib_parsing/Loc.mli
+++ b/libs/lib_parsing/Loc.mli
@@ -24,7 +24,7 @@
 *)
 
 (* The type of a token, i.e. a leaf in a syntax tree. *)
-type tok = Parse_info.t
+type tok = Parse_info.t [@@deriving show]
 
 (* A location or 'loc' for short.
 
@@ -35,7 +35,7 @@ type tok = Parse_info.t
 
    Tuples are convenient, let's not make this type abstract.
 *)
-type t = tok * tok
+type t = tok * tok [@@deriving show]
 
 (*
    'create tok1 tok2' is essentially '(tok1, tok2)' except if one of the

--- a/src/experiments/misc/Function_range.ml
+++ b/src/experiments/misc/Function_range.ml
@@ -1,0 +1,35 @@
+open AST_generic
+
+(*****************************************************************************)
+(* Prelude *)
+(*****************************************************************************)
+(* Return the ranges of the functions in a AST_generic program *)
+
+(*****************************************************************************)
+(* Types *)
+(*****************************************************************************)
+
+type function_info = { name : string; range : Loc.t } [@@deriving show]
+type ranges = function_info list [@@deriving show]
+
+(*****************************************************************************)
+(* Entry point *)
+(*****************************************************************************)
+
+let ranges (prog : AST_generic.program) : ranges =
+  let visitor =
+    object (_self : 'self)
+      inherit [_] AST_generic.iter
+
+      method! visit_definition env def =
+        match def with
+        | { name = EN (Id ((s, _), _idinfo)); _ }, FuncDef _ ->
+            let ii = Visitor_AST.ii_of_any (Def def) in
+            let range = Visitor_AST.range_of_tokens ii in
+            Common.push { name = s; range } env
+        | _else_ -> ()
+    end
+  in
+  let aref = ref [] in
+  visitor#visit_program aref prog;
+  List.rev !aref

--- a/src/experiments/misc/Function_range.mli
+++ b/src/experiments/misc/Function_range.mli
@@ -1,0 +1,4 @@
+type function_info = { name : string; range : Loc.t } [@@deriving show]
+type ranges = function_info list [@@deriving show]
+
+val ranges : AST_generic.program -> ranges

--- a/src/experiments/misc/Raja_experiment.ml
+++ b/src/experiments/misc/Raja_experiment.ml
@@ -1,5 +1,7 @@
 module Out = Output_from_core_j
 
+let logger = Logging.get_logger [ __MODULE__ ]
+
 (*****************************************************************************)
 (* Prelude *)
 (*****************************************************************************)
@@ -15,6 +17,33 @@ module Out = Output_from_core_j
 (* Helpers *)
 (*****************************************************************************)
 
+let find_function_info (range_offsets : int * int)
+    (ranges : Function_range.ranges) : Function_range.function_info option =
+  let start, end_ = range_offsets in
+  ranges
+  |> List.find_opt (fun { Function_range.range = t1, t2; _ } ->
+         let offset1 = Parse_info.pos_of_info t1 in
+         let offset2 = Parse_info.pos_of_info t2 in
+         start >= offset1 && end_ <= offset2)
+
+(*****************************************************************************)
+(* Cache *)
+(*****************************************************************************)
+let (cache : (Fpath.t, Function_range.ranges) Hashtbl.t) = Hashtbl.create 101
+
+let ranges_of_path (path : Fpath.t) : Function_range.ranges =
+  match Hashtbl.find_opt cache path with
+  | Some x -> x
+  | None ->
+      (* alt: could use just_parse_with_lang and get the lang
+       * from the languages: field in the rule corresponding to
+       * the rule_id of the match
+       *)
+      let ast = Parse_target.parse_program (Fpath.to_string path) in
+      let ranges = Function_range.ranges ast in
+      Hashtbl.add cache path ranges;
+      ranges
+
 (*****************************************************************************)
 (* Entry point *)
 (*****************************************************************************)
@@ -24,18 +53,35 @@ let adjust_core_match_results (x : Out.core_match_results) :
   let matches =
     x.matches
     |> Common.map (fun (m : Out.core_match) ->
-           let extra =
-             {
-               m.extra with
-               extra_extra =
-                 Some
-                   (`Assoc
-                     [
-                       ("function_name", `String "TODO: funcname");
-                       ("function_body", `String "TODO: body text or range?");
-                     ]);
-             }
+           let _rule_id = m.rule_id in
+           let path = Fpath.v m.location.path in
+           let ranges = ranges_of_path path in
+           let start, end_ =
+             (m.location.start.offset, m.location.end_.offset)
            in
-           { m with extra })
+           match find_function_info (start, end_) ranges with
+           | None ->
+               logger#info "no function info found for range: %d, %d" start end_;
+               m
+           | Some { Function_range.name; range = t1, t2 } ->
+               let offset1 = Parse_info.pos_of_info t1 in
+               let offset2 = Parse_info.pos_of_info t2 in
+               let extra =
+                 {
+                   m.extra with
+                   extra_extra =
+                     Some
+                       (`Assoc
+                         [
+                           ("function_name", `String name);
+                           ( "function_range",
+                             `Assoc
+                               [
+                                 ("start", `Int offset1); ("end", `Int offset2);
+                               ] );
+                         ]);
+                 }
+               in
+               { m with extra })
   in
   { x with matches }

--- a/src/experiments/misc/dune
+++ b/src/experiments/misc/dune
@@ -9,6 +9,10 @@
 
    semgrep.core
    semgrep.reporting
+   semgrep.parsing
  )
- (preprocess (pps ppx_profiling))
+ (preprocess (pps
+   ppx_deriving.show
+   ppx_profiling
+   ))
 )


### PR DESCRIPTION
test plan:
```
semgrep --core-opts="-raja" -l ocaml --config ~/test.yaml ~/test.ml --json | jq
{
  "errors": [],
  "paths": {
    "_comment": "<add --verbose for a list of skipped paths>",
    "scanned": [
      "/home/pad/test.ml"
    ]
  },
  "results": [
    {
      "check_id": "home.pad.stupid-eq",
      "end": {
        "col": 11,
        "line": 5,
        "offset": 39
      },
      "extra": {
        "engine_kind": "OSS",
        "extra_extra": {
          "function_name": "bar",
          "function_range": {
            "end": 56,
            "start": 17
          }
        },
        "fingerprint": "873b52c00b5b7d8a14d66330ffc767cfacb2b64ff075c4294a67264235c166324bc3f1e0f540853bef4d997a22d43e661d452ffa0a0d8ba93c9fbef2543808a1_0",
        "is_ignored": false,
        "lines": "  if n = n",
        "message": "Found it",
        "metadata": {
          "reference": "wikipedia",
          "type": "XSS"

...
```


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)