### PR TITLE
feat(scala): parse indented `for` exprs

### DIFF
--- a/changelog.d/pa-2694.added
+++ b/changelog.d/pa-2694.added
@@ -1,0 +1,1 @@
+Scala: Can now parse top-level definitions (as added in Scala 3)

--- a/changelog.d/pa-2695.added
+++ b/changelog.d/pa-2695.added
@@ -1,1 +1,6 @@
-Scala: Can now parse indented `for` expressions
+Scala: Can now parse indented `for` expression, such as
+
+for
+  _ <- 5
+yield
+  ...

--- a/changelog.d/pa-2695.added
+++ b/changelog.d/pa-2695.added
@@ -1,0 +1,1 @@
+Scala: Can now parse indented `for` expressions

--- a/languages/scala/ast/AST_scala.ml
+++ b/languages/scala/ast/AST_scala.ml
@@ -387,6 +387,7 @@ and modifier_kind =
   | Override
   | Inline
   | Open
+  | Opaque
   (* pad: not in original spec *)
   | CaseClassOrObject
   (* less: rewrite as Packaging and object def like in original code? *)

--- a/languages/scala/generic/scala_to_generic.ml
+++ b/languages/scala/generic/scala_to_generic.ml
@@ -789,6 +789,7 @@ and v_modifier_kind = function
   | Override -> Left G.Override
   | Inline -> Right "inline"
   | Open -> Right "open"
+  | Opaque -> Right "opaque"
   | CaseClassOrObject -> Left G.RecordClass
   | PackageObject -> Right "PackageObject"
   | Val -> Left G.Const

--- a/languages/scala/recursive_descent/Parser_scala_recursive_descent.ml
+++ b/languages/scala/recursive_descent/Parser_scala_recursive_descent.ml
@@ -3599,7 +3599,7 @@ let templateStats in_ : template_stat list = statSeq templateStat in_
 
 (** {{{
  *  TopStatSeq ::= TopStat {semi TopStat}
- *  TopStat ::= Annotations Modifiers Def
+ *  TopStat ::= Annotations Modifiers Def  (see below for discrepancy with Scala 2)
  *            | Packaging
  *            | package object ObjectDef
  *            | Import
@@ -3619,6 +3619,9 @@ let topStat in_ : top_stat option =
   | Kexport _ ->
       let x = exportClause in_ in
       Some (Ex x)
+  (* This used to be a TmplDef, but in Scala 3, this can actually be any Def.
+     Def is a superset of TmplDef anyways, so we lose nothing here.
+  *)
   | t when TH.isAnnotation t || TH.isDefIntro t || is_modifier in_ ->
       let x = nonLocalDefOrDcl in_ in
       Some (D x)

--- a/languages/scala/recursive_descent/Parser_scala_recursive_descent.ml
+++ b/languages/scala/recursive_descent/Parser_scala_recursive_descent.ml
@@ -958,7 +958,6 @@ let template_ = ref (fun _ -> failwith "forward ref not set")
 let defOrDcl_ = ref (fun _ _ -> failwith "forward ref not set")
 let tmplDef_ = ref (fun _ -> failwith "forward ref not set")
 let blockStatSeq_ = ref (fun _ -> failwith "forward ref not set")
-let topLevelTmplDef_ = ref (fun _ -> failwith "forward ref not set")
 let packageOrPackageObject_ = ref (fun _ _ -> failwith "forward ref not set")
 let typeCaseClauses_ = ref (fun _ -> failwith "forward ref not set")
 
@@ -2790,6 +2789,7 @@ let is_modifier in_ =
   ||
   match in_.token with
   | ID_LOWER ("inline", _)
+  | ID_LOWER ("opaque", _)
   | ID_LOWER ("open", _) ->
       next_is_soft_modifier_follower
   | __else__ -> false
@@ -2804,6 +2804,7 @@ let modifier_of_isLocalModifier_opt in_ =
   | Klazy ii -> Some (Lazy, ii)
   | ID_LOWER ("inline", ii) when is_modifier in_ -> Some (Inline, ii)
   | ID_LOWER ("open", ii) when is_modifier in_ -> Some (Open, ii)
+  | ID_LOWER ("opaque", ii) when is_modifier in_ -> Some (Opaque, ii)
   | _ -> None
 
 (** {{{
@@ -3598,7 +3599,7 @@ let templateStats in_ : template_stat list = statSeq templateStat in_
 
 (** {{{
  *  TopStatSeq ::= TopStat {semi TopStat}
- *  TopStat ::= Annotations Modifiers TmplDef
+ *  TopStat ::= Annotations Modifiers Def
  *            | Packaging
  *            | package object ObjectDef
  *            | Import
@@ -3618,8 +3619,8 @@ let topStat in_ : top_stat option =
   | Kexport _ ->
       let x = exportClause in_ in
       Some (Ex x)
-  | t when TH.isAnnotation t || TH.isTemplateIntro t || is_modifier in_ ->
-      let x = !topLevelTmplDef_ in_ in
+  | t when TH.isAnnotation t || TH.isDefIntro t || is_modifier in_ ->
+      let x = nonLocalDefOrDcl in_ in
       Some (D x)
   | _ -> None
 
@@ -4240,18 +4241,6 @@ let tmplDef attrs in_ : definition =
   | _ -> error "expected start of definition" in_
 
 (*****************************************************************************)
-(* Toplevel  *)
-(*****************************************************************************)
-
-(** Hook for IDE, for top-level classes/objects. *)
-let topLevelTmplDef in_ : definition =
-  let annots = annotations ~skipNewLines:true in_ in
-  let mods = modifiers in_ in
-  (* ast: mods withAnnotations annots *)
-  let x = tmplDef (mods_with_annots mods annots) in_ in
-  x
-
-(*****************************************************************************)
 (* Entry points  *)
 (*****************************************************************************)
 
@@ -4261,7 +4250,6 @@ let _ =
   defOrDcl_ := defOrDcl;
   tmplDef_ := tmplDef;
   blockStatSeq_ := blockStatSeq;
-  topLevelTmplDef_ := topLevelTmplDef;
   packageOrPackageObject_ := packageOrPackageObject;
 
   exprTypeArgs_ := exprTypeArgs;

--- a/tests/parsing/scala/for_exprs.scala
+++ b/tests/parsing/scala/for_exprs.scala
@@ -1,0 +1,30 @@
+
+val x = 
+  for 
+    _ <- 2 
+    x <- 5
+    y <- foo(a, b, c)
+  yield
+    6
+
+val y = 
+  for 
+    y <- foo(a, b, c)
+    if true
+    if false
+  yield
+    6
+
+val w = 
+  for {
+    _ <- 2 
+  }
+  yield
+    6
+
+val z = 
+  for (
+    _ <- 2 
+  )
+  yield
+    6

--- a/tests/parsing/scala/opaque.scala
+++ b/tests/parsing/scala/opaque.scala
@@ -1,0 +1,4 @@
+
+opaque type t = Int
+
+opaque def foo() = 3


### PR DESCRIPTION
## What:
This PR makes it so we can parse `for` expressions whose enumerators are indented, as opposed to wrapped in braces/parens.

## Why:
Parse rate.

## How:
Cased on if it was in a braces or parens. If not, it's assumed to be indented, so we just call `enumerators` directly.

I deliberately did not call `inBracesOrIndented`, because entering the indentation region of the `for` will mess us up at the end, when determining when to end the `enumerators`. This is because we will see a `DEDENT`, but because of the way the code is structured, this will make it difficult to properly have the tokens synchronized properly when we break out of the enumerators sequence.

This is similar to what the Scala compiler does: https://github.com/lampepfl/dotty/blob/865aa639c98e0a8771366b3ebc9580cc8b61bfeb/compiler/src/dotty/tools/dotc/parsing/Parsers.scala#L2730

## Test plan:
`make test`, and parse rate goes from `0.9672796646272888` to `0.9707749361511622`

Closes PA-2695

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
