### PR TITLE
feat(scala): imports

### DIFF
--- a/changelog.d/pa-2678.added
+++ b/changelog.d/pa-2678.added
@@ -1,0 +1,1 @@
+Scala: Added proper parsing for Scala 3 style imports

--- a/languages/scala/ast/AST_scala.ml
+++ b/languages/scala/ast/AST_scala.ml
@@ -114,11 +114,8 @@ type named_selector = import_path_elem * ident_or_wildcard option
 and wildcard_selector = (ident, tok * type_ option) either
 
 and import_selector =
-  | ImportBasic of ident_or_wildcard * alias option
   | NamedSelector of named_selector
   | WildCardSelector of wildcard_selector
-
-and alias = tok (* => | `as` (scala 3) *) * ident_or_wildcard
 
 (* semgrep-ext: we allow single identifiers here so we can support import $X *)
 and import_expr =

--- a/languages/scala/ast/AST_scala.ml
+++ b/languages/scala/ast/AST_scala.ml
@@ -102,20 +102,36 @@ type stable_id = path [@@deriving show]
 (* Directives *)
 (*****************************************************************************)
 
-type import_selector = ident_or_wildcard * alias option
-and alias = tok (* => *) * ident_or_wildcard [@@deriving show]
+type import_path_elem =
+  | ImportId of ident
+  | ImportThis of tok
+  | ImportSuper of tok
+[@@deriving show]
+
+type import_path = import_path_elem list [@@deriving show]
+
+type named_selector = import_path_elem * ident_or_wildcard option
+and wildcard_selector = (ident, tok * type_ option) either
+
+and import_selector =
+  | ImportBasic of ident_or_wildcard * alias option
+  | NamedSelector of named_selector
+  | WildCardSelector of wildcard_selector
+
+and alias = tok (* => | `as` (scala 3) *) * ident_or_wildcard
 
 (* semgrep-ext: we allow single identifiers here so we can support import $X *)
-type import_expr = (ident, stable_id * import_spec) either
+and import_expr =
+  | ImportExprSpec of import_path * import_spec
+  | ImportExprMvar of ident
 
 and import_spec =
-  | ImportId of ident
-  | ImportWildcard of tok (* '_' *)
+  | ImportNamed of named_selector
+  | ImportWildcard of wildcard_selector
   | ImportSelectors of import_selector list bracket
-[@@deriving show { with_path = false }]
 
-type import = tok (* 'import' *) * import_expr list [@@deriving show]
-type package = tok (* 'package' *) * qualified_ident [@@deriving show]
+and import = tok (* 'import' *) * import_expr list
+and package = tok (* 'package' *) * qualified_ident
 
 (*****************************************************************************)
 (* Start of big recursive type *)
@@ -133,7 +149,7 @@ type package = tok (* 'package' *) * qualified_ident [@@deriving show]
 (* todo: interpolated strings? can be a literal pattern too?
  * scala3: called simple_literal
  *)
-type literal =
+and literal =
   | Int of int option wrap
   | Float of float option wrap
   | Char of string wrap

--- a/languages/scala/generic/scala_to_generic.ml
+++ b/languages/scala/generic/scala_to_generic.ml
@@ -111,14 +111,6 @@ let v_path (v1, v2) =
   (v1, v2)
 
 let rec v_import_selector tk (path : G.dotted_ident) = function
-  | ImportBasic (id, alias) ->
-      let module_name = G.DottedName (path) in
-      let alias =
-        match alias with
-        | None -> None
-        | Some (_, alias_id) -> Some (v_ident alias_id, G.empty_id_info ())
-      in
-      G.ImportFrom (tk, module_name, [id, alias]) |> G.d
   | NamedSelector x -> v_named_selector tk path x
   | WildCardSelector x -> v_wildcard_selector tk path x
 

--- a/languages/scala/recursive_descent/Parser_scala_recursive_descent.ml
+++ b/languages/scala/recursive_descent/Parser_scala_recursive_descent.ml
@@ -144,8 +144,6 @@ type location = Local | InBlock | InTemplate
 (* to correctly handle infix operators (in expressions, patterns, and types)*)
 type mode = FirstOp | LeftOp | RightOp [@@deriving show { with_path = false }]
 
-let report in_ s = Common.(pr2 (spf "%s: %s" s ([%show: token] in_.token)))
-
 (*****************************************************************************)
 (* Logging/Dumpers  *)
 (*****************************************************************************)
@@ -2580,7 +2578,6 @@ and importExpr in_ : import_expr =
 let importClause in_ : import =
   let ii = TH.info_of_tok in_.token in
   accept (Kimport ab) in_;
-  report in_ "importepxr";
   let xs = commaSeparated importExpr in_ in
   (ii, xs)
 

--- a/languages/scala/recursive_descent/Parser_scala_recursive_descent.ml
+++ b/languages/scala/recursive_descent/Parser_scala_recursive_descent.ml
@@ -144,6 +144,8 @@ type location = Local | InBlock | InTemplate
 (* to correctly handle infix operators (in expressions, patterns, and types)*)
 type mode = FirstOp | LeftOp | RightOp [@@deriving show { with_path = false }]
 
+let report in_ s = Common.(pr2 (spf "%s: %s" s ([%show: token] in_.token)))
+
 (*****************************************************************************)
 (* Logging/Dumpers  *)
 (*****************************************************************************)
@@ -2401,28 +2403,67 @@ let annotTypeRest t in_ : type_ =
 (* Parsing directives  *)
 (*****************************************************************************)
 
-let wildImportSelector in_ =
-  (* AST: val selector = ImportSelector.wildAt(in.offset) *)
-  nextToken in_
+(* For imports, we will parse a less restrictive version of the Scala grammar.
+   Essentially, we notice that some sequence of dot-separated elements
+   make up the primary path, namely "this", "super", and an identifier.
+   Once that primary path is done, we may see a `as` or `=>`, and then
+   another identifier.
+
+   Otherwise, the primary path may also be terminated with a `*`, `given`,
+   `_`, or brace-delimited list of import specifications.
+*)
 
 (** {{{
- *  ImportSelector ::= Id [`=>` Id | `=>` `_`]
+ *  NamedSelector     ::=  id [‘as’ (id | ‘_’)]
+ *  WildCardSelector  ::=  ‘*' | ‘given’ [InfixType]
+ *  }}}
+*)
+let wildCardSelector in_ =
+  match in_.token with
+  | USCORE ii ->
+      skipToken in_;
+      Left ("_", ii)
+  | STAR ii ->
+      skipToken in_;
+      Left ("*", ii)
+  | _ ->
+      let ii = TH.info_of_tok in_.token in
+      accept (ID_LOWER ("given", ab)) in_;
+      (* only a keyword in Scala 3*)
+      (* TODO: this type is only optional, is this too eager? *)
+      if TH.isTypeIntroToken in_.token then
+        let ty = startInfixType in_ in
+        Right (ii, Some ty)
+      else Right (ii, None)
+
+(** {{{
+ *  ImportSelector ::= Id [`=>` Id | `=>` `_`]  (scala 2)
+                     | NamedSelector            (scala 3)
+                     | WildCardSelector         (scala 3)
  *  }}}
 *)
 let importSelector in_ : import_selector =
-  let name = wildcardOrIdent in_ in
-  let rename =
-    match in_.token with
-    | ARROW ii ->
-        nextToken in_;
-        (* CHECK: "Wildcard import cannot be renamed" *)
-        let alias = wildcardOrIdent in_ in
-        Some (ii, alias)
-    (* AST: if name = nme.WILDCARD && !bbq => null *)
-    | _ -> None
-  in
-  (* ast: ImportSelector(name, start, rename, renameOffset) *)
-  (name, rename)
+  match in_.token with
+  | STAR _
+  | ID_LOWER ("given", _) ->
+      WildCardSelector (wildCardSelector in_)
+  | _ ->
+      (* namedSelector case:
+       *)
+      let name = wildcardOrIdent in_ in
+      let rename =
+        match in_.token with
+        | ARROW ii
+        | ID_LOWER ("as", ii) ->
+            nextToken in_;
+            (* CHECK: "Wildcard import cannot be renamed" *)
+            let alias = wildcardOrIdent in_ in
+            Some (ii, alias)
+        (* AST: if name = nme.WILDCARD && !bbq => null *)
+        | _ -> None
+      in
+      (* ast: ImportSelector(name, start, rename, renameOffset) *)
+      ImportBasic (name, rename)
 
 (** {{{
  *  ImportSelectors ::= `{` {ImportSelector `,`} (ImportSelector | `_`) `}`
@@ -2433,82 +2474,97 @@ let importSelectors in_ : import_selector list bracket =
   inBracesOrNil (commaSeparated importSelector) in_
 
 (** {{{
- *  ImportExpr ::= StableId `.` (Id | `_` | ImportSelectors)
-                 | (* scala-ext: allow this for things like `import $X` *)
+ *  ImportExpr ::= StableId `.` (NamedSelector | WildCardSelector | `_` | ImportSelectors)
+                 | StableId `as` id  (scala 3)
+                 | (* semgrep-ext: allow this for things like `import $X` *)
                    metavariable
  *  }}}
 *)
-let importExpr in_ : import_expr =
+
+(* Since we just accumulate the entire list of the import path, we may have
+   to run it back one step if we reach the end. That's because parsing
+   a.b.c
+   means that our path will be [`a`, `b`, `c`], but we really want to
+   turn it into importing the name `c` from the path `a.b`.
+
+   So this function just splits the last element, taking the "tl".
+*)
+let tl_path path =
+  (* presumably this means the end of the stable id,
+      with nothing after it *)
+  match List.rev path with
+  | last :: rest -> (List.rev rest, last)
+  | [] -> failwith "shouldn't happen"
+
+(* A single "path element". In reality, `super` and `this` are more
+   restricted in where they can appear, but for our purposes we will
+   be lenient.
+*)
+let read_path_elem in_ : import_path_elem =
+  match in_.token with
+  | Ksuper ii ->
+      skipToken in_;
+      ImportSuper ii
+  | Kthis ii ->
+      skipToken in_;
+      ImportThis ii
+  | _ ->
+      let id = ident in_ in
+      ImportId id
+
+(* This walks the import path, reading things like a.b.c until it
+   finds something different.
+*)
+let rec collect_import_path (path : import_path) in_ =
+  match in_.token with
+  (* All the things that can terminate an imported StableId.
+  *)
+  | ARROW _
+  | ID_LOWER ("as", _) -> (
+      nextToken in_;
+      match in_.token with
+      | USCORE _ -> ImportExprSpec (path, ImportWildcard (wildCardSelector in_))
+      | _ ->
+          let path, id = tl_path path in
+          (* either "as" or `=>` *)
+          let id' = ident in_ in
+          ImportExprSpec (path, ImportNamed (id, Some id')))
+  | DOT _ -> (
+      accept (DOT ab) in_;
+      match in_.token with
+      (* import foo.bar._; (scala 2) *)
+      | USCORE _
+      (* import foo.bar.*; (scala 3) *)
+      | STAR _
+      (* import foo.bar.given; (scala 3) *)
+      | ID_LOWER ("given", _) ->
+          ImportExprSpec (path, ImportWildcard (wildCardSelector in_))
+      (* import foo.bar.{ x, y, z } *)
+      | LBRACE _ ->
+          let internal = importSelectors in_ in
+          ImportExprSpec (path, ImportSelectors internal)
+      (* Otherwise, the import path just continues. *)
+      | _ ->
+          let new_path_elem = read_path_elem in_ in
+          collect_import_path (path @ [ new_path_elem ]) in_)
+  (* Here, we probably reached the end of the import expression.
+   *)
+  | _ ->
+      let stable_id, id = tl_path path in
+      ImportExprSpec (stable_id, ImportNamed (id, None))
+
+(* To parse an import expression, first we find a single "element".
+   Then, we collect a dot-separated list of them, until we have
+   reason to read something else.
+*)
+and importExpr in_ : import_expr =
   in_
   |> with_logging "importExpr" (fun () ->
-         let thisDotted nameopt in_ : stable_id =
-           let ii = TH.info_of_tok in_.token in
-           nextToken in_;
-           (* 'this' *)
-           (* AST: val t = This(name) *)
-           accept (DOT ab) in_;
-           let result = selector (*t*) in_ in
-           accept (DOT ab) in_;
-           (This (nameopt, ii), [ result ])
-         in
          (* Walks down import `foo.bar.baz.{ ... }` until it ends at
           * an underscore, a left brace, or an undotted identifier.
           *)
-         let rec loop (expr : stable_id) in_ =
-           (* ast: let selectors = *)
-           match in_.token with
-           (* import foo.bar._; *)
-           | USCORE ii ->
-               let _ = wildImportSelector in_ in
-               (expr, ImportWildcard ii)
-           (* import foo.bar.{ x, y, z } *)
-           | LBRACE _ ->
-               let xs = importSelectors in_ in
-               (expr, ImportSelectors xs)
-           | _ -> (
-               let name = ident in_ in
-               match in_.token with
-               | DOT _ ->
-                   (* import foo.bar.ident.<unknown> and so create a select node and recurse. *)
-                   (* AST: (Select(expr, name)) *)
-                   let sref, selectors = expr in
-                   let t = (sref, selectors @ [ name ]) in
-                   nextToken in_;
-                   loop t in_
-               | _ ->
-                   (* import foo.bar.Baz; *)
-                   (* AST: List(makeImportSelector(name, nameOffset)) *)
-                   (expr, ImportId name))
-           (* reaching here means we're done walking. *)
-           (* AST: Import(expr, selectors) *)
-         in
-         let handle_potential_this_with_id id in_ =
-           let start =
-             match in_.token with
-             | Kthis _ -> thisDotted (Some id) in_
-             | _ -> (Id id, [])
-           in
-           Right (loop start in_)
-         in
-         match in_.token with
-         | Kthis _ ->
-             let start = thisDotted None (*ast: empty*) in_ in
-             Right (loop start in_)
-         (* We should allow single metavariables to be imported. *)
-         | ID_LOWER ((s, _) as id) when AST_generic.is_metavar_name s -> (
-             nextToken in_;
-             match in_.token with
-             | DOT _ ->
-                 nextToken in_;
-                 handle_potential_this_with_id id in_
-             (* If there is no dot next, then it must be a lone metavariable. *)
-             | _ -> Left id)
-         | _ ->
-             (* AST: Ident() *)
-             let id = ident in_ in
-             (* A dot has to come after an ident. *)
-             accept (DOT ab) in_;
-             handle_potential_this_with_id id in_)
+         let new_path_elem = read_path_elem in_ in
+         collect_import_path [ new_path_elem ] in_)
 
 (** {{{
  *  Import  ::= import ImportExpr {`,` ImportExpr}
@@ -2517,6 +2573,7 @@ let importExpr in_ : import_expr =
 let importClause in_ : import =
   let ii = TH.info_of_tok in_.token in
   accept (Kimport ab) in_;
+  report in_ "importepxr";
   let xs = commaSeparated importExpr in_ in
   (ii, xs)
 

--- a/languages/scala/recursive_descent/Parser_scala_recursive_descent.ml
+++ b/languages/scala/recursive_descent/Parser_scala_recursive_descent.ml
@@ -2453,17 +2453,17 @@ let importSelector in_ : import_selector =
       let name = wildcardOrIdent in_ in
       let rename =
         match in_.token with
-        | ARROW ii
-        | ID_LOWER ("as", ii) ->
+        | ARROW _
+        | ID_LOWER ("as", _) ->
             nextToken in_;
             (* CHECK: "Wildcard import cannot be renamed" *)
             let alias = wildcardOrIdent in_ in
-            Some (ii, alias)
+            Some alias
         (* AST: if name = nme.WILDCARD && !bbq => null *)
         | _ -> None
       in
       (* ast: ImportSelector(name, start, rename, renameOffset) *)
-      ImportBasic (name, rename)
+      NamedSelector (ImportId name, rename)
 
 (** {{{
  *  ImportSelectors ::= `{` {ImportSelector `,`} (ImportSelector | `_`) `}`
@@ -2523,10 +2523,10 @@ let rec collect_import_path (path : import_path) in_ =
   | ID_LOWER ("as", _) -> (
       nextToken in_;
       match in_.token with
-      | USCORE _ -> 
+      | USCORE _ ->
           (* This is something like `import a as _`
              Kind of a weird thing to write. I assume it's just binding it to a weird name.
-           *)
+          *)
           let ii = TH.info_of_tok in_.token in
           accept (USCORE ab) in_;
           let path, id = tl_path path in

--- a/languages/scala/recursive_descent/Parser_scala_recursive_descent.ml
+++ b/languages/scala/recursive_descent/Parser_scala_recursive_descent.ml
@@ -2523,7 +2523,14 @@ let rec collect_import_path (path : import_path) in_ =
   | ID_LOWER ("as", _) -> (
       nextToken in_;
       match in_.token with
-      | USCORE _ -> ImportExprSpec (path, ImportWildcard (wildCardSelector in_))
+      | USCORE _ -> 
+          (* This is something like `import a as _`
+             Kind of a weird thing to write. I assume it's just binding it to a weird name.
+           *)
+          let ii = TH.info_of_tok in_.token in
+          accept (USCORE ab) in_;
+          let path, id = tl_path path in
+          ImportExprSpec (path, ImportNamed (id, Some ("_", ii)))
       | _ ->
           let path, id = tl_path path in
           (* either "as" or `=>` *)

--- a/tests/parsing/scala/imports.scala
+++ b/tests/parsing/scala/imports.scala
@@ -1,0 +1,52 @@
+// basic paths
+
+import a
+
+import a.b
+
+import a.b.c
+
+
+// this 
+
+import this
+
+import this.a
+
+import a.this.b
+
+// super 
+
+import a.super.b
+
+// lone metavariable
+
+import $X
+
+// wildcards
+
+import a.*
+
+import a._
+
+import a.given
+
+import a.given Int
+
+// alias
+
+import a => b
+
+import a as b
+
+import a as _ 
+
+import a.b => c 
+
+import a.b as c
+
+// selectors
+
+import a.b.{c, d, e}
+
+import a.b.{c as d, e, f as g, *}


### PR DESCRIPTION
## What:
This PR refactors the code that parsed imports in Scala, as well as supporting imports as specified in Scala 3.

## Why:
Parse rate.

## How:
The Scala 3 grammar is a little more permissive than Scala 2. It is now possible to do imports that are single identifiers, and also there are more kinds of import syntax (`as`, `*`), so I just ripped out the old import code and rewrote it. I made some simplifying assumptions that are in line with Scala 3, but also permit more things in general, so the code could be nicer. The old code was very stringent about sticking to the grammar, but it doesn't actually matter. 

Now, there are several phases. The first phase is the one where we collect the entire "path" of the import, and the second phase has to do with parsing any special import constructs that come at the end, such as `*`, `as`, `=>`, `{`, and so on and so forth.

I also had to make a few more things mutually recursive because in Scala 3 imports can use types.

## Test plan:
Parse rate went up.
```
lang/scala/stats.json:3
   "global": {
     "name": "*",
     "parsing_rate": 0.9201002165638166,
     "line_count": 2307403,
     "error_line_count": 184361,
     "file_count": 14684,
     "error_file_count": 1570,
     "total_node_count": 30467426,
     "untranslated_node_count": 100979
   },
```
from `0.9189534728003734`

I also tried it out on the test case and verified the results looked good. Parsing
```
// basic paths

import a

import a.b

import a.b.c


// this 

import this

import this.a

import a.this.b

// super 

import a.super.b

// lone metavariable

import $X

// wildcards

import a.*

import a._

import a.given

import a.given Int

// alias

import a => b

import a as b

import a as _ 

import a.b => c 

import a.b as c

// selectors

import a.b.{c, d, e}

import a.b.{c as d, e, f as g, *}
```
yields
```
Pr(
  [DirectiveStmt({d_attrs=[]; d=ImportFrom((), DottedName([]), [(("a", ()), None)]); });
   DirectiveStmt({d_attrs=[]; d=ImportFrom((), DottedName([("a", ())]), [(("b", ()), None)]); });
   DirectiveStmt({d_attrs=[]; d=ImportFrom((), DottedName([("a", ()); ("b", ())]), [(("c", ()), None)]); });
   DirectiveStmt({d_attrs=[]; d=ImportFrom((), DottedName([]), [(("this", ()), None)]); });
   DirectiveStmt({d_attrs=[]; d=ImportFrom((), DottedName([("this", ())]), [(("a", ()), None)]); });
   DirectiveStmt({d_attrs=[]; d=ImportFrom((), DottedName([("a", ()); ("this", ())]), [(("b", ()), None)]); });
   DirectiveStmt({d_attrs=[]; d=ImportFrom((), DottedName([("a", ()); ("super", ())]), [(("b", ()), None)]); });
   DirectiveStmt({d_attrs=[]; d=ImportFrom((), DottedName([]), [(("$X", ()), None)]); });
   DirectiveStmt({d_attrs=[]; d=ImportAll((), DottedName([("a", ())]), ()); });
   DirectiveStmt({d_attrs=[]; d=ImportAll((), DottedName([("a", ())]), ()); });
   DirectiveStmt({d_attrs=[]; d=OtherDirective(("ImportGiven", ()), []); });
   DirectiveStmt(
     {d_attrs=[];
      d=OtherDirective(("ImportGiven", ()),
          [T(
             {t_attrs=[];
              t=TyN(
                  Id(("Int", ()),
                    {id_info_id=1; id_hidden=false; id_resolved=Ref(None); id_type=Ref(None); id_svalue=Ref(None); }));
              })]);
      });
   DirectiveStmt(
     {d_attrs=[];
      d=ImportFrom((), DottedName([]),
          [(("a", ()),
            Some((("b", ()),
                  {id_info_id=2; id_hidden=false; id_resolved=Ref(None); id_type=Ref(None); id_svalue=Ref(None); })))]);
      });
   DirectiveStmt(
     {d_attrs=[];
      d=ImportFrom((), DottedName([]),
          [(("a", ()),
            Some((("b", ()),
                  {id_info_id=3; id_hidden=false; id_resolved=Ref(None); id_type=Ref(None); id_svalue=Ref(None); })))]);
      });
   DirectiveStmt(
     {d_attrs=[];
      d=ImportFrom((), DottedName([]),
          [(("a", ()),
            Some((("_", ()),
                  {id_info_id=4; id_hidden=false; id_resolved=Ref(None); id_type=Ref(None); id_svalue=Ref(None); })))]);
      });
   DirectiveStmt(
     {d_attrs=[];
      d=ImportFrom((), DottedName([("a", ())]),
          [(("b", ()),
            Some((("c", ()),
                  {id_info_id=5; id_hidden=false; id_resolved=Ref(None); id_type=Ref(None); id_svalue=Ref(None); })))]);
      });
   DirectiveStmt(
     {d_attrs=[];
      d=ImportFrom((), DottedName([("a", ())]),
          [(("b", ()),
            Some((("c", ()),
                  {id_info_id=6; id_hidden=false; id_resolved=Ref(None); id_type=Ref(None); id_svalue=Ref(None); })))]);
      }); DirectiveStmt({d_attrs=[]; d=ImportFrom((), DottedName([("a", ()); ("b", ())]), [(("c", ()), None)]); });
   DirectiveStmt({d_attrs=[]; d=ImportFrom((), DottedName([("a", ()); ("b", ())]), [(("d", ()), None)]); });
   DirectiveStmt({d_attrs=[]; d=ImportFrom((), DottedName([("a", ()); ("b", ())]), [(("e", ()), None)]); });
   DirectiveStmt(
     {d_attrs=[];
      d=ImportFrom((), DottedName([("a", ()); ("b", ())]),
          [(("c", ()),
            Some((("d", ()),
                  {id_info_id=7; id_hidden=false; id_resolved=Ref(None); id_type=Ref(None); id_svalue=Ref(None); })))]);
      }); DirectiveStmt({d_attrs=[]; d=ImportFrom((), DottedName([("a", ()); ("b", ())]), [(("e", ()), None)]); });
   DirectiveStmt(
     {d_attrs=[];
      d=ImportFrom((), DottedName([("a", ()); ("b", ())]),
          [(("f", ()),
            Some((("g", ()),
                  {id_info_id=8; id_hidden=false; id_resolved=Ref(None); id_type=Ref(None); id_svalue=Ref(None); })))]);
      }); DirectiveStmt({d_attrs=[]; d=ImportAll((), DottedName([("a", ()); ("b", ())]), ()); })])
```
where this looks good to me.

Closes PA-2678

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
