### PR TITLE
Semgrep.js: comment in js/dune files

### DIFF
--- a/js/Main.ml
+++ b/js/Main.ml
@@ -2,6 +2,12 @@ open Js_of_ocaml
 
 let _ =
   Common.jsoo := true;
+  (* Using semgrep.parsing_languages makes the JS goes
+     from 16MB to 7MB (in release mode) and from 110MB to 50MB (in dev mode)
+     TODO: we should add language parsers dynamically, loading language "bundles"
+     from the web on demand when one select a language in the playground.
+     old: Parsing_init.init ();
+  *)
   Js.Unsafe.global ##. Semgrep
   := object%js
        method execute language rule_file source_file =

--- a/js/dune
+++ b/js/dune
@@ -1,16 +1,32 @@
+; Building with dune build --profile=release (instead of the default --profile=dev)
+; has a significant impact on the size of the generated JS file. You can go
+; from 110MB to 16MB!
+; See https://discuss.ocaml.org/t/tutorial-full-stack-web-dev-in-ocaml-w-dream-bonsai-and-graphql/9963/8?u=aryx
+
 (executables
  (names Main)
- (libraries semgrep.running js_of_ocaml integers_stubs_js ctypes_stubs_js)
+ (libraries
+    js_of_ocaml
+    integers_stubs_js ctypes_stubs_js
+    semgrep.running
+    ; semgrep.parsing_languages ; skipped to go from 16MB to 7MB
+    )
  (js_of_ocaml
   (javascript_files
    ./pcre.js
    ./ocaml-tree-sitter.js
    ./semgrep.js
    ./unix.js
-   ./core.js))
+   ./core.js)
+  ; --no-inline was suggested here:
+  ; https://discuss.ocaml.org/t/js-of-ocaml-output-performs-considerably-worse-when-built-with-profile-release-flag/8862/14
+  ; but this does not appear to have an effect for us
+  ;(flags (:standard --no-inline))
+ )
  (modes js)
  (preprocess
   (pps js_of_ocaml-ppx)))
+
 
 (rule
  (target semgrep-core.js)


### PR DESCRIPTION
test plan:
```
$ source libs/ocaml-tree-sitter-core/tree-sitter-config.sh
$ dune build --profile=release
$ ls -l _build/default/js/semgrep-core.js

=> 6.7MB!!
```


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)