### PR TITLE
Osemgrep: add calls to Parsing_init.init() too

### DIFF
--- a/src/core_cli/Core_CLI.ml
+++ b/src/core_cli/Core_CLI.ml
@@ -767,7 +767,7 @@ let main (sys_argv : string array) : unit =
   if config.lsp then LSP_client.init ();
   (* hacks to reduce the size of engine.js
    * coupling: if you add an init() call here, you probably need to modify
-   * also tests/Test.ml
+   * also tests/Test.ml and osemgrep/cli/CLI.ml
    *)
   Parsing_init.init ();
   Data_init.init ();

--- a/src/osemgrep/cli/CLI.ml
+++ b/src/osemgrep/cli/CLI.ml
@@ -245,6 +245,10 @@ let main argv : Exit_code.t =
      profile_start := Unix.gettimeofday ();
      if config.lsp then LSP_client.init ();
   *)
+  (* hacks for having a smaller engine.js file *)
+  Parsing_init.init ();
+  Data_init.init ();
+
   (* TOPORT:
       state.terminal.init_for_cli()
       abort_if_linux_arm64()


### PR DESCRIPTION
test plan:
osemgrep scan --config p/default --profile src/osemgrep/
works again (instead of showing lots of "parse_pattern_ref is unset" errors


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)