### PR TITLE
Copy osemgrep to where semgrep expects it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,14 +89,49 @@ core:
 	# make executables easily accessible for manual testing:
 	test -e bin || ln -s _build/install/default/bin .
 
+# Make binaries available to 'semgrep', the Python wrapper.
+#
+# TODO: find out and explain why we can't use symlinks
+# (symlink-core-for-cli) which is faster, clearer, and less wasteful
+# than full copies. It may have something to do with how we do Python
+# or Homebrew packaging.
 .PHONY: copy-core-for-cli
 copy-core-for-cli:
+	# Executables
 	rm -f cli/src/semgrep/bin/semgrep-core
 	cp _build/install/default/bin/semgrep-core cli/src/semgrep/bin/
+	rm -f cli/src/semgrep/bin/osemgrep
+	cp _build/install/default/bin/osemgrep cli/src/semgrep/bin/
+	# Libraries
 	rm -f cli/src/semgrep/bin/semgrep_bridge_core.so
-	cp _build/install/default/bin/semgrep_bridge_core.so cli/src/semgrep/bin/
+	cp _build/install/default/bin/semgrep_bridge_core.so \
+	  cli/src/semgrep/bin/
 	rm -f cli/src/semgrep/bin/semgrep_bridge_python.so
-	cp _build/install/default/bin/semgrep_bridge_python.so cli/src/semgrep/bin/
+	cp _build/install/default/bin/semgrep_bridge_python.so \
+	  cli/src/semgrep/bin/
+
+# Same as copy-core-for-cli but faster. This is suitable for local testing
+# of semgrep.
+#
+# Creating symlinks is much faster than making full copies with cp
+# (< 100 ms vs. 500 ms), which is significant during development.
+#
+.PHONY: symlink-core-for-cli
+symlink-core-for-cli:
+	# Executables
+	rm -f cli/src/semgrep/bin/semgrep-core
+	ln -s ../../../../bin/semgrep-core \
+	  cli/src/semgrep/bin/semgrep-core
+	rm -f cli/src/semgrep/bin/osemgrep
+	ln -s ../../../../bin/osemgrep \
+	  cli/src/semgrep/bin/osemgrep
+	# Libraries
+	rm -f cli/src/semgrep/bin/semgrep_bridge_core.so
+	ln -s ../../../../bin/semgrep_bridge_core.so \
+	  cli/src/semgrep/bin/semgrep_bridge_core.so
+	rm -f cli/src/semgrep/bin/semgrep_bridge_python.so
+	ln -s ../../../../bin/semgrep_bridge_python.so \
+	  cli/src/semgrep/bin/semgrep_bridge_python.so
 
 # Minimal build of the semgrep-core executable. Intended for the docker build.
 # Requires the environment variables set by the included file above.
@@ -158,6 +193,11 @@ uninstall:
 # as part of the semgrep project.
 .PHONY: core-install
 core-install: copy-core-for-cli
+	# The executable created by dune doesn't have the write permission,
+	# causing an error when running a straight cp if a file is already
+	# there.
+	# Known alternative: use 'install -m 0644 ...' instead of cp
+	$(MAKE) uninstall
 	cp bin/semgrep-core "$$(opam var bin)"/
 
 # Try to uninstall what was installed by 'make core-install'.
@@ -443,18 +483,7 @@ check_for_emacs:
 .PHONY: dev
 dev:
 	$(MAKE) core
-	rm -f cli/src/semgrep/bin/semgrep-core
-	ln -s ../../../../bin/semgrep-core \
-	  cli/src/semgrep/bin/semgrep-core
-	rm -f cli/src/semgrep/bin/osemgrep
-	ln -s ../../../../bin/osemgrep \
-	  cli/src/semgrep/bin/osemgrep
-	rm -f cli/src/semgrep/bin/semgrep_bridge_core.so
-	ln -s ../../../../bin/semgrep_bridge_core.so \
-	  cli/src/semgrep/bin/semgrep_bridge_core.so
-	rm -f cli/src/semgrep/bin/semgrep_bridge_python.so
-	ln -s ../../../../bin/semgrep_bridge_python.so \
-	  cli/src/semgrep/bin/semgrep_bridge_python.so
+	$(MAKE) symlink-core-for-cli
 
 ###############################################################################
 # Pad's targets


### PR DESCRIPTION
osemgrep was not being copied like semgrep-core was. This became a problem since `make build` no longer installs the executables to a folder in PATH. It wasn't a problem for me because I use `make dev`.

test plan: CI + hopefully no breakage at release time. There are questions surrounding `cp` vs. `ln -s` which why I preserved the legacy behavior of using cp.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
