### PR TITLE
misc: fix code to compile also with semgrep 4.12.0

### DIFF
--- a/languages/terraform/generic/Terraform_to_generic.ml
+++ b/languages/terraform/generic/Terraform_to_generic.ml
@@ -64,7 +64,7 @@ and map_block ({ btype = _kind, tk; blabels; bbody = lb, body, rb } : block) :
   let n = H2.name_of_id id in
   (* convert in a Record like map_object *)
   let flds = Common.map map_block_body_element body in
-  let body = Record (lb, flds, rb) |> G.e in
+  let body = G.Record (lb, flds, rb) |> G.e in
   let es = labels_id @ [ body ] in
   let args = es |> Common.map G.arg in
   (* coupling: if you modify this code, you should adjust
@@ -79,7 +79,7 @@ and map_block ({ btype = _kind, tk; blabels; bbody = lb, body, rb } : block) :
    * TODO: should we use something else than Call since it's already used
    * for expressions in map_expr_term() above?
    *)
-  G.Call (N n |> G.e, Parse_info.unsafe_fake_bracket args) |> G.e
+  G.Call (G.N n |> G.e, Parse_info.unsafe_fake_bracket args) |> G.e
 
 (*****************************************************************************)
 (* Entry points *)

--- a/languages/terraform/tree-sitter/Parse_terraform_tree_sitter.ml
+++ b/languages/terraform/tree-sitter/Parse_terraform_tree_sitter.ml
@@ -268,13 +268,13 @@ and map_expr_term (env : env) (x : CST.expr_term) : expr =
   match x with
   | `Choice_lit_value x -> (
       match x with
-      | `Lit_value x -> L (map_literal_value env x) |> G.e
+      | `Lit_value x -> G.L (map_literal_value env x) |> G.e
       | `Temp_expr x -> map_template_expr env x
       | `Coll_value x -> map_collection_value env x
       | `Var_expr tok ->
           (* identifier *)
           let id = map_identifier env tok in
-          N (H2.name_of_id id) |> G.e
+          G.N (H2.name_of_id id) |> G.e
       | `Func_call (v1, v2, v3, v4) ->
           let v1 = (* identifier *) map_identifier env v1 in
           let v2 = (* "(" *) token env v2 in
@@ -284,8 +284,8 @@ and map_expr_term (env : env) (x : CST.expr_term) : expr =
             | None -> []
           in
           let v4 = (* ")" *) token env v4 in
-          let n = N (H2.name_of_id v1) |> G.e in
-          Call (n, (v2, v3, v4)) |> G.e
+          let n = G.N (H2.name_of_id v1) |> G.e in
+          G.Call (n, (v2, v3, v4)) |> G.e
       | `For_expr x -> map_for_expr env x
       | `Oper x -> map_operation env x
       | `Expr_term_index (v1, v2) ->
@@ -305,12 +305,12 @@ and map_expr_term (env : env) (x : CST.expr_term) : expr =
           let v2 = map_expression env v2 in
           let _v3 = (* ")" *) token env v3 in
           v2)
-  | `Semg_ellips tok -> Ellipsis ((* "..." *) token env tok) |> G.e
+  | `Semg_ellips tok -> G.Ellipsis ((* "..." *) token env tok) |> G.e
   | `Deep_ellips (v1, v2, v3) ->
       let v1 = (* "<..." *) token env v1 in
       let v2 = map_expression env v2 in
       let v3 = (* "...>" *) token env v3 in
-      DeepEllipsis (v1, v2, v3) |> G.e
+      G.DeepEllipsis (v1, v2, v3) |> G.e
 
 and map_expression (env : env) (x : CST.expression) : expr =
   match x with
@@ -321,12 +321,12 @@ and map_expression (env : env) (x : CST.expression) : expr =
       let v3 = map_expression env v3 in
       let _v4 = (* ":" *) token env v4 in
       let v5 = map_expression env v5 in
-      Conditional (v1, v3, v5) |> G.e
+      G.Conditional (v1, v3, v5) |> G.e
 
 and map_for_cond (env : env) ((v1, v2) : CST.for_cond) : G.for_or_if_comp =
   let v1 = (* "if" *) token env v1 in
   let v2 = map_expression env v2 in
-  CompIf (v1, v2)
+  G.CompIf (v1, v2)
 
 and map_for_expr (env : env) (x : CST.for_expr) =
   match x with
@@ -432,7 +432,7 @@ and map_object_ (env : env) ((v1, v2, v3) : CST.object_) =
     | None -> []
   in
   let v3 = (* "}" *) token env v3 in
-  Record (v1, v2, v3) |> G.e
+  G.Record (v1, v2, v3) |> G.e
 
 and map_object_elem (env : env) (x : CST.object_elem) : G.field =
   match x with

--- a/src/matching/SubAST_generic.ml
+++ b/src/matching/SubAST_generic.ml
@@ -347,14 +347,15 @@ let do_visit_with_ref visitor any =
   List.rev !res
 
 let lambdas_in_expr e =
-  do_visit_with_ref
+  let visitor =
     object (_self : 'self)
       inherit [_] AST_generic.iter_no_id_info
 
       (* TODO Should we recurse into the Lambda? *)
       method! visit_Lambda aref def = Common.push def aref
     end
-    (E e)
+  in
+  do_visit_with_ref visitor (E e)
   [@@profiling]
 
 (* opti: using memoization speed things up a bit too

--- a/src/osemgrep/targeting/Glob_matcher.ml
+++ b/src/osemgrep/targeting/Glob_matcher.ml
@@ -68,7 +68,9 @@ let append a b = remove_trailing_slash a @ remove_leading_slash b
 let of_path_segments segments =
   Common.map
     (fun s ->
-      let chars = String.fold_right (fun c acc -> Char c :: acc) s [] in
+      let chars =
+        Stdcompat.String.fold_right (fun c acc -> Char c :: acc) s []
+      in
       Segment chars)
     segments
 

--- a/src/osemgrep/targeting/dune
+++ b/src/osemgrep/targeting/dune
@@ -6,6 +6,7 @@
 (library
   (name osemgrep_targeting)
   (libraries
+    stdcompat
     commons
     fpath
   )

--- a/src/tainting/Dataflow_tainting.ml
+++ b/src/tainting/Dataflow_tainting.ml
@@ -302,7 +302,8 @@ let top_level_sinks_in_nodes config flow =
                      Seq.empty)
              in
              origs
-             |> Seq.concat_map (fun o -> orig_is_sink config o |> List.to_seq)
+             |> Stdcompat.Seq.concat_map (fun o ->
+                    orig_is_sink config o |> List.to_seq)
          | NCond (_, exp)
          | NReturn (_, exp)
          | NThrow (_, exp) ->
@@ -586,7 +587,7 @@ let propagate_taint_via_java_setter env e args all_args_taints =
       },
       [ _ ] )
     when env.lang =*= Lang.Java
-         && String.starts_with ~prefix:"set" (fst m.IL.ident) ->
+         && Stdcompat.String.starts_with ~prefix:"set" (fst m.IL.ident) ->
       let prop_name = "get" ^ Str.string_after (fst m.IL.ident) 3 in
       let prop_lval =
         let o = Dot { m with ident = (prop_name, snd m.IL.ident) } in
@@ -603,8 +604,8 @@ let resolve_poly_taint_for_java_getters env lval st =
    * needs some testing and for now it's safer to restrict it to Java and getX. *)
   if env.lang =*= Java then
     match lval.rev_offset with
-    | { o = Dot n; _ } :: _ when String.starts_with ~prefix:"get" (fst n.ident)
-      -> (
+    | { o = Dot n; _ } :: _
+      when Stdcompat.String.starts_with ~prefix:"get" (fst n.ident) -> (
         match st with
         | `Clean -> `Clean
         | `None -> `None


### PR DESCRIPTION
My tool codegraph relies on the .cmt files generated by
OCaml 4.12.0 and I need codegraph to visualize semgrep dependencies
(e.g., to move around code to optimize semgrep.js), hence
those fixes.

test plan:
```
opam switch 4.12.0
eval $(opam env)
make core
```


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)