### PR TITLE
osemgrep: do not put engine_requested in JSON output

### DIFF
--- a/src/osemgrep/cli_scan/Cli_json_output.ml
+++ b/src/osemgrep/cli_scan/Cli_json_output.ml
@@ -441,13 +441,13 @@ let cli_output_of_core_results ~logging_level ~rules_source
    matches;
    errors;
    skipped_targets;
-   rules_by_engine;
-   engine_requested;
    (* LATER *)
    skipped_rules = _;
    explanations = _;
    stats = _;
    time = _;
+   rules_by_engine = _;
+   engine_requested = _;
   } ->
       let env =
         {
@@ -490,6 +490,6 @@ let cli_output_of_core_results ~logging_level ~rules_source
         (* LATER *)
         time = None;
         explanations = None;
-        rules_by_engine = Some rules_by_engine;
-        engine_requested = Some engine_requested;
+        rules_by_engine = None;
+        engine_requested = None;
       }

--- a/src/osemgrep/main/Main.ml
+++ b/src/osemgrep/main/Main.ml
@@ -3,8 +3,6 @@
    Translated from __main__.py
 *)
 
-open Printf
-
 let register_stdlib_exception_printers () =
   (* Needs to take place after JaneStreet Base does its own registration.
      https://github.com/janestreet/base/issues/146 *)
@@ -16,14 +14,14 @@ let register_stdlib_exception_printers () =
 
 let init () =
   register_stdlib_exception_printers ();
-  Parsing_init.init ()
+  ()
 
 let main () =
   init ();
   let exit_code = CLI.main Sys.argv |> Exit_code.to_int in
   (* TODO: remove or make debug-only *)
   if exit_code <> 0 then
-    eprintf "exiting with error status %i: %s\n%!" exit_code
+    Printf.eprintf "exiting with error status %i: %s\n%!" exit_code
       (String.concat " " (Array.to_list Sys.argv));
   exit exit_code
 


### PR DESCRIPTION
test plan:
make osemgrep-e2e

goes from 107 passed to 165 passed


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)