### PR TITLE
Common: remove path type

### DIFF
--- a/languages/javascript/menhir/test_parsing_js.mli
+++ b/languages/javascript/menhir/test_parsing_js.mli
@@ -4,7 +4,7 @@
  * of_files_and_dirs> and compares it with any previous run, providing some
  * form of regression testing.
  *)
-val test_parse_js : Common.path list -> unit
+val test_parse_js : Common.filename list -> unit
 
 (* Print the set of tokens in a JS file *)
 val test_tokens_js : Common.filename -> unit

--- a/languages/php/menhir/test_parsing_php.mli
+++ b/languages/php/menhir/test_parsing_php.mli
@@ -6,7 +6,7 @@
  * of_files_and_dirs> and compares it with any previous run, providing some
  * form of regression testing.
  *)
-val test_parse_php : Common.path list -> unit
+val test_parse_php : Common.filename list -> unit
 
 (*x: test_parsing_php.mli *)
 (* Print the set of tokens in a PHP file *)

--- a/libs/commons/Common.ml
+++ b/libs/commons/Common.ml
@@ -759,14 +759,7 @@ let null_string s = s = ""
 type filename = string (* TODO could check that exist :) type sux *)
 [@@deriving show, eq]
 
-(* with sexp *)
 type dirname = string
-
-(* TODO could check that exist :) type sux *)
-(* with sexp *)
-
-(* file or dir *)
-type path = string
 
 let chop_dirsymbol = function
   | s when s =~ "\\(.*\\)/$" -> matched1 s

--- a/libs/commons/Common.mli
+++ b/libs/commons/Common.mli
@@ -163,7 +163,6 @@ type filename = string [@@deriving show, eq]
 
 (* TODO: those are not used very often, maybe we should delete them *)
 type dirname = string
-type path = string
 
 (* for realpath, see efuns_c library  *)
 (*

--- a/src/parsing/tests/Test_parsing.mli
+++ b/src/parsing/tests/Test_parsing.mli
@@ -10,10 +10,10 @@
  *   {"total":111,"bad":0,"percent_correct":100.0}
  *)
 val parsing_stats :
-  ?json:bool -> ?verbose:bool -> Lang.t -> Common.path list -> unit
+  ?json:bool -> ?verbose:bool -> Lang.t -> Common.filename list -> unit
 
 (* TODO: parsing regressions as in pfff (unfinished) *)
-val parsing_regressions : Lang.t -> Common.path list -> unit
+val parsing_regressions : Lang.t -> Common.filename list -> unit
 
 (* Similar to [parsing_stats], but uses only tree-sitter parsers,
  * and stop the parsing at the tree-sitter CST level (it does not
@@ -42,4 +42,4 @@ val diff_pfff_tree_sitter : Common.filename list -> unit
  * find YAML files containing rules and check if they
  * parse correctly using Parse_rule.parse.
  *)
-val test_parse_rules : Common.path list -> unit
+val test_parse_rules : Common.filename list -> unit

--- a/src/runner/Run_semgrep.mli
+++ b/src/runner/Run_semgrep.mli
@@ -140,7 +140,7 @@ val semgrep_with_rules :
   Runner_config.t ->
   (Rule.mode Rule.rule_info Common.stack * Rule.invalid_rule_error Common.stack)
   * float ->
-  Report.final_result * Common.path Common.stack
+  Report.final_result * Common.filename Common.stack
 
 (* utilities functions used in tests or semgrep-core variants *)
 


### PR DESCRIPTION
Anyway we should use Fpath.t ultimately

test plan:
make core


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)