### PR TITLE
misc: small fix for ocaml 4.12.0

### DIFF
--- a/languages/scala/generic/scala_to_generic.ml
+++ b/languages/scala/generic/scala_to_generic.ml
@@ -153,7 +153,7 @@ and v_wildcard_selector tk path (x : wildcard_selector) =
         | None -> []
         | Some ty -> [ G.T (v_type_ ty) ]
       in
-      OtherDirective (("ImportGiven", tok), anys) |> G.d
+      G.OtherDirective (("ImportGiven", tok), anys) |> G.d
 
 and v_import_spec tk path = function
   | ImportNamed v1 -> [ v_named_selector tk path v1 ]
@@ -528,7 +528,7 @@ and v_type_case_clause v : G.case_and_body =
         | Right ty -> PatType ty
       in
       G.CasesAndBody
-        ([ Case (icase, pat) ], OtherStmt (OS_Todo, [ G.T r_ty ]) |> G.s)
+        ([ Case (icase, pat) ], G.OtherStmt (OS_Todo, [ G.T r_ty ]) |> G.s)
   | CaseEllipsis ii -> G.CaseEllipsis ii
 
 and v_case_clause v : G.case_and_body =

--- a/src/experiments/misc/dune
+++ b/src/experiments/misc/dune
@@ -3,7 +3,6 @@
  (name semgrep_experiments_misc)
  (wrapped false)
  (libraries
-   camlp-streams
    commons
    lib_parsing
    pfff-lang_GENERIC-analyze


### PR DESCRIPTION
test plan:
opam switch 4.12.0
eval $(opam env)
make core


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)