### PR TITLE
fix: use correct env var for referencing new brew fork location

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -265,6 +265,9 @@ jobs:
     name: Update on Homebrew-Core
     needs: [dry-run, sleep-before-homebrew] # Needs to run after pypi released so brew can update pypi dependency hashes
     runs-on: macos-12
+    env:
+      R2C_HOMEBREW_CORE_OWNER: semgrep-release
+      R2C_HOMEBREW_CORE_FORK_HTTPS_URL: https://github.com/semgrep-release/homebrew-core.git
     steps:
       - name: Get the version
         id: get-version
@@ -303,7 +306,6 @@ jobs:
       - name: Prepare Branch
         env:
           GITHUB_TOKEN: ${{ secrets.SEMGREP_HOMEBREW_RELEASE_PAT }}
-          R2C_HOMEBREW_CORE_FORK_HTTPS_URL: https://github.com/semgrep-release/homebrew-core.git
         run: |
           cd "$(brew --repository)/Library/Taps/homebrew/homebrew-core"
           git status
@@ -325,7 +327,6 @@ jobs:
       - name: Push to Fork
         env:
           GITHUB_TOKEN: ${{ secrets.SEMGREP_HOMEBREW_RELEASE_PAT }}
-          R2C_HOMEBREW_CORE_OWNER: returntocorp
         if: ${{ !contains(github.ref, '-test-release') && needs.dry-run.outputs.dry-run != 'true' }}
         run: |
           gh pr create --repo homebrew/homebrew-core \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -265,9 +265,6 @@ jobs:
     name: Update on Homebrew-Core
     needs: [dry-run, sleep-before-homebrew] # Needs to run after pypi released so brew can update pypi dependency hashes
     runs-on: macos-12
-    env:
-      R2C_HOMEBREW_CORE_OWNER: semgrep-release
-      R2C_HOMEBREW_CORE_FORK_HTTPS_URL: https://github.com/semgrep-release/homebrew-core.git
     steps:
       - name: Get the version
         id: get-version
@@ -306,6 +303,7 @@ jobs:
       - name: Prepare Branch
         env:
           GITHUB_TOKEN: ${{ secrets.SEMGREP_HOMEBREW_RELEASE_PAT }}
+          R2C_HOMEBREW_CORE_FORK_HTTPS_URL: https://github.com/semgrep-release/homebrew-core.git
         run: |
           cd "$(brew --repository)/Library/Taps/homebrew/homebrew-core"
           git status
@@ -327,6 +325,7 @@ jobs:
       - name: Push to Fork
         env:
           GITHUB_TOKEN: ${{ secrets.SEMGREP_HOMEBREW_RELEASE_PAT }}
+          R2C_HOMEBREW_CORE_OWNER: semgrep-release
         if: ${{ !contains(github.ref, '-test-release') && needs.dry-run.outputs.dry-run != 'true' }}
         run: |
           gh pr create --repo homebrew/homebrew-core \


### PR DESCRIPTION
[Release failed when we switched over to using a personal account for opening brew PRs.](https://github.com/returntocorp/semgrep/actions/runs/4702193871/jobs/8339806665). This PR standardizes the naming such that a PR will be opened from `semgrep-release` fork, not returntocorp.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
