### PR TITLE
tests: Add regression test for #4185

### DIFF
--- a/cli/tests/e2e/rules/autofix/imported-entity.yaml
+++ b/cli/tests/e2e/rules/autofix/imported-entity.yaml
@@ -1,0 +1,7 @@
+rules:
+  - id: exception-useless-parentheses
+    pattern: raise $X()
+    fix: raise $X
+    message: Found useless parentheses
+    languages: [python]
+    severity: ERROR

--- a/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofiximported-entity.yaml-autofiximported-entity.py-dryrun/autofix/imported-entity.py-dryrun
+++ b/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofiximported-entity.yaml-autofiximported-entity.py-dryrun/autofix/imported-entity.py-dryrun
@@ -1,0 +1,4 @@
+from randomlib.errors import RandomError
+
+def test_test():
+  raise RandomError()

--- a/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofiximported-entity.yaml-autofiximported-entity.py-dryrun/results.json
+++ b/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofiximported-entity.yaml-autofiximported-entity.py-dryrun/results.json
@@ -1,0 +1,54 @@
+{
+  "errors": [],
+  "paths": {
+    "_comment": "<add --verbose for a list of skipped paths>",
+    "scanned": [
+      "targets/autofix/imported-entity.py"
+    ]
+  },
+  "results": [
+    {
+      "check_id": "rules.autofix.exception-useless-parentheses",
+      "end": {
+        "col": 22,
+        "line": 4,
+        "offset": 80
+      },
+      "extra": {
+        "engine_kind": "OSS",
+        "fingerprint": "0x42",
+        "fix": "raise RandomError",
+        "fixed_lines": [
+          "  raise RandomError"
+        ],
+        "is_ignored": false,
+        "lines": "  raise RandomError()",
+        "message": "Found useless parentheses",
+        "metadata": {},
+        "metavars": {
+          "$X": {
+            "abstract_content": "RandomError RandomError RandomError",
+            "end": {
+              "col": 20,
+              "line": 4,
+              "offset": 78
+            },
+            "start": {
+              "col": 9,
+              "line": 4,
+              "offset": 67
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/autofix/imported-entity.py",
+      "start": {
+        "col": 3,
+        "line": 4,
+        "offset": 61
+      }
+    }
+  ],
+  "version": "0.42"
+}

--- a/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofiximported-entity.yaml-autofiximported-entity.py-not-dryrun/autofix/imported-entity.py-fixed
+++ b/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofiximported-entity.yaml-autofiximported-entity.py-not-dryrun/autofix/imported-entity.py-fixed
@@ -1,0 +1,4 @@
+from randomlib.errors import RandomError
+
+def test_test():
+  raise RandomError

--- a/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofiximported-entity.yaml-autofiximported-entity.py-not-dryrun/results.json
+++ b/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofiximported-entity.yaml-autofiximported-entity.py-not-dryrun/results.json
@@ -1,0 +1,51 @@
+{
+  "errors": [],
+  "paths": {
+    "_comment": "<add --verbose for a list of skipped paths>",
+    "scanned": [
+      "targets/autofix/imported-entity.py"
+    ]
+  },
+  "results": [
+    {
+      "check_id": "rules.autofix.exception-useless-parentheses",
+      "end": {
+        "col": 22,
+        "line": 4,
+        "offset": 80
+      },
+      "extra": {
+        "engine_kind": "OSS",
+        "fingerprint": "0x42",
+        "fix": "raise RandomError",
+        "is_ignored": false,
+        "lines": "  raise RandomError()",
+        "message": "Found useless parentheses",
+        "metadata": {},
+        "metavars": {
+          "$X": {
+            "abstract_content": "RandomError RandomError RandomError",
+            "end": {
+              "col": 20,
+              "line": 4,
+              "offset": 78
+            },
+            "start": {
+              "col": 9,
+              "line": 4,
+              "offset": 67
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/autofix/imported-entity.py",
+      "start": {
+        "col": 3,
+        "line": 4,
+        "offset": 61
+      }
+    }
+  ],
+  "version": "0.42"
+}

--- a/cli/tests/e2e/targets/autofix/imported-entity.py
+++ b/cli/tests/e2e/targets/autofix/imported-entity.py
@@ -1,0 +1,4 @@
+from randomlib.errors import RandomError
+
+def test_test():
+  raise RandomError()

--- a/cli/tests/e2e/test_autofix.py
+++ b/cli/tests/e2e/test_autofix.py
@@ -10,6 +10,7 @@ from tests.fixtures import RunSemgrep
         ("rules/autofix/autofix.yaml", "autofix/autofix.py"),
         ("rules/autofix/csv-writer.yaml", "autofix/csv-writer.py"),
         ("rules/autofix/defaulthttpclient.yaml", "autofix/defaulthttpclient.java"),
+        ("rules/autofix/imported-entity.yaml", "autofix/imported-entity.py"),
         ("rules/autofix/flask-use-jsonify.yaml", "autofix/flask-use-jsonify.py"),
         ("rules/autofix/requests-use-timeout.yaml", "autofix/requests-use-timeout.py"),
         (


### PR DESCRIPTION
PR #6900 fixed #4185 already.

Closes #4185
Follows #6900

test plan:
make test # test added

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
