### PR TITLE
Fix local rule use-concat-map and fix the subsequent Semgrep findings

### DIFF
--- a/semgrep.yml
+++ b/semgrep.yml
@@ -111,6 +111,10 @@ rules:
       - pattern: Common.map ... |> List.flatten
       - pattern: List.map ... |> List.concat
       - pattern: Common.map ... |> List.concat
+      - pattern: ... |> List.map ... |> List.flatten
+      - pattern: ... |> Common.map ... |> List.flatten
+      - pattern: ... |> List.map ... |> List.concat
+      - pattern: ... |> Common.map ... |> List.concat
       - pattern: List.flatten ( List.map ... )
       - pattern: List.flatten ( Common.map ... )
       - pattern: List.concat ( List.map ... )

--- a/src/analyzing/AST_to_IL.ml
+++ b/src/analyzing/AST_to_IL.ml
@@ -1085,7 +1085,7 @@ and expr_with_pre_stmts_opt env eopt =
 
 and for_var_or_expr_list env xs =
   xs
-  |> Common.map (function
+  |> List.concat_map (function
        | G.ForInitExpr e ->
            let ss, _eIGNORE = expr_with_pre_stmts env e in
            ss
@@ -1098,7 +1098,6 @@ and for_var_or_expr_list env xs =
                ss
                @ [ mk_s (Instr (mk_i (Assign (lv, e')) (Related (G.En ent)))) ]
            | _ -> []))
-  |> List.flatten
 
 (*****************************************************************************)
 (* Parameters *)
@@ -1157,7 +1156,7 @@ and stmt_aux env st =
       ss @ [ mk_s (Instr (mk_i (Assign (lv, e')) (Related (G.S st)))) ]
   | G.DefStmt def -> [ mk_s (MiscStmt (DefStmt def)) ]
   | G.DirectiveStmt dir -> [ mk_s (MiscStmt (DirectiveStmt dir)) ]
-  | G.Block xs -> xs |> PI.unbracket |> Common.map (stmt env) |> List.flatten
+  | G.Block xs -> xs |> PI.unbracket |> List.concat_map (stmt env)
   | G.If (tok, cond, st1, st2) ->
       let ss, e' = cond_with_pre_stmts env cond in
       let st1 = stmt env st1 in

--- a/src/analyzing/Constant_propagation.ml
+++ b/src/analyzing/Constant_propagation.ml
@@ -502,7 +502,7 @@ let terraform_sid = SId.unsafe_default
 
 let add_special_constants env lang prog =
   if lang = Lang.Terraform then
-    let vars = prog |> Common.map terraform_stmt_to_vardefs |> List.flatten in
+    let vars = prog |> List.concat_map terraform_stmt_to_vardefs in
     vars
     |> List.iter (fun (id, v) ->
            match v.e with

--- a/src/engine/Match_search_mode.ml
+++ b/src/engine/Match_search_mode.ml
@@ -189,7 +189,7 @@ let debug_semgrep config mini_rules file lang ast =
   (* process one mini rule at a time *)
   logger#info "DEBUG SEMGREP MODE!";
   mini_rules
-  |> Common.map (fun mr ->
+  |> List.concat_map (fun mr ->
          logger#debug "Checking mini rule with pattern %s" mr.MR.pattern_string;
          let res =
            Match_patterns.check
@@ -210,7 +210,6 @@ let debug_semgrep config mini_rules file lang ast =
            *)
            res |> List.iter (fun m -> logger#debug "match = %s" (PM.show m));
          res)
-  |> List.flatten
 
 (*****************************************************************************)
 (* Evaluating Semgrep patterns *)

--- a/src/engine/Unit_engine.ml
+++ b/src/engine/Unit_engine.ml
@@ -592,7 +592,7 @@ let tainting_test lang rules_file file =
 
   let matches =
     taint_rules
-    |> Common.map (fun rule ->
+    |> List.concat_map (fun rule ->
            let xtarget =
              {
                Xtarget.file = !!file;
@@ -616,7 +616,6 @@ let tainting_test lang rules_file file =
            | []
            | _ :: _ :: _ ->
                raise Impossible)
-    |> List.flatten
   in
   let actual =
     matches

--- a/src/engine/Xpattern_matcher.ml
+++ b/src/engine/Xpattern_matcher.ml
@@ -72,7 +72,7 @@ let (matches_of_matcher :
         let res, match_time =
           Common.with_time (fun () ->
               xpatterns
-              |> Common.map (fun (xpat, id, pstr) ->
+              |> List.concat_map (fun (xpat, id, pstr) ->
                      let xs = matcher.matcher target_content file xpat in
                      xs
                      |> Common.map (fun ((loc1, loc2), env) ->
@@ -86,8 +86,7 @@ let (matches_of_matcher :
                               taint_trace = None;
                               tokens = lazy [ info_of_token_location loc1 ];
                               engine_kind = OSS;
-                            }))
-              |> List.flatten)
+                            })))
         in
         RP.make_match_result res Report.ErrorSet.empty
           { RP.parse_time; match_time }

--- a/src/il/IL_helpers.ml
+++ b/src/il/IL_helpers.ml
@@ -70,7 +70,7 @@ and lvals_in_lval lval =
   in
   base_lvals @ offset_lvals
 
-and lvals_of_exps xs = xs |> Common.map lvals_of_exp |> List.flatten
+and lvals_of_exps xs = xs |> List.concat_map lvals_of_exp
 
 (** The lvals in the RHS of the instruction. *)
 let rlvals_of_instr x =

--- a/src/matching/Matching_generic.ml
+++ b/src/matching/Matching_generic.ml
@@ -419,8 +419,7 @@ let rec all_splits = function
   | [] -> [ ([], []) ]
   | x :: xs ->
       all_splits xs
-      |> Common.map (function ls, rs -> [ (x :: ls, rs); (ls, x :: rs) ])
-      |> List.flatten
+      |> List.concat_map (function ls, rs -> [ (x :: ls, rs); (ls, x :: rs) ])
 
 (* let _ = Common2.example
     (all_elem_and_rest_of_list ['a';'b';'c'] =
@@ -609,15 +608,13 @@ let m_comb_bind (comb_result : _ comb_result) f : _ comb_result =
   let rec loop = function
     | [] -> []
     | (bs, tout) :: comb_matches' ->
-        let bs_matches =
-          tout |> Common.map (fun tin -> f bs tin) |> List.flatten
-        in
+        let bs_matches = tout |> List.concat_map (fun tin -> f bs tin) in
         bs_matches @ loop comb_matches'
   in
   loop (comb_result tin)
 
 let m_comb_flatten (comb_result : _ comb_result) (tin : tin) : tout =
-  comb_result tin |> Common.map snd |> List.flatten
+  comb_result tin |> List.concat_map snd
 
 let m_comb_fold (m_comb : _ comb_matcher) (xs : _ list)
     (comb_result : _ comb_result) : _ comb_result =

--- a/src/matching/SubAST_generic.ml
+++ b/src/matching/SubAST_generic.ml
@@ -153,7 +153,7 @@ let subexprs_of_expr with_symbolic_propagation e =
       e1
       :: (e2 |> PI.unbracket
          |> (fun (a, b, c) -> [ a; b; c ])
-         |> Common.map Option.to_list |> List.flatten)
+         |> List.concat_map Option.to_list)
   | Yield (_, eopt, _) -> Option.to_list eopt
   | StmtExpr st -> subexprs_of_stmt st
   | OtherExpr (_, anys) ->
@@ -304,10 +304,9 @@ let substmts_of_stmt st =
   | Block (_, xs, _) -> xs
   | Switch (_, _, xs) ->
       xs
-      |> Common.map (function
+      |> List.concat_map (function
            | CasesAndBody (_, st) -> [ st ]
            | CaseEllipsis _ -> [])
-      |> List.flatten
   | Try (_, st, xs, opt) -> (
       [ st ]
       @ (xs |> Common.map Common2.thd3)
@@ -394,7 +393,7 @@ let flatten_substmts_of_stmts xs =
     (if !go_really_deeper_stmt then
      let es = subexprs_of_stmt x in
      (* getting deeply nested lambdas stmts *)
-     let lambdas = es |> Common.map lambdas_in_expr_memo |> List.flatten in
+     let lambdas = es |> List.concat_map lambdas_in_expr_memo in
      lambdas
      |> Common.map (fun def -> H.funcbody_to_stmt def.fbody)
      |> List.iter aux);

--- a/src/metachecking/Check_rule.ml
+++ b/src/metachecking/Check_rule.ml
@@ -240,11 +240,11 @@ let run_checks config fparser metachecks xs =
       let semgrep_found_errs = semgrep_check config metachecks rules in
       let ocaml_found_errs =
         rules
-        |> Common.map (fun file ->
+        |> List.concat_map (fun file ->
                logger#info "processing %s" !!file;
                try
                  let rs = fparser file in
-                 rs |> Common.map (fun file -> check file) |> List.flatten
+                 rs |> List.concat_map (fun file -> check file)
                with
                (* TODO this error is special cased because YAML files that *)
                (* aren't semgrep rules are getting scanned *)
@@ -252,7 +252,6 @@ let run_checks config fparser metachecks xs =
                | exn ->
                    let e = Exception.catch exn in
                    [ E.exn_to_error !!file e ])
-        |> List.flatten
       in
       semgrep_found_errs @ ocaml_found_errs
 

--- a/src/optimizing/Analyze_rule.ml
+++ b/src/optimizing/Analyze_rule.ml
@@ -204,7 +204,7 @@ let rec (cnf : Rule.formula -> cnf_step0) =
   | R.And (_, { conjuncts = xs; conditions = conds; _ }) ->
       let ys = Common.map cnf xs in
       let zs = Common.map (fun (_t, cond) -> And [ Or [ LCond cond ] ]) conds in
-      And (ys @ zs |> Common.map (function And ors -> ors) |> List.flatten)
+      And (ys @ zs |> List.concat_map (function And ors -> ors))
   | R.Or (_, xs) ->
       let is_dangerously_large l = List.compare_length_with l 1_000_000 > 0 in
       let ys = Common.map cnf xs in

--- a/src/reporting/Report.ml
+++ b/src/reporting/Report.ml
@@ -342,15 +342,11 @@ let collate_rule_results :
 let make_final_result results
     (rules_with_engine : (Rule.t * Pattern_match.engine_kind) list)
     ~rules_parse_time =
-  let matches = results |> Common.map (fun x -> x.matches) |> List.flatten in
+  let matches = results |> List.concat_map (fun x -> x.matches) in
   let errors =
-    results
-    |> Common.map (fun x -> x.errors |> ErrorSet.elements)
-    |> List.flatten
+    results |> List.concat_map (fun x -> x.errors |> ErrorSet.elements)
   in
-  let explanations =
-    results |> Common.map (fun x -> x.explanations) |> List.flatten
-  in
+  let explanations = results |> List.concat_map (fun x -> x.explanations) in
   let final_rules =
     Common.map (fun (r, ek) -> (fst r.Rule.id, ek)) rules_with_engine
   in
@@ -389,7 +385,7 @@ let make_final_result results
     match !mode with
     | MDebug ->
         let skipped_targets =
-          results |> Common.map (fun x -> get_skipped_targets x) |> List.flatten
+          results |> List.concat_map (fun x -> get_skipped_targets x)
         in
         Debug { skipped_targets; profiling = mk_profiling () }
     | MTime -> Time { profiling = mk_profiling () }

--- a/src/reporting/Semgrep_error_code.ml
+++ b/src/reporting/Semgrep_error_code.ml
@@ -245,7 +245,7 @@ let (expected_error_lines_of_files :
       (Common.filename * int) (* line *) list) =
  fun ?(regexp = default_error_regexp) test_files ->
   test_files
-  |> Common.map (fun file ->
+  |> List.concat_map (fun file ->
          Common.cat file |> Common.index_list_1
          |> Common.map_filter (fun (s, idx) ->
                 (* Right now we don't care about the actual error messages. We
@@ -255,7 +255,6 @@ let (expected_error_lines_of_files :
                 if s =~ regexp (* + 1 because the comment is one line before *)
                 then Some (file, idx + 1)
                 else None))
-  |> List.flatten
 
 (* A copy-paste of Error_code.compare_actual_to_expected but
  * with Semgrep_error_code.error instead of Error_code.t for the error type.

--- a/src/reporting/Statistics_report.ml
+++ b/src/reporting/Statistics_report.ml
@@ -124,15 +124,14 @@ let stat file =
   (* reporting *)
   pr2 (spf "TIMEOUT FILES (timeout = %.1f" !timeout);
   let timeout_files =
-    runs |> Common.map (fun x -> x.timeout) |> List.flatten |> Common2.uniq
+    runs |> List.concat_map (fun x -> x.timeout) |> Common2.uniq
   in
   timeout_files |> List.iter pr2_gen;
 
   pr2 "SLOW FILES";
   let problematic_files =
     runs
-    |> Common.map (fun x -> x.files)
-    |> List.flatten
+    |> List.concat_map (fun x -> x.files)
     |> Common.exclude (fun (file, _) -> List.mem file timeout_files)
     |> Common.sort_by_val_highfirst |> Common.take_safe 30
   in
@@ -156,8 +155,8 @@ let stat file =
            let total_rules = List.length xs in
            let total_time =
              xs
-             |> Common.map (fun x -> x.files)
-             |> List.flatten |> Common.map snd |> Common2.sum_float
+             |> List.concat_map (fun x -> x.files)
+             |> Common.map snd |> Common2.sum_float
            in
            let total_files =
              xs |> Common.map (fun x -> List.length x.files) |> Common2.sum


### PR DESCRIPTION
as reported by @hannesm.

This found 24 uses of "map |> flatten"!

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
