### PR TITLE
feat: support webhooks for Zapier rather than relying on GH integrations

### DIFF
--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -430,6 +430,9 @@ jobs:
       - run: echo "${{needs.get-version.outputs.version}}"
       - name: Notify Success
         run: |
+          curl "${{ secrets.ZAPIER_WEBHOOK_URL }}" \
+            -d '{"version":"${{needs.get-version.outputs.version}}","changelog_url":"https://github.com/returntocorp/semgrep/releases/tag/v${{needs.get-version.outputs.version}}"}'
+
           curl --request POST \
           --url  ${{ secrets.NOTIFICATIONS_URL }} \
           --header 'content-type: application/json' \

--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -430,6 +430,7 @@ jobs:
       - run: echo "${{needs.get-version.outputs.version}}"
       - name: Notify Success
         run: |
+          # POST a webhook to Zapier to allow for public notifications to our users via Twitter
           curl "${{ secrets.ZAPIER_WEBHOOK_URL }}" \
             -d '{"version":"${{needs.get-version.outputs.version}}","changelog_url":"https://github.com/returntocorp/semgrep/releases/tag/v${{needs.get-version.outputs.version}}"}'
 


### PR DESCRIPTION
This will simplify follow-on actions we take in Zapier.

I'll be manually testing this step once the PR has approval - Zapier needs to be prepared to accept this request. 

Confirmed that because URL is kept as secret, GH will mask any occurrences in the log output. 

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
