### PR TITLE
Move the extensions of Fpath to File.Path.

### DIFF
--- a/languages/c/menhir/test_parsing_c.ml
+++ b/languages/c/menhir/test_parsing_c.ml
@@ -8,7 +8,7 @@ module Stat = Parse_info
 let test_parse_c xs =
   Parse_cpp.init_defs !Flag_parsing_cpp.macros_h;
 
-  let xs = File.of_strings xs in
+  let xs = File.Path.of_strings xs in
   let fullxs = Lib_parsing_c.find_source_files_of_dir_or_files xs in
   let stat_list = ref [] in
 

--- a/languages/cpp/menhir/test_parsing_cpp.ml
+++ b/languages/cpp/menhir/test_parsing_cpp.ml
@@ -17,7 +17,7 @@ let test_tokens_cpp file =
   ()
 
 let test_parse_cpp ?lang xs =
-  let xs = File.of_strings xs in
+  let xs = File.Path.of_strings xs in
   let fullxs, _skipped_paths =
     Lib_parsing_cpp.find_source_files_of_dir_or_files xs
     |> Skip_code.filter_files_if_skip_list ~root:xs
@@ -124,7 +124,7 @@ let test_dump_cpp_view file =
   pr s
 
 let test_parse_cpp_fuzzy xs =
-  let xs = File.of_strings xs in
+  let xs = File.Path.of_strings xs in
   let fullxs, _skipped_paths =
     Lib_parsing_cpp.find_source_files_of_dir_or_files xs
     |> Skip_code.filter_files_if_skip_list ~root:xs

--- a/languages/cpp/menhir/unit_parsing_cpp.ml
+++ b/languages/cpp/menhir/unit_parsing_cpp.ml
@@ -39,7 +39,7 @@ let tests =
           let files =
             Common2.glob (spf "%s/*.cpp" dir) @ Common2.glob (spf "%s/*.h" dir)
           in
-          files |> File.of_strings
+          files |> File.Path.of_strings
           |> List.iter (fun file ->
                  try
                    let _ast = parse file in
@@ -51,7 +51,7 @@ let tests =
         fun () ->
           let dir = Filename.concat tests_path "cpp/parsing_errors" in
           let files = Common2.glob (spf "%s/*.cpp" dir) in
-          files |> File.of_strings
+          files |> File.Path.of_strings
           |> List.iter (fun file ->
                  try
                    let _ast = parse file in
@@ -70,7 +70,7 @@ let tests =
             Common2.glob (spf "%s/*.c" dir)
             (* @ Common2.glob (spf "%s/*.h" dir) *)
           in
-          files |> File.of_strings
+          files |> File.Path.of_strings
           |> List.iter (fun file ->
                  try
                    let _ast = parse file in

--- a/languages/go/menhir/test_parsing_go.ml
+++ b/languages/go/menhir/test_parsing_go.ml
@@ -24,7 +24,7 @@ let test_tokens_go file =
 let try_with_print_exn_and_reraise _a b = b ()
 
 let test_parse_go xs =
-  let xs = xs |> File.of_strings |> List.map File.fullpath in
+  let xs = xs |> File.Path.of_strings |> List.map File.fullpath in
 
   let fullxs, _skipped_paths =
     Lib_parsing_go.find_source_files_of_dir_or_files xs

--- a/languages/java/menhir/test_parsing_java.ml
+++ b/languages/java/menhir/test_parsing_java.ml
@@ -24,7 +24,7 @@ module Ast = Ast_java
 (*****************************************************************************)
 
 let test_parse xs =
-  let xs = xs |> File.of_strings |> List.map File.fullpath in
+  let xs = xs |> File.Path.of_strings |> List.map File.fullpath in
 
   let fullxs, _skipped_paths =
     Lib_parsing_java.find_source_files_of_dir_or_files xs

--- a/languages/javascript/menhir/test_parsing_js.ml
+++ b/languages/javascript/menhir/test_parsing_js.ml
@@ -76,7 +76,7 @@ let test_parse_common xs fullxs ext =
   ()
 
 let test_parse_js xs =
-  let xs = File.of_strings xs in
+  let xs = File.Path.of_strings xs in
   let fullxs =
     Lib_parsing_js.find_source_files_of_dir_or_files ~include_scripts:false xs
   in
@@ -85,7 +85,7 @@ let test_parse_js xs =
 module FT = File_type
 
 let test_parse_ts xs =
-  let xs = File.of_strings xs in
+  let xs = File.Path.of_strings xs in
   let fullxs =
     File.files_of_dirs_or_files_no_vcs_nofilter xs
     |> List.filter (fun filename ->
@@ -124,7 +124,7 @@ let info_to_json_range info =
       ] )
 
 let parse_js_r2c xs =
-  let xs = File.of_strings xs in
+  let xs = File.Path.of_strings xs in
   let fullxs =
     Lib_parsing_js.find_source_files_of_dir_or_files ~include_scripts:false xs
   in

--- a/languages/lisp/recursive_descent/test_parsing_lisp.ml
+++ b/languages/lisp/recursive_descent/test_parsing_lisp.ml
@@ -20,7 +20,7 @@ let test_tokens_lisp file =
   ()
 
 let test_parse_lisp xs =
-  let xs = File.of_strings xs in
+  let xs = File.Path.of_strings xs in
   let fullxs = Lib_parsing_lisp.find_source_files_of_dir_or_files xs in
   let stat_list = ref [] in
 

--- a/languages/ocaml/ast/lib_parsing_ml.ml
+++ b/languages/ocaml/ast/lib_parsing_ml.ml
@@ -64,7 +64,7 @@ let find_cmt_files_of_dir_or_files xs =
                   Common2.filename_of_dbe (d, b, "cmt")
               | [ "cmti" ] -> Common2.filename_of_dbe (d, b, "cmti")
               | _ -> raise Impossible))
-  |> File.of_strings |> Common.sort
+  |> File.Path.of_strings |> Common.sort
 
 (*****************************************************************************)
 (* Extract infos *)

--- a/languages/ocaml/menhir/test_parsing_ml.ml
+++ b/languages/ocaml/menhir/test_parsing_ml.ml
@@ -18,7 +18,7 @@ let test_tokens_ml file =
   ()
 
 let test_parse_ml_or_mli xs =
-  let xs = File.of_strings xs in
+  let xs = File.Path.of_strings xs in
   let xs = List.map File.fullpath xs in
 
   let fullxs, _skipped_paths =

--- a/languages/php/menhir/test_analyze_php.ml
+++ b/languages/php/menhir/test_analyze_php.ml
@@ -14,7 +14,7 @@ let try_with_print_exn_and_reraise _a b = b ()
 (*****************************************************************************)
 (* mostly a copy paste of Test_parsing_php.parse_php *)
 let test_parse_simple xs =
-  let xs = xs |> File.of_strings |> List.map File.fullpath in
+  let xs = xs |> File.Path.of_strings |> List.map File.fullpath in
   let fullxs, _skipped_paths =
     Lib_parsing_php.find_source_files_of_dir_or_files xs
     |> Skip_code.filter_files_if_skip_list ~root:xs

--- a/languages/php/menhir/test_parsing_php.ml
+++ b/languages/php/menhir/test_parsing_php.ml
@@ -21,7 +21,7 @@ let test_tokens_php file =
 (*e: test_tokens_php *)
 (*s: test_parse_php *)
 let test_parse_php xs =
-  let xs = File.of_strings xs in
+  let xs = File.Path.of_strings xs in
   let fullxs = Lib_parsing_php.find_source_files_of_dir_or_files xs in
 
   let fullxs, _skipped_paths =

--- a/languages/python/menhir/Test_parsing_python.ml
+++ b/languages/python/menhir/Test_parsing_python.ml
@@ -23,7 +23,7 @@ let test_tokens_python file =
   ()
 
 let test_parse_python_common parsing_mode xs =
-  let xs = File.of_strings xs in
+  let xs = File.Path.of_strings xs in
   let xs = List.map File.fullpath xs in
 
   let fullxs, _skipped_paths =

--- a/languages/ruby/dyp/test_analyze_ruby.ml
+++ b/languages/ruby/dyp/test_analyze_ruby.ml
@@ -9,7 +9,7 @@ module PS = Parsing_stat
 (*****************************************************************************)
 
 let test_parse xs =
-  let xs = List.map Common.fullpath xs |> File.of_strings in
+  let xs = List.map Common.fullpath xs |> File.Path.of_strings in
 
   let fullxs, _skipped_paths =
     Lib_parsing_ruby.find_source_files_of_dir_or_files xs

--- a/languages/ruby/dyp/test_parsing_ruby.ml
+++ b/languages/ruby/dyp/test_parsing_ruby.ml
@@ -38,7 +38,7 @@ let test_tokens file =
   ()
 
 let test_parse xs =
-  let xs = xs |> File.of_strings |> List.map File.fullpath in
+  let xs = xs |> File.Path.of_strings |> List.map File.fullpath in
 
   let fullxs, _skipped_paths =
     Lib_parsing_ruby.find_source_files_of_dir_or_files xs

--- a/languages/scala/recursive_descent/Test_parsing_scala.ml
+++ b/languages/scala/recursive_descent/Test_parsing_scala.ml
@@ -20,7 +20,7 @@ let test_tokens file =
   ()
 
 let test_parse xs =
-  let xs = xs |> File.of_strings |> List.map File.fullpath in
+  let xs = xs |> File.Path.of_strings |> List.map File.fullpath in
 
   let fullxs, _skipped_paths =
     Parse_scala.find_source_files_of_dir_or_files xs

--- a/libs/commons/File.ml
+++ b/libs/commons/File.ml
@@ -5,21 +5,28 @@
    to get rid of the interface exposed by Common.
 *)
 
+module Path = struct
+  include Fpath
+
+  let of_strings strings = Common.map Fpath.v strings
+  let to_strings paths = Common.map Fpath.to_string paths
+  let ( !! ) = Fpath.to_string
+end
+
 module Operators = struct
   let ( / ) = Fpath.( / )
   let ( // ) = Fpath.( // )
-  let ( !! ) = Fpath.to_string
+  let ( !! ) = Path.( !! )
 end
 
 open Operators
 
-let of_strings strings = Common.map Fpath.v strings
-let to_strings paths = Common.map Fpath.to_string paths
 let fullpath file = Common.fullpath !!file |> Fpath.v
 let readable ~root path = Common.readable ~root:!!root !!path |> Fpath.v
 
 let files_of_dirs_or_files_no_vcs_nofilter xs =
-  xs |> to_strings |> Common.files_of_dir_or_files_no_vcs_nofilter |> of_strings
+  xs |> Path.to_strings |> Common.files_of_dir_or_files_no_vcs_nofilter
+  |> Path.of_strings
 
 let input_text_line = Common.input_text_line
 let cat path = Common.cat !!path

--- a/libs/commons/File.mli
+++ b/libs/commons/File.mli
@@ -8,7 +8,45 @@
              and stop using 'string' for file paths.
 *)
 
-(* Usage:
+(*
+   Extended version of Fpath.
+
+   Provides operations on file system paths only, without any access
+   to the file system.
+*)
+module Path : sig
+  include Fpath
+
+  (*
+    Extra utilities to convert between lists of files between
+    string and Fpath.t without having to write
+    'Common.map Fpath.v ...' every time.
+
+    For converting a single path, use Fpath.v and Fpath.to_string directly.
+
+    of_strings, like Fpath.v which it uses, will raise an exception
+    in case of a malformed path such as "" or "foo\000bar".
+
+    Performance notes:
+    - these operations involve creating a new list.
+    - converting a path to a string is assumed to be cheap since Fpath.t
+      internally is a string.
+    - converting a string to a path involves validating the path syntax,
+      which is more expensive.
+   *)
+  val of_strings : string list -> Fpath.t list
+  val to_strings : Fpath.t list -> string list
+
+  (* Fpath.to_string. Like for the other operators, we recommend using it
+     with 'open File.Operators'. *)
+  val ( !! ) : Fpath.t -> string
+end
+
+(*
+   Operators on files or file paths or anything related to files.
+   This is module is meant to be opened:
+
+   Usage:
 
      open File.Operators
 *)
@@ -19,29 +57,9 @@ module Operators : sig
   (* Fpath.append = Fpath.(//) *)
   val ( // ) : Fpath.t -> Fpath.t -> Fpath.t
 
-  (* Fpath.to_string *)
+  (* File.Path.(!!) = Fpath.to_string *)
   val ( !! ) : Fpath.t -> string
 end
-
-(*
-   Extra utilities to convert between lists of files between
-   string and Fpath.t without having to write
-   'Common.map Fpath.v ...' every time.
-
-   For converting a single path, use Fpath.v and Fpath.to_string directly.
-
-   of_strings, like Fpath.v which it uses, will raise an exception
-   in case of a malformed path such as "" or "foo\000bar".
-
-   Performance notes:
-   - these operations involve creating a new list.
-   - converting a path to a string is assumed to be cheap since Fpath.t
-     internally is a string.
-   - converting a string to a path involves validating the path syntax,
-     which is more expensive.
-*)
-val of_strings : string list -> Fpath.t list
-val to_strings : Fpath.t list -> string list
 
 (* for realpath, use Unix.realpath in ocaml >= 4.13 *)
 (*

--- a/libs/commons/File.mli
+++ b/libs/commons/File.mli
@@ -15,7 +15,7 @@
    to the file system.
 *)
 module Path : sig
-  include Fpath
+  include module type of Fpath
 
   (*
     Extra utilities to convert between lists of files between

--- a/libs/commons/Testutil_files.ml
+++ b/libs/commons/Testutil_files.ml
@@ -209,6 +209,6 @@ let () =
           let tree2 = read root in
           assert (sort tree2 = sort tree);
 
-          let paths = flatten tree |> File.to_strings in
+          let paths = flatten tree |> File.Path.to_strings in
           List.iter print_endline paths;
           assert (paths = [ "a"; "b"; "c"; "d/e" ])))

--- a/libs/commons/common2.mli
+++ b/libs/commons/common2.mli
@@ -765,6 +765,11 @@ val compile_regexp_union : regexp list -> Str.regexp
 (*****************************************************************************)
 (* Filenames *)
 (*****************************************************************************)
+(* TODO: migrate pure path operations to File.Path which is Fpath +
+   extensions.
+   TODO: migrate other file operations to the File module.
+   TODO: alternatively, use the bos library; this would be a bigger migration.
+*)
 
 (* now at beginning of this file: type filename = string *)
 val dirname : string -> string
@@ -946,6 +951,10 @@ val indent_string : int -> string -> string
 (*****************************************************************************)
 (* Process/Files *)
 (*****************************************************************************)
+(*
+   TODO: migrate file operations to the File module.
+   TODO: alternatively, use the bos library; this would be a bigger migration.
+*)
 val cat : filename -> string list
 val cat_orig : filename -> string list
 val cat_array : filename -> string array

--- a/libs/lib_parsing/Parsing_stat.ml
+++ b/libs/lib_parsing/Parsing_stat.ml
@@ -186,7 +186,7 @@ let print_parsing_stat_list ?(verbose = false) statxs =
 (*****************************************************************************)
 
 let print_regression_information ~ext xs newscore =
-  let xs = File.to_strings xs in
+  let xs = File.Path.to_strings xs in
   let dirname_opt =
     match xs with
     | [ x ] when Common2.is_directory x -> Some (Common.fullpath x)

--- a/libs/lib_parsing/Skip_code.ml
+++ b/libs/lib_parsing/Skip_code.ml
@@ -129,7 +129,7 @@ let find_skip_file_from_root root =
       (* www specific *)
       "conf/codegraph/skip_list.txt";
     ]
-    |> File.of_strings
+    |> File.Path.of_strings
   in
   candidates
   |> Common.find_some_opt (fun f ->

--- a/src/analyzing/tests/Unit_dataflow.ml
+++ b/src/analyzing/tests/Unit_dataflow.ml
@@ -18,7 +18,7 @@ let tests parse_program =
         fun () ->
           let dir = Filename.concat tests_path "dataflow/python" in
           let files = Common2.glob (spf "%s/*.py" dir) in
-          files |> File.of_strings
+          files |> File.Path.of_strings
           |> List.iter (fun file ->
                  let ast = parse_program !!file in
                  let lang = List.hd (Lang.langs_of_filename file) in

--- a/src/core_cli/Core_CLI.ml
+++ b/src/core_cli/Core_CLI.ml
@@ -794,7 +794,7 @@ let main (sys_argv : string array) : unit =
              tune these parameters in the future/do more testing, but
              for now just turn it off *)
           (* if !Flag.gc_tuning && config.max_memory_mb = 0 then set_gc (); *)
-          let config = { config with roots = File.of_strings roots } in
+          let config = { config with roots = File.Path.of_strings roots } in
           Run_semgrep.semgrep_dispatch config)
 
 (*****************************************************************************)

--- a/src/engine/Test_engine.ml
+++ b/src/engine/Test_engine.ml
@@ -306,7 +306,7 @@ let make_tests ?(unit_testing = false) ?(get_xlang = None) xs =
   (tests, print_summary)
 
 let test_rules ?unit_testing xs =
-  let paths = File.of_strings xs in
+  let paths = File.Path.of_strings xs in
   let tests, print_summary = make_tests ?unit_testing paths in
   tests |> List.iter (fun (_name, test) -> test ());
   print_summary ()

--- a/src/engine/Unit_engine.ml
+++ b/src/engine/Unit_engine.ml
@@ -370,7 +370,9 @@ let pack_regression_tests_for_lang ~test_pattern_path ~polyglot_pattern_path
   pack_tests
     (spf "semgrep %s" (Lang.show lang))
     (let dir = test_pattern_path / dir in
-     let files = Common2.glob (spf "%s/*%s" !!dir ext) |> File.of_strings in
+     let files =
+       Common2.glob (spf "%s/*%s" !!dir ext) |> File.Path.of_strings
+     in
      regression_tests_for_lang ~polyglot_pattern_path ~with_caching files lang)
 
 let pack_regression_tests ~with_caching lang_tests =
@@ -438,14 +440,16 @@ let lang_regression_tests ~polyglot_pattern_path ~with_caching =
            let files = Common2.glob (spf "%s/*.js" !!dir) in
            let files =
              Common.exclude (fun s -> s =~ ".*xml" || s =~ ".*jsx") files
-             |> File.of_strings
+             |> File.Path.of_strings
            in
            let lang = Lang.Ts in
            regression_tests_for_lang ~polyglot_pattern_path ~with_caching files
              lang);
         pack_tests "semgrep C++ on C tests"
           (let dir = test_pattern_path / "c" in
-           let files = Common2.glob (spf "%s/*.c" !!dir) |> File.of_strings in
+           let files =
+             Common2.glob (spf "%s/*.c" !!dir) |> File.Path.of_strings
+           in
            let lang = Lang.Cpp in
            regression_tests_for_lang ~polyglot_pattern_path ~with_caching files
              lang);
@@ -519,7 +523,7 @@ let filter_irrelevant_rules_tests () =
     (let dir = tests_path / "irrelevant_rules" in
      let target_files =
        Common2.glob (spf "%s/*" !!dir)
-       |> File.of_strings
+       |> File.Path.of_strings
        |> File_type.files_of_dirs_or_files (function
             | File_type.Config File_type.Yaml -> false
             | _ -> true (* TODO include .test.yaml*))
@@ -649,37 +653,51 @@ let lang_tainting_tests () =
     [
       pack_tests "tainting Go"
         (let dir = taint_tests_path / "go" in
-         let files = Common2.glob (spf "%s/*.go" !!dir) |> File.of_strings in
+         let files =
+           Common2.glob (spf "%s/*.go" !!dir) |> File.Path.of_strings
+         in
          let lang = Lang.Go in
          tainting_tests_for_lang files lang);
       pack_tests "tainting PHP"
         (let dir = taint_tests_path / "php" in
-         let files = Common2.glob (spf "%s/*.php" !!dir) |> File.of_strings in
+         let files =
+           Common2.glob (spf "%s/*.php" !!dir) |> File.Path.of_strings
+         in
          let lang = Lang.Php in
          tainting_tests_for_lang files lang);
       pack_tests "tainting Python"
         (let dir = taint_tests_path / "python" in
-         let files = Common2.glob (spf "%s/*.py" !!dir) |> File.of_strings in
+         let files =
+           Common2.glob (spf "%s/*.py" !!dir) |> File.Path.of_strings
+         in
          let lang = Lang.Python in
          tainting_tests_for_lang files lang);
       pack_tests "tainting Java"
         (let dir = taint_tests_path / "java" in
-         let files = Common2.glob (spf "%s/*.java" !!dir) |> File.of_strings in
+         let files =
+           Common2.glob (spf "%s/*.java" !!dir) |> File.Path.of_strings
+         in
          let lang = Lang.Java in
          tainting_tests_for_lang files lang);
       pack_tests "tainting Javascript"
         (let dir = taint_tests_path / "js" in
-         let files = Common2.glob (spf "%s/*.js" !!dir) |> File.of_strings in
+         let files =
+           Common2.glob (spf "%s/*.js" !!dir) |> File.Path.of_strings
+         in
          let lang = Lang.Js in
          tainting_tests_for_lang files lang);
       pack_tests "tainting Typescript"
         (let dir = taint_tests_path / "ts" in
-         let files = Common2.glob (spf "%s/*.ts" !!dir) |> File.of_strings in
+         let files =
+           Common2.glob (spf "%s/*.ts" !!dir) |> File.Path.of_strings
+         in
          let lang = Lang.Ts in
          tainting_tests_for_lang files lang);
       pack_tests "tainting Scala"
         (let dir = taint_tests_path / "scala" in
-         let files = Common2.glob (spf "%s/*.scala" !!dir) |> File.of_strings in
+         let files =
+           Common2.glob (spf "%s/*.scala" !!dir) |> File.Path.of_strings
+         in
          let lang = Lang.Scala in
          tainting_tests_for_lang files lang);
     ]

--- a/src/naming/Unit_naming_generic.ml
+++ b/src/naming/Unit_naming_generic.ml
@@ -23,7 +23,7 @@ let tests parse_program =
           let files4 = Common2.glob (spf "%s/*.java" dir) in
 
           files1 @ files2 @ files3 @ files4
-          |> File.of_strings
+          |> File.Path.of_strings
           |> List.iter (fun file ->
                  try
                    (* at least we can assert we don't thrown an exn or go

--- a/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -564,7 +564,7 @@ let o_target_roots : string list Term.t =
       ~doc:{|Files or folders to be scanned by semgrep.|}
   in
   Arg.value
-    (Arg.pos_all Arg.string (default.target_roots |> File.to_strings) info)
+    (Arg.pos_all Arg.string (default.target_roots |> File.Path.to_strings) info)
 
 (* ------------------------------------------------------------------ *)
 (* !!NEW arguments!! not in pysemgrep *)
@@ -598,7 +598,7 @@ let cmdline_term : conf Term.t =
       | [] -> None
       | nonempty -> Some nonempty
     in
-    let target_roots = target_roots |> File.of_strings in
+    let target_roots = target_roots |> File.Path.of_strings in
     let logging_level =
       match (verbose, debug, quiet) with
       | false, false, false -> Some Logs.Warning

--- a/src/parsing/Unit_parsing.ml
+++ b/src/parsing/Unit_parsing.ml
@@ -104,7 +104,7 @@ let parsing_error_tests () =
   let dir = tests_path / "parsing_errors" in
   pack_tests "Parsing error detection"
     (let tests = Common2.glob (spf "%s/*" !!dir) in
-     tests |> File.of_strings
+     tests |> File.Path.of_strings
      |> Common.map (fun file ->
             ( Fpath.basename file,
               fun () ->
@@ -130,7 +130,7 @@ let parsing_rules_tests () =
         * CI: Common2.glob (spf "%s/*.jsonnet" dir)
         *)
      in
-     tests |> File.of_strings
+     tests |> File.Path.of_strings
      |> Common.map (fun file ->
             (Fpath.basename file, fun () -> Parse_rule.parse file |> ignore)))
 

--- a/src/parsing/tests/Test_parsing.ml
+++ b/src/parsing/tests/Test_parsing.ml
@@ -214,12 +214,12 @@ let dump_tree_sitter_cst lang file =
   | _ -> failwith "lang not supported by ocaml-tree-sitter"
 
 let test_parse_tree_sitter lang root_paths =
-  let paths = Common.map Common.fullpath root_paths |> File.of_strings in
+  let paths = Common.map Common.fullpath root_paths |> File.Path.of_strings in
   let paths, _skipped_paths =
     Find_target.files_of_dirs_or_files (Some lang) paths
   in
   let stat_list = ref [] in
-  paths |> File.to_strings
+  paths |> File.Path.to_strings
   |> Console.progress (fun k ->
          List.iter (fun file ->
              k ();
@@ -331,11 +331,11 @@ let parsing_common ?(verbose = true) lang files_or_dirs =
 
   let paths =
     (* = absolute paths *)
-    Common.map Common.fullpath files_or_dirs |> File.of_strings
+    Common.map Common.fullpath files_or_dirs |> File.Path.of_strings
   in
   let paths, skipped = Find_target.files_of_dirs_or_files (Some lang) paths in
   let stats =
-    paths |> File.to_strings
+    paths |> File.Path.to_strings
     |> List.rev_map (fun file ->
            pr2
              (spf "%05.1fs: [%s] processing %s" (Sys.time ())
@@ -542,7 +542,7 @@ let diff_pfff_tree_sitter xs =
 (*****************************************************************************)
 
 let test_parse_rules roots =
-  let roots = File.of_strings roots in
+  let roots = File.Path.of_strings roots in
   let targets, _skipped_paths =
     Find_target.files_of_dirs_or_files (Some Lang.Yaml) roots
   in

--- a/src/targeting/Find_target.ml
+++ b/src/targeting/Find_target.ml
@@ -402,8 +402,8 @@ let files_of_dirs_or_files ?(keep_root_files = true)
     else (roots, [])
   in
   let paths =
-    paths |> File.to_strings |> Common.files_of_dir_or_files_no_vcs_nofilter
-    |> File.of_strings
+    paths |> File.Path.to_strings
+    |> Common.files_of_dir_or_files_no_vcs_nofilter |> File.Path.of_strings
   in
   let paths, skipped = global_filter ~opt_lang ~sort_by_decr_size paths in
   let paths = explicit_targets @ paths in

--- a/src/targeting/Git.ml
+++ b/src/targeting/Git.ml
@@ -58,4 +58,5 @@ let files_from_git_ls ~cwd =
   (* TODO: use Unix.chdir in forked process instead of Common.cmd_to_list
    * and also redirect stderr to null
    *)
-  Common.cmd_to_list (spf "cd '%s' && git ls-files" cwd_s) |> File.of_strings
+  Common.cmd_to_list (spf "cd '%s' && git ls-files" cwd_s)
+  |> File.Path.of_strings


### PR DESCRIPTION
File.to_strings becomes File.Path.to_strings which clearer, addressing https://github.com/returntocorp/semgrep/pull/7274#discussion_r1141828054

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
