### PR TITLE
tainting: Fix bug in field sensitivity

### DIFF
--- a/changelog.d/pa-2486.fixed
+++ b/changelog.d/pa-2486.fixed
@@ -1,0 +1,3 @@
+taint-mode: Given `x = tainted`, then `x.a = safe`, then `x.a.b = tainted`, Semgrep
+did not report `sink(x.a.b)`. Because `x.a` was clean, that made Semgrep disregard
+the tainting of any field of `x.a` such as `x.a.b`. This now works as expected.

--- a/src/tainting/Dataflow_tainting.ml
+++ b/src/tainting/Dataflow_tainting.ml
@@ -230,9 +230,9 @@ let propagate_through_indexes env =
 (*****************************************************************************)
 
 let status_to_taints = function
-  | `None
-  | `Clean
-  | `Sanitized ->
+  | `None (* no info *)
+  | `Clean (* clean, from previous sanitization *)
+  | `Sanitized (* clean, because a sanitizer matched "right now" *) ->
       Taints.empty
   | `Tainted taints -> taints
 
@@ -791,9 +791,9 @@ and check_tainted_lval_aux env (lval : IL.lval) :
        *  If lval is sanitized, then we will "bubble up" the `Sanitized status, so
        *  any taint recorded in lval_env for any extension of lval will be discarded.
        *
-       *  So, if we are checking `x.a.b.c` and `x.a` is clean (could be due to
-       *  sanitization) then any extension of `x.a` is considered clean as well,
-       *  and we do look for taint info in the environment.
+       *  So, if we are checking `x.a.b.c` and `x.a` is sanitized then any extension
+       *  of `x.a` is considered sanitized as well, and we do look for taint info in
+       *  the environment.
        *
        *  *IF* sanitization is side-effectful then any taint info will be removed
        *  from lval_env by sanitize_lval, but that is not guaranteed.

--- a/tests/rules/field_sensitive8.py
+++ b/tests/rules/field_sensitive8.py
@@ -1,0 +1,10 @@
+def test():
+  x = source()
+  x.a = sanitize()
+  x.a.i = source()
+  #ruleid: test
+  sink(x.a.i)
+  #ok: test
+  sink(x.a)
+  #ruleid: test
+  sink(x)

--- a/tests/rules/field_sensitive8.yaml
+++ b/tests/rules/field_sensitive8.yaml
@@ -1,0 +1,13 @@
+rules:
+  - id: test
+    languages:
+      - python
+    severity: ERROR
+    message: Test
+    mode: taint
+    pattern-sources:
+      - pattern: source(...)
+    pattern-sanitizers:
+      - pattern: sanitize(...)
+    pattern-sinks:
+      - pattern: sink(...)


### PR DESCRIPTION
Closes PA-2486

We have to distinguish between "clean in the environment" versus "matches a sanitizer". If an l-value such as `x.a.b` is tainted, but that same occurrence of `x.a` matches a sanitizer, we will not taint `x.a.b` (the sanitizer "blocks" the taint). However, if `x.a` is just clean in the environment from a previous sanitization, then `x.a.b` must get tainted.

test plan:
make test # test added

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
