### PR TITLE
Rules and stack

### DIFF
--- a/libs/commons/Common.ml
+++ b/libs/commons/Common.ml
@@ -315,6 +315,8 @@ let map2 f l1 l2 = fast_map2 1000 f l1 l2
 (* Other list functions *)
 (*****************************************************************************)
 
+let mapi f l = map2 f (List.init (List.length l) Fun.id) l
+
 (* Tail-recursive to prevent stack overflows. *)
 let flatten xss =
   xss |> List.fold_left (fun acc xs -> List.rev_append xs acc) [] |> List.rev

--- a/libs/commons/Common.mli
+++ b/libs/commons/Common.mli
@@ -273,6 +273,12 @@ val map2 : ('a -> 'b -> 'c) -> 'a list -> 'b list -> 'c list
     left to right like for [List.iter].
 *)
 
+val mapi : (int -> 'a -> 'b) -> 'a list -> 'b list
+(** Same as [List.mapi] but stack-safe and slightly faster on short lists.
+    Additionally, we guarantee that the mapping function is applied from
+    left to right like for [List.iter].
+*)
+
 val flatten : 'a list list -> 'a list
 (** Same as [List.flatten] but tail recursive. *)
 

--- a/libs/spacegrep/src/bin/Spacegrep_main.ml
+++ b/libs/spacegrep/src/bin/Spacegrep_main.ml
@@ -134,7 +134,7 @@ let run_all ~search_param ~debug ~force ~warn ~comment_style patterns docs :
                        Match.timef (fun () -> parse_doc comment_style doc_src)
                      in
                      let matches_in_file =
-                       List.mapi
+                       Common.mapi
                          (fun pat_id (pat_src, pat) ->
                            if debug then
                              printf

--- a/libs/spacegrep/src/bin/Spacegrep_main.ml
+++ b/libs/spacegrep/src/bin/Spacegrep_main.ml
@@ -78,7 +78,7 @@ let run_all ~search_param ~debug ~force ~warn ~comment_style patterns docs :
   let skipped = ref [] in
   let matches =
     docs
-    |> List.filter_map
+    |> Common.map_filter
          (fun (get_doc_src : ?max_len:int -> unit -> Src_file.t) ->
            let matches, run_time =
              Match.timef (fun () ->

--- a/semgrep.yml
+++ b/semgrep.yml
@@ -141,6 +141,24 @@ rules:
         - graph_code/*
         - lib_parsing/*
 
+  - id: no-list-mapi
+    pattern: List.mapi
+    message: >-
+      `List.mapi` creates O(N) stack depth, and can lead to a
+      stack overflow. Use `Common.mapi` instead.
+    fix: Common.mapi
+    languages: [ocaml]
+    severity: ERROR
+    paths:
+      include:
+        - src/*
+      exclude:
+        - profiling/*
+        - ppx_profiling/*
+        - commons/*
+        - graph_code/*
+        - lib_parsing/*
+
   - id: use-concat-map
     pattern-either:
       - pattern: List.map ... |> List.flatten

--- a/semgrep.yml
+++ b/semgrep.yml
@@ -87,6 +87,24 @@ rules:
       exclude:
         - SPcre.ml
 
+  - id: no-list-map2
+    pattern: List.map2
+    message: >-
+      `List.map2` creates O(N) stack depth, and can lead to a
+      stack overflow. Use `Common.map2` instead.
+    fix: Common.map2
+    languages: [ocaml]
+    severity: ERROR
+    paths:
+      include:
+        - src/*
+      exclude:
+        - profiling/*
+        - ppx_profiling/*
+        - commons/*
+        - graph_code/*
+        - lib_parsing/*
+
   - id: no-list-map
     pattern: List.map
     message: >-

--- a/semgrep.yml
+++ b/semgrep.yml
@@ -123,6 +123,24 @@ rules:
         - graph_code/*
         - lib_parsing/*
 
+  - id: no-list-filter-map
+    pattern: List.filter_map
+    message: >-
+      `List.filter_map` creates O(N) stack depth, and can lead to a
+      stack overflow. Use `Common.map_filter` instead.
+    fix: Common.map_filter
+    languages: [ocaml]
+    severity: ERROR
+    paths:
+      include:
+        - src/*
+      exclude:
+        - profiling/*
+        - ppx_profiling/*
+        - commons/*
+        - graph_code/*
+        - lib_parsing/*
+
   - id: use-concat-map
     pattern-either:
       - pattern: List.map ... |> List.flatten

--- a/src/analyzing/AST_to_IL.ml
+++ b/src/analyzing/AST_to_IL.ml
@@ -308,7 +308,7 @@ and pattern env pat =
       (* Pi = tmp[i] *)
       let ss =
         pats
-        |> List.mapi (fun i pat_i ->
+        |> Common.mapi (fun i pat_i ->
                let eorig = Related (G.P pat_i) in
                let index_i = Literal (G.Int (Some i, tok1)) in
                let offset_i =
@@ -369,7 +369,7 @@ and assign env lhs tok rhs_exp e_gen =
       (* Ei = tmp[i] *)
       let tup_elems =
         lhss
-        |> List.mapi (fun i lhs_i ->
+        |> Common.mapi (fun i lhs_i ->
                let index_i = Literal (G.Int (Some i, tok1)) in
                let offset_i =
                  {

--- a/src/analyzing/AST_to_IL.ml
+++ b/src/analyzing/AST_to_IL.ml
@@ -946,7 +946,7 @@ and record env ((_tok, origfields, _) as record_def) =
 and xml_expr env xml =
   let attrs =
     xml.G.xml_attrs
-    |> List.filter_map (function
+    |> Common.map_filter (function
          | G.XmlAttr (_, tok, eorig)
          | G.XmlAttrExpr (tok, eorig, _) ->
              let exp = expr env eorig in
@@ -956,7 +956,7 @@ and xml_expr env xml =
   in
   let body =
     xml.G.xml_body
-    |> List.filter_map (function
+    |> Common.map_filter (function
          | G.XmlExpr (tok, Some eorig, _) ->
              let exp = expr env eorig in
              let _, lval = mk_aux_var env tok exp in
@@ -1105,7 +1105,7 @@ and for_var_or_expr_list env xs =
 (*****************************************************************************)
 and parameters _env params : name list =
   params |> Parse_info.unbracket
-  |> List.filter_map (function
+  |> Common.map_filter (function
        | G.Param { pname = Some i; pinfo; _ } -> Some (var_of_id_info i pinfo)
        | ___else___ -> None (* TODO *))
 

--- a/src/analyzing/CFG_build.ml
+++ b/src/analyzing/CFG_build.ml
@@ -308,7 +308,7 @@ and build_cfg_for_lambdas_in state previ n =
    *   as the function being called, or as arguments to a higher-order function. *)
   let lambda_names, lambda_fdefs =
     IL_helpers.rlvals_of_node n
-    |> List.filter_map (lval_is_lambda state)
+    |> Common.map_filter (lval_is_lambda state)
     |> List.split
   in
   if lambda_fdefs <> [] then (

--- a/src/engine/Match_extract_mode.ml
+++ b/src/engine/Match_extract_mode.ml
@@ -303,7 +303,7 @@ let extract_and_concat erule_table xtarget rule_ids matches =
   |> Common.map (fun matches -> nonempty_to_list matches)
   (* Convert matches to the extract metavariable / bound value *)
   |> Common.map
-       (List.filter_map (fun m ->
+       (Common.map_filter (fun m ->
             match extract_of_match erule_table m with
             | Some ({ mode = `Extract { Rule.extract; _ }; id = id, _; _ }, None)
               ->
@@ -312,13 +312,13 @@ let extract_and_concat erule_table xtarget rule_ids matches =
             | Some (r, Some mval) -> Some (r, mval)
             | None -> None))
   (* Factor out rule *)
-  |> List.filter_map (function
+  |> Common.map_filter (function
        | [] -> None
        | (r, _) :: _ as xs -> Some (r, Common.map snd xs))
   (* Convert mval match to offset of location in file *)
   |> Common.map (fun (r, mvals) ->
          ( r,
-           List.filter_map
+           Common.map_filter
              (fun mval ->
                let offsets = offsets_of_mval mval in
                if Option.is_none offsets then report_no_source_range r;
@@ -435,7 +435,7 @@ let extract_and_concat erule_table xtarget rule_ids matches =
 
 let extract_as_separate erule_table xtarget rule_ids matches =
   matches
-  |> List.filter_map (fun m ->
+  |> Common.map_filter (fun m ->
          match extract_of_match erule_table m with
          | Some (erule, Some extract_mvalue) ->
              (* Note: char/line offset should be relative to the extracted

--- a/src/engine/Match_extract_mode.ml
+++ b/src/engine/Match_extract_mode.ml
@@ -144,7 +144,7 @@ let rules_for_extracted_lang (all_rules : Rule.t list) =
     | None ->
         let rule_ids_for_lang =
           all_rules
-          |> List.mapi (fun i r -> (i, r))
+          |> Common.mapi (fun i r -> (i, r))
           |> List.filter (fun (_i, r) ->
                  let r_lang = r.Rule.languages in
                  match (xlang, r_lang) with

--- a/src/engine/Match_search_mode.ml
+++ b/src/engine/Match_search_mode.ml
@@ -361,7 +361,7 @@ let apply_focus_on_ranges env (focus_mvars_list : R.focus_mv_list list)
     in
     let fm_mval_range_locs =
       fm_mvals
-      |> List.filter_map (fun (focus_mvar, mval) ->
+      |> Common.map_filter (fun (focus_mvar, mval) ->
              let* range_loc =
                Visitor_AST.range_of_any_opt (MV.mvalue_to_any mval)
              in
@@ -382,7 +382,7 @@ let apply_focus_on_ranges env (focus_mvars_list : R.focus_mv_list list)
     in
     let focused_ranges =
       (* Filter out focused ranges that are outside of the original range *)
-      List.filter_map
+      Common.map_filter
         (fun fms -> intersect (RM.match_result_to_range fms) range)
         focus_matches
     in
@@ -526,7 +526,7 @@ let children_explanations_of_xpat (env : env) (xpat : Xpattern.t) : ME.t list =
 let rec filter_ranges (env : env) (xs : (RM.t * MV.bindings list) list)
     (cond : R.metavar_cond) : (RM.t * MV.bindings list) list =
   xs
-  |> List.filter_map (fun (r, new_bindings) ->
+  |> Common.map_filter (fun (r, new_bindings) ->
          let map_bool r b = if b then Some (r, new_bindings) else None in
          let bindings = r.RM.mvars in
          match cond with

--- a/src/engine/Match_tainting_mode.ml
+++ b/src/engine/Match_tainting_mode.ml
@@ -280,7 +280,7 @@ let find_propagators_matches formula_cache (xconf : Match_env.xconfig)
           * location info for that code (i.e., we have real tokens rather than
           * fake ones). *)
          ranges_w_metavars
-         |> List.filter_map (fun rwm ->
+         |> Common.map_filter (fun rwm ->
                 (* The piece of code captured by the `from` metavariable.  *)
                 let* _mvar_from, mval_from =
                   List.find_opt
@@ -373,7 +373,7 @@ let any_is_in_sources_matches rule any matches =
   let ( let* ) = option_bind_list in
   let* r = range_of_any any in
   matches
-  |> List.filter_map (fun (rwm, ts) ->
+  |> Common.map_filter (fun (rwm, ts) ->
          if Range.( $<=$ ) r rwm.RM.r then
            Some
              (let spec_pm = RM.range_to_pattern_match_adjusted rule rwm in
@@ -407,7 +407,7 @@ let any_is_in_sanitizers_matches rule any matches =
   let ( let* ) = option_bind_list in
   let* r = range_of_any any in
   matches
-  |> List.filter_map (fun (rwm, spec) ->
+  |> Common.map_filter (fun (rwm, spec) ->
          if Range.( $<=$ ) r rwm.RM.r then
            Some
              (let spec_pm = RM.range_to_pattern_match_adjusted rule rwm in
@@ -419,7 +419,7 @@ let any_is_in_sinks_matches rule any matches =
   let ( let* ) = option_bind_list in
   let* r = range_of_any any in
   matches
-  |> List.filter_map (fun (rwm, spec) ->
+  |> Common.map_filter (fun (rwm, spec) ->
          if Range.( $<=$ ) r rwm.RM.r then
            Some
              (let spec_pm = RM.range_to_pattern_match_adjusted rule rwm in
@@ -469,7 +469,7 @@ let taint_config_of_rule ~per_file_formula_cache xconf file ast_and_errors
      * Without this, `$F(...)` will automatically sanitize any other function
      * call acting as a sink or a source. *)
     sanitizers_ranges
-    |> List.filter_map (fun (not_conflicting, range, spec) ->
+    |> Common.map_filter (fun (not_conflicting, range, spec) ->
            (* TODO: Warn user when we filter out a sanitizer? *)
            if not_conflicting then
              if

--- a/src/engine/Metavariable_pattern.ml
+++ b/src/engine/Metavariable_pattern.ml
@@ -81,7 +81,7 @@ let get_persistent_bindings revert_loc r nested_matches =
          *)
          let readjusted_mvars =
            nested_match.RM.mvars
-           |> List.filter_map (fun (mvar, mval) ->
+           |> Common.map_filter (fun (mvar, mval) ->
                   match
                     mval |> MV.mvalue_to_any |> reverting_visitor.Map_AST.vany
                     |> MV.mvalue_of_any

--- a/src/engine/Range_with_metavars.ml
+++ b/src/engine/Range_with_metavars.ml
@@ -108,7 +108,7 @@ let intersect_ranges config debug_matches xs ys =
     us
     |> Common2.map_flatten (fun u ->
            vs
-           |> List.filter_map (fun v ->
+           |> Common.map_filter (fun v ->
                   if included_in config u v && inside_compatible u v then
                     Some (left_merge u v)
                   else None))

--- a/src/experiments/synthesizing/Pattern_from_Targets.ml
+++ b/src/experiments/synthesizing/Pattern_from_Targets.ml
@@ -510,7 +510,7 @@ let rec generate_with_env (target_patterns : pattern_instrs list list) :
   | [ cur ] -> [ List.hd (generate_patterns_help cur) ]
   | cur :: next :: rest ->
       let curpats = generate_patterns_help cur in
-      let next' = List.map2 cp_meta_env curpats next in
+      let next' = Common.map2 cp_meta_env curpats next in
       List.hd curpats :: generate_with_env (next' :: rest)
 
 (*****************************************************************************)

--- a/src/experiments/synthesizing/Pattern_from_diff.ml
+++ b/src/experiments/synthesizing/Pattern_from_diff.ml
@@ -120,7 +120,7 @@ let pattern_from_diff f =
   let functions =
     try
       let file_ast = Parse_target.parse_program file in
-      List.filter_map (function_from_range file_ast) f.In.diffs
+      Common.map_filter (function_from_range file_ast) f.In.diffs
     with
     | _ -> []
   in

--- a/src/matching/Generic_vs_generic.ml
+++ b/src/matching/Generic_vs_generic.ml
@@ -941,7 +941,7 @@ and m_expr ?(is_root = false) ?(arguments_have_changed = true) a b =
       | B.Container (B.Tuple, (_, vars, _)), B.Container (B.Tuple, (_, vals, _))
         when List.length vars =|= List.length vals ->
           let create_assigns expr1 expr2 = B.Assign (expr1, bt, expr2) |> G.e in
-          let mult_assigns = List.map2 create_assigns vars vals in
+          let mult_assigns = Common.map2 create_assigns vars vals in
           let rec aux xs =
             match xs with
             | [] -> fail ()

--- a/src/matching/Matching_generic.ml
+++ b/src/matching/Matching_generic.ml
@@ -628,7 +628,7 @@ let m_comb_fold (m_comb : _ comb_matcher) (xs : _ list)
 let m_comb_1to1 (m : _ matcher) a bs : _ comb_result =
  fun tin ->
   bs |> all_elem_and_rest_of_list
-  |> List.filter_map (fun (b, other_bs) ->
+  |> Common.map_filter (fun (b, other_bs) ->
          match m a b tin with
          | [] -> None
          | tout -> Some (Lazy.force other_bs, tout))
@@ -636,7 +636,7 @@ let m_comb_1to1 (m : _ matcher) a bs : _ comb_result =
 let m_comb_1toN m_1toN a bs : _ comb_result =
  fun tin ->
   bs |> all_splits
-  |> List.filter_map (fun (l, r) ->
+  |> Common.map_filter (fun (l, r) ->
          match m_1toN a l tin with
          | [] -> None
          | tout -> Some (r, tout))

--- a/src/matching/SubAST_generic.ml
+++ b/src/matching/SubAST_generic.ml
@@ -63,7 +63,7 @@ let subexprs_of_stmt_kind = function
   (* n *)
   | For (_, MultiForEach es, _) ->
       es
-      |> List.filter_map (function
+      |> Common.map_filter (function
            | FE (_, _, e) -> Some [ e ]
            | FECond ((_, _, e1), _, e2) -> Some [ e1; e2 ]
            | FEllipsis _ -> None)
@@ -165,14 +165,14 @@ let subexprs_of_expr with_symbolic_propagation e =
   (* TODO? or call recursively on e? *)
   | ParenExpr (_, e, _) -> [ e ]
   | Xml { xml_attrs; xml_body; _ } ->
-      List.filter_map
+      Common.map_filter
         (function
           | XmlAttr (_, _, e)
           | XmlAttrExpr (_, e, _) ->
               Some e
           | _ -> None)
         xml_attrs
-      @ List.filter_map
+      @ Common.map_filter
           (function
             | XmlExpr (_, Some e, _) -> Some e
             | XmlXml xml -> Some (Xml xml |> AST_generic.e)

--- a/src/metachecking/Translate_rule.ml
+++ b/src/metachecking/Translate_rule.ml
@@ -169,7 +169,7 @@ let translate_files fparser xs =
       match rules with
       | `O [ ("rules", `A rules) ] ->
           let new_rules =
-            List.map2
+            Common.map2
               (fun rule new_formula ->
                 match rule with
                 | `O rule_fields -> `O (replace_pattern rule_fields new_formula)

--- a/src/naming/Naming_AST.ml
+++ b/src/naming/Naming_AST.ml
@@ -431,7 +431,7 @@ let js_get_angular_constructor_args env attrs defs =
       attrs
   in
   defs
-  |> List.filter_map (function
+  |> Common.map_filter (function
        | {
            s =
              DefStmt

--- a/src/optimizing/Analyze_rule.ml
+++ b/src/optimizing/Analyze_rule.ml
@@ -393,7 +393,7 @@ let or_step2 (Or xs) =
   | GeneralPattern -> None
 
 let and_step2 (And xs) =
-  let ys = xs |> List.filter_map or_step2 in
+  let ys = xs |> Common.map_filter or_step2 in
   if null ys then raise GeneralPattern;
   And ys
 

--- a/src/osemgrep/cli_scan/Output.ml
+++ b/src/osemgrep/cli_scan/Output.ml
@@ -28,7 +28,7 @@ module Out = Semgrep_output_v1_j
 let apply_fixes (conf : Scan_CLI.conf) (cli_output : Out.cli_output) =
   (* TODO fix_regex *)
   let edits : Textedit.t list =
-    List.filter_map
+    Common.map_filter
       (fun (result : Out.cli_match) ->
         let path = result.Out.path in
         let* fix = result.Out.extra.fix in

--- a/src/osemgrep/reporting/Nosemgrep.ml
+++ b/src/osemgrep/reporting/Nosemgrep.ml
@@ -123,7 +123,7 @@ let rule_match_nosem ~strict (rule_match : Out.cli_match) :
           (Option.value ~default:[||] ids_line)
           (Option.value ~default:[||] ids_previous_line)
       in
-      let ids = List.filter_map Fun.id (Array.to_list ids) in
+      let ids = Common.map_filter Fun.id (Array.to_list ids) in
       (* check if the id specified by the user is the [rule_match]'s [rule_id]. *)
       List.fold_left
         (fun (result, errors) id ->

--- a/src/osemgrep/reporting/Nosemgrep.ml
+++ b/src/osemgrep/reporting/Nosemgrep.ml
@@ -164,7 +164,7 @@ let rule_match_nosem ~strict (rule_match : Out.cli_match) :
 let process_ignores ~strict (out : Out.cli_output) : Out.cli_output =
   let results, errors =
     (* filters [rule_match]s by the [nosemgrep] tag. *)
-    List.filter_map
+    Common.map_filter
       (fun rule_match ->
         let to_ignore, errors = rule_match_nosem ~strict rule_match in
         if not to_ignore then Some (rule_match, errors) else None)

--- a/src/osemgrep/targeting/Gitignore_syntax.ml
+++ b/src/osemgrep/targeting/Gitignore_syntax.ml
@@ -113,7 +113,7 @@ let parse_line ~anchor source_name source_kind line_number line_contents =
 
 let from_string ~anchor ~name ~kind str =
   let lines = read_lines_from_string str in
-  List.mapi
+  Common.mapi
     (fun i contents ->
       let linenum = i + 1 in
       parse_line ~anchor name kind linenum contents)

--- a/src/osemgrep/targeting/Gitignore_syntax.ml
+++ b/src/osemgrep/targeting/Gitignore_syntax.ml
@@ -118,7 +118,7 @@ let from_string ~anchor ~name ~kind str =
       let linenum = i + 1 in
       parse_line ~anchor name kind linenum contents)
     lines
-  |> List.filter_map (fun x -> x)
+  |> Common.map_filter (fun x -> x)
 
 let from_file ~anchor ~kind path =
   Fpath.to_string path |> Common.read_file

--- a/src/parsing/Parse_rule.ml
+++ b/src/parsing/Parse_rule.ml
@@ -304,7 +304,7 @@ let parse_listi env (key : key) f x =
     f env x
   in
   match x.G.e with
-  | G.Container (Array, (_, xs, _)) -> List.mapi get_component xs
+  | G.Container (Array, (_, xs, _)) -> Common.mapi get_component xs
   | _ -> error_at_key env key ("Expected a list for " ^ fst key)
 
 (* TODO: delete at some point, should use parse_string_wrap_list *)
@@ -657,7 +657,7 @@ and parse_pair_old env ((key, value) : key * G.expr) : R.formula =
   let env = { env with path = fst key :: env.path } in
   let parse_listi env (key : key) f x =
     match x.G.e with
-    | G.Container (Array, (_, xs, _)) -> List.mapi f xs
+    | G.Container (Array, (_, xs, _)) -> Common.mapi f xs
     | _ -> error_at_key env key ("Expected a list for " ^ fst key)
   in
   let get_pattern str_e = parse_xpattern_expr env str_e in
@@ -1486,7 +1486,7 @@ let parse_generic_ast ?(error_recovery = false) (file : Fpath.t)
   in
   let xs =
     rules
-    |> List.mapi (fun i rule ->
+    |> Common.mapi (fun i rule ->
            if error_recovery then (
              try Left (parse_one_rule t i rule) with
              | R.Err (R.InvalidRule ((kind, ruleid, _) as err)) ->

--- a/src/reporting/JSON_report.ml
+++ b/src/reporting/JSON_report.ml
@@ -179,7 +179,7 @@ let parse_info_to_location pi =
   |> Option.map (fun token_location ->
          OutH.location_of_token_location token_location)
 
-let tokens_to_locations toks = List.filter_map parse_info_to_location toks
+let tokens_to_locations toks = Common.map_filter parse_info_to_location toks
 
 let tokens_to_single_loc toks =
   (* toks should be nonempty and should contain only origintoks, but since we
@@ -199,7 +199,7 @@ let token_to_intermediate_var token =
   Some { Out.location }
 
 let tokens_to_intermediate_vars tokens =
-  List.filter_map token_to_intermediate_var tokens
+  Common.map_filter token_to_intermediate_var tokens
 
 let rec taint_call_trace = function
   | Toks toks ->

--- a/src/runner/Run_semgrep.ml
+++ b/src/runner/Run_semgrep.ml
@@ -731,7 +731,8 @@ let semgrep_with_rules config ((rules, invalid_rules), rules_parse_time) =
              (* Assumption: find_opt will return None iff a r_id
                  is in skipped_rules *)
              target.In.rule_nums
-             |> Common.map_filter (fun r_num -> Hashtbl.find_opt rule_table r_num)
+             |> Common.map_filter (fun r_num ->
+                    Hashtbl.find_opt rule_table r_num)
              (* Don't run the extract rules
                 Note: we can't filter this out earlier because the rule indexes need to be stable *)
              |> List.filter (fun r ->

--- a/src/runner/Run_semgrep.ml
+++ b/src/runner/Run_semgrep.ml
@@ -522,7 +522,7 @@ let mk_rule_table (rules : Rule.t list) (list_of_rule_ids : Rule.rule_id list) :
   in
   let id_pairs =
     list_of_rule_ids
-    |> List.mapi (fun i x -> (i, x))
+    |> Common.mapi (fun i x -> (i, x))
     (* We filter out rules here if they don't exist, because we might have a
      * rule_id for an extract mode rule, but extract mode rules won't appear in
      * rule pairs, because they won't be in the table we make for search
@@ -595,7 +595,7 @@ let targets_of_config (config : Runner_config.t)
                {
                  In.path = Fpath.to_string file;
                  language = Xlang.to_string xlang;
-                 rule_nums = List.mapi (fun i _ -> i) rule_ids;
+                 rule_nums = Common.mapi (fun i _ -> i) rule_ids;
                })
       in
       ({ target_mappings; rule_ids }, skipped)
@@ -861,7 +861,7 @@ let semgrep_with_prepared_rules_and_targets config (x : lang_job) =
         id)
       x.rules
   in
-  let rule_nums = List.mapi (fun i _ -> i) rule_ids in
+  let rule_nums = Common.mapi (fun i _ -> i) rule_ids in
   let target_mappings =
     Common.map
       (fun path : Input_to_core_t.target ->

--- a/src/runner/Run_semgrep.ml
+++ b/src/runner/Run_semgrep.ml
@@ -230,7 +230,7 @@ let filter_files_with_too_many_matches_and_transform_as_timeout
   in
   let offending_file_list =
     per_files
-    |> List.filter_map (fun (file, xs) ->
+    |> Common.map_filter (fun (file, xs) ->
            if List.length xs > max_match_per_file then Some file else None)
   in
   let offending_files = Common.hashset_of_list offending_file_list in
@@ -528,7 +528,7 @@ let mk_rule_table (rules : Rule.t list) (list_of_rule_ids : Rule.rule_id list) :
      * rule pairs, because they won't be in the table we make for search
      * because we don't want to run them at this stage.
      *)
-    |> List.filter_map (fun (i, rule_id) ->
+    |> Common.map_filter (fun (i, rule_id) ->
            let* x = Hashtbl.find_opt rule_table rule_id in
            Some (i, x))
   in
@@ -634,7 +634,7 @@ let extracted_targets_of_config (config : Runner_config.t)
         Match_extract_mode.match_result_location_adjuster )
       Hashtbl.t =
   let extractors =
-    List.filter_map
+    Common.map_filter
       (fun r ->
         match r.Rule.mode with
         | `Extract _ as e -> Some { r with mode = e }
@@ -731,7 +731,7 @@ let semgrep_with_rules config ((rules, invalid_rules), rules_parse_time) =
              (* Assumption: find_opt will return None iff a r_id
                  is in skipped_rules *)
              target.In.rule_nums
-             |> List.filter_map (fun r_num -> Hashtbl.find_opt rule_table r_num)
+             |> Common.map_filter (fun r_num -> Hashtbl.find_opt rule_table r_num)
              (* Don't run the extract rules
                 Note: we can't filter this out earlier because the rule indexes need to be stable *)
              |> List.filter (fun r ->

--- a/src/tainting/Dataflow_tainting.ml
+++ b/src/tainting/Dataflow_tainting.ml
@@ -435,7 +435,7 @@ let findings_of_tainted_sink env taints (sink : T.sink) : T.finding list =
      * And `ArgtoSink` needs to carry the other taint that reaches the
      * sink besides the argument. *)
   taints |> Taints.elements
-  |> List.filter_map (fun (taint : T.taint) ->
+  |> Common.map_filter (fun (taint : T.taint) ->
          let tokens = List.rev taint.tokens in
          match taint.orig with
          | Arg i ->
@@ -970,7 +970,7 @@ let check_function_signature env fun_exp args args_taints =
       let* fparams, fun_sig = hook env.config eorig in
       Some
         (fun_sig
-        |> List.filter_map (function
+        |> Common.map_filter (function
              | T.SrcToReturn (src, tokens, _return_tok) ->
                  let call_trace = T.Call (eorig, tokens, src.call_trace) in
                  Some

--- a/src/targeting/List_files.ml
+++ b/src/targeting/List_files.ml
@@ -79,7 +79,7 @@ let list path = list_with_stat path |> Common.map fst
 (* python: Target.files_from_filesystem *)
 let list_regular_files ?(keep_root = false) root_path =
   list_with_stat root_path
-  |> List.filter_map (fun (path, (stat : Unix.stats)) ->
+  |> Common.map_filter (fun (path, (stat : Unix.stats)) ->
          logger#info "root: %s path: %s" !!root_path !!path;
          if keep_root && path = root_path then Some path
          else

--- a/src/targeting/List_files.mli
+++ b/src/targeting/List_files.mli
@@ -30,7 +30,7 @@ val list_regular_files : ?keep_root:bool -> Fpath.t -> Fpath.t list
 
 (*
    List all files recursively. Exclude folders/directories.
-   Use List.filter_map to exclude more file types.
+   Use Common.map_filter to exclude more file types.
 *)
 val list_with_stat : Fpath.t -> (Fpath.t * Unix.stats) list
 


### PR DESCRIPTION
Add avoidance of List.map2 and List.filter_map to the rules

Use Common.map_filter throughout the repository.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
