### PR TITLE
cleanup: move Parse_info.xxx_of_info to Tok.xxx_of_tok

### DIFF
--- a/languages/cpp/menhir/parse_cpp.ml
+++ b/languages/cpp/menhir/parse_cpp.ml
@@ -292,7 +292,7 @@ let parse_with_lang ?(lang = Flag_parsing_cpp.Cplusplus) file :
      * It would be better to record when we have a } or ; in parser.mly,
      *  cos we know that they are the last symbols of external_declaration2.
      *)
-    let checkpoint = PI.line_of_info info in
+    let checkpoint = Tok.line_of_tok info in
     (* bugfix: may not be equal to 'file' as after macro expansions we can
      * start to parse a new entity from the body of a macro, for instance
      * when parsing a define_machine() body, cf standard.h
@@ -380,7 +380,7 @@ let parse_with_lang ?(lang = Flag_parsing_cpp.Cplusplus) file :
 
           (* <> line_error *)
           let info = TH.info_of_tok tr.Parsing_helpers.current in
-          let checkpoint2 = PI.line_of_info info in
+          let checkpoint2 = Tok.line_of_tok info in
           let checkpoint2_file = PI.file_of_info info in
 
           was_define := passed_a_define tr;
@@ -402,7 +402,7 @@ let parse_with_lang ?(lang = Flag_parsing_cpp.Cplusplus) file :
 
     (* again not sure if checkpoint2 corresponds to end of bad region *)
     let info = TH.info_of_tok tr.Parsing_helpers.current in
-    let checkpoint2 = PI.line_of_info info in
+    let checkpoint2 = Tok.line_of_tok info in
     let checkpoint2_file = PI.file_of_info info in
 
     let diffline =

--- a/languages/cpp/menhir/parsing_hacks_cpp.ml
+++ b/languages/cpp/menhir/parsing_hacks_cpp.ml
@@ -40,7 +40,7 @@ open Parsing_hacks_lib
 (*****************************************************************************)
 
 let no_space_between i1 i2 =
-  PI.line_of_info i1 =|= PI.line_of_info i2
+  Tok.line_of_tok i1 =|= Tok.line_of_tok i2
   && PI.col_of_info i1 + String.length (PI.str_of_info i1) =|= PI.col_of_info i2
 
 (*****************************************************************************)

--- a/languages/cpp/menhir/parsing_hacks_define.ml
+++ b/languages/cpp/menhir/parsing_hacks_define.ml
@@ -102,7 +102,7 @@ let rec define_line_1 acc xs =
   match xs with
   | [] -> List.rev acc
   | (TDefine ii as x) :: xs ->
-      let line = PI.line_of_info ii in
+      let line = Tok.line_of_tok ii in
       define_line_2 (x :: acc) line ii xs
   | TCppEscapedNewline ii :: xs ->
       pr2 (spf "WEIRD: a \\ outside a #define at %s" (pos ii));

--- a/languages/cpp/menhir/parsing_recovery_cpp.ml
+++ b/languages/cpp/menhir/parsing_recovery_cpp.ml
@@ -89,7 +89,7 @@ and find_next_synchro_orig next already_passed =
       pr2_err "end of file while in recovery mode";
       (already_passed, [])
   | (T.TCBrace i as v) :: xs when PI.col_of_info i =|= 0 -> (
-      pr2_err (spf "found sync '}' at line %d" (PI.line_of_info i));
+      pr2_err (spf "found sync '}' at line %d" (Tok.line_of_tok i));
 
       match xs with
       | [] -> raise Impossible (* there is a EOF token normally *)
@@ -109,6 +109,6 @@ and find_next_synchro_orig next already_passed =
   | v :: xs ->
       let info = TH.info_of_tok v in
       if PI.col_of_info info =|= 0 && TH.is_start_of_something v then (
-        pr2_err (spf "found sync col 0 at line %d " (PI.line_of_info info));
+        pr2_err (spf "found sync col 0 at line %d " (Tok.line_of_tok info));
         (already_passed, v :: xs))
       else find_next_synchro_orig xs (v :: already_passed)

--- a/languages/cpp/menhir/token_helpers_cpp.ml
+++ b/languages/cpp/menhir/token_helpers_cpp.ml
@@ -582,4 +582,4 @@ let info_of_tok tok =
 
 let line_of_tok tok =
   let info = info_of_tok tok in
-  Parse_info.line_of_info info
+  Tok.line_of_tok info

--- a/languages/cpp/menhir/token_views_cpp.ml
+++ b/languages/cpp/menhir/token_views_cpp.ml
@@ -133,7 +133,7 @@ exception UnclosedSymbol of string
 
 let mk_token_extended x =
   let info = TH.info_of_tok x in
-  let line, col = (PI.line_of_info info, PI.col_of_info info) in
+  let line, col = (Tok.line_of_tok info, PI.col_of_info info) in
   {
     t = x;
     line;

--- a/languages/dockerfile/tree-sitter/Parse_dockerfile_tree_sitter.ml
+++ b/languages/dockerfile/tree-sitter/Parse_dockerfile_tree_sitter.ml
@@ -532,7 +532,7 @@ let label_pair (env : env) (x : CST.label_pair) : label_pair =
 (* hack to obtain correct locations when parsing a string extracted from
    a larger file. *)
 let shift_locations (str, tok) =
-  let line (* 0-based *) = max 0 (PI.line_of_info tok - 1) (* 1-based *) in
+  let line (* 0-based *) = max 0 (Tok.line_of_tok tok - 1) (* 1-based *) in
   let column (* 0-based *) = max 0 (PI.col_of_info tok) in
   String.make line '\n' ^ String.make column ' ' ^ str
 

--- a/languages/go/menhir/parse_go.ml
+++ b/languages/go/menhir/parse_go.ml
@@ -80,7 +80,7 @@ let parse filename =
         pr2 ("parse error \n = " ^ error_msg_tok cur);
         let filelines = Common2.cat_array filename in
         let checkpoint2 = Common.cat filename |> List.length in
-        let line_error = PI.line_of_info (TH.info_of_tok cur) in
+        let line_error = Tok.line_of_tok (TH.info_of_tok cur) in
         Parsing_helpers.print_bad line_error (0, checkpoint2) filelines);
       {
         Parsing_result.ast = [];

--- a/languages/java/menhir/token_helpers_java.ml
+++ b/languages/java/menhir/token_helpers_java.ml
@@ -185,4 +185,4 @@ let info_of_tok tok =
  *)
 let line_of_tok tok =
   let info = info_of_tok tok in
-  Parse_info.line_of_info info
+  Tok.line_of_tok info

--- a/languages/javascript/menhir/token_helpers_js.ml
+++ b/languages/javascript/menhir/token_helpers_js.ml
@@ -218,7 +218,7 @@ let info_of_tok tok =
 
 let line_of_tok tok =
   let info = info_of_tok tok in
-  Parse_info.line_of_info info
+  Tok.line_of_tok info
 
 let col_of_tok tok =
   let info = info_of_tok tok in

--- a/languages/ocaml/menhir/token_helpers_ml.ml
+++ b/languages/ocaml/menhir/token_helpers_ml.ml
@@ -200,4 +200,4 @@ let info_of_tok tok =
 
 let line_of_tok tok =
   let info = info_of_tok tok in
-  Parse_info.line_of_info info
+  Tok.line_of_tok info

--- a/languages/php/menhir/token_helpers_php.ml
+++ b/languages/php/menhir/token_helpers_php.ml
@@ -265,4 +265,4 @@ let info_of_tok tok =
 
 let line_of_tok tok =
   let info = info_of_tok tok in
-  Parse_info.line_of_info info
+  Tok.line_of_tok info

--- a/languages/python/menhir/Parse_python.ml
+++ b/languages/python/menhir/Parse_python.ml
@@ -155,7 +155,7 @@ let rec parse_basic ?(parsing_mode = Python) filename =
 
           let filelines = Common2.cat_array filename in
           let checkpoint2 = Common.cat filename |> List.length in
-          let line_error = PI.line_of_info (TH.info_of_tok cur) in
+          let line_error = Tok.line_of_tok (TH.info_of_tok cur) in
           Parsing_helpers.print_bad line_error (0, checkpoint2) filelines);
         stat.PS.error_line_count <- stat.PS.total_line_count;
         { Parsing_result.ast = []; tokens = toks; stat }

--- a/languages/python/tree-sitter/Parse_python_tree_sitter.ml
+++ b/languages/python/tree-sitter/Parse_python_tree_sitter.ml
@@ -40,7 +40,7 @@ let str = H.str
 (* this is not used anyway by Python_to_generic.ml, so I took whatever *)
 let no_ctx = Param
 let fb = Parse_info.unsafe_fake_bracket
-let invalid () = raise (PI.NoTokenLocation "Invalid program")
+let invalid () = raise (Tok.NoTokenLocation "Invalid program")
 
 (* AST builders helpers
  * less: could be moved in AST_Python.ml to factorize things with

--- a/languages/python/tree-sitter/Parse_python_tree_sitter.ml
+++ b/languages/python/tree-sitter/Parse_python_tree_sitter.ml
@@ -721,7 +721,7 @@ and map_pattern_to_parameter (env : env) (x : CST.pattern) : param_pattern =
   | `Subs _
   | `List_pat _
   | `Attr _ ->
-      raise (PI.NoTokenLocation "")
+      raise (Tok.NoTokenLocation "")
   | `List_splat_pat x ->
       (* Via the Python 3 grammar, you can only have a pow in a pattern if the next
          is just a NAME.

--- a/languages/ruby/dyp/il_ruby_build.ml
+++ b/languages/ruby/dyp/il_ruby_build.ml
@@ -62,9 +62,7 @@ let fresh acc =
   (seen_lhs acc (LId id), LId id)
 
 let fresh_global pos =
-  let name =
-    sprintf "$__druby_global_%d_%d" (Parse_info.line_of_info pos) (uniq ())
-  in
+  let name = sprintf "$__druby_global_%d_%d" (Tok.line_of_tok pos) (uniq ()) in
   Var (Global, name)
 
 let formal_counter = ref 0
@@ -232,7 +230,7 @@ let special_of_string pos x : expr =
   | "true" -> EId True
   | "false" -> EId False
   | "__FILE__" -> ELit (String (Parse_info.file_of_info pos))
-  | "__LINE__" -> ELit (Num (spf "%d" (Parse_info.line_of_info pos)))
+  | "__LINE__" -> ELit (Num (spf "%d" (Tok.line_of_tok pos)))
   | _ -> raise (Invalid_argument "special_of_string")
 
 let refactor_id_kind _pos : Ast.id_kind -> var_kind = function

--- a/languages/ruby/dyp/parse_ruby.ml
+++ b/languages/ruby/dyp/parse_ruby.ml
@@ -157,7 +157,7 @@ let parse2 opt_timeout file =
             pr2 ("parse error \n = " ^ error_msg_tok cur);
             let filelines = Common2.cat_array file in
             let checkpoint2 = Common.cat file |> List.length in
-            let line_error = PI.line_of_info (TH.info_of_tok cur) in
+            let line_error = Tok.line_of_tok (TH.info_of_tok cur) in
             Parsing_helpers.print_bad line_error (0, checkpoint2) filelines);
 
           stat.PS.error_line_count <- stat.PS.total_line_count;

--- a/languages/scala/recursive_descent/Parse_scala.ml
+++ b/languages/scala/recursive_descent/Parse_scala.ml
@@ -80,7 +80,7 @@ let parse filename =
         pr2 ("parse error \n = " ^ Parsing_helpers.error_message_info cur);
         let filelines = Common2.cat_array filename in
         let checkpoint2 = Common.cat filename |> List.length in
-        let line_error = PI.line_of_info cur in
+        let line_error = Tok.line_of_tok cur in
         Parsing_helpers.print_bad line_error (0, checkpoint2) filelines);
       stat.PS.error_line_count <- stat.PS.total_line_count;
       { Parsing_result.ast = []; tokens = toks; stat }

--- a/languages/scala/recursive_descent/Parser_scala_recursive_descent.ml
+++ b/languages/scala/recursive_descent/Parser_scala_recursive_descent.ml
@@ -314,7 +314,7 @@ let getIndentStatus ?(is_opportunistic = false) in_ =
   in
 
   let info = TH.info_of_tok tok in
-  let line = PI.line_of_info info in
+  let line = Tok.line_of_tok info in
   let col = PI.col_of_info info in
 
   let is_indented =

--- a/libs/ast_generic/Meta_AST.ml
+++ b/libs/ast_generic/Meta_AST.ml
@@ -112,7 +112,7 @@ let vof_info_adjustable_precision x =
   else if !_current_precision.token_info then
     OCaml.VDict
       [
-        ("line", OCaml.VInt (Parse_info.line_of_info x));
+        ("line", OCaml.VInt (Tok.line_of_tok x));
         ("col", OCaml.VInt (Parse_info.col_of_info x));
       ]
   else OCaml.VUnit

--- a/libs/lib_parsing/Parse_info.ml
+++ b/libs/lib_parsing/Parse_info.ml
@@ -27,8 +27,6 @@ open Tok
 (* TODO: remove at some point *)
 type t = Tok.t [@@deriving eq, show]
 
-exception NoTokenLocation of string
-
 let mk_info_of_loc loc = { token = OriginTok loc; transfo = NoTransfo }
 
 let token_location_of_info ii =
@@ -108,7 +106,6 @@ let str_of_info ii =
 
 let _str_of_info ii = (unsafe_token_location_of_info ii).str
 let file_of_info ii = (unsafe_token_location_of_info ii).pos.file
-let line_of_info ii = (unsafe_token_location_of_info ii).pos.line
 let col_of_info ii = (unsafe_token_location_of_info ii).pos.column
 
 (* todo: return a Real | Virt position ? *)

--- a/libs/lib_parsing/Parse_info.mli
+++ b/libs/lib_parsing/Parse_info.mli
@@ -28,16 +28,6 @@ val split_info_at_pos : int -> t -> t * t
 (*****************************************************************************)
 (* Fake tokens: safe vs unsafe *)
 (*****************************************************************************)
-(* "Safe" fake tokens require an existing location to attach to, and so
- * token_location_of_info will work on these fake tokens. "Unsafe" fake tokens
- * do not carry any location info, so calling token_location_of_info on these
- * will raise a NoTokenLocation exception.
- *
- * Always prefer "safe" functions (no "unsafe_" prefix), which only introduce
- * "safe" fake tokens. The unsafe_* functions introduce "unsafe" fake tokens,
- * please use them only as a last resort. *)
-
-exception NoTokenLocation of string
 
 val is_fake : t -> bool
 val is_origintok : t -> bool
@@ -72,7 +62,6 @@ val unbracket : t * 'a * t -> 'a
 val str_of_info : t -> string
 
 (* Extract position information *)
-val line_of_info : t -> int
 val col_of_info : t -> int
 val pos_of_info : t -> int
 val file_of_info : t -> Common.filename

--- a/libs/lib_parsing/Tok.ml
+++ b/libs/lib_parsing/Tok.ml
@@ -155,7 +155,7 @@ let fake_location = { str = ""; pos = Pos.fake_pos }
 (* Accessors *)
 (*****************************************************************************)
 
-let token_location_of_info ii =
+let location_of_tok (ii : t) : (location, string) Result.t =
   match ii.token with
   | OriginTok pinfo -> Ok pinfo
   (* TODO ? dangerous ? *)
@@ -164,12 +164,12 @@ let token_location_of_info ii =
   | FakeTokStr (_, None) -> Error "FakeTokStr"
   | Ab -> Error "Ab"
 
-let unsafe_token_location_of_info ii =
-  match token_location_of_info ii with
+let unsafe_location_of_tok ii =
+  match location_of_tok ii with
   | Ok pinfo -> pinfo
   | Error msg -> raise (NoTokenLocation msg)
 
-let line_of_info ii = (unsafe_token_location_of_info ii).pos.line
+let line_of_tok ii = (unsafe_location_of_tok ii).pos.line
 
 (* Token locations are supposed to denote the beginning of a token.
    Suppose we are interested in instead having line, column, and charpos of

--- a/libs/lib_parsing/Tok.ml
+++ b/libs/lib_parsing/Tok.ml
@@ -144,14 +144,32 @@ let pp_full_token_info = ref false
 let pp fmt t = if !pp_full_token_info then pp fmt t else Format.fprintf fmt "()"
 
 (*****************************************************************************)
-(* Fake stuff *)
+(* Fake tokens (safe and unsafe) *)
 (*****************************************************************************)
+
+exception NoTokenLocation of string
 
 let fake_location = { str = ""; pos = Pos.fake_pos }
 
 (*****************************************************************************)
 (* Accessors *)
 (*****************************************************************************)
+
+let token_location_of_info ii =
+  match ii.token with
+  | OriginTok pinfo -> Ok pinfo
+  (* TODO ? dangerous ? *)
+  | ExpandedTok (pinfo_pp, _pinfo_orig, _offset) -> Ok pinfo_pp
+  | FakeTokStr (_, Some (pi, _)) -> Ok pi
+  | FakeTokStr (_, None) -> Error "FakeTokStr"
+  | Ab -> Error "Ab"
+
+let unsafe_token_location_of_info ii =
+  match token_location_of_info ii with
+  | Ok pinfo -> pinfo
+  | Error msg -> raise (NoTokenLocation msg)
+
+let line_of_info ii = (unsafe_token_location_of_info ii).pos.line
 
 (* Token locations are supposed to denote the beginning of a token.
    Suppose we are interested in instead having line, column, and charpos of

--- a/libs/lib_parsing/Tok.mli
+++ b/libs/lib_parsing/Tok.mli
@@ -91,8 +91,28 @@ val pp_full_token_info : bool ref
 type t_always_equal = t [@@deriving show, eq, hash]
 
 (*****************************************************************************)
+(* Fake tokens (safe and unsafe) *)
+(*****************************************************************************)
+(* "Safe" fake tokens require an existing location to attach to, and so
+ * token_location_of_info will work on these fake tokens. "Unsafe" fake tokens
+ * do not carry any location info, so calling token_location_of_info on these
+ * will raise a NoTokenLocation exception.
+ *
+ * Always prefer "safe" functions (no "unsafe_" prefix), which only introduce
+ * "safe" fake tokens. The unsafe_* functions introduce "unsafe" fake tokens,
+ * please use them only as a last resort.
+ *)
+
+exception NoTokenLocation of string
+
+val fake_location : location
+
+(*****************************************************************************)
 (* Accessors *)
 (*****************************************************************************)
+
+(* Extract position information *)
+val line_of_tok : t -> int
 
 (* Token locations are supposed to denote the beginning of a token.
    Suppose we are interested in instead having line, column, and charpos of
@@ -102,12 +122,6 @@ type t_always_equal = t [@@deriving show, eq, hash]
    TODO: rename to end_pos_of_loc and return a Pos.t instead
 *)
 val get_token_end_info : location -> int * int * int
-
-(*****************************************************************************)
-(* Fake tokens (safe and unsafe) *)
-(*****************************************************************************)
-
-val fake_location : location
 
 (*****************************************************************************)
 (* Builders *)

--- a/src/analyzing/AST_to_IL.ml
+++ b/src/analyzing/AST_to_IL.ml
@@ -64,7 +64,7 @@ let impossible any_generic = raise (Fixme (Impossible, any_generic))
 let locate opt_tok s =
   let opt_loc =
     try Option.map Parse_info.string_of_info opt_tok with
-    | Parse_info.NoTokenLocation _ -> None
+    | Tok.NoTokenLocation _ -> None
   in
   match opt_loc with
   | Some loc -> spf "%s: %s" loc s

--- a/src/core/Range.ml
+++ b/src/core/Range.ml
@@ -118,7 +118,7 @@ let range_of_tokens xs =
     in
     Some { start; end_ }
   with
-  | PI.NoTokenLocation _ -> None
+  | Tok.NoTokenLocation _ -> None
 
 let hmemo = Hashtbl.create 101
 

--- a/src/experiments/lsp/LSP_client.ml
+++ b/src/experiments/lsp/LSP_client.ml
@@ -190,7 +190,7 @@ let final_type_string s =
   s
 
 let def_at_tok tk uri io =
-  let line = PI.line_of_info tk in
+  let line = Tok.line_of_tok tk in
   let col = PI.col_of_info tk in
   logger#debug "def_at_tok: %d, %d" line col;
   (* LSP is using 0-based lines and offset (column) *)
@@ -220,7 +220,7 @@ let def_at_tok tk uri io =
       None
 
 let type_at_tok tk uri io =
-  let line = PI.line_of_info tk in
+  let line = Tok.line_of_tok tk in
   let col = PI.col_of_info tk in
   logger#debug "type_at_tok: %d, %d" line col;
   (* LSP is using 0-based lines and offset (column) *)

--- a/src/printing/Pretty_print_AST.ml
+++ b/src/printing/Pretty_print_AST.ml
@@ -86,7 +86,7 @@ let token ?(d = "TODO") tok =
   (* this exn can trigger now only for Parse_info.Ab (abstracted token),
    * which should never happen. We don't use Parse_info.Ab anymore.
    *)
-  | Parse_info.NoTokenLocation _ -> d
+  | Tok.NoTokenLocation _ -> d
 
 type lang_kind = CLikeSemiColon | Other
 

--- a/src/reporting/JSON_report.ml
+++ b/src/reporting/JSON_report.ml
@@ -283,7 +283,7 @@ let match_to_match render_fix (x : Pattern_match.t) :
      * pattern in x.code or the metavar does not contain any token
      *)
   with
-  | Parse_info.NoTokenLocation s ->
+  | Tok.NoTokenLocation s ->
       let loc = Tok.first_loc_of_file x.file in
       let s =
         spf "NoTokenLocation with pattern %s, %s" x.rule_id.pattern_string s

--- a/src/reporting/JSON_report.ml
+++ b/src/reporting/JSON_report.ml
@@ -159,7 +159,7 @@ let metavars startp_of_match_range (s, mval) =
   match range_of_any_opt startp_of_match_range any with
   | None ->
       raise
-        (Parse_info.NoTokenLocation
+        (Tok.NoTokenLocation
            (spf "NoTokenLocation with metavar %s, close location = %s" s
               (SJ.string_of_position startp_of_match_range)))
   | Some (startp, endp) ->

--- a/src/reporting/Matching_report.ml
+++ b/src/reporting/Matching_report.ml
@@ -64,10 +64,10 @@ let print_match ?(format = Normal) ?(str = "") ?(spaces = 0) ii =
     let end_line, _, _ =
       Tok.get_token_end_info (PI.unsafe_token_location_of_info maxi)
     in
-    let file, line = (PI.file_of_info mini, PI.line_of_info mini) in
+    let file, line = (PI.file_of_info mini, Tok.line_of_tok mini) in
     let prefix = spf "%s:%d" file line in
     let lines_str =
-      File.lines_of_file (PI.line_of_info mini, end_line) (Fpath.v file)
+      File.lines_of_file (Tok.line_of_tok mini, end_line) (Fpath.v file)
     in
     match format with
     | Normal ->

--- a/src/runner/Run_semgrep.ml
+++ b/src/runner/Run_semgrep.ml
@@ -148,7 +148,7 @@ let print_match ?str config match_ ii_of_any =
      * factorize code a bit.
      *)
     let mini, _maxi = PI.min_max_ii_by_pos toks in
-    let file, line = (PI.file_of_info mini, PI.line_of_info mini) in
+    let file, line = (PI.file_of_info mini, Tok.line_of_tok mini) in
 
     let strings_metavars =
       mvars


### PR DESCRIPTION
Used osemgrep with some ocaml refactoring rules (in jsonnet) to assist!

test plan:
make core


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)