### PR TITLE
fix: Ignore tokens from YAML aliases when computing range

### DIFF
--- a/changelog.d/yaml-alias.fixed
+++ b/changelog.d/yaml-alias.fixed
@@ -1,0 +1,1 @@
+Fixed the range reported by findings for YAML files that include an anchor, so that the match does not include the original location of the snippet bound to the anchor.

--- a/libs/ast_generic/Visitor_AST.ml
+++ b/libs/ast_generic/Visitor_AST.ml
@@ -69,7 +69,7 @@ class ['self] range_visitor =
       let tok_loc = PI.unsafe_token_location_of_info tok in
       incorporate_tokens ranges (tok_loc, tok_loc)
   in
-  object (_self : 'self)
+  object (self : 'self)
     inherit ['self] AST_generic.iter_no_id_info as super
     method! visit_tok ranges tok = incorporate_token ranges tok
 
@@ -96,6 +96,9 @@ class ['self] range_visitor =
           | None -> ()
           | Some r -> incorporate_tokens ranges r)
       | Some range -> incorporate_tokens ranges range
+
+    (* Ignore the tokens from the aliased expression *)
+    method! visit_Alias ranges id _e = self#visit_ident ranges id
   end
 
 let extract_ranges :


### PR DESCRIPTION
This way, the location of the match does not include the original location of the aliased section. See the difference in output for the `anchor.yaml` test below.

#4517 excluded these tokens from the visitor that gets the tokens from an AST node, but not from the visitor that computes ranges. The semgrep core tests use the tokens from the pattern match instead of the range associated with the pattern match, which is why, according to the tests, that has worked. Unfortunately, I believe the range as reported to end users has been wrong this whole time.

I will follow up with a change that updates the test runner.

Test plan:

From `tests/patterns/yaml`:

`semgrep scan -l yaml -e "$(cat anchor.sgrep)" anchor.yaml`

Before: https://gist.github.com/nmote/e6008ecb38e20749a6163916542b0160
After: https://gist.github.com/nmote/fd3d2800484213d2a75fe818172ae227

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
