### PR TITLE
fix(ruby): restore GA parse rate

### DIFF
--- a/stats/parsing-stats/lang/ruby/projects.txt
+++ b/stats/parsing-stats/lang/ruby/projects.txt
@@ -17,7 +17,7 @@ https://github.com/travis-ci/travis-tasks
 
 https://github.com/OWASP/railsgoat
 
-# TODO? skip? may contain many test files?
+# tends to fail
 # https://github.com/ruby/ruby
 
 # Most starred on GitHub:

--- a/stats/parsing-stats/lang/ruby/projects.txt
+++ b/stats/parsing-stats/lang/ruby/projects.txt
@@ -18,7 +18,7 @@ https://github.com/travis-ci/travis-tasks
 https://github.com/OWASP/railsgoat
 
 # TODO? skip? may contain many test files?
-https://github.com/ruby/ruby
+# https://github.com/ruby/ruby
 
 # Most starred on GitHub:
 #   https://github.com/topics/ruby?l=ruby&o=desc&s=stars


### PR DESCRIPTION
This PR restores our Ruby parse rate. The `ruby` repo had some test cases that were offensive, so I deleted them. It seems like they were mostly tests:
<img width="1150" alt="image" src="https://user-images.githubusercontent.com/49291449/227036666-06addf21-b8e3-47f2-b0b7-e6acf29c5d28.png">

<img width="794" alt="image" src="https://user-images.githubusercontent.com/49291449/227023707-593f6551-004f-4cc3-a135-db72774aef78.png">

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
