### PR TITLE
osemgrep: add mirage-crypto-rng-lwt to ignored log sources

### DIFF
--- a/libs/commons/Logs_helpers.ml
+++ b/libs/commons/Logs_helpers.ml
@@ -29,6 +29,7 @@ let setup_logging ~force_color ~level =
          | "ca-certs"
          | "bos"
          | "mirage-crypto-rng.lwt"
+         | "mirage-crypto-rng-lwt"
          | "mirage-crypto-rng.unix"
          | "handshake"
          | "tls.config"


### PR DESCRIPTION
PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)

Recently (with mirage-crypto 0.11 https://github.com/mirage/mirage-crypto/pull/168/commits/0b732b72b607bf4ea593a60fc7327094aaae61a2) the mirage-crypto-rng-lwt packages was introduced (to remove the `lwt` dependency from mirage-crypto-rng). In the same commit, the log source was renamed to match the ocamlfind name. This commit ignores the log source (keeping the old mirage-crypto-rng.lwt since not everybody is up to mirage-crypto 0.11 yet).