### PR TITLE
fix(autofix): Fix rare Python argument reordering

### DIFF
--- a/changelog.d/keywordarg-autofix.fixed
+++ b/changelog.d/keywordarg-autofix.fixed
@@ -1,0 +1,1 @@
+In rare cases, Semgrep could generate invalid autofixes where Python keyword arguments were placed before positional arguments. When using AST-based autofix, it no longer makes that error.

--- a/libs/commons/Textedit.mli
+++ b/libs/commons/Textedit.mli
@@ -12,7 +12,7 @@ type edit_application_result =
   | Overlap of {
       partial_result : string;
       (* nonempty *)
-      discarded_edits : t list;
+      conflicting_edits : t list;
     }
 
 (* Apply a list of edits, modifying the files in place. If dryrun, do everything

--- a/tests/patterns/python/fix_ellipsis_metavar.fixed
+++ b/tests/patterns/python/fix_ellipsis_metavar.fixed
@@ -8,8 +8,7 @@ foo(baz=True)
 # MATCH:
 foo(bar =  False)
 
-# TODO These should work, but end up with overlapping fixes. See
-# https://github.com/returntocorp/semgrep/issues/4963
-
-# foo(x, bar=True)
-# foo(x, bar=True, y)
+# MATCH:
+foo(x, bar =  False)
+# MATCH:
+foo(x, bar =  False, baz=True)

--- a/tests/patterns/python/fix_ellipsis_metavar.py
+++ b/tests/patterns/python/fix_ellipsis_metavar.py
@@ -8,8 +8,7 @@ foo(baz=True)
 # MATCH:
 foo(  bar   =    True  )
 
-# TODO These should work, but end up with overlapping fixes. See
-# https://github.com/returntocorp/semgrep/issues/4963
-
-# foo(x, bar=True)
-# foo(x, bar=True, y)
+# MATCH:
+foo(x, bar=True)
+# MATCH:
+foo(x, bar=True, baz=True)


### PR DESCRIPTION
Due to unordered keyword matching, and how it leads ellipsis metavariables to be bound to arguments, in some cases Semgrep can generate autofixes that reorder keyword arguments. In Python, this is a problem when it moves keyword arguments in front of positional arguments, since Python disallows that.

This addresses this case by adding a transformation step after the fix is generated that moves positional arguments in front of keyword arguments.

I've also included a change so that the `Textedit` module only reports conflicting edits if they overlap and are not identical. This allows the test cases I added to pass. Semgrep generates multiple matches, but due to the changes here they end up with the same autofix.

Partially addresses #4963

Test plan: Automated tests

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
