### PR TITLE
tainting: First batch of taint maturity tests

### DIFF
--- a/src/analyzing/AST_to_IL.ml
+++ b/src/analyzing/AST_to_IL.ml
@@ -611,9 +611,10 @@ and expr_aux env ?(void = false) e_gen =
   | G.Assign (e1, tok, e2) ->
       let exp = expr env e2 in
       assign env e1 tok exp e_gen
-  | G.AssignOp (e1, (G.Eq, tok), e2) when Parse_info.str_of_info tok = ":=" ->
-      (* We encode Go's `:=` as `AssignOp(Eq)`,
-       * see "go_to_generic.ml" in Pfff. *)
+  | G.AssignOp (e1, (G.Eq, tok), e2) ->
+      (* AsssignOp(Eq) is used to represent plain assignment in some languages,
+       * e.g. Go's `:=` is represented as `AssignOp(Eq)`, and C#'s assignments
+       * are all represented this way too. *)
       let exp = expr env e2 in
       assign env e1 tok exp e_gen
   | G.AssignOp (e1, op, e2) ->

--- a/src/engine/Unit_engine.ml
+++ b/src/engine/Unit_engine.ml
@@ -696,7 +696,7 @@ let lang_tainting_tests () =
 (* TODO: We could have a taint_maturity/POLYGLOT/ directory to put reusable rules
  * that can work for multiple languages (like we have for tests/patterns/POLYGLOT/ *)
 let full_rule_taint_maturity_tests () =
-  let path = Filename.concat tests_path "taint_maturity" in
+  let path = tests_path / "taint_maturity" in
   pack_tests "taint maturity"
     (let tests, _print_summary =
        Test_engine.make_tests ~unit_testing:true [ path ]

--- a/src/engine/Unit_engine.ml
+++ b/src/engine/Unit_engine.ml
@@ -688,6 +688,18 @@ let lang_tainting_tests () =
 (* Full rule tests *)
 (*****************************************************************************)
 
+(* TODO: For now we only have taint maturity tests for Beta, there are no specific
+ * tests for GA, but eventually we'll need something more sophisticated. Ideally
+ * we can integrate these tests into the same `maturity_tests` function that packs
+ * search-mode maturity tests. *)
+let full_rule_taint_maturity_tests () =
+  let path = Filename.concat tests_path "taint_maturity" in
+  pack_tests "taint maturity"
+    (let tests, _print_summary =
+       Test_engine.make_tests ~unit_testing:true [ path ]
+     in
+     tests)
+
 let full_rule_regression_tests () =
   let path = tests_path / "rules" in
   pack_tests "full rule"
@@ -825,6 +837,7 @@ let tests () =
       extract_tests ();
       lang_tainting_tests ();
       maturity_tests ();
+      full_rule_taint_maturity_tests ();
       full_rule_regression_tests ();
       full_rule_semgrep_rules_regression_tests ();
     ]

--- a/src/engine/Unit_engine.ml
+++ b/src/engine/Unit_engine.ml
@@ -689,9 +689,12 @@ let lang_tainting_tests () =
 (*****************************************************************************)
 
 (* TODO: For now we only have taint maturity tests for Beta, there are no specific
- * tests for GA, but eventually we'll need something more sophisticated. Ideally
- * we can integrate these tests into the same `maturity_tests` function that packs
- * search-mode maturity tests. *)
+ * tests for GA. *)
+(* TODO: We should also have here an explicit list of test filenames, like "taint_if",
+ * that is then checked for every language, like we do for the search mode maturity
+ * tests. *)
+(* TODO: We could have a taint_maturity/POLYGLOT/ directory to put reusable rules
+ * that can work for multiple languages (like we have for tests/patterns/POLYGLOT/ *)
 let full_rule_taint_maturity_tests () =
   let path = Filename.concat tests_path "taint_maturity" in
   pack_tests "taint maturity"

--- a/tests/taint_maturity/c/taint_if.c
+++ b/tests/taint_maturity/c/taint_if.c
@@ -1,0 +1,42 @@
+void test1(bool cond)
+{
+  char* x;
+  if (cond)
+    x = "tainted";
+  else
+    x = "safe";
+  /* ruleid: taint-maturity */
+  sink(x);
+}
+
+void test2(bool cond)
+{
+  char* x;
+  x = "tainted";
+  if (cond)
+    x = sanitize(x);
+  /* ruleid: taint-maturity */
+  sink(x);
+  x = sanitize(x);
+  /* OK: taint-maturity */
+  sink(x);
+}
+
+void test3()
+{
+  char* x, y;
+  x = "tainted";
+  if (cond)
+  {
+    /* ruleid: taint-maturity */
+    sink(x);
+    y = sanitize(x);
+  }
+  else
+    y = sanitize(x);
+  /* ruleid: taint-maturity */
+  sink(x);
+  /* OK: taint-maturity */
+  sink(y);
+}
+

--- a/tests/taint_maturity/c/taint_if.yaml
+++ b/tests/taint_maturity/c/taint_if.yaml
@@ -10,7 +10,6 @@ rules:
     pattern-sources:
       - pattern: |
           "tainted"
-      - pattern: source(...)
     pattern-sanitizers:
       - pattern: sanitize(...)
     severity: ERROR

--- a/tests/taint_maturity/c/taint_if.yaml
+++ b/tests/taint_maturity/c/taint_if.yaml
@@ -1,0 +1,17 @@
+rules:
+  - id: taint-maturity
+    mode: taint
+    languages:
+      - c
+    message: |
+      This confirms taint mode works.
+    pattern-sinks:
+      - pattern: sink(...)
+    pattern-sources:
+      - pattern: |
+          "tainted"
+      - pattern: source(...)
+    pattern-sanitizers:
+      - pattern: sanitize(...)
+    severity: ERROR
+

--- a/tests/taint_maturity/c/taint_seq.c
+++ b/tests/taint_maturity/c/taint_seq.c
@@ -1,0 +1,36 @@
+void test1()
+{
+  /* ruleid: taint-maturity */
+  sink("tainted");
+}
+
+void test2()
+{
+  char* a, x, y, z;
+  x = "safe";
+  a = x;
+  x = "tainted";
+  y = x;
+  z = y;
+  /* ruleid: taint-maturity */
+  sink(z);
+  /* OK: taint-maturity */
+  sink(a);
+  /* OK: taint-maturity */
+  safe(z);
+}
+
+void test3()
+{
+  /* OK: taint-maturity */
+  sink(sanitize("tainted"));
+}
+
+void test4()
+{
+  char* x;
+  x = "tainted";
+  x = sanitize(x);
+  /* OK: taint-maturity */
+  sink(x);
+}

--- a/tests/taint_maturity/c/taint_seq.yaml
+++ b/tests/taint_maturity/c/taint_seq.yaml
@@ -1,0 +1,16 @@
+rules:
+  - id: taint-maturity
+    mode: taint
+    languages:
+      - c
+    message: |
+      This confirms taint mode works.
+    pattern-sinks:
+      - pattern: sink(...)
+    pattern-sources:
+      - pattern: |
+          "tainted"
+    pattern-sanitizers:
+      - pattern: sanitize(...)
+    severity: ERROR
+

--- a/tests/taint_maturity/csharp/taint_if.cs
+++ b/tests/taint_maturity/csharp/taint_if.cs
@@ -1,0 +1,44 @@
+public class Test
+{
+  public void test1(bool cond)
+  {
+    string x;
+    if (cond)
+      x = "tainted";
+    else
+      x = "safe";
+    //ruleid: taint-maturity
+    sink(x);
+  }
+
+  public void test2(bool cond)
+  {
+    string x;
+    x = "tainted";
+    if (cond)
+      x = sanitize(x);
+    //ruleid: taint-maturity
+    sink(x);
+    x = sanitize(x);
+    //OK: taint-maturity
+    sink(x);
+  }
+
+  public void test3()
+  {
+    string x, y;
+    x = "tainted";
+    if (cond)
+    {
+      //ruleid: taint-maturity
+      sink(x);
+      y = sanitize(x);
+    }
+    else
+      y = sanitize(x);
+    //ruleid: taint-maturity
+    sink(x);
+    //OK: taint-maturity
+    sink(y);
+  }
+}

--- a/tests/taint_maturity/csharp/taint_if.yaml
+++ b/tests/taint_maturity/csharp/taint_if.yaml
@@ -1,0 +1,17 @@
+rules:
+  - id: taint-maturity
+    mode: taint
+    languages:
+      - csharp
+    message: |
+      This confirms taint mode works.
+    pattern-sinks:
+      - pattern: sink(...)
+    pattern-sources:
+      - pattern: |
+          "tainted"
+      - pattern: source(...)
+    pattern-sanitizers:
+      - pattern: sanitize(...)
+    severity: ERROR
+

--- a/tests/taint_maturity/csharp/taint_if.yaml
+++ b/tests/taint_maturity/csharp/taint_if.yaml
@@ -10,7 +10,6 @@ rules:
     pattern-sources:
       - pattern: |
           "tainted"
-      - pattern: source(...)
     pattern-sanitizers:
       - pattern: sanitize(...)
     severity: ERROR

--- a/tests/taint_maturity/csharp/taint_seq.cs
+++ b/tests/taint_maturity/csharp/taint_seq.cs
@@ -1,0 +1,39 @@
+public class Test
+{
+  public void test1()
+  {
+    //ruleid: taint-maturity
+    sink("tainted");
+  }
+
+  public void test2()
+  {
+    string a, x, y, z;
+    x = "safe";
+    a = x;
+    x = "tainted";
+    y = x;
+    z = y;
+    //ruleid: taint-maturity
+    sink(z);
+    //OK: taint-maturity
+    sink(a);
+    //OK: taint-maturity
+    safe(z);
+  }
+
+  public void test3()
+  {
+    //ok: taint-maturity
+    sink(sanitize("tainted"));
+  }
+
+  public void test4()
+  {
+    string x;
+    x = "tainted";
+    x = sanitize(x);
+    //ok: taint-maturity
+    sink(x);
+  }
+}

--- a/tests/taint_maturity/csharp/taint_seq.yaml
+++ b/tests/taint_maturity/csharp/taint_seq.yaml
@@ -1,0 +1,16 @@
+rules:
+  - id: taint-maturity
+    mode: taint
+    languages:
+      - csharp
+    message: |
+      This confirms taint mode works.
+    pattern-sinks:
+      - pattern: sink(...)
+    pattern-sources:
+      - pattern: |
+          "tainted"
+    pattern-sanitizers:
+      - pattern: sanitize(...)
+    severity: ERROR
+

--- a/tests/taint_maturity/java/taint_if.java
+++ b/tests/taint_maturity/java/taint_if.java
@@ -1,0 +1,44 @@
+public class Test
+{
+  public void test1(boolean cond)
+  {
+    String x;
+    if (cond)
+      x = "tainted";
+    else
+      x = "safe";
+    //ruleid: taint-maturity
+    sink(x);
+  }
+
+  public void test2(boolean cond)
+  {
+    String x;
+    x = "tainted";
+    if (cond)
+      x = sanitize(x);
+    //ruleid: taint-maturity
+    sink(x);
+    x = sanitize(x);
+    //OK: taint-maturity
+    sink(x);
+  }
+
+  public void test3()
+  {
+    String x, y;
+    x = "tainted";
+    if (cond)
+    {
+      //ruleid: taint-maturity
+      sink(x);
+      y = sanitize(x);
+    }
+    else
+      y = sanitize(x);
+    //ruleid: taint-maturity
+    sink(x);
+    //OK: taint-maturity
+    sink(y);
+  }
+}

--- a/tests/taint_maturity/java/taint_if.yaml
+++ b/tests/taint_maturity/java/taint_if.yaml
@@ -10,7 +10,6 @@ rules:
     pattern-sources:
       - pattern: |
           "tainted"
-      - pattern: source(...)
     pattern-sanitizers:
       - pattern: sanitize(...)
     severity: ERROR

--- a/tests/taint_maturity/java/taint_if.yaml
+++ b/tests/taint_maturity/java/taint_if.yaml
@@ -1,0 +1,17 @@
+rules:
+  - id: taint-maturity
+    mode: taint
+    languages:
+      - java
+    message: |
+      This confirms taint mode works.
+    pattern-sinks:
+      - pattern: sink(...)
+    pattern-sources:
+      - pattern: |
+          "tainted"
+      - pattern: source(...)
+    pattern-sanitizers:
+      - pattern: sanitize(...)
+    severity: ERROR
+

--- a/tests/taint_maturity/java/taint_seq.java
+++ b/tests/taint_maturity/java/taint_seq.java
@@ -1,0 +1,39 @@
+public class Test
+{
+  public void test1()
+  {
+    //ruleid: taint-maturity
+    sink("tainted");
+  }
+
+  public void test2()
+  {
+    String a, x, y, z;
+    x = "safe";
+    a = x;
+    x = "tainted";
+    y = x;
+    z = y;
+    //ruleid: taint-maturity
+    sink(z);
+    //OK: taint-maturity
+    sink(a);
+    //OK: taint-maturity
+    safe(z);
+  }
+
+  public void test3()
+  {
+    //ok: taint-maturity
+    sink(sanitize("tainted"));
+  }
+
+  public void test4()
+  {
+    String x;
+    x = "tainted";
+    x = sanitize(x);
+    //ok: taint-maturity
+    sink(x);
+  }
+}

--- a/tests/taint_maturity/java/taint_seq.yaml
+++ b/tests/taint_maturity/java/taint_seq.yaml
@@ -1,0 +1,16 @@
+rules:
+  - id: taint-maturity
+    mode: taint
+    languages:
+      - java
+    message: |
+      This confirms taint mode works.
+    pattern-sinks:
+      - pattern: sink(...)
+    pattern-sources:
+      - pattern: |
+          "tainted"
+    pattern-sanitizers:
+      - pattern: sanitize(...)
+    severity: ERROR
+

--- a/tests/taint_maturity/php/taint_if.php
+++ b/tests/taint_maturity/php/taint_if.php
@@ -1,0 +1,41 @@
+<?php
+
+function test1($cond)
+{
+  if ($cond)
+    $x = "tainted";
+  else
+    $x = "safe";
+  //ruleid: taint-maturity
+  sink($x);
+}
+
+function test2($cond)
+{
+  $x = "tainted";
+  if ($cond)
+    $x = sanitize($x);
+  //ruleid: taint-maturity
+  sink($x);
+  $x = sanitize($x);
+  //OK: taint-maturity
+  sink($x);
+}
+
+function test3($cond)
+{
+  $x = "tainted";
+  if ($cond)
+  {
+    //ruleid: taint-maturity
+    sink($x);
+    $y = sanitize($x);
+  }
+  else
+    $y = sanitize($x);
+  //ruleid: taint-maturity
+  sink($x);
+  //OK: taint-maturity
+  sink($y);
+}
+

--- a/tests/taint_maturity/php/taint_if.yaml
+++ b/tests/taint_maturity/php/taint_if.yaml
@@ -10,7 +10,6 @@ rules:
     pattern-sources:
       - pattern: |
           "tainted"
-      - pattern: source(...)
     pattern-sanitizers:
       - pattern: sanitize(...)
     severity: ERROR

--- a/tests/taint_maturity/php/taint_if.yaml
+++ b/tests/taint_maturity/php/taint_if.yaml
@@ -1,0 +1,17 @@
+rules:
+  - id: taint-maturity
+    mode: taint
+    languages:
+      - php
+    message: |
+      This confirms taint mode works.
+    pattern-sinks:
+      - pattern: sink(...)
+    pattern-sources:
+      - pattern: |
+          "tainted"
+      - pattern: source(...)
+    pattern-sanitizers:
+      - pattern: sanitize(...)
+    severity: ERROR
+

--- a/tests/taint_maturity/php/taint_seq.php
+++ b/tests/taint_maturity/php/taint_seq.php
@@ -1,0 +1,36 @@
+<?php
+
+function test1()
+{
+  //ruleid: taint-maturity
+  sink("tainted");
+}
+
+function test2()
+{
+  $x = "safe";
+  $a = $x;
+  $x = "tainted";
+  $y = $x;
+  $z = $y;
+  //ruleid: taint-maturity
+  sink($z);
+  //OK: taint-maturity
+  sink($a);
+  //OK: taint-maturity
+  safe($z);
+}
+
+function test3()
+{
+  //OK: taint-maturity
+  sink(sanitize("tainted"));
+}
+
+function test4()
+{
+  $x = "tainted";
+  $x = sanitize($x);
+  //OK: taint-maturity
+  sink($x);
+}

--- a/tests/taint_maturity/php/taint_seq.yaml
+++ b/tests/taint_maturity/php/taint_seq.yaml
@@ -1,0 +1,16 @@
+rules:
+  - id: taint-maturity
+    mode: taint
+    languages:
+      - php
+    message: |
+      This confirms taint mode works.
+    pattern-sinks:
+      - pattern: sink(...)
+    pattern-sources:
+      - pattern: |
+          "tainted"
+    pattern-sanitizers:
+      - pattern: sanitize(...)
+    severity: ERROR
+

--- a/tests/taint_maturity/python/taint_if.py
+++ b/tests/taint_maturity/python/taint_if.py
@@ -1,0 +1,30 @@
+def test1(cond):
+  if cond:
+    x = "tainted"
+  else:
+    x = "safe"
+  #ruleid: taint-maturity
+  sink(x)
+
+def test2(cond):
+  x = "tainted"
+  if cond:
+    x = sanitize(x)
+  #ruleid: taint-maturity
+  sink(x)
+  x = sanitize(x)
+  #OK: taint-maturity
+  sink(x)
+
+def test3(cond):
+  x = "tainted"
+  if cond:
+    #ruleid: taint-maturity
+    sink(x)
+    y = sanitize(x)
+  else:
+    y = sanitize(x)
+  #ruleid: taint-maturity
+  sink(x)
+  #OK: taint-maturity
+  sink(y)

--- a/tests/taint_maturity/python/taint_if.yaml
+++ b/tests/taint_maturity/python/taint_if.yaml
@@ -1,15 +1,17 @@
 rules:
-  - id: tainting
+  - id: taint-maturity
     mode: taint
     languages:
       - python
     message: |
       This confirms taint mode works.
     pattern-sinks:
-      - pattern: sink1(...)
+      - pattern: sink(...)
     pattern-sources:
-      - pattern: source1(...)
+      - pattern: |
+          "tainted"
+      - pattern: source(...)
     pattern-sanitizers:
-      - pattern: sanitize1(...)
+      - pattern: sanitize(...)
     severity: ERROR
 

--- a/tests/taint_maturity/python/taint_if.yaml
+++ b/tests/taint_maturity/python/taint_if.yaml
@@ -10,7 +10,6 @@ rules:
     pattern-sources:
       - pattern: |
           "tainted"
-      - pattern: source(...)
     pattern-sanitizers:
       - pattern: sanitize(...)
     severity: ERROR

--- a/tests/taint_maturity/python/taint_seq.py
+++ b/tests/taint_maturity/python/taint_seq.py
@@ -1,0 +1,26 @@
+def test1():
+  #ruleid: taint-maturity
+  sink("tainted")
+
+def test2():
+  x = "safe"
+  a = x
+  x = "tainted"
+  y = x
+  z = y
+  #ruleid: taint-maturity
+  sink(z)
+  #OK: taint-maturity
+  sink(a)
+  #OK: taint-maturity
+  safe(z)
+
+def test3():
+  #ok: taint-maturity
+  sink(sanitize("tainted"))
+
+def test4():
+  x = "tainted"
+  x = sanitize(x)
+  #ok: taint-maturity
+  sink(x)

--- a/tests/taint_maturity/python/taint_seq.yaml
+++ b/tests/taint_maturity/python/taint_seq.yaml
@@ -1,0 +1,16 @@
+rules:
+  - id: taint-maturity
+    mode: taint
+    languages:
+      - python
+    message: |
+      This confirms taint mode works.
+    pattern-sinks:
+      - pattern: sink(...)
+    pattern-sources:
+      - pattern: |
+          "tainted"
+    pattern-sanitizers:
+      - pattern: sanitize(...)
+    severity: ERROR
+

--- a/tests/tainting_rules/python/tainting.py
+++ b/tests/tainting_rules/python/tainting.py
@@ -1,9 +1,0 @@
-def foo():
-  a = source1()
-  if True:
-     b = a
-     b = sanitize1()
-  else:
-     b = a
-  #ERROR:
-  sink1(b)


### PR DESCRIPTION
Found out that C# assignemnts are all encoded as AssignOp(Eq) and that was causing sanitizers not to work as expected, `y = sanitize(x)` was viewed as `y = x = sanitize(x)` and thus `y` was still considered as tainted.

test plan:
make test

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
