### PR TITLE
fix(swift): let lambdas translate to IL

### DIFF
--- a/changelog.d/pa-2718.fixed
+++ b/changelog.d/pa-2718.fixed
@@ -1,0 +1,2 @@
+Swift: Made it so that taint correctly propagates into
+the bodies of lambdas

--- a/languages/swift/generic/Parse_swift_tree_sitter.ml
+++ b/languages/swift/generic/Parse_swift_tree_sitter.ml
@@ -1849,13 +1849,18 @@ and map_lambda_literal (env : env) ((v1, v2, v3, v4) : CST.lambda_literal) :
     (* We inject into an `OtherStmtWithStmt` here because we needed somewhere for the
        capture list to go. This is not permitted with just a regular statement, so there is
        a new variant `OSWS_Closure` to signify this.
+       We put it into the top-level statements so that we do not prevent the inner statements
+       from surviving IL translation. It shouldn't mess anything up, because it shouldn't be
+       translated.
     *)
+    let capture_group_stmt =
+      G.exprstmt
+        (G.OtherExpr
+           (("CaptureGroup", v1), Common.map (fun x -> G.Pa x) captures)
+        |> G.e)
+    in
     G.FBStmt
-      (G.OtherStmtWithStmt
-         ( G.OSWS_Closure,
-           Common.map (fun x -> G.Pa x) captures,
-           G.Block (Tok.unsafe_fake_bracket stmts) |> G.s )
-      |> G.s)
+      (G.Block (Tok.unsafe_fake_bracket (capture_group_stmt :: stmts)) |> G.s)
   in
   let _rb = (* "}" *) token env v4 in
   let def =

--- a/languages/swift/generic/Parse_swift_tree_sitter.ml
+++ b/languages/swift/generic/Parse_swift_tree_sitter.ml
@@ -1846,12 +1846,11 @@ and map_lambda_literal (env : env) ((v1, v2, v3, v4) : CST.lambda_literal) :
     (* Fake brackets here since the brackets delimit the lambda expression as a
      * whole, not just the statements *)
     (* TODO consider using `in` and the closing bracket as the delimiters *)
-    (* We inject into an `OtherStmtWithStmt` here because we needed somewhere for the
-       capture list to go. This is not permitted with just a regular statement, so there is
-       a new variant `OSWS_Closure` to signify this.
-       We put it into the top-level statements so that we do not prevent the inner statements
+    (* We put it into the top-level statements so that we do not prevent the inner statements
        from surviving IL translation. It shouldn't mess anything up, because it shouldn't be
        translated.
+       We need somewhere for the capture list to go, however, so we just put it first in the
+       list of statements. It shouldn't survive to semantic analysis anyways.
     *)
     let capture_group_stmt =
       G.exprstmt

--- a/libs/ast_generic/AST_generic.ml
+++ b/libs/ast_generic/AST_generic.ml
@@ -1260,8 +1260,6 @@ and other_stmt_with_stmt_operator =
   | OSWS_Else_in_try
   (* C/C++/cpp *)
   | OSWS_Iterator
-  (* Closures in Swift *)
-  | OSWS_Closure
   (* e.g., Case/Default outside of switch in C/C++, StmtTodo in C++ *)
   | OSWS_Todo
 

--- a/libs/ast_generic/AST_generic_to_v1.ml
+++ b/libs/ast_generic/AST_generic_to_v1.ml
@@ -820,7 +820,6 @@ and map_other_stmt_with_stmt_operator = function
   | OSWS_With -> "S_With"
   | OSWS_Else_in_try -> "S_Else_in_try"
   | OSWS_Iterator -> "S_Iterator"
-  | OSWS_Closure -> "S_Closure"
   | OSWS_Todo -> "S_Todo"
   | OSWS_Block _TODO -> "S_Todo"
 

--- a/libs/ast_generic/Meta_AST.ml
+++ b/libs/ast_generic/Meta_AST.ml
@@ -915,7 +915,6 @@ and vof_other_stmt_with_stmt_operator = function
   | OSWS_With -> OCaml.VSum ("OSWS_With", [])
   | OSWS_Else_in_try -> OCaml.VSum ("OSWS_Else_in_try", [])
   | OSWS_Iterator -> OCaml.VSum ("OSWS_Iterator", [])
-  | OSWS_Closure -> OCaml.VSum ("OSWS_Closure", [])
   | OSWS_Todo -> OCaml.VSum ("OSWS_Todo", [])
 
 and vof_label_ident = function

--- a/src/matching/Generic_vs_generic.ml
+++ b/src/matching/Generic_vs_generic.ml
@@ -2634,7 +2634,6 @@ and m_other_stmt_with_stmt_operator a b =
   | G.OSWS_With, G.OSWS_With
   | G.OSWS_Else_in_try, G.OSWS_Else_in_try
   | G.OSWS_Iterator, G.OSWS_Iterator
-  | G.OSWS_Closure, G.OSWS_Closure
   | G.OSWS_Todo, G.OSWS_Todo ->
       return ()
   | G.OSWS_Block a, G.OSWS_Block b -> m_todo_kind a b
@@ -2642,7 +2641,6 @@ and m_other_stmt_with_stmt_operator a b =
   | G.OSWS_Block _, _
   | G.OSWS_Else_in_try, _
   | G.OSWS_Iterator, _
-  | G.OSWS_Closure, _
   | G.OSWS_Todo, _ ->
       fail ()
 

--- a/tests/rules/swift_lambda_taint.swift
+++ b/tests/rules/swift_lambda_taint.swift
@@ -1,0 +1,7 @@
+       
+let foo = source 
+
+let bar = qux { x in
+    // ruleid: swift-lambda-taint
+    sink(foo)
+}

--- a/tests/rules/swift_lambda_taint.yaml
+++ b/tests/rules/swift_lambda_taint.yaml
@@ -1,0 +1,13 @@
+rules:
+  - id: swift-lambda-taint
+    message: Taint should go into the lambda! 
+    languages:
+      - swift
+    severity: WARNING
+    mode: taint
+    pattern-sources:
+      - pattern: |
+          source
+    pattern-sinks:
+      - pattern: |
+          sink(...)


### PR DESCRIPTION
## What:
This PR makes it so that lambdas in Swift now correctly survive to the IL.

## Why:
This prevents taint analysis on the interior of lambdas.

## How:
Previously, this was happening because of injecting into a new variant, `OSWS_Closure`, however this ends up putting the body of the lambda in an unhandled construct, creating a `Fixme` node. We just injected it into the list of statements denoting the lambda, because it could potentially be useful still for matching purposes. This shouldn't affect any semantic analysis, though.

Closes PA-2718

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
