### PR TITLE
fix(taint): update keys with `Taints.map`

### DIFF
--- a/changelog.d/pa-2682.fixed
+++ b/changelog.d/pa-2682.fixed
@@ -1,0 +1,1 @@
+Taint: Fixed a bug where the new labeled propagators would sometimes not behave properly

--- a/tests/rules/labeled_propagators.py
+++ b/tests/rules/labeled_propagators.py
@@ -1,0 +1,14 @@
+# ruleid:test
+sink(foo(input()));
+
+# ruleid:test
+sink(bar(foo(input())));
+
+# ruleid:test
+sink(foo(bar(input())));
+
+# ok:test
+sink(bar(baz(foo())));
+
+# ok:test
+sink(bar(input()));

--- a/tests/rules/labeled_propagators.yaml
+++ b/tests/rules/labeled_propagators.yaml
@@ -1,0 +1,23 @@
+rules:
+  - id: test
+    languages:
+      - python
+    severity: ERROR
+    mode: taint
+    message: Test
+    pattern-sources:
+      - label: INPUT
+        pattern: input()
+    pattern-propagators:
+      - by-side-effect: false
+        patterns:
+          - pattern-inside: $F($X)
+          - focus-metavariable: $F
+          - pattern: foo
+        from: $X
+        to: $F
+        label: FOO
+        requires: INPUT
+    pattern-sinks:
+      - requires: FOO
+        pattern: sink(...)


### PR DESCRIPTION
## What:
This PR fixes a bug which made `Taints.map` cause taints to become conflated with each other, and erase each other's existence even though they shouldn't.

## Why:
This was causing cases to fail, because taints would become deleted when they shouldn't be. See https://semgrep.dev/s/Onon

## How:
This was happening because the internal representation of `Taint_set` is as a `Taint_map`. Since we're using the regular `map` function on maps (which doesn't touch the keys), this would make keys associate to different values, but then cause clashes between different values which originated from the same key.

I fixed it by simply making the `map` function also work on the keys. Because the type of keys was different than the type of maps, I had to change the key type for `Taint_map` as well, because otherwise I'd be shoehorned into a function which worked only on `orig` or `taint`, when I want the freedom to choose both.

## Test plan:
`make test`

Closes PA-2682

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
