### PR TITLE
Add --{enable,disable}-nosem option

### DIFF
--- a/src/osemgrep/cli_scan/Output.ml
+++ b/src/osemgrep/cli_scan/Output.ml
@@ -161,7 +161,9 @@ let output_result (conf : Scan_CLI.conf) (res : Core_runner.result) : unit =
       ~rules_source:conf.rules_source res
   in
   let cli_output =
-    Nosemgrep.process_ignores ~strict:conf.Scan_CLI.strict cli_output
+    if conf.nosem then
+      Nosemgrep.process_ignores ~strict:conf.Scan_CLI.strict cli_output
+    else cli_output
   in
   (* ugly: but see the comment above why we do it here *)
   if conf.autofix then apply_fixes_and_warn conf cli_output;

--- a/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -607,14 +607,10 @@ let o_project_root : string option Term.t =
   Arg.value (Arg.opt Arg.(some string) None info)
 
 let o_nosem : bool Term.t =
-  let enable =
-    Arg.info [ "enable-nosem" ]
-      ~doc:
-        {|Enables 'nosem'. Findings will not be reported on lines containing
+  H.negatable_flag [ "enable-nosem" ] ~neg_options:[ "disable-nosem" ]
+    ~doc:
+      {|Enables 'nosem'. Findings will not be reported on lines containing
           a 'nosem' comment at the end.|}
-  in
-  let disable = Arg.info [ "disable-nosem" ] in
-  Arg.value (Arg.vflag true [ (true, enable); (false, disable) ])
 
 (*****************************************************************************)
 (* Turn argv into a conf *)
@@ -625,11 +621,11 @@ let cmdline_term : conf Term.t =
    * of the corresponding '$ o_xx $' further below! *)
   let combine autofix baseline_commit config debug dryrun dump_ast dump_config
       emacs error exclude exclude_rule_ids force_color include_ json lang
-      max_memory_mb max_target_bytes metrics num_jobs optimizations pattern
-      profile project_root quiet replacement respect_git_ignore rewrite_rule_ids
-      scan_unknown_extensions severity show_supported_languages strict
-      target_roots test test_ignore_todo time_flag timeout timeout_threshold
-      validate verbose version version_check vim nosem =
+      max_memory_mb max_target_bytes metrics num_jobs nosem optimizations
+      pattern profile project_root quiet replacement respect_git_ignore
+      rewrite_rule_ids scan_unknown_extensions severity show_supported_languages
+      strict target_roots test test_ignore_todo time_flag timeout
+      timeout_threshold validate verbose version version_check vim =
     let include_ =
       match include_ with
       | [] -> None
@@ -871,13 +867,13 @@ let cmdline_term : conf Term.t =
     const combine $ o_autofix $ o_baseline_commit $ o_config $ o_debug
     $ o_dryrun $ o_dump_ast $ o_dump_config $ o_emacs $ o_error $ o_exclude
     $ o_exclude_rule_ids $ o_force_color $ o_include $ o_json $ o_lang
-    $ o_max_memory_mb $ o_max_target_bytes $ o_metrics $ o_num_jobs
+    $ o_max_memory_mb $ o_max_target_bytes $ o_metrics $ o_num_jobs $ o_nosem
     $ o_optimizations $ o_pattern $ o_profile $ o_project_root $ o_quiet
     $ o_replacement $ o_respect_git_ignore $ o_rewrite_rule_ids
     $ o_scan_unknown_extensions $ o_severity $ o_show_supported_languages
     $ o_strict $ o_target_roots $ o_test $ o_test_ignore_todo $ o_time
     $ o_timeout $ o_timeout_threshold $ o_validate $ o_verbose $ o_version
-    $ o_version_check $ o_vim $ o_nosem)
+    $ o_version_check $ o_vim)
 
 let doc = "run semgrep rules on files"
 

--- a/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -59,6 +59,7 @@ type conf = {
   dump : Dump_subcommand.conf option;
   validate : Validate_subcommand.conf option;
   test : Test_subcommand.conf option;
+  nosem : bool;
 }
 [@@deriving show]
 
@@ -113,6 +114,7 @@ let default : conf =
     dump = None;
     validate = None;
     test = None;
+    nosem = true;
   }
 
 (*************************************************************************)
@@ -604,6 +606,16 @@ let o_project_root : string option Term.t =
   in
   Arg.value (Arg.opt Arg.(some string) None info)
 
+let o_nosem : bool Term.t =
+  let enable =
+    Arg.info [ "enable-nosem" ]
+      ~doc:
+        {|Enables 'nosem'. Findings will not be reported on lines containing
+          a 'nosem' comment at the end.|}
+  in
+  let disable = Arg.info [ "disable-nosem" ] in
+  Arg.value (Arg.vflag true [ (true, enable); (false, disable) ])
+
 (*****************************************************************************)
 (* Turn argv into a conf *)
 (*****************************************************************************)
@@ -617,7 +629,7 @@ let cmdline_term : conf Term.t =
       profile project_root quiet replacement respect_git_ignore rewrite_rule_ids
       scan_unknown_extensions severity show_supported_languages strict
       target_roots test test_ignore_todo time_flag timeout timeout_threshold
-      validate verbose version version_check vim =
+      validate verbose version version_check vim nosem =
     let include_ =
       match include_ with
       | [] -> None
@@ -849,6 +861,7 @@ let cmdline_term : conf Term.t =
       dump;
       validate;
       test;
+      nosem;
     }
   in
   (* Term defines 'const' but also the '$' operator *)
@@ -864,7 +877,7 @@ let cmdline_term : conf Term.t =
     $ o_scan_unknown_extensions $ o_severity $ o_show_supported_languages
     $ o_strict $ o_target_roots $ o_test $ o_test_ignore_todo $ o_time
     $ o_timeout $ o_timeout_threshold $ o_validate $ o_verbose $ o_version
-    $ o_version_check $ o_vim)
+    $ o_version_check $ o_vim $ o_nosem)
 
 let doc = "run semgrep rules on files"
 

--- a/src/osemgrep/cli_scan/Scan_CLI.mli
+++ b/src/osemgrep/cli_scan/Scan_CLI.mli
@@ -39,6 +39,7 @@ type conf = {
   dump : Dump_subcommand.conf option;
   validate : Validate_subcommand.conf option;
   test : Test_subcommand.conf option;
+  nosem : bool;
 }
 [@@deriving show]
 


### PR DESCRIPTION
PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)

This PR adds options: `--{disable,enable}-nosem` as we can found the, into the Python code.