### PR TITLE
osemgrep: add "Files skipped" and "Scan summary" output

### DIFF
--- a/src/osemgrep/cli_scan/Cli_json_output.ml
+++ b/src/osemgrep/cli_scan/Cli_json_output.ml
@@ -415,8 +415,8 @@ let cli_skipped_target_of_skipped_target (x : Out.skipped_target) :
   { path = x.path; reason = x.reason }
 
 (* skipping the python intermediate FileTargetingLog for now *)
-let cli_skipped_targets ~(errors : Out.core_error list)
-    ~(skipped_targets : Out.skipped_target list) : Out.cli_skipped_target list =
+let cli_skipped_targets ~(skipped_targets : Out.skipped_target list) :
+    Out.cli_skipped_target list =
   (* TODO: skipped targets are coming from the FileIgnoreLog which is
    * populated from many places in the code.
    *)
@@ -424,19 +424,11 @@ let cli_skipped_targets ~(errors : Out.core_error list)
   (* TODO: see _make_failed_to_analyze() in output.py,
    * core_failure_lines_by_file in target_manager.py
    *)
-  let skipped_because_of_core_errors : Out.cli_skipped_target list =
-    errors
-    |> Common.map (fun (err : Out.core_error) ->
-           {
-             Out.path = err.location.path;
-             reason = Analysis_failed_parser_or_internal_error;
-           })
-  in
   let core_skipped =
     skipped_targets |> Common.map cli_skipped_target_of_skipped_target
   in
   (* TODO: need to sort *)
-  skipped_because_of_core_errors @ core_skipped
+  core_skipped
 
 (*****************************************************************************)
 (* Entry point *)
@@ -477,7 +469,7 @@ let cli_output_of_core_results ~logging_level ~rules_source
       let (paths : Out.cli_paths) =
         match logging_level with
         | Some (Logs.Info | Logs.Debug) ->
-            let skipped = cli_skipped_targets ~errors ~skipped_targets in
+            let skipped = cli_skipped_targets ~skipped_targets in
             { scanned; _comment = None; skipped }
         | _else_ ->
             {

--- a/src/osemgrep/cli_scan/Core_runner.ml
+++ b/src/osemgrep/cli_scan/Core_runner.ml
@@ -410,9 +410,10 @@ let pp_skipped ppf
 (*
    Take in rules and targets and return object with findings.
 *)
-let invoke_semgrep_core ?(respect_git_ignore = true) (conf : conf)
-    (all_rules : Rule.t list) (rule_errors : Rule.invalid_rule_error list)
-    ?(ignored_targets = []) (all_targets : Fpath.t list) : result =
+let invoke_semgrep_core ?(respect_git_ignore = true) ?(ignored_targets = [])
+    (conf : conf) (all_rules : Rule.t list)
+    (rule_errors : Rule.invalid_rule_error list) (all_targets : Fpath.t list) :
+    result =
   let config : Runner_config.t = runner_config_of_conf conf in
 
   match rule_errors with

--- a/src/osemgrep/cli_scan/Core_runner.ml
+++ b/src/osemgrep/cli_scan/Core_runner.ml
@@ -198,6 +198,7 @@ let pp_status rules targets lang_jobs respect_git_ignore ppf () =
          summary_line += f", {unit_str(pro_rule_count, 'Pro rule')}"
   *)
   Fmt.pf ppf ":@.@.";
+  (* TODO origin table [Origin Rules] [Community N] *)
   Fmt_helpers.pp_table
     ("Language", [ "Rules"; "Files" ])
     ppf
@@ -209,6 +210,195 @@ let pp_status rules targets lang_jobs respect_git_ignore ppf () =
          []
     |> List.rev)
 
+let errors_to_skipped (errors : Out.core_error list) : Out.skipped_target list =
+  errors
+  |> Common.map (fun Out.{ location; message; rule_id; _ } ->
+         Out.
+           {
+             path = location.path;
+             reason = Analysis_failed_parser_or_internal_error;
+             details = message;
+             rule_id;
+           })
+
+let analyze_skipped (skipped : Out.skipped_target list) =
+  let reason_ht = Hashtbl.create 13 in
+  List.iter
+    (fun r -> Hashtbl.add reason_ht r [])
+    Out.
+      [
+        Semgrepignore_patterns_match;
+        Cli_include_flags_do_not_match;
+        Cli_exclude_flags_match;
+        Exceeded_size_limit;
+      ];
+  let skipped_by_reason (Out.{ reason; _ } as e : Out.skipped_target) =
+    let reason =
+      match reason with
+      | Out.Gitignore_patterns_match
+      | Semgrepignore_patterns_match ->
+          Out.Semgrepignore_patterns_match
+      | Too_big
+      | Exceeded_size_limit ->
+          Out.Exceeded_size_limit
+      | Cli_include_flags_do_not_match -> Out.Cli_include_flags_do_not_match
+      | Cli_exclude_flags_match -> Out.Cli_exclude_flags_match
+      | Always_skipped
+      | Analysis_failed_parser_or_internal_error
+      | Excluded_by_config
+      | Wrong_language
+      | Minified
+      | Binary
+      | Irrelevant_rule
+      | Too_many_matches ->
+          assert false
+    in
+    let v = e :: Option.value ~default:[] (Hashtbl.find_opt reason_ht reason) in
+    Hashtbl.replace reason_ht reason v
+  in
+  List.iter skipped_by_reason skipped;
+  ( Hashtbl.find reason_ht Out.Semgrepignore_patterns_match,
+    Hashtbl.find reason_ht Out.Cli_include_flags_do_not_match,
+    Hashtbl.find reason_ht Out.Cli_exclude_flags_match,
+    Hashtbl.find reason_ht Out.Exceeded_size_limit )
+
+let pp_summary ppf
+    (( _respect_git_ignore,
+       semgrep_ignored,
+       include_ignored,
+       exclude_ignored,
+       file_size_ignored,
+       errors ) :
+      bool
+      * Out.skipped_target list
+      * Out.skipped_target list
+      * Out.skipped_target list
+      * Out.skipped_target list
+      * Out.skipped_target list) =
+  Fmt_helpers.pp_heading ppf "Scan summary";
+  (* TODO
+        if self.target_manager.baseline_handler:
+            limited_fragments.append(
+                "Scan was limited to files changed since baseline commit."
+            )
+  *)
+  (* TODO
+        elif self.target_manager.respect_git_ignore:
+            # Each target could be a git repo, and we respect the git ignore
+            # of each target, so to be accurate with this print statement we
+            # need to check if any target is a git repo and not just the cwd
+            targets_not_in_git = 0
+            dir_targets = 0
+            for t in self.target_manager.targets:
+                if t.path.is_dir():
+                    dir_targets += 1
+                    try:
+                        t.files_from_git_ls()
+                    except (subprocess.SubprocessError, FileNotFoundError):
+                        targets_not_in_git += 1
+                        continue
+            if targets_not_in_git != dir_targets:
+                limited_fragments.append(f"Scan was limited to files tracked by git.")
+  *)
+  let opt_msg msg = function
+    | [] -> None
+    | xs -> Some (string_of_int (List.length xs) ^ " " ^ msg)
+  in
+  let out_skipped =
+    Common.map_filter Fun.id
+      [
+        opt_msg "files not matching --include patterns" include_ignored;
+        opt_msg "files matching --exclude patterns" exclude_ignored;
+        opt_msg
+          "files larger than {self.target_manager.max_target_bytes / 1000 / \
+           1000} MB"
+          file_size_ignored;
+        opt_msg "files matching .semgrepignore patterns" semgrep_ignored;
+      ]
+  in
+  let out_partial =
+    opt_msg
+      "files only partially analyzed due to a parsing or internal Semgrep error"
+      errors
+  in
+  match (out_skipped, out_partial) with
+  | [], None -> ()
+  | xs, parts ->
+      (* TODO if limited_fragments:
+              for fragment in limited_fragments:
+                  message += f"\n  {fragment}" *)
+      Fmt.pf ppf "Some files were skipped or only partially analyzed.@.";
+      Option.iter (fun txt -> Fmt.pf ppf "  Partially scanned: %s@." txt) parts;
+      (match xs with
+      | [] -> ()
+      | xs ->
+          Fmt.pf ppf "  Scan skipped: %s@." (String.concat ", " xs);
+          Fmt.pf ppf
+            "  For a full list of skipped files, run semgrep with the \
+             --verbose flag.@.");
+      Fmt.pf ppf "@."
+
+let pp_skipped ppf
+    (( respect_git_ignore,
+       semgrep_ignored,
+       include_ignored,
+       exclude_ignored,
+       file_size_ignored,
+       errors ) :
+      bool
+      * Out.skipped_target list
+      * Out.skipped_target list
+      * Out.skipped_target list
+      * Out.skipped_target list
+      * Out.skipped_target list) =
+  Fmt_helpers.pp_heading ppf "Files skipped";
+  (* TODO: always skipped *)
+  Fmt.pf ppf " Skipped by .gitignore:@.";
+  if respect_git_ignore then (
+    Fmt.pf ppf " (Disable by passing --no-git-ignore)@.@.";
+    Fmt.pf ppf "  o <all files not listed by `git ls-files` were skipped>@.")
+  else (
+    Fmt.pf ppf " (Disabled with --no-git-ignore)@.@.";
+    Fmt.pf ppf "  o <none>@.");
+  Fmt.pf ppf "@.";
+
+  let pp_list (xs : Out.skipped_target list) =
+    match xs with
+    | [] -> Fmt.pf ppf "  o <none>@."
+    | xs ->
+        List.iter
+          (fun (Out.{ path; _ } : Out.skipped_target) ->
+            Fmt.pf ppf "  o %s@." path)
+          xs
+  in
+
+  Fmt.pf ppf " Skipped by .semgrepignore:@.";
+  Fmt.pf ppf
+    " See: \
+     https://semgrep.dev/docs/ignoring-files-folders-code/#understanding-semgrep-defaults)@.@.";
+  pp_list semgrep_ignored;
+  Fmt.pf ppf "@.";
+
+  Fmt.pf ppf " Skipped by --include patterns:@.@.";
+  pp_list include_ignored;
+  Fmt.pf ppf "@.";
+
+  Fmt.pf ppf " Skipped by --exclude patterns:@.@.";
+  pp_list exclude_ignored;
+  Fmt.pf ppf "@.";
+
+  Fmt.pf ppf
+    " Skipped by limiting to files smaller than \
+     {self.target_manager.max_target_bytes} bytes:@.";
+  Fmt.pf ppf " (Adjust with the --max-target-bytes flag)@.@.";
+  pp_list file_size_ignored;
+  Fmt.pf ppf "@.";
+
+  Fmt.pf ppf
+    " Skipped by analysis failure due to parsing or internal Semgrep error@.@.";
+  pp_list errors;
+  Fmt.pf ppf "@."
+
 (*************************************************************************)
 (* Entry point *)
 (*************************************************************************)
@@ -218,7 +408,7 @@ let pp_status rules targets lang_jobs respect_git_ignore ppf () =
 *)
 let invoke_semgrep_core ?(respect_git_ignore = true) (conf : conf)
     (all_rules : Rule.t list) (rule_errors : Rule.invalid_rule_error list)
-    (all_targets : Fpath.t list) : result =
+    ?(ignored_targets = []) (all_targets : Fpath.t list) : result =
   let config : Runner_config.t = runner_config_of_conf conf in
 
   match rule_errors with
@@ -263,6 +453,7 @@ let invoke_semgrep_core ?(respect_git_ignore = true) (conf : conf)
           m "%a"
             (pp_status all_rules all_targets lang_jobs respect_git_ignore)
             ());
+      (* TODO progress bar *)
       let results_by_language =
         lang_jobs
         |> Common.map (fun lang_job ->
@@ -285,6 +476,38 @@ let invoke_semgrep_core ?(respect_git_ignore = true) (conf : conf)
         JSON_report.match_results_of_matches_and_errors
           (Some Autofix.render_fix) (Set_.cardinal scanned) res
       in
+      let errors_skipped = errors_to_skipped match_results.errors in
+      let semgrepignored, included, excluded, size =
+        analyze_skipped ignored_targets
+      in
+      let match_results =
+        let skipped_targets =
+          ignored_targets @ errors_skipped @ match_results.skipped_targets
+        in
+        (* Add the targets that were semgrepignored or errorneous *)
+        { match_results with skipped_targets }
+      in
+
+      Logs.info (fun m ->
+          m "%a" pp_skipped
+            ( respect_git_ignore,
+              semgrepignored,
+              included,
+              excluded,
+              size,
+              errors_skipped ));
+      Logs.app (fun m ->
+          m "%a" pp_summary
+            ( respect_git_ignore,
+              semgrepignored,
+              included,
+              excluded,
+              size,
+              errors_skipped ));
+      Logs.app (fun m ->
+          m "Ran %d rules on %d files: %d findings@." (List.length all_rules)
+            (List.length all_targets)
+            (List.length match_results.matches));
 
       (* TOPORT? or move in semgrep-core so get info ASAP
          if match_results.skipped_targets:

--- a/src/osemgrep/cli_scan/Core_runner.ml
+++ b/src/osemgrep/cli_scan/Core_runner.ml
@@ -257,10 +257,14 @@ let analyze_skipped (skipped : Out.skipped_target list) =
     Hashtbl.replace reason_ht reason v
   in
   List.iter skipped_by_reason skipped;
-  ( Hashtbl.find reason_ht Out.Semgrepignore_patterns_match,
-    Hashtbl.find reason_ht Out.Cli_include_flags_do_not_match,
-    Hashtbl.find reason_ht Out.Cli_exclude_flags_match,
-    Hashtbl.find reason_ht Out.Exceeded_size_limit )
+  ( (try Hashtbl.find reason_ht Out.Semgrepignore_patterns_match with
+    | Not_found -> []),
+    (try Hashtbl.find reason_ht Out.Cli_include_flags_do_not_match with
+    | Not_found -> []),
+    (try Hashtbl.find reason_ht Out.Cli_exclude_flags_match with
+    | Not_found -> []),
+    try Hashtbl.find reason_ht Out.Exceeded_size_limit with
+    | Not_found -> [] )
 
 let pp_summary ppf
     (( _respect_git_ignore,

--- a/src/osemgrep/cli_scan/Core_runner.mli
+++ b/src/osemgrep/cli_scan/Core_runner.mli
@@ -28,6 +28,7 @@ val invoke_semgrep_core :
   (* LATER? use Config_resolve.rules_and_origin instead? *)
   Rule.rules ->
   Rule.invalid_rule_error list ->
+  ?ignored_targets:Semgrep_output_v1_t.skipped_target list ->
   Fpath.t list ->
   result
 

--- a/src/osemgrep/cli_scan/Core_runner.mli
+++ b/src/osemgrep/cli_scan/Core_runner.mli
@@ -24,11 +24,11 @@ type result = {
 *)
 val invoke_semgrep_core :
   ?respect_git_ignore:bool ->
+  ?ignored_targets:Semgrep_output_v1_t.skipped_target list ->
   conf ->
   (* LATER? use Config_resolve.rules_and_origin instead? *)
   Rule.rules ->
   Rule.invalid_rule_error list ->
-  ?ignored_targets:Semgrep_output_v1_t.skipped_target list ->
   Fpath.t list ->
   result
 

--- a/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -201,17 +201,7 @@ let run (conf : Scan_CLI.conf) : Exit_code.t =
           m "]%s" "");
       let (res : Core_runner.result) =
         Core_runner.invoke_semgrep_core conf.core_runner_conf filtered_rules
-          errors targets
-      in
-      (* Add the targets that were semgrepignored *)
-      let res =
-        let core =
-          {
-            res.core with
-            skipped_targets = semgrepignored_targets @ res.core.skipped_targets;
-          }
-        in
-        { res with core }
+          errors ~ignored_targets:semgrepignored_targets targets
       in
       (* TOPORT? was in formater/base.py
          def keep_ignores(self) -> bool:

--- a/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -200,8 +200,10 @@ let run (conf : Scan_CLI.conf) : Exit_code.t =
           |> List.iter (fun file -> m "target = %s" (Fpath.to_string file));
           m "]%s" "");
       let (res : Core_runner.result) =
-        Core_runner.invoke_semgrep_core conf.core_runner_conf filtered_rules
-          errors ~ignored_targets:semgrepignored_targets targets
+        Core_runner.invoke_semgrep_core
+          ~respect_git_ignore:conf.targeting_conf.respect_git_ignore
+          ~ignored_targets:semgrepignored_targets conf.core_runner_conf
+          filtered_rules errors targets
       in
       (* TOPORT? was in formater/base.py
          def keep_ignores(self) -> bool:


### PR DESCRIPTION
Note this is not yet on par with pysemgrep, as you can observe below. But it is a good step forward. Some questions:
- (a) relative or absolute paths (pysemgrep prints relative, osemgrep absolute ones)
- (b) the skipped files are collected and categorized in Find_target, but then concatenated into a single list, not Core_runner partitions that list again -- should we instead move these across
- (c) I've no idea about "Always skipped by Semgrep" -- this seems to be files inside of `.git`, but that information is not availabe in osemgrep (should it be computed?)
- (d) baseline stuff left as todo
- (e) max target bytes: that's somehow duplicated now, both semgrep-core has a ref (set to 5MB) and osemgrep has it in its config (unused) -- should we just set the semgrep-core value?

The (bottom half) output of osemgrep with "--config r/ocaml --config r/python src/osemgrep/ --verbose --json > /dev/null"

```
Main.exe: [INFO] -----------------
| Files skipped |
-----------------
 Skipped by .gitignore:
 (Disable by passing --no-git-ignore)

  o <all files not listed by `git ls-files` were skipped>

 Skipped by .semgrepignore:
 See: https://semgrep.dev/docs/ignoring-files-folders-code/#understanding-semgrep-defaults)

  o /usr/home/hannes/devel/mirage/semgrep/src/osemgrep/targeting/Realpath.ml

 Skipped by --include patterns:

  o <none>

 Skipped by --exclude patterns:

  o <none>

 Skipped by limiting to files smaller than {self.target_manager.max_target_bytes} bytes:
 (Adjust with the --max-target-bytes flag)

  o <none>

 Skipped by analysis failure due to parsing or internal Semgrep error

  o /usr/home/hannes/devel/mirage/semgrep/src/osemgrep/core/Exit_code.mli

----------------
| Scan summary |
----------------
Some files were skipped or only partially analyzed.
  Partially scanned: 1 files only partially analyzed due to a parsing or internal Semgrep error
  Scan skipped: 1 files matching .semgrepignore patterns
  For a full list of skipped files, run semgrep with the --verbose flag.

Ran 429 rules on 162 files: 56 findings
```

For comparisong, the output of pysemgrep:

```
========================================
Files skipped:
========================================

  Always skipped by Semgrep:

   • <none>

  Skipped by .gitignore:
  (Disable by passing --no-git-ignore)

   • <all files not listed by `git ls-files` were skipped>

  Skipped by .semgrepignore:
  (See: https://semgrep.dev/docs/ignoring-files-folders-code/#understanding-semgrep-
  defaults)

   • src/osemgrep/targeting/Realpath.ml

  Skipped by --include patterns:

   • <none>

  Skipped by --exclude patterns:

   • <none>

  Skipped by limiting to files smaller than 1000000 bytes:
  (Adjust with the --max-target-bytes flag)

   • <none>

  Skipped by analysis failure due to parsing or internal Semgrep error

   • src/osemgrep/core/Exit_code.mli (13 lines skipped)

┌──────────────┐
│ Scan Summary │
└──────────────┘
Some files were skipped or only partially analyzed.
  Scan was limited to files tracked by git.
  Partially scanned: 1 files only partially analyzed due to a parsing or internal Semgrep error
  Scan skipped: 1 files matching .semgrepignore patterns
  For a full list of skipped files, run semgrep with the --verbose flag.

Ran 429 rules on 161 files: 48 findings.
Sending pseudonymous metrics since metrics are configured to AUTO and registry usage is True
```

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
