### PR TITLE
refactor: new Lang.lang_of_filename_exn

### DIFF
--- a/src/analyzing/tests/Test_analyze_generic.ml
+++ b/src/analyzing/tests/Test_analyze_generic.ml
@@ -6,9 +6,7 @@ module H = AST_generic_helpers
 let test_typing_generic ~parse_program file =
   let file = Fpath.v file in
   let ast = parse_program !!file in
-  let lang =
-    Common.hd_exn "unexpected empty list" (Lang.langs_of_filename file)
-  in
+  let lang = Lang.lang_of_filename_exn file in
   Naming_AST.resolve lang ast;
 
   let v =
@@ -30,9 +28,7 @@ let test_typing_generic ~parse_program file =
 let test_constant_propagation ~parse_program file =
   let file = Fpath.v file in
   let ast = parse_program !!file in
-  let lang =
-    Common.hd_exn "unexpected empty list" (Lang.langs_of_filename file)
-  in
+  let lang = Lang.lang_of_filename_exn file in
   Naming_AST.resolve lang ast;
   Constant_propagation.propagate_basic lang ast;
   let s = AST_generic.show_any (AST_generic.Pr ast) in
@@ -41,9 +37,7 @@ let test_constant_propagation ~parse_program file =
 let test_il_generic ~parse_program file =
   let file = Fpath.v file in
   let ast = parse_program !!file in
-  let lang =
-    Common.hd_exn "unexpected empty list" (Lang.langs_of_filename file)
-  in
+  let lang = Lang.lang_of_filename_exn file in
   Naming_AST.resolve lang ast;
 
   let v =
@@ -66,9 +60,7 @@ let test_il_generic ~parse_program file =
 let test_cfg_il ~parse_program file =
   let file = Fpath.v file in
   let ast = parse_program !!file in
-  let lang =
-    Common.hd_exn "unexpected empty list" (Lang.langs_of_filename file)
-  in
+  let lang = Lang.lang_of_filename_exn file in
   Naming_AST.resolve lang ast;
   Visit_function_defs.visit
     (fun _ fdef ->
@@ -90,9 +82,7 @@ end)
 let test_dfg_svalue ~parse_program file =
   let file = Fpath.v file in
   let ast = parse_program !!file in
-  let lang =
-    Common.hd_exn "unexpected empty list" (Lang.langs_of_filename file)
-  in
+  let lang = Lang.lang_of_filename_exn file in
   Naming_AST.resolve lang ast;
   let v =
     object

--- a/src/analyzing/tests/Unit_dataflow.ml
+++ b/src/analyzing/tests/Unit_dataflow.ml
@@ -21,10 +21,7 @@ let tests parse_program =
           files |> File.Path.of_strings
           |> List.iter (fun file ->
                  let ast = parse_program !!file in
-                 let lang =
-                   Common.hd_exn "unexpected empty list"
-                     (Lang.langs_of_filename file)
-                 in
+                 let lang = Lang.lang_of_filename_exn file in
                  Naming_AST.resolve lang ast;
                  match
                    Time_limit.set_timeout ~name:"cst_prop" timeout_secs

--- a/src/core/Lang.ml.j2
+++ b/src/core/Lang.ml.j2
@@ -1,6 +1,6 @@
 (* Yoann Padioleau
  *
- * Copyright (C) 2019-2022 r2c
+ * Copyright (C) 2019-2023 r2c
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
@@ -106,6 +106,12 @@ let langs_of_filename filename =
   | FT.PL FT.Scala -> [ Scala ]
   | FT.PL (FT.Web FT.Html) -> [ Html ]
   | _ -> []
+
+let lang_of_filename_exn filename =
+  match langs_of_filename filename with
+  | x :: _ -> x
+  | [] -> failwith ("Could not infer a language from the filename: " ^
+                      Fpath.to_string filename)
 
 let to_string = function
 {% for item in langs %}  | {{ item.id }} -> "{{ item.name }}"

--- a/src/core/Lang.mli.j2
+++ b/src/core/Lang.mli.j2
@@ -64,6 +64,12 @@ val shebangs_of_lang : t -> string list
 (* See also Find_target.files_of_dirs_or_files *)
 val langs_of_filename : Fpath.t -> t list
 
+(* This should be used only in testing code. This may raise
+ * Failure "Could not infer a language from the filename".
+ * Use langs_of_filename() if you can instead.
+ *)
+val lang_of_filename_exn : Fpath.t -> t
+
 (* accept any variants *)
 val is_js : t -> bool
 

--- a/src/core_cli/Core_CLI.ml
+++ b/src/core_cli/Core_CLI.ml
@@ -224,10 +224,8 @@ let dump_ast ?(naming = false) lang file =
 
 (* mostly a copy paste of Test_analyze_generic.ml *)
 let dump_il_all file =
-  let lang =
-    Common.hd_exn "unexpected empty list" (Lang.langs_of_filename file)
-  in
   let ast = Parse_target.parse_program !!file in
+  let lang = Lang.lang_of_filename_exn file in
   Naming_AST.resolve lang ast;
   let xs = AST_to_IL.stmt lang (AST_generic.stmt1 ast) in
   List.iter (fun stmt -> pr2 (IL.show_stmt stmt)) xs
@@ -236,10 +234,8 @@ let dump_il_all file =
 let dump_il file =
   let module G = AST_generic in
   let module V = Visitor_AST in
-  let lang =
-    Common.hd_exn "unexpected empty list" (Lang.langs_of_filename file)
-  in
   let ast = Parse_target.parse_program !!file in
+  let lang = Lang.lang_of_filename_exn file in
   Naming_AST.resolve lang ast;
   let report_func_def_with_name ent_opt fdef =
     let name =

--- a/src/engine/Test_dataflow_tainting.ml
+++ b/src/engine/Test_dataflow_tainting.ml
@@ -46,9 +46,7 @@ let test_tainting lang file options config def =
 let test_dfg_tainting rules_file file =
   let rules_file = Fpath.v rules_file in
   let file = Fpath.v file in
-  let lang =
-    Common.hd_exn "unexpected empty list" (Lang.langs_of_filename file)
-  in
+  let lang = Lang.lang_of_filename_exn file in
   let rules =
     try Parse_rule.parse rules_file with
     | exn ->

--- a/src/experiments/datalog/Datalog_experiment.ml
+++ b/src/experiments/datalog/Datalog_experiment.ml
@@ -106,11 +106,8 @@ let facts_of_function lang def =
 (* Entry point *)
 (*****************************************************************************)
 let gen_facts file outdir =
-  let lang =
-    Common.hd_exn "unexpected empty list"
-      (Lang.langs_of_filename (Fpath.v file))
-  in
   let ast = Parse_target.parse_program file in
+  let lang = Lang.lang_of_filename_exn (Fpath.v file) in
   Naming_AST.resolve lang ast;
 
   (* less: use treesitter also later

--- a/src/experiments/misc/Raja_experiment.ml
+++ b/src/experiments/misc/Raja_experiment.ml
@@ -37,7 +37,7 @@ let ranges_of_path (path : Fpath.t) : Function_range.ranges =
   | Some x -> x
   | None ->
       let ast =
-        (* ugly: parse_program may raise the "hd" exn when we can't infer
+        (* ugly: parse_program may raise an exn when we can't infer
          * the language from the filename.
          * TODO: we should use just_parse_with_lang and get the language
          * from the languages: field in the rule corresponding to
@@ -45,9 +45,7 @@ let ranges_of_path (path : Fpath.t) : Function_range.ranges =
          * more info to ranges_of_path() though.
          *)
         try Parse_target.parse_program !!path with
-        (* TODO: does this still catch what it's supposed to catch
-           since we no longer use List.hd? *)
-        | Failure "hd" -> []
+        | Failure _ -> []
       in
       let ranges = Function_range.ranges ast in
       Hashtbl.add cache path ranges;

--- a/src/experiments/synthesizing/Synthesizer.ml
+++ b/src/experiments/synthesizing/Synthesizer.ml
@@ -16,9 +16,7 @@ let range_to_ast file lang s =
   | Some a -> a
 
 let synthesize_patterns config s file =
-  let lang =
-    Lang.langs_of_filename file |> Common.hd_exn "unexpected empty list"
-  in
+  let lang = Lang.lang_of_filename_exn file in
   let a = range_to_ast file lang s in
   let patterns = Pattern_from_Code.from_any config a in
   Common.map
@@ -49,9 +47,7 @@ let parse_range_args xs =
 
 let parse_targets (args : string list) : Pattern.t list * Lang.t =
   let ranges, file = parse_range_args args in
-  let lang =
-    Lang.langs_of_filename file |> Common.hd_exn "unexpected empty list"
-  in
+  let lang = Lang.lang_of_filename_exn file in
   let targets = Common.map (range_to_ast file lang) ranges in
   (targets, lang)
 

--- a/src/experiments/synthesizing/Test_synthesizing.ml
+++ b/src/experiments/synthesizing/Test_synthesizing.ml
@@ -22,9 +22,7 @@ let expr_at_range s file =
   pr2_gen r;
   let ast = Parse_target.parse_program !!file in
   (* just to see if it works with Naming on *)
-  let lang =
-    Lang.langs_of_filename file |> Common.hd_exn "unexpected empty list"
-  in
+  let lang = Lang.lang_of_filename_exn file in
   Naming_AST.resolve lang ast;
   let e_opt = Range_to_AST.expr_at_range r ast in
   match e_opt with

--- a/src/naming/Test_naming_generic.ml
+++ b/src/naming/Test_naming_generic.ml
@@ -6,9 +6,7 @@ module V = Visitor_AST
 let test_naming_generic ~parse_program file =
   let file = Fpath.v file in
   let ast = parse_program !!file in
-  let lang =
-    Common.hd_exn "unexpected empty list" (Lang.langs_of_filename file)
-  in
+  let lang = Lang.lang_of_filename_exn file in
   Naming_AST.resolve lang ast;
   let s = AST_generic.show_any (AST_generic.Pr ast) in
   pr2 s

--- a/src/naming/Unit_naming_generic.ml
+++ b/src/naming/Unit_naming_generic.ml
@@ -29,10 +29,7 @@ let tests parse_program =
                    (* at least we can assert we don't thrown an exn or go
                       into infinite loops *)
                    let ast = parse_program !!file in
-                   let lang =
-                     Common.hd_exn "unexpected empty list"
-                       (Lang.langs_of_filename file)
-                   in
+                   let lang = Lang.lang_of_filename_exn file in
                    Naming_AST.resolve lang ast;
                    (* this used to loop forever if you were not handling correctly
                       possible cycles with id_type *)

--- a/src/naming/Unit_typing_generic.ml
+++ b/src/naming/Unit_typing_generic.ml
@@ -18,10 +18,7 @@ let tests parse_program parse_pattern =
           let file = tests_path_typing / "VarDef.java" in
           try
             let ast = parse_program !!file in
-            let lang =
-              Common.hd_exn "unexpected empty list"
-                (Lang.langs_of_filename file)
-            in
+            let lang = Lang.lang_of_filename_exn file in
             Naming_AST.resolve lang ast;
 
             let v =
@@ -49,10 +46,7 @@ let tests parse_program parse_pattern =
           let file = tests_path_typing / "EqVarCmp.java" in
           try
             let ast = parse_program !!file in
-            let lang =
-              Common.hd_exn "unexpected empty list"
-                (Lang.langs_of_filename file)
-            in
+            let lang = Lang.lang_of_filename_exn file in
             Naming_AST.resolve lang ast;
 
             let v =
@@ -101,10 +95,7 @@ let tests parse_program parse_pattern =
           let file = tests_path_typing / "BasicParam.java" in
           try
             let ast = parse_program !!file in
-            let lang =
-              Common.hd_exn "unexpected empty list"
-                (Lang.langs_of_filename file)
-            in
+            let lang = Lang.lang_of_filename_exn file in
             Naming_AST.resolve lang ast;
 
             let v =
@@ -145,10 +136,7 @@ let tests parse_program parse_pattern =
           let file = tests_path_typing / "ClassFields.java" in
           try
             let ast = parse_program !!file in
-            let lang =
-              Common.hd_exn "unexpected empty list"
-                (Lang.langs_of_filename file)
-            in
+            let lang = Lang.lang_of_filename_exn file in
             Naming_AST.resolve lang ast;
 
             let v =
@@ -208,10 +196,7 @@ let tests parse_program parse_pattern =
           let file = tests_path_typing / "StaticVarDef.go" in
           try
             let ast = parse_program !!file in
-            let lang =
-              Common.hd_exn "unexpected empty list"
-                (Lang.langs_of_filename file)
-            in
+            let lang = Lang.lang_of_filename_exn file in
             Naming_AST.resolve lang ast;
 
             let v =
@@ -239,10 +224,7 @@ let tests parse_program parse_pattern =
           let file = tests_path_typing / "FuncParam.go" in
           try
             let ast = parse_program !!file in
-            let lang =
-              Common.hd_exn "unexpected empty list"
-                (Lang.langs_of_filename file)
-            in
+            let lang = Lang.lang_of_filename_exn file in
             Naming_AST.resolve lang ast;
 
             let v =
@@ -290,10 +272,7 @@ let tests parse_program parse_pattern =
           let file = tests_path_typing / "PropVarDef.go" in
           try
             let ast = parse_program !!file in
-            let lang =
-              Common.hd_exn "unexpected empty list"
-                (Lang.langs_of_filename file)
-            in
+            let lang = Lang.lang_of_filename_exn file in
             Naming_AST.resolve lang ast;
 
             let v =

--- a/src/parsing/Parse_target.ml
+++ b/src/parsing/Parse_target.ml
@@ -134,8 +134,6 @@ let parse_and_resolve_name_fail_if_partial lang file =
 (*****************************************************************************)
 let parse_program file =
   let file = Fpath.v file in
-  let lang =
-    Common.hd_exn "unexpected empty list" (Lang.langs_of_filename file)
-  in
+  let lang = Lang.lang_of_filename_exn file in
   let res = just_parse_with_lang lang !!file in
   res.ast

--- a/src/parsing/Unit_parsing.ml
+++ b/src/parsing/Unit_parsing.ml
@@ -109,10 +109,7 @@ let parsing_error_tests () =
             ( Fpath.basename file,
               fun () ->
                 try
-                  let lang =
-                    Common.hd_exn "unexpected empty list"
-                      (Lang.langs_of_filename file)
-                  in
+                  let lang = Lang.lang_of_filename_exn file in
                   let res = Parse_target.just_parse_with_lang lang !!file in
                   if res.skipped_tokens =*= [] then
                     Alcotest.fail


### PR DESCRIPTION
This avoids some use of Common.hd_exn

test plan:
make core


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)