### PR TITLE
Mitigate the damage caused by semgrep errors in pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -189,6 +189,10 @@ repos:
         #
         #      docker pull returntocorp/semgrep:develop
         #
+        # 3. Re-run job with
+        #
+        #      pre-commit run --all --verbose semgrep-jsonnet
+        #
         # Only run this job in CI since it is slow
         language: docker_image
         # See .pre-commit-hooks.yaml for why we need to set those

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -181,6 +181,14 @@ repos:
     hooks:
       - id: semgrep-jsonnet
         name: semgrep jsonnet
+        #
+        # Troubleshooting:
+        # 1. Make sure '--quiet' option is not passed to semgrep so
+        #    that we can see error messages.
+        # 2. Obtain the latest version of semgrep with:
+        #
+        #      docker pull returntocorp/semgrep:develop
+        #
         # Only run this job in CI since it is slow
         language: docker_image
         # See .pre-commit-hooks.yaml for why we need to set those
@@ -205,6 +213,7 @@ repos:
             "--config",
             "semgrep.jsonnet",
             "--error",
+            #
             # note that pre-commit can call multiple times semgrep in
             # one run if there are many files in a PR (or in CI where
             # it runs on all the files in a repo).  In that case I
@@ -213,7 +222,11 @@ repos:
             # important to use --quiet otherwise you can have the same
             # banner repeated many times in the output in case of
             # errors.
-            "--quiet",
+            #
+            # It's a much bigger problem to not see the error
+            # messages, so let's try without --quiet:
+            # "--quiet",
+            #
             # this is useful in a pre-commit context because
             # pre-commit calls the hooks with all the files in the PR
             # (or in CI with all the files in the repo) but we don't


### PR DESCRIPTION
It takes a while to figure out what's wrong when the semgrep-jsonnet pre-commit hook fails. To improve this,

* I commented out `--quiet`. The same error message is repeated 7 times, but I think it's better than not seeing an error message at all.
* I added a note about upgrading the docker image. Alternatively, we could use a specific image ID instead of the moving tag `:develop`.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
