### PR TITLE
cli: Fix messaging (rename: OSS engine -> within-a-file)

### DIFF
--- a/cli/src/semgrep/formatter/text.py
+++ b/cli/src/semgrep/formatter/text.py
@@ -717,21 +717,23 @@ class TextFormatter(BaseFormatter):
                 else []
             )
 
-            oss_rules = [
+            rules_ran_within_a_file = [
                 with_color(Colors.foreground, rule.value[0].value, bold=True)
                 for rule in rules_by_engine
                 if isinstance(rule.value[1].value, out.OSS)
             ]
 
-            if (extra["engine_requested"].is_interfile) and oss_rules:
+            if (extra["engine_requested"].is_interfile) and rules_ran_within_a_file:
                 console.print(
-                    "Some rules were run as OSS rules because `interfile: true` was not specified."
+                    f"{unit_str(len(rules_ran_within_a_file), 'rule')} ran in a within-a-file fashion."
+                    + " because `interfile: true` was not specified"
                 )
                 if extra.get("verbose_errors"):
-                    console.print("These rules were:\n   " + "   \n   ".join(oss_rules))
-                else:
                     console.print(
-                        f"{unit_str(len(oss_rules), 'rule')} ran with OSS engine (--verbose to see which)"
+                        "These rules were:\n   "
+                        + "   \n   ".join(rules_ran_within_a_file)
                     )
+                else:
+                    console.print("(Use --verbose to see which ones.)")
 
         return captured_output.get()

--- a/cli/src/semgrep/formatter/text.py
+++ b/cli/src/semgrep/formatter/text.py
@@ -725,8 +725,8 @@ class TextFormatter(BaseFormatter):
 
             if (extra["engine_requested"].is_interfile) and rules_ran_within_a_file:
                 console.print(
-                    f"{unit_str(len(rules_ran_within_a_file), 'rule')} ran in a within-a-file fashion."
-                    + " because `interfile: true` was not specified"
+                    f"{unit_str(len(rules_ran_within_a_file), 'rule')} ran in a within-a-file fashion"
+                    + " because `interfile: true` was not specified."
                 )
                 if extra.get("verbose_errors"):
                     console.print(


### PR DESCRIPTION
Semgrep Pro is not only about inter-file analysis, so even if a rule is missing `interfile: true` it is still being ran by the "Pro engine".

Closes PA-2565

test plan:
% semgrep -c p/default-v2 --pro stress-test-monorepo/repos/dokuwiki

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
