### PR TITLE
bump js_of_ocaml to 5.1.1

### DIFF
--- a/.github/workflows/build-test-core-x86.yaml
+++ b/.github/workflows/build-test-core-x86.yaml
@@ -8,7 +8,7 @@ jobs:
   build-test-core-x86:
     name: Build Test Semgrep Core
     runs-on: ubuntu-latest
-    container: returntocorp/ocaml:alpine-2023-03-03
+    container: returntocorp/ocaml:alpine-2023-03-21
     # We need this hack because GHA tampers with the HOME in container
     # and this does not play well with 'opam' installed in /root
     env:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -71,7 +71,7 @@ jobs:
     # This custom image provides 'ocamlformat' with a specific version needed to check
     # OCaml code (must be the same than the one in dev/dev.opam)
     # See https://github.com/returntocorp/ocaml-layer/blob/master/configs/ubuntu.sh
-    container: returntocorp/ocaml:ubuntu-2023-03-03
+    container: returntocorp/ocaml:ubuntu-2023-03-21
     # HOME in the container is tampered by GHA and modified from /root to /home/github
     # which then confuses opam below which can not find its ~/.opam (which is at /root/.opam)
     # hence the ugly use of 'env: HOME ...' below.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
     # TODO: why not use the artifact of build-semgrep-core in this job instead?
     name: test semgrep-core
     runs-on: ubuntu-22.04
-    container: returntocorp/ocaml:alpine-2023-03-03
+    container: returntocorp/ocaml:alpine-2023-03-21
     env:
       HOME: /root
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@
 #
 # coupling: if you modify the FROM below, you probably need to modify also
 # a few .github/workflows/ files. grep for returntocorp/ocaml there.
-FROM returntocorp/ocaml:alpine-2023-03-03 as semgrep-core-container
+FROM returntocorp/ocaml:alpine-2023-03-21 as semgrep-core-container
 
 WORKDIR /src/semgrep
 COPY . .

--- a/semgrep.opam
+++ b/semgrep.opam
@@ -55,9 +55,9 @@ depends: [
   "lsp" {= "1.7.0"}
   "comby-kernel" {= "1.4.1"}
   "visitors" {= "20210608"}
-  "js_of_ocaml"
-  "js_of_ocaml-compiler"
-  "js_of_ocaml-ppx"
+  "js_of_ocaml" {= "5.1.1"}
+  "js_of_ocaml-compiler" {= "5.1.1"}
+  "js_of_ocaml-ppx" {= "5.1.1"}
   "ctypes_stubs_js"
   "integers_stubs_js"
 ]


### PR DESCRIPTION
Allows us our bridge code to be written in modern javascript (+ misc improvements and fixes: https://github.com/ocsigen/js_of_ocaml/releases)

@aryx, 

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
