### PR TITLE
CLI: Better verbose info about partially analyzed files

### DIFF
--- a/changelog.d/pa-2683.changed
+++ b/changelog.d/pa-2683.changed
@@ -1,0 +1,6 @@
+Partially analyzed files are no longer reported as skipped by --verbose. And if we
+lack info about what lines have been skipped we no longer report that all lines have
+been skipped. That was not accurate. For example, an error while evaluating a
+`metavariable-pattern` operator in one rule may cause a finding to be missed, and
+the file being reported as partially analyzed. However, that error did not affect
+any other rules, and even the affected rule may be able to produce some findings.

--- a/cli/src/semgrep/output.py
+++ b/cli/src/semgrep/output.py
@@ -15,6 +15,7 @@ from typing import NamedTuple
 from typing import Optional
 from typing import Sequence
 from typing import Set
+from typing import Tuple
 from typing import Type
 
 import requests
@@ -273,19 +274,24 @@ class OutputHandler:
     @staticmethod
     def _make_failed_to_analyze(
         semgrep_core_errors: Sequence[SemgrepCoreError],
-    ) -> Mapping[Path, Optional[int]]:
+    ) -> Mapping[Path, Tuple[Optional[int], List[out.RuleId]]]:
         def update_failed_to_analyze(
-            memo: Mapping[Path, Optional[int]], err: SemgrepCoreError
-        ) -> Mapping[Path, Optional[int]]:
+            memo: Mapping[Path, Tuple[Optional[int], List[out.RuleId]]],
+            err: SemgrepCoreError,
+        ) -> Mapping[Path, Tuple[Optional[int], List[out.RuleId]]]:
             path = Path(err.core.location.path)
-            so_far = memo.get(path, 0)
-            if err.spans is None or so_far is None:
+            so_far = memo.get(path, (0, []))
+            if err.spans is None or so_far[0] is None:
                 num_lines = None
             else:
-                num_lines = so_far + sum(
+                num_lines = so_far[0] + sum(
                     s.end.line - s.start.line + 1 for s in err.spans
                 )
-            return {**memo, path: num_lines}
+            rule_ids = so_far[1]
+            if err.core.rule_id is not None:
+                rule_ids.append(err.core.rule_id)
+
+            return {**memo, path: (num_lines, rule_ids)}
 
         return reduce(update_failed_to_analyze, semgrep_core_errors, {})
 

--- a/cli/src/semgrep/target_manager.py
+++ b/cli/src/semgrep/target_manager.py
@@ -22,6 +22,7 @@ from typing import Set
 from typing import Tuple
 from typing import Union
 
+import semgrep.output_from_core as core
 from semgrep.git import BaselineHandler
 
 # usually this would be a try...except ImportError
@@ -132,7 +133,9 @@ class FileTargetingLog:
     size_limit: Set[Path] = Factory(set)
 
     # "None" indicates that all lines were skipped
-    core_failure_lines_by_file: Mapping[Path, Optional[int]] = Factory(dict)
+    core_failure_lines_by_file: Mapping[
+        Path, Tuple[Optional[int], List[core.RuleId]]
+    ] = Factory(dict)
 
     # Indicates which files were NOT scanned by each language
     # e.g. for python, should be a list of all non-python-compatible files
@@ -208,7 +211,7 @@ class FileTargetingLog:
             )
         if self.core_failure_lines_by_file:
             partial_fragments.append(
-                f"{len(self.core_failure_lines_by_file)} files only partially analyzed due to a parsing or internal Semgrep error"
+                f"{len(self.core_failure_lines_by_file)} files only partially analyzed due to parsing or internal Semgrep errors"
             )
 
         if not limited_fragments and not skip_fragments and not partial_fragments:
@@ -279,16 +282,27 @@ class FileTargetingLog:
         else:
             yield 2, "<none>"
 
-        yield 1, "Skipped by analysis failure due to parsing or internal Semgrep error"
+        yield 1, "Partially analyzed due to parsing or internal Semgrep errors"
         if self.core_failure_lines_by_file:
-            for path, lines in sorted(self.core_failure_lines_by_file.items()):
+            for path, (lines, rule_ids) in sorted(
+                self.core_failure_lines_by_file.items()
+            ):
+                num_rule_ids = len(rule_ids) if rule_ids else 0
+                if num_rule_ids == 0:
+                    with_rule = ""
+                elif num_rule_ids == 1:
+                    with_rule = f" with rule {rule_ids[0].value}"
+                else:
+                    with_rule = f" with {num_rule_ids} rules (e.g. {rule_ids[0].value})"
                 if lines is None:
-                    skipped = "all"
+                    # No lines does not mean all lines, we simply don't know how many.
+                    # TODO: Maybe for parsing errors this would mean all lines?
+                    lines_skipped = ""
                 else:
                     # TODO: use pluralization library
-                    skipped = str(lines)
+                    lines_skipped = f" ({lines} lines skipped)"
 
-                yield 2, with_color(Colors.cyan, f"{path} ({skipped} lines skipped)")
+                yield 2, with_color(Colors.cyan, f"{path}{with_rule}{lines_skipped}")
         else:
             yield 2, "<none>"
 

--- a/cli/tests/e2e/snapshots/test_check/test_max_memory/error.txt
+++ b/cli/tests/e2e/snapshots/test_check/test_max_memory/error.txt
@@ -41,9 +41,9 @@ Files skipped:
 
    • <none>
 
-  Skipped by analysis failure due to parsing or internal Semgrep error
+  Partially analyzed due to parsing or internal Semgrep errors
 
-   • targets/equivalence/open_redirect.py (all lines skipped)
+   • targets/equivalence/open_redirect.py
 
                 
                 
@@ -52,7 +52,7 @@ Files skipped:
 └──────────────┘
 Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
-  Partially scanned: 1 files only partially analyzed due to a parsing or internal Semgrep error
+  Partially scanned: 1 files only partially analyzed due to parsing or internal Semgrep errors
 
 Ran 1 rule on 1 file: 0 findings.
 Not sending pseudonymous metrics since metrics are configured to OFF and registry usage is False

--- a/cli/tests/e2e/snapshots/test_check/test_spacegrep_timeout/error.txt
+++ b/cli/tests/e2e/snapshots/test_check/test_spacegrep_timeout/error.txt
@@ -12,6 +12,6 @@ Warning: 1 timeout error(s) in targets/spacegrep_timeout/gnu-lgplv2.txt when run
 │ Scan Summary │
 └──────────────┘
 Some files were skipped or only partially analyzed.
-  Partially scanned: 1 files only partially analyzed due to a parsing or internal Semgrep error
+  Partially scanned: 1 files only partially analyzed due to parsing or internal Semgrep errors
 
 Ran 1 rule on 1 file: 0 findings.

--- a/cli/tests/e2e/snapshots/test_check/test_timeout_threshold/error.txt
+++ b/cli/tests/e2e/snapshots/test_check/test_timeout_threshold/error.txt
@@ -48,9 +48,9 @@ Files skipped:
 
    • <none>
 
-  [1m[24mSkipped by analysis failure due to parsing or internal Semgrep error[0m
+  [1m[24mPartially analyzed due to parsing or internal Semgrep errors[0m
 
-   • [36m[22m[24mtargets/equivalence/open_redirect.py (all lines skipped)[0m
+   • [36m[22m[24mtargets/equivalence/open_redirect.py with rule rules.forcetimeout[0m
 
                 
                 
@@ -59,7 +59,7 @@ Files skipped:
 └──────────────┘
 Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
-  Partially scanned: 1 files only partially analyzed due to a parsing or internal Semgrep error
+  Partially scanned: 1 files only partially analyzed due to parsing or internal Semgrep errors
 
 Ran 3 rules on 1 file: 0 findings.
 Not sending pseudonymous metrics since metrics are configured to OFF and registry usage is False

--- a/cli/tests/e2e/snapshots/test_check/test_timeout_threshold/error_2.txt
+++ b/cli/tests/e2e/snapshots/test_check/test_timeout_threshold/error_2.txt
@@ -46,9 +46,9 @@ Files skipped:
 
    • <none>
 
-  [1m[24mSkipped by analysis failure due to parsing or internal Semgrep error[0m
+  [1m[24mPartially analyzed due to parsing or internal Semgrep errors[0m
 
-   • [36m[22m[24mtargets/equivalence/open_redirect.py (all lines skipped)[0m
+   • [36m[22m[24mtargets/equivalence/open_redirect.py with rule rules.forcetimeout2[0m
 
                 
                 
@@ -57,7 +57,7 @@ Files skipped:
 └──────────────┘
 Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
-  Partially scanned: 1 files only partially analyzed due to a parsing or internal Semgrep error
+  Partially scanned: 1 files only partially analyzed due to parsing or internal Semgrep errors
 
 Ran 3 rules on 1 file: 0 findings.
 Not sending pseudonymous metrics since metrics are configured to OFF and registry usage is False

--- a/cli/tests/e2e/snapshots/test_cli_test/test_parse_errors/errors.txt
+++ b/cli/tests/e2e/snapshots/test_cli_test/test_parse_errors/errors.txt
@@ -45,7 +45,7 @@ Files skipped:
 
    • <none>
 
-  [1m[24mSkipped by analysis failure due to parsing or internal Semgrep error[0m
+  [1m[24mPartially analyzed due to parsing or internal Semgrep errors[0m
 
    • [36m[22m[24mtargets/cli_test/parse_errors/invalid_javascript.js (2 lines skipped)[0m
 
@@ -55,7 +55,7 @@ Files skipped:
 │ Scan Summary │
 └──────────────┘
 Some files were skipped or only partially analyzed.
-  Partially scanned: 1 files only partially analyzed due to a parsing or internal Semgrep error
+  Partially scanned: 1 files only partially analyzed due to parsing or internal Semgrep errors
 
 Ran 2 rules on 1 file: 3 findings.
 Not sending pseudonymous metrics since metrics are configured to OFF and registry usage is False

--- a/cli/tests/e2e/snapshots/test_exclude_include/test_exclude_include_verbose_sorted_1/results.err
+++ b/cli/tests/e2e/snapshots/test_exclude_include/test_exclude_include_verbose_sorted_1/results.err
@@ -47,7 +47,7 @@ Files skipped:
 
    • <none>
 
-  Skipped by analysis failure due to parsing or internal Semgrep error
+  Partially analyzed due to parsing or internal Semgrep errors
 
    • <none>
 

--- a/cli/tests/e2e/snapshots/test_exclude_include/test_exclude_include_verbose_sorted_2/results.err
+++ b/cli/tests/e2e/snapshots/test_exclude_include/test_exclude_include_verbose_sorted_2/results.err
@@ -57,7 +57,7 @@ Files skipped:
 
    • <none>
 
-  Skipped by analysis failure due to parsing or internal Semgrep error
+  Partially analyzed due to parsing or internal Semgrep errors
 
    • <none>
 

--- a/cli/tests/e2e/snapshots/test_output/test_debug_experimental_rule/results.txt
+++ b/cli/tests/e2e/snapshots/test_output/test_debug_experimental_rule/results.txt
@@ -103,7 +103,7 @@ Files skipped:
 
    • <none>
 
-  Skipped by analysis failure due to parsing or internal Semgrep error
+  Partially analyzed due to parsing or internal Semgrep errors
 
    • <none>
 

--- a/cli/tests/e2e/snapshots/test_semgrep_core_parse_error/test_file_parser__failure__error_messages/settings0/error.txt
+++ b/cli/tests/e2e/snapshots/test_semgrep_core_parse_error/test_file_parser__failure__error_messages/settings0/error.txt
@@ -42,7 +42,7 @@ Files skipped:
 
    • <none>
 
-  [1m[24mSkipped by analysis failure due to parsing or internal Semgrep error[0m
+  [1m[24mPartially analyzed due to parsing or internal Semgrep errors[0m
 
    • [36m[22m[24mtargets/bad/invalid_go.go (2 lines skipped)[0m
 
@@ -52,7 +52,7 @@ Files skipped:
 │ Scan Summary │
 └──────────────┘
 Some files were skipped or only partially analyzed.
-  Partially scanned: 1 files only partially analyzed due to a parsing or internal Semgrep error
+  Partially scanned: 1 files only partially analyzed due to parsing or internal Semgrep errors
 
 Ran 1 rule on 1 file: 0 findings.
 Not sending pseudonymous metrics since metrics are configured to OFF and registry usage is False

--- a/cli/tests/e2e/snapshots/test_semgrep_core_parse_error/test_file_parser__failure__error_messages/settings1/error.txt
+++ b/cli/tests/e2e/snapshots/test_semgrep_core_parse_error/test_file_parser__failure__error_messages/settings1/error.txt
@@ -43,7 +43,7 @@ Files skipped:
 
    • <none>
 
-  [1m[24mSkipped by analysis failure due to parsing or internal Semgrep error[0m
+  [1m[24mPartially analyzed due to parsing or internal Semgrep errors[0m
 
    • [36m[22m[24mtargets/bad/invalid_python.py (2 lines skipped)[0m
 
@@ -53,7 +53,7 @@ Files skipped:
 │ Scan Summary │
 └──────────────┘
 Some files were skipped or only partially analyzed.
-  Partially scanned: 1 files only partially analyzed due to a parsing or internal Semgrep error
+  Partially scanned: 1 files only partially analyzed due to parsing or internal Semgrep errors
 
 Ran 2 rules on 1 file: 0 findings.
 Not sending pseudonymous metrics since metrics are configured to OFF and registry usage is False


### PR DESCRIPTION
When a file is partially analyzed e.g. due to an error while evaluating a metavariable-pattern operator in ONE rule, that does NOT mean that the entire file has been skipped (which is what CLI was reporting)!

test plan:
See PA-2683 for an example

PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
