### PR TITLE
fix(cli): git URL parsing for subgroups

### DIFF
--- a/changelog.d/pa-2669.fixed
+++ b/changelog.d/pa-2669.fixed
@@ -1,0 +1,3 @@
+CLI: Fixed a bug where Git projects with URLs with subgroups would not parse correctly,
+and produce non-clickable links in Semgrep App. These are such as:
+https://gitlab.com/example/group2/group3/test-case.git

--- a/cli/src/semgrep/external/git_url_parser.py
+++ b/cli/src/semgrep/external/git_url_parser.py
@@ -104,7 +104,6 @@ class Parser(str):
             'owner': None,
         }
         for regex in POSSIBLE_REGEXES:
-            print("url", self._url)
             match = regex.search(self._url)
             if match:
                 d.update(match.groupdict())

--- a/cli/src/semgrep/external/git_url_parser.py
+++ b/cli/src/semgrep/external/git_url_parser.py
@@ -43,7 +43,7 @@ POSSIBLE_REGEXES = (
                r'(?P<resource>[a-z0-9_.-]*)'
                r'[:/]*'
                r'(?P<port>[\d]+){0,1}'
-               r'(?P<pathname>\/((?P<owner>[\w\-]+)\/)?'
+               r'(?P<pathname>\/((?P<owner>[\w\-\/]+)\/)?'
                r'((?P<name>[\w\-\.]+?)(\.git|\/)?)?)$'),
     re.compile(r'(git\+)?'
                r'((?P<protocol>\w+)://)'
@@ -104,6 +104,7 @@ class Parser(str):
             'owner': None,
         }
         for regex in POSSIBLE_REGEXES:
+            print("url", self._url)
             match = regex.search(self._url)
             if match:
                 d.update(match.groupdict())

--- a/cli/tests/e2e/test_ci.py
+++ b/cli/tests/e2e/test_ci.py
@@ -282,11 +282,6 @@ def mock_autofix(request, mocker):
             "SEMGREP_APP_TOKEN": "dummy",
             "SEMGREP_REPO_URL": REMOTE_REPO_URL,
         },
-        {  # Same as above, but with a repo URL that has a dot in the name.
-            # This used to cause the URL parser to crash.
-            "SEMGREP_APP_TOKEN": "dummy",
-            "SEMGREP_REPO_URL": "https://test@dev.azure.com/test/TestName/_git/Core.Thing",
-        },
         {  # Github full scan
             "CI": "true",
             "GITHUB_ACTIONS": "true",
@@ -557,7 +552,6 @@ def mock_autofix(request, mocker):
     ],
     ids=[
         "local",
-        "local_with_dot_url",
         "github-push",
         "github-push-special-env-vars",
         "github-enterprise",

--- a/cli/tests/e2e/test_meta.py
+++ b/cli/tests/e2e/test_meta.py
@@ -1,0 +1,23 @@
+from semgrep.meta import get_url_from_sstp_url
+
+
+def test_git_url_parser():
+    tests = [
+        # This used to cause the URL parser to crash.
+        (
+            "https://test@dev.azure.com/test/TestName/_git/Core.Thing",
+            "https://dev.azure.com/test/TestName/_git/Core.Thing",
+        ),
+        # This one has a "subgroup" structure, which we should be able to parse.
+        (
+            "https://gitlab.com/example/group2/group3/test-case.git",
+            "https://gitlab.com/example/group2/group3/test-case",
+        ),
+        (
+            "https://gitlab.com/example/test-case.git",
+            "https://gitlab.com/example/test-case",
+        ),
+    ]
+
+    for url, expected in tests:
+        assert get_url_from_sstp_url(url) == expected


### PR DESCRIPTION
y'all would have thought this was Lagrange's theorem, because today we're talking about subgroups

## What:
This PR fixes URL parsing for URLs which have a "subgroup" structure, which is to say that it is in a "nested grouping structure". Previously, we would butcher these URLs, and produce things like `https://https//gitlab.com/r2cexamples2/group2/group3/chess-game` from `https://gitlab.com/r2cexamples2/group2/group3/chess-game.git`.

## Why:
We want clickable URLs.

## How:
Made it such that when parsing the "owner" of a project, it can include slashes (so it might be multiple such entries in the URL, instead of just one).

## Test plan:
Added a test suite for git URL parsing, which we can use for the future.

I don't actually know what the end target URL is supposed to look like, but I presume it should look similar to what the working example is (which produces `https://gitlab.com/r2cexamples2/webgoat` from `https://gitlab.com/r2cexamples2/webgoat.git`)

Closes PA-2669

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
