### PR TITLE
osemgrep: fix the --help tests

### DIFF
--- a/cli/tests/semgrep_runner.py
+++ b/cli/tests/semgrep_runner.py
@@ -49,7 +49,7 @@ USE_OSEMGREP = get_env_bool("PYTEST_USE_OSEMGREP")
 
 # The --project-root option is used to prevent the .semgrepignore
 # at the root of the git project to be taken into account when testing,
-# which is is a new behavior in osemgrep.
+# which is a new behavior in osemgrep.
 OSEMGREP_COMPATIBILITY_ARGS = ["--project-root", "."]
 
 # The semgrep command suitable to run semgrep as a separate process.
@@ -109,7 +109,12 @@ def invoke_osemgrep(
         arg_list = shlex.split(args)
     elif isinstance(args, List):
         arg_list = args
-    argv: List[str] = [OSEMGREP_PATH] + OSEMGREP_COMPATIBILITY_ARGS + arg_list
+    argv: List[str] = []
+    # ugly: adding --project-root for --help would trigger the wrong help message
+    if "-h" in arg_list or "--help" in arg_list:
+        argv = [OSEMGREP_PATH] + arg_list
+    else:
+        argv = [OSEMGREP_PATH] + OSEMGREP_COMPATIBILITY_ARGS + arg_list
     env_dict = {}
     if env:
         env_dict = env

--- a/dune
+++ b/dune
@@ -1,6 +1,9 @@
 ; The default combination of flags is ':standard', which is made of the
 ; following options:
-;  -w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs
+;  -w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence
+;  -strict-formats -short-paths -keep-locs
+; The documentation for the warning numbers is available at:
+; https://v2.ocaml.org/manual/comp.html#s%3Acomp-options
 ;
 ; We considered disabling the '-short-paths' option due to bad aliases
 ; being shown in type hints and error messages, but the alternative also
@@ -10,7 +13,10 @@
 ;
 (env
   (_
-    (flags (:standard  -w -52-6))
+    ; -6 is to allow to omit labels in function application
+    ; -52 is to allow to match on Failure "precise_string"
+    ; -58 is to allow missing cmx files (only a problem with Dyp)
+    (flags (:standard  -w -6-52-58))
     ; TODO: I've tried this, but this does not work so I've added --table in
     ; the few dune files using menhir
     ;(menhir_flags (--table))

--- a/src/osemgrep/TOPORT/oct_11_2022_apr_13_2023.diff
+++ b/src/osemgrep/TOPORT/oct_11_2022_apr_13_2023.diff
@@ -623,15 +623,6 @@ diff -u -p -b -B -r -x .semantic.cache -x .depend -x CVS -x .hg -x .svn -x .git 
  
      maybe_set_git_safe_directories()
  
-@@ -76,6 +92,6 @@ cli.add_command(login)
- cli.add_command(logout)
- cli.add_command(publish)
- cli.add_command(scan)
--cli.add_command(install_deep_semgrep)
-+cli.add_command(install_semgrep_pro)
- cli.add_command(shouldafound)
- cli.add_command(lsp)
-Only in /home/pad/yy/cli/src/semgrep: command.py
 diff -u -p -b -B -r -x .semantic.cache -x .depend -x CVS -x .hg -x .svn -x .git -x _darcs /tmp/semgrep/cli/src/semgrep/commands/ci.py /home/pad/yy/cli/src/semgrep/commands/ci.py
 --- /tmp/semgrep/cli/src/semgrep/commands/ci.py	2023-04-13 11:00:52.889774289 +0200
 +++ /home/pad/yy/cli/src/semgrep/commands/ci.py	2023-04-12 12:55:37.489634222 +0200

--- a/src/osemgrep/cli/CLI.ml
+++ b/src/osemgrep/cli/CLI.ml
@@ -5,7 +5,7 @@
    Semgrep command-line entry point.
 
    This module determines the subcommand invoked on the command line
-   and has another module handle it as if it were an independent command.
+   and has another module handle it as if it was an independent command.
    Exceptions are caught and turned into an appropriate exit code
    (unless you used --debug).
 
@@ -36,13 +36,14 @@ Options:
   -h, --help  Show this message and exit.
 
 Commands:
-  ci            The recommended way to run semgrep in CI
-  login         Obtain and save credentials for semgrep.dev
-  logout        Remove locally stored credentials to semgrep.dev
-  lsp           [EXPERIMENTAL] Start the Semgrep LSP server
-  publish       Upload rule to semgrep.dev
-  scan          Run semgrep rules on files
-  shouldafound  Report a false negative in this project.
+  ci                   The recommended way to run semgrep in CI
+  install-semgrep-pro  Install the Semgrep Pro Engine
+  login                Obtain and save credentials for semgrep.dev
+  logout               Remove locally stored credentials to semgrep.dev
+  lsp                  [EXPERIMENTAL] Start the Semgrep LSP server
+  publish              Upload rule to semgrep.dev
+  scan                 Run semgrep rules on files
+  shouldafound         Report a false negative in this project.
 |}
 
 let default_subcommand = "scan"
@@ -92,7 +93,16 @@ let default_subcommand = "scan"
 
 (* This is used to determine if we should fall back to assuming 'scan'. *)
 let known_subcommands =
-  [ "ci"; "login"; "logout"; "lsp"; "publish"; "scan"; "shouldafound" ]
+  [
+    "ci";
+    "install-semgrep-pro";
+    "login";
+    "logout";
+    "lsp";
+    "publish";
+    "scan";
+    "shouldafound";
+  ]
 
 (* Exit with a code that a proper semgrep implementation would never return.
    Uncaught OCaml exception result in exit code 2.
@@ -128,13 +138,13 @@ let dispatch_subcommand argv =
        *)
       match subcmd with
       | "ci" -> Ci_subcommand.main subcmd_argv
+      | "install-semgrep-pro" -> missing_subcommand ()
       | "login" -> Login_subcommand.main subcmd_argv
       | "logout" -> Logout_subcommand.main subcmd_argv
       | "lsp" -> missing_subcommand ()
       | "publish" -> missing_subcommand ()
       | "scan" -> Scan_subcommand.main subcmd_argv
       | "shouldafound" -> missing_subcommand ()
-      (* TOPORT: cli.add_command(install_pro) *)
       | _else_ -> (* should have defaulted to 'scan' above *) assert false)
   [@@profiling]
 


### PR DESCRIPTION
test plan:
make osemgrep-e2e now gets 172 passed (from 170), and 360 remaining failed


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)