### PR TITLE
interfaces/semgrep_metrics: add maxMemoryBytes and engineRequestted

### DIFF
--- a/interfaces/semgrep_metrics.atd
+++ b/interfaces/semgrep_metrics.atd
@@ -67,6 +67,7 @@ type performance = {
     fileStats: file_stats list;
     ruleStats: rule_stats list;
     profilingTimes: (string * float) list;
+    maxMemoryBytes: int option;
   }
 
 type file_stats = {
@@ -118,6 +119,7 @@ type value = {
     numFinding: int;
     numIgnored: int;
     ruleHashesWithFindings: (string * int) list;
+    engineRequested: string;
   }
 
 type value_required = {

--- a/src/osemgrep/core/Metrics_.ml
+++ b/src/osemgrep/core/Metrics_.ml
@@ -69,6 +69,7 @@ let default_payload =
         fileStats = [];
         ruleStats = [];
         profilingTimes = [];
+        maxMemoryBytes = None;
       };
     errors = { returnCode = None; errors = [] };
     value =
@@ -77,6 +78,7 @@ let default_payload =
         numFinding = 0;
         numIgnored = 0;
         ruleHashesWithFindings = [];
+        engineRequested = "OSS";
       };
     fix_rate = { lowerLimits = []; upperLimits = [] };
     parse_rate = [];


### PR DESCRIPTION
osemgrep Metrics_: adapt to interface changes

The two fields were added in metrics.py with 640ea0e77f and 83b7ddcac1

This brings the ATD in sync with metrics.py

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
