### PR TITLE
Post translation_rate stats to dashboard

### DIFF
--- a/stats/parsing-stats/upload-parsing-rates
+++ b/stats/parsing-stats/upload-parsing-rates
@@ -14,7 +14,7 @@ from typing import List
 
 HOST = "https://dashboard.semgrep.dev"
 
-Stat = namedtuple("Stat", ["lang", "line_count", "parse_success"])
+Stat = namedtuple("Stat", ["lang", "line_count", "parse_success", "translation_rate"])
 
 #
 # Return an array of 0 or 1 dicts, whose field values will be posted over HTTP.
@@ -29,9 +29,17 @@ def load_stat_file(in_file: str) -> List[Stat]:
     stat = root["global"]
     line_count = stat["line_count"]
     parse_success = stat["parsing_rate"]
+    translation_rate = 1 - (stat["untranslated_node_count"] / stat["total_node_count"])
 
     if lang is not None and line_count is not None and parse_success is not None:
-        res.append(Stat(lang=lang, line_count=line_count, parse_success=parse_success))
+        res.append(
+            Stat(
+                lang=lang,
+                line_count=line_count,
+                parse_success=parse_success,
+                translation_rate=translation_rate,
+            )
+        )
     return res
 
 
@@ -46,6 +54,11 @@ def upload_stats(stats: List[Stat]) -> None:
         url = f"{HOST}/api/metric/semgrep.core.{stat.lang}.parse-coverage-lines.num"
         r = urllib.request.urlopen(  # nosemgrep
             url=url, data=str(stat.line_count).encode("ascii")
+        )
+        print(r.read().decode())
+        url = f"{HOST}/api/metric/semgrep.core.{stat.lang}.parse-translation-rate.num"
+        r = urllib.request.urlopen(  # nosemgrep
+            url=url, data=str(stat.translation_rate).encode("ascii")
         )
         print(r.read().decode())
 

--- a/stats/parsing-stats/upload-parsing-rates
+++ b/stats/parsing-stats/upload-parsing-rates
@@ -56,9 +56,9 @@ def upload_stats(stats: List[Stat]) -> None:
             url=url, data=str(stat.line_count).encode("ascii")
         )
         print(r.read().decode())
-        url = f"{HOST}/api/metric/semgrep.core.{stat.lang}.parse-translation-rate.num"
+        url = f"{HOST}/api/metric/semgrep.core.{stat.lang}.parse-translation-rate.pct"
         r = urllib.request.urlopen(  # nosemgrep
-            url=url, data=str(stat.translation_rate).encode("ascii")
+            url=url, data=str(100 * stat.translation_rate).encode("ascii")
         )
         print(r.read().decode())
 


### PR DESCRIPTION
The number of raw (untranslated) nodes was already being computed but not posted to the dashboard.

Test plan:
* safe: `cd stats/parsing-stats; ./run-lang ocaml` (or any other language)
* once you're getting correct results: `cd stats/parsing-stats; ./run-lang ocaml --upload`

Check that the correct number gets posted to the dashboard at e.g. ~~https://dashboard.semgrep.dev/metric/semgrep.core.Ocaml.parse-translation-rate.num~~ (oops)
https://dashboard.semgrep.dev/metric/semgrep.core.Ocaml.parse-translation-rate.pct

After merging this PR, stats will be posted once a day via a CircleCI job.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
