### PR TITLE
fix(perf-tests): check number of findings when comparing snapshots

### DIFF
--- a/perf/compare-bench-findings
+++ b/perf/compare-bench-findings
@@ -60,6 +60,10 @@ def main() -> None:
 
     errors = 0
 
+    if len(expected) != len(findings):
+        print(f"Error: expected {len(expected)} results, got {len(findings)}")
+        errors += 1
+
     for expected, findings in zip(expected, findings):
         if findings_differ(expected, findings):
             errors += 1


### PR DESCRIPTION
Previously, we only compared the ones that overlapped. It was possible that if there was an extra finding that it wouldn't show up.

Test plan: I tested locally with a findings file that previously passed. This file contained only the first three results in the expected findings

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
