### PR TITLE
Don't install libraries or executables when running 'make build'.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,7 @@ PR checklist:
 - [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
 - [ ] Change has no security implications (otherwise, ping security team)
 
-If you're unsure on any of this, please see:
+If you're unsure about any of this, please see:
 
 - [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
 - [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)

--- a/Makefile
+++ b/Makefile
@@ -76,9 +76,7 @@ endif
 .PHONY: build
 build:
 	$(MAKE) core
-	# We run this command because the Python code in cli/ assumes the
-	# presence of a semgrep-core binary in the PATH somewhere.
-	$(MAKE) core-install
+	$(MAKE) copy-core-for-cli
 	cd cli && pipenv install --dev
 	$(MAKE) -C cli build
 
@@ -90,6 +88,15 @@ core:
 	dune build ./_build/default/tests/test.exe
 	# make executables easily accessible for manual testing:
 	test -e bin || ln -s _build/install/default/bin .
+
+.PHONY: copy-core-for-cli
+copy-core-for-cli:
+	rm -f cli/src/semgrep/bin/semgrep-core
+	cp _build/install/default/bin/semgrep-core cli/src/semgrep/bin/
+	rm -f cli/src/semgrep/bin/semgrep_bridge_core.so
+	cp _build/install/default/bin/semgrep_bridge_core.so cli/src/semgrep/bin/
+	rm -f cli/src/semgrep/bin/semgrep_bridge_python.so
+	cp _build/install/default/bin/semgrep_bridge_python.so cli/src/semgrep/bin/
 
 # Minimal build of the semgrep-core executable. Intended for the docker build.
 # Requires the environment variables set by the included file above.
@@ -128,24 +135,36 @@ core-clean:
 # Install targets
 ###############################################################################
 
+# Install semgrep on a developer's machine with pip and opam installed.
 .PHONY: install
 install:
+	# Install semgrep-core into opam's bin which is in our PATH.
+	# This is not needed or used by the pip install.
 	$(MAKE) core-install
-	python3 -m pip install semgrep
+	# Install semgrep and semgrep-core in a place known to pip.
+	python3 -m pip install ./cli
 
-# This may install more than you want.
-# See the 'dev' target if all you need is access to the semgrep-core
-# executable for testing.
-# was the 'install' target in in semgrep-core/Makefile before
+.PHONY: uninstall
+uninstall:
+	-$(MAKE) core-uninstall
+	-python3 -m pip uninstall --yes semgrep
+
+# Install the semgrep-core executable, as well as any other executable or
+# library built from OCaml or C and needed for a complete semgrep install
+# for a user of semgrep who builds and installs semgrep from source
+# for local use.
+#
+# This should *not* install the open-source libraries that we maintain
+# as part of the semgrep project.
 .PHONY: core-install
 core-install:
-	dune install
-	rm -f cli/src/semgrep/bin/semgrep-core
-	cp _build/install/default/bin/semgrep-core cli/src/semgrep/bin/
-	rm -f cli/src/semgrep/bin/semgrep_bridge_core.so
-	cp _build/install/default/bin/semgrep_bridge_core.so cli/src/semgrep/bin/
-	rm -f cli/src/semgrep/bin/semgrep_bridge_python.so
-	cp _build/install/default/bin/semgrep_bridge_python.so cli/src/semgrep/bin/
+	cp bin/semgrep-core "$$(opam var bin)"/
+
+# Try to uninstall what was installed by 'make core-install'.
+# This is a best effort.
+.PHONY: core-uninstall
+core-uninstall:
+	rm -f "$$(opam var bin)"/semgrep-core
 
 ###############################################################################
 # Test target


### PR DESCRIPTION
`make` was calling `dune install` for no good reason. This was installing any internal library or executable declared as public.

Fixed:
- `make` = `make build`: no longer installs OCaml libraries or executables.
- `make install`: installs `semgrep-core` and `semgrep` correctly. This now installs from the local Python code rather than installing the public semgrep package. This doesn't install OCaml libraries or executables other than `semgrep-core`.

New:
- `make uninstall`: uninstall what may have been installed by `make install`.

These makefile targets are intended for semgrep developers only so I don't think we should document them as part of the changelog.

Test plan: let's see if CI breaks.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
