### PR TITLE
osemgrep: color complete log lines, avoid the logging level

### DIFF
--- a/libs/commons/Logs_helpers.ml
+++ b/libs/commons/Logs_helpers.ml
@@ -1,23 +1,50 @@
+(* ansii escape sequences for colored output, depending on log level *)
+let color level =
+  match level with
+  | Logs.Warning -> Some "33" (*yellow*)
+  | Logs.Error -> Some "31" (*red*)
+  | _else -> None
+
+(* print an ansi escape sequence *)
+let pp_sgr ppf style =
+  Format.pp_print_as ppf 0 "\027[";
+  Format.pp_print_as ppf 0 style;
+  Format.pp_print_as ppf 0 "m"
+
+(* log reporter *)
+let reporter ?(dst = Format.err_formatter) () =
+  let report _src level ~over k msgf =
+    let pp_style, style, style_off =
+      match color level with
+      | None -> ((fun _ppf _style -> ()), "", "")
+      | Some x -> (pp_sgr, x, "0")
+    in
+    let k _ =
+      over ();
+      k ()
+    in
+    let r =
+      msgf @@ fun ?header:_ ?tags:_ fmt ->
+      Format.kfprintf k dst ("@[%a" ^^ fmt ^^ "@]@.") pp_style style
+    in
+    Format.fprintf dst "%a" pp_style style_off;
+    r
+  in
+  { Logs.report }
+
 (* Enable basic logging (level = Logs.Warning) so that you can use Logging
  * calls even before a precise call to setup_logging.
  *)
 let enable_logging () =
-  let pp_header _ppf (_level, _opt_header) = () in
   Logs.set_level ~all:true (Some Logs.Warning);
-  Logs.set_reporter (Logs_fmt.reporter ~pp_header ~app:Format.err_formatter ());
+  Logs.set_reporter (reporter ());
   ()
 
-(* TOPORT: with Logs a warning is displayed as:
- *    osemgrep: [WARNING] Paths that match both --include ...
- *  with the WARNING in yellow. In python it's displayed as:
- *    Paths that match both --include ...
- *  without any header but with the whole line in yellow.
- *)
 let setup_logging ~force_color ~level =
   let style_renderer = if force_color then Some `Ansi_tty else None in
   Fmt_tty.setup_std_outputs ?style_renderer ();
   Logs.set_level ~all:true level;
-  Logs.set_reporter (Logs_fmt.reporter ~app:Format.err_formatter ());
+  Logs.set_reporter (reporter ());
   (* from https://github.com/mirage/ocaml-cohttp#debugging *)
   (* Disable all third-party libs logs *)
   Logs.Src.list ()


### PR DESCRIPTION
test plan:
 make core
 osemgrep --config r/python --include foo --exclude foo .

-> now the line "Paths that match both --include and --exclude will be skipped by Semgrep." is yellow

Though this does no longer compose -- if styles in log messages are used, the color will be dropped (the Fmt library does composition (reading the current style, and adding the new style), but does not expose the required functionailty basically for "style start" fmt "style end", only if fmt is known upfront.

I don't think this is an issue since all bold/color styling is only done in normal application output (not in warning/error) -- but I wanted to mention it.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
