### PR TITLE
Implementation of nosemgrep tag in OCaml

### DIFF
--- a/libs/commons/File.ml
+++ b/libs/commons/File.ml
@@ -39,3 +39,12 @@ let erase_temp_files = Common.erase_temp_files
 let erase_this_temp_file path = Common.erase_this_temp_file !!path
 let is_executable path = Common2.is_executable !!path
 let filesize path = Common2.filesize !!path
+
+(* TODO? slow, and maybe we should cache it to avoid rereading
+ * each time the same file for each match.
+ * Note that the returned lines do not contain \n.
+ *)
+let lines_of_file (start_line, end_line) file : string list =
+  let arr = Common2.cat_array file in
+  let lines = Common2.enum start_line end_line in
+  lines |> Common.map (fun i -> arr.(i))

--- a/libs/commons/File.mli
+++ b/libs/commons/File.mli
@@ -126,3 +126,12 @@ val erase_this_temp_file : Fpath.t -> unit
 (*****************************************************************************)
 val is_executable : Fpath.t -> bool
 val filesize : Fpath.t -> int
+
+(* [lines_of_file (start_line, end_line) file] returns
+ * the list of lines from start_line to end_line included.
+ *
+ * Note that the returned lines do not contain \n.
+ *
+ * This function is slow, you should not use it!
+ *)
+val lines_of_file : int * int -> Common.filename -> string list

--- a/src/osemgrep/cli_scan/Cli_json_output.ml
+++ b/src/osemgrep/cli_scan/Cli_json_output.ml
@@ -64,7 +64,7 @@ type metavars = (string * Out.metavar_value) list
 let lines_of_file (range : Out.position * Out.position) (file : filename) :
     string list =
   let start, end_ = range in
-  Matching_report.lines_of_file (start.line, end_.line) file
+  File.lines_of_file (start.line, end_.line) file
   [@@profiling]
 
 (* Returns the text between the positions; start inclusive, end exclusive.

--- a/src/osemgrep/cli_scan/Output.ml
+++ b/src/osemgrep/cli_scan/Output.ml
@@ -159,7 +159,9 @@ let output_result (conf : Scan_CLI.conf) (res : Core_runner.result) : unit =
       ~rules_source:conf.rules_source res
   in
   (* TODO: pass the -strict? other flags? *)
-  let cli_output = Nosem.process_ignores cli_output in
+  let cli_output =
+    Nosem.process_ignores ~strict:conf.Scan_CLI.strict cli_output
+  in
   (* ugly: but see the comment above why we do it here *)
   if conf.autofix then apply_fixes_and_warn conf cli_output;
   dispatch_output_format conf.output_format cli_output;

--- a/src/osemgrep/reporting/Nosem.ml
+++ b/src/osemgrep/reporting/Nosem.ml
@@ -35,7 +35,7 @@ let rule_id_re_str = {|(?:[:=][\s]?(?P<ids>([^,\s](?:[,\s]+)?)+))?|}
    * nosem and nosemgrep should be interchangeable
 *)
 let nosem_inline_re_str = {| nosem(?:grep)?|} ^ rule_id_re_str
-let _nosem_inline_re = SPcre.regexp nosem_inline_re_str ~flags:[ `CASELESS ]
+let nosem_inline_re = SPcre.regexp nosem_inline_re_str ~flags:[ `CASELESS ]
 
 (*
    As a hack adapted from semgrep-agent,
@@ -43,6 +43,7 @@ let _nosem_inline_re = SPcre.regexp nosem_inline_re_str ~flags:[ `CASELESS ]
 *)
 let _nosem_inline_comment_re =
   SPcre.regexp (spf {|[:#/]+%s$|} nosem_inline_re_str) ~flags:[ `CASELESS ]
+(* XXX(dinosaure): seems unused by the last version of `cli/` *)
 
 (*
    A nosemgrep comment alone on its line.
@@ -56,7 +57,7 @@ let _nosem_inline_comment_re =
      # nosemgrep
      print('nosemgrep');
 *)
-let _nosem_previous_line_re =
+let nosem_previous_line_re =
   SPcre.regexp
     ({|^[^a-zA-Z0-9]* nosem(?:grep)?|} ^ rule_id_re_str)
     ~flags:[ `CASELESS ]
@@ -69,11 +70,96 @@ let _nosem_previous_line_re =
 (* Entry point *)
 (*****************************************************************************)
 
-(* TODO: probably need to pass some flags from the CLI *)
-let process_ignores (out : Out.cli_output) : Out.cli_output =
-  (* TODO: port nosemgrep.py, filter in out.matches the
-     matches where the match has a corresponding nosem: annotation in
-     the corresponding file, and add new errors if nosem: has the wrong
-     format in the file.
-  *)
-  out
+let rule_match_nosem ~strict (rule_match : Out.cli_match) :
+    bool * Out.cli_error list =
+  let lines =
+    File.lines_of_file
+      (max 0 (rule_match.Out.start.line - 1), rule_match.Out.end_.line)
+      rule_match.Out.path
+  in
+
+  let previous_line, line =
+    match lines with
+    | line0 :: line1 :: _ when rule_match.Out.start.line > 0 ->
+        (Some line0, Some line1)
+    | line :: _ -> (None, Some line)
+    | [] (* XXX(dinosaure): is it possible? *) -> (None, None)
+  in
+
+  let recognise_and_collect ~rex line =
+    Result.map
+      (Array.map (fun subst ->
+           try Some (Pcre.get_named_substring rex "ids" subst) with
+           | _ -> None))
+      (SPcre.exec_all ~rex line)
+    |> Result.to_option
+  in
+
+  let no_ids = Array.for_all Option.is_none in
+
+  let ids_line, ids_previous_line =
+    ( Option.bind line (recognise_and_collect ~rex:nosem_inline_re),
+      Option.bind previous_line
+        (recognise_and_collect ~rex:nosem_previous_line_re) )
+  in
+
+  match (ids_line, ids_previous_line) with
+  | None, None
+  | Some [||], Some [||] ->
+      (* no lines or no [nosemgrep] occurrences found, keep the [rule_match]. *)
+      (false, [])
+  | Some ids_line, Some ids_previous_line
+    when no_ids ids_line && no_ids ids_previous_line ->
+      (* [nosemgrep] occurrences found but no [ids]. *)
+      (true, [])
+  | __else__ ->
+      let ids =
+        Array.append
+          (Option.value ~default:[||] ids_line)
+          (Option.value ~default:[||] ids_previous_line)
+      in
+      let ids = List.filter_map Fun.id (Array.to_list ids) in
+      (* check if the id specified by the user is the [rule_match]'s [rule_id]. *)
+      List.fold_left
+        (fun (result, errors) id ->
+          let errors =
+            if strict && id <> rule_match.Out.check_id then
+              let msg =
+                Format.asprintf
+                  "found 'nosem' comment with id '%s', but no corresponding \
+                   rule trying '%s'"
+                  id rule_match.Out.check_id
+              in
+              let cli_error : Out.cli_error =
+                {
+                  Out.code = 0;
+                  level =
+                    "warn"
+                    (* XXX(dinosaure): use [Severity.string_of_basic_severity]? *);
+                  type_ = "nosemgrep error" (* TODO(dinosaure): correct? *);
+                  rule_id = Some rule_match.Out.check_id;
+                  message = Some msg;
+                  path = Some rule_match.Out.path;
+                  long_msg = None;
+                  short_msg = Some msg;
+                  spans = None;
+                  help = None;
+                }
+              in
+              cli_error :: errors
+            else errors
+          in
+          (id = rule_match.Out.check_id || result, errors))
+        (true, []) ids
+
+let process_ignores ~strict (out : Out.cli_output) : Out.cli_output =
+  let results, errors =
+    (* filters [rule_match]s by the [nosemgrep] tag. *)
+    List.filter_map
+      (fun rule_match ->
+        let to_ignore, errors = rule_match_nosem ~strict rule_match in
+        if not to_ignore then Some (rule_match, errors) else None)
+      out.Out.results
+    |> List.split
+  in
+  { out with results; errors = List.concat (out.Out.errors :: errors) }

--- a/src/osemgrep/reporting/Nosem.mli
+++ b/src/osemgrep/reporting/Nosem.mli
@@ -1,2 +1,4 @@
 val process_ignores :
-  Semgrep_output_v1_j.cli_output -> Semgrep_output_v1_j.cli_output
+  strict:bool ->
+  Semgrep_output_v1_j.cli_output ->
+  Semgrep_output_v1_j.cli_output

--- a/src/reporting/Matching_report.ml
+++ b/src/reporting/Matching_report.ml
@@ -55,15 +55,6 @@ let rec join_with_space_if_needed xs =
         x ^ " " ^ join_with_space_if_needed (y :: xs)
       else x ^ join_with_space_if_needed (y :: xs)
 
-(* TODO? slow, and maybe we should cache it to avoid rereading
- * each time the same file for each match.
- * Note that the returned lines do not contain \n.
- *)
-let lines_of_file (start_line, end_line) file : string list =
-  let arr = Common2.cat_array file in
-  let lines = Common2.enum start_line end_line in
-  lines |> Common.map (fun i -> arr.(i))
-
 (*****************************************************************************)
 (* Entry point *)
 (*****************************************************************************)
@@ -75,7 +66,7 @@ let print_match ?(format = Normal) ?(str = "") ?(spaces = 0) ii =
     in
     let file, line = (PI.file_of_info mini, PI.line_of_info mini) in
     let prefix = spf "%s:%d" file line in
-    let lines_str = lines_of_file (PI.line_of_info mini, end_line) file in
+    let lines_str = File.lines_of_file (PI.line_of_info mini, end_line) file in
     match format with
     | Normal ->
         let prefix = if str = "" then prefix else prefix ^ " " ^ str in

--- a/src/reporting/Matching_report.mli
+++ b/src/reporting/Matching_report.mli
@@ -18,12 +18,3 @@ val print_match :
   unit
 
 val join_with_space_if_needed : string list -> string
-
-(* [lines_of_file (start_line, end_line) file] returns
- * the list of lines from start_line to end_line included.
- *
- * Note that the returned lines do not contain \n.
- *
- * This function is slow, you should not use it!
- *)
-val lines_of_file : int * int -> Common.filename -> string list


### PR DESCRIPTION
PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)

This PR wants to implement the `nosemgrep` tag into the `osemgrep` OCaml code as the Python implemention (`semgrep`). Currently, from my handmade tests, the `nosemgrep` tag works. However, the end-to-end test fails due to some other things unrelated to this PR (like absolute path of files into the `scanned` JSON field).

Some questions persists however:
- [ ] do we have a function to _trim_ ID collected?
- [ ] my usage of `cli_error` is correct?
- [ ] `nosem_line_comment_re` seems unused by the current Python implemention, should I delete it?

I make this PR as a draft because I'm still unsure that it's ready to merge.