### PR TITLE
Tests: mask taint traces in the benchmarks

### DIFF
--- a/perf/run-benchmarks
+++ b/perf/run-benchmarks
@@ -74,6 +74,8 @@ class SemgrepResult:
                 dict2["extra"]["metavars"] = "<masked in benchmarks>"
                 # the paths being different will change the fingerprint
                 dict2["extra"]["fingerprint"] = "<masked in benchmarks>"
+            if "dataflow_traces" in dict2["extra"]:
+                dict2["extra"]["dataflow_traces"] = "<masked in benchmarks>"
 
         if "check_id" in dict2:
             relative_path_start = dict2["check_id"].find(PERF_RULE_PATH)
@@ -483,7 +485,11 @@ def run_benchmarks(
             for variant in variants:
 
                 # Run variant
-                name = ".".join(["semgrep", "bench", corpus.name, variant.name])
+                name = ".".join(
+                    ["semgrep"]
+                    + corpus.semgrep_options
+                    + ["bench", corpus.name, variant.name]
+                )
                 metric_name = ".".join([name, "duration"])
                 print(f"------ {name} ------")
                 try:

--- a/perf/run-benchmarks
+++ b/perf/run-benchmarks
@@ -482,7 +482,9 @@ def run_benchmarks(
                 continue
 
             std_findings = {}
-            options = [re.sub(r"\W+", "", option) for option in corpus.semgrep_options]
+            options = sorted(
+                re.sub(r"\W+", "", option) for option in corpus.semgrep_options
+            )
             for variant in variants:
 
                 # Run variant

--- a/perf/run-benchmarks
+++ b/perf/run-benchmarks
@@ -74,8 +74,8 @@ class SemgrepResult:
                 dict2["extra"]["metavars"] = "<masked in benchmarks>"
                 # the paths being different will change the fingerprint
                 dict2["extra"]["fingerprint"] = "<masked in benchmarks>"
-            if "dataflow_traces" in dict2["extra"]:
-                dict2["extra"]["dataflow_traces"] = "<masked in benchmarks>"
+            if "dataflow_trace" in dict2["extra"]:
+                dict2["extra"]["dataflow_trace"] = "<masked in benchmarks>"
 
         if "check_id" in dict2:
             relative_path_start = dict2["check_id"].find(PERF_RULE_PATH)

--- a/perf/run-benchmarks
+++ b/perf/run-benchmarks
@@ -482,13 +482,12 @@ def run_benchmarks(
                 continue
 
             std_findings = {}
+            options = [re.sub(r"\W+", "", option) for option in corpus.semgrep_options]
             for variant in variants:
 
                 # Run variant
                 name = ".".join(
-                    ["semgrep"]
-                    + corpus.semgrep_options
-                    + ["bench", corpus.name, variant.name]
+                    ["semgrep"] + options + ["bench", corpus.name, variant.name]
                 )
                 metric_name = ".".join([name, "duration"])
                 print(f"------ {name} ------")


### PR DESCRIPTION
The taint traces can change pretty easily when we add intermediate variables, so let's mask them.

Also in this PR: add the options passed to semgrep in the benchmarks name so that they are reported when uploaded.

Test plan: see the outputted findings and check dashboard.semgrep.dev

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
