### PR TITLE
tainting: deep: Enable arg-to-arg propagation via function calls

### DIFF
--- a/changelog.d/pa-2570.added
+++ b/changelog.d/pa-2570.added
@@ -1,0 +1,9 @@
+Pro: Java: Semgrep is now able to track the propagation of taint from the
+arguments of a method, to the object being called. So e.g. given a method
+
+    public void foo(int x) {
+        this.x = x;
+    }
+
+and a call `o.foo(tainted)`, Semgrep will be able to track that the field
+`x` of `o` has been tainted.

--- a/src/analyzing/CFG_build.ml
+++ b/src/analyzing/CFG_build.ml
@@ -420,4 +420,4 @@ let (cfg_of_stmts : stmt list -> F.cfg) =
    * connect last stmt to the exit node
    *)
   g |> add_arc_from_opt (last_node_opt, exiti);
-  CFG.make g enteri
+  CFG.make g enteri exiti

--- a/src/engine/Match_tainting_mode.ml
+++ b/src/engine/Match_tainting_mode.ml
@@ -571,6 +571,7 @@ let pm_of_finding finding =
       let sink_pm, _ = T.pm_of_trace sink in
       Some { sink_pm with env = merged_env; taint_trace }
   | T.SrcToReturn _
+  | T.ArgToArg _
   (* TODO: We might want to report functions that let input taint
    * go into a sink (?) *)
   | T.ArgToSink _

--- a/src/il/CFG.ml
+++ b/src/il/CFG.ml
@@ -26,12 +26,13 @@ module NodeiSet = Set.Make (Int)
 type ('node, 'edge) t = {
   graph : ('node, 'edge) Ograph_extended.ograph_mutable;
   entry : nodei;
+  exit : nodei;
   reachable : NodeiSet.t;
 }
 
 type ('node, 'edge) cfg = ('node, 'edge) t
 
-let make (graph : _ Ograph_extended.ograph_mutable) entry : _ t =
+let make (graph : _ Ograph_extended.ograph_mutable) entry exit : _ t =
   let rec aux nodei seen =
     if NodeiSet.mem nodei seen then seen
     else
@@ -43,7 +44,7 @@ let make (graph : _ Ograph_extended.ograph_mutable) entry : _ t =
       in
       NodeiSet.fold aux succs seen
   in
-  { graph; entry; reachable = aux entry NodeiSet.empty }
+  { graph; entry; exit; reachable = aux entry NodeiSet.empty }
 
 (* Predecessors of a node (that can be reached from the entry node). *)
 let predecessors cfg nodei : (nodei * 'node) list =

--- a/src/tainting/Dataflow_tainting.ml
+++ b/src/tainting/Dataflow_tainting.ml
@@ -998,76 +998,118 @@ and check_tainted_expr env exp : Taints.t * Lval_env.t =
 let check_tainted_var env (var : IL.name) : Taints.t * Lval_env.t =
   check_tainted_lval env (LV.lval_of_var var)
 
+let lval_of_sig_arg fun_exp fparams args_exps (sig_arg : T.arg) =
+  let* base_lval, obj =
+    match sig_arg.pos with
+    | "<this>", -1 -> (
+        match fun_exp with
+        | {
+         e = Fetch { base = Var obj; rev_offset = [ { o = Dot _method; _ } ] };
+         _;
+        } ->
+            Some ({ base = Var obj; rev_offset = [] }, obj)
+        | __else__ -> None)
+    | pos -> (
+        let* arg_exp = find_pos_in_actual_args args_exps fparams pos in
+        match arg_exp.e with
+        | Fetch ({ base = Var obj; _ } as arg_lval) -> Some (arg_lval, obj)
+        | __else__ -> None)
+  in
+  let os =
+    sig_arg.offset |> Common.map (fun x -> { o = Dot x; oorig = NoOrig })
+  in
+  let lval =
+    { base_lval with rev_offset = List.rev_append os base_lval.rev_offset }
+  in
+  Some (lval, obj)
+
 (* What is the taint denoted by 'sig_arg' ? *)
-let taints_of_sig_arg env fparams args_exps args_taints (sig_arg : T.arg) =
+let taints_of_sig_arg env fparams fun_exp args_exps args_taints
+    (sig_arg : T.arg) =
   match sig_arg.offset with
-  | [] -> find_pos_in_actual_args args_taints fparams sig_arg.pos
-  | xs -> (
+  | [] when snd sig_arg.pos >= 0 (* not `this`/`self` *) ->
+      find_pos_in_actual_args args_taints fparams sig_arg.pos
+  | __else__ ->
       (* We want to know what's the taint carried by 'arg_exp.x1. ... .xN'. *)
-      let* arg_exp = find_pos_in_actual_args args_exps fparams sig_arg.pos in
-      match arg_exp.e with
-      | Fetch arg_lval ->
-          let os = xs |> Common.map (fun x -> { o = Dot x; oorig = NoOrig }) in
-          let lval =
-            {
-              arg_lval with
-              rev_offset = List.rev_append os arg_lval.rev_offset;
-            }
-          in
-          let arg_taints = check_tainted_lval env lval |> fst in
-          Some arg_taints
-      | __else__ -> None)
+      let* lval, _obj = lval_of_sig_arg fun_exp fparams args_exps sig_arg in
+      let arg_taints = check_tainted_lval env lval |> fst in
+      Some arg_taints
 
 let check_function_signature env fun_exp args args_taints =
   match (!hook_function_taint_signature, fun_exp) with
   | Some hook, { e = Fetch f; eorig = SameAs eorig } ->
       let* fparams, fun_sig = hook env.config eorig in
+      let process_sig : T.finding -> _ option = function
+        | T.SrcToReturn (src, tokens, _return_tok) ->
+            let call_trace = T.Call (eorig, tokens, src.call_trace) in
+            Some
+              (`Return
+                (Taints.singleton
+                   { orig = Src { src with call_trace }; tokens = [] }))
+        | T.ArgToReturn (arg, tokens, _return_tok) ->
+            let* arg_taints =
+              taints_of_sig_arg env fparams fun_exp args args_taints arg
+            in
+            (* Get the token of the function *)
+            let* ident =
+              match f with
+              (* Case `$F()` *)
+              | { base = Var { ident; _ }; rev_offset = []; _ }
+              (* Case `$X. ... .$F()` *)
+              | { base = _; rev_offset = { o = Dot { ident; _ }; _ } :: _; _ }
+                ->
+                  Some ident
+              | __else__ -> None
+            in
+            Some
+              (`Return
+                (arg_taints
+                |> Taints.map (fun taint ->
+                       let tokens =
+                         List.rev_append tokens (snd ident :: taint.tokens)
+                       in
+                       { taint with tokens })))
+        | T.ArgToSink (arg, tokens, sink) ->
+            let sink = T.Call (eorig, tokens, sink) in
+            let* arg_taints =
+              taints_of_sig_arg env fparams fun_exp args args_taints arg
+            in
+            arg_taints
+            |> Taints.iter (fun t ->
+                   findings_of_tainted_sink env (Taints.singleton t) sink
+                   |> report_findings env);
+            None
+        | T.ArgToArg (src_arg, tokens, dst_arg) ->
+            let* src_taints =
+              taints_of_sig_arg env fparams fun_exp args args_taints src_arg
+            in
+            let* dst_lval, dst_obj =
+              lval_of_sig_arg fun_exp fparams args dst_arg
+            in
+            let dst_taints =
+              src_taints
+              |> Taints.map (fun taint ->
+                     let tokens =
+                       List.rev_append tokens (snd dst_obj.ident :: taint.tokens)
+                     in
+                     { taint with tokens })
+            in
+            if Taints.is_empty dst_taints then None
+            else Some (`UpdateEnv (dst_lval, dst_taints))
+        (* THINK: Should we report something here? *)
+        | T.SrcToSink _ -> None
+      in
       Some
         (fun_sig
-        |> Common.map_filter (function
-             | T.SrcToReturn (src, tokens, _return_tok) ->
-                 let call_trace = T.Call (eorig, tokens, src.call_trace) in
-                 Some
-                   (Taints.singleton
-                      { orig = Src { src with call_trace }; tokens = [] })
-             | T.ArgToReturn (arg, tokens, _return_tok) ->
-                 let* arg_taints =
-                   taints_of_sig_arg env fparams args args_taints arg
-                 in
-                 (* Get the token of the function *)
-                 let* ident =
-                   match f with
-                   (* Case `$F()` *)
-                   | { base = Var { ident; _ }; rev_offset = []; _ }
-                   (* Case `$X. ... .$F()` *)
-                   | {
-                       base = _;
-                       rev_offset = { o = Dot { ident; _ }; _ } :: _;
-                       _;
-                     } ->
-                       Some ident
-                   | __else__ -> None
-                 in
-                 Some
-                   (arg_taints
-                   |> Taints.map (fun taint ->
-                          let tokens =
-                            List.rev_append tokens (snd ident :: taint.tokens)
-                          in
-                          { taint with tokens }))
-             | T.ArgToSink (arg, tokens, sink) ->
-                 let sink = T.Call (eorig, tokens, sink) in
-                 let* arg_taints =
-                   taints_of_sig_arg env fparams args args_taints arg
-                 in
-                 arg_taints
-                 |> Taints.iter (fun t ->
-                        findings_of_tainted_sink env (Taints.singleton t) sink
-                        |> report_findings env);
-                 None
-             (* THINK: Should we report something here? *)
-             | T.SrcToSink _ -> None)
-        |> List.fold_left Taints.union Taints.empty)
+        |> List.fold_left
+             (fun (taints_acc, lval_env) fsig ->
+               match process_sig fsig with
+               | None -> (taints_acc, lval_env)
+               | Some (`Return taints) ->
+                   (Taints.union taints taints_acc, lval_env)
+               | Some (`UpdateEnv (lval, taints)) ->
+                   (taints_acc, Lval_env.add lval_env lval taints))
+             (Taints.empty, env.lval_env))
   | None, _
   | Some _, _ ->
       None
@@ -1101,28 +1143,32 @@ let check_tainted_instr env instr : Taints.t * Lval_env.t =
         let all_args_taints =
           List.fold_left Taints.union Taints.empty all_taints
         in
-        let opt_taint_sig = check_function_signature env e args args_taints in
-        let lval_env =
-          (* HACK: Java: If we encounter `obj.setX(arg)` we interpret this as `obj.getX = arg`. *)
-          propagate_taint_via_java_setter { env with lval_env } e args
-            all_args_taints
-        in
         (* After we introduced Top_sinks, we need to explicitly support sinks like
          * `sink(...)` by considering that all of the parameters are sinks. To make
          * sure that we are backwards compatible, we do this for any sink that does
          * not match the `is_func_sink_with_focus` pattern.
          *)
-        check_orig_if_sink env instr.iorig all_args_taints
+        check_orig_if_sink { env with lval_env } instr.iorig all_args_taints
           ~filter_sinks:(fun m -> not (is_func_sink_with_focus m.spec));
-        let call_taints =
-          match opt_taint_sig with
-          | Some call_taints -> call_taints
+        let call_taints, lval_env =
+          match
+            check_function_signature { env with lval_env } e args args_taints
+          with
+          | Some (call_taints, lval_env) -> (call_taints, lval_env)
           | None ->
-              if not (propagate_through_functions env) then Taints.empty
-              else
-                (* Otherwise assume that the function will propagate
-                   * the taint of its arguments. *)
-                all_args_taints
+              let call_taints =
+                if not (propagate_through_functions env) then Taints.empty
+                else
+                  (* Otherwise assume that the function will propagate
+                     * the taint of its arguments. *)
+                  all_args_taints
+              in
+              let lval_env =
+                (* HACK: Java: If we encounter `obj.setX(arg)` we interpret this as `obj.getX = arg`. *)
+                propagate_taint_via_java_setter { env with lval_env } e args
+                  all_args_taints
+              in
+              (call_taints, lval_env)
         in
         (* We add the taint of the function itselt (i.e., 'e_taints') too.
          * DEEP: In DeepSemgrep this also helps identifying `x.foo()` as tainted
@@ -1171,6 +1217,37 @@ let check_tainted_return env tok e : Taints.t * Lval_env.t =
   let findings = findings_of_tainted_sinks env taints sinks in
   report_findings env findings;
   (taints, var_env')
+
+let findings_from_arg_updates_at_exit enter_env exit_env : T.finding list =
+  (* TOOD: We need to get a map of `lval` to `Taint.arg`, and if an extension
+   * of `lval` has new taints, then we can compute its correspoding `Taint.arg`
+   * extension and generate an `ArgToArg` finding too. *)
+  enter_env |> Lval_env.seq_of_tainted |> List.of_seq
+  |> List.concat_map (fun (lval, enter_taints) ->
+         (* For each lval in the enter_env, we get its `T.arg`, and check
+          * if it got new taints at the exit_env. If so, we generate an
+          * ArgToArg. *)
+         match
+           enter_taints |> Taints.elements
+           |> Common.map_filter (fun taint ->
+                  match taint.T.orig with
+                  | T.Arg arg -> Some arg
+                  | _ -> None)
+         with
+         | []
+         | _ :: _ :: _ ->
+             []
+         | [ arg ] ->
+             let exit_taints =
+               Lval_env.dumb_find exit_env lval |> status_to_taints
+             in
+             let new_taints = Taints.diff exit_taints enter_taints in
+             (* TODO: Also report if taints are _cleaned_. *)
+             new_taints |> Taints.elements
+             |> Common.map_filter (fun taint ->
+                    match taint.T.orig with
+                    | T.Arg t -> Some (T.ArgToArg (t, taint.tokens, arg))
+                    | T.Src _ -> None (* TODO SrcToArg *)))
 
 (*****************************************************************************)
 (* Transfer *)
@@ -1300,7 +1377,13 @@ let (fixpoint :
   in
   (* THINK: Why I cannot just update mapping here ? if I do, the mapping gets overwritten later on! *)
   (* DataflowX.display_mapping flow init_mapping show_tainted; *)
-  DataflowX.fixpoint ~eq_env:Lval_env.equal ~init:init_mapping
-    ~trans:(transfer lang options config enter_env opt_name ~flow ~top_sinks)
-      (* tainting is a forward analysis! *)
-    ~forward:true ~flow
+  let end_mapping =
+    DataflowX.fixpoint ~eq_env:Lval_env.equal ~init:init_mapping
+      ~trans:(transfer lang options config enter_env opt_name ~flow ~top_sinks)
+        (* tainting is a forward analysis! *)
+      ~forward:true ~flow
+  in
+  let exit_env = end_mapping.(flow.exit).D.out_env in
+  ( findings_from_arg_updates_at_exit enter_env exit_env |> fun findings ->
+    if findings <> [] then config.handle_findings opt_name findings exit_env );
+  end_mapping

--- a/src/tainting/Dataflow_tainting.ml
+++ b/src/tainting/Dataflow_tainting.ml
@@ -998,6 +998,15 @@ and check_tainted_expr env exp : Taints.t * Lval_env.t =
 let check_tainted_var env (var : IL.name) : Taints.t * Lval_env.t =
   check_tainted_lval env (LV.lval_of_var var)
 
+(* Given a function/method call 'fun_exp'('args_exps'), and an argument
+ * spec 'sig_arg' from the taint signature of the called function/method,
+ * determine what lvalue corresponds to 'sig_arg'.
+ *
+ * In the simplest case this just obtains the actual argument:
+ * E.g. `lval_of_sig_arg f [x;y;z] [a;b;c] (x,0) = a`
+ *
+ * But 'sig_arg' may also specify an offset.
+ *)
 let lval_of_sig_arg fun_exp fparams args_exps (sig_arg : T.arg) =
   let* base_lval, obj =
     match sig_arg.pos with

--- a/src/tainting/Taint.ml
+++ b/src/tainting/Taint.ml
@@ -100,6 +100,7 @@ type finding =
   | SrcToReturn of source * tainted_tokens * G.tok
   | ArgToSink of arg * tainted_tokens * sink
   | ArgToReturn of arg * tainted_tokens * G.tok
+  | ArgToArg of arg * tainted_tokens * arg (* TODO: CleanArg ? *)
 [@@deriving show]
 
 type signature = finding list
@@ -121,6 +122,8 @@ let _show_finding = function
   | SrcToReturn (src, _, _) -> Printf.sprintf "return (%s)" (_show_source src)
   | ArgToSink (a, _, _) -> Printf.sprintf "%s ----> sink" (_show_arg a)
   | ArgToReturn (a, _, _) -> Printf.sprintf "return (%s)" (_show_arg a)
+  | ArgToArg (a1, _, a2) ->
+      Printf.sprintf "%s ----> %s" (_show_arg a1) (_show_arg a2)
 
 (*****************************************************************************)
 (* Taint *)

--- a/src/tainting/Taint.mli
+++ b/src/tainting/Taint.mli
@@ -47,6 +47,7 @@ type finding =
       (** If this argument was tainted, the taint would reach a sink. *)
   | ArgToReturn of arg * tainted_tokens * AST_generic.tok
       (** If this argument was tainted, the taint would reach a `return` statement. *)
+  | ArgToArg of arg * tainted_tokens * arg
 [@@deriving show]
 
 type signature = finding list

--- a/src/tainting/Taint_lval_env.ml
+++ b/src/tainting/Taint_lval_env.ml
@@ -207,3 +207,5 @@ let to_string taint_to_str { tainted; propagated; cleaned } =
   ^ LvalSet.fold
       (fun dn s -> s ^ Display_IL.string_of_lval dn ^ " ")
       cleaned "[CLEANED]"
+
+let seq_of_tainted env = LvalMap.to_seq env.tainted

--- a/src/tainting/Taint_lval_env.mli
+++ b/src/tainting/Taint_lval_env.mli
@@ -68,3 +68,4 @@ val union : env -> env -> env
 
 val equal : env -> env -> bool
 val to_string : (Taint.taints -> string) -> env -> string
+val seq_of_tainted : env -> (IL.lval * Taint.taints) Seq.t


### PR DESCRIPTION
Helps PA-2570

test plan:
See returntocorp/semgrep-proprietary#636

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
