### PR TITLE
chore: disallow major releases

### DIFF
--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -17,7 +17,8 @@ on:
         type: "choice"
         # These options are passed directly into christian-draeger/increment-semantic-version in the `next-vesion` step to decide which of X.Y.Z to increment
         options:
-          - "major"
+          # Many folks are concerned about a mis-click and releasing 2.0 - remove the option.
+          # - "major"
           - "feature"
           - "bug"
       dry-run:


### PR DESCRIPTION
I've gotten several pieces of feedback that folks are concerned about a mis-click and releasing v2.0 - remove that possibility.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
