### PR TITLE
feat(scala): `enum`s parsing

### DIFF
--- a/changelog.d/pa-2691.added
+++ b/changelog.d/pa-2691.added
@@ -1,0 +1,1 @@
+Scala: Added parsing of `enum` constructs.

--- a/languages/scala/ast/AST_scala.ml
+++ b/languages/scala/ast/AST_scala.ml
@@ -553,7 +553,13 @@ and template_body = (self_type option * block) bracket
 and self_type = ident_or_this * type_ option * tok (* '=>' *)
 
 (* Case classes/objects are handled via attributes in the entity *)
-and template_kind = Class | Trait | Object | Singleton | Enum (* via new *)
+and template_kind =
+  | Class
+  | Trait
+  | Object
+  | Singleton
+  (* via new *)
+  | Enum
 
 (* ------------------------------------------------------------------------- *)
 (* Typedef *)

--- a/languages/scala/ast/AST_scala.ml
+++ b/languages/scala/ast/AST_scala.ml
@@ -392,6 +392,7 @@ and modifier_kind =
   (* just for variables/fields/class params *)
   | Val (* immutable *)
   | Var (* mutable *)
+  | EnumClass (* for enum classes *)
 
 and annotation = tok (* @ *) * type_ (* usually just a TyName*) * arguments list
 and attribute = A of annotation | M of modifier
@@ -426,6 +427,7 @@ and type_parameters = type_parameter list bracket option
 (* definition or declaration (def or dcl) *)
 and definition =
   | DefEnt of entity * definition_kind
+  | EnumCaseDef of attribute list * enum_case_definition
   (* note that some VarDefs are really disgused FuncDef when
    * the vbody is a BECases
    *)
@@ -460,6 +462,21 @@ and definition_kind =
   | TypeDef of type_definition
   (* class/traits/objects *)
   | Template of template_definition
+
+(* ------------------------------------------------------------------------- *)
+(* Enums *)
+(* ------------------------------------------------------------------------- *)
+and enum_case_definition = EnumConstr of enum_constr | EnumIds of ident list
+
+and enum_constr = {
+  eid : ident;
+  etyparams : type_parameters;
+  eparams : bindings list;
+  eattrs : attribute list;
+  eextends : constr_app list;
+}
+
+and constr_app = type_ * annotation list * arguments
 
 (* ------------------------------------------------------------------------- *)
 (* Functions/Methods *)
@@ -535,7 +552,7 @@ and template_body = (self_type option * block) bracket
 and self_type = ident_or_this * type_ option * tok (* '=>' *)
 
 (* Case classes/objects are handled via attributes in the entity *)
-and template_kind = Class | Trait | Object | Singleton (* via new *)
+and template_kind = Class | Trait | Object | Singleton | Enum (* via new *)
 
 (* ------------------------------------------------------------------------- *)
 (* Typedef *)

--- a/languages/scala/ast/AST_scala.ml
+++ b/languages/scala/ast/AST_scala.ml
@@ -477,7 +477,7 @@ and enum_constr = {
 }
 
 (* annotations built into type *)
-and constr_app = type_ * arguments
+and constr_app = type_ * arguments list
 
 (* ------------------------------------------------------------------------- *)
 (* Functions/Methods *)

--- a/languages/scala/ast/AST_scala.ml
+++ b/languages/scala/ast/AST_scala.ml
@@ -476,7 +476,8 @@ and enum_constr = {
   eextends : constr_app list;
 }
 
-and constr_app = type_ * annotation list * arguments
+(* annotations built into type *)
+and constr_app = type_ * arguments
 
 (* ------------------------------------------------------------------------- *)
 (* Functions/Methods *)

--- a/languages/scala/generic/scala_to_generic.ml
+++ b/languages/scala/generic/scala_to_generic.ml
@@ -856,13 +856,23 @@ and v_enum_case_definition attrs v1 =
          case Foo(x : int, y : string)
          essentially an algebraic datatype
       *)
-      let _params = eparams in
+      let params = v_list v_bindings eparams |> List.concat in
       let attrs = v_list v_attribute eattrs @ attrs in
       (* TODO *)
       let _extends = v_list v_constr_app eextends in
+      let fake = PI.unsafe_fake_info "Param" in
+      let args =
+        match
+          Common.map
+            (fun param -> G.OtherArg (("Param", fake), [ G.Pa param ]))
+            params
+        with
+        | [] -> None
+        | args -> Some (fb args)
+      in
       [
         ( G.basic_entity ~attrs ~tparams id,
-          G.EnumEntryDef { ee_args = None; ee_body = None } );
+          G.EnumEntryDef { ee_args = args; ee_body = None } );
       ]
 
 and v_constr_app _v1 = ()

--- a/languages/scala/generic/scala_to_generic.ml
+++ b/languages/scala/generic/scala_to_generic.ml
@@ -852,15 +852,16 @@ and v_enum_case_definition attrs v1 =
   | EnumConstr { eid; etyparams; eparams; eattrs; eextends } ->
       let id = v_ident eid in
       let tparams = v_type_parameters etyparams in
-      (* TODO: This is something which looks like
-         case Foo(x : int, y : string)
-         essentially an algebraic datatype
-      *)
       let params = v_list v_bindings eparams |> List.concat in
       let attrs = v_list v_attribute eattrs @ attrs in
       (* TODO *)
       let _extends = v_list v_constr_app eextends in
       let fake = PI.unsafe_fake_info "Param" in
+      (* Here, we turn the params into arguments.
+         They are represented syntactically as parameters, but they'll fit
+         fine here too. This is with the understanding that this probably
+         won't matter semantically.
+      *)
       let args =
         match
           Common.map

--- a/languages/scala/recursive_descent/Lexer_scala.mll
+++ b/languages/scala/recursive_descent/Lexer_scala.mll
@@ -381,7 +381,8 @@ rule token = parse
 
         | "class"      -> Kclass t
         | "trait"      -> Ktrait t
-        | "object"      -> Kobject t
+        | "object"     -> Kobject t
+        | "enum"       -> Kenum t
         | "new"      -> Knew t
         | "super" -> Ksuper t
         | "this" -> Kthis t

--- a/languages/scala/recursive_descent/Parser_scala_recursive_descent.ml
+++ b/languages/scala/recursive_descent/Parser_scala_recursive_descent.ml
@@ -3928,10 +3928,10 @@ let classDef ?(isTrait = false) ?(isCase = None) attrs in_ : definition =
 
 let constrApp in_ =
   (* TODO: simpleType1? *)
-  let ty = simpleType in_ in
-  let annots = annotations ~skipNewLines:true in_ in
+  (* annotations are built into type *)
+  let ty = annotType in_ in
   let args = parArgumentExprs in_ in
-  (ty, annots, args)
+  (ty, args)
 
 let constrApps in_ =
   report in_ "constr app";

--- a/languages/scala/recursive_descent/Parsing_hacks_scala.ml
+++ b/languages/scala/recursive_descent/Parsing_hacks_scala.ml
@@ -66,6 +66,7 @@ let can_start_indentation_tok tok =
   | ARROW _
   | LARROW _
   | Kif _
+  | ID_LOWER ("then", _)
   (* there is no "then" keyword, because it's only a keyword in Scala 3 *)
   (* for now, let's just say "then" doesn't trigger an indentation region *)
   | Kelse _

--- a/languages/scala/recursive_descent/Parsing_hacks_scala.ml
+++ b/languages/scala/recursive_descent/Parsing_hacks_scala.ml
@@ -66,7 +66,6 @@ let can_start_indentation_tok tok =
   | ARROW _
   | LARROW _
   | Kif _
-  | ID_LOWER ("then", _)
   (* there is no "then" keyword, because it's only a keyword in Scala 3 *)
   (* for now, let's just say "then" doesn't trigger an indentation region *)
   | Kelse _

--- a/languages/scala/recursive_descent/Token_helpers_scala.ml
+++ b/languages/scala/recursive_descent/Token_helpers_scala.ml
@@ -132,6 +132,7 @@ let visitor_info_of_tok f = function
   | Kpackage ii -> Kpackage (f ii)
   | Koverride ii -> Koverride (f ii)
   | Kobject ii -> Kobject (f ii)
+  | Kenum ii -> Kenum (f ii)
   | Knull ii -> Knull (f ii)
   | Knew ii -> Knew (f ii)
   | Kmatch ii -> Kmatch (f ii)
@@ -380,6 +381,7 @@ let isLocalModifier = function
 let isTemplateIntro = function
   | Kobject _
   | Kclass _
+  | Kenum _
   | Ktrait _ ->
       true
   (*TODO | Kcaseobject | | Kcaseclass *)
@@ -390,6 +392,7 @@ let isDclIntro = function
   | Kval _
   | Kvar _
   | Kdef _
+  | Kcase _
   | Ktype _ ->
       true
   | _ -> false

--- a/languages/scala/recursive_descent/Token_scala.ml
+++ b/languages/scala/recursive_descent/Token_scala.ml
@@ -66,6 +66,7 @@ type token =
   | Kclass of Parse_info.t
   | Kcatch of Parse_info.t
   | Kcase of Parse_info.t
+  | Kenum of Parse_info.t
   | Kabstract of Parse_info.t
   | IntegerLiteral of (int option * Parse_info.t)
   | ID_UPPER of (string * Parse_info.t)

--- a/tests/parsing/scala/enums.scala
+++ b/tests/parsing/scala/enums.scala
@@ -1,0 +1,23 @@
+
+enum Foo {
+}
+
+enum Foo: 
+  val x = 2
+
+enum Foo[+ T >: T1 <: T2] @foo private (x : Int) (y : String) {
+}
+
+enum Foo {
+  @foo private case A
+}
+
+enum Foo {
+  case A, B, C
+}
+
+enum Foo {
+  case A[+T] @foo private (x : Int) (y : Int) extends Foo (3, 4, 5), Bar (3, 4, 5)
+  case A[+T] @foo private (x : Int) (y : Int) extends Foo (3, 4, 5) with Bar (3, 4, 5)
+  case A, B, C
+}


### PR DESCRIPTION
## What:
This PR makes it so we can parse the Scala `enum` construct, from Scala 3.

## Why:
I noticed this was unparseable.

## How:
We inject it into much the same construct as Java and Swift, which is a class marked as an `EnumClass`, where the
enums themselves are individual `EnumEntryDef` definitions.

This is made tricky somewhat by the fact that Scala allows the mixing and matching of `enum` variants that are both
simple instantiated class instances, like:
```
enum Color(val rgb: Int):
  case Red   extends Color(0xFF0000)
  case Green extends Color(0x00FF00)
  case Blue  extends Color(0x0000FF)
```

but also algebraic datatypes, such as
```
enum Option[+T]:
  case Some(x: T)
  case None
```

Now, this would not be a problem, normally. Swift does this too. But Swift only permits it to be one of these at a time. Scala actually allows mixing and matching of either.

So while in the Swift case, I would determine which case we were in, and thus then either inject it into a `ClassDef`, or a `TypeDef`, we actually will have to be able to replicate behavior of both. This is tricky because the `EnumEntryDef` construct currently does not support parameters, which the arguments to the enum variants actually are. As such, we'd need to be able to do one of two things:
1) either embed `parameter` into `argument` somehow
2) allow `EnumEntryDef` to support parameters

I chose the first option, by abusing `OtherArg` to get it into the syntax tree at all. I think this won't end up really mattering, anyways, because we're unlikely to need this semantic information later on.

For the `extends`, I chose to ignore this in the translation, because I don't think we have the appropriate constructs yet. It's confusing, because you are not guaranteed to have to extend an instance of the same class. Technically this desugars to a kind of binding.

## Test plan:
Parse rate goes down slightly, from `0.9590214626573684` to `0.9580818781981301`. I tested it out and this seems to be due to the fact that making "enum" a token messes up some Scala 2 programs where this wasn't a keyword.

It seems that programs which use `enum` also heavily use other Scala 3 features I haven't gotten around to parsing yet, so we wouldn't expect to see a parsing rate increase here. More to come.

Closes PA-2691

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
