### PR TITLE
fix: Avoid crashing when outputting a string containing [/#]

### DIFF
--- a/changelog.d/rich-markup-crash.fixed
+++ b/changelog.d/rich-markup-crash.fixed
@@ -1,0 +1,1 @@
+Fix an issue that could lead to a crash when printing findings that contain snippets that look like markup to the Rich Python library

--- a/cli/src/semgrep/commands/ci.py
+++ b/cli/src/semgrep/commands/ci.py
@@ -274,7 +274,7 @@ def ci(
     )
 
     console.print(Title("Scan Environment", order=2))
-    console.print(debugging_table)
+    console.print(debugging_table, markup=True)
 
     fix_head_if_github_action(metadata)
 
@@ -339,9 +339,13 @@ def ci(
         console.print(Padding(Title("Engine", order=2), (1, 0, 0, 0)))
         if engine_type.check_if_installed():
             console.print(
-                f"Using Semgrep Pro Version: [bold]{engine_type.get_pro_version()}[/bold]"
+                f"Using Semgrep Pro Version: [bold]{engine_type.get_pro_version()}[/bold]",
+                markup=True,
             )
-            console.print(f"Installed at [bold]{engine_type.get_binary_path()}[/bold]")
+            console.print(
+                f"Installed at [bold]{engine_type.get_binary_path()}[/bold]",
+                markup=True,
+            )
         else:
             run_install_semgrep_pro()
 

--- a/cli/src/semgrep/console.py
+++ b/cli/src/semgrep/console.py
@@ -45,7 +45,7 @@ class AutoIndentingConsole(Console):
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         self.active_title: Optional[Title] = None
-        super().__init__(*args, **kwargs)
+        super().__init__(*args, markup=False, **kwargs)
 
     @property
     def auto_indent_size(self) -> int:
@@ -103,7 +103,7 @@ console.width = min(console.width, MAX_WIDTH)
 
 if __name__ == "__main__":
     """Print samples of the above components."""
-    console.print("[bold]Semgrep output formatting samples:[/bold]")
+    console.print("[bold]Semgrep output formatting samples:[/bold]", markup=True)
     console.print(Title("Level 1"))
     console.print("auto-indented text")
     console.print(Title("Level 2", order=2))
@@ -112,3 +112,4 @@ if __name__ == "__main__":
     console.print("auto-indented text")
     console.reset_title()
     console.print("auto-indented text after title reset")
+    console.print("bit of markup: [/#]")


### PR DESCRIPTION
The `rich` library uses in-band signaling, and crashes when it detects what it interprets as a closing tag without a matching open tag. If Semgrep tries to print a finding that contains such a snippet, it crashes.

We can avoid this by disabling markup in the `rich` library. We can still do formatting, we just need to use its out-of-band signaling options.

See https://github.com/Textualize/rich/issues/2636

Test plan:

From `cli/src/semgrep`, run `python console.py`. The little test there does not crash. Without the `markup` argument, the newly-added line does crash.

Also ran `semgrep scan --pro --config p/default .` from the Juice Shop repo, while logged in. Before, this crashed. Now, it does not. The output looks reasonable -- it doesn't appear that we were relying on the `rich` library's markup, or at least not in any major way with the `scan` command.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
