### PR TITLE
fix: Bump timeout for semgrep install-semgrep-pro

### DIFF
--- a/changelog.d/timeout.fixed
+++ b/changelog.d/timeout.fixed
@@ -1,0 +1,1 @@
+Increase timeout for `semgrep install-semgrep-pro` to avoid failures when the download is slow.

--- a/cli/src/semgrep/commands/install.py
+++ b/cli/src/semgrep/commands/install.py
@@ -78,7 +78,7 @@ def run_install_semgrep_pro() -> None:
 
     semgrep_pro_path_tmp = semgrep_pro_path.with_suffix(".tmp_download")
 
-    with state.app_session.get(url, timeout=60, stream=True) as r:
+    with state.app_session.get(url, timeout=180, stream=True) as r:
         if r.status_code == 401:
             logger.info(
                 "API token not valid. Try to run `semgrep logout` and `semgrep login` again."


### PR DESCRIPTION
We've been seeing this time out occasionally, with very low download speeds. It seems like there is an issue on the server side causing this. But, for now, let's bump the timeout to avoid failing when this happens.

Test plan: `semgrep install-semgrep-pro`

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
