### PR TITLE
cli: Sort output to so that it's easier to compare between runs

### DIFF
--- a/changelog.d/pa-2700.changed
+++ b/changelog.d/pa-2700.changed
@@ -1,0 +1,2 @@
+The different lists of skipped files output by Semgrep when given --verbose will
+now be sorted, to make it easier to `diff` the outputs of two runs.

--- a/cli/src/semgrep/ignores.py
+++ b/cli/src/semgrep/ignores.py
@@ -98,7 +98,7 @@ class FileIgnore:
         )
 
     def filter_paths(self, *, candidates: Iterable[Path]) -> FilteredFiles:
-        kept, removed = partition(candidates, self._filter)
+        kept, removed = partition(sorted(candidates), self._filter)
         return FilteredFiles(frozenset(kept), frozenset(removed))
 
     @classmethod

--- a/cli/src/semgrep/target_manager.py
+++ b/cli/src/semgrep/target_manager.py
@@ -236,7 +236,7 @@ class FileTargetingLog:
 
         yield 1, "Always skipped by Semgrep:"
         if self.always_skipped:
-            for path in self.always_skipped:
+            for path in sorted(self.always_skipped):
                 yield 2, with_color(Colors.cyan, str(path))
         else:
             yield 2, "<none>"
@@ -252,21 +252,21 @@ class FileTargetingLog:
         yield 1, "Skipped by .semgrepignore:"
         yield 1, "(See: https://semgrep.dev/docs/ignoring-files-folders-code/#understanding-semgrep-defaults)"
         if self.semgrepignored:
-            for path in self.semgrepignored:
+            for path in sorted(self.semgrepignored):
                 yield 2, with_color(Colors.cyan, str(path))
         else:
             yield 2, "<none>"
 
         yield 1, "Skipped by --include patterns:"
         if self.cli_includes:
-            for path in self.cli_includes:
+            for path in sorted(self.cli_includes):
                 yield 2, with_color(Colors.cyan, str(path))
         else:
             yield 2, "<none>"
 
         yield 1, "Skipped by --exclude patterns:"
         if self.cli_excludes:
-            for path in self.cli_excludes:
+            for path in sorted(self.cli_excludes):
                 yield 2, with_color(Colors.cyan, str(path))
         else:
             yield 2, "<none>"
@@ -274,14 +274,14 @@ class FileTargetingLog:
         yield 1, f"Skipped by limiting to files smaller than {self.target_manager.max_target_bytes} bytes:"
         yield 1, "(Adjust with the --max-target-bytes flag)"
         if self.size_limit:
-            for path in self.size_limit:
+            for path in sorted(self.size_limit):
                 yield 2, with_color(Colors.cyan, str(path))
         else:
             yield 2, "<none>"
 
         yield 1, "Skipped by analysis failure due to parsing or internal Semgrep error"
         if self.core_failure_lines_by_file:
-            for path, lines in self.core_failure_lines_by_file.items():
+            for path, lines in sorted(self.core_failure_lines_by_file.items()):
                 if lines is None:
                     skipped = "all"
                 else:

--- a/cli/tests/e2e/snapshots/test_exclude_include/test_exclude_include_verbose_sorted_1/results.err
+++ b/cli/tests/e2e/snapshots/test_exclude_include/test_exclude_include_verbose_sorted_1/results.err
@@ -1,0 +1,65 @@
+running 4 rules from 1 config rules/eqeq.yaml_0
+No .semgrepignore found. Using default .semgrepignore rules. See the docs for the list of default ignores: https://semgrep.dev/docs/cli-usage/#ignoring-files
+Rules:
+- rules.assert-eqeq-is-ok
+- rules.eqeq-is-bad
+- rules.javascript-basic-eqeq-bad
+- rules.python37-compatability-os-module
+               
+               
+┌─────────────┐
+│ Scan Status │
+└─────────────┘
+  Scanning 5 files tracked by git with 4 Code rules:
+  Nothing to scan.
+
+========================================
+Files skipped:
+========================================
+
+  Always skipped by Semgrep:
+
+   • <none>
+
+  Skipped by .gitignore:
+  (Disable by passing --no-git-ignore)
+
+   • <all files not listed by `git ls-files` were skipped>
+
+  Skipped by .semgrepignore:
+  (See: https://semgrep.dev/docs/ignoring-files-folders-code/#understanding-semgrep-defaults)
+
+   • <none>
+
+  Skipped by --include patterns:
+
+   • <none>
+
+  Skipped by --exclude patterns:
+
+   • targets/exclude_include/excluded/excluded.js
+   • targets/exclude_include/excluded/included.js
+   • targets/exclude_include/included/excluded.js
+   • targets/exclude_include/included/included.js
+
+  Skipped by limiting to files smaller than 1000000 bytes:
+  (Adjust with the --max-target-bytes flag)
+
+   • <none>
+
+  Skipped by analysis failure due to parsing or internal Semgrep error
+
+   • <none>
+
+                
+                
+┌──────────────┐
+│ Scan Summary │
+└──────────────┘
+Some files were skipped or only partially analyzed.
+  Scan was limited to files tracked by git.
+  Scan skipped: 4 files matching --exclude patterns
+  For a full list of skipped files, run semgrep with the --verbose flag.
+
+Ran 4 rules on 0 files: 0 findings.
+Not sending pseudonymous metrics since metrics are configured to OFF and registry usage is False

--- a/cli/tests/e2e/snapshots/test_exclude_include/test_exclude_include_verbose_sorted_2/results.err
+++ b/cli/tests/e2e/snapshots/test_exclude_include/test_exclude_include_verbose_sorted_2/results.err
@@ -1,0 +1,75 @@
+running 1 rules from 1 config rules/nosem.yaml_0
+No .semgrepignore found. Using default .semgrepignore rules. See the docs for the list of default ignores: https://semgrep.dev/docs/cli-usage/#ignoring-files
+Rules:
+- rules.test-nosem
+               
+               
+┌─────────────┐
+│ Scan Status │
+└─────────────┘
+  Scanning 23 files tracked by git with 1 Code rule:
+  Nothing to scan.
+
+========================================
+Files skipped:
+========================================
+
+  Always skipped by Semgrep:
+
+   • <none>
+
+  Skipped by .gitignore:
+  (Disable by passing --no-git-ignore)
+
+   • <all files not listed by `git ls-files` were skipped>
+
+  Skipped by .semgrepignore:
+  (See: https://semgrep.dev/docs/ignoring-files-folders-code/#understanding-semgrep-defaults)
+
+   • <none>
+
+  Skipped by --include patterns:
+
+   • <none>
+
+  Skipped by --exclude patterns:
+
+   • targets/basic/inside.py
+   • targets/basic/metavariable-comparison-bad-content.py
+   • targets/basic/metavariable-comparison-base.py
+   • targets/basic/metavariable-comparison-strip.py
+   • targets/basic/metavariable-comparison.py
+   • targets/basic/metavariable-regex-multi-regex.py
+   • targets/basic/metavariable-regex-multi-rule.py
+   • targets/basic/metavariable-regex.py
+   • targets/basic/nested-patterns.js
+   • targets/basic/nosem.c
+   • targets/basic/nosem.go
+   • targets/basic/nosem.java
+   • targets/basic/nosem.js
+   • targets/basic/nosem.py
+   • targets/basic/regex.py
+   • targets/basic/stupid.js
+   • targets/basic/stupid.py
+
+  Skipped by limiting to files smaller than 1000000 bytes:
+  (Adjust with the --max-target-bytes flag)
+
+   • <none>
+
+  Skipped by analysis failure due to parsing or internal Semgrep error
+
+   • <none>
+
+                
+                
+┌──────────────┐
+│ Scan Summary │
+└──────────────┘
+Some files were skipped or only partially analyzed.
+  Scan was limited to files tracked by git.
+  Scan skipped: 17 files matching --exclude patterns
+  For a full list of skipped files, run semgrep with the --verbose flag.
+
+Ran 1 rule on 0 files: 0 findings.
+Not sending pseudonymous metrics since metrics are configured to OFF and registry usage is False

--- a/cli/tests/e2e/test_exclude_include.py
+++ b/cli/tests/e2e/test_exclude_include.py
@@ -1,6 +1,8 @@
 import pytest
 from tests.fixtures import RunSemgrep
 
+from semgrep.constants import OutputFormat
+
 
 def idfn(options):
     return "-and-".join(flag.strip("-") for flag in options if flag.startswith("--"))
@@ -34,3 +36,31 @@ def test_exclude_include(run_semgrep_in_tmp: RunSemgrep, snapshot, options):
     )
     snapshot.assert_match(stdout, "results.json")
     snapshot.assert_match(stderr, "err.out")
+
+
+@pytest.mark.kinda_slow
+def test_exclude_include_verbose_sorted_1(run_semgrep_in_tmp: RunSemgrep, snapshot):
+    snapshot.assert_match(
+        run_semgrep_in_tmp(
+            "rules/eqeq.yaml",
+            options=["--exclude", "excluded.*", "--exclude", "included.*", "--verbose"],
+            output_format=OutputFormat.TEXT,
+            target_name="exclude_include",
+            assert_exit_code=None,
+        ).stderr,
+        "results.err",
+    )
+
+
+@pytest.mark.kinda_slow
+def test_exclude_include_verbose_sorted_2(run_semgrep_in_tmp: RunSemgrep, snapshot):
+    snapshot.assert_match(
+        run_semgrep_in_tmp(
+            "rules/nosem.yaml",
+            options=["--exclude", "*.*", "--verbose"],
+            output_format=OutputFormat.TEXT,
+            target_name="basic",
+            assert_exit_code=None,
+        ).stderr,
+        "results.err",
+    )


### PR DESCRIPTION
test plan:
Run `semgrep -c p/default-v2 --verbose` twice on the same repo and diff the output

test plan:
make test # tests added

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
