### PR TITLE
fix(autofix/python): Fix range of expressions wrapped in parens

### DIFF
--- a/changelog.d/gh-2902.fixed
+++ b/changelog.d/gh-2902.fixed
@@ -1,0 +1,1 @@
+Fixed an issue where incorrect ranges for expressions containing parentheses could lead Semgrep to generate invalid autofixes in Python.

--- a/cli/tests/e2e/snapshots/test_check/test_multiline/results.json
+++ b/cli/tests/e2e/snapshots/test_check/test_multiline/results.json
@@ -61,15 +61,15 @@
     {
       "check_id": "rules.eqeq-is-bad",
       "end": {
-        "col": 55,
-        "line": 8,
-        "offset": 213
+        "col": 6,
+        "line": 9,
+        "offset": 219
       },
       "extra": {
         "engine_kind": "OSS",
         "fingerprint": "0x42",
         "is_ignored": false,
-        "lines": "        SUPER_LONG_CONSTANT_TO_TRIGGER_A_LINE_BREAK\n        == SUPER_LONG_CONSTANT_TO_TRIGGER_A_LINE_BREAK",
+        "lines": "    return (\n        SUPER_LONG_CONSTANT_TO_TRIGGER_A_LINE_BREAK\n        == SUPER_LONG_CONSTANT_TO_TRIGGER_A_LINE_BREAK\n    )",
         "message": "useless comparison operation `SUPER_LONG_CONSTANT_TO_TRIGGER_A_LINE_BREAK == SUPER_LONG_CONSTANT_TO_TRIGGER_A_LINE_BREAK` or `SUPER_LONG_CONSTANT_TO_TRIGGER_A_LINE_BREAK != SUPER_LONG_CONSTANT_TO_TRIGGER_A_LINE_BREAK`; possible bug?",
         "metadata": {
           "shortlink": "https://sg.run/xyz1"
@@ -106,9 +106,9 @@
       },
       "path": "targets/multiline/stupid.py",
       "start": {
-        "col": 9,
-        "line": 7,
-        "offset": 115
+        "col": 12,
+        "line": 6,
+        "offset": 105
       }
     }
   ],

--- a/languages/python/ast/AST_python.ml
+++ b/languages/python/ast/AST_python.ml
@@ -170,6 +170,7 @@ type expr =
   | DeepEllipsis of expr bracket
   | TypedMetavar of name * tok * type_
   | DotAccessEllipsis of expr * tok (* ... *)
+  | ParenExpr of expr bracket
 
 and number =
   | Int of int option wrap

--- a/languages/python/generic/Python_to_generic.ml
+++ b/languages/python/generic/Python_to_generic.ml
@@ -309,6 +309,10 @@ let rec expr env (x : expr) =
       let l, v1, _ = bracket (expr env) v1 in
       G.OtherExpr (("Repr", l), [ G.E v1 ]) |> G.e
   | NamedExpr (v, t, e) -> G.Assign (expr env v, t, expr env e) |> G.e
+  | ParenExpr (l, e, r) ->
+      let e = expr env e in
+      H.set_e_range l r e;
+      e
 
 and argument env = function
   | Arg e ->

--- a/languages/python/menhir/Parser_python.mly
+++ b/languages/python/menhir/Parser_python.mly
@@ -42,7 +42,7 @@ let cons e = function
 
 let tuple_expr = function
   | Single e -> e
-  (* the fake could be set later in rewrap_paren_if_tuple below *)
+  (* the fake could be set later in rewrap_paren below *)
   | Tup l -> Tuple (CompList (PI.unsafe_fake_bracket l), Load)
 
 let to_list = function
@@ -50,13 +50,13 @@ let to_list = function
   | Tup l -> l
 
 (* this is important for semgrep, to get the right range (and for autofix) *)
-let rewrap_paren_if_tuple l e r =
+let rewrap_paren l e r =
   match e with
   | Tuple (CompList (_, xs, _), Load) ->
       Tuple (CompList (l, xs, r), Load)
   | Tuple (CompForIf (_, x, _), Load) ->
       Tuple (CompForIf (l, x, r), Load)
-  | _ -> e
+  | _ -> ParenExpr (l, e, r)
 
 (* TODO: TypedExpr? ExprStar? then can appear as lvalue
  * CompForIf though is not an lvalue.
@@ -882,7 +882,7 @@ format_token:
 
 atom_tuple:
   | "("               ")"         { Tuple (CompList ($1, [], $2), Load) }
-  | "(" testlist_comp_or_expr ")" { rewrap_paren_if_tuple $1 $2 $3 }
+  | "(" testlist_comp_or_expr ")" { rewrap_paren $1 $2 $3 }
   | "(" yield_expr    ")"         { $2 }
 
 atom_list:

--- a/languages/python/menhir/Visitor_python.ml
+++ b/languages/python/menhir/Visitor_python.ml
@@ -186,6 +186,9 @@ let (mk_visitor : visitor_in -> visitor_out) =
       | NamedExpr (v, t, e) ->
           let v = v_expr v and t = v_tok t and e = v_expr e in
           ()
+      | ParenExpr v1 ->
+          let v1 = v_bracket v_expr v1 in
+          ()
     in
     vin.kexpr (k, all_functions) x
   and v_argument = function

--- a/languages/python/tree-sitter/Parse_python_tree_sitter.ml
+++ b/languages/python/tree-sitter/Parse_python_tree_sitter.ml
@@ -925,15 +925,14 @@ and map_primary_expression (env : env) (x : CST.primary_expression) : expr =
       let r = (* ")" *) token env v3 in
       Tuple (CompList (l, xs, r), no_ctx)
   | `Paren_exp (v1, v2, v3) ->
-      let _lp = (* "(" *) token env v1 in
+      let lp = (* "(" *) token env v1 in
       let e =
         match v2 with
         | `Exp x -> map_type_ env x
         | `Yield x -> map_yield env x
       in
-      let _rp = (* ")" *) token env v3 in
-      (* TODO? ParenExpr? *)
-      e
+      let rp = (* ")" *) token env v3 in
+      ParenExpr (lp, e, rp)
   | `Gene_exp x ->
       let x = map_generator_expression env x in
       x

--- a/libs/ast_generic/AST_generic_helpers.ml
+++ b/libs/ast_generic/AST_generic_helpers.ml
@@ -401,3 +401,16 @@ let undo_ac_matching_nf tok op : expr list -> expr option = function
         |> G.e
       in
       Some (List.fold_left mk_op (mk_op a1 a2) args)
+
+let set_e_range l r e =
+  match
+    (Parse_info.token_location_of_info l, Parse_info.token_location_of_info r)
+  with
+  | Ok l, Ok r -> e.e_range <- Some (l, r)
+  | Error _, _
+  | _, Error _ ->
+      (* Probably not super useful to dump the whole expression, or to log the
+       * fake tokens themselves. Perhaps this will be useful for debugging
+       * isolated examples, though. *)
+      logger#debug "set_e_range failed: missing token location";
+      ()

--- a/libs/ast_generic/AST_generic_helpers.mli
+++ b/libs/ast_generic/AST_generic_helpers.mli
@@ -106,3 +106,7 @@ val undo_ac_matching_nf :
  * E.g.
  *    undo_ac_matching_nf tok And [a; b; c] = Call(Op And, [Call(Op And, [a; b]); c])
  *)
+
+(* Sets the e_range on the expression based on the left and right tokens
+ * provided. No-op if either has a fake location. *)
+val set_e_range : Parse_info.t -> Parse_info.t -> AST_generic.expr -> unit

--- a/perf/snapshots/ci_small_repos_baseline.json
+++ b/perf/snapshots/ci_small_repos_baseline.json
@@ -167,9 +167,9 @@
           },
           "path": "<masked in benchmarks>/semgrep/perf/bench/zulip/input/zulip/zilencer/management/commands/rundjangoserver.py",
           "start": {
-            "col": 14,
+            "col": 13,
             "line": 31,
-            "offset": 1142
+            "offset": 1141
           }
         },
         {

--- a/src/fixing/Autofix.ml
+++ b/src/fixing/Autofix.ml
@@ -63,6 +63,12 @@ let transform_fix lang ast =
           mk_visitor
             {
               default_visitor with
+              (* The default visitor behavior is to create a new expr node every
+               * time, with a new e_id and e_range. Avoid this by overriding
+               * such that we take the new expr_kind and put it in the original
+               * expression. *)
+              kexpr =
+                (fun (k, _) expr -> AST_generic.{ expr with e = (k expr).e });
               kargs =
                 (fun (k, _) args ->
                   let args =

--- a/tests/patterns/python/fix_binop.fixed
+++ b/tests/patterns/python/fix_binop.fixed
@@ -2,3 +2,6 @@
 bar((3 * 2))
 # MATCH:
 bar(((5 + 3) * 2))
+# Test case for #2902
+# MATCH:
+bar(((1 + (5 + 3)) * 2))

--- a/tests/patterns/python/fix_binop.py
+++ b/tests/patterns/python/fix_binop.py
@@ -2,3 +2,6 @@
 foo(3)
 # MATCH:
 foo(5 + 3)
+# Test case for #2902
+# MATCH:
+foo(1 + (5 + 3))


### PR DESCRIPTION
Previously, the `$X` metavariable binding in the new fix_binop.py example was given the range associated with `1 + (5 + 3`. This is because the parentheses get dropped by the parser, so the location of the second plus operation is associated with only `5 + 3`. In isolation that's fine, but in cases like this where it is part of a larger expression, this can mean that one parenthesis is included in the range while the other is not.

This issue affects both text-based autofix and AST-based autofix. Both need to know which snippet to replace with the fix, and both need to know the correct location of the original text for bound metavariables.

My first attempt to address this was to create `ParenExpr` nodes in the generic AST, which are already used on a limited basis for Go. Even after adding cases to unwrap them in `m_expr`, there was still a fairly large difference in matching behavior. I assume that there are a lot of places outside of `m_expr` that match on expression nodes, and we'd have to add unwrapping logic everywhere that happens. This seemed error prone and hard to maintain. This is another case that illustrates the tension between an AST, most useful for matching and analysis, and a CST, most useful for manipulating and printing code.

Instead, I decided to write the range, including the parentheses, to `e_range` when the expression node was created. This is a bit of a departure from the way e_range has historically been used. Until now, as far as I know, it has only been a cache. Now, it serves as the canonical source of range information in this case. I think that this is a good direction to move in -- many of our location issues stem from some tokens not making it into the resulting AST, so I think that explicitly setting the range based on locations from the parser, when the node is constructed, will help. That way, we would be free to drop semantically meaningless tokens from the AST without worrying that they are needed to compute locations.

Fixes #2902

Test plan:

- Automated tests
- Manual test with the example from #2902 (https://semgrep.dev/playground/s/20WB)
  - Also manual test after putting the tree sitter parser first in Parse_target2.ml

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
