### PR TITLE
osemgrep: initial text output

### DIFF
--- a/src/osemgrep/cli_scan/Output.ml
+++ b/src/osemgrep/cli_scan/Output.ml
@@ -133,7 +133,7 @@ let dispatch_output_format (output_format : Output_format.t)
                    ]
                  in
                  pr (String.concat ":" parts))
-  | Text
+  | Text -> Text_output.pp_cli_output Format.std_formatter cli_output
   | Gitlab_sast
   | Gitlab_secrets
   | Junit_xml

--- a/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -414,6 +414,9 @@ let run (conf : Scan_CLI.conf) : Exit_code.t =
         { res with core }
       in
 
+      (* outputting the result! in JSON/Text/... depending on conf *)
+      Output.output_result conf res;
+
       Logs.info (fun m ->
           m "%a" pp_skipped
             ( conf.targeting_conf.respect_git_ignore,
@@ -447,8 +450,6 @@ let run (conf : Scan_CLI.conf) : Exit_code.t =
            """
            return False
       *)
-      (* outputting the result! in JSON/Text/... depending on conf *)
-      Output.output_result conf res;
       (* final result for the shell *)
       exit_code_of_errors ~strict:conf.strict res.core.errors
 

--- a/src/osemgrep/reporting/Text_output.ml
+++ b/src/osemgrep/reporting/Text_output.ml
@@ -1,0 +1,104 @@
+module Out = Semgrep_output_v1_t
+
+let group_titles = function
+  | `Unreachable -> "Unreachable Supply Chain Finding"
+  | `Undetermined -> "Undetermined Supply Chain Finding"
+  | `Reachable -> "Reachable Supply Chain Finding"
+  | `Nonblocking -> "Non-blocking Code Finding"
+  | `Blocking -> "Blocking Code Finding"
+  | `Merged -> "Code Finding"
+
+let is_blocking (json : Yojson.Basic.t) =
+  match Yojson.Basic.Util.member "dev.semgrep.actions" json with
+  | `List stuff ->
+      List.exists
+        (function
+          | `String s -> String.equal s "block"
+          | _else -> false)
+        stuff
+  | _else -> false
+
+let pp_finding ppf (m : Out.cli_match) =
+  (* TODO trim lines *)
+  (* TODO dedent lines *)
+  (* TODO strip lines *)
+  (* TODO coloring, bold *)
+  let lines =
+    Option.value
+      ~default:(String.split_on_char '\n' m.extra.lines)
+      m.extra.fixed_lines
+  in
+  let start_line = m.start.line in
+  List.iteri
+    (fun i line -> Fmt.pf ppf "      %u| %s@." (start_line + i) line)
+    lines
+
+let pp_text_outputs ppf (matches : Out.cli_match list) =
+  (* TODO sorting, skipping path if same as previous *)
+  List.iter
+    (fun (m : Out.cli_match) ->
+      let shortlink =
+        match Yojson.Basic.Util.member "shortlink" m.extra.metadata with
+        | `String s -> "      Details: " ^ s
+        | _ -> ""
+      in
+      Fmt.pf ppf "  %s@." m.path;
+      Fmt.pf ppf "    %s@." m.check_id;
+      (* TODO message wrapping *)
+      Fmt.pf ppf "      %s@.%s@.@." m.extra.message shortlink;
+      pp_finding ppf m;
+      Fmt.pf ppf "@.")
+    matches
+
+let pp_cli_output ppf (cli_output : Out.cli_output) =
+  let groups =
+    Common.group_by
+      (fun (m : Out.cli_match) ->
+        (* TODO: python (text.py):
+           if match.product == RuleProduct.sast:
+             subgroup = "blocking" if match.is_blocking else "nonblocking"
+           else:
+             subgroup = match.exposure_type or "undetermined"
+
+           figuring out the product, python uses (rule.py):
+              RuleProduct.sca
+              if "r2c-internal-project-depends-on" in self._raw
+              else RuleProduct.sast
+
+           and exposure_type (rule_match.py):
+           if "sca_info" not in self.extra:
+               return None
+
+           if self.metadata.get("sca-kind") == "upgrade-only":
+               return "reachable"
+           elif self.metadata.get("sca-kind") == "legacy":
+               return "undetermined"
+           else:
+               return "reachable" if self.extra["sca_info"].reachable else "unreachable"
+        *)
+        if is_blocking m.Out.extra.Out.metadata then `Blocking else `Nonblocking)
+      cli_output.results
+  in
+  (* if not is_ci_invocation *)
+  let groups =
+    let merged =
+      (try List.assoc `Nonblocking groups with
+      | Not_found -> [])
+      @
+      try List.assoc `Blocking groups with
+      | Not_found -> []
+    in
+    (`Merged, merged)
+    :: List.filter
+         (fun (k, _) -> not (k = `Nonblocking || k = `Blocking))
+         groups
+  in
+  List.iter
+    (fun (group, matches) ->
+      (match matches with
+      | [] -> ()
+      | _non_empty ->
+          Fmt_helpers.pp_heading ppf
+            (string_of_int (List.length matches) ^ " " ^ group_titles group));
+      pp_text_outputs ppf matches)
+    groups

--- a/src/osemgrep/reporting/Text_output.ml
+++ b/src/osemgrep/reporting/Text_output.ml
@@ -40,7 +40,7 @@ let pp_text_outputs ppf (matches : Out.cli_match list) =
       let shortlink =
         match Yojson.Basic.Util.member "shortlink" m.extra.metadata with
         | `String s -> "      Details: " ^ s
-        | _ -> ""
+        | _else -> ""
       in
       Fmt.pf ppf "  %s@." m.path;
       Fmt.pf ppf "    %s@." m.check_id;


### PR DESCRIPTION
still work in progress with various todos

For the sake of brevity, only two examples here:
```
  /usr/home/hannes/devel/mirage/semgrep/src/osemgrep/TOPORT/error_handler.py
    r.python.requests.best-practice.use-raise-for-status.use-raise-for-status
      There's an HTTP request made with requests, but the raise_for_status() utility method isn't used. This can result in request errors going unnoticed and your code behaving in unexpected ways, such as if your authorization API returns a 500 error while you're only checking for a 401.
      Details: https://sg.run/J3Xw

      67|             requests.post(
      68|                 state.env.fail_open_url, headers=headers, json=self.payload, timeout=3
      69|             )

  /usr/home/hannes/devel/mirage/semgrep/src/osemgrep/TOPORT/error_handler.py
    r.python.lang.maintainability.is-function-without-parentheses.is-function-without-parentheses
      Is "is_enabled" a function or an attribute? If it is a function, you may have meant self.is_enabled() because self.is_enabled is always true.
      Details: https://sg.run/oYR7

      47|             not self.is_enabled
```

in pysemgrep:
```
    src/osemgrep/TOPORT/error_handler.py 
       python.lang.maintainability.is-function-without-parentheses.is-function-without-parentheses
0m                                                                                                    
          Is "is_enabled" a function or an attribute? If it is a function, you may have meant            
          self.is_enabled() because self.is_enabled is always true.                                      
          Details: https://sg.run/oYR7                                                                   
                                                                                                         
           47┆ not self.is_enabled
            ⋮┆----------------------------------------
       python.requests.best-practice.use-raise-for-status.use-raise-for-status              
          There's an HTTP request made with requests, but the raise_for_status() utility method isn't 
          used. This can result in request errors going unnoticed and your code behaving in unexpected
          ways, such as if your authorization API returns a 500 error while you're only checking for a
          401.                                                                                        
          Details: https://sg.run/J3Xw                                                                
                                                                                                      
           67┆ requests.post(
           68┆     state.env.fail_open_url, headers=headers, json=self.payload, timeout=3
           69┆ )
```

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
