### PR TITLE
Don't skip over an expected closing brace

### DIFF
--- a/libs/aliengrep/Unit_Match.ml
+++ b/libs/aliengrep/Unit_Match.ml
@@ -161,15 +161,17 @@ let test_ellipsis_brackets () =
   check mconf {|(...)|} {|(")")|} [ Num_matches 1; Match_value {|(")|} ]
 
 let test_explicit_brackets () =
-  check uconf {|(...)|} {|())|} [ Num_matches 1; Match_value {|()|} ]
-(*;
+  check uconf {|(...)|} {|())|} [ Num_matches 1; Match_value {|()|} ];
   (* Since parentheses are defined as brackets, we're not allowed to reject
-     a closing parenthesis that match the opening parenthesis. *)
-  (* TODO: make the top-level ellipses exclude the expected closing bracket.
-     This requires new variety of node with [^\)[:blank:]] instead of
-     [^[:blank:]] when the expected closing brace is ')'. *)
-  check uconf {|(... x)|} {|()x)|} [ Num_matches 0 ]
-*)
+     a closing parenthesis that matches the opening parenthesis. *)
+  check uconf {|(... x)|} {|()x)|} [ Num_matches 0 ];
+  check uconf {|(...)|} {|([])|} [ Num_matches 1; Match_value {|([])|} ];
+  (* The behavior of the following test cases is subject to change.
+     There's only so much we can do when braces are mismatched. *)
+  check uconf {|(...)|} {|([)|} [ Num_matches 1; Match_value {|([)|} ];
+  check uconf {|(...)|} {|(])|} [ Num_matches 1; Match_value {|(])|} ];
+  check uconf {|(...)|} {|([)]|} [ Num_matches 0 ];
+  check uconf {|(...)|} {|[([)]|} [ Num_matches 0 ]
 
 let test_backreferences () =
   check uconf {|$A ... $A|} {|a, b, c, a, d|}


### PR DESCRIPTION
The bug was that the pattern `(...x)` was matching `()x)`. This should no longer happen.

We still tolerate mismatched closing braces in some cases (`(]x)`). I'm worried about string literals like `")"` or `"\""`. Maybe it doesn't matter much in practice. We can revisit this when the time comes.

With this, I'm done with known bugs for aliengrep.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
