### PR TITLE
tests: add e2e tests for jsonnet

### DIFF
--- a/cli/tests/e2e/rules/jsonnet/example_rule.yaml
+++ b/cli/tests/e2e/rules/jsonnet/example_rule.yaml
@@ -1,0 +1,6 @@
+rules:
+  - id: example_rule
+    pattern: print("...")
+    message: Semgrep found a match
+    languages: [python]
+    severity: WARNING

--- a/cli/tests/e2e/rules/jsonnet/lib/template.libsonnet
+++ b/cli/tests/e2e/rules/jsonnet/lib/template.libsonnet
@@ -1,0 +1,8 @@
+{
+  local rule = self,
+  ruleid:: error 'Must override the rule id',
+  local severity = "ERROR",
+
+  id: rule.ruleid,
+  severity: severity,
+}

--- a/cli/tests/e2e/rules/jsonnet/part_of_rule.unknown_yaml_extension
+++ b/cli/tests/e2e/rules/jsonnet/part_of_rule.unknown_yaml_extension
@@ -1,0 +1,1 @@
+{ "languages": ["python"] }

--- a/cli/tests/e2e/rules/jsonnet/python/basic.jsonnet
+++ b/cli/tests/e2e/rules/jsonnet/python/basic.jsonnet
@@ -1,0 +1,11 @@
+local lib = import '../lib/template.libsonnet';
+local example = import '../example_rule.yaml';
+local partial = import '../part_of_rule.unknown_yaml_extension';
+{
+  'rules': [ lib {
+    ruleid: 'basic',
+    'message': example.rules[0].message,
+    'languages': partial.languages,
+    'pattern': '$X == $X'
+  } ]
+}

--- a/cli/tests/e2e/snapshots/test_check/test_basic_jsonnet_rule/results.json
+++ b/cli/tests/e2e/snapshots/test_check/test_basic_jsonnet_rule/results.json
@@ -1,0 +1,136 @@
+{
+  "errors": [],
+  "paths": {
+    "_comment": "<add --verbose for a list of skipped paths>",
+    "scanned": [
+      "targets/basic/inside.py",
+      "targets/basic/metavariable-comparison-bad-content.py",
+      "targets/basic/metavariable-comparison-base.py",
+      "targets/basic/metavariable-comparison-strip.py",
+      "targets/basic/metavariable-comparison.py",
+      "targets/basic/metavariable-regex-multi-regex.py",
+      "targets/basic/metavariable-regex-multi-rule.py",
+      "targets/basic/metavariable-regex.py",
+      "targets/basic/nosem.py",
+      "targets/basic/regex.py",
+      "targets/basic/stupid.py"
+    ]
+  },
+  "results": [
+    {
+      "check_id": "rules.jsonnet.python.basic",
+      "end": {
+        "col": 26,
+        "line": 3,
+        "offset": 69
+      },
+      "extra": {
+        "engine_kind": "OSS",
+        "fingerprint": "0x42",
+        "is_ignored": false,
+        "lines": "    return a + b == a + b",
+        "message": "Semgrep found a match",
+        "metadata": {},
+        "metavars": {
+          "$X": {
+            "abstract_content": "a+b",
+            "end": {
+              "col": 17,
+              "line": 3,
+              "offset": 60
+            },
+            "start": {
+              "col": 12,
+              "line": 3,
+              "offset": 55
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/basic/stupid.py",
+      "start": {
+        "col": 12,
+        "line": 3,
+        "offset": 55
+      }
+    },
+    {
+      "check_id": "rules.jsonnet.python.basic",
+      "end": {
+        "col": 11,
+        "line": 8,
+        "offset": 174
+      },
+      "extra": {
+        "engine_kind": "OSS",
+        "fingerprint": "0x42",
+        "is_ignored": false,
+        "lines": "    x == x",
+        "message": "Semgrep found a match",
+        "metadata": {},
+        "metavars": {
+          "$X": {
+            "abstract_content": "x",
+            "end": {
+              "col": 6,
+              "line": 8,
+              "offset": 169
+            },
+            "start": {
+              "col": 5,
+              "line": 8,
+              "offset": 168
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/basic/stupid.py",
+      "start": {
+        "col": 5,
+        "line": 8,
+        "offset": 168
+      }
+    },
+    {
+      "check_id": "rules.jsonnet.python.basic",
+      "end": {
+        "col": 18,
+        "line": 12,
+        "offset": 266
+      },
+      "extra": {
+        "engine_kind": "OSS",
+        "fingerprint": "0x42",
+        "is_ignored": false,
+        "lines": "assertTrue(x == x)",
+        "message": "Semgrep found a match",
+        "metadata": {},
+        "metavars": {
+          "$X": {
+            "abstract_content": "x",
+            "end": {
+              "col": 13,
+              "line": 12,
+              "offset": 261
+            },
+            "start": {
+              "col": 12,
+              "line": 12,
+              "offset": 260
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/basic/stupid.py",
+      "start": {
+        "col": 12,
+        "line": 12,
+        "offset": 260
+      }
+    }
+  ],
+  "version": "0.42"
+}

--- a/cli/tests/e2e/test_check.py
+++ b/cli/tests/e2e/test_check.py
@@ -54,6 +54,14 @@ def test_basic_rule__relative(run_semgrep_in_tmp: RunSemgrep, snapshot):
 
 
 @pytest.mark.kinda_slow
+def test_basic_jsonnet_rule(run_semgrep_in_tmp: RunSemgrep, snapshot):
+    snapshot.assert_match(
+        run_semgrep_in_tmp("rules/jsonnet/python/basic.jsonnet").stdout,
+        "results.json",
+    )
+
+
+@pytest.mark.kinda_slow
 def test_deduplication(run_semgrep_in_tmp: RunSemgrep, snapshot):
     """
     Check that semgrep runs a rule only once even when different in the metadata


### PR DESCRIPTION
Test plan: make test

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
