### PR TITLE
Semgrep.js: use --table for menhir js parser

### DIFF
--- a/dune
+++ b/dune
@@ -10,7 +10,11 @@
 ;
 (env
   (_
-    (flags (:standard  -w -52-6))))
+    (flags (:standard  -w -52-6))
+    ; TODO: I've tried this, but this does not work so I've added --table in
+    ; the few dune files using menhir
+    ;(menhir_flags (--table))
+    ))
 
 ; coupling: if you modify this, you probably need to modify the core-cache
 ; regexps in .github/workflow/tests.yml passed to the hashFiles function

--- a/dune-project
+++ b/dune-project
@@ -1,3 +1,3 @@
 (lang dune 2.7)
 (name semgrep)
-(using menhir 2.0)
+(using menhir 2.1)

--- a/languages/javascript/menhir/dune
+++ b/languages/javascript/menhir/dune
@@ -3,7 +3,7 @@
  (name parser_javascript_menhir)
  (wrapped false)
  (libraries
-
+   menhirLib ; this is needed when using --table
    commons
    process_limits
    lib_parsing
@@ -12,5 +12,6 @@
  (preprocess (pps ppx_deriving.show ppx_profiling))
 )
 (ocamllex lexer_js)
+; --table helps to generate a smaller engine.js file
 (menhir (modules parser_js)
-        (flags --unused-tokens --explain --fixed-exception))
+        (flags --unused-tokens --explain --table --fixed-exception))

--- a/languages/regexp/dune
+++ b/languages/regexp/dune
@@ -1,11 +1,13 @@
 (library
  (public_name parser_regexp)
  (libraries
+   menhirLib ; needed when using --table
    commons
    lib_parsing
  )
  (preprocess (pps ppx_deriving.show))
 )
 (ocamllex Lexer)
+; --table helps to generate a smaller engine.js file
 (menhir (modules Parser)
-        (flags --unused-tokens --explain --fixed-exception))
+        (flags --unused-tokens --explain --table --fixed-exception))

--- a/src/parsing/Parse_target.ml
+++ b/src/parsing/Parse_target.ml
@@ -50,13 +50,36 @@ let errors_from_skipped_tokens xs =
       let locs = xs |> Common.map OutH.location_of_token_location in
       Report.ErrorSet.singleton { err with typ = Out.PartialParsing locs }
 
+let undefined_just_parse_with_lang _lang _file =
+  failwith "just_parse_with_lang_ref unset"
+
 (* TODO: factorize with Parsing_plugin mechanism
  * hack to reduce the engine.js file. Set in Parsing_init.init().
  *)
-let just_parse_with_lang_ref =
-  ref (fun _lang _file -> failwith "just_parse_with_lang_ref unset")
+let just_parse_with_lang_ref = ref undefined_just_parse_with_lang
 
-let just_parse_with_lang lang file = !just_parse_with_lang_ref lang file
+let just_parse_with_lang lang file =
+  match lang with
+  (* TODO: ideally this should also be in Parse_target2.ml, but we
+   * still have a few dependencies to the Js parser because of
+   * Parse_json.parse used in Parse_rule, so at this point
+   * we can add support for JSON/JS also here. This does
+   * not increase the size of the engine.js file.
+   *)
+  | Lang.Json ->
+      run file
+        [
+          Pfff
+            (fun file ->
+              (Parse_json.parse_program file, Parsing_stat.correct_stat file));
+        ]
+        Json_to_generic.program
+  | Lang.Js
+    when Stdlib.( == ) !just_parse_with_lang_ref undefined_just_parse_with_lang
+    ->
+      (* no TreeSitter here, this would add 400K in engine.js *)
+      run file [ Pfff (throw_tokens Parse_js.parse) ] Js_to_generic.program
+  | _else_ -> !just_parse_with_lang_ref lang file
   [@@profiling]
 
 (*****************************************************************************)

--- a/src/parsing/dune
+++ b/src/parsing/dune
@@ -1,5 +1,5 @@
 ; This library should not depend on languages/ (parsing_languages/ can though).
-; This allows to generate a smaller JS file for the engine.
+; This allows to generate a smaller engine.js file.
 (library
  (public_name semgrep.parsing)
  (name semgrep_parsing)
@@ -9,11 +9,13 @@
 
    commons
    lib_parsing
-   pfff-lang_GENERIC-naming
-   ojsonnet
    process_limits
    spacegrep
 
+   pfff-lang_GENERIC-naming
+
+   ; remaining language dependencies (the main one are in ../parsing_languages/)
+   ojsonnet
    ;TODO: use lighter JSON parser at some point or move
    ; also out of Parse_rule.ml to reduce even more JS size
    parser_json.menhir parser_json.ast_generic


### PR DESCRIPTION
This makes engine.js from 5.7MB to 4.7MB.
engine.js.br is now at 871000B

test plan:
dune --profile=release
ls -l _build/.../engine.js


PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)