### PR TITLE
osemgrep: fix make osemgrep-e2e, specify osemgrep PATH

### DIFF
--- a/cli/Makefile
+++ b/cli/Makefile
@@ -34,9 +34,10 @@ qa:
 	$(PYTEST) -n auto -v tests/qa
 
 # Run the end-to-end tests using osemgrep instead of the Python CLI.
+# See tests/semgrep_runner.py for the use of the environment variables below
 .PHONY: osemgrep-e2e
 osemgrep-e2e:
-	PYTEST_USE_OSEMGREP=true $(MAKE) e2e
+	PYTEST_OSEMGREP=$(PWD)/src/semgrep/bin/osemgrep PYTEST_USE_OSEMGREP=true $(MAKE) e2e
 
 # Run the quality assurance tests using osemgrep instead of the Python CLI.
 .PHONY: osemgrep-qa

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -34,7 +34,9 @@ qa:
 	$(PYTEST) -n auto -v tests/qa
 
 # Run the end-to-end tests using osemgrep instead of the Python CLI.
-# See tests/semgrep_runner.py for the use of the environment variables below
+# See tests/semgrep_runner.py for the use of the environment variables below.
+# To run individual tests, export PYTEST_OSEMGREP=... export PYTEST_USE_OSEMGREP=true
+# and run 'pytest tests/e2e/test_output.py' in a shell for example.
 .PHONY: osemgrep-e2e
 osemgrep-e2e:
 	PYTEST_OSEMGREP=$(PWD)/src/semgrep/bin/osemgrep PYTEST_USE_OSEMGREP=true $(MAKE) e2e


### PR DESCRIPTION
test plan:
make osemgrep-e2e now works.

I have 101 passed and 420 failed currently


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)