### PR TITLE
feat(scala): parse rhs indented block expr

### DIFF
--- a/tests/parsing/scala/indented_block_expr_rhs.scala
+++ b/tests/parsing/scala/indented_block_expr_rhs.scala
@@ -1,0 +1,5 @@
+
+object foo:
+  private def foo(x: Int) =
+    val x = 2 
+    return 5


### PR DESCRIPTION
## What:
This PR allows us to parse indented `blockExpr`s that occur as the RHS to def statements.

## Why:
Parse rate.

In reality, _any_ `blockExpr` anywhere could be indented, but this causes a bunch of weirdness with cases like
```
def foo() =
  3
```
Are we supposed to read that as `3`, or an indented block expression which contains `3`, in other words:
```
def foo() = {
  3
}
```

I don't think it's very clear. So to be safe, to not mess up a bunch of parse trees every time we have an indented expression, I'm only allowing it in this case where we have it on the RHS of a `def`, and we can see if more cases fail later.

## How:
I made a parameter, `is_block_expr`, which is set by parsing the RHS to a `def` and noticing that it is both indented, and not the start to an expression.

We want this to make the `expr` call immediately descend down the recursive call chain to the `simpleExpr` `blockExpr` case, but unfortunately since there's a bunch of intermediary calls, we can't do that. We'll solve it by keeping the `is_block_expr` optional param up until it reaches that brace, to kind of guide the call to the `blockExpr` case.

## Test plan:
`make test`

Parse rate goes from `0.9460688054925819` to `0.95648527803769`.


PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
