### PR TITLE
Upgrade various dependencies

### DIFF
--- a/languages/json/generic/json_to_generic.ml
+++ b/languages/json/generic/json_to_generic.ml
@@ -24,7 +24,7 @@ let parse_json_string json =
   try
     Some
       (Yojson.Safe.read_string
-         (Yojson.init_lexer ~buf:(Bi_outbuf.create 128) ())
+         (Yojson.init_lexer ~buf:(Buffer.create 128) ())
          (Lexing.from_string json))
   with
   | Yojson.Json_error _ -> None

--- a/semgrep.opam
+++ b/semgrep.opam
@@ -41,7 +41,7 @@ depends: [
   "easy_logging_yojson" { = "0.8.1" }
   "logs"
   "atdgen"
-  "yojson"
+  "yojson" { >= "2.0.0" }
   "yaml"
   "cmdliner"
   "ppxlib"

--- a/src/experiments/misc/dune
+++ b/src/experiments/misc/dune
@@ -3,6 +3,7 @@
  (name semgrep_experiments_misc)
  (wrapped false)
  (libraries
+   camlp-streams
    commons
    lib_parsing
    pfff-lang_GENERIC-analyze


### PR DESCRIPTION
This unblocks the CI checks on MacOS.

Removing the dependency on comby triggers an upgrade to yojson2 and other libraries that depend on it.

Requires `make setup` for local development.

test plan: CI checks must succeed

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
