### PR TITLE
refactor: Create `Naming_utils` module

### DIFF
--- a/src/naming/Naming_AST.mli
+++ b/src/naming/Naming_AST.mli
@@ -3,12 +3,3 @@
  * specific to a language.
  *)
 val resolve : Lang.t -> AST_generic.program -> unit
-
-(* We expose this language-specific (and framework-specific!)
-   function here because it is needed in Semgrep Pro.
-   This lets us avoid having to duplicate the logic of this function.
-
-   There's not really a better place to put this, so we'll just
-   let it exist here.
-*)
-val is_js_angular_decorator : string -> bool

--- a/src/naming/Naming_utils.ml
+++ b/src/naming/Naming_utils.ml
@@ -1,0 +1,45 @@
+(* Copyright (C) 2020-2023 r2c
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * version 2.1 as published by the Free Software Foundation, with the
+ * special exception on linking described in file LICENSE.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
+ * LICENSE for more details.
+ *)
+
+open Common
+
+(* In Angular JS, we have some "Injectable" classes, which are marked with an
+   @Injectable decorator.
+   https://angular.io/guide/dependency-injection-in-action
+   These classes may reference parameters to the constructor of the class, outside
+   of the actual code of the constructor itself.
+   So we must add them to the scope, should we find the decorator and a constructor's
+   parameters.
+   This also works for `@Component`.
+*)
+let is_js_angular_decorator s =
+  match s with
+  | "Injectable"
+  | "Component" ->
+      true
+  | _else_ -> false
+
+(* This extracts package aliases from Go import specifiers that users may find
+ * convenient for rule-writing purposes. *)
+let go_package_alias s =
+  let pkgpath, pkgbase = Common2.dirs_and_base_of_file s in
+  if pkgbase =~ "v[0-9]+" then
+    (* e.g. google.golang.org/api/youtube/v3 *)
+    match pkgpath with
+    | [] -> pkgbase
+    | _else_ -> Common2.list_last pkgpath
+  else if pkgbase =~ "\\(.+\\)-go" then
+    (* e.g. github.com/dgrijalva/jwt-go *)
+    matched1 pkgbase
+  else (* default convention *)
+    pkgbase

--- a/src/naming/Naming_utils.mli
+++ b/src/naming/Naming_utils.mli
@@ -1,0 +1,6 @@
+(* We expose these language-specific functions here because they are needed in
+ * Semgrep Pro.
+ *
+ * This lets us avoid having to duplicate the logic of these functions. *)
+val is_js_angular_decorator : string -> bool
+val go_package_alias : string -> string


### PR DESCRIPTION
I need what is now exposed as `go_package_alias` to implement #3352 for Pro Engine Interfile. Since this is now the second thing that we need from `Naming_AST`, I decided to create `Naming_utils` for standalone utilities that are part of naming but also needed elsewhere.

Test plan: Automated tests

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
