### PR TITLE
fix: remove old checkouts on non-hermetic runners

### DIFF
--- a/.github/workflows/build-test-osx-m1.yaml
+++ b/.github/workflows/build-test-osx-m1.yaml
@@ -9,6 +9,15 @@ jobs:
     name: Build the OSX M1 binaries
     runs-on: [self-hosted, macOS, ARM64]
     steps:
+      # Force hard cleanup of any old checkouts.
+      # This is needed when submodules move around, as they are no longer removed by the default clean: true of the checkout step below.
+      # This misses some files (like hidden files) but should take care of the issues we've been seeing.
+      # A more targeted approach we tried previously seems to have failed to clean up all issues
+      - name: Clean Checkout
+        run: |
+          rm -rf ./*
+          rm .gitmodules
+          rm -rf .git
       - name: Checkout
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/build-test-osx-x86.yaml
+++ b/.github/workflows/build-test-osx-x86.yaml
@@ -9,6 +9,15 @@ jobs:
     name: Build the OSX binaries
     runs-on: ["self-hosted", "macOS", "X64"]
     steps:
+      # Force hard cleanup of any old checkouts.
+      # This is needed when submodules move around, as they are no longer removed by the default clean: true of the checkout step below.
+      # This misses some files (like hidden files) but should take care of the issues we've been seeing.
+      # A more targeted approach we tried previously seems to have failed to clean up all issues
+      - name: Clean Checkout
+        run: |
+          rm -rf ./*
+          rm .gitmodules
+          rm -rf .git
       - name: Make checkout speedy
         run: git config --global fetch.parallel 50
       - uses: actions/checkout@v3


### PR DESCRIPTION
Leftover moved submodules were causing issues on non-hermetic runners.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
