### PR TITLE
const-prop: Private static variables set once in a static block

### DIFF
--- a/changelog.d/pa-2228.added
+++ b/changelog.d/pa-2228.added
@@ -1,0 +1,3 @@
+Java: Private static variables that are defined just once in a static block,
+even if they are not declared `final`, will be considered as `final` by
+constant-propagation.

--- a/cli/tests/e2e/snapshots/test_metavariable_matching/test_equivalence/results.json
+++ b/cli/tests/e2e/snapshots/test_metavariable_matching/test_equivalence/results.json
@@ -90,6 +90,19 @@
               "line": 14,
               "offset": 261
             },
+            "propagated_value": {
+              "svalue_abstract_content": "request.get(\"unsafe\")",
+              "svalue_end": {
+                "col": 26,
+                "line": 12,
+                "offset": 239
+              },
+              "svalue_start": {
+                "col": 5,
+                "line": 12,
+                "offset": 218
+              }
+            },
             "start": {
               "col": 10,
               "line": 14,

--- a/libs/commons/Gensym.ml
+++ b/libs/commons/Gensym.ml
@@ -35,6 +35,7 @@ module MkId () : sig
   val mk : unit -> t
   val to_int : t -> int
   val unsafe_default : t
+  val is_unsafe_default : t -> bool
   val unsafe_reset_counter : unit -> unit
 end = struct
   open Ppx_hash_lib.Std.Hash.Builtin
@@ -49,5 +50,6 @@ end = struct
 
   let to_int = Fun.id
   let unsafe_default = -1
+  let is_unsafe_default id = id = unsafe_default
   let unsafe_reset_counter () = counter := 0
 end

--- a/libs/commons/Gensym.mli
+++ b/libs/commons/Gensym.mli
@@ -12,6 +12,7 @@ module MkId () : sig
      `unsafe_default`s.
   *)
   val unsafe_default : t
+  val is_unsafe_default : t -> bool
 
   (* This will reset the internal counter used by the identifiers, making `mk`
      generate already-generated identifiers.

--- a/tests/rules/cp_private_class_attr2.java
+++ b/tests/rules/cp_private_class_attr2.java
@@ -1,0 +1,25 @@
+class Test {
+
+    private static int s;
+
+    private int x;
+
+    static {
+        s = 42;
+    }
+
+    public void doSomething1() {
+        x = 42;
+    }
+
+    public void doSomething2(){
+        //ok:test
+        foo(x);
+    }
+
+    public void doSomething3(){
+        //ruleid:test
+        foo(s);
+    }
+
+}

--- a/tests/rules/cp_private_class_attr2.yaml
+++ b/tests/rules/cp_private_class_attr2.yaml
@@ -1,0 +1,7 @@
+rules:
+  - id: test
+    severity: ERROR
+    message: Test
+    languages:
+      - java
+    pattern: foo(42)

--- a/tests/rules/sym_prop_class_attr.java
+++ b/tests/rules/sym_prop_class_attr.java
@@ -1,0 +1,31 @@
+package example;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.ParserConfigurationException;
+
+class BadDocumentBuilderFactoryStatic {
+
+    private static DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+
+    public void doSomething(){
+        //ruleid:documentbuilderfactory-disallow-doctype-decl-missing
+        dbf.newDocumentBuilder();
+    }
+
+}
+
+class BadDocumentBuilderFactoryStatic {
+
+    private static DocumentBuilderFactory dbf;
+
+    static {
+        dbf = DocumentBuilderFactory.newInstance();
+    }
+
+    public void doSomething(){
+        //ruleid:documentbuilderfactory-disallow-doctype-decl-missing
+        dbf.newDocumentBuilder();
+    }
+
+}

--- a/tests/rules/sym_prop_class_attr.yaml
+++ b/tests/rules/sym_prop_class_attr.yaml
@@ -1,0 +1,16 @@
+rules:
+  - id: documentbuilderfactory-disallow-doctype-decl-missing
+    options:
+      symbolic_propagation: true
+    severity: ERROR
+    message: Test.
+    mode: taint
+    pattern-sources:
+      - pattern: |
+          DocumentBuilderFactory.newInstance();
+    pattern-sinks:
+      - patterns:
+          - pattern: $FACTORY.newDocumentBuilder();
+    languages:
+      - java
+


### PR DESCRIPTION
They will be considered like `final` for constant-propagation purposes, for now just in Java.

Closes PA-2228

test plan:
make test # tests added

PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
