### PR TITLE
fix: semgrep release cannot use org fork for brew PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -286,52 +286,17 @@ jobs:
         # This step does some brew oddities (setting a fake version, and setting a revision) to allow the brew PR prep to succeed
         # The `brew bump-formula-pr` does checks to ensure your PR is legit, but we want to do a phony PR (or at least prep it) for Dry Run only
         env:
-          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.HOMEBREW_PR_TOKEN }}
+          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.SEMGREP_HOMEBREW_RELEASE_PAT }}
         if: ${{ contains(github.ref, '-test-release') || needs.dry-run.outputs.dry-run == 'true' }}
         run: |
           brew bump-formula-pr --force --no-audit --no-browse --write-only \
             --message="Bump semgrep to version v99.99.99" \
-            --fork-org=returntocorp --tag="v99.99.99" --revision="${GITHUB_SHA}" semgrep --python-exclude-packages semgrep
-      - name: Prepare Brew PR
+            --tag="v99.99.99" --revision="${GITHUB_SHA}" semgrep --python-exclude-packages semgrep
+      - name: Open Brew PR
         if: ${{ !contains(github.ref, '-test-release') && needs.dry-run.outputs.dry-run != 'true' }}
         env:
-          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.HOMEBREW_PR_TOKEN }}
+          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.SEMGREP_HOMEBREW_RELEASE_PAT }}
         run: |
-          brew bump-formula-pr --force --no-audit --no-browse --write-only \
+          brew bump-formula-pr --force --no-audit --no-browse \
             --message="Bump semgrep to version ${{ steps.get-version.outputs.VERSION }}" \
-            --fork-org=returntocorp --tag="${{ steps.get-version.outputs.VERSION }}" semgrep
-      - name: Prepare Branch
-        env:
-          GITHUB_TOKEN: ${{ secrets.HOMEBREW_PR_TOKEN }}
-          R2C_HOMEBREW_CORE_FORK_HTTPS_URL: https://github.com/returntocorp/homebrew-core.git
-        run: |
-          cd "$(brew --repository)/Library/Taps/homebrew/homebrew-core"
-          git status
-          git diff
-
-          git config user.name ${{ github.actor }}
-          git config user.email ${{ github.actor }}@users.noreply.github.com
-
-          gh auth setup-git
-          git remote add r2c "${R2C_HOMEBREW_CORE_FORK_HTTPS_URL}"
-
-          git checkout -b bump-semgrep-${{ steps.get-version.outputs.VERSION }}
-          git add Formula/semgrep.rb
-          git commit -m "Bump semgrep to version ${{ steps.get-version.outputs.VERSION }}"
-      - name: Push Branch to Fork
-        env:
-          GITHUB_TOKEN: ${{ secrets.HOMEBREW_PR_TOKEN }}
-        if: ${{ !contains(github.ref, '-test-release') && needs.dry-run.outputs.dry-run != 'true' }}
-        run: |
-          cd "$(brew --repository)/Library/Taps/homebrew/homebrew-core"
-          git push --set-upstream r2c --force "bump-semgrep-${{ steps.get-version.outputs.VERSION }}"
-      - name: Push to Fork
-        env:
-          GITHUB_TOKEN: ${{ secrets.HOMEBREW_PR_TOKEN }}
-          R2C_HOMEBREW_CORE_OWNER: returntocorp
-        if: ${{ !contains(github.ref, '-test-release') && needs.dry-run.outputs.dry-run != 'true' }}
-        run: |
-          gh pr create --repo homebrew/homebrew-core \
-            --base master --head "${R2C_HOMEBREW_CORE_OWNER}:bump-semgrep-${{ steps.get-version.outputs.VERSION }}" \
-            --title="semgrep ${{ steps.get-version.outputs.VERSION }}" \
-            --body "Bump semgrep to version ${{ steps.get-version.outputs.VERSION }}"
+            --tag="${{ steps.get-version.outputs.VERSION }}" semgrep

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -289,7 +289,7 @@ jobs:
           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.SEMGREP_HOMEBREW_RELEASE_PAT }}
         if: ${{ contains(github.ref, '-test-release') || needs.dry-run.outputs.dry-run == 'true' }}
         run: |
-          brew bump-formula-pr --force --no-audit --no-browse --dry-run \
+          brew bump-formula-pr --force --no-audit --no-browse --write-only \
             --message="Bump semgrep to version v99.99.99" \
             --tag="v99.99.99" --revision="${GITHUB_SHA}" semgrep --python-exclude-packages semgrep
       - name: Open Brew PR

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -297,6 +297,38 @@ jobs:
         env:
           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.SEMGREP_HOMEBREW_RELEASE_PAT }}
         run: |
-          brew bump-formula-pr --force --no-audit --no-browse \
+          brew bump-formula-pr --force --no-audit --no-browse --write-only \
             --message="Bump semgrep to version ${{ steps.get-version.outputs.VERSION }}" \
             --tag="${{ steps.get-version.outputs.VERSION }}" semgrep
+      - name: Prepare Branch
+        env:
+          GITHUB_TOKEN: ${{ secrets.SEMGREP_HOMEBREW_RELEASE_PAT }}
+          R2C_HOMEBREW_CORE_FORK_HTTPS_URL: https://github.com/semgrep-release/homebrew-core.git
+        run: |
+          cd "$(brew --repository)/Library/Taps/homebrew/homebrew-core"
+          git status
+          git diff
+          git config user.name ${{ github.actor }}
+          git config user.email ${{ github.actor }}@users.noreply.github.com
+          gh auth setup-git
+          git remote add r2c "${R2C_HOMEBREW_CORE_FORK_HTTPS_URL}"
+          git checkout -b bump-semgrep-${{ steps.get-version.outputs.VERSION }}
+          git add Formula/semgrep.rb
+          git commit -m "Bump semgrep to version ${{ steps.get-version.outputs.VERSION }}"
+      - name: Push Branch to Fork
+        env:
+          GITHUB_TOKEN: ${{ secrets.SEMGREP_HOMEBREW_RELEASE_PAT }}
+        if: ${{ !contains(github.ref, '-test-release') && needs.dry-run.outputs.dry-run != 'true' }}
+        run: |
+          cd "$(brew --repository)/Library/Taps/homebrew/homebrew-core"
+          git push --set-upstream r2c --force "bump-semgrep-${{ steps.get-version.outputs.VERSION }}"
+      - name: Push to Fork
+        env:
+          GITHUB_TOKEN: ${{ secrets.SEMGREP_HOMEBREW_RELEASE_PAT }}
+          R2C_HOMEBREW_CORE_OWNER: returntocorp
+        if: ${{ !contains(github.ref, '-test-release') && needs.dry-run.outputs.dry-run != 'true' }}
+        run: |
+          gh pr create --repo homebrew/homebrew-core \
+            --base master --head "${R2C_HOMEBREW_CORE_OWNER}:bump-semgrep-${{ steps.get-version.outputs.VERSION }}" \
+            --title="semgrep ${{ steps.get-version.outputs.VERSION }}" \
+            --body "Bump semgrep to version ${{ steps.get-version.outputs.VERSION }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -289,7 +289,7 @@ jobs:
           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.SEMGREP_HOMEBREW_RELEASE_PAT }}
         if: ${{ contains(github.ref, '-test-release') || needs.dry-run.outputs.dry-run == 'true' }}
         run: |
-          brew bump-formula-pr --force --no-audit --no-browse --write-only \
+          brew bump-formula-pr --force --no-audit --no-browse --dry-run \
             --message="Bump semgrep to version v99.99.99" \
             --tag="v99.99.99" --revision="${GITHUB_SHA}" semgrep --python-exclude-packages semgrep
       - name: Open Brew PR


### PR DESCRIPTION
Homebrew recently updated their merge processes to push commits back to the branch from which the PR was opened - this doesn't work with organization forks.

This PR does the following:
- Uses a new GitHub account to open PRs to homebrew 
  - This account is not linked to an individual and is not an organization - therefore the brew maintainers will be able to push commits to our PRs and the flow will begin working again

In the future, we'll likely want to remove our custom machinery around opening PRs, but I've downscoped this to avoid any possible complications.

See an in-progress dry-run here: https://github.com/returntocorp/semgrep/actions/runs/4659620491

Note that a dry-run is not completely indicative of a success on the real thing - previously we had issues with GitHub and opening the PR, which the dry run does not test. However, I've validated this command locally using a token with the same scope. If any issues occur, I'll be available this week to manually complete the release and address the issues.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
