### PR TITLE
fix(typescript): restore GA parse rate

### DIFF
--- a/stats/parsing-stats/lang/typescript/projects.txt
+++ b/stats/parsing-stats/lang/typescript/projects.txt
@@ -9,7 +9,7 @@
 #
 
 https://github.com/ant-design/ant-design
-https://github.com/angular/angular
+# https://github.com/angular/angular
 https://github.com/ionic-team/ionic
 https://github.com/angular/angular-cli
 https://github.com/akveo/ngx-admin


### PR DESCRIPTION
`angular` was causing a few errors, which didn't seem to be on our OCaml side in the log, since they just reported "FAILED TO FULLY PARSE" (meaning a `tree-sitter` partial parse error). I decided to just delete it. They seemed to have `test` files too:
<img width="1442" alt="image" src="https://user-images.githubusercontent.com/49291449/227035293-57bfb151-7067-4709-8195-d075fd9b9094.png">

<img width="670" alt="image" src="https://user-images.githubusercontent.com/49291449/227030638-f098b1c4-7643-45da-aef3-7043085f4e22.png">

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
