### PR TITLE
tests(perf): fix pr comments

### DIFF
--- a/scripts/run-benchmarks.sh
+++ b/scripts/run-benchmarks.sh
@@ -8,7 +8,7 @@ set -e
 cd cli || return
 
 # Run timing benchmark
-pipenv install semgrep==1.0.0
+pipenv install semgrep==1.14.0
 pipenv run python -m semgrep --version
 export PATH=/github/home/.local/bin:$PATH
 

--- a/scripts/run-benchmarks.sh
+++ b/scripts/run-benchmarks.sh
@@ -34,5 +34,5 @@ jq . timing2.json
 jq . ci_small_repos_findings.json
 
 # Compare timing infos
-../perf/compare-perf baseline_timing1.json baseline_timing2.json timing1.json timing2.json "$1" "$2"
-../perf/compare-bench-findings ci_small_repos_findings.json
+pipenv run ../perf/compare-perf baseline_timing1.json baseline_timing2.json timing1.json timing2.json "$1" "$2"
+pipenv run ../perf/compare-bench-findings ci_small_repos_findings.json

--- a/scripts/run-benchmarks.sh
+++ b/scripts/run-benchmarks.sh
@@ -3,12 +3,12 @@
 # Coupling: If you update this script, you likely also want
 # to update run-pro-benchmarks.sh
 
-set e
+set -e
 
 cd cli || return
 
 # Run timing benchmark
-pipenv install semgrep==1.14.0
+pipenv install semgrep==1.0.0
 pipenv run python -m semgrep --version
 export PATH=/github/home/.local/bin:$PATH
 

--- a/scripts/test-pro.sh
+++ b/scripts/test-pro.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 
-set e
+set -e
 
 cp /root/semgrep-core-proprietary /usr/local/bin/semgrep-core-proprietary
 


### PR DESCRIPTION
Perf tests normally leave PR comments for significant changes, but previously this failed because of an error in my script.

Test plan: set the semgrep version to a previous one (this should cause a comment to be left), then move it back once confirmed.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
