### PR TITLE
php: metavariable-pattern: Only add <?php when needed

### DIFF
--- a/changelog.d/pa-2696.fixed
+++ b/changelog.d/pa-2696.fixed
@@ -1,0 +1,3 @@
+When using `metavariable-pattern` to match embedded PHP code, Semgrep was
+unconditionally adding the `<?php` opening to the embedded code. When
+`<?php` was already present, this caused parsing errors.

--- a/cli/tests/e2e/rules/metavariable-pattern/test2.yaml
+++ b/cli/tests/e2e/rules/metavariable-pattern/test2.yaml
@@ -1,0 +1,15 @@
+rules:
+- id: test
+  languages: [generic]
+  severity: ERROR
+  message: Test
+  patterns:
+    - pattern-inside: <$TAG .../>
+    - pattern: $ATTR="$...CODE"
+    - metavariable-regex:
+        metavariable: $...CODE
+        regex: ^\s*<\?(?:php|=)\s+.*
+    - metavariable-pattern:
+        metavariable: $...CODE
+        language: php
+        pattern: echo ...;

--- a/cli/tests/e2e/snapshots/test_metavariable_pattern/test2/results.json
+++ b/cli/tests/e2e/snapshots/test_metavariable_pattern/test2/results.json
@@ -1,0 +1,76 @@
+{
+  "errors": [],
+  "paths": {
+    "_comment": "<add --verbose for a list of skipped paths>",
+    "scanned": [
+      "targets/metavariable-pattern/test2.php"
+    ]
+  },
+  "results": [
+    {
+      "check_id": "rules.metavariable-pattern.test",
+      "end": {
+        "col": 50,
+        "line": 2,
+        "offset": 70
+      },
+      "extra": {
+        "engine_kind": "OSS",
+        "fingerprint": "0x42",
+        "is_ignored": false,
+        "lines": "<input type=\"date\" value=\"<?php echo $foobar; ?>\" />",
+        "message": "Test",
+        "metadata": {},
+        "metavars": {
+          "$...CODE": {
+            "abstract_content": "<?php echo $foobar; ?>",
+            "end": {
+              "col": 49,
+              "line": 2,
+              "offset": 69
+            },
+            "start": {
+              "col": 27,
+              "line": 2,
+              "offset": 47
+            }
+          },
+          "$ATTR": {
+            "abstract_content": "value",
+            "end": {
+              "col": 25,
+              "line": 2,
+              "offset": 45
+            },
+            "start": {
+              "col": 20,
+              "line": 2,
+              "offset": 40
+            }
+          },
+          "$TAG": {
+            "abstract_content": "input",
+            "end": {
+              "col": 7,
+              "line": 2,
+              "offset": 27
+            },
+            "start": {
+              "col": 2,
+              "line": 2,
+              "offset": 22
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/metavariable-pattern/test2.php",
+      "start": {
+        "col": 20,
+        "line": 2,
+        "offset": 40
+      }
+    }
+  ],
+  "version": "0.42"
+}

--- a/cli/tests/e2e/targets/metavariable-pattern/test2.php
+++ b/cli/tests/e2e/targets/metavariable-pattern/test2.php
@@ -1,0 +1,2 @@
+<!-- ruleid:test -->
+<input type="date" value="<?php echo $foobar; ?>" />

--- a/cli/tests/e2e/test_metavariable_pattern.py
+++ b/cli/tests/e2e/test_metavariable_pattern.py
@@ -13,3 +13,15 @@ def test1(run_semgrep_in_tmp: RunSemgrep, snapshot):
         ).stdout,
         "results.json",
     )
+
+
+@pytest.mark.kinda_slow
+def test2(run_semgrep_in_tmp: RunSemgrep, snapshot):
+    # https://linear.app/r2c/issue/PA-2696
+    snapshot.assert_match(
+        run_semgrep_in_tmp(
+            "rules/metavariable-pattern/test2.yaml",
+            target_name="metavariable-pattern/test2.php",
+        ).stdout,
+        "results.json",
+    )

--- a/src/engine/Metavariable_pattern.ml
+++ b/src/engine/Metavariable_pattern.ml
@@ -30,7 +30,9 @@ let logger = Logging.get_logger [ __MODULE__ ]
 
 let adjust_content_for_language (xlang : Xlang.t) (content : string) : string =
   match xlang with
-  | Xlang.L (Lang.Php, _) -> "<?php " ^ content
+  | Xlang.L (Lang.Php, _)
+    when not (content =~ {|[ \t\n]*<\?\(php\|=\)?[ \t\n]+|}) ->
+      "<?php " ^ content
   | __else__ -> content
 
 (* This function adds mvars to a range, but only the mvars which are not already

--- a/src/engine/Metavariable_pattern.ml
+++ b/src/engine/Metavariable_pattern.ml
@@ -32,6 +32,10 @@ let adjust_content_for_language (xlang : Xlang.t) (content : string) : string =
   match xlang with
   | Xlang.L (Lang.Php, _)
     when not (content =~ {|[ \t\n]*<\?\(php\|=\)?[ \t\n]+|}) ->
+      (* THINK:
+         * - Shouldn't the parser just handle the absence of `<?php` ?
+         * - Isn't the `?>` closing needed ?
+      *)
       "<?php " ^ content
   | __else__ -> content
 


### PR DESCRIPTION
PR #5501 adds `<?php` to the content to be parsed as PHP without checking if the `<?php` opening is already present. The PHP parser does not like that.

Closes PA-2696
Follows #5501

test plan:
make test # test added

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
