### PR TITLE
feat(scala): parse match types

### DIFF
--- a/changelog.d/pa-2673.added
+++ b/changelog.d/pa-2673.added
@@ -1,0 +1,4 @@
+Scala: Can now parse programs containing matches on types, such as:
+type t = K match {
+  case Int => String
+}

--- a/languages/scala/ast/AST_scala.ml
+++ b/languages/scala/ast/AST_scala.ml
@@ -170,6 +170,7 @@ and type_ =
   | TyByName of tok (* => *) * type_
   | TyAnnotated of type_ * annotation list (* at least one *)
   | TyRefined of type_ option * refinement
+  | TyMatch of type_ * tok (* match *) * type_case_clauses
   | TyExistential of type_ * tok (* 'forSome' *) * refinement
   | TyWith of type_ * tok (* 'with' *) * type_
   | TyWildcard of tok (* '_' *) * type_bounds
@@ -263,18 +264,19 @@ and arguments =
 (* less: no keyword argument in Scala? *)
 
 and argument = expr
-and case_clauses = case_clause list
+and case_clauses = (pattern, block) case_clause list
+and type_case_clauses = (((* _ *) tok, type_) either, type_) case_clause list
 
-and case_clause =
-  | CC of case_clause_classic
+and ('a, 'b) case_clause =
+  | CC of ('a, 'b) case_clause_classic
   (* semgrep-ext: *)
   | CaseEllipsis of tok
 
-and case_clause_classic = {
+and ('a, 'b) case_clause_classic = {
   casetoks : tok (* 'case' *) * tok (* '=>' *);
-  casepat : pattern;
+  case_left : 'a;
   caseguard : guard option;
-  casebody : block;
+  case_right : 'b;
 }
 
 and guard = tok (* 'if' *) * expr

--- a/languages/scala/recursive_descent/Parser_scala_recursive_descent.ml
+++ b/languages/scala/recursive_descent/Parser_scala_recursive_descent.ml
@@ -1144,10 +1144,6 @@ and compoundTypeRest topt in_ =
     ts += (iwith, x)
   done;
   newLineOptWhenFollowedBy (LBRACE ab) in_;
-  (* in the Scala 3 grammar, this is necessary to preface with a colon
-     in the Scala 2 grammar, this actually is kind of an ambiguity, because
-     this could just be a new BlockStat entry, specifically a BlockExpr.
-  *)
   let refinements =
     if in_.token =~= LBRACE ab then Some (refinement in_) else None
   in
@@ -2059,6 +2055,7 @@ and typeCaseClause icase in_ : ((tok, type_) either, type_) case_clause =
   let iarrow = TH.info_of_tok in_.token in
   accept (ARROW ab) in_;
   let r_ty = typ in_ in
+  if TH.isStatSep in_.token then nextToken in_;
   (* ast: makeCaseDef *)
   CC
     {

--- a/languages/scala/recursive_descent/Parser_scala_recursive_descent.ml
+++ b/languages/scala/recursive_descent/Parser_scala_recursive_descent.ml
@@ -838,6 +838,7 @@ let tmplDef_ = ref (fun _ -> failwith "forward ref not set")
 let blockStatSeq_ = ref (fun _ -> failwith "forward ref not set")
 let topLevelTmplDef_ = ref (fun _ -> failwith "forward ref not set")
 let packageOrPackageObject_ = ref (fun _ _ -> failwith "forward ref not set")
+let typeCaseClauses_ = ref (fun _ -> failwith "forward ref not set")
 
 let paramType_ =
   ref (fun ?repeatedParameterOK _ ->
@@ -924,6 +925,7 @@ let pushOpInfo _topTODO in_ : ident * type_ list bracket option =
  *  Type ::= InfixType `=>` Type
  *         | `(` [`=>` Type] `)` `=>` Type
  *         | InfixType [ExistentialClause]
+ *         | InfixType `match` <<< TypeCaseClauses >>>
  *  ExistentialClause ::= forSome `{` ExistentialDcl {semi ExistentialDcl} `}`
  *  ExistentialDcl    ::= type TypeDcl | val ValDcl
  *  }}}
@@ -946,6 +948,10 @@ let rec typ in_ : type_ =
          | KforSome ii ->
              skipToken in_;
              makeExistentialTypeTree t ii in_
+         | Kmatch ii ->
+             skipToken in_;
+             let _, type_case_clauses, _ = inBraces !typeCaseClauses_ in_ in
+             TyMatch (t, ii, type_case_clauses)
          | _ -> t)
 
 (** {{{
@@ -1138,6 +1144,10 @@ and compoundTypeRest topt in_ =
     ts += (iwith, x)
   done;
   newLineOptWhenFollowedBy (LBRACE ab) in_;
+  (* in the Scala 3 grammar, this is necessary to preface with a colon
+     in the Scala 2 grammar, this actually is kind of an ambiguity, because
+     this could just be a new BlockStat entry, specifically a BlockExpr.
+  *)
   let refinements =
     if in_.token =~= LBRACE ab then Some (refinement in_) else None
   in
@@ -1991,13 +2001,18 @@ and caseBlock in_ : tok * block =
   let x = block in_ in
   (ii, x)
 
-and caseClause icase in_ : case_clause =
+and caseClause icase in_ : (pattern, block) case_clause =
   let p = pattern in_ in
   let g = guard in_ in
   let iarrow, block = caseBlock in_ in
   (* ast: makeCaseDef *)
   CC
-    { casetoks = (icase, iarrow); casepat = p; caseguard = g; casebody = block }
+    {
+      casetoks = (icase, iarrow);
+      case_left = p;
+      caseguard = g;
+      case_right = block;
+    }
 
 (** {{{
  *  CaseClauses ::= CaseClause {CaseClause}
@@ -2020,6 +2035,55 @@ and caseClauses in_ : case_clauses =
     | Kcase ii ->
         nextToken in_;
         let x = caseClause ii in_ in
+        ts += x
+    | Ellipsis ii ->
+        nextToken in_;
+        ts += CaseEllipsis ii
+    | _ -> raise Impossible
+  done;
+  List.rev !ts
+
+(** {{{
+ *  TypeCaseClauses ::= TypeCaseClause {TypeCaseClause}
+ *  TypeCaseClause  ::= `case` (InfixType | `_`) `=>` Type [semi]
+ *  }}}
+*)
+and typeCaseClause icase in_ : ((tok, type_) either, type_) case_clause =
+  let l_ty =
+    match in_.token with
+    | USCORE ii ->
+        skipToken in_;
+        Left ii
+    | _ -> Right (startInfixType in_)
+  in
+  let iarrow = TH.info_of_tok in_.token in
+  accept (ARROW ab) in_;
+  let r_ty = typ in_ in
+  (* ast: makeCaseDef *)
+  CC
+    {
+      casetoks = (icase, iarrow);
+      case_left = l_ty;
+      caseguard = None;
+      case_right = r_ty;
+    }
+
+and typeCaseClauses in_ : type_case_clauses =
+  (* CHECK: empty cases *)
+  (* old: was
+   *   caseSeparated caseClause in_s
+   * with
+   *   let caseSeparated part in_ =
+   *     separatedToken (Kcase ab) part in_
+   * but for semgrep we also need to handle ellipsis
+   *)
+  (* similar to separatedToken body *)
+  let ts = ref [] in
+  while in_.token =~= Kcase ab || in_.token =~= Ellipsis ab do
+    match in_.token with
+    | Kcase ii ->
+        nextToken in_;
+        let x = typeCaseClause ii in_ in
         ts += x
     | Ellipsis ii ->
         nextToken in_;
@@ -3635,6 +3699,8 @@ let _ =
   annotTypeRest_ := annotTypeRest;
 
   paramType_ := paramType;
+
+  typeCaseClauses_ := typeCaseClauses;
   ()
 
 (** {{{

--- a/tests/parsing/scala/match_type.scala
+++ b/tests/parsing/scala/match_type.scala
@@ -1,0 +1,8 @@
+
+type t = K match {
+  case _ => String
+}
+
+type t2 = K match {
+  case Int => T[A]
+}

--- a/tests/parsing/scala/type_case_clauses.scala
+++ b/tests/parsing/scala/type_case_clauses.scala
@@ -1,0 +1,8 @@
+
+type t = K match {
+  case _ => String
+}
+
+type t2 = K match {
+  case Int => T[A]
+}

--- a/tests/patterns/scala/match_type_ellipsis.scala
+++ b/tests/patterns/scala/match_type_ellipsis.scala
@@ -1,0 +1,5 @@
+// MATCH:
+type t = K match {
+  case String => Int;
+  case Int => Int;
+}

--- a/tests/patterns/scala/match_type_ellipsis.sgrep
+++ b/tests/patterns/scala/match_type_ellipsis.sgrep
@@ -1,0 +1,4 @@
+type t = $FOO match {
+  case $X => Int;
+  ...
+}


### PR DESCRIPTION
## What:
This PR adds the ability to parse match types, which are type expressions that case on the particular type of something.

## Why:
Trying to parse more programs.

## How:
I used the existing `case_clause` code and parameterized it, as it seems in the Scala grammar there's quite a few things of that form, except with different nonterminals for the LHS and RHS of the cases.

I put it into a `Switch` and then embedded that into `type_`, as it seems we have no actual analogue in `type_` as of right now. I wanted to preserve usage of the ellipses, and I thought this was the most explicit construct that denoted what it was doing. I don't think we'll need a special other construct for this for a very long time, if ever.

## Test plan:
Automated tests, and parse rate went from `0.9189344037430826` to `0.9189534728003734`

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
