### PR TITLE
metavariable-pattern: Handle parsing errors gracefully

### DIFF
--- a/changelog.d/gh-7271.fixed
+++ b/changelog.d/gh-7271.fixed
@@ -1,0 +1,4 @@
+metavariable-pattern: When used with the nested `language` key, if there was an
+error parsing the `metavariable`'s content, that error could abort the analysis
+of the current file. If there were other rules that were going to produce findings
+on that file, those findings were not being reported.

--- a/cli/tests/e2e/rules/metavariable-pattern/test1.json
+++ b/cli/tests/e2e/rules/metavariable-pattern/test1.json
@@ -1,0 +1,192 @@
+{
+  "rules": [
+    {
+      "id": "yaml.github-actions.security.run-shell-injection.run-shell-injection",
+      "languages": [
+        "yaml"
+      ],
+      "message": "Using variable interpolation `${{...}}` with `github` context data in a `run:` step could allow an attacker to inject their own code into the runner. This would allow them to steal secrets and code. `github` context data can have arbitrary user input and should be treated as untrusted. Instead, use an intermediate environment variable with `env:` to store the data and use the environment variable in the `run:` script. Be sure to use double-quotes the environment variable, like this: \"$ENVVAR\".",
+      "metadata": {
+        "category": "security",
+        "confidence": "HIGH",
+        "cwe": [
+          "CWE-78: Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')"
+        ],
+        "cwe2021-top25": true,
+        "cwe2022-top25": true,
+        "impact": "HIGH",
+        "license": "Commons Clause License Condition v1.0[LGPL-2.1-only]",
+        "likelihood": "HIGH",
+        "owasp": [
+          "A01:2017 - Injection",
+          "A03:2021 - Injection"
+        ],
+        "references": [
+          "https://docs.github.com/en/actions/learn-github-actions/security-hardening-for-github-actions#understanding-the-risk-of-script-injections",
+          "https://securitylab.github.com/research/github-actions-untrusted-input/"
+        ],
+        "semgrep.dev": {
+          "rule": {
+            "origin": "community",
+            "rule_id": "v8UjQj",
+            "url": "https://semgrep.dev/playground/r/K3TPZA/yaml.github-actions.security.run-shell-injection.run-shell-injection",
+            "version_id": "K3TPZA"
+          }
+        },
+        "shortlink": "https://sg.run/pkzk",
+        "source": "https://semgrep.dev/r/yaml.github-actions.security.run-shell-injection.run-shell-injection",
+        "subcategory": [
+          "vuln"
+        ],
+        "technology": [
+          "github-actions"
+        ]
+      },
+      "patterns": [
+        {
+          "pattern-inside": "steps: [...]"
+        },
+        {
+          "pattern-inside": "- run: ...\n  ...\n"
+        },
+        {
+          "pattern": "run: $SHELL"
+        },
+        {
+          "metavariable-pattern": {
+            "language": "generic",
+            "metavariable": "$SHELL",
+            "patterns": [
+              {
+                "pattern-either": [
+                  {
+                    "pattern": "${{ github.event.issue.title }}"
+                  },
+                  {
+                    "pattern": "${{ github.event.issue.body }}"
+                  },
+                  {
+                    "pattern": "${{ github.event.pull_request.title }}"
+                  },
+                  {
+                    "pattern": "${{ github.event.pull_request.body }}"
+                  },
+                  {
+                    "pattern": "${{ github.event.comment.body }}"
+                  },
+                  {
+                    "pattern": "${{ github.event.review.body }}"
+                  },
+                  {
+                    "pattern": "${{ github.event.review_comment.body }}"
+                  },
+                  {
+                    "pattern": "${{ github.event.pages. ... .page_name}}"
+                  },
+                  {
+                    "pattern": "${{ github.event.head_commit.message }}"
+                  },
+                  {
+                    "pattern": "${{ github.event.head_commit.author.email }}"
+                  },
+                  {
+                    "pattern": "${{ github.event.head_commit.author.name }}"
+                  },
+                  {
+                    "pattern": "${{ github.event.commits ... .author.email }}"
+                  },
+                  {
+                    "pattern": "${{ github.event.commits ... .author.name }}"
+                  },
+                  {
+                    "pattern": "${{ github.event.pull_request.head.ref }}"
+                  },
+                  {
+                    "pattern": "${{ github.event.pull_request.head.label }}"
+                  },
+                  {
+                    "pattern": "${{ github.event.pull_request.head.repo.default_branch }}"
+                  },
+                  {
+                    "pattern": "${{ github.head_ref }}"
+                  },
+                  {
+                    "pattern": "${{ github.event.inputs ... }}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ],
+      "severity": "ERROR"
+    },
+    {
+      "id": "yaml.github-actions.security.curl-eval.curl-eval",
+      "languages": [
+        "yaml"
+      ],
+      "message": "Data is being eval'd from a `curl` command. An attacker with control of the server in the `curl` command could inject malicious code into the `eval`, resulting in a system comrpomise. Avoid eval'ing untrusted data if you can. If you must do this, consider checking the SHA sum of the content returned by the server to verify its integrity.",
+      "metadata": {
+        "category": "security",
+        "confidence": "LOW",
+        "cwe": [
+          "CWE-78: Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')"
+        ],
+        "cwe2021-top25": true,
+        "cwe2022-top25": true,
+        "impact": "HIGH",
+        "license": "Commons Clause License Condition v1.0[LGPL-2.1-only]",
+        "likelihood": "LOW",
+        "owasp": [
+          "A01:2017 - Injection",
+          "A03:2021 - Injection"
+        ],
+        "references": [
+          "https://docs.github.com/en/actions/learn-github-actions/security-hardening-for-github-actions#understanding-the-risk-of-script-injections"
+        ],
+        "semgrep.dev": {
+          "rule": {
+            "origin": "community",
+            "rule_id": "X5Udrd",
+            "url": "https://semgrep.dev/playground/r/DkT3ge/yaml.github-actions.security.curl-eval.curl-eval",
+            "version_id": "DkT3ge"
+          }
+        },
+        "shortlink": "https://sg.run/9r7r",
+        "source": "https://semgrep.dev/r/yaml.github-actions.security.curl-eval.curl-eval",
+        "subcategory": [
+          "audit"
+        ],
+        "technology": [
+          "github-actions",
+          "bash",
+          "curl"
+        ]
+      },
+      "patterns": [
+        {
+          "pattern-inside": "steps: [...]"
+        },
+        {
+          "pattern-inside": "- run: ...\n  ...\n"
+        },
+        {
+          "pattern": "run: $SHELL"
+        },
+        {
+          "metavariable-pattern": {
+            "language": "bash",
+            "metavariable": "$SHELL",
+            "patterns": [
+              {
+                "pattern": "$DATA=<... curl ...>\n...\neval <... $DATA ...>\n"
+              }
+            ]
+          }
+        }
+      ],
+      "severity": "ERROR"
+    }
+  ]
+}

--- a/cli/tests/e2e/snapshots/test_metavariable_pattern/test1/results.json
+++ b/cli/tests/e2e/snapshots/test_metavariable_pattern/test1/results.json
@@ -1,0 +1,94 @@
+{
+  "errors": [
+    {
+      "code": 2,
+      "level": "warn",
+      "message": "Internal matching error when running rules.metavariable-pattern.yaml.github-actions.security.curl-eval.curl-eval on targets/metavariable-pattern/test1.yml:\n An error occurred while invoking the Semgrep engine. Please help us fix this by creating an issue at https://github.com/returntocorp/semgrep\n\nrule rules.metavariable-pattern.yaml.github-actions.security.curl-eval.curl-eval: metavariable-pattern failed when parsing $SHELL's content as Bash: if ${{ steps.pss.outcome=='failure' }}; then FAILED=pss; fi\nif ${{ steps.soc.outcome=='failure' }}; then FAILED=soc; fi\nif ${{ steps.pushsync-chunks-1.outcome=='failure' }}; then FAILED=pushsync-chunks-1; fi\nif ${{ steps.pushsync-chunks-2.outcome=='failure' }}; then FAILED=pushsync-chunks-2; fi\nif ${{ steps.retrieval.outcome=='failure' }}; then FAILED=retrieval; fi\nif ${{ steps.manifest.outcome=='failure' }}; then FAILED=manifest; fi\nif ${{ steps.content-availability.outcome=='failure' }}; then FAILED=content-availability; fi\ncurl -sSf -X POST -H \"Content-Type: application/json\" -d \"{\\\"text\\\": \\\"**${RUN_TYPE}** Test Error\\nBranch: \\`${{ github.head_ref }}\\`\\nUser: @${{ github.event.pull_request.user.login }}\\nDebugging artifacts: [click](https://$BUCKET_NAME.$AWS_ENDPOINT/artifacts_$VERTAG.tar.gz)\\nStep failed: \\`${FAILED}\\`\\\"}\" https://foobar.test.org/hooks/${{ secrets.TUNSHELL_KEY }}\n",
+      "path": "targets/metavariable-pattern/test1.yml",
+      "rule_id": "rules.metavariable-pattern.yaml.github-actions.security.curl-eval.curl-eval",
+      "type": "Internal matching error"
+    }
+  ],
+  "paths": {
+    "_comment": "<add --verbose for a list of skipped paths>",
+    "scanned": [
+      "targets/metavariable-pattern/test1.yml"
+    ]
+  },
+  "results": [
+    {
+      "check_id": "rules.metavariable-pattern.yaml.github-actions.security.run-shell-injection.run-shell-injection",
+      "end": {
+        "col": 378,
+        "line": 15,
+        "offset": 1093
+      },
+      "extra": {
+        "engine_kind": "OSS",
+        "fingerprint": "0x42",
+        "is_ignored": false,
+        "lines": "        run: |\n          if ${{ steps.pss.outcome=='failure' }}; then FAILED=pss; fi\n          if ${{ steps.soc.outcome=='failure' }}; then FAILED=soc; fi\n          if ${{ steps.pushsync-chunks-1.outcome=='failure' }}; then FAILED=pushsync-chunks-1; fi\n          if ${{ steps.pushsync-chunks-2.outcome=='failure' }}; then FAILED=pushsync-chunks-2; fi\n          if ${{ steps.retrieval.outcome=='failure' }}; then FAILED=retrieval; fi\n          if ${{ steps.manifest.outcome=='failure' }}; then FAILED=manifest; fi\n          if ${{ steps.content-availability.outcome=='failure' }}; then FAILED=content-availability; fi\n          curl -sSf -X POST -H \"Content-Type: application/json\" -d \"{\\\"text\\\": \\\"**${RUN_TYPE}** Test Error\\nBranch: \\`${{ github.head_ref }}\\`\\nUser: @${{ github.event.pull_request.user.login }}\\nDebugging artifacts: [click](https://$BUCKET_NAME.$AWS_ENDPOINT/artifacts_$VERTAG.tar.gz)\\nStep failed: \\`${FAILED}\\`\\\"}\" https://foobar.test.org/hooks/${{ secrets.TUNSHELL_KEY }}",
+        "message": "Using variable interpolation `${{...}}` with `github` context data in a `run:` step could allow an attacker to inject their own code into the runner. This would allow them to steal secrets and code. `github` context data can have arbitrary user input and should be treated as untrusted. Instead, use an intermediate environment variable with `env:` to store the data and use the environment variable in the `run:` script. Be sure to use double-quotes the environment variable, like this: \"$ENVVAR\".",
+        "metadata": {
+          "category": "security",
+          "confidence": "HIGH",
+          "cwe": [
+            "CWE-78: Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')"
+          ],
+          "cwe2021-top25": true,
+          "cwe2022-top25": true,
+          "impact": "HIGH",
+          "license": "Commons Clause License Condition v1.0[LGPL-2.1-only]",
+          "likelihood": "HIGH",
+          "owasp": [
+            "A01:2017 - Injection",
+            "A03:2021 - Injection"
+          ],
+          "references": [
+            "https://docs.github.com/en/actions/learn-github-actions/security-hardening-for-github-actions#understanding-the-risk-of-script-injections",
+            "https://securitylab.github.com/research/github-actions-untrusted-input/"
+          ],
+          "semgrep.dev": {
+            "rule": {
+              "origin": "community",
+              "rule_id": "v8UjQj",
+              "url": "https://semgrep.dev/playground/r/K3TPZA/yaml.github-actions.security.run-shell-injection.run-shell-injection",
+              "version_id": "K3TPZA"
+            }
+          },
+          "shortlink": "https://sg.run/pkzk",
+          "source": "https://semgrep.dev/r/yaml.github-actions.security.run-shell-injection.run-shell-injection",
+          "subcategory": [
+            "vuln"
+          ],
+          "technology": [
+            "github-actions"
+          ]
+        },
+        "metavars": {
+          "$SHELL": {
+            "abstract_content": "|\n          if ${{ steps.pss.outcome=='failure' }}; then FAILED=pss; fi\n          if ${{ steps.soc.outcome=='failure' }}; then FAILED=soc; fi\n          if ${{ steps.pushsync-chunks-1.outcome=='failure' }}; then FAILED=pushsync-chunks-1; fi\n          if ${{ steps.pushsync-chunks-2.outcome=='failure' }}; then FAILED=pushsync-chunks-2; fi\n          if ${{ steps.retrieval.outcome=='failure' }}; then FAILED=retrieval; fi\n          if ${{ steps.manifest.outcome=='failure' }}; then FAILED=manifest; fi\n          if ${{ steps.content-availability.outcome=='failure' }}; then FAILED=content-availability; fi\n          curl -sSf -X POST -H \"Content-Type: application/json\" -d \"{\\\"text\\\": \\\"**${RUN_TYPE}** Test Error\\nBranch: \\`${{ github.head_ref }}\\`\\nUser: @${{ github.event.pull_request.user.login }}\\nDebugging artifacts: [click](https://$BUCKET_NAME.$AWS_ENDPOINT/artifacts_$VERTAG.tar.gz)\\nStep failed: \\`${FAILED}\\`\\\"}\" https://foobar.test.org/hooks/${{ secrets.TUNSHELL_KEY }}\n",
+            "end": {
+              "col": 1,
+              "line": 16,
+              "offset": 1093
+            },
+            "start": {
+              "col": 14,
+              "line": 7,
+              "offset": 112
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/metavariable-pattern/test1.yml",
+      "start": {
+        "col": 9,
+        "line": 7,
+        "offset": 107
+      }
+    }
+  ],
+  "version": "0.42"
+}

--- a/cli/tests/e2e/targets/metavariable-pattern/test1.yml
+++ b/cli/tests/e2e/targets/metavariable-pattern/test1.yml
@@ -1,0 +1,15 @@
+jobs:
+  test:
+    name: Integration tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Test
+        run: |
+          if ${{ steps.pss.outcome=='failure' }}; then FAILED=pss; fi
+          if ${{ steps.soc.outcome=='failure' }}; then FAILED=soc; fi
+          if ${{ steps.pushsync-chunks-1.outcome=='failure' }}; then FAILED=pushsync-chunks-1; fi
+          if ${{ steps.pushsync-chunks-2.outcome=='failure' }}; then FAILED=pushsync-chunks-2; fi
+          if ${{ steps.retrieval.outcome=='failure' }}; then FAILED=retrieval; fi
+          if ${{ steps.manifest.outcome=='failure' }}; then FAILED=manifest; fi
+          if ${{ steps.content-availability.outcome=='failure' }}; then FAILED=content-availability; fi
+          curl -sSf -X POST -H "Content-Type: application/json" -d "{\"text\": \"**${RUN_TYPE}** Test Error\nBranch: \`${{ github.head_ref }}\`\nUser: @${{ github.event.pull_request.user.login }}\nDebugging artifacts: [click](https://$BUCKET_NAME.$AWS_ENDPOINT/artifacts_$VERTAG.tar.gz)\nStep failed: \`${FAILED}\`\"}" https://foobar.test.org/hooks/${{ secrets.TUNSHELL_KEY }}

--- a/cli/tests/e2e/test_metavariable_pattern.py
+++ b/cli/tests/e2e/test_metavariable_pattern.py
@@ -1,0 +1,15 @@
+import pytest
+from tests.fixtures import RunSemgrep
+
+
+@pytest.mark.kinda_slow
+def test1(run_semgrep_in_tmp: RunSemgrep, snapshot):
+    # https://github.com/returntocorp/semgrep/issues/7271
+    snapshot.assert_match(
+        run_semgrep_in_tmp(
+            "rules/metavariable-pattern/test1.json",
+            target_name="metavariable-pattern/test1.yml",
+            assert_exit_code=2,
+        ).stdout,
+        "results.json",
+    )

--- a/src/engine/Metavariable_pattern.ml
+++ b/src/engine/Metavariable_pattern.ml
@@ -254,10 +254,10 @@ let get_nested_metavar_pattern_bindings get_nested_formula_matches env r mvar
                   (* We re-parse the matched text as `xlang`. *)
                   Xpattern_matcher.with_tmp_file ~str:content
                     ~ext:"mvar-pattern" (fun file ->
-                      let lazy_ast_and_errors =
-                        lazy
-                          (match xlang with
-                          | L (lang, _) ->
+                      let ast_and_errors_res =
+                        match xlang with
+                        | L (lang, _) -> (
+                            try
                               let { Parsing_result2.ast; skipped_tokens; _ } =
                                 Parse_target.parse_and_resolve_name lang file
                               in
@@ -275,22 +275,39 @@ let get_nested_metavar_pattern_bindings get_nested_formula_matches env r mvar
                                      "rule %s: metavariable-pattern: failed to \
                                       fully parse the content of %s"
                                      (fst env.rule.Rule.id) mvar);
-                              (ast, skipped_tokens)
-                          | LRegex
-                          | LGeneric ->
-                              failwith
-                                "requesting generic AST for LRegex|LGeneric")
+                              Ok (lazy (ast, skipped_tokens))
+                            with
+                            | PI.Parsing_error msg ->
+                                logger#flash "OK";
+                                Error (PI.str_of_info msg))
+                        | LRegex
+                        | LGeneric ->
+                            Ok
+                              (lazy
+                                (failwith
+                                   "requesting generic AST for LRegex|LGeneric"))
                       in
-                      let xtarget =
-                        {
-                          Xtarget.file;
-                          xlang;
-                          lazy_ast_and_errors;
-                          lazy_content = lazy content;
-                        }
-                      in
-                      (* Persist the bindings from inside the `metavariable-pattern`
-                         matches
-                      *)
-                      get_nested_formula_matches { env with xtarget } formula r'
-                      |> get_persistent_bindings revert_loc r))))
+                      match ast_and_errors_res with
+                      | Error msg ->
+                          error env
+                            (Common.spf
+                               "rule %s: metavariable-pattern failed when \
+                                parsing %s's content as %s: %s"
+                               (fst env.rule.Rule.id) mvar
+                               (Xlang.to_string xlang) msg);
+                          []
+                      | Ok lazy_ast_and_errors ->
+                          let xtarget =
+                            {
+                              Xtarget.file;
+                              xlang;
+                              lazy_ast_and_errors;
+                              lazy_content = lazy content;
+                            }
+                          in
+                          (* Persist the bindings from inside the `metavariable-pattern`
+                             matches
+                          *)
+                          get_nested_formula_matches { env with xtarget }
+                            formula r'
+                          |> get_persistent_bindings revert_loc r))))


### PR DESCRIPTION
When using `metavariable-pattern` with the nested `language` key, if there was an error parsing the `metavariable`'s content, that exception was allowed to bubble up and then probably aborted the analysis of the current file.

Closes #7271

test plan:
make test # test added

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
