### PR TITLE
CLI: Allow --pro to take a single target that is not a dir

### DIFF
--- a/changelog.d/misc-1.changed
+++ b/changelog.d/misc-1.changed
@@ -1,0 +1,2 @@
+Pro: `semgrep --pro` still requires a single target, but this target no longer
+needs to be a directory, it can be an individual file too.

--- a/cli/src/semgrep/core_runner.py
+++ b/cli/src/semgrep/core_runner.py
@@ -1035,11 +1035,12 @@ class CoreRunner:
 
                 if engine is EngineType.PRO_INTERFILE:
                     targets = target_manager.targets
-                    if len(targets) == 1 and targets[0].path.is_dir():
+                    if len(targets) == 1:
                         root = str(targets[0].path)
                     else:
-                        # TODO: This is no longer true...
-                        raise SemgrepError("deep mode needs a single target (root) dir")
+                        raise SemgrepError(
+                            "Inter-file analysis can only take a single target (for multiple files pass a directory)"
+                        )
                     cmd += ["-deep_inter_file"]
                     cmd += [
                         "-timeout_for_interfile_analysis",


### PR DESCRIPTION
test plan:
% semgrep --pro -c p/default-v2 some_file.js # now works!

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
