### PR TITLE
update docker base image to 2023-04-17 (includes terminal_size opam package)

### DIFF
--- a/.github/workflows/build-test-core-x86.yaml
+++ b/.github/workflows/build-test-core-x86.yaml
@@ -8,7 +8,7 @@ jobs:
   build-test-core-x86:
     name: Build Test Semgrep Core
     runs-on: ubuntu-latest
-    container: returntocorp/ocaml:alpine-2023-04-03
+    container: returntocorp/ocaml:alpine-2023-04-17
     # We need this hack because GHA tampers with the HOME in container
     # and this does not play well with 'opam' installed in /root
     env:

--- a/.github/workflows/build-test-javascript.yaml
+++ b/.github/workflows/build-test-javascript.yaml
@@ -8,7 +8,7 @@ jobs:
   build-test-javascript:
     name: Build Test Semgrep Javascript
     runs-on: ubuntu-latest
-    container: returntocorp/ocaml:ubuntu-2023-04-03
+    container: returntocorp/ocaml:ubuntu-2023-04-17
     # We need this hack because GHA tampers with the HOME in container
     # and this does not play well with 'opam' installed in /root
     env:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -71,7 +71,7 @@ jobs:
     # This custom image provides 'ocamlformat' with a specific version needed to check
     # OCaml code (must be the same than the one in dev/dev.opam)
     # See https://github.com/returntocorp/ocaml-layer/blob/master/configs/ubuntu.sh
-    container: returntocorp/ocaml:ubuntu-2023-04-03
+    container: returntocorp/ocaml:ubuntu-2023-04-17
     # HOME in the container is tampered by GHA and modified from /root to /home/github
     # which then confuses opam below which can not find its ~/.opam (which is at /root/.opam)
     # hence the ugly use of 'env: HOME ...' below.

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@
 #
 # coupling: if you modify the FROM below, you probably need to modify also
 # a few .github/workflows/ files. grep for returntocorp/ocaml there.
-FROM returntocorp/ocaml:alpine-2023-04-03 as semgrep-core-container
+FROM returntocorp/ocaml:alpine-2023-04-17 as semgrep-core-container
 
 WORKDIR /src/semgrep
 COPY . .


### PR DESCRIPTION
The dependency was introduced in #7530 (and https://github.com/returntocorp/ocaml-layer/pull/23)

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
