### PR TITLE
chore: Fix autofix stats script

### DIFF
--- a/stats/autofix-printing-stats/run
+++ b/stats/autofix-printing-stats/run
@@ -214,7 +214,8 @@ let upload_results opts results =
 
 let make_opts () =
   (* Get the args. Remove the first element since that is the binary name *)
-  let args = Sys.argv |> Array.to_list |> Common.tl_exn "unexpected empty list" in
+  (* nosemgrep *)
+  let args = Sys.argv |> Array.to_list |> List.tl in
   {
     upload = List.mem "--upload" args;
     verbose = List.mem "--verbose" args;


### PR DESCRIPTION
This is a standalone script and doesn't have access to Common.

Test plan: `./stats/autofix-printing-stats/run`

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
