### PR TITLE
chore(core): flag to not do name resolution/const prop

### DIFF
--- a/src/configuring/Flag_semgrep.ml
+++ b/src/configuring/Flag_semgrep.ml
@@ -71,3 +71,9 @@ let equivalence_mode = ref false
 
 (* One-off experiment for Raja (See Raja_experiment.ml) *)
 let raja = ref false
+
+(* No constant propagation or naming
+   This is useful for quick searches which don't need full
+   semantic information. We could use this for the VS Code extension.
+*)
+let no_resolving = ref false

--- a/src/core_cli/Core_CLI.ml
+++ b/src/core_cli/Core_CLI.ml
@@ -615,6 +615,9 @@ let options actions =
     ( "-filter_irrelevant_rules",
       Arg.Set filter_irrelevant_rules,
       " filter rules not containing any strings in target file" );
+    ( "-no_resolving",
+      Arg.Set Flag.no_resolving,
+      " don't do naming/constant prop" );
     ( "-no_filter_irrelevant_rules",
       Arg.Clear filter_irrelevant_rules,
       " do not filter rules" );

--- a/src/parsing/Parse_target.ml
+++ b/src/parsing/Parse_target.ml
@@ -108,9 +108,10 @@ let parse_and_resolve_name lang file =
    * among a set of files in a project like codegraph.
    *)
   AST_generic.SId.unsafe_reset_counter ();
-  Naming_AST.resolve lang ast;
-  Constant_propagation.propagate_basic lang ast;
-  Constant_propagation.propagate_dataflow lang ast;
+  if not !Flag.no_resolving then (
+    Naming_AST.resolve lang ast;
+    Constant_propagation.propagate_basic lang ast;
+    Constant_propagation.propagate_dataflow lang ast);
   if !Flag.use_bloom_filter then Bloom_annotation.annotate_program ast;
   logger#info "Parse_target.parse_and_resolve_name done";
   res


### PR DESCRIPTION
## What:
This PR adds in a `-no_resolving` flag to `semgrep-core`, which will cause ASTs to be parsed without constant propagation or naming.

## Why:
This would allow speedier searches for the VS Code extension, possibly.

## Test plan:
I ran it and it was noticeably faster. 5s to 2.5s on `django`

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
