### PR TITLE
test: Update core test engine to use match range

### DIFF
--- a/src/engine/Unit_engine.ml
+++ b/src/engine/Unit_engine.ml
@@ -347,15 +347,9 @@ let regression_tests_for_lang ~polyglot_pattern_path ~with_caching files lang =
                (fun () ->
                  let matches =
                    match_pattern ~lang
-                     ~hook:(fun { Pattern_match.tokens = (lazy xs); _ } ->
-                       (* there are a few fake tokens in the generic ASTs now (e.g.,
-                        * for DotAccess generated outside the grammar) *)
-                       let toks = xs |> List.filter Parse_info.is_origintok in
-                       let minii, _maxii = Parse_info.min_max_ii_by_pos toks in
-                       let minii_loc =
-                         Parse_info.unsafe_token_location_of_info minii
-                       in
-                       E.error "test pattern" minii_loc "" Out.SemgrepMatchFound)
+                     ~hook:(fun { Pattern_match.range_loc; _ } ->
+                       let start_loc, _end_loc = range_loc in
+                       E.error "test pattern" start_loc "" Out.SemgrepMatchFound)
                      ~file ~pattern ~fix_pattern
                  in
                  (match fix_pattern with

--- a/tests/patterns/python/cp_label.py
+++ b/tests/patterns/python/cp_label.py
@@ -1,15 +1,21 @@
+# This is not actually valid Python. Python does not allow comments after line
+# continuations. But, we don't have any other reasonable way to verify that the
+# string itself matches, but not the variable to which it is assigned.
+#
+# Luckily, our current parser accepts this even though the actual Python parser
+# does not. But, if that ever changes in the future it's probably fine to delete
+# this test and rely on the cp_label.js test which tests the same behavior.
+
 #OK:
-a =(
+a =\
     #ERROR:
     "foo"
-)
 
 #OK:
 a[b] = 1
 
 def f():
     #OK:
-    c =(
+    c =\
         #ERROR:
         "foo"
-    )


### PR DESCRIPTION
This is consistent with what is reported via JSON and therefore what the CLI and all end users see.

Previously, the test runner used the tokens associated with the match rather than the range associated with the match, which led to different results in two test cases. The first is the one addressed by #7472, and was due to an inconsistency between the visitor used for computing ranges and the visitor used for extracting tokens from AST. The second is the one caused by #7437 and updated here. That difference is caused by the fact that we now update `e_range` to include the range of the parentheses, even though the tokens associated with the parentheses do not appear in the AST.

The `cp_label.py` test was added in #3042. I had to do some shenanigans to make it continue to test what it was originally intended to test. This is explained inline.

Test plan:

Automated tests

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
