### PR TITLE
Remove use of Skip_code in src/targeting/Skip_target.ml

### DIFF
--- a/src/targeting/Find_target.ml
+++ b/src/targeting/Find_target.ml
@@ -203,15 +203,14 @@ let sort_files_by_decreasing_size files =
    the language-independent 'select_global_targets'.
 *)
 let global_filter ~opt_lang ~sort_by_decr_size paths =
-  let paths, skipped1 = Skip_target.exclude_files_in_skip_lists paths in
-  let paths, skipped2 =
+  let paths, skipped1 =
     match opt_lang with
     | None -> (paths, [])
     | Some lang -> Guess_lang.inspect_files lang paths
   in
-  let paths, skipped3 = Skip_target.exclude_big_files paths in
-  let paths, skipped4 = Skip_target.exclude_minified_files paths in
-  let skipped = Common.flatten [ skipped1; skipped2; skipped3; skipped4 ] in
+  let paths, skipped2 = Skip_target.exclude_big_files paths in
+  let paths, skipped3 = Skip_target.exclude_minified_files paths in
+  let skipped = Common.flatten [ skipped1; skipped2; skipped3 ] in
   let sorted_paths =
     if sort_by_decr_size then sort_files_by_decreasing_size paths else paths
   in

--- a/src/targeting/Skip_target.ml
+++ b/src/targeting/Skip_target.ml
@@ -118,26 +118,6 @@ let is_minified (path : Fpath.t) =
 let exclude_minified_files paths = Common.partition_result is_minified paths
 
 (****************************************************************************)
-(* Pad's Skip_code filtering *)
-(****************************************************************************)
-
-let exclude_files_in_skip_lists roots =
-  let paths, skipped_paths =
-    Skip_code.filter_files_if_skip_list ~root:roots roots
-  in
-  let skipped =
-    skipped_paths
-    |> Common.map (fun path ->
-           {
-             Resp.path = Fpath.to_string path;
-             reason = Excluded_by_config;
-             details = "excluded by 'skip list' file";
-             rule_id = None;
-           })
-  in
-  (paths, skipped)
-
-(****************************************************************************)
 (* Big file filtering *)
 (****************************************************************************)
 

--- a/src/targeting/Skip_target.mli
+++ b/src/targeting/Skip_target.mli
@@ -1,7 +1,3 @@
-(* This is using the skip_list.txt of pfff Skip_code.ml *)
-val exclude_files_in_skip_lists :
-  Fpath.t list -> Fpath.t list * Output_from_core_t.skipped_target list
-
 (* This is using Flag_semgrep.max_target_bytes *)
 val exclude_big_files :
   Fpath.t list -> Fpath.t list * Output_from_core_t.skipped_target list


### PR DESCRIPTION
The skip_list.txt is a feature used only by Pad, and it's
deprecated in favor of the new libs/gitignore/ mechanism.

test plan:
osemgrep -l ocaml -e ': Common.dirname' --verbose
now analyzes 2107 files
and does not skip files mentioned in my skip_list.txt file


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)