### PR TITLE
bugfix: fix bug with -raja on List.hd exn

### DIFF
--- a/src/experiments/misc/Raja_experiment.ml
+++ b/src/experiments/misc/Raja_experiment.ml
@@ -35,11 +35,17 @@ let ranges_of_path (path : Fpath.t) : Function_range.ranges =
   match Hashtbl.find_opt cache path with
   | Some x -> x
   | None ->
-      (* alt: could use just_parse_with_lang and get the lang
-       * from the languages: field in the rule corresponding to
-       * the rule_id of the match
-       *)
-      let ast = Parse_target.parse_program (Fpath.to_string path) in
+      let ast =
+        (* parse_program may raise the "hd" exn when we can't infer
+         * the language from the filename.
+         * alt: we could use just_parse_with_lang and get the language
+         * from the languages: field in the rule corresponding to
+         * the rule_id of the match. That would require to pass
+         * more info to ranges_of_path() though.
+         *)
+        try Parse_target.parse_program (Fpath.to_string path) with
+        | Failure "hd" -> []
+      in
       let ranges = Function_range.ranges ast in
       Hashtbl.add cache path ranges;
       ranges

--- a/src/experiments/misc/Raja_experiment.ml
+++ b/src/experiments/misc/Raja_experiment.ml
@@ -36,9 +36,9 @@ let ranges_of_path (path : Fpath.t) : Function_range.ranges =
   | Some x -> x
   | None ->
       let ast =
-        (* parse_program may raise the "hd" exn when we can't infer
+        (* ugly: parse_program may raise the "hd" exn when we can't infer
          * the language from the filename.
-         * alt: we could use just_parse_with_lang and get the language
+         * TODO: we should use just_parse_with_lang and get the language
          * from the languages: field in the rule corresponding to
          * the rule_id of the match. That would require to pass
          * more info to ranges_of_path() though.


### PR DESCRIPTION
test plan:
in juice-shop directory:
semgrep --config p/default --core-opts="-raja"
does not thrown an error anymore.


PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)