### PR TITLE
drop header in log reporter ("osemgrep: [INFO]" becomes "")

### DIFF
--- a/libs/commons/Logs_helpers.ml
+++ b/libs/commons/Logs_helpers.ml
@@ -2,8 +2,9 @@
  * calls even before a precise call to setup_logging.
  *)
 let enable_logging () =
+  let pp_header _ppf (_level, _opt_header) = () in
   Logs.set_level ~all:true (Some Logs.Warning);
-  Logs.set_reporter (Logs_fmt.reporter ~app:Format.err_formatter ());
+  Logs.set_reporter (Logs_fmt.reporter ~pp_header ~app:Format.err_formatter ());
   ()
 
 (* TOPORT: with Logs a warning is displayed as:


### PR DESCRIPTION
This moves osemgrep output closer to semgrep

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
