### PR TITLE
fix(scala): parse indented for bodies, parse fun dcls

### DIFF
--- a/languages/scala/recursive_descent/Parser_scala_recursive_descent.ml
+++ b/languages/scala/recursive_descent/Parser_scala_recursive_descent.ml
@@ -342,9 +342,13 @@ let getIndentStatus ?(is_opportunistic = false) in_ =
     | _ -> false
   in
 
-  if is_indented then Some (Indent (line, col))
-  else if is_dedented then Some (Dedent (line, col))
-  else None
+  match tok with
+  (* Don't emit before an EOF. *)
+  | EOF _ -> None
+  | __else__ ->
+      if is_indented then Some (Indent (line, col))
+      else if is_dedented then Some (Dedent (line, col))
+      else None
 
 (* Sometimes, we can emit an indent, irrespective of the specific token that we
    just passed. This is in certain contextual parsing positions, such as after
@@ -2514,6 +2518,7 @@ and parseFor in_ : stmt =
         fb (PI.unsafe_fake_info "") (enumerators in_)
   in
   newLinesOpt in_;
+  opportunisticIndent in_;
   let body =
     match in_.token with
     | Kyield ii ->
@@ -3430,9 +3435,7 @@ let funDefRest fkind _attrs name in_ : function_definition * type_parameters =
                  nextToken in_ (* AST: newmmods |= MACRO *);
                let x = expr in_ in
                Some (FExpr (ii, x))
-           | _ ->
-               accept (EQUALS ab) in_ (* generate error message *);
-               None
+           | _ -> None
          in
          (* ast: DefDef(newmods, name.toTermName, tparams,vparamss,restype, rhs) *)
          (* CHECK: "unary prefix operator definition with empty parameter list.."*)
@@ -3466,7 +3469,6 @@ let funDefOrDcl attrs in_ : definition =
                    let x = constrExpr vparamss in_ in
                    FExpr (ii, x)
                | _ ->
-                   accept (EQUALS ab) in_;
                    (* generate error message *)
                    raise Impossible
              in

--- a/tests/parsing/scala/fun_dcl.scala
+++ b/tests/parsing/scala/fun_dcl.scala
@@ -1,0 +1,2 @@
+trait foo:
+  def bar : T

--- a/tests/parsing/scala/indented_for_body.scala
+++ b/tests/parsing/scala/indented_for_body.scala
@@ -1,0 +1,4 @@
+
+val x =
+  for (i <- 9 to 5)
+    import foo


### PR DESCRIPTION
Parse indented `for` bodies in Scala 3, like
```
val x =
  for (i <- 9 to 5)
    import foo
```
and fun dcls.

## Test plan:
`make test`

Parse rate: `0.978346652058613` to `0.9785559783011464`

No changelog because I'm sick of opening tickets for a bunch of really small things, I'll just make a really big changelog before I merge all this

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
