### PR TITLE
refactor: move code out of Parse_pattern2.ml in Pfff_or_tree_sitter

### DIFF
--- a/src/parsing/Pfff_or_tree_sitter.mli
+++ b/src/parsing/Pfff_or_tree_sitter.mli
@@ -2,6 +2,11 @@ type 'ast parser =
   | Pfff of (Common.filename -> 'ast * Parsing_stat.t)
   | TreeSitter of (Common.filename -> 'ast Tree_sitter_run.Parsing_result.t)
 
+(* TODO: factorize with previous type *)
+type 'ast pattern_parser =
+  | PfffPat of (string -> 'ast)
+  | TreeSitterPat of (string -> 'ast Tree_sitter_run.Parsing_result.t)
+
 (* usage:
     run file [
         TreeSitter (Parse_typescript_tree_sitter.parse);
@@ -13,6 +18,18 @@ val run :
   'ast parser list ->
   ('ast -> AST_generic.program) ->
   Parsing_result2.t
+
+(* usage:
+    let js_ast =
+      str |> run_pattern ~print_errors [
+         PfffPat Parse_js.any_of_string;
+         TreeSitterPat Parse_typescript_tree_sitter.parse_pattern;
+         ]
+      in
+      Js_to_generic.any js_ast
+*)
+val run_pattern :
+  print_errors:bool -> 'ast pattern_parser list -> string -> 'ast
 
 (* helpers used both in Parse_target.ml and Parse_target2.ml *)
 
@@ -34,3 +51,11 @@ val run_external_parser :
   Common.filename ->
   (Common.filename -> AST_generic.program Tree_sitter_run.Parsing_result.t) ->
   Parsing_result2.t
+
+(* helpers used both in Parse_pattern.ml and Parse_pattern2.ml *)
+
+val extract_pattern_from_tree_sitter_result :
+  'any Tree_sitter_run.Parsing_result.t -> bool (* print_errors *) -> 'any
+
+val dump_and_print_errors :
+  ('a -> unit) -> 'a Tree_sitter_run.Parsing_result.t -> unit

--- a/src/parsing_languages/Parse_pattern2.ml
+++ b/src/parsing_languages/Parse_pattern2.ml
@@ -12,84 +12,15 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
  * LICENSE for more details.
  *)
-open Common
-
-let logger = Logging.get_logger [ __MODULE__ ]
+open Pfff_or_tree_sitter
 
 (*****************************************************************************)
 (* Prelude *)
 (*****************************************************************************)
 (* Most of the code here used to be in Parse_pattern.ml, but was moved
- * to make the engine language independent so that we can generate
- * a smaller JS file for the engine
+ * here to make the engine/ language independent so that we can generate
+ * a smaller engine.js file.
  *)
-
-(*****************************************************************************)
-(* Helpers *)
-(*****************************************************************************)
-
-let dump_and_print_errors dumper (res : 'a Tree_sitter_run.Parsing_result.t) =
-  (match res.program with
-  | Some cst -> dumper cst
-  | None -> failwith "unknown error from tree-sitter parser");
-  res.errors
-  |> List.iter (fun err ->
-         pr2 (Tree_sitter_run.Tree_sitter_error.to_string ~color:true err))
-
-let extract_pattern_from_tree_sitter_result
-    (res : 'a Tree_sitter_run.Parsing_result.t) (print_errors : bool) =
-  match (res.Tree_sitter_run.Parsing_result.program, res.errors) with
-  | None, _ -> failwith "no pattern found"
-  | Some x, [] -> x
-  | Some _, _ :: _ ->
-      if print_errors then
-        res.errors
-        |> List.iter (fun err ->
-               pr2 (Tree_sitter_run.Tree_sitter_error.to_string ~color:true err));
-      failwith "error parsing the pattern"
-
-type 'ast parser =
-  | Pfff of (string -> 'ast)
-  | TreeSitter of (string -> 'ast Tree_sitter_run.Parsing_result.t)
-
-let run_parser ~print_errors p str =
-  let parse () =
-    match p with
-    | Pfff f ->
-        logger#trace "trying to parse with Pfff parser the pattern";
-        f str
-    | TreeSitter f ->
-        logger#trace "trying to parse with Tree-sitter parser the pattern";
-        let res = f str in
-        extract_pattern_from_tree_sitter_result res print_errors
-  in
-  try Ok (parse ()) with
-  | Time_limit.Timeout _ as e -> Exception.catch_and_reraise e
-  | exn -> Error (Exception.catch exn)
-
-(* This is a simplified version of run_either in Parse_target.ml. We don't need
- * most of the logic there when we're parsing patterns, so it doesn't make sense
- * to reuse it. *)
-let run_either ~print_errors parsers program =
-  let rec f parsers =
-    match parsers with
-    | [] ->
-        Error
-          (Exception.trace
-             (Failure "internal error: No pattern parser available"))
-    | p :: xs -> (
-        match run_parser ~print_errors p program with
-        | Ok res -> Ok res
-        | Error e -> (
-            match f xs with
-            | Ok res -> Ok res
-            | Error _ ->
-                (* Return the error from the first parser. *)
-                Error e))
-  in
-  match f parsers with
-  | Ok res -> res
-  | Error e -> Exception.reraise e
 
 (*****************************************************************************)
 (* Entry point *)
@@ -152,10 +83,10 @@ let parse_pattern lang print_errors str =
   | Lang.Vue ->
       let js_ast =
         str
-        |> run_either ~print_errors
+        |> run_pattern ~print_errors
              [
-               Pfff Parse_js.any_of_string;
-               TreeSitter Parse_typescript_tree_sitter.parse_pattern;
+               PfffPat Parse_js.any_of_string;
+               TreeSitterPat Parse_typescript_tree_sitter.parse_pattern;
              ]
       in
       Js_to_generic.any js_ast
@@ -177,21 +108,21 @@ let parse_pattern lang print_errors str =
   | Lang.Cpp ->
       let any =
         str
-        |> run_either ~print_errors
+        |> run_pattern ~print_errors
              [
-               Pfff
+               PfffPat
                  (fun x -> Parse_cpp.any_of_string Flag_parsing_cpp.Cplusplus x);
-               TreeSitter Parse_cpp_tree_sitter.parse_pattern;
+               TreeSitterPat Parse_cpp_tree_sitter.parse_pattern;
              ]
       in
       Cpp_to_generic.any any
   | Lang.Java ->
       let any =
         str
-        |> run_either ~print_errors
+        |> run_pattern ~print_errors
              [
-               Pfff Parse_java.any_of_string;
-               TreeSitter Parse_java_tree_sitter.parse_pattern;
+               PfffPat Parse_java.any_of_string;
+               TreeSitterPat Parse_java_tree_sitter.parse_pattern;
              ]
       in
       Java_to_generic.any any


### PR DESCRIPTION
test plan:
make core


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)