### PR TITLE
cleanup: Parse_tree_sitter_helpers

### DIFF
--- a/libs/lib_parsing_tree_sitter/Parse_tree_sitter_helpers.ml
+++ b/libs/lib_parsing_tree_sitter/Parse_tree_sitter_helpers.ml
@@ -28,6 +28,7 @@ let logger = Logging.get_logger [ __MODULE__ ]
 (* Types *)
 (*****************************************************************************)
 type 'a env = {
+  (* TODO: use Fpath.t *)
   file : Common.filename;
   (* get the charpos (offset) in file given a line x col *)
   conv : (int * int, int) Hashtbl.t;
@@ -88,13 +89,6 @@ let token env (tok : Tree_sitter_run.Token.t) =
 let str env (tok : Tree_sitter_run.Token.t) =
   let _, s = tok in
   (s, token env tok)
-
-let combine_tokens_DEPRECATED env xs =
-  match xs with
-  | [] -> failwith "combine_tokens: empty list"
-  | x :: _xsTODO ->
-      let t = token env x in
-      t
 
 let debug_sexp_cst_after_error sexp_cst =
   let s = Printexc.get_backtrace () in

--- a/libs/lib_parsing_tree_sitter/Parse_tree_sitter_helpers.mli
+++ b/libs/lib_parsing_tree_sitter/Parse_tree_sitter_helpers.mli
@@ -5,14 +5,12 @@ type 'a env = {
   extra : 'a;
 }
 
+(* to fill in conv *)
 val line_col_to_pos : Common.filename -> (int * int, int) Hashtbl.t
-val token : 'a env -> Tree_sitter_run.Token.t -> Parse_info.t
-val str : 'a env -> Tree_sitter_run.Token.t -> string * Parse_info.t
 
-(* Use Parse_info.combine_infos instead *)
-val combine_tokens_DEPRECATED :
-  'a env -> Tree_sitter_run.Token.t list -> Parse_info.t
-
+(* Tree_sitter_run tokens to Tok.t converters *)
+val token : 'a env -> Tree_sitter_run.Token.t -> Tok.t
+val str : 'a env -> Tree_sitter_run.Token.t -> string * Tok.t
 val debug_sexp_cst_after_error : Sexplib.Sexp.t -> unit
 
 (*

--- a/libs/lib_parsing_tree_sitter/dune
+++ b/libs/lib_parsing_tree_sitter/dune
@@ -5,7 +5,7 @@
  (libraries
    commons
    lib_parsing
-   tree-sitter.run ; Parse_tree_sitter_helpers
+   tree-sitter.run
  )
- (preprocess (pps ppx_profiling ppx_deriving.show ppx_deriving.eq))
+ (preprocess (pps profiling.ppx ppx_deriving.show))
 )


### PR DESCRIPTION
remove deprecated function

test plan:
make core


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)