### PR TITLE
fix semgrep-dev docker build

### DIFF
--- a/dockerfiles/semgrep-dev.Dockerfile
+++ b/dockerfiles/semgrep-dev.Dockerfile
@@ -26,7 +26,8 @@ RUN apk add --no-cache \
 #
 # Install python >= 3.11 needed by pre-commit (for what operation?)
 RUN apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main python3 && \
-  [[ "$(python3 --version)" =~ 3\.11\.[0-9]+ ]]
+  python3 --version > /tmp/python-version && \
+  grep -F 3.11 /tmp/python-version
 # Install version XXX of pre-commit needed for YYY (requires python >= 3.11):
 RUN apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing pre-commit
 

--- a/dockerfiles/semgrep-dev.Dockerfile
+++ b/dockerfiles/semgrep-dev.Dockerfile
@@ -17,10 +17,13 @@ FROM returntocorp/semgrep:develop
 # Various utilities. We can always install them during the CI job but it's
 # it's nice to do it here while we're root.
 #
+# TODO: remove the explicit python3 install once our version of alpine has python3.11
+#
 RUN apk add --no-cache \
   bash \
   curl \
   jq && \
+  apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main python3 && \
   apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing pre-commit
 
 # Let the user know how their container was built

--- a/dockerfiles/semgrep-dev.Dockerfile
+++ b/dockerfiles/semgrep-dev.Dockerfile
@@ -17,14 +17,18 @@ FROM returntocorp/semgrep:develop
 # Various utilities. We can always install them during the CI job but it's
 # it's nice to do it here while we're root.
 #
-# TODO: remove the explicit python3 install once our version of alpine has python3.11
-#
 RUN apk add --no-cache \
   bash \
   curl \
-  jq && \
-  apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main python3 && \
-  apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing pre-commit
+  jq
+
+# TODO: remove the explicit python3 install once our version of alpine has python3.11
+#
+# Install python >= 3.11 needed by pre-commit (for what operation?)
+RUN apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main python3 && \
+  [[ "$(python3 --version)" =~ 3\.11\.[0-9]+ ]]
+# Install version XXX of pre-commit needed for YYY (requires python >= 3.11):
+RUN apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing pre-commit
 
 # Let the user know how their container was built
 COPY dockerfiles/semgrep-dev.Dockerfile /Dockerfile


### PR DESCRIPTION
At some point the `pre-commit` alpine package took a dependency on python 3.11, which broke docker builds because alpine 3.17's `python3` package installs 3.10. Installing `python3` from edge fixes the build for now.
