### PR TITLE
Semgrep.js: adding back tree-sitter Typescript parser in engine.js

### DIFF
--- a/src/parsing/Parse_target.ml
+++ b/src/parsing/Parse_target.ml
@@ -77,8 +77,23 @@ let just_parse_with_lang lang file =
   | Lang.Js
     when Stdlib.( == ) !just_parse_with_lang_ref undefined_just_parse_with_lang
     ->
-      (* no TreeSitter here, this would add 400K in engine.js *)
-      run file [ Pfff (throw_tokens Parse_js.parse) ] Js_to_generic.program
+      (* we start directly with tree-sitter here, because
+       * the pfff parser is slow on minified files due to its (slow) error
+       * recovery strategy.
+       *)
+      run file
+        [
+          (* adding TreeSitter adds 400K in engine.js (30k in .js.br) *)
+          TreeSitter (Parse_typescript_tree_sitter.parse ~dialect:`TSX);
+          Pfff (throw_tokens Parse_js.parse);
+        ]
+        Js_to_generic.program
+  | Lang.Ts
+    when Stdlib.( == ) !just_parse_with_lang_ref undefined_just_parse_with_lang
+    ->
+      run file
+        [ TreeSitter (Parse_typescript_tree_sitter.parse ?dialect:None) ]
+        Js_to_generic.program
   | _else_ -> !just_parse_with_lang_ref lang file
   [@@profiling]
 

--- a/src/parsing/dune
+++ b/src/parsing/dune
@@ -19,6 +19,7 @@
    ;TODO: use lighter JSON parser at some point or move
    ; also out of Parse_rule.ml to reduce even more JS size
    parser_json.menhir parser_json.ast_generic
+   parser_typescript.tree_sitter
 
    semgrep_core
    semgrep_optimizing


### PR DESCRIPTION
This will make it easier to test the integration between engine.js
and the wasm tree-sitter files. Otherwise we would have to
fix now the dynamic loading of languages (now out of engine.js,
except for JS/TS).

test plan:
dune build --profile=release
engine.js.br is 830K, not too bad.


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)