### PR TITLE
feat(scala): parse unparenthesized conditions in `if`, `while`

### DIFF
--- a/changelog.d/pa-2691.added
+++ b/changelog.d/pa-2691.added
@@ -1,0 +1,1 @@
+Scala: Added parsing of `enum` constructs.

--- a/languages/scala/ast/AST_scala.ml
+++ b/languages/scala/ast/AST_scala.ml
@@ -392,6 +392,7 @@ and modifier_kind =
   (* just for variables/fields/class params *)
   | Val (* immutable *)
   | Var (* mutable *)
+  | EnumClass (* for enum classes *)
 
 and annotation = tok (* @ *) * type_ (* usually just a TyName*) * arguments list
 and attribute = A of annotation | M of modifier
@@ -426,6 +427,7 @@ and type_parameters = type_parameter list bracket option
 (* definition or declaration (def or dcl) *)
 and definition =
   | DefEnt of entity * definition_kind
+  | EnumCaseDef of attribute list * enum_case_definition
   (* note that some VarDefs are really disgused FuncDef when
    * the vbody is a BECases
    *)
@@ -460,6 +462,22 @@ and definition_kind =
   | TypeDef of type_definition
   (* class/traits/objects *)
   | Template of template_definition
+
+(* ------------------------------------------------------------------------- *)
+(* Enums *)
+(* ------------------------------------------------------------------------- *)
+and enum_case_definition = EnumConstr of enum_constr | EnumIds of ident list
+
+and enum_constr = {
+  eid : ident;
+  etyparams : type_parameters;
+  eparams : bindings list;
+  eattrs : attribute list;
+  eextends : constr_app list;
+}
+
+(* annotations built into type *)
+and constr_app = type_ * arguments list
 
 (* ------------------------------------------------------------------------- *)
 (* Functions/Methods *)
@@ -535,7 +553,13 @@ and template_body = (self_type option * block) bracket
 and self_type = ident_or_this * type_ option * tok (* '=>' *)
 
 (* Case classes/objects are handled via attributes in the entity *)
-and template_kind = Class | Trait | Object | Singleton (* via new *)
+and template_kind =
+  | Class
+  | Trait
+  | Object
+  | Singleton
+  (* via new *)
+  | Enum
 
 (* ------------------------------------------------------------------------- *)
 (* Typedef *)

--- a/languages/scala/recursive_descent/Lexer_scala.mll
+++ b/languages/scala/recursive_descent/Lexer_scala.mll
@@ -381,7 +381,8 @@ rule token = parse
 
         | "class"      -> Kclass t
         | "trait"      -> Ktrait t
-        | "object"      -> Kobject t
+        | "object"     -> Kobject t
+        | "enum"       -> Kenum t
         | "new"      -> Knew t
         | "super" -> Ksuper t
         | "this" -> Kthis t

--- a/languages/scala/recursive_descent/Parser_scala_recursive_descent.ml
+++ b/languages/scala/recursive_descent/Parser_scala_recursive_descent.ml
@@ -2311,6 +2311,7 @@ and parseIf in_ : stmt =
     | _ ->
         let e = expr in_ in
         accept (ID_LOWER ("then", ab)) in_;
+        newLinesOpt in_;
         fb (PI.unsafe_fake_info "") e
   in
   let thenp = expr in_ in
@@ -2347,6 +2348,7 @@ and parseWhile in_ : stmt =
         cond
     | _ ->
         let e = expr in_ in
+        newLinesOpt in_;
         accept (Kdo ab) in_;
         fb (PI.unsafe_fake_info "") e
   in

--- a/languages/scala/recursive_descent/Token_helpers_scala.ml
+++ b/languages/scala/recursive_descent/Token_helpers_scala.ml
@@ -132,6 +132,7 @@ let visitor_info_of_tok f = function
   | Kpackage ii -> Kpackage (f ii)
   | Koverride ii -> Koverride (f ii)
   | Kobject ii -> Kobject (f ii)
+  | Kenum ii -> Kenum (f ii)
   | Knull ii -> Knull (f ii)
   | Knew ii -> Knew (f ii)
   | Kmatch ii -> Kmatch (f ii)
@@ -380,6 +381,7 @@ let isLocalModifier = function
 let isTemplateIntro = function
   | Kobject _
   | Kclass _
+  | Kenum _
   | Ktrait _ ->
       true
   (*TODO | Kcaseobject | | Kcaseclass *)
@@ -390,6 +392,7 @@ let isDclIntro = function
   | Kval _
   | Kvar _
   | Kdef _
+  | Kcase _
   | Ktype _ ->
       true
   | _ -> false

--- a/languages/scala/recursive_descent/Token_scala.ml
+++ b/languages/scala/recursive_descent/Token_scala.ml
@@ -66,6 +66,7 @@ type token =
   | Kclass of Parse_info.t
   | Kcatch of Parse_info.t
   | Kcase of Parse_info.t
+  | Kenum of Parse_info.t
   | Kabstract of Parse_info.t
   | IntegerLiteral of (int option * Parse_info.t)
   | ID_UPPER of (string * Parse_info.t)

--- a/tests/parsing/scala/enums.scala
+++ b/tests/parsing/scala/enums.scala
@@ -1,0 +1,23 @@
+
+enum Foo {
+}
+
+enum Foo: 
+  val x = 2
+
+enum Foo[+ T >: T1 <: T2] @foo private (x : Int) (y : String) {
+}
+
+enum Foo {
+  @foo private case A
+}
+
+enum Foo {
+  case A, B, C
+}
+
+enum Foo {
+  case A[+T] @foo private (x : Int) (y : Int) extends Foo (3, 4, 5), Bar (3, 4, 5)
+  case A[+T] @foo private (x : Int) (y : Int) extends Foo (3, 4, 5) with Bar (3, 4, 5)
+  case A, B, C
+}

--- a/tests/parsing/scala/if_expr.scala
+++ b/tests/parsing/scala/if_expr.scala
@@ -1,3 +1,9 @@
 
 
 val x = if true then 1 else 3
+
+val y = 
+  if true then 
+    4
+  else
+    5

--- a/tests/parsing/scala/if_expr.scala
+++ b/tests/parsing/scala/if_expr.scala
@@ -1,0 +1,3 @@
+
+
+val x = if true then 1 else 3

--- a/tests/parsing/scala/while_expr.scala
+++ b/tests/parsing/scala/while_expr.scala
@@ -1,0 +1,2 @@
+
+val x = while true do 5

--- a/tests/parsing/scala/while_expr.scala
+++ b/tests/parsing/scala/while_expr.scala
@@ -1,2 +1,8 @@
 
 val x = while true do 5
+
+val y = 
+  while
+    true
+  do
+    5


### PR DESCRIPTION
## What:
This PR lets us parse conditions without parens in `if` and `while`, which is a thing in Scala 3.

## Why:
Parse rate.

## How:
Added two cases.

I tried this a bit ago and ran into an issue, because in Scala, you can have unlimited postfix identifiers after an expression.

So when we saw something like `<expr> then`, it was interpreted as a postfix call from the identifier `then` to `expr`. We can't change this by having `then` lexed as a keyword, because `then` is only a _soft_ keyword.

I just made it such that this postfix logic activates specifically only if it's not `then`. I anticipate this should be fairly
unlikely, anyways.

## Test plan:
`make test`
Parse rate goes to `0.9589261173709144` from `0.9570153111528416`

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
