### PR TITLE
fix: pypi package names are case insensitive

### DIFF
--- a/cli/src/semdep/parsers/pipfile.py
+++ b/cli/src/semdep/parsers/pipfile.py
@@ -52,6 +52,13 @@ def parse_pipfile(
         manifest_path, manifest, preprocess=preprocessors.CommentRemover()
     )
 
+    # According to PEP 426: pypi distributions are case insensitive and consider hyphens and underscores to be equivalent
+    sanitized_manifest_deps = (
+        {dep.lower().replace("-", "_") for dep in manifest_deps}
+        if manifest_deps
+        else manifest_deps
+    )
+
     def extract_pipfile_hashes(
         hashes: List[str],
     ) -> Dict[str, List[str]]:
@@ -84,7 +91,9 @@ def parse_pipfile(
                 )
                 if "hashes" in fields
                 else {},
-                transitivity=transitivity(manifest_deps, [package]),
+                transitivity=transitivity(
+                    sanitized_manifest_deps, [package.lower().replace("-", "_")]
+                ),
                 line_number=dep_json.line_number,
             )
         )

--- a/cli/src/semdep/parsers/poetry.py
+++ b/cli/src/semdep/parsers/poetry.py
@@ -132,6 +132,14 @@ def parse_poetry(
     if not deps:
         return []
     manifest_deps = safe_path_parse(manifest_path, manifest)
+
+    # According to PEP 426: pypi distributions are case insensitive and consider hyphens and underscores to be equivalent
+    sanitized_manifest_deps = (
+        {dep.lower().replace("-", "_") for dep in manifest_deps}
+        if manifest_deps
+        else manifest_deps
+    )
+
     output = []
     for line_number, dep in deps:
         if "name" not in dep or "version" not in dep:
@@ -142,7 +150,9 @@ def parse_poetry(
                 version=dep["version"],
                 ecosystem=Ecosystem(Pypi()),
                 allowed_hashes={},
-                transitivity=transitivity(manifest_deps, [dep["name"]]),
+                transitivity=transitivity(
+                    sanitized_manifest_deps, [dep["name"].lower().replace("-", "_")]
+                ),
                 line_number=line_number,
             )
         )


### PR DESCRIPTION
We were mistagging packages as transitive dependencies because of the case sensitive matching we were using. This PR fixes python transitivity tagging (poetry and pipenv).

PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
