### PR TITLE
refactor: Add ParamReceiver AST node

### DIFF
--- a/languages/go/generic/go_to_generic.ml
+++ b/languages/go/generic/go_to_generic.ml
@@ -623,7 +623,12 @@ let top_func () =
         and v4 = stmt v4 in
         let ent = G.basic_entity v1 in
         let def = mk_func_def (G.Method, ftok) params ret (G.FBStmt v4) in
-        let receiver = G.OtherParam (("Receiver", snd v1), [ G.Pa v2 ]) in
+        let receiver =
+          match v2 with
+          | G.Param x -> G.ParamReceiver x
+          (* Can this happen? Probably not, but the Go AST allows it *)
+          | _ -> G.OtherParam (("Receiver", snd v1), [ G.Pa v2 ])
+        in
         let l, params, r = def.G.fparams in
         let fparams = (l, receiver :: params, r) in
         G.DefStmt (ent, G.FuncDef { def with G.fparams }) |> G.s

--- a/libs/ast_generic/AST_generic.ml
+++ b/libs/ast_generic/AST_generic.ml
@@ -1672,7 +1672,9 @@ and parameter =
   (* sgrep: ... in parameters
    * note: foo(...x) of Js/Go is using the ParamRest, not this *)
   | ParamEllipsis of tok
-  (* e.g., ParamTodo in OCaml, Reciever param in Go, SingleStar and Slash
+  (* Receiver param in Go *)
+  | ParamReceiver of parameter_classic
+  (* e.g., ParamTodo in OCaml, SingleStar and Slash
    * in Python to delimit regular parameters from special one.
    * TODO ParamRef of tok * parameter_classic in PHP/Ruby *)
   | OtherParam of todo_kind * any list

--- a/libs/ast_generic/AST_generic_helpers.ml
+++ b/libs/ast_generic/AST_generic_helpers.ml
@@ -320,7 +320,9 @@ let parameter_to_catch_exn_opt p =
   | ParamRest (_, _p)
   | ParamHashSplat (_, _p) ->
       None
-  | OtherParam _ -> None
+  | ParamReceiver _
+  | OtherParam _ ->
+      None
 
 (*****************************************************************************)
 (* Abstract position and svalue for comparison *)

--- a/libs/ast_generic/AST_generic_to_v1.ml
+++ b/libs/ast_generic/AST_generic_to_v1.ml
@@ -1136,6 +1136,10 @@ and map_parameter = function
       let v1 = map_pattern v1 in
       `ParamPattern v1
   | ParamEllipsis v1 -> raise (SemgrepConstruct v1)
+  | ParamReceiver v1 ->
+      let v1 = map_parameter_classic v1 in
+      (* TODO Make a ParamReceiver node *)
+      `ParamClassic v1
   | OtherParam (v1, v2) ->
       let v1 = map_todo_kind v1 and v2 = map_of_list map_any v2 in
       `OtherParam (v1, v2)

--- a/libs/ast_generic/Map_AST.ml
+++ b/libs/ast_generic/Map_AST.ml
@@ -996,6 +996,9 @@ let (mk_visitor : visitor_in -> visitor_out) =
     | ParamEllipsis v1 ->
         let v1 = map_tok v1 in
         ParamEllipsis v1
+    | ParamReceiver v1 ->
+        let v1 = map_parameter_classic v1 in
+        ParamReceiver v1
     | OtherParam (v1, v2) ->
         let v1 = map_todo_kind v1 and v2 = map_of_list map_any v2 in
         OtherParam (v1, v2)

--- a/libs/ast_generic/Meta_AST.ml
+++ b/libs/ast_generic/Meta_AST.ml
@@ -1172,6 +1172,9 @@ and vof_parameter = function
   | ParamEllipsis v1 ->
       let v1 = vof_tok v1 in
       OCaml.VSum ("ParamEllipsis", [ v1 ])
+  | ParamReceiver v1 ->
+      let v1 = vof_parameter_classic v1 in
+      OCaml.VSum ("ParamReceiver", [ v1 ])
   | OtherParam (v1, v2) ->
       let v1 = vof_todo_kind v1 and v2 = OCaml.vof_list vof_any v2 in
       OCaml.VSum ("OtherParam", [ v1; v2 ])

--- a/src/engine/Match_tainting_mode.ml
+++ b/src/engine/Match_tainting_mode.ml
@@ -642,6 +642,7 @@ let check_fundef lang options taint_config opt_ent fdef =
         | G.ParamRest (_, _)
         | G.ParamHashSplat (_, _)
         | G.ParamEllipsis _
+        | G.ParamReceiver _
         | G.OtherParam (_, _) ->
             env)
       Lval_env.empty

--- a/src/matching/Generic_vs_generic.ml
+++ b/src/matching/Generic_vs_generic.ml
@@ -2894,6 +2894,7 @@ and m_parameter a b =
       let* () = m_tok a1 b1 in
       m_parameter_classic a2 b2
   | G.ParamPattern a1, B.ParamPattern b1 -> m_pattern a1 b1
+  | G.ParamReceiver a1, B.ParamReceiver b1 -> m_parameter_classic a1 b1
   | G.OtherParam (a1, a2), B.OtherParam (b1, b2) ->
       m_todo_kind a1 b1 >>= fun () -> (m_list m_any) a2 b2
   | G.ParamEllipsis a1, B.ParamEllipsis b1 -> m_tok a1 b1
@@ -2902,6 +2903,7 @@ and m_parameter a b =
   | G.ParamRest _, _
   | G.ParamHashSplat _, _
   | G.ParamEllipsis _, _
+  | G.ParamReceiver _, _
   | G.OtherParam _, _ ->
       fail ()
 


### PR DESCRIPTION
This is a Go construct that needs special handling in the Pro Engine.

Test plan: Automated tests

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
