### PR TITLE
Osemgrep: lang rules matrix

### DIFF
--- a/libs/commons/Common.ml
+++ b/libs/commons/Common.ml
@@ -232,7 +232,7 @@ let map f l = fast_map 1000 f l
 (*****************************************************************************)
 
 let rec slow_map2 acc f l1 l2 =
-  match l1, l2 with
+  match (l1, l2) with
   | [], [] -> rev5 acc
   | [ a1 ], [ a2 ] -> rev5 (Elt (f a1 a2, acc))
   | [ a1; b1 ], [ a2; b2 ] ->
@@ -269,7 +269,7 @@ let rec slow_map2 acc f l1 l2 =
 let rec fast_map2 rec_calls_remaining f l1 l2 =
   if rec_calls_remaining <= 0 then slow_map2 Empty f l1 l2
   else
-    match l1, l2 with
+    match (l1, l2) with
     | [], [] -> []
     | [ a1 ], [ a2 ] -> [ f a1 a2 ]
     | [ a1; b1 ], [ a2; b2 ] ->
@@ -294,14 +294,14 @@ let rec fast_map2 rec_calls_remaining f l1 l2 =
         let d = f d1 d2 in
         let e = f e1 e2 in
         [ a; b; c; d; e ]
-  | a1 :: b1 :: c1 :: d1 :: e1 :: l1, a2 :: b2 :: c2 :: d2 :: e2 :: l2 ->
-      let a = f a1 a2 in
-      let b = f b1 b2 in
-      let c = f c1 c2 in
-      let d = f d1 d2 in
-      let e = f e1 e2 in
-      a :: b :: c :: d :: e :: fast_map2 (rec_calls_remaining - 1) f l1 l2
-  | _other -> raise (Failure "Common.map2: lists not equal length")
+    | a1 :: b1 :: c1 :: d1 :: e1 :: l1, a2 :: b2 :: c2 :: d2 :: e2 :: l2 ->
+        let a = f a1 a2 in
+        let b = f b1 b2 in
+        let c = f c1 c2 in
+        let d = f d1 d2 in
+        let e = f e1 e2 in
+        a :: b :: c :: d :: e :: fast_map2 (rec_calls_remaining - 1) f l1 l2
+    | _other -> raise (Failure "Common.map2: lists not equal length")
 
 (*
    This implementation of List.map makes at most 1000 non-tailrec calls
@@ -310,7 +310,6 @@ let rec fast_map2 rec_calls_remaining f l1 l2 =
    Additionally, this implementation guarantees left-to-right evaluation.
 *)
 let map2 f l1 l2 = fast_map2 1000 f l1 l2
-
 
 (*****************************************************************************)
 (* Other list functions *)

--- a/libs/commons/Common.ml
+++ b/libs/commons/Common.ml
@@ -228,6 +228,91 @@ let rec fast_map rec_calls_remaining f l =
 let map f l = fast_map 1000 f l
 
 (*****************************************************************************)
+(* List.map2 *)
+(*****************************************************************************)
+
+let rec slow_map2 acc f l1 l2 =
+  match l1, l2 with
+  | [], [] -> rev5 acc
+  | [ a1 ], [ a2 ] -> rev5 (Elt (f a1 a2, acc))
+  | [ a1; b1 ], [ a2; b2 ] ->
+      let a = f a1 a2 in
+      let b = f b1 b2 in
+      rev5 (Elt (b, Elt (a, acc)))
+  | [ a1; b1; c1 ], [ a2; b2; c2 ] ->
+      let a = f a1 a2 in
+      let b = f b1 b2 in
+      let c = f c1 c2 in
+      rev5 (Elt (c, Elt (b, Elt (a, acc))))
+  | [ a1; b1; c1; d1 ], [ a2; b2; c2; d2 ] ->
+      let a = f a1 a2 in
+      let b = f b1 b2 in
+      let c = f c1 c2 in
+      let d = f d1 d2 in
+      rev5 (Elt (d, Elt (c, Elt (b, Elt (a, acc)))))
+  | [ a1; b1; c1; d1; e1 ], [ a2; b2; c2; d2; e2 ] ->
+      let a = f a1 a2 in
+      let b = f b1 b2 in
+      let c = f c1 c2 in
+      let d = f d1 d2 in
+      let e = f e1 e2 in
+      rev5 (Elt (e, Elt (d, Elt (c, Elt (b, Elt (a, acc))))))
+  | a1 :: b1 :: c1 :: d1 :: e1 :: l1, a2 :: b2 :: c2 :: d2 :: e2 :: l2 ->
+      let a = f a1 a2 in
+      let b = f b1 b2 in
+      let c = f c1 c2 in
+      let d = f d1 d2 in
+      let e = f e1 e2 in
+      slow_map2 (Tuple (e, d, c, b, a, acc)) f l1 l2
+  | _other -> raise (Failure "Common.map2: lists not equal length")
+
+let rec fast_map2 rec_calls_remaining f l1 l2 =
+  if rec_calls_remaining <= 0 then slow_map2 Empty f l1 l2
+  else
+    match l1, l2 with
+    | [], [] -> []
+    | [ a1 ], [ a2 ] -> [ f a1 a2 ]
+    | [ a1; b1 ], [ a2; b2 ] ->
+        let a = f a1 a2 in
+        let b = f b1 b2 in
+        [ a; b ]
+    | [ a1; b1; c1 ], [ a2; b2; c2 ] ->
+        let a = f a1 a2 in
+        let b = f b1 b2 in
+        let c = f c1 c2 in
+        [ a; b; c ]
+    | [ a1; b1; c1; d1 ], [ a2; b2; c2; d2 ] ->
+        let a = f a1 a2 in
+        let b = f b1 b2 in
+        let c = f c1 c2 in
+        let d = f d1 d2 in
+        [ a; b; c; d ]
+    | [ a1; b1; c1; d1; e1 ], [ a2; b2; c2; d2; e2 ] ->
+        let a = f a1 a2 in
+        let b = f b1 b2 in
+        let c = f c1 c2 in
+        let d = f d1 d2 in
+        let e = f e1 e2 in
+        [ a; b; c; d; e ]
+  | a1 :: b1 :: c1 :: d1 :: e1 :: l1, a2 :: b2 :: c2 :: d2 :: e2 :: l2 ->
+      let a = f a1 a2 in
+      let b = f b1 b2 in
+      let c = f c1 c2 in
+      let d = f d1 d2 in
+      let e = f e1 e2 in
+      a :: b :: c :: d :: e :: fast_map2 (rec_calls_remaining - 1) f l1 l2
+  | _other -> raise (Failure "Common.map2: lists not equal length")
+
+(*
+   This implementation of List.map makes at most 1000 non-tailrec calls
+   before switching to a slower tailrec implementation.
+
+   Additionally, this implementation guarantees left-to-right evaluation.
+*)
+let map2 f l1 l2 = fast_map2 1000 f l1 l2
+
+
+(*****************************************************************************)
 (* Other list functions *)
 (*****************************************************************************)
 

--- a/libs/commons/Common.mli
+++ b/libs/commons/Common.mli
@@ -267,6 +267,12 @@ val map : ('a -> 'b) -> 'a list -> 'b list
     left to right like for [List.iter].
 *)
 
+val map2 : ('a -> 'b -> 'c) -> 'a list -> 'b list -> 'c list
+(** Same as [List.map2] but stack-safe and slightly faster on short lists.
+    Additionally, we guarantee that the mapping function is applied from
+    left to right like for [List.iter].
+*)
+
 val flatten : 'a list list -> 'a list
 (** Same as [List.flatten] but tail recursive. *)
 

--- a/libs/commons/Logs_helpers.ml
+++ b/libs/commons/Logs_helpers.ml
@@ -3,7 +3,7 @@
  *)
 let enable_logging () =
   Logs.set_level ~all:true (Some Logs.Warning);
-  Logs.set_reporter (Logs_fmt.reporter ());
+  Logs.set_reporter (Logs_fmt.reporter ~app:Format.err_formatter ());
   ()
 
 (* TOPORT: with Logs a warning is displayed as:
@@ -16,7 +16,7 @@ let setup_logging ~force_color ~level =
   let style_renderer = if force_color then Some `Ansi_tty else None in
   Fmt_tty.setup_std_outputs ?style_renderer ();
   Logs.set_level ~all:true level;
-  Logs.set_reporter (Logs_fmt.reporter ());
+  Logs.set_reporter (Logs_fmt.reporter ~app:Format.err_formatter ());
   (* from https://github.com/mirage/ocaml-cohttp#debugging *)
   (* Disable all third-party libs logs *)
   Logs.Src.list ()

--- a/semgrep.opam
+++ b/semgrep.opam
@@ -44,6 +44,7 @@ depends: [
   "yojson" { >= "2.0.0" }
   "yaml"
   "cmdliner"
+  "fmt"
   "ppxlib"
   "ppx_deriving"
   "ppx_hash"

--- a/src/osemgrep/cli_scan/Core_runner.ml
+++ b/src/osemgrep/cli_scan/Core_runner.ml
@@ -201,15 +201,13 @@ let pp_status rules targets lang_jobs respect_git_ignore ppf () =
   Fmt_helpers.pp_table
     ("Language", [ "Rules"; "Files" ])
     ppf
-    (List.combine
-       (Common.map
-          (fun (job : Runner_config.lang_job) ->
-            Xlang.to_string job.Runner_config.lang)
-          lang_jobs)
-       (Common.map
-          (fun Runner_config.{ targets; rules; _ } ->
-            [ List.length rules; List.length targets ])
-          lang_jobs))
+    (lang_jobs
+    |> List.fold_left
+         (fun acc Runner_config.{ lang; targets; rules } ->
+           (Xlang.to_string lang, [ List.length rules; List.length targets ])
+           :: acc)
+         []
+    |> List.rev)
 
 (*************************************************************************)
 (* Entry point *)

--- a/src/osemgrep/cli_scan/Core_runner.ml
+++ b/src/osemgrep/cli_scan/Core_runner.ml
@@ -181,55 +181,8 @@ let runner_config_of_conf (conf : conf) : Runner_config.t =
         version = Version.version;
       }
 
-let pp_table (h1, heading) ppf entries =
-  let int_size i =
-    let rec dec acc = function
-      | 0 -> acc
-      | n -> dec (succ acc) (n / 10)
-    in
-    dec 1 i
-  in
-  let len1, lengths =
-    let acc = Common.map String.length heading in
-    List.fold_left
-      (fun (n1, needed) (c1, curr) ->
-        ( max (String.length c1) n1,
-          Common.map2 max needed (Common.map int_size curr) ))
-      (String.length h1, acc)
-      entries
-  in
-  let llen = List.fold_left (fun acc w -> acc + w + 1) len1 lengths in
-  let line = String.make llen '-' in
-  let pad str_size len =
-    let to_pad = succ (len - str_size) in
-    String.make to_pad ' '
-  in
-  Fmt.pf ppf "%s%s" h1 (pad (String.length h1) len1);
-  List.iter2
-    (fun h l -> Fmt.pf ppf "%s%s" h (pad (String.length h) l))
-    heading lengths;
-  Fmt.pf ppf "@.%s@." line;
-  List.iter
-    (fun (e1, entries) ->
-      Fmt.pf ppf "%s%s"
-        (String.capitalize_ascii e1)
-        (pad (String.length e1) len1);
-      List.iter2
-        (fun e l -> Fmt.pf ppf "%s%u" (pad (int_size e) l) e)
-        entries lengths;
-      Fmt.pf ppf "@.")
-    entries;
-  Fmt.pf ppf "@."
-
-let pp_heading ppf txt =
-  let chars = String.length txt + 4 in
-  let line = String.make chars '-' in
-  Fmt.pf ppf "%s@." line;
-  Fmt.pf ppf "| %s |@." txt;
-  Fmt.pf ppf "%s@." line
-
 let pp_status rules targets lang_jobs respect_git_ignore ppf () =
-  pp_heading ppf "Scan status";
+  Fmt_helpers.pp_heading ppf "Scan status";
   (* TODO indentation of the body *)
   let pp_s ppf x = if x = 1 then Fmt.string ppf "" else Fmt.string ppf "s" in
   let rule_count = List.length rules in
@@ -245,7 +198,7 @@ let pp_status rules targets lang_jobs respect_git_ignore ppf () =
          summary_line += f", {unit_str(pro_rule_count, 'Pro rule')}"
   *)
   Fmt.pf ppf ":@.@.";
-  pp_table
+  Fmt_helpers.pp_table
     ("Language", [ "Rules"; "Files" ])
     ppf
     (List.combine

--- a/src/osemgrep/cli_scan/Core_runner.ml
+++ b/src/osemgrep/cli_scan/Core_runner.ml
@@ -190,22 +190,19 @@ let pp_table (h1, heading) ppf entries =
     dec 1 i
   in
   let len1, lengths =
-    let acc = List.map String.length heading in
+    let acc = Common.map String.length heading in
     List.fold_left
       (fun (n1, needed) (c1, curr) ->
         ( max (String.length c1) n1,
-          List.map2 max needed (List.map int_size curr) ))
+          Common.map2 max needed (Common.map int_size curr) ))
       (String.length h1, acc)
       entries
   in
   let llen = List.fold_left (fun acc w -> acc + w + 1) len1 lengths in
   let line = String.make llen '-' in
-  let pad =
-    let max_len = List.fold_left max len1 lengths in
-    let spaces = String.make max_len ' ' in
-    fun str_size len ->
-      let to_pad = succ (len - str_size) in
-      String.sub spaces 0 to_pad
+  let pad str_size len =
+    let to_pad = succ (len - str_size) in
+    String.make to_pad ' '
   in
   Fmt.pf ppf "%s%s" h1 (pad (String.length h1) len1);
   List.iter2
@@ -252,11 +249,11 @@ let pp_status rules targets lang_jobs respect_git_ignore ppf () =
     ("Language", [ "Rules"; "Files" ])
     ppf
     (List.combine
-       (List.map
+       (Common.map
           (fun (job : Runner_config.lang_job) ->
             Xlang.to_string job.Runner_config.lang)
           lang_jobs)
-       (List.map
+       (Common.map
           (fun Runner_config.{ targets; rules; _ } ->
             [ List.length rules; List.length targets ])
           lang_jobs))

--- a/src/osemgrep/cli_scan/Core_runner.ml
+++ b/src/osemgrep/cli_scan/Core_runner.ml
@@ -191,9 +191,10 @@ let pp_table (h1, heading) ppf entries =
   in
   let len1, lengths =
     let acc = List.map String.length heading in
-    List.fold_left (fun (n1, needed) (c1, curr) ->
-        max (String.length c1) n1,
-        List.map2 max needed (List.map int_size curr))
+    List.fold_left
+      (fun (n1, needed) (c1, curr) ->
+        ( max (String.length c1) n1,
+          List.map2 max needed (List.map int_size curr) ))
       (String.length h1, acc)
       entries
   in
@@ -211,11 +212,13 @@ let pp_table (h1, heading) ppf entries =
     (fun h l -> Fmt.pf ppf "%s%s" h (pad (String.length h) l))
     heading lengths;
   Fmt.pf ppf "@.%s@." line;
-  List.iter (fun (e1, entries) ->
+  List.iter
+    (fun (e1, entries) ->
       Fmt.pf ppf "%s%s"
         (String.capitalize_ascii e1)
         (pad (String.length e1) len1);
-      List.iter2 (fun e l -> Fmt.pf ppf "%s%u" (pad (int_size e) l) e)
+      List.iter2
+        (fun e l -> Fmt.pf ppf "%s%u" (pad (int_size e) l) e)
         entries lengths;
       Fmt.pf ppf "@.")
     entries;
@@ -232,28 +235,31 @@ let pp_status rules targets lang_jobs respect_git_ignore ppf () =
   pp_heading ppf "Scan status";
   (* TODO indentation of the body *)
   let pp_s ppf x = if x = 1 then Fmt.string ppf "" else Fmt.string ppf "s" in
-  Fmt.pf ppf "Scanning %d files%s with %d Code rule%a"
-    (List.length targets)
+  let rule_count = List.length rules in
+  Fmt.pf ppf "Scanning %d files%s with %d Code rule%a" (List.length targets)
     (if respect_git_ignore then " tracked by git" else "")
-    (List.length rules)
-    pp_s (List.length rules);
+    rule_count pp_s rule_count;
   (* TODO if sca_rules ...
      Fmt.(option ~none:(any "") (any ", " ++ int ++ any "Supply Chain rule" *)
   (* TODO pro_rule
-        if get_path(rule.metadata, ("semgrep.dev", "rule", "origin"), default=None)
-        == "pro_rules"
-    if pro_rule_count:
-        summary_line += f", {unit_str(pro_rule_count, 'Pro rule')}"
+         if get_path(rule.metadata, ("semgrep.dev", "rule", "origin"), default=None)
+         == "pro_rules"
+     if pro_rule_count:
+         summary_line += f", {unit_str(pro_rule_count, 'Pro rule')}"
   *)
   Fmt.pf ppf ":@.@.";
-  pp_table ("Language", [ "Rules" ; "Files" ]) ppf
+  pp_table
+    ("Language", [ "Rules"; "Files" ])
+    ppf
     (List.combine
-       (List.map (fun (job : Runner_config.lang_job) ->
-            (Xlang.to_string job.Runner_config.lang))
+       (List.map
+          (fun (job : Runner_config.lang_job) ->
+            Xlang.to_string job.Runner_config.lang)
           lang_jobs)
-       (List.map (fun Runner_config.{ targets ; rules ; _ } ->
-            [ List.length rules ; List.length targets ])
-           lang_jobs))
+       (List.map
+          (fun Runner_config.{ targets; rules; _ } ->
+            [ List.length rules; List.length targets ])
+          lang_jobs))
 
 (*************************************************************************)
 (* Entry point *)
@@ -306,7 +312,8 @@ let invoke_semgrep_core ?(respect_git_ignore = true) (conf : conf)
        *)
       let lang_jobs = split_jobs_by_language all_rules all_targets in
       Logs.app (fun m ->
-          m "%a" (pp_status all_rules all_targets lang_jobs respect_git_ignore)
+          m "%a"
+            (pp_status all_rules all_targets lang_jobs respect_git_ignore)
             ());
       let results_by_language =
         lang_jobs

--- a/src/osemgrep/cli_scan/Core_runner.mli
+++ b/src/osemgrep/cli_scan/Core_runner.mli
@@ -23,6 +23,7 @@ type result = {
    integrated into what's currently semgrep-core.
 *)
 val invoke_semgrep_core :
+  ?respect_git_ignore:bool ->
   conf ->
   (* LATER? use Config_resolve.rules_and_origin instead? *)
   Rule.rules ->

--- a/src/osemgrep/cli_scan/dune
+++ b/src/osemgrep/cli_scan/dune
@@ -7,7 +7,6 @@
     cmdliner
     logs
     commons
-    fmt
 
     semgrep_core_cli
     semgrep_reporting

--- a/src/osemgrep/cli_scan/dune
+++ b/src/osemgrep/cli_scan/dune
@@ -7,6 +7,7 @@
     cmdliner
     logs
     commons
+    fmt
 
     semgrep_core_cli
     semgrep_reporting

--- a/src/osemgrep/reporting/Fmt_helpers.ml
+++ b/src/osemgrep/reporting/Fmt_helpers.ml
@@ -1,0 +1,55 @@
+(*****************************************************************************)
+(* Prelude *)
+(*****************************************************************************)
+(* Helper functions for pretty printing (ASCII-art) *)
+
+(*****************************************************************************)
+(* Entry point *)
+(*****************************************************************************)
+
+let pp_table (h1, heading) ppf entries =
+  let int_size i =
+    let rec dec acc = function
+      | 0 -> acc
+      | n -> dec (succ acc) (n / 10)
+    in
+    dec 1 i
+  in
+  let len1, lengths =
+    let acc = Common.map String.length heading in
+    List.fold_left
+      (fun (n1, needed) (c1, curr) ->
+        ( max (String.length c1) n1,
+          Common.map2 max needed (Common.map int_size curr) ))
+      (String.length h1, acc)
+      entries
+  in
+  let llen = List.fold_left (fun acc w -> acc + w + 1) len1 lengths in
+  let line = String.make llen '-' in
+  let pad str_size len =
+    let to_pad = succ (len - str_size) in
+    String.make to_pad ' '
+  in
+  Fmt.pf ppf "%s%s" h1 (pad (String.length h1) len1);
+  List.iter2
+    (fun h l -> Fmt.pf ppf "%s%s" (pad (String.length h) l) h)
+    heading lengths;
+  Fmt.pf ppf "@.%s@." line;
+  List.iter
+    (fun (e1, entries) ->
+      Fmt.pf ppf "%s%s"
+        (String.capitalize_ascii e1)
+        (pad (String.length e1) len1);
+      List.iter2
+        (fun e l -> Fmt.pf ppf "%s%u" (pad (int_size e) l) e)
+        entries lengths;
+      Fmt.pf ppf "@.")
+    entries;
+  Fmt.pf ppf "@."
+
+let pp_heading ppf txt =
+  let chars = String.length txt + 4 in
+  let line = String.make chars '-' in
+  Fmt.pf ppf "%s@." line;
+  Fmt.pf ppf "| %s |@." txt;
+  Fmt.pf ppf "%s@." line

--- a/src/osemgrep/reporting/Fmt_helpers.mli
+++ b/src/osemgrep/reporting/Fmt_helpers.mli
@@ -1,0 +1,20 @@
+(** Pretty-prints the heading in a box: [pp_heading ppf "Hello"] is layouted as:
+    {[
+      ---------
+      | Hello |
+      ---------
+    ]} *)
+val pp_heading : string Fmt.t
+
+(** Pretty-prints the table with the heading. The first row are strings,
+    the remaining are integers. The first row is left-aligned, all others
+    right-aligned.
+    [pp_table ("H1", [ "H2"; "H3"]) ppf [ ("A", [ 1; 2 ]); ("B", [ 100; 20 ]) ]]
+
+    {[
+      H1  H2 H3
+      ---------
+      A    1  2
+      B  100 20
+    ]} *)
+val pp_table : (string * string list) -> (string * int list) list Fmt.t

--- a/src/osemgrep/reporting/Fmt_helpers.mli
+++ b/src/osemgrep/reporting/Fmt_helpers.mli
@@ -1,11 +1,12 @@
+val pp_heading : string Fmt.t
 (** Pretty-prints the heading in a box: [pp_heading ppf "Hello"] is layouted as:
     {[
       ---------
       | Hello |
       ---------
     ]} *)
-val pp_heading : string Fmt.t
 
+val pp_table : string * string list -> (string * int list) list Fmt.t
 (** Pretty-prints the table with the heading. The first row are strings,
     the remaining are integers. The first row is left-aligned, all others
     right-aligned.
@@ -17,4 +18,3 @@ val pp_heading : string Fmt.t
       A    1  2
       B  100 20
     ]} *)
-val pp_table : (string * string list) -> (string * int list) list Fmt.t

--- a/src/osemgrep/reporting/dune
+++ b/src/osemgrep/reporting/dune
@@ -4,6 +4,7 @@
  (wrapped false)
  (libraries
    commons
+   fmt
    semgrep.reporting
  )
  (preprocess


### PR DESCRIPTION
This adds prelimary "Scan Status" output, similar to what is in the python version.

Some questions are remaning:
- (a) the Python code prints an origin table, based on "rule.metadata, ("semgrep.dev", "rule", "origin"), default="unknown" -- we should probably do the same
 - (b) stdout vs stderr -- esp. with json output, I suspect we should output the "Scan status" to stderr?
 - (c) supply chain analysis -- would you mind to educate me with an example passed to semgrep so I can see the output?
 - (d) pro rules (see (a)), would be great to have a running example for this as well

Now, there are some differences, as seen below (indentation, "<multilang>" vs "generic" and "regex"). I tried to get indentation with OCaml's formatter but wasn't lucky.


Python output (on semgrep --config r/ocaml --config r/python src/osemgrep/):
    
```
┌─────────────┐
│ Scan Status │
└─────────────┘
Scanning 160 files tracked by git with 429 Code rules:
    
Language      Rules   Files          Origin      Rules
 ─────────────────────────────        ───────────────────
<multilang>       5     159          Community     429
ocaml            32      86
python          385      57
    
  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:02
```
    
Osemgrep output:
    
```
---------------
| Scan status |
---------------
Scanning 160 files tracked by git with 429 Code rule:
    
Language Rules Files
--------------------
generic      8  160
Python     385   57
OCaml       32   86
regex        4  160
```

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)