### PR TITLE
Add parsing stats for elixir

### DIFF
--- a/stats/parsing-stats/lang/elixir/projects.txt
+++ b/stats/parsing-stats/lang/elixir/projects.txt
@@ -1,0 +1,34 @@
+#
+# Top elixir projects from GitHub, sorted by stars.
+# Created by ./most-starred-for-language.
+#
+https://github.com/elixir-lang/elixir
+https://github.com/phoenixframework/phoenix
+https://github.com/h4cc/awesome-elixir
+https://github.com/plausible/analytics
+https://github.com/elixir-ecto/ecto
+https://github.com/papercups-io/papercups
+https://github.com/phoenixframework/phoenix_live_view
+https://github.com/rrrene/credo
+https://github.com/supabase/realtime
+https://github.com/christopheradams/elixir_style_guide
+https://github.com/absinthe-graphql/absinthe
+https://github.com/ueberauth/guardian
+https://github.com/seven1m/30-days-of-elixir
+https://github.com/bitwalker/distillery
+https://github.com/sergiotapia/magnetissimo
+https://github.com/elixir-plug/plug
+https://github.com/thechangelog/changelog.com
+https://github.com/livebook-dev/livebook
+https://github.com/edgurgel/httpoison
+https://github.com/sorentwo/oban
+https://github.com/edeliver/edeliver
+https://github.com/adriankumpf/teslamate
+https://github.com/devinus/poison
+https://github.com/quantum-elixir/quantum-core
+https://github.com/asciinema/asciinema-server
+https://github.com/elixirkoans/elixir-koans
+https://github.com/thoughtbot/bamboo
+https://github.com/nerves-project/nerves
+https://github.com/boydm/scenic
+https://github.com/thoughtbot/ex_machina


### PR DESCRIPTION
Just a copy of the projects.txt files in ocaml-tree-sitter-semgrep
for Elixir

test plan:
cd stats/parsing-stats
./run-lang elixir
=>
```
lang/elixir/stats.json:3
   "global": {
     "name": "*",
     "parsing_rate": 0.9906758538791348,
     "line_count": 869034,
     "error_line_count": 8103,
     "file_count": 5240,
     "error_file_count": 125,
     "total_node_count": 13550384,
     "untranslated_node_count": 108627
   },
```


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)