### PR TITLE
osemgrep: add output (about rules, skips) when --verbose is used

### DIFF
--- a/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -171,7 +171,7 @@ let run (conf : Scan_CLI.conf) : Exit_code.t =
           List.iter (fun rule -> m "- %s" (rule_id rule)) (sorted normal);
           match exp with
           | [] -> ()
-          | _ ->
+          | __non_empty__ ->
               m "Experimental rules:%s" "";
               List.iter (fun rule -> m "- %s" (rule_id rule)) (sorted exp));
       let targets, semgrepignored_targets =

--- a/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -146,6 +146,34 @@ let run (conf : Scan_CLI.conf) : Exit_code.t =
       let filtered_rules =
         Rule_filtering.filter_rules conf.rule_filtering_conf rules
       in
+      let pp_rule_sources ppf = function
+        | Rule_fetching.Pattern _ -> Format.pp_print_string ppf "pattern"
+        | Configs [ x ] -> Format.fprintf ppf "1 config %s" x
+        | Configs xs -> Format.fprintf ppf "%d configs" (List.length xs)
+      in
+      Logs.info (fun m ->
+          m "running %d rules from %a"
+            (List.length filtered_rules)
+            pp_rule_sources conf.rules_source);
+      (* TODO should output whether .semgrepignore is found and used
+         (as done in semgrep_main.py get_file_ignore()) *)
+      Logs.info (fun m ->
+          m "Rules:%s" "";
+          let exp, normal =
+            List.partition
+              (fun rule -> rule.Rule.severity = Rule.Experiment)
+              filtered_rules
+          in
+          let rule_id r = fst r.Rule.id in
+          let sorted =
+            List.sort (fun r1 r2 -> String.compare (rule_id r1) (rule_id r2))
+          in
+          List.iter (fun rule -> m "- %s" (rule_id rule)) (sorted normal);
+          match exp with
+          | [] -> ()
+          | _ ->
+              m "Experimental rules:%s" "";
+              List.iter (fun rule -> m "- %s" (rule_id rule)) (sorted exp));
       let targets, semgrepignored_targets =
         Find_target.get_targets conf.targeting_conf conf.target_roots
       in
@@ -159,6 +187,13 @@ let run (conf : Scan_CLI.conf) : Exit_code.t =
           |> List.iter (fun x ->
                  m "  %s" (Output_from_core_t.show_skipped_target x));
           m "]%s" "");
+      Logs.info (fun m ->
+          semgrepignored_targets
+          |> List.iter (fun (x : Output_from_core_t.skipped_target) ->
+                 m "Ignoring %s due to %s (%s)" x.Output_from_core_t.path
+                   (Output_from_core_t.show_skip_reason
+                      x.Output_from_core_t.reason)
+                   x.Output_from_core_t.details));
       Logs.debug (fun m ->
           m "selected targets: [%s" "";
           targets


### PR DESCRIPTION
With this change, the output of:
`_build/default/src/osemgrep/main/Main.exe --config p/ocaml src/osemgrep/ --json --verbose`

```
Main.exe: [INFO] running 32 rules from 1 config p/ocaml
Main.exe: [INFO] Rules:
Main.exe: [INFO] - ocaml.lang.best-practice.bool.ocamllint-bool-false
Main.exe: [INFO] - ocaml.lang.best-practice.bool.ocamllint-bool-true
Main.exe: [INFO] - ocaml.lang.best-practice.exception.bad-reraise
Main.exe: [INFO] - ocaml.lang.best-practice.hashtbl.hashtbl-find-outside-try
Main.exe: [INFO] - ocaml.lang.best-practice.ifs.ocamllint-backwards-if
Main.exe: [INFO] - ocaml.lang.best-practice.ifs.ocamllint-useless-else
Main.exe: [INFO] - ocaml.lang.best-practice.list.list-find-outside-try
Main.exe: [INFO] - ocaml.lang.best-practice.ref.ocamllint-ref-decr
Main.exe: [INFO] - ocaml.lang.best-practice.ref.ocamllint-ref-incr
Main.exe: [INFO] - ocaml.lang.best-practice.string.ocamllint-str-first-chars
Main.exe: [INFO] - ocaml.lang.best-practice.string.ocamllint-str-last-chars
Main.exe: [INFO] - ocaml.lang.best-practice.string.ocamllint-str-string-after
Main.exe: [INFO] - ocaml.lang.best-practice.string.ocamllint-useless-sprintf
Main.exe: [INFO] - ocaml.lang.compatibility.deprecated.deprecated-pervasives
Main.exe: [INFO] - ocaml.lang.correctness.physical-vs-structural.physical-equal
Main.exe: [INFO] - ocaml.lang.correctness.physical-vs-structural.physical-not-equal
Main.exe: [INFO] - ocaml.lang.correctness.physical_vs_structural.physical-equal
Main.exe: [INFO] - ocaml.lang.correctness.physical_vs_structural.physical-not-equal
Main.exe: [INFO] - ocaml.lang.correctness.useless-compare.useless-compare
Main.exe: [INFO] - ocaml.lang.correctness.useless-eq.useless-equal
Main.exe: [INFO] - ocaml.lang.correctness.useless-if.ocamllint-useless-if
Main.exe: [INFO] - ocaml.lang.correctness.useless-let.useless-let
Main.exe: [INFO] - ocaml.lang.correctness.useless_eq.useless-equal
Main.exe: [INFO] - ocaml.lang.correctness.useless_if.ocamllint-useless-if
Main.exe: [INFO] - ocaml.lang.correctness.useless_let.useless-let
Main.exe: [INFO] - ocaml.lang.performance.list.ocamllint-length-list-zero
Main.exe: [INFO] - ocaml.lang.performance.list.ocamllint-length-more-than-zero
Main.exe: [INFO] - ocaml.lang.portability.crlf-support.broken-input-line
Main.exe: [INFO] - ocaml.lang.portability.crlf-support.prefer-read-in-binary-mode
Main.exe: [INFO] - ocaml.lang.portability.crlf-support.prefer-write-in-binary-mode
Main.exe: [INFO] - ocaml.lang.portability.slash-tmp.not-portable-tmp-string
Main.exe: [INFO] - ocaml.lang.portability.slash_tmp.not-portable-tmp-string
Main.exe: [INFO] Ignoring /usr/home/hannes/devel/mirage/semgrep/src/osemgrep/targeting/Realpath.ml due to Semgrep_output_v1_t.Semgrepignore_patterns_match (excluded by --include/--exclude, gitignore, or semgrepignore)
<json>
```

For reference, the output of
`semgrep --config r/ocaml src/osemgrep/ --json --verbose`

```
running 32 rules from 1 config remote-url_0
using path ignore rules from user provided .semgrepignore
Rules:
- ocaml.lang.best-practice.bool.ocamllint-bool-false
- ocaml.lang.best-practice.bool.ocamllint-bool-true
- ocaml.lang.best-practice.exception.bad-reraise
- ocaml.lang.best-practice.hashtbl.hashtbl-find-outside-try
- ocaml.lang.best-practice.ifs.ocamllint-backwards-if
- ocaml.lang.best-practice.ifs.ocamllint-useless-else
- ocaml.lang.best-practice.list.list-find-outside-try
- ocaml.lang.best-practice.ref.ocamllint-ref-decr
- ocaml.lang.best-practice.ref.ocamllint-ref-incr
- ocaml.lang.best-practice.string.ocamllint-str-first-chars
- ocaml.lang.best-practice.string.ocamllint-str-last-chars
- ocaml.lang.best-practice.string.ocamllint-str-string-after
- ocaml.lang.best-practice.string.ocamllint-useless-sprintf
- ocaml.lang.compatibility.deprecated.deprecated-pervasives
- ocaml.lang.correctness.physical-vs-structural.physical-equal
- ocaml.lang.correctness.physical-vs-structural.physical-not-equal
- ocaml.lang.correctness.physical_vs_structural.physical-equal
- ocaml.lang.correctness.physical_vs_structural.physical-not-equal
- ocaml.lang.correctness.useless-compare.useless-compare
- ocaml.lang.correctness.useless-eq.useless-equal
- ocaml.lang.correctness.useless-if.ocamllint-useless-if
- ocaml.lang.correctness.useless-let.useless-let
- ocaml.lang.correctness.useless_eq.useless-equal
- ocaml.lang.correctness.useless_if.ocamllint-useless-if
- ocaml.lang.correctness.useless_let.useless-let
- ocaml.lang.performance.list.ocamllint-length-list-zero
- ocaml.lang.performance.list.ocamllint-length-more-than-zero
- ocaml.lang.portability.crlf-support.broken-input-line
- ocaml.lang.portability.crlf-support.prefer-read-in-binary-mode
- ocaml.lang.portability.crlf-support.prefer-write-in-binary-mode
- ocaml.lang.portability.slash-tmp.not-portable-tmp-string
- ocaml.lang.portability.slash_tmp.not-portable-tmp-string

┌─────────────┐
│ Scan Status │
└─────────────┘
Ignoring /home/administrator/semgrep/src/osemgrep/targeting/Realpath.ml due to .semgrepignore
  Scanning 160 files tracked by git with 32 Code rules:
  Scanning 86 files with 32 ocaml rules.
  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
<json>
```

Please let me know if this is the right direction. We can strip the prefix `Main.exe [INFO]` (by installing a custom Logs reporter).

The python code uses "verbose" for stuff that's output on `--verbose` and "debug" for `--debug`, while in OCaml the log level is `info` (for `--verbsoe`) and `debug` (for `--debug`).

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)