### PR TITLE
fix(java): restore GA parse rate

### DIFF
--- a/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awarelog4shell.yaml-dependency_awarelog4j/results.txt
+++ b/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awarelog4shell.yaml-dependency_awarelog4j/results.txt
@@ -52,19 +52,6 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
               "line": 33,
               "offset": 1020
             },
-            "propagated_value": {
-              "svalue_abstract_content": "LogManager.getLogger(com.example.log4shell.log4j.class)",
-              "svalue_end": {
-                "col": 84,
-                "line": 32,
-                "offset": 1000
-              },
-              "svalue_start": {
-                "col": 29,
-                "line": 32,
-                "offset": 945
-              }
-            },
             "start": {
               "col": 13,
               "line": 33,

--- a/languages/java/tree-sitter/Parse_java_tree_sitter.ml
+++ b/languages/java/tree-sitter/Parse_java_tree_sitter.ml
@@ -122,14 +122,53 @@ let int_literal env tok =
   let s, t = str env tok in
   (Common2.int_of_string_c_octal_opt s, t)
 
-let string_literal env tok =
-  let s, t = str env tok in
-  (* remove enclosing quotes *)
-  let s =
-    if s =~ "^\"\\(.*\\)\"$" then Common.matched1 s
-    else failwith (spf "not a Java string: %s" s)
-  in
-  (s, t)
+let multiline_string_fragment (env : env) (x : CST.multiline_string_fragment) =
+  match x with
+  | `Pat_98d585a x -> str env x
+  | `Pat_9347a80_rep_pat_98d585a (v1, v2) ->
+      (* pattern "\"[^\"]*" *)
+      let s, t = str env v1 in
+      let strs, toks =
+        Common.map
+          (fun x ->
+            (* pattern "[^\"]+" *)
+            str env x)
+          v2
+        |> Common2.unzip
+      in
+      (s ^ String.concat "" strs, PI.combine_infos t toks)
+
+let escape_sequence_ (env : env) (x : CST.escape_sequence_) =
+  match x with
+  | `Imm_tok_bslash_pat_36cdeeb x -> str env x
+  | `Esc_seq tok -> (* escape_sequence *) str env tok
+
+let string_literal env s =
+  match s with
+  | `Str_lit_ (quote1, contents, quote2) ->
+      let tok1 = token env quote1 in
+      let strs, toks =
+        Common.map
+          (function
+            | `Str_frag x -> str env x
+            | `Esc_seq x -> str env x)
+          contents
+        |> Common2.unzip
+      in
+      let tok2 = token env quote2 in
+      (String.concat "" strs, PI.combine_infos tok1 (toks @ [ tok2 ]))
+  | `Mult_str_lit (quote1, contents, quote2) ->
+      let tok1 = token env quote1 in
+      let strs, toks =
+        Common.map
+          (function
+            | `Mult_str_frag x -> multiline_string_fragment env x
+            | `Esc_seq_ x -> escape_sequence_ env x)
+          contents
+        |> Common2.unzip
+      in
+      let tok2 = token env quote2 in
+      (String.concat "" strs, PI.combine_infos tok1 (toks @ [ tok2 ]))
 
 let float_literal env tok =
   let s, t = str env tok in
@@ -148,10 +187,9 @@ let literal (env : env) (x : CST.literal) =
   | `True tok -> Bool (true, token env tok) (* "true" *)
   | `False tok -> Bool (false, token env tok) (* "false" *)
   | `Char_lit tok -> Char (str env tok) (* character_literal *)
-  | `Str_lit tok -> String (string_literal env tok) (* string_literal *)
-  | `Null_lit tok -> Null (token env tok) (* "null" *)
-  (* TODO: remove enclosing triple quotes? *)
-  | `Text_blk tok -> TextBlock (str env tok)
+  | `Str_lit s -> String (string_literal env s) (* string_literal *)
+  | `Null_lit tok -> Null (token env tok)
+(* "null" *)
 
 (* TODO: add in AST *)
 let module_directive (env : env) (v : CST.module_directive) : unit =
@@ -241,12 +279,18 @@ let rec expression (env : env) (x : CST.expression) =
       | Left (), t -> Assign (v1, t, v3)
       | Right op, t -> AssignOp (v1, (op, t), v3))
   | `Bin_exp x -> binary_expression env x
-  | `Inst_exp (v1, v2, v3, _identifier) ->
+  | `Inst_exp (v1, v2, v3, v4, _v5) ->
       let v1 = expression env v1 in
       let _v2 = token env v2 (* "instanceof" *) in
-      let v3 = type_ env v3 in
+      (* TODO: use attrs *)
+      let _attrs =
+        match v3 with
+        | Some _ -> Some "final"
+        | None -> None
+      in
+      let v4 = type_ env v4 in
       (* TODO make identifier available to the AST*)
-      InstanceOf (v1, v3)
+      InstanceOf (v1, v4)
   | `Lambda_exp (v1, v2, v3) ->
       let v1 =
         match v1 with
@@ -1215,9 +1259,7 @@ and enum_body (env : env) ((v1, v2, v3, v4, v5) : CST.enum_body) =
   (v2, v4)
 
 and record_declaration (env : env)
-    ((v1, v2, v3, _type_parameter, v5, v6) : CST.record_declaration) :
-    class_decl =
-  (* TODO add support for type parameters. Don't ignore them *)
+    ((v1, v2, v3, v4, v5, v6, v7) : CST.record_declaration) : class_decl =
   let v1 =
     match v1 with
     | Some x -> modifiers env x
@@ -1225,23 +1267,49 @@ and record_declaration (env : env)
   in
   let v2 = token env v2 (* "record" *) in
   let v3 = identifier env v3 (* pattern [a-zA-Z_]\w* *) in
+  let v4 =
+    match v4 with
+    | Some x -> type_parameters env x
+    | None -> []
+  in
   let v5 = formal_parameters env v5 in
-  let v6 = class_body env v6 in
+  let v6 =
+    match v6 with
+    | Some x -> super_interfaces env x
+    | None -> []
+  in
+  let v7 = class_body env v7 in
   {
     cl_name = v3;
     cl_kind = (Record, v2);
-    cl_tparams = [];
+    cl_tparams = v4;
     cl_mods = v1;
     cl_extends = None;
-    cl_impls = [];
+    cl_impls = v6;
     cl_formals = v5;
-    cl_body = v6;
+    cl_body = v7;
   }
+
+and comp_cons_decl env (v1, v2, v3) =
+  (* Compact constructors are a way to rewrite the default constructors for
+     a record, a kind of metaprogramming. We won't be able to analyze it
+     super meaningfully, but that should be fine.
+  *)
+  let v1 =
+    match v1 with
+    | Some x -> modifiers env x
+    | None -> []
+  in
+  let v2 = (* pattern [\p{L}_$][\p{L}\p{Nd}_$]* *) str env v2 in
+  let ent = { name = v2; mods = v1; type_ = None } in
+  let v3 = block env v3 in
+  { m_var = ent; m_formals = []; m_throws = []; m_body = v3 }
 
 and class_body_decl env = function
   | `Record_decl x -> [ Class (record_declaration env x) ]
   | `Field_decl x -> field_declaration env x
   | `Meth_decl x -> [ Method (method_declaration env x) ]
+  | `Comp_cons_decl (v1, v2, v3) -> [ Method (comp_cons_decl env (v1, v2, v3)) ]
   | `Class_decl x -> [ Class (class_declaration env x) ]
   | `Inte_decl x -> [ Class (interface_declaration env x) ]
   | `Anno_type_decl x -> [ Class (annotation_type_declaration env x) ]
@@ -1617,6 +1685,7 @@ and interface_body (env : env) ((v1, v2, v3) : CST.interface_body) =
         | `Meth_decl x -> [ Method (method_declaration env x) ]
         | `Class_decl x -> [ Class (class_declaration env x) ]
         | `Inte_decl x -> [ Class (interface_declaration env x) ]
+        | `Record_decl x -> [ Class (record_declaration env x) ]
         | `Anno_type_decl x -> [ Class (annotation_type_declaration env x) ]
         | `SEMI tok -> [ EmptyDecl (token env tok) (* ";" *) ])
       v2

--- a/src/parsing/tests/Test_parsing.ml
+++ b/src/parsing/tests/Test_parsing.ml
@@ -143,7 +143,7 @@ let dump_tree_sitter_cst lang file =
       |> dump_and_print_errors Tree_sitter_ruby.Boilerplate.dump_tree
   | Lang.Java ->
       Tree_sitter_java.Parse.file file
-      |> dump_and_print_errors Tree_sitter_java.CST.dump_tree
+      |> dump_and_print_errors Tree_sitter_java.Boilerplate.dump_tree
   | Lang.Go ->
       Tree_sitter_go.Parse.file file
       |> dump_and_print_errors Tree_sitter_go.CST.dump_tree

--- a/stats/parsing-stats/lang/java/projects.txt
+++ b/stats/parsing-stats/lang/java/projects.txt
@@ -1,7 +1,6 @@
 #
 # Collection of public git repositories of java code.
 #
-https://github.com/elastic/elasticsearch
 https://github.com/spring-projects/spring-boot
 https://github.com/ReactiveX/RxJava
 https://github.com/google/guava
@@ -9,6 +8,12 @@ https://github.com/google/guava
 https://github.com/square/okhttp
 https://github.com/square/retrofit
 https://github.com/PhilJay/MPAndroidChart
+https://github.com/quarkusio/quarkus
+https://github.com/facebook/react-native
+https://github.com/apache/doris
+https://github.com/seata/seata
+https://github.com/alibaba/nacos
+https://github.com/apache/dubbo
 # project in "maintenance-mode"
 https://github.com/zxing/zxing
 # last update was 1 year ago, seems dead


### PR DESCRIPTION
## What:
This PR restores our GA parse rate for Java. It turns out that there was a very specific repo with a copy-pasted comment in several of their files, which broke our parser for whatever reason. I don't know why the parser couldn't handle it, but from looking at the files, they were mostly in `test`, which makes me less inclined to want to parse them.

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/49291449/227034192-edbc1e6e-476e-4f81-a8c6-1c9c8e2b32b5.png">

## Why:
GA parse rate!

## How:
Updated the Java parser and added some mapping code. Deleted the test case and added a few more repos. I would add enough repos that the denominator would be leveled out, but unfortunately because of the way that division works, this would be an impractically large amount of repositories.

## Test plan:
<img width="670" alt="image" src="https://user-images.githubusercontent.com/49291449/227014166-55a441a7-bd62-4ff1-be38-61b8ac312a93.png">

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
