### PR TITLE
feat(scala): indentation tokens

### DIFF
--- a/languages/scala/recursive_descent/Parse_scala.ml
+++ b/languages/scala/recursive_descent/Parse_scala.ml
@@ -49,6 +49,7 @@ let tokens input_source =
   (* set to false to parse correctly arrows *)
   Parsing_helpers.tokenize_all_and_adjust_pos input_source token
     TH.visitor_info_of_tok TH.is_eof
+  |> Parsing_hacks_scala.insert_indentation_tokens
   [@@profiling]
 
 (*****************************************************************************)

--- a/languages/scala/recursive_descent/Parser_scala_recursive_descent.ml
+++ b/languages/scala/recursive_descent/Parser_scala_recursive_descent.ml
@@ -3767,7 +3767,6 @@ let try_rule toks frule =
   x
 
 let parse toks =
-  Common.(pr2 (spf "%s" ([%show: token list] toks)));
   try try_rule toks compilationUnit with
   | PI.Parsing_error _ as err1 -> (
       let e1 = Exception.catch err1 in

--- a/languages/scala/recursive_descent/Parser_scala_recursive_descent.ml
+++ b/languages/scala/recursive_descent/Parser_scala_recursive_descent.ml
@@ -236,7 +236,9 @@ let rec in_next_token xs =
   | x :: xs -> (
       match x with
       | Space _
-      | Comment _ ->
+      | Comment _
+      | INDENT
+      | DEDENT ->
           in_next_token xs
       | _ -> Some x)
 
@@ -326,7 +328,9 @@ let afterLineEnd in_ =
         | NEWLINES _ ->
             true
         | Space _
-        | Comment _ ->
+        | Comment _
+        | INDENT
+        | DEDENT ->
             loop xs
         | _ ->
             if !debug_newline then
@@ -360,7 +364,9 @@ let fetchToken in_ =
 
         match x with
         | Space _
-        | Comment _ ->
+        | Comment _
+        | INDENT
+        | DEDENT ->
             loop (x :: aux)
         (* pad: the newline is skipped here, but reinserted conditionally in
          * insertNL() *)
@@ -3761,6 +3767,7 @@ let try_rule toks frule =
   x
 
 let parse toks =
+  Common.(pr2 (spf "%s" ([%show: token list] toks)));
   try try_rule toks compilationUnit with
   | PI.Parsing_error _ as err1 -> (
       let e1 = Exception.catch err1 in

--- a/languages/scala/recursive_descent/Parsing_hacks_scala.ml
+++ b/languages/scala/recursive_descent/Parsing_hacks_scala.ml
@@ -1,6 +1,6 @@
 (* Brandon Wu
  *
- * Copyright (C) 2019 r2c
+ * Copyright (C) 2023 r2c
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/languages/scala/recursive_descent/Parsing_hacks_scala.ml
+++ b/languages/scala/recursive_descent/Parsing_hacks_scala.ml
@@ -1,0 +1,55 @@
+(* Brandon Wu
+ *
+ * Copyright (C) 2019 r2c
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * version 2.1 as published by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
+ * license.txt for more details.
+ *
+ *)
+open Common
+module Flag = Flag_parsing
+module T = Token_scala
+module TH = Token_helpers_scala
+module PI = Parse_info
+module PS = Parsing_stat
+
+(*****************************************************************************)
+(* Prelude *)
+(*****************************************************************************)
+(* The goal for this module is to insert INDENT and DEDENT tokens to the token
+ * stream, so that we can detect whitespace-sensitive indentation-delimited
+ * blocks.
+ *)
+
+(*****************************************************************************)
+(* Prelude *)
+(*****************************************************************************)
+
+let insert_indentation_tokens toks =
+  List.fold_left
+    (fun (line, col, acc) tok ->
+      let info = TH.info_of_tok tok in
+      let line2 = PI.line_of_info info in
+      let col2 = PI.col_of_info info in
+      match tok with
+      (* We ignore any newlines and spaces, because we're trying to estimate
+          the relationship between the "real" tokens in the stream.
+      *)
+      | Nl _
+      | Space _ ->
+          (line, col, tok :: acc)
+      | _ ->
+          (* For tokens on the same line, there has been no indentation. *)
+          if line2 =*= line then (line2, col, tok :: acc)
+            (* This must mean we're on a new line. *)
+          else if col2 < col then (line2, col2, tok :: DEDENT :: acc)
+          else if col2 > col then (line2, col2, tok :: INDENT :: acc)
+          else (line2, col2, tok :: acc))
+    (0, 0, []) toks
+  |> fun (_, _, acc) -> List.rev acc

--- a/languages/scala/recursive_descent/Token_helpers_scala.ml
+++ b/languages/scala/recursive_descent/Token_helpers_scala.ml
@@ -28,7 +28,9 @@ let is_eof = function
 
 let is_comment = function
   | Comment _
-  | Space _ ->
+  | Space _
+  | INDENT
+  | DEDENT ->
       true
   (* newline has a meaning in the parser, so should not skip *)
   (* old: | Nl _ -> true *)
@@ -45,6 +47,7 @@ let token_kind_of_tok t =
   | Comment _ -> PI.Esthet PI.Comment
   | Space _ -> PI.Esthet PI.Space
   | Nl _ -> PI.Esthet PI.Newline
+  (* TODO? indent and dedent *)
   | _ -> PI.Other
 
 (*****************************************************************************)
@@ -148,6 +151,8 @@ let visitor_info_of_tok f = function
   | Kcatch ii -> Kcatch (f ii)
   | Kcase ii -> Kcase (f ii)
   | Kabstract ii -> Kabstract (f ii)
+  | INDENT -> INDENT
+  | DEDENT -> DEDENT
   | Ellipsis ii -> Ellipsis (f ii)
 
 let info_of_tok tok =
@@ -322,6 +327,7 @@ let isNumericLit = function
 (* Statement separators *)
 (* ------------------------------------------------------------------------- *)
 
+(* TODO? indent and dedent *)
 let isStatSep = function
   | NEWLINE _
   | NEWLINES _

--- a/languages/scala/recursive_descent/Token_scala.ml
+++ b/languages/scala/recursive_descent/Token_scala.ml
@@ -87,6 +87,8 @@ type token =
   | BANG of Parse_info.t
   | AT of Parse_info.t
   | ARROW of Parse_info.t
+  | INDENT
+  | DEDENT
 [@@deriving show { with_path = false }]
 
 type t = token [@@deriving show]

--- a/stats/parsing-stats/lang/scala/projects.txt
+++ b/stats/parsing-stats/lang/scala/projects.txt
@@ -8,7 +8,7 @@ https://github.com/akka/akka
 https://github.com/yahoo/CMAK
 https://github.com/ornicar/lila
 https://github.com/gitbucket/gitbucket
-https://github.com/twitter/finagle
+# https://github.com/twitter/finagle
 https://github.com/rtyley/bfg-repo-cleaner
 https://github.com/twitter-archive/snowflake
 https://github.com/lhartikk/ArnoldC

--- a/stats/parsing-stats/lang/scala/projects.txt
+++ b/stats/parsing-stats/lang/scala/projects.txt
@@ -8,7 +8,7 @@ https://github.com/akka/akka
 https://github.com/yahoo/CMAK
 https://github.com/ornicar/lila
 https://github.com/gitbucket/gitbucket
-# https://github.com/twitter/finagle
+https://github.com/twitter/finagle
 https://github.com/rtyley/bfg-repo-cleaner
 https://github.com/twitter-archive/snowflake
 https://github.com/lhartikk/ArnoldC


### PR DESCRIPTION
## What:
This PR adds in `INDENT` and `DEDENT` tokens to the token stream of Scala programs, to be consumed at a later date.

## Why:
In the Scala 3 specification, there is a notion of "optional braces" (https://docs.scala-lang.org/scala3/reference/syntax.html#optional-braces), where explicit curly braces can be omitted in favor of clear indentation and dedentation.

As it happens, right now, we only insert tokens for some number of spaces and newlines. Things like whether there is an indent or dedent are lost on us, so we don't have enough information in the token stream to distinguish cases like
```
object Foo:
  val x = 2
val y = 3
```
and
```
object Foo:
  val x = 2
  val y = 3
```
(actually, we might, because there would be no space before `val y = 3` in the first, but imagine this was further nested one level, and you get the point)

## How:
I wrote a fold which just goes and inserts `INDENT` and `DEDENT` tokens any time that it finds we are on a new line, and the column has changed with respect to the start column on the prior line.

Every other function which skips newlines and spaces and stuff also skips these tokens, so they are functionally "invisible" unless you explicitly go looking for them, which future functions can be written to do (such as for detection of these optional braces).

## Test plan:
Parse rate has not changed.
![image](https://user-images.githubusercontent.com/49291449/228908686-7b003f78-109c-47ad-8305-4ad2e0ff7f3a.png)

I also manually inspected the token stream for an example:
```
{
<
  >
    {

    }
  {

}
}
```
produces
```
[(LBRACE ()); (Nl ()); (OP ("<", ())); (Nl ()); (Space ()); INDENT;
  (OP (">", ())); (Space ()); (Nl ()); (Space ()); INDENT; (LBRACE ());
  (Space ()); (Nl ()); (Nl ()); (Space ()); (RBRACE ()); (Nl ()); (Space ());
  DEDENT; (LBRACE ()); (Nl ()); (Nl ()); DEDENT; (RBRACE ()); (Nl ());
  (RBRACE ()); (Nl ()); (EOF ())]
```
As we can see, we get two indents and two dedents, in the right places.


PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
