### PR TITLE
osemgrep: wrap, colorize, bold

### DIFF
--- a/semgrep.opam
+++ b/semgrep.opam
@@ -60,6 +60,7 @@ depends: [
   "parmap"
   "uri"
   "http-lwt-client" # this brings lots of dependencies. This is for osemgrep.
+  "terminal_size"
   "lsp" {= "1.7.0"}
   "visitors" {= "20210608"}
   "js_of_ocaml" {= "5.1.1"}

--- a/src/osemgrep/reporting/dune
+++ b/src/osemgrep/reporting/dune
@@ -5,6 +5,7 @@
  (libraries
    commons
    fmt
+   terminal_size
    semgrep.reporting
  )
  (preprocess


### PR DESCRIPTION
I think there's still some issue when "ellipsis_string" is used, but it's too late to fix that up.... in any case, should be good to be merged, and can be fixed subsequently.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
