### PR TITLE
Change the type from a simple string to Fpath.v for the function lines_of_file

### DIFF
--- a/libs/commons/File.ml
+++ b/libs/commons/File.ml
@@ -45,6 +45,6 @@ let filesize path = Common2.filesize !!path
  * Note that the returned lines do not contain \n.
  *)
 let lines_of_file (start_line, end_line) file : string list =
-  let arr = Common2.cat_array file in
+  let arr = Common2.cat_array (Fpath.to_string file) in
   let lines = Common2.enum start_line end_line in
   lines |> Common.map (fun i -> arr.(i))

--- a/libs/commons/File.mli
+++ b/libs/commons/File.mli
@@ -134,4 +134,4 @@ val filesize : Fpath.t -> int
  *
  * This function is slow, you should not use it!
  *)
-val lines_of_file : int * int -> Common.filename -> string list
+val lines_of_file : int * int -> Fpath.t -> string list

--- a/src/osemgrep/cli_scan/Cli_json_output.ml
+++ b/src/osemgrep/cli_scan/Cli_json_output.ml
@@ -61,7 +61,7 @@ type metavars = (string * Out.metavar_value) list
  * python: # 'lines' already contains '\n' at the end of each line
  *   lines="".join(rule_match.lines).rstrip(),
  *)
-let lines_of_file (range : Out.position * Out.position) (file : filename) :
+let lines_of_file (range : Out.position * Out.position) (file : Fpath.t) :
     string list =
   let start, end_ = range in
   File.lines_of_file (start.line, end_.line) file
@@ -355,7 +355,9 @@ let cli_match_of_core_match (env : env) (x : Out.core_match) : Out.cli_match =
         | None -> `Assoc []
         | Some json -> JSON.to_yojson json
       in
-      let lines = lines_of_file (start, end_) path |> String.concat "\n" in
+      let lines =
+        lines_of_file (start, end_) (Fpath.v path) |> String.concat "\n"
+      in
       {
         check_id;
         path;

--- a/src/osemgrep/cli_scan/Cli_json_output.mli
+++ b/src/osemgrep/cli_scan/Cli_json_output.mli
@@ -11,7 +11,7 @@ val cli_output_of_core_results :
  *)
 val lines_of_file :
   Semgrep_output_v1_j.position * Semgrep_output_v1_j.position ->
-  Common.filename ->
+  Fpath.t ->
   string list
 
 (* for now used only to interpolate metavars in the 'message:' field *)

--- a/src/osemgrep/cli_scan/Output.ml
+++ b/src/osemgrep/cli_scan/Output.ml
@@ -115,7 +115,9 @@ let dispatch_output_format (output_format : Output_format.t)
                     * we can't use m.extra.lines because this field actually
                     * contains a string, not a string list.
                     *)
-                   match Cli_json_output.lines_of_file (start, end_) path with
+                   match
+                     Cli_json_output.lines_of_file (start, end_) (Fpath.v path)
+                   with
                    | [] -> ""
                    | x :: _ -> x (* TOPORT rstrip? *)
                  in

--- a/src/osemgrep/reporting/Nosem.ml
+++ b/src/osemgrep/reporting/Nosem.ml
@@ -80,7 +80,7 @@ let rule_match_nosem ~strict (rule_match : Out.cli_match) :
   let lines =
     File.lines_of_file
       (max 0 (rule_match.Out.start.line - 1), rule_match.Out.end_.line)
-      rule_match.Out.path
+      (Fpath.v rule_match.Out.path)
   in
 
   let previous_line, line =

--- a/src/reporting/Matching_report.ml
+++ b/src/reporting/Matching_report.ml
@@ -66,7 +66,9 @@ let print_match ?(format = Normal) ?(str = "") ?(spaces = 0) ii =
     in
     let file, line = (PI.file_of_info mini, PI.line_of_info mini) in
     let prefix = spf "%s:%d" file line in
-    let lines_str = File.lines_of_file (PI.line_of_info mini, end_line) file in
+    let lines_str =
+      File.lines_of_file (PI.line_of_info mini, end_line) (Fpath.v file)
+    in
     match format with
     | Normal ->
         let prefix = if str = "" then prefix else prefix ^ " " ^ str in


### PR DESCRIPTION
PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)

A simple patch to retype `lines_of_file` and use `Fpath.t` instead of a simple string.