### PR TITLE
osemgrep: sort skipped output (as done in #7535)

### DIFF
--- a/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -258,7 +258,10 @@ let pp_skipped ppf
         List.iter
           (fun (Out.{ path; _ } : Out.skipped_target) ->
             Fmt.pf ppf "  o %s@." path)
-          xs
+          (List.sort
+             (fun (a : Out.skipped_target) (b : Out.skipped_target) ->
+               String.compare a.path b.path)
+             xs)
   in
 
   Fmt.pf ppf " Skipped by .semgrepignore:@.";


### PR DESCRIPTION
aligns with pysemgrep changes in #7535

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
