### PR TITLE
use /usr/bin/env bash instead of /bin/bash

### DIFF
--- a/js/languages/shared/generate-semgrep-js.sh
+++ b/js/languages/shared/generate-semgrep-js.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -eu
+#!/usr/bin/env bash
+set -eu
 
 for LANG in "$@"; do
 cat <<EOF


### PR DESCRIPTION
This allows to compile on systems where /bin/bash does not exist (such as FreeBSD) -- but /usr/local/bin/bash does

Tested locally on my FreeBSD laptop.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
