### PR TITLE
fix CI: pin virtualenv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -266,6 +266,10 @@ ALPINE_APK_DEPS=pcre-dev python3 python3-dev gmp-dev
 # We could update to a more recent version.
 # coupling: if you modify the version, please modify also .github/workflows/*
 PIPENV='pipenv==2022.6.7'
+#TODO: virtualenv 20.22.0 is causing the build to fail with some weird errors:
+# 'AttributeError: module 'virtualenv.create.via_global_ref.builtin.cpython.mac_os' has no attribute 'CPython2macOsArmFramework'
+# so I pinned an older version
+VIRTENV='virtualenv==20.21.0'
 
 # This target is used in our Dockerfile and a few GHA workflows.
 # There are pros and cons of having those commands here instead
@@ -282,7 +286,7 @@ PIPENV='pipenv==2022.6.7'
 # https://stackoverflow.com/questions/63515454/why-does-pip3-install-pipenv-give-error-error-cannot-uninstall-distlib
 install-deps-ALPINE-for-semgrep-core:
 	apk add --no-cache $(ALPINE_APK_DEPS)
-	pip install --no-cache-dir --ignore-installed distlib $(PIPENV)
+	pip install --no-cache-dir --ignore-installed distlib $(PIPENV) $(VIRTENV)
 
 #TODO: deprecate scripts/install-alpine-xxx in favor of that
 install-deps-and-build-ALPINE-semgrep-core:


### PR DESCRIPTION
No idea why 20.22 is failing. yesterday
the default was 20.21 which was working, but today alpine
changed and install 20.22 by default which fails with some weird
errors.

test plan:
make docker-build is now passing
wait for green check in CI


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)