### PR TITLE
fix(error): Improve the message given when Semgrep OOMs

### DIFF
--- a/cli/src/semgrep/core_runner.py
+++ b/cli/src/semgrep/core_runner.py
@@ -243,32 +243,6 @@ class StreamingSemgrepCore:
         # TODO: read progress from one channel and JSON data from another.
         # or at least write/read progress as a stream of JSON objects so that
         # we don't have to hack a parser together.
-        raise SemgrepError(
-            f"""
-            You are seeing this because the engine was killed.
-
-            The most common reason this happens is because it used too much memory.
-            If your repo is large (~10k files or more), you have three options:
-              1. Increase the amount of memory available to semgrep
-              2. Reduce the number of jobs semgrep runs with via `-j <jobs>`. We
-                 recommend using 1 job if you are running out of memory.
-              3. Scan the repo in parts (contact us for help)
-
-            Otherwise, it is likely that semgrep is hitting the limit on only some
-            files. In this case, you can try to set the limit on the amount of memory
-            semgrep can use on each file with `--max-memory <memory>`. We recommend
-            lowering this to a limit 70% of the available memory. For CI runs with
-            interfile analysis, the default max-memory is 5000MB. Without, the default
-            is unlimited.
-
-            The last thing you can try if none of these work is to raise the stack
-            limit with `ulimit -s <limit>`.
-
-            If you have tried all these steps and still are seeing this error, please
-            contact us.
-            """
-        )
-
         has_started = False
         while True:
             # blocking read if buffer doesnt contain any lines or EOF
@@ -282,7 +256,33 @@ class StreamingSemgrepCore:
                 # Hack: the exact wording of parts this message may be used in metrics queries
                 # that are looking for it. Make sure `semgrep-core exited with unexpected output`
                 # and `interfile analysis` are both in the message, or talk to Emma.
-                print("TODO")
+                raise SemgrepError(
+                    f"""
+                    You are seeing this because the engine was killed.
+
+                    The most common reason this happens is because it used too much memory.
+                    If your repo is large (~10k files or more), you have three options:
+                    1. Increase the amount of memory available to semgrep
+                    2. Reduce the number of jobs semgrep runs with via `-j <jobs>`. We
+                        recommend using 1 job if you are running out of memory.
+                    3. Scan the repo in parts (contact us for help)
+
+                    Otherwise, it is likely that semgrep is hitting the limit on only some
+                    files. In this case, you can try to set the limit on the amount of memory
+                    semgrep can use on each file with `--max-memory <memory>`. We recommend
+                    lowering this to a limit 70% of the available memory. For CI runs with
+                    interfile analysis, the default max-memory is 5000MB. Without, the default
+                    is unlimited.
+
+                    The last thing you can try if none of these work is to raise the stack
+                    limit with `ulimit -s <limit>`.
+
+                    If you have tried all these steps and still are seeing this error, please
+                    contact us.
+
+                       Error: semgrep-core exited with unexpected output
+                    """
+                )
 
             if (
                 not has_started

--- a/cli/src/semgrep/core_runner.py
+++ b/cli/src/semgrep/core_runner.py
@@ -243,6 +243,31 @@ class StreamingSemgrepCore:
         # TODO: read progress from one channel and JSON data from another.
         # or at least write/read progress as a stream of JSON objects so that
         # we don't have to hack a parser together.
+        raise SemgrepError(
+            f"""
+            You are seeing this because the engine was killed.
+
+            The most common reason this happens is because it used too much memory.
+            If your repo is large (~10k files or more), you have three options:
+              1. Increase the amount of memory available to semgrep
+              2. Reduce the number of jobs semgrep runs with via `-j <jobs>`. We
+                 recommend using 1 job if you are running out of memory.
+              3. Scan the repo in parts (contact us for help)
+
+            Otherwise, it is likely that semgrep is hitting the limit on only some
+            files. In this case, you can try to set the limit on the amount of memory
+            semgrep can use on each file with `--max-memory <memory>`. We recommend
+            lowering this to a limit 70% of the available memory. For CI runs with
+            interfile analysis, the default max-memory is 5000MB. Without, the default
+            is unlimited.
+
+            The last thing you can try if none of these work is to raise the stack
+            limit with `ulimit -s <limit>`.
+
+            If you have tried all these steps and still are seeing this error, please
+            contact us.
+            """
+        )
 
         has_started = False
         while True:
@@ -257,16 +282,7 @@ class StreamingSemgrepCore:
                 # Hack: the exact wording of parts this message may be used in metrics queries
                 # that are looking for it. Make sure `semgrep-core exited with unexpected output`
                 # and `interfile analysis` are both in the message, or talk to Emma.
-                raise SemgrepError(
-                    "semgrep-core exited with unexpected output.\n\n"
-                    "\tThis can happen because it overflowed the stack or used too much memory.\n"
-                    "\tTry changing the stack limit with `ulimit -s <limit>` or adding\n"
-                    "\t`--max-memory <memory>` to the semgrep command. For CI runs with interfile\n"
-                    "\tanalysis, the default max-memory is 5000MB. Depending on the memory\n"
-                    "\tavailable in your runner, you may need to lower it. We recommend choosing\n"
-                    "\ta limit 70% of the available memory to allow for some overhead. If you have\n"
-                    "\ttried these steps and still are seeing this error, please contact us."
-                )
+                print("TODO")
 
             if (
                 not has_started


### PR DESCRIPTION
This change reflects how Semgrep works more accurately
    
Test plan: run `semgrep -e "$X == $X" -lang python` on the first commit

```
➜  semgrep git:(develop) ✗ semgrep -e "$X == $X" --lang python
               
               
┌─────────────┐
│ Scan Status │
└─────────────┘
  Scanning 6415 files tracked by git with 1 Code rule:
  Scanning 317 files.
  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━   0% -:--:--                                                                                                                        
[ERROR] Error while running rules: 
            You are seeing this because the engine was killed.

            The most common reason this happens is because it used too much memory.
            If your repo is large (~10k files or more), you have three options:
              1. Increase the amount of memory available to semgrep
              2. Reduce the number of jobs semgrep runs with via `-j <jobs>`. We
                 recommend using 1 job if you are running out of memory.
              3. Scan the repo in parts (contact us for help)

            Otherwise, it is likely that semgrep is hitting the limit on only some
            files. In this case, you can try to set the limit on the amount of memory
            semgrep can use on each file with `--max-memory <memory>`. We recommend 
            lowering this to a limit 70% of the available memory. For CI runs with 
            interfile analysis, the default max-memory is 5000MB. Without, the default 
            is unlimited.

            The last thing you can try if none of these work is to raise the stack
            limit with `ulimit -s <limit>`.
            
            If you have tried all these steps and still are seeing this error, please 
            contact us.
        
                  Error: semgrep-core exited with unexpected output
```

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
