### PR TITLE
new libs/gitignore/ lib, part 1

### DIFF
--- a/libs/gitignore/Git_path.ml
+++ b/libs/gitignore/Git_path.ml
@@ -5,7 +5,15 @@
 open Printf
 open File.Operators
 
+(*****************************************************************************)
+(* Types *)
+(*****************************************************************************)
+
 type t = { string : string; segments : string list }
+
+(*****************************************************************************)
+(* Helpers *)
+(*****************************************************************************)
 
 let of_string string =
   let segments =
@@ -151,12 +159,20 @@ let remove_prefix root path =
       in
       Some rel_path
 
+(*****************************************************************************)
+(* Entry point *)
+(*****************************************************************************)
+
 let in_project ~root path =
   match remove_prefix root path with
   | None ->
       Error
         (sprintf "cannot make path %S relative to project root %S" !!path !!root)
   | Some path -> path |> of_fpath |> make_absolute |> normalize
+
+(*****************************************************************************)
+(* Inline tests *)
+(*****************************************************************************)
 
 let () =
   Testutil.test "Git_path" (fun () ->

--- a/libs/gitignore/Git_path.mli
+++ b/libs/gitignore/Git_path.mli
@@ -9,6 +9,20 @@
 
 type t = private { string : string; segments : string list }
 
+(*
+   Return an absolute, normalized git path relative to the project root.
+   This is purely syntactic. It is recommended to work on physical paths
+   as returned by 'realpath' to ensure that both paths share the longest
+   common prefix.
+
+     in_project ~root:(Fpath.v "/a") (Fpath.v "/a/b/c")
+
+   equals
+
+     Ok (Git_path.of_string "/b/c")
+*)
+val in_project : root:Fpath.t -> Fpath.t -> (t, string) result
+
 (* A slash-separated path. *)
 val of_string : string -> t
 val to_string : t -> string
@@ -50,17 +64,3 @@ val to_fpath : root:Fpath.t -> t -> Fpath.t
 
 (* / *)
 val root : t
-
-(*
-   Return an absolute, normalized git path relative to the project root.
-   This is purely syntactic. It is recommended to work on physical paths
-   as returned by 'realpath' to ensure that both paths share the longest
-   common prefix.
-
-     in_project ~root:(Fpath.v "/a") (Fpath.v "/a/b/c")
-
-   equals
-
-     Ok (Git_path.of_string "/b/c")
-*)
-val in_project : root:Fpath.t -> Fpath.t -> (t, string) result

--- a/libs/gitignore/Git_project.ml
+++ b/libs/gitignore/Git_project.ml
@@ -6,7 +6,7 @@
 
 open File.Operators
 
-let is_git_root path =
+let is_git_root (path : Fpath.t) : bool =
   match (Unix.stat !!(path / ".git")).st_kind with
   | S_DIR -> true
   | _ -> false

--- a/libs/gitignore/Git_project.mli
+++ b/libs/gitignore/Git_project.mli
@@ -24,17 +24,6 @@ val find_git_project_root : Fpath.t -> (Fpath.t * Git_path.t) option
 
 type kind = Git_project | Other_project [@@deriving show]
 
-(* The default value of '?fallback_project_root' *)
-val default_project_root : Fpath.t
-
-(*
-   Provide a similar result as 'find_git_project_root' but don't look
-   for a git project root. Instead, use the project root provided
-   by 'project_root' which defaults to the current directory.
-*)
-val force_project_root :
-  ?project_root:Fpath.t -> Fpath.t -> Fpath.t * Git_path.t
-
 (*
    Find a project root even if the given path is not within a git project.
 
@@ -56,3 +45,14 @@ val find_any_project_root :
   ?force_root:kind * Fpath.t ->
   Fpath.t ->
   kind * Fpath.t * Git_path.t
+
+(* The default value of '?fallback_project_root' *)
+val default_project_root : Fpath.t
+
+(*
+   Provide a similar result as 'find_git_project_root' but don't look
+   for a git project root. Instead, use the project root provided
+   by 'project_root' which defaults to the current directory.
+*)
+val force_project_root :
+  ?project_root:Fpath.t -> Fpath.t -> Fpath.t * Git_path.t

--- a/libs/gitignore/Gitignore_level.ml
+++ b/libs/gitignore/Gitignore_level.ml
@@ -13,5 +13,5 @@ type t = {
   (* Informational text indicating where the gitignore patterns came from *)
   source_name : string;
   (* Sequence of path selectors derived from gitignore patterns *)
-  patterns : Gitignore_syntax.path_selector list;
+  patterns : Gitignore_syntax.t;
 }

--- a/libs/gitignore/Gitignore_syntax.ml
+++ b/libs/gitignore/Gitignore_syntax.ml
@@ -6,6 +6,10 @@
 
 module M = Glob_matcher
 
+(*****************************************************************************)
+(* Types *)
+(*****************************************************************************)
+
 type selection_event = Selected of M.loc | Deselected of M.loc
 
 type path_selector = {
@@ -14,6 +18,10 @@ type path_selector = {
 }
 
 type t = path_selector list
+
+(*****************************************************************************)
+(* Dumpers *)
+(*****************************************************************************)
 
 let show_selection_event x =
   match x with
@@ -25,6 +33,10 @@ let show_selection_events xs =
   List.rev xs
   |> Common.map (fun x -> show_selection_event x ^ "\n")
   |> String.concat ""
+
+(*****************************************************************************)
+(* Parser *)
+(*****************************************************************************)
 
 let read_lines_from_string =
   (*
@@ -110,6 +122,10 @@ let parse_line ~anchor source_name source_kind line_number line_contents =
       | false -> None
     in
     Some { loc; matcher }
+
+(*****************************************************************************)
+(* Entry points *)
+(*****************************************************************************)
 
 let from_string ~anchor ~name ~kind str =
   let lines = read_lines_from_string str in

--- a/libs/gitignore/Gitignore_syntax.mli
+++ b/libs/gitignore/Gitignore_syntax.mli
@@ -2,7 +2,22 @@
    Implement the full gitignore syntax
 
    https://git-scm.com/docs/gitignore
+
+   This is mostly the syntax supported by ../globbing/ with the addition
+   of negator (!) at the beginning of a line to "deselect" a file.
 *)
+
+(* content of a .gitignore *)
+type t = path_selector list
+
+and path_selector = {
+  loc : Glob_matcher.loc;
+  (* The matcher tells whether a given path matches the pattern.
+     For example, the pattern '/f*' matches the path '/foo'.
+
+     The result comes with a selection event in case of a match. *)
+  matcher : Git_path.t -> selection_event option;
+}
 
 (*
    An event representing where a pattern matched a path. The sequence
@@ -14,7 +29,7 @@
    - Deselected: deselect the file (= don't ignore it for git purposes)
      e.g. a file deselected via '!generated/main.c'
 *)
-type selection_event =
+and selection_event =
   | Selected of Glob_matcher.loc
   | Deselected of Glob_matcher.loc
 
@@ -25,18 +40,6 @@ val show_selection_event : selection_event -> string
    (unlike the list which has the most recent first).
 *)
 val show_selection_events : selection_event list -> string
-
-(* Path selector. *)
-type path_selector = {
-  loc : Glob_matcher.loc;
-  (* The matcher tells whether a given path matches the pattern.
-     For example, the pattern '/f*' matches the path '/foo'.
-
-     The result comes with a selection event in case of a match. *)
-  matcher : Git_path.t -> selection_event option;
-}
-
-type t = path_selector list
 
 (* Parsing functions. They will raise exceptions if the input is malformed.
 
@@ -50,7 +53,7 @@ val from_string :
 
 val from_file : anchor:Glob_matcher.pattern -> kind:string -> Fpath.t -> t
 
-(*
+(* Internals.
    Remove the leading exclamation mark from the string, returning
    'Some new_string' if successful, 'None' otherwise.
 *)

--- a/libs/gitignore/dune
+++ b/libs/gitignore/dune
@@ -1,0 +1,12 @@
+; parse and match .gitignore files
+; TODO? Git_project.ml and Git_path.ml could be in a separate library
+; but simpler to put everything together for now
+(library
+  (public_name gitignore)
+  (name gitignore)
+  (wrapped false)
+  (libraries
+    globbing
+  )
+  (preprocess (pps ppx_deriving.show))
+)

--- a/src/osemgrep/targeting/dune
+++ b/src/osemgrep/targeting/dune
@@ -11,6 +11,7 @@
     commons
     fpath
     globbing
+    gitignore
   )
   (preprocess (pps ppx_deriving.show))
 )


### PR DESCRIPTION
This was also in src/osemgrep/targeting/ but is independent
of (o)semgrep and could be used in other projects, hence the
move to libs/

test plan:
make core


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)