### PR TITLE
core: generic AST: Add id_info to New constructor

### DIFF
--- a/languages/c/generic/c_to_generic.ml
+++ b/languages/c/generic/c_to_generic.ml
@@ -274,7 +274,12 @@ and expr e =
       G.Record v1 |> G.e
   | GccConstructor (v1, v2) ->
       let v1 = type_ v1 and v2 = expr v2 in
-      G.New (unsafe_fake "new", v1, fb ([ v2 ] |> Common.map G.arg)) |> G.e
+      G.New
+        ( unsafe_fake "new",
+          v1,
+          G.empty_id_info (),
+          fb ([ v2 ] |> Common.map G.arg) )
+      |> G.e
   | TypedMetavar (v1, v2) ->
       let v1 = name v1 in
       let v2 = type_ v2 in

--- a/languages/cpp/generic/cpp_to_generic.ml
+++ b/languages/cpp/generic/cpp_to_generic.ml
@@ -455,10 +455,12 @@ and map_expr env x : G.expr =
       and lbrace, xs, rbrace =
         map_brace env (map_of_list (map_initialiser env)) v2
       in
-      G.New (lpar, t, (lbrace, xs |> Common.map G.arg, rbrace)) |> G.e
+      G.New
+        (lpar, t, G.empty_id_info (), (lbrace, xs |> Common.map G.arg, rbrace))
+      |> G.e
   | ConstructedObject (v1, v2) ->
       let t = map_type_ env v1 and l, args, r = map_obj_init env v2 in
-      G.New (PI.fake_info l "new", t, (l, args, r)) |> G.e
+      G.New (PI.fake_info l "new", t, G.empty_id_info (), (l, args, r)) |> G.e
   | TypeId (v1, v2) ->
       let v1 = map_tok env v1
       and _l, either, _r =
@@ -484,7 +486,7 @@ and map_expr env x : G.expr =
         | None -> PI.unsafe_fake_bracket []
         | Some (l, args, r) -> (l, args, r)
       in
-      G.New (v2, v4, (l, args, r)) |> G.e
+      G.New (v2, v4, G.empty_id_info (), (l, args, r)) |> G.e
   | Delete (v1, v2, v3, v4) ->
       let _topqualifierTODO = map_of_option (map_tok env) v1
       and v2 = map_tok env v2

--- a/languages/csharp/generic/Parse_csharp_tree_sitter.ml
+++ b/languages/csharp/generic/Parse_csharp_tree_sitter.ml
@@ -263,7 +263,11 @@ let new_index_from_end tok expr =
     H2.name_of_ids [ ("System", fake "System"); ("Index", fake "Index") ]
   in
   let index = TyN name |> G.t in
-  New (tok, index, fb [ Arg expr; Arg (L (Bool (true, fake "true")) |> G.e) ])
+  New
+    ( tok,
+      index,
+      empty_id_info (),
+      fb [ Arg expr; Arg (L (Bool (true, fake "true")) |> G.e) ] )
   |> G.e
 
 module List = struct
@@ -1246,7 +1250,7 @@ and expression (env : env) (x : CST.expression) : G.expr =
       in
       let lb, _, rb = v3 in
       let args = (lb, [ Arg (G.Container (G.Tuple, v3) |> G.e) ], rb) in
-      New (v1, v2, args) |> G.e
+      New (v1, v2, empty_id_info (), args) |> G.e
   | `As_exp (v1, v2, v3) ->
       let v1 = expression env v1 in
       let v2 = token env v2 (* "as" *) in
@@ -1387,7 +1391,7 @@ and expression (env : env) (x : CST.expression) : G.expr =
       in
       let lp, v3', rp = v3 in
       let args = (lp, v3' @ [ Arg (Container (Tuple, v4) |> G.e) ], rp) in
-      New (v1, v2, args) |> G.e
+      New (v1, v2, empty_id_info (), args) |> G.e
   | `Paren_exp x -> parenthesized_expression env x
   | `Post_un_exp x -> postfix_unary_expression env x
   | `Prefix_un_exp x -> prefix_unary_expression env x

--- a/languages/elixir/generic/Parse_elixir_tree_sitter.ml
+++ b/languages/elixir/generic/Parse_elixir_tree_sitter.ml
@@ -1060,7 +1060,8 @@ and map_expression (env : env) (x : CST.expression) : expr =
       | Some (Left id) ->
           let n = H2.name_of_id id in
           let ty = TyN n |> G.t in
-          New (tpercent, ty, (l, Common.map G.arg xs, r)) |> G.e
+          New (tpercent, ty, empty_id_info (), (l, Common.map G.arg xs, r))
+          |> G.e
       | Some (Right e) -> Call (e, (l, Common.map G.arg xs, r)) |> G.e)
   | `Un_op x -> map_unary_operator env x
   | `Bin_op x -> map_binary_operator env x

--- a/languages/go/generic/go_to_generic.ml
+++ b/languages/go/generic/go_to_generic.ml
@@ -274,7 +274,7 @@ let top_func () =
     | CompositeLit (v1, v2) ->
         let v1 = type_ v1
         and l, v2, r = bracket (list init_for_composite_lit) v2 in
-        G.New (fake l "new", v1, (l, v2, r))
+        G.New (fake l "new", v1, G.empty_id_info (), (l, v2, r))
     | Slice (v1, (t1, v2, t2)) ->
         let e = expr v1 in
         let v1, v2, v3 = v2 in

--- a/languages/java/generic/java_to_generic.ml
+++ b/languages/java/generic/java_to_generic.ml
@@ -274,7 +274,7 @@ and expr e =
       and v2 = list argument v2
       and v3 = option (bracket decls) v3 in
       match v3 with
-      | None -> G.New (v0, v1, (lp, v2, rp))
+      | None -> G.New (v0, v1, G.empty_id_info (), (lp, v2, rp))
       | Some decls ->
           let anonclass =
             G.AnonClass
@@ -302,8 +302,8 @@ and expr e =
       in
       let t = mk_array (v3 + List.length v2) in
       match v4 with
-      | None -> G.New (v0, t, fb v2)
-      | Some e -> G.New (v0, t, fb (G.Arg e :: v2)))
+      | None -> G.New (v0, t, G.empty_id_info (), fb v2)
+      | Some e -> G.New (v0, t, G.empty_id_info (), fb (G.Arg e :: v2)))
   (* x.new Y(...) {...} *)
   | NewQualifiedClass (v0, _tok1, tok2, v2, v3, v4) ->
       let v0 = expr v0

--- a/languages/javascript/generic/js_to_generic.ml
+++ b/languages/javascript/generic/js_to_generic.ml
@@ -319,7 +319,7 @@ and expr (x : expr) =
       let tok = info tok in
       let e = expr e in
       let args = bracket (list (fun arg -> G.Arg (expr arg))) args in
-      G.New (tok, H.expr_to_type e, args)
+      G.New (tok, H.expr_to_type e, G.empty_id_info (), args)
   | Arr v1 ->
       let v1 = bracket (list expr) v1 in
       G.Container (G.Array, v1)

--- a/languages/ocaml/generic/ml_to_generic.ml
+++ b/languages/ocaml/generic/ml_to_generic.ml
@@ -335,7 +335,7 @@ and expr e =
       )
   | New (v1, v2) ->
       let v1 = tok v1 and v2 = name v2 in
-      G.New (v1, G.TyN v2 |> G.t, fb [])
+      G.New (v1, G.TyN v2 |> G.t, G.empty_id_info (), fb [])
   | ObjAccess (v1, t, v2) ->
       let v1 = expr v1 and v2 = ident v2 in
       let t = tok t in

--- a/languages/php/generic/php_to_generic.ml
+++ b/languages/php/generic/php_to_generic.ml
@@ -292,7 +292,7 @@ and expr e : G.expr =
   | New (v0, v1, v2) ->
       let v1 = expr v1 and v2 = list argument v2 in
       let t = H.expr_to_type v1 in
-      G.New (v0, t, fb v2) |> G.e
+      G.New (v0, t, G.empty_id_info (), fb v2) |> G.e
   | NewAnonClass (_tTODO, args, cdef) ->
       let _ent, cdef = class_def cdef in
       let args = list argument args in

--- a/languages/scala/generic/scala_to_generic.ml
+++ b/languages/scala/generic/scala_to_generic.ml
@@ -465,7 +465,7 @@ and v_expr e : G.expr =
             | None -> PI.unsafe_fake_bracket []
             | Some args -> args
           in
-          G.New (v1, tp, args) |> G.e
+          G.New (v1, tp, G.empty_id_info (), args) |> G.e
       | _ ->
           let cl = G.AnonClass v2 |> G.e in
           G.Call (cl, fb []) |> G.e)

--- a/languages/solidity/generic/Parse_solidity_tree_sitter.ml
+++ b/languages/solidity/generic/Parse_solidity_tree_sitter.ml
@@ -1414,8 +1414,9 @@ and map_primary_expression (env : env) (x : CST.primary_expression) : expr =
         | None -> None
       in
       match argsopt with
-      | None -> New (tnew, t, fb []) |> G.e
-      | Some (lp, es, rp) -> New (tnew, t, (lp, es, rp)) |> G.e)
+      | None -> New (tnew, t, empty_id_info (), fb []) |> G.e
+      | Some (lp, es, rp) ->
+          New (tnew, t, empty_id_info (), (lp, es, rp)) |> G.e)
 
 and map_return_parameters (env : env)
     ((v0, v1, v2, v3, v4, v5) : CST.return_parameters) : type_ =

--- a/languages/swift/generic/Parse_swift_tree_sitter.ml
+++ b/languages/swift/generic/Parse_swift_tree_sitter.ml
@@ -3040,7 +3040,7 @@ and map_unary_expression (env : env) (x : CST.unary_expression) : G.expr =
         | `User_type x -> map_user_type env x
       in
       let v2 = map_constructor_suffix env v2 in
-      G.New (G.fake "new", v1, v2) |> G.e
+      G.New (G.fake "new", v1, G.empty_id_info (), v2) |> G.e
   | `Navi_exp x -> map_navigation_expression env x
   | `Prefix_exp (v1, v2) ->
       let e = map_expression env v2 in

--- a/languages/tree-sitter-to-generic/Parse_hack_tree_sitter.ml
+++ b/languages/tree-sitter-to-generic/Parse_hack_tree_sitter.ml
@@ -1600,7 +1600,7 @@ and expression (env : env) (x : CST.expression) : G.expr =
             | None -> None
           in
           let v4 = arguments env v4 in
-          G.New (tnew, ty, v4) |> G.e
+          G.New (tnew, ty, G.empty_id_info (), v4) |> G.e
       | `Incl_exp (v1, v2) ->
           (* Q: See question below in Requ *)
           let v1 =

--- a/libs/ast_generic/AST_generic.ml
+++ b/libs/ast_generic/AST_generic.ml
@@ -169,7 +169,7 @@
  * to correspond mostly to Semgrep versions. So version below can jump from
  * "1.12.1" to "1.20.0" and that's fine.
  *)
-let version = "1.12.1"
+let version = "1.19.0"
 
 (* Provide hash_* and hash_fold_* for the core ocaml types *)
 open Ppx_hash_lib.Std.Hash.Builtin
@@ -587,6 +587,7 @@ and expr_kind =
   (* operators and function application *)
   | Call of expr * arguments
   (* 'type_' below is usually a TyN or TyArray (or TyExpr).
+   * 'id_info' refers to the constructor.
    * Note that certain languages do not have a 'new' keyword
    * (e.g., Python, Scala 3), instead certain 'Call' are really 'New'.
    * old: this is used to be an IdSpecial used in conjunction with
@@ -594,7 +595,7 @@ and expr_kind =
    * New is really important for typing (and other program analysis).
    * note: see also AnonClass which is also a New.
    *)
-  | New of tok (* 'new' (can be fake) *) * type_ * arguments
+  | New of tok (* 'new' (can be fake) *) * type_ * id_info * arguments
   (* TODO? Separate regular Calls from OpCalls where no need bracket and Arg *)
   (* (XHP, JSX, TSX), could be transpiled also (done in IL.ml?) *)
   | Xml of xml

--- a/libs/ast_generic/AST_generic_to_v1.ml
+++ b/libs/ast_generic/AST_generic_to_v1.ml
@@ -274,11 +274,11 @@ and map_expr x : B.expr =
   | Call (v1, v2) ->
       let v1 = map_expr v1 and v2 = map_arguments v2 in
       `Call (v1, v2)
-  | New (v1, v2, v3) ->
+  | New (v1, v2, _v3, v4) ->
       let v1 = map_tok v1 in
       let v2 = map_type_ v2 in
-      let v3 = map_arguments v3 in
-      `New (v1, v2, v3)
+      let v4 = map_arguments v4 in
+      `New (v1, v2, v4)
   | Assign (v1, v2, v3) ->
       let v1 = map_expr v1 and v2 = map_tok v2 and v3 = map_expr v3 in
       `Assign (v1, v2, v3)

--- a/libs/ast_generic/Map_AST.ml
+++ b/libs/ast_generic/Map_AST.ml
@@ -278,11 +278,12 @@ let (mk_visitor : visitor_in -> visitor_out) =
         | Call (v1, v2) ->
             let v1 = map_expr v1 and v2 = map_arguments v2 in
             Call (v1, v2)
-        | New (v1, v2, v3) ->
+        | New (v1, v2, v3, v4) ->
             let v1 = map_tok v1
             and v2 = map_type_ v2
-            and v3 = map_arguments v3 in
-            New (v1, v2, v3)
+            and v3 = map_id_info v3
+            and v4 = map_arguments v4 in
+            New (v1, v2, v3, v4)
         | Assign (v1, v2, v3) ->
             let v1 = map_expr v1 and v2 = map_tok v2 and v3 = map_expr v3 in
             Assign (v1, v2, v3)

--- a/libs/ast_generic/Meta_AST.ml
+++ b/libs/ast_generic/Meta_AST.ml
@@ -243,10 +243,10 @@ and vof_expr e =
   | Call (v1, v2) ->
       let v1 = vof_expr v1 and v2 = vof_arguments v2 in
       OCaml.VSum ("Call", [ v1; v2 ])
-  | New (v0, v1, v2) ->
+  | New (v0, v1, v2, v3) ->
       let v0 = vof_tok v0 in
-      let v1 = vof_type_ v1 and v2 = vof_arguments v2 in
-      OCaml.VSum ("New", [ v0; v1; v2 ])
+      let v1 = vof_type_ v1 and v2 = vof_id_info v2 and v3 = vof_arguments v3 in
+      OCaml.VSum ("New", [ v0; v1; v2; v3 ])
   | Assign (v1, v2, v3) ->
       let v1 = vof_expr v1 and v2 = vof_tok v2 and v3 = vof_expr v3 in
       OCaml.VSum ("Assign", [ v1; v2; v3 ])

--- a/src/analyzing/AST_to_IL.ml
+++ b/src/analyzing/AST_to_IL.ml
@@ -573,7 +573,7 @@ and expr_aux env ?(void = false) e_gen =
        * interpolated strings, but we do not have an use for it yet during
        * semantic analysis, so in the IL we just unwrap the expression. *)
       expr env e
-  | G.New (tok, ty, args) ->
+  | G.New (tok, ty, _TODO, args) ->
       (* TODO: lift up New in IL like we did in AST_generic *)
       let special = (New, tok) in
       let arg = G.ArgType ty in

--- a/src/analyzing/Dataflow_svalue.ml
+++ b/src/analyzing/Dataflow_svalue.ml
@@ -378,7 +378,7 @@ let rec is_symbolic_expr expr =
   | G.ArrayAccess (e1, (_, e2, _)) -> is_symbolic_expr e1 && is_symbolic_expr e2
   | G.Call (e, (_, args, _)) ->
       is_symbolic_expr e && List.for_all is_symbolic_arg args
-  | G.New (_, _, args) ->
+  | G.New (_, _, _, args) ->
       let args = PI.unbracket args in
       List.for_all is_symbolic_arg args
   | _else -> false

--- a/src/experiments/synthesizing/Pattern_from_Code.ml
+++ b/src/experiments/synthesizing/Pattern_from_Code.ml
@@ -197,7 +197,7 @@ let deep_typed_metavar (e, (lp, es, rp)) env =
 
 let generalize_call env e =
   match e.e with
-  | New (_, _, _) -> []
+  | New (_, _, _, _) -> []
   | Call (e, (lp, es, rp)) -> (
       (* only show the deep_metavar and deep_typed_metavar options if relevant *)
       let d_mvar =

--- a/src/matching/Generic_vs_generic.ml
+++ b/src/matching/Generic_vs_generic.ml
@@ -931,8 +931,8 @@ and m_expr ?(is_root = false) ?(arguments_have_changed = true) a b =
   (* boilerplate *)
   | G.Call (a1, a2), B.Call (b1, b2) ->
       m_expr a1 b1 >>= fun () -> m_arguments a2 b2
-  | G.New (_a0, a1, a2), B.New (_b0, b1, b2) ->
-      m_type_ a1 b1 >>= fun () -> m_arguments a2 b2
+  | G.New (_a0, a1, _a2, a3), B.New (_b0, b1, _b2, b3) ->
+      m_type_ a1 b1 >>= fun () -> m_arguments a3 b3
   | G.Assign (a1, at, a2), B.Assign (b1, bt, b2) -> (
       m_expr a1 b1
       >>= (fun () -> m_tok at bt >>= fun () -> m_expr a2 b2)
@@ -1475,7 +1475,7 @@ and m_compatible_type lang typed_mvar t e =
 and type_of_expr lang e : G.type_ option * G.ident option =
   match e.B.e with
   (* TODO? or generate a fake "new" id for LSP to query on tk? *)
-  | B.New (_tk, t, _) -> (Some t, None)
+  | B.New (_tk, t, _ii, _) -> (Some t, None)
   (* this is covered by the basic type propagation done in Naming_AST.ml *)
   | B.N
       (B.IdQualified

--- a/src/matching/SubAST_generic.ml
+++ b/src/matching/SubAST_generic.ml
@@ -145,7 +145,7 @@ let subexprs_of_expr with_symbolic_propagation e =
          |> Common.map (function
               | CompFor (_, _pat, _, e) -> e
               | CompIf (_, e) -> e))
-  | New (_, _t, args) -> subexprs_of_args args
+  | New (_, _t, _ii, args) -> subexprs_of_args args
   | Call (e, args) ->
       (* not sure we want to return 'e' here *)
       e :: subexprs_of_args args
@@ -255,7 +255,7 @@ let subexprs_of_expr_implicit with_symbolic_propagation e =
   | ArrayAccess (_e1, (_, _e2, _)) -> []
   | SliceAccess (_e1, _e2) -> []
   | Comprehension (_, (_, (_e, _xs), _)) -> []
-  | New (_, _t, _args) -> []
+  | New (_, _t, _ii, _args) -> []
   | OtherExpr (_, _anys) -> []
   | RawExpr _ -> []
   | Alias (_, _e1) -> []

--- a/src/naming/Naming_AST.ml
+++ b/src/naming/Naming_AST.ml
@@ -349,7 +349,7 @@ let get_resolved_type lang (vinit, vtype) =
       | Some { e = L (Imag (_, tok)); _ } -> make_type "imag" tok
       (* alt: lookup id in env to get its type, which would be cleaner *)
       | Some { e = N (Id (_, { id_type; _ })); _ } -> !id_type
-      | Some { e = New (_, tp, (_, _, _)); _ } -> Some tp
+      | Some { e = New (_, tp, _, (_, _, _)); _ } -> Some tp
       | _ -> None)
   | Some _ -> vtype
 

--- a/src/printing/Pretty_print_AST.ml
+++ b/src/printing/Pretty_print_AST.ml
@@ -556,7 +556,7 @@ and expr env e =
   | N (IdQualified qualified_info) -> id_qualified env qualified_info
   | IdSpecial (sp, tok) -> special env (sp, tok)
   | Call (e1, e2) -> call env (e1, e2)
-  | New (_, t, es) -> new_call env (t, es)
+  | New (_, t, _, es) -> new_call env (t, es)
   | L x -> literal env x
   | Container (Tuple, (_, es, _)) -> F.sprintf "(%s)" (tuple env es)
   | ArrayAccess (e1, (_, e2, _)) ->


### PR DESCRIPTION
This id_info can be filled in by Semgrep Pro to point to the corresponding constructor method. This will enable Pro to look at class constructors during dataflow analyses.

No changelog entry because for now this change is not visible to users.

test plan:
See PR returntocorp/semgrep-proprietary#663

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
