### PR TITLE
tainting: Add new option to avoid taint propagation via comparisons

### DIFF
--- a/changelog.d/pa-2645.changed
+++ b/changelog.d/pa-2645.changed
@@ -1,0 +1,4 @@
+taint-mode: Added option `taint_assume_safe_comparisons`, disabled by default, that
+prevents comparison operators to propagate taint, so e.g. `tainted != "something"`
+will not be considered tainted. Note that this a syntactic check, if the operator
+is overloaded to perform a different operation this will not be detected.

--- a/interfaces/Config_semgrep.atd
+++ b/interfaces/Config_semgrep.atd
@@ -26,6 +26,7 @@ type t = {
   ~taint_unify_mvars <ocaml default="false"> : bool;
   ~taint_assume_safe_functions <ocaml default="false"> : bool;
   ~taint_assume_safe_indexes <ocaml default="false"> : bool;
+  ~taint_assume_safe_comparisons <ocaml default="false"> : bool;
   (* when you are paranoid about minimizing FPs, and probably useful for
    * writing secret detection rules *)
   ~taint_only_propagate_through_assignments <ocaml default="false"> : bool;

--- a/src/tainting/Dataflow_tainting.ml
+++ b/src/tainting/Dataflow_tainting.ml
@@ -908,10 +908,64 @@ and check_tainted_expr env exp : Taints.t * Lval_env.t =
     | FixmeExp (_, _, None) ->
         (Taints.empty, env.lval_env)
     | Composite (_, (_, es, _)) -> union_map_taints_and_vars env check es
-    | Operator (_, es) ->
-        es
-        |> Common.map IL_helpers.exp_of_arg
-        |> union_map_taints_and_vars env check
+    | Operator ((op, _), es) ->
+        let args_taints, lval_env =
+          es
+          |> Common.map IL_helpers.exp_of_arg
+          |> union_map_taints_and_vars env check
+        in
+        let op_taints =
+          match op with
+          | G.Eq
+          | G.NotEq
+          | G.PhysEq
+          | G.NotPhysEq
+          | G.Lt
+          | G.LtE
+          | G.Gt
+          | G.GtE
+          | G.Cmp
+          | G.RegexpMatch
+          | G.NotMatch
+          | G.In
+          | G.NotIn
+          | G.Is
+          | G.NotIs ->
+              if env.options.taint_assume_safe_comparisons then Taints.empty
+              else args_taints
+          | G.And
+          | G.Or
+          | G.Xor
+          | G.Not
+          | G.LSL
+          | G.LSR
+          | G.ASR
+          | G.BitOr
+          | G.BitXor
+          | G.BitAnd
+          | G.BitNot
+          | G.BitClear
+          | G.Plus
+          | G.Minus
+          | G.Mult
+          | G.Div
+          | G.Mod
+          | G.Pow
+          | G.FloorDiv
+          | G.MatMult
+          | G.Concat
+          | G.Append
+          | G.Range
+          | G.RangeInclusive
+          | G.NotNullPostfix
+          | G.Length
+          | G.Elvis
+          | G.Nullish
+          | G.Background
+          | G.Pipe ->
+              args_taints
+        in
+        (op_taints, lval_env)
     | Record fields ->
         union_map_taints_and_vars env
           (fun env -> function

--- a/tests/rules/taint_safe_comparisons.py
+++ b/tests/rules/taint_safe_comparisons.py
@@ -1,0 +1,6 @@
+x = "tainted"
+#ruleid: tainting
+sink(x)
+y = x != "something"
+#ok: tainting
+sink(y)

--- a/tests/rules/taint_safe_comparisons.yaml
+++ b/tests/rules/taint_safe_comparisons.yaml
@@ -1,0 +1,14 @@
+rules:
+  - id: tainting
+    languages:
+      - python
+    message: Test
+    mode: taint
+    options:
+      taint_assume_safe_comparisons: true
+    pattern-sources:
+      - pattern: |
+          "tainted"
+    pattern-sinks:
+      - pattern: sink(...)
+    severity: ERROR


### PR DESCRIPTION
Helps PA-2645

test plan:
make test # new test added

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
