### PR TITLE
osemgrep: pass "output" (Core_runner.result -> unit) to invoke_semgrep_core

### DIFF
--- a/src/osemgrep/cli_scan/Core_runner.ml
+++ b/src/osemgrep/cli_scan/Core_runner.ml
@@ -402,7 +402,7 @@ let pp_skipped ppf
    Take in rules and targets and return object with findings.
 *)
 let invoke_semgrep_core ?(respect_git_ignore = true) ?(ignored_targets = [])
-    (conf : conf) (all_rules : Rule.t list)
+    (output : result -> unit) (conf : conf) (all_rules : Rule.t list)
     (rule_errors : Rule.invalid_rule_error list) (all_targets : Fpath.t list) :
     result =
   let config : Runner_config.t = runner_config_of_conf conf in
@@ -484,6 +484,16 @@ let invoke_semgrep_core ?(respect_git_ignore = true) ?(ignored_targets = [])
         { match_results with skipped_targets }
       in
 
+      let res =
+        {
+          core = match_results;
+          hrules = Rule.hrules_of_rules all_rules;
+          scanned;
+        }
+      in
+
+      output res;
+
       Logs.info (fun m ->
           m "%a" pp_skipped
             ( respect_git_ignore,
@@ -522,4 +532,4 @@ let invoke_semgrep_core ?(respect_git_ignore = true) ?(ignored_targets = [])
           | Some e -> Runner_exit.exit_semgrep (Unknown_exception e)
           | None -> ())
       *)
-      { core = match_results; hrules = Rule.hrules_of_rules all_rules; scanned }
+      res

--- a/src/osemgrep/cli_scan/Core_runner.mli
+++ b/src/osemgrep/cli_scan/Core_runner.mli
@@ -25,6 +25,7 @@ type result = {
 val invoke_semgrep_core :
   ?respect_git_ignore:bool ->
   ?ignored_targets:Semgrep_output_v1_t.skipped_target list ->
+  (result -> unit) ->
   conf ->
   (* LATER? use Config_resolve.rules_and_origin instead? *)
   Rule.rules ->

--- a/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -199,10 +199,14 @@ let run (conf : Scan_CLI.conf) : Exit_code.t =
           targets
           |> List.iter (fun file -> m "target = %s" (Fpath.to_string file));
           m "]%s" "");
+      let output res =
+        (* outputting the result! in JSON/Text/... depending on conf *)
+        Output.output_result conf res
+      in
       let (res : Core_runner.result) =
         Core_runner.invoke_semgrep_core
           ~respect_git_ignore:conf.targeting_conf.respect_git_ignore
-          ~ignored_targets:semgrepignored_targets conf.core_runner_conf
+          ~ignored_targets:semgrepignored_targets output conf.core_runner_conf
           filtered_rules errors targets
       in
       (* TOPORT? was in formater/base.py
@@ -214,8 +218,6 @@ let run (conf : Scan_CLI.conf) : Exit_code.t =
            """
            return False
       *)
-      (* outputting the result! in JSON/Text/... depending on conf *)
-      Output.output_result conf res;
       (* final result for the shell *)
       exit_code_of_errors ~strict:conf.strict res.core.errors
 

--- a/src/osemgrep/cli_scan/Validate_subcommand.ml
+++ b/src/osemgrep/cli_scan/Validate_subcommand.ml
@@ -98,8 +98,9 @@ let run (conf : conf) : Exit_code.t =
           Error.abort (spf "error in metachecks! please fix %s" metarules_pack);
 
         let res =
-          Core_runner.invoke_semgrep_core conf.core_runner_conf metarules []
-            targets
+          Core_runner.invoke_semgrep_core
+            (fun _ -> ())
+            conf.core_runner_conf metarules [] targets
         in
 
         (* TODO? sanity check errors below too? *)


### PR DESCRIPTION
Previously, the output (scan summary, skipped files) was before the actual findings. Now it is possible to output them at the end, as done in the python implementation.

Another option (to avoid passing a higher-order function) would be to expose a separate binding in Core_runner and call that from Scan_subcommand after the `output` was done. Any preferences?

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
