### PR TITLE
fix CI: update snapshot

### DIFF
--- a/.semgrepignore
+++ b/.semgrepignore
@@ -16,18 +16,19 @@
 # using this syntax will be dropped from the ignore list:
 # - Explicit "include syntax", e.g. "!kept/".
 # - Multi-character expansion syntax, e.g. "*.py[cod]"
-#
 # To include ignore patterns from another file, start a line
 # with ':include', followed by the path of the file. E.g.
 # ":include path/to/other/ignore/file".
+# UPDATE: this will not be be needed in osemgrep which supports
+# all of the .gitignore syntax (!kept/, *.py[cod])
 #
 # To ignore a file with a literal ':' character, escape it with
 # a backslash, e.g. "\:foo".
 
 /tests/
 /cli/tests/e2e/targets/
-/cli/tests/performance/targets/
 /cli/tests/e2e/snapshots/
+/cli/tests/performance/targets/
 
 # rules being tested for performance
 /perf/rules/

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push-special-env-vars/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push-special-env-vars/findings_and_ignores.json
@@ -84,15 +84,15 @@
     {
       "check_id": "supply-chain1",
       "path": "poetry.lock",
-      "line": 0,
+      "line": 1,
       "column": 0,
-      "end_line": 0,
+      "end_line": 2,
       "end_column": 0,
       "message": "found a dependency",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "ff8806e5d262f88aeebbc15b80d84f12",
+      "syntactic_id": "6090c1bab6c8853da43c7119a6eb2ad0",
       "metadata": {
         "dev.semgrep.actions": [
           "block"
@@ -102,9 +102,9 @@
       "is_blocking": false,
       "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
       "hashes": {
-        "start_line_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-        "end_line_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-        "code_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "start_line_hash": "b153a50b131c8c33766f9a6658610e68af55399f8c6b69818f1b62ccd0a7d80d",
+        "end_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",
+        "code_hash": "46ce1ef80ef40363ab95f7f71ca6425d7b7b0248d191b6c3006301793c7c252f",
         "pattern_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
       },
       "sca_info": {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push-special-env-vars/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push-special-env-vars/results.txt
@@ -69,6 +69,8 @@ CI="true" GITHUB_ACTIONS="true" GITHUB_EVENT_NAME="push" SEMGREP_REPO_NAME="proj
        supply-chain1        
           found a dependency
                             
+            1┆ [[package]]
+            2┆ name = "badlib"
                                
                                
 ┌─────────────────────────────┐

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push-special-env-vars/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push-special-env-vars/findings_and_ignores.json
@@ -84,15 +84,15 @@
     {
       "check_id": "supply-chain1",
       "path": "poetry.lock",
-      "line": 0,
+      "line": 1,
       "column": 0,
-      "end_line": 0,
+      "end_line": 2,
       "end_column": 0,
       "message": "found a dependency",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "ff8806e5d262f88aeebbc15b80d84f12",
+      "syntactic_id": "6090c1bab6c8853da43c7119a6eb2ad0",
       "metadata": {
         "dev.semgrep.actions": [
           "block"
@@ -102,9 +102,9 @@
       "is_blocking": false,
       "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
       "hashes": {
-        "start_line_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-        "end_line_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-        "code_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "start_line_hash": "b153a50b131c8c33766f9a6658610e68af55399f8c6b69818f1b62ccd0a7d80d",
+        "end_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",
+        "code_hash": "46ce1ef80ef40363ab95f7f71ca6425d7b7b0248d191b6c3006301793c7c252f",
         "pattern_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
       },
       "sca_info": {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push-special-env-vars/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push-special-env-vars/results.txt
@@ -69,6 +69,8 @@ CI="true" GITHUB_ACTIONS="true" GITHUB_EVENT_NAME="push" SEMGREP_REPO_NAME="proj
        supply-chain1        
           found a dependency
                             
+            1┆ [[package]]
+            2┆ name = "badlib"
                                
                                
 ┌─────────────────────────────┐


### PR DESCRIPTION
Not sure what happened with
https://github.com/returntocorp/semgrep/pull/7361

probably didn't rebase correctly on develop and things changed
in between

test plan:
wait for CI green checks


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)