### PR TITLE
add liquidjs as an explicit dev dependency

### DIFF
--- a/js/languages/bash/package-lock.json
+++ b/js/languages/bash/package-lock.json
@@ -13,7 +13,8 @@
       },
       "devDependencies": {
         "esbuild": "^0.17.17",
-        "jest": "^29.5.0"
+        "jest": "^29.5.0",
+        "liquidjs": "^10.7.1"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1783,6 +1784,15 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3025,6 +3035,26 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
+    },
+    "node_modules/liquidjs": {
+      "version": "10.7.1",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.7.1.tgz",
+      "integrity": "sha512-tl9nWBZrrKcC61yfih3lbtSjAn+k7e0HhwydPjQKI4+metLk927HYBfXfbf6yrCcYjnBnLzk8xMjUF83yknAQQ==",
+      "dev": true,
+      "dependencies": {
+        "commander": "^10.0.0"
+      },
+      "bin": {
+        "liquid": "bin/liquid.js",
+        "liquidjs": "bin/liquid.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/liquidjs"
+      }
     },
     "node_modules/locate-path": {
       "version": "5.0.0",
@@ -5098,6 +5128,12 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -6034,6 +6070,15 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
+    },
+    "liquidjs": {
+      "version": "10.7.1",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.7.1.tgz",
+      "integrity": "sha512-tl9nWBZrrKcC61yfih3lbtSjAn+k7e0HhwydPjQKI4+metLk927HYBfXfbf6yrCcYjnBnLzk8xMjUF83yknAQQ==",
+      "dev": true,
+      "requires": {
+        "commander": "^10.0.0"
+      }
     },
     "locate-path": {
       "version": "5.0.0",

--- a/js/languages/bash/package.json
+++ b/js/languages/bash/package.json
@@ -22,7 +22,8 @@
   "license": "LGPL-2.1",
   "devDependencies": {
     "esbuild": "^0.17.17",
-    "jest": "^29.5.0"
+    "jest": "^29.5.0",
+    "liquidjs": "^10.7.1"
   },
   "dependencies": {
     "cross-dirname": "^0.1.0"

--- a/js/languages/c/package-lock.json
+++ b/js/languages/c/package-lock.json
@@ -13,7 +13,8 @@
       },
       "devDependencies": {
         "esbuild": "^0.17.17",
-        "jest": "^29.5.0"
+        "jest": "^29.5.0",
+        "liquidjs": "^10.7.1"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1783,6 +1784,15 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3025,6 +3035,26 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
+    },
+    "node_modules/liquidjs": {
+      "version": "10.7.1",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.7.1.tgz",
+      "integrity": "sha512-tl9nWBZrrKcC61yfih3lbtSjAn+k7e0HhwydPjQKI4+metLk927HYBfXfbf6yrCcYjnBnLzk8xMjUF83yknAQQ==",
+      "dev": true,
+      "dependencies": {
+        "commander": "^10.0.0"
+      },
+      "bin": {
+        "liquid": "bin/liquid.js",
+        "liquidjs": "bin/liquid.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/liquidjs"
+      }
     },
     "node_modules/locate-path": {
       "version": "5.0.0",
@@ -5098,6 +5128,12 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -6034,6 +6070,15 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
+    },
+    "liquidjs": {
+      "version": "10.7.1",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.7.1.tgz",
+      "integrity": "sha512-tl9nWBZrrKcC61yfih3lbtSjAn+k7e0HhwydPjQKI4+metLk927HYBfXfbf6yrCcYjnBnLzk8xMjUF83yknAQQ==",
+      "dev": true,
+      "requires": {
+        "commander": "^10.0.0"
+      }
     },
     "locate-path": {
       "version": "5.0.0",

--- a/js/languages/c/package.json
+++ b/js/languages/c/package.json
@@ -22,7 +22,8 @@
   "license": "LGPL-2.1",
   "devDependencies": {
     "esbuild": "^0.17.17",
-    "jest": "^29.5.0"
+    "jest": "^29.5.0",
+    "liquidjs": "^10.7.1"
   },
   "dependencies": {
     "cross-dirname": "^0.1.0"

--- a/js/languages/cpp/package-lock.json
+++ b/js/languages/cpp/package-lock.json
@@ -13,7 +13,8 @@
       },
       "devDependencies": {
         "esbuild": "^0.17.17",
-        "jest": "^29.5.0"
+        "jest": "^29.5.0",
+        "liquidjs": "^10.7.1"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1783,6 +1784,15 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3025,6 +3035,26 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
+    },
+    "node_modules/liquidjs": {
+      "version": "10.7.1",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.7.1.tgz",
+      "integrity": "sha512-tl9nWBZrrKcC61yfih3lbtSjAn+k7e0HhwydPjQKI4+metLk927HYBfXfbf6yrCcYjnBnLzk8xMjUF83yknAQQ==",
+      "dev": true,
+      "dependencies": {
+        "commander": "^10.0.0"
+      },
+      "bin": {
+        "liquid": "bin/liquid.js",
+        "liquidjs": "bin/liquid.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/liquidjs"
+      }
     },
     "node_modules/locate-path": {
       "version": "5.0.0",
@@ -5098,6 +5128,12 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -6034,6 +6070,15 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
+    },
+    "liquidjs": {
+      "version": "10.7.1",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.7.1.tgz",
+      "integrity": "sha512-tl9nWBZrrKcC61yfih3lbtSjAn+k7e0HhwydPjQKI4+metLk927HYBfXfbf6yrCcYjnBnLzk8xMjUF83yknAQQ==",
+      "dev": true,
+      "requires": {
+        "commander": "^10.0.0"
+      }
     },
     "locate-path": {
       "version": "5.0.0",

--- a/js/languages/cpp/package.json
+++ b/js/languages/cpp/package.json
@@ -22,7 +22,8 @@
   "license": "LGPL-2.1",
   "devDependencies": {
     "esbuild": "^0.17.17",
-    "jest": "^29.5.0"
+    "jest": "^29.5.0",
+    "liquidjs": "^10.7.1"
   },
   "dependencies": {
     "cross-dirname": "^0.1.0"

--- a/js/languages/csharp/package-lock.json
+++ b/js/languages/csharp/package-lock.json
@@ -13,7 +13,8 @@
       },
       "devDependencies": {
         "esbuild": "^0.17.17",
-        "jest": "^29.5.0"
+        "jest": "^29.5.0",
+        "liquidjs": "^10.7.1"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1783,6 +1784,15 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3025,6 +3035,26 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
+    },
+    "node_modules/liquidjs": {
+      "version": "10.7.1",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.7.1.tgz",
+      "integrity": "sha512-tl9nWBZrrKcC61yfih3lbtSjAn+k7e0HhwydPjQKI4+metLk927HYBfXfbf6yrCcYjnBnLzk8xMjUF83yknAQQ==",
+      "dev": true,
+      "dependencies": {
+        "commander": "^10.0.0"
+      },
+      "bin": {
+        "liquid": "bin/liquid.js",
+        "liquidjs": "bin/liquid.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/liquidjs"
+      }
     },
     "node_modules/locate-path": {
       "version": "5.0.0",
@@ -5098,6 +5128,12 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -6034,6 +6070,15 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
+    },
+    "liquidjs": {
+      "version": "10.7.1",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.7.1.tgz",
+      "integrity": "sha512-tl9nWBZrrKcC61yfih3lbtSjAn+k7e0HhwydPjQKI4+metLk927HYBfXfbf6yrCcYjnBnLzk8xMjUF83yknAQQ==",
+      "dev": true,
+      "requires": {
+        "commander": "^10.0.0"
+      }
     },
     "locate-path": {
       "version": "5.0.0",

--- a/js/languages/csharp/package.json
+++ b/js/languages/csharp/package.json
@@ -22,7 +22,8 @@
   "license": "LGPL-2.1",
   "devDependencies": {
     "esbuild": "^0.17.17",
-    "jest": "^29.5.0"
+    "jest": "^29.5.0",
+    "liquidjs": "^10.7.1"
   },
   "dependencies": {
     "cross-dirname": "^0.1.0"

--- a/js/languages/dockerfile/package-lock.json
+++ b/js/languages/dockerfile/package-lock.json
@@ -13,7 +13,8 @@
       },
       "devDependencies": {
         "esbuild": "^0.17.17",
-        "jest": "^29.5.0"
+        "jest": "^29.5.0",
+        "liquidjs": "^10.7.1"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1783,6 +1784,15 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3025,6 +3035,26 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
+    },
+    "node_modules/liquidjs": {
+      "version": "10.7.1",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.7.1.tgz",
+      "integrity": "sha512-tl9nWBZrrKcC61yfih3lbtSjAn+k7e0HhwydPjQKI4+metLk927HYBfXfbf6yrCcYjnBnLzk8xMjUF83yknAQQ==",
+      "dev": true,
+      "dependencies": {
+        "commander": "^10.0.0"
+      },
+      "bin": {
+        "liquid": "bin/liquid.js",
+        "liquidjs": "bin/liquid.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/liquidjs"
+      }
     },
     "node_modules/locate-path": {
       "version": "5.0.0",
@@ -5098,6 +5128,12 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -6034,6 +6070,15 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
+    },
+    "liquidjs": {
+      "version": "10.7.1",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.7.1.tgz",
+      "integrity": "sha512-tl9nWBZrrKcC61yfih3lbtSjAn+k7e0HhwydPjQKI4+metLk927HYBfXfbf6yrCcYjnBnLzk8xMjUF83yknAQQ==",
+      "dev": true,
+      "requires": {
+        "commander": "^10.0.0"
+      }
     },
     "locate-path": {
       "version": "5.0.0",

--- a/js/languages/dockerfile/package.json
+++ b/js/languages/dockerfile/package.json
@@ -22,7 +22,8 @@
   "license": "LGPL-2.1",
   "devDependencies": {
     "esbuild": "^0.17.17",
-    "jest": "^29.5.0"
+    "jest": "^29.5.0",
+    "liquidjs": "^10.7.1"
   },
   "dependencies": {
     "cross-dirname": "^0.1.0"

--- a/js/languages/elixir/package-lock.json
+++ b/js/languages/elixir/package-lock.json
@@ -13,7 +13,8 @@
       },
       "devDependencies": {
         "esbuild": "^0.17.17",
-        "jest": "^29.5.0"
+        "jest": "^29.5.0",
+        "liquidjs": "^10.7.1"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1783,6 +1784,15 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3025,6 +3035,26 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
+    },
+    "node_modules/liquidjs": {
+      "version": "10.7.1",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.7.1.tgz",
+      "integrity": "sha512-tl9nWBZrrKcC61yfih3lbtSjAn+k7e0HhwydPjQKI4+metLk927HYBfXfbf6yrCcYjnBnLzk8xMjUF83yknAQQ==",
+      "dev": true,
+      "dependencies": {
+        "commander": "^10.0.0"
+      },
+      "bin": {
+        "liquid": "bin/liquid.js",
+        "liquidjs": "bin/liquid.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/liquidjs"
+      }
     },
     "node_modules/locate-path": {
       "version": "5.0.0",
@@ -5098,6 +5128,12 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -6034,6 +6070,15 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
+    },
+    "liquidjs": {
+      "version": "10.7.1",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.7.1.tgz",
+      "integrity": "sha512-tl9nWBZrrKcC61yfih3lbtSjAn+k7e0HhwydPjQKI4+metLk927HYBfXfbf6yrCcYjnBnLzk8xMjUF83yknAQQ==",
+      "dev": true,
+      "requires": {
+        "commander": "^10.0.0"
+      }
     },
     "locate-path": {
       "version": "5.0.0",

--- a/js/languages/elixir/package.json
+++ b/js/languages/elixir/package.json
@@ -22,7 +22,8 @@
   "license": "LGPL-2.1",
   "devDependencies": {
     "esbuild": "^0.17.17",
-    "jest": "^29.5.0"
+    "jest": "^29.5.0",
+    "liquidjs": "^10.7.1"
   },
   "dependencies": {
     "cross-dirname": "^0.1.0"

--- a/js/languages/go/package-lock.json
+++ b/js/languages/go/package-lock.json
@@ -13,7 +13,8 @@
       },
       "devDependencies": {
         "esbuild": "^0.17.17",
-        "jest": "^29.5.0"
+        "jest": "^29.5.0",
+        "liquidjs": "^10.7.1"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1783,6 +1784,15 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3025,6 +3035,26 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
+    },
+    "node_modules/liquidjs": {
+      "version": "10.7.1",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.7.1.tgz",
+      "integrity": "sha512-tl9nWBZrrKcC61yfih3lbtSjAn+k7e0HhwydPjQKI4+metLk927HYBfXfbf6yrCcYjnBnLzk8xMjUF83yknAQQ==",
+      "dev": true,
+      "dependencies": {
+        "commander": "^10.0.0"
+      },
+      "bin": {
+        "liquid": "bin/liquid.js",
+        "liquidjs": "bin/liquid.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/liquidjs"
+      }
     },
     "node_modules/locate-path": {
       "version": "5.0.0",
@@ -5098,6 +5128,12 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -6034,6 +6070,15 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
+    },
+    "liquidjs": {
+      "version": "10.7.1",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.7.1.tgz",
+      "integrity": "sha512-tl9nWBZrrKcC61yfih3lbtSjAn+k7e0HhwydPjQKI4+metLk927HYBfXfbf6yrCcYjnBnLzk8xMjUF83yknAQQ==",
+      "dev": true,
+      "requires": {
+        "commander": "^10.0.0"
+      }
     },
     "locate-path": {
       "version": "5.0.0",

--- a/js/languages/go/package.json
+++ b/js/languages/go/package.json
@@ -22,7 +22,8 @@
   "license": "LGPL-2.1",
   "devDependencies": {
     "esbuild": "^0.17.17",
-    "jest": "^29.5.0"
+    "jest": "^29.5.0",
+    "liquidjs": "^10.7.1"
   },
   "dependencies": {
     "cross-dirname": "^0.1.0"

--- a/js/languages/html/package-lock.json
+++ b/js/languages/html/package-lock.json
@@ -13,7 +13,8 @@
       },
       "devDependencies": {
         "esbuild": "^0.17.17",
-        "jest": "^29.5.0"
+        "jest": "^29.5.0",
+        "liquidjs": "^10.7.1"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1783,6 +1784,15 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3025,6 +3035,26 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
+    },
+    "node_modules/liquidjs": {
+      "version": "10.7.1",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.7.1.tgz",
+      "integrity": "sha512-tl9nWBZrrKcC61yfih3lbtSjAn+k7e0HhwydPjQKI4+metLk927HYBfXfbf6yrCcYjnBnLzk8xMjUF83yknAQQ==",
+      "dev": true,
+      "dependencies": {
+        "commander": "^10.0.0"
+      },
+      "bin": {
+        "liquid": "bin/liquid.js",
+        "liquidjs": "bin/liquid.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/liquidjs"
+      }
     },
     "node_modules/locate-path": {
       "version": "5.0.0",
@@ -5098,6 +5128,12 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -6034,6 +6070,15 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
+    },
+    "liquidjs": {
+      "version": "10.7.1",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.7.1.tgz",
+      "integrity": "sha512-tl9nWBZrrKcC61yfih3lbtSjAn+k7e0HhwydPjQKI4+metLk927HYBfXfbf6yrCcYjnBnLzk8xMjUF83yknAQQ==",
+      "dev": true,
+      "requires": {
+        "commander": "^10.0.0"
+      }
     },
     "locate-path": {
       "version": "5.0.0",

--- a/js/languages/html/package.json
+++ b/js/languages/html/package.json
@@ -22,7 +22,8 @@
   "license": "LGPL-2.1",
   "devDependencies": {
     "esbuild": "^0.17.17",
-    "jest": "^29.5.0"
+    "jest": "^29.5.0",
+    "liquidjs": "^10.7.1"
   },
   "dependencies": {
     "cross-dirname": "^0.1.0"

--- a/js/languages/java/package-lock.json
+++ b/js/languages/java/package-lock.json
@@ -13,7 +13,8 @@
       },
       "devDependencies": {
         "esbuild": "^0.17.17",
-        "jest": "^29.5.0"
+        "jest": "^29.5.0",
+        "liquidjs": "^10.7.1"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1783,6 +1784,15 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3025,6 +3035,26 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
+    },
+    "node_modules/liquidjs": {
+      "version": "10.7.1",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.7.1.tgz",
+      "integrity": "sha512-tl9nWBZrrKcC61yfih3lbtSjAn+k7e0HhwydPjQKI4+metLk927HYBfXfbf6yrCcYjnBnLzk8xMjUF83yknAQQ==",
+      "dev": true,
+      "dependencies": {
+        "commander": "^10.0.0"
+      },
+      "bin": {
+        "liquid": "bin/liquid.js",
+        "liquidjs": "bin/liquid.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/liquidjs"
+      }
     },
     "node_modules/locate-path": {
       "version": "5.0.0",
@@ -5098,6 +5128,12 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -6034,6 +6070,15 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
+    },
+    "liquidjs": {
+      "version": "10.7.1",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.7.1.tgz",
+      "integrity": "sha512-tl9nWBZrrKcC61yfih3lbtSjAn+k7e0HhwydPjQKI4+metLk927HYBfXfbf6yrCcYjnBnLzk8xMjUF83yknAQQ==",
+      "dev": true,
+      "requires": {
+        "commander": "^10.0.0"
+      }
     },
     "locate-path": {
       "version": "5.0.0",

--- a/js/languages/java/package.json
+++ b/js/languages/java/package.json
@@ -22,7 +22,8 @@
   "license": "LGPL-2.1",
   "devDependencies": {
     "esbuild": "^0.17.17",
-    "jest": "^29.5.0"
+    "jest": "^29.5.0",
+    "liquidjs": "^10.7.1"
   },
   "dependencies": {
     "cross-dirname": "^0.1.0"

--- a/js/languages/json/package-lock.json
+++ b/js/languages/json/package-lock.json
@@ -13,7 +13,8 @@
       },
       "devDependencies": {
         "esbuild": "^0.17.17",
-        "jest": "^29.5.0"
+        "jest": "^29.5.0",
+        "liquidjs": "^10.7.1"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1783,6 +1784,15 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3025,6 +3035,26 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
+    },
+    "node_modules/liquidjs": {
+      "version": "10.7.1",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.7.1.tgz",
+      "integrity": "sha512-tl9nWBZrrKcC61yfih3lbtSjAn+k7e0HhwydPjQKI4+metLk927HYBfXfbf6yrCcYjnBnLzk8xMjUF83yknAQQ==",
+      "dev": true,
+      "dependencies": {
+        "commander": "^10.0.0"
+      },
+      "bin": {
+        "liquid": "bin/liquid.js",
+        "liquidjs": "bin/liquid.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/liquidjs"
+      }
     },
     "node_modules/locate-path": {
       "version": "5.0.0",
@@ -5098,6 +5128,12 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -6034,6 +6070,15 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
+    },
+    "liquidjs": {
+      "version": "10.7.1",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.7.1.tgz",
+      "integrity": "sha512-tl9nWBZrrKcC61yfih3lbtSjAn+k7e0HhwydPjQKI4+metLk927HYBfXfbf6yrCcYjnBnLzk8xMjUF83yknAQQ==",
+      "dev": true,
+      "requires": {
+        "commander": "^10.0.0"
+      }
     },
     "locate-path": {
       "version": "5.0.0",

--- a/js/languages/json/package.json
+++ b/js/languages/json/package.json
@@ -22,7 +22,8 @@
   "license": "LGPL-2.1",
   "devDependencies": {
     "esbuild": "^0.17.17",
-    "jest": "^29.5.0"
+    "jest": "^29.5.0",
+    "liquidjs": "^10.7.1"
   },
   "dependencies": {
     "cross-dirname": "^0.1.0"

--- a/js/languages/jsonnet/package-lock.json
+++ b/js/languages/jsonnet/package-lock.json
@@ -13,7 +13,8 @@
       },
       "devDependencies": {
         "esbuild": "^0.17.17",
-        "jest": "^29.5.0"
+        "jest": "^29.5.0",
+        "liquidjs": "^10.7.1"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1783,6 +1784,15 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3025,6 +3035,26 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
+    },
+    "node_modules/liquidjs": {
+      "version": "10.7.1",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.7.1.tgz",
+      "integrity": "sha512-tl9nWBZrrKcC61yfih3lbtSjAn+k7e0HhwydPjQKI4+metLk927HYBfXfbf6yrCcYjnBnLzk8xMjUF83yknAQQ==",
+      "dev": true,
+      "dependencies": {
+        "commander": "^10.0.0"
+      },
+      "bin": {
+        "liquid": "bin/liquid.js",
+        "liquidjs": "bin/liquid.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/liquidjs"
+      }
     },
     "node_modules/locate-path": {
       "version": "5.0.0",
@@ -5098,6 +5128,12 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -6034,6 +6070,15 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
+    },
+    "liquidjs": {
+      "version": "10.7.1",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.7.1.tgz",
+      "integrity": "sha512-tl9nWBZrrKcC61yfih3lbtSjAn+k7e0HhwydPjQKI4+metLk927HYBfXfbf6yrCcYjnBnLzk8xMjUF83yknAQQ==",
+      "dev": true,
+      "requires": {
+        "commander": "^10.0.0"
+      }
     },
     "locate-path": {
       "version": "5.0.0",

--- a/js/languages/jsonnet/package.json
+++ b/js/languages/jsonnet/package.json
@@ -22,7 +22,8 @@
   "license": "LGPL-2.1",
   "devDependencies": {
     "esbuild": "^0.17.17",
-    "jest": "^29.5.0"
+    "jest": "^29.5.0",
+    "liquidjs": "^10.7.1"
   },
   "dependencies": {
     "cross-dirname": "^0.1.0"

--- a/js/languages/kotlin/package-lock.json
+++ b/js/languages/kotlin/package-lock.json
@@ -13,7 +13,8 @@
       },
       "devDependencies": {
         "esbuild": "^0.17.17",
-        "jest": "^29.5.0"
+        "jest": "^29.5.0",
+        "liquidjs": "^10.7.1"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1783,6 +1784,15 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3025,6 +3035,26 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
+    },
+    "node_modules/liquidjs": {
+      "version": "10.7.1",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.7.1.tgz",
+      "integrity": "sha512-tl9nWBZrrKcC61yfih3lbtSjAn+k7e0HhwydPjQKI4+metLk927HYBfXfbf6yrCcYjnBnLzk8xMjUF83yknAQQ==",
+      "dev": true,
+      "dependencies": {
+        "commander": "^10.0.0"
+      },
+      "bin": {
+        "liquid": "bin/liquid.js",
+        "liquidjs": "bin/liquid.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/liquidjs"
+      }
     },
     "node_modules/locate-path": {
       "version": "5.0.0",
@@ -5098,6 +5128,12 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -6034,6 +6070,15 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
+    },
+    "liquidjs": {
+      "version": "10.7.1",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.7.1.tgz",
+      "integrity": "sha512-tl9nWBZrrKcC61yfih3lbtSjAn+k7e0HhwydPjQKI4+metLk927HYBfXfbf6yrCcYjnBnLzk8xMjUF83yknAQQ==",
+      "dev": true,
+      "requires": {
+        "commander": "^10.0.0"
+      }
     },
     "locate-path": {
       "version": "5.0.0",

--- a/js/languages/kotlin/package.json
+++ b/js/languages/kotlin/package.json
@@ -22,7 +22,8 @@
   "license": "LGPL-2.1",
   "devDependencies": {
     "esbuild": "^0.17.17",
-    "jest": "^29.5.0"
+    "jest": "^29.5.0",
+    "liquidjs": "^10.7.1"
   },
   "dependencies": {
     "cross-dirname": "^0.1.0"

--- a/js/languages/lisp/package-lock.json
+++ b/js/languages/lisp/package-lock.json
@@ -13,7 +13,8 @@
       },
       "devDependencies": {
         "esbuild": "^0.17.17",
-        "jest": "^29.5.0"
+        "jest": "^29.5.0",
+        "liquidjs": "^10.7.1"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1783,6 +1784,15 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3025,6 +3035,26 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
+    },
+    "node_modules/liquidjs": {
+      "version": "10.7.1",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.7.1.tgz",
+      "integrity": "sha512-tl9nWBZrrKcC61yfih3lbtSjAn+k7e0HhwydPjQKI4+metLk927HYBfXfbf6yrCcYjnBnLzk8xMjUF83yknAQQ==",
+      "dev": true,
+      "dependencies": {
+        "commander": "^10.0.0"
+      },
+      "bin": {
+        "liquid": "bin/liquid.js",
+        "liquidjs": "bin/liquid.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/liquidjs"
+      }
     },
     "node_modules/locate-path": {
       "version": "5.0.0",
@@ -5098,6 +5128,12 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -6034,6 +6070,15 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
+    },
+    "liquidjs": {
+      "version": "10.7.1",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.7.1.tgz",
+      "integrity": "sha512-tl9nWBZrrKcC61yfih3lbtSjAn+k7e0HhwydPjQKI4+metLk927HYBfXfbf6yrCcYjnBnLzk8xMjUF83yknAQQ==",
+      "dev": true,
+      "requires": {
+        "commander": "^10.0.0"
+      }
     },
     "locate-path": {
       "version": "5.0.0",

--- a/js/languages/lisp/package.json
+++ b/js/languages/lisp/package.json
@@ -22,7 +22,8 @@
   "license": "LGPL-2.1",
   "devDependencies": {
     "esbuild": "^0.17.17",
-    "jest": "^29.5.0"
+    "jest": "^29.5.0",
+    "liquidjs": "^10.7.1"
   },
   "dependencies": {
     "cross-dirname": "^0.1.0"

--- a/js/languages/lua/package-lock.json
+++ b/js/languages/lua/package-lock.json
@@ -13,7 +13,8 @@
       },
       "devDependencies": {
         "esbuild": "^0.17.17",
-        "jest": "^29.5.0"
+        "jest": "^29.5.0",
+        "liquidjs": "^10.7.1"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1783,6 +1784,15 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3025,6 +3035,26 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
+    },
+    "node_modules/liquidjs": {
+      "version": "10.7.1",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.7.1.tgz",
+      "integrity": "sha512-tl9nWBZrrKcC61yfih3lbtSjAn+k7e0HhwydPjQKI4+metLk927HYBfXfbf6yrCcYjnBnLzk8xMjUF83yknAQQ==",
+      "dev": true,
+      "dependencies": {
+        "commander": "^10.0.0"
+      },
+      "bin": {
+        "liquid": "bin/liquid.js",
+        "liquidjs": "bin/liquid.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/liquidjs"
+      }
     },
     "node_modules/locate-path": {
       "version": "5.0.0",
@@ -5098,6 +5128,12 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -6034,6 +6070,15 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
+    },
+    "liquidjs": {
+      "version": "10.7.1",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.7.1.tgz",
+      "integrity": "sha512-tl9nWBZrrKcC61yfih3lbtSjAn+k7e0HhwydPjQKI4+metLk927HYBfXfbf6yrCcYjnBnLzk8xMjUF83yknAQQ==",
+      "dev": true,
+      "requires": {
+        "commander": "^10.0.0"
+      }
     },
     "locate-path": {
       "version": "5.0.0",

--- a/js/languages/lua/package.json
+++ b/js/languages/lua/package.json
@@ -22,7 +22,8 @@
   "license": "LGPL-2.1",
   "devDependencies": {
     "esbuild": "^0.17.17",
-    "jest": "^29.5.0"
+    "jest": "^29.5.0",
+    "liquidjs": "^10.7.1"
   },
   "dependencies": {
     "cross-dirname": "^0.1.0"

--- a/js/languages/ocaml/package-lock.json
+++ b/js/languages/ocaml/package-lock.json
@@ -13,7 +13,8 @@
       },
       "devDependencies": {
         "esbuild": "^0.17.17",
-        "jest": "^29.5.0"
+        "jest": "^29.5.0",
+        "liquidjs": "^10.7.1"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1783,6 +1784,15 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3025,6 +3035,26 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
+    },
+    "node_modules/liquidjs": {
+      "version": "10.7.1",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.7.1.tgz",
+      "integrity": "sha512-tl9nWBZrrKcC61yfih3lbtSjAn+k7e0HhwydPjQKI4+metLk927HYBfXfbf6yrCcYjnBnLzk8xMjUF83yknAQQ==",
+      "dev": true,
+      "dependencies": {
+        "commander": "^10.0.0"
+      },
+      "bin": {
+        "liquid": "bin/liquid.js",
+        "liquidjs": "bin/liquid.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/liquidjs"
+      }
     },
     "node_modules/locate-path": {
       "version": "5.0.0",
@@ -5098,6 +5128,12 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -6034,6 +6070,15 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
+    },
+    "liquidjs": {
+      "version": "10.7.1",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.7.1.tgz",
+      "integrity": "sha512-tl9nWBZrrKcC61yfih3lbtSjAn+k7e0HhwydPjQKI4+metLk927HYBfXfbf6yrCcYjnBnLzk8xMjUF83yknAQQ==",
+      "dev": true,
+      "requires": {
+        "commander": "^10.0.0"
+      }
     },
     "locate-path": {
       "version": "5.0.0",

--- a/js/languages/ocaml/package.json
+++ b/js/languages/ocaml/package.json
@@ -22,7 +22,8 @@
   "license": "LGPL-2.1",
   "devDependencies": {
     "esbuild": "^0.17.17",
-    "jest": "^29.5.0"
+    "jest": "^29.5.0",
+    "liquidjs": "^10.7.1"
   },
   "dependencies": {
     "cross-dirname": "^0.1.0"

--- a/js/languages/php/package-lock.json
+++ b/js/languages/php/package-lock.json
@@ -13,7 +13,8 @@
       },
       "devDependencies": {
         "esbuild": "^0.17.17",
-        "jest": "^29.5.0"
+        "jest": "^29.5.0",
+        "liquidjs": "^10.7.1"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1783,6 +1784,15 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3025,6 +3035,26 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
+    },
+    "node_modules/liquidjs": {
+      "version": "10.7.1",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.7.1.tgz",
+      "integrity": "sha512-tl9nWBZrrKcC61yfih3lbtSjAn+k7e0HhwydPjQKI4+metLk927HYBfXfbf6yrCcYjnBnLzk8xMjUF83yknAQQ==",
+      "dev": true,
+      "dependencies": {
+        "commander": "^10.0.0"
+      },
+      "bin": {
+        "liquid": "bin/liquid.js",
+        "liquidjs": "bin/liquid.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/liquidjs"
+      }
     },
     "node_modules/locate-path": {
       "version": "5.0.0",
@@ -5098,6 +5128,12 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -6034,6 +6070,15 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
+    },
+    "liquidjs": {
+      "version": "10.7.1",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.7.1.tgz",
+      "integrity": "sha512-tl9nWBZrrKcC61yfih3lbtSjAn+k7e0HhwydPjQKI4+metLk927HYBfXfbf6yrCcYjnBnLzk8xMjUF83yknAQQ==",
+      "dev": true,
+      "requires": {
+        "commander": "^10.0.0"
+      }
     },
     "locate-path": {
       "version": "5.0.0",

--- a/js/languages/php/package.json
+++ b/js/languages/php/package.json
@@ -22,7 +22,8 @@
   "license": "LGPL-2.1",
   "devDependencies": {
     "esbuild": "^0.17.17",
-    "jest": "^29.5.0"
+    "jest": "^29.5.0",
+    "liquidjs": "^10.7.1"
   },
   "dependencies": {
     "cross-dirname": "^0.1.0"

--- a/js/languages/python/package-lock.json
+++ b/js/languages/python/package-lock.json
@@ -13,7 +13,8 @@
       },
       "devDependencies": {
         "esbuild": "^0.17.17",
-        "jest": "^29.5.0"
+        "jest": "^29.5.0",
+        "liquidjs": "^10.7.1"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1783,6 +1784,15 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3025,6 +3035,26 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
+    },
+    "node_modules/liquidjs": {
+      "version": "10.7.1",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.7.1.tgz",
+      "integrity": "sha512-tl9nWBZrrKcC61yfih3lbtSjAn+k7e0HhwydPjQKI4+metLk927HYBfXfbf6yrCcYjnBnLzk8xMjUF83yknAQQ==",
+      "dev": true,
+      "dependencies": {
+        "commander": "^10.0.0"
+      },
+      "bin": {
+        "liquid": "bin/liquid.js",
+        "liquidjs": "bin/liquid.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/liquidjs"
+      }
     },
     "node_modules/locate-path": {
       "version": "5.0.0",
@@ -5098,6 +5128,12 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -6034,6 +6070,15 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
+    },
+    "liquidjs": {
+      "version": "10.7.1",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.7.1.tgz",
+      "integrity": "sha512-tl9nWBZrrKcC61yfih3lbtSjAn+k7e0HhwydPjQKI4+metLk927HYBfXfbf6yrCcYjnBnLzk8xMjUF83yknAQQ==",
+      "dev": true,
+      "requires": {
+        "commander": "^10.0.0"
+      }
     },
     "locate-path": {
       "version": "5.0.0",

--- a/js/languages/python/package.json
+++ b/js/languages/python/package.json
@@ -22,7 +22,8 @@
   "license": "LGPL-2.1",
   "devDependencies": {
     "esbuild": "^0.17.17",
-    "jest": "^29.5.0"
+    "jest": "^29.5.0",
+    "liquidjs": "^10.7.1"
   },
   "dependencies": {
     "cross-dirname": "^0.1.0"

--- a/js/languages/r/package-lock.json
+++ b/js/languages/r/package-lock.json
@@ -13,7 +13,8 @@
       },
       "devDependencies": {
         "esbuild": "^0.17.17",
-        "jest": "^29.5.0"
+        "jest": "^29.5.0",
+        "liquidjs": "^10.7.1"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1783,6 +1784,15 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3025,6 +3035,26 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
+    },
+    "node_modules/liquidjs": {
+      "version": "10.7.1",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.7.1.tgz",
+      "integrity": "sha512-tl9nWBZrrKcC61yfih3lbtSjAn+k7e0HhwydPjQKI4+metLk927HYBfXfbf6yrCcYjnBnLzk8xMjUF83yknAQQ==",
+      "dev": true,
+      "dependencies": {
+        "commander": "^10.0.0"
+      },
+      "bin": {
+        "liquid": "bin/liquid.js",
+        "liquidjs": "bin/liquid.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/liquidjs"
+      }
     },
     "node_modules/locate-path": {
       "version": "5.0.0",
@@ -5098,6 +5128,12 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -6034,6 +6070,15 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
+    },
+    "liquidjs": {
+      "version": "10.7.1",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.7.1.tgz",
+      "integrity": "sha512-tl9nWBZrrKcC61yfih3lbtSjAn+k7e0HhwydPjQKI4+metLk927HYBfXfbf6yrCcYjnBnLzk8xMjUF83yknAQQ==",
+      "dev": true,
+      "requires": {
+        "commander": "^10.0.0"
+      }
     },
     "locate-path": {
       "version": "5.0.0",

--- a/js/languages/r/package.json
+++ b/js/languages/r/package.json
@@ -22,7 +22,8 @@
   "license": "LGPL-2.1",
   "devDependencies": {
     "esbuild": "^0.17.17",
-    "jest": "^29.5.0"
+    "jest": "^29.5.0",
+    "liquidjs": "^10.7.1"
   },
   "dependencies": {
     "cross-dirname": "^0.1.0"

--- a/js/languages/ruby/package-lock.json
+++ b/js/languages/ruby/package-lock.json
@@ -13,7 +13,8 @@
       },
       "devDependencies": {
         "esbuild": "^0.17.17",
-        "jest": "^29.5.0"
+        "jest": "^29.5.0",
+        "liquidjs": "^10.7.1"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1783,6 +1784,15 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3025,6 +3035,26 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
+    },
+    "node_modules/liquidjs": {
+      "version": "10.7.1",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.7.1.tgz",
+      "integrity": "sha512-tl9nWBZrrKcC61yfih3lbtSjAn+k7e0HhwydPjQKI4+metLk927HYBfXfbf6yrCcYjnBnLzk8xMjUF83yknAQQ==",
+      "dev": true,
+      "dependencies": {
+        "commander": "^10.0.0"
+      },
+      "bin": {
+        "liquid": "bin/liquid.js",
+        "liquidjs": "bin/liquid.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/liquidjs"
+      }
     },
     "node_modules/locate-path": {
       "version": "5.0.0",
@@ -5098,6 +5128,12 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -6034,6 +6070,15 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
+    },
+    "liquidjs": {
+      "version": "10.7.1",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.7.1.tgz",
+      "integrity": "sha512-tl9nWBZrrKcC61yfih3lbtSjAn+k7e0HhwydPjQKI4+metLk927HYBfXfbf6yrCcYjnBnLzk8xMjUF83yknAQQ==",
+      "dev": true,
+      "requires": {
+        "commander": "^10.0.0"
+      }
     },
     "locate-path": {
       "version": "5.0.0",

--- a/js/languages/ruby/package.json
+++ b/js/languages/ruby/package.json
@@ -22,7 +22,8 @@
   "license": "LGPL-2.1",
   "devDependencies": {
     "esbuild": "^0.17.17",
-    "jest": "^29.5.0"
+    "jest": "^29.5.0",
+    "liquidjs": "^10.7.1"
   },
   "dependencies": {
     "cross-dirname": "^0.1.0"

--- a/js/languages/rust/package-lock.json
+++ b/js/languages/rust/package-lock.json
@@ -13,7 +13,8 @@
       },
       "devDependencies": {
         "esbuild": "^0.17.17",
-        "jest": "^29.5.0"
+        "jest": "^29.5.0",
+        "liquidjs": "^10.7.1"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1783,6 +1784,15 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3025,6 +3035,26 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
+    },
+    "node_modules/liquidjs": {
+      "version": "10.7.1",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.7.1.tgz",
+      "integrity": "sha512-tl9nWBZrrKcC61yfih3lbtSjAn+k7e0HhwydPjQKI4+metLk927HYBfXfbf6yrCcYjnBnLzk8xMjUF83yknAQQ==",
+      "dev": true,
+      "dependencies": {
+        "commander": "^10.0.0"
+      },
+      "bin": {
+        "liquid": "bin/liquid.js",
+        "liquidjs": "bin/liquid.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/liquidjs"
+      }
     },
     "node_modules/locate-path": {
       "version": "5.0.0",
@@ -5098,6 +5128,12 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -6034,6 +6070,15 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
+    },
+    "liquidjs": {
+      "version": "10.7.1",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.7.1.tgz",
+      "integrity": "sha512-tl9nWBZrrKcC61yfih3lbtSjAn+k7e0HhwydPjQKI4+metLk927HYBfXfbf6yrCcYjnBnLzk8xMjUF83yknAQQ==",
+      "dev": true,
+      "requires": {
+        "commander": "^10.0.0"
+      }
     },
     "locate-path": {
       "version": "5.0.0",

--- a/js/languages/rust/package.json
+++ b/js/languages/rust/package.json
@@ -22,7 +22,8 @@
   "license": "LGPL-2.1",
   "devDependencies": {
     "esbuild": "^0.17.17",
-    "jest": "^29.5.0"
+    "jest": "^29.5.0",
+    "liquidjs": "^10.7.1"
   },
   "dependencies": {
     "cross-dirname": "^0.1.0"

--- a/js/languages/scala/package-lock.json
+++ b/js/languages/scala/package-lock.json
@@ -13,7 +13,8 @@
       },
       "devDependencies": {
         "esbuild": "^0.17.17",
-        "jest": "^29.5.0"
+        "jest": "^29.5.0",
+        "liquidjs": "^10.7.1"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1783,6 +1784,15 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3025,6 +3035,26 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
+    },
+    "node_modules/liquidjs": {
+      "version": "10.7.1",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.7.1.tgz",
+      "integrity": "sha512-tl9nWBZrrKcC61yfih3lbtSjAn+k7e0HhwydPjQKI4+metLk927HYBfXfbf6yrCcYjnBnLzk8xMjUF83yknAQQ==",
+      "dev": true,
+      "dependencies": {
+        "commander": "^10.0.0"
+      },
+      "bin": {
+        "liquid": "bin/liquid.js",
+        "liquidjs": "bin/liquid.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/liquidjs"
+      }
     },
     "node_modules/locate-path": {
       "version": "5.0.0",
@@ -5098,6 +5128,12 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -6034,6 +6070,15 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
+    },
+    "liquidjs": {
+      "version": "10.7.1",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.7.1.tgz",
+      "integrity": "sha512-tl9nWBZrrKcC61yfih3lbtSjAn+k7e0HhwydPjQKI4+metLk927HYBfXfbf6yrCcYjnBnLzk8xMjUF83yknAQQ==",
+      "dev": true,
+      "requires": {
+        "commander": "^10.0.0"
+      }
     },
     "locate-path": {
       "version": "5.0.0",

--- a/js/languages/scala/package.json
+++ b/js/languages/scala/package.json
@@ -22,7 +22,8 @@
   "license": "LGPL-2.1",
   "devDependencies": {
     "esbuild": "^0.17.17",
-    "jest": "^29.5.0"
+    "jest": "^29.5.0",
+    "liquidjs": "^10.7.1"
   },
   "dependencies": {
     "cross-dirname": "^0.1.0"

--- a/js/languages/shared/Makefile.include
+++ b/js/languages/shared/Makefile.include
@@ -70,6 +70,7 @@ node_modules/.package-lock.json: package-lock.json
 
 dist/entrypoint.js: ../shared/entrypoint.js.liquid
 	mkdir -p dist
+	npm ci
 	npx liquidjs -t @$^ -o $@ --context '{"lang": "$(SEMGREP_LANG)", "wasm": "$(WASM_NAME)"}'
 
 dist/index.cjs: dist/entrypoint.js $(WASM_DEP) ../../../_build/default/js/languages/$(SEMGREP_LANG)/Parser.bc.js node_modules/.package-lock.json

--- a/js/languages/shared/Makefile.include
+++ b/js/languages/shared/Makefile.include
@@ -68,10 +68,9 @@ package-lock.json: package.json
 node_modules/.package-lock.json: package-lock.json
 	npm ci
 
-dist/entrypoint.js: ../shared/entrypoint.js.liquid
+dist/entrypoint.js: ../shared/entrypoint.js.liquid node_modules/.package-lock.json
 	mkdir -p dist
-	npm ci
-	npx liquidjs -t @$^ -o $@ --context '{"lang": "$(SEMGREP_LANG)", "wasm": "$(WASM_NAME)"}'
+	npx liquidjs -t @$< -o $@ --context '{"lang": "$(SEMGREP_LANG)", "wasm": "$(WASM_NAME)"}'
 
 dist/index.cjs: dist/entrypoint.js $(WASM_DEP) ../../../_build/default/js/languages/$(SEMGREP_LANG)/Parser.bc.js node_modules/.package-lock.json
 	mkdir -p dist

--- a/js/languages/shared/package.json.liquid
+++ b/js/languages/shared/package.json.liquid
@@ -22,7 +22,8 @@
   "license": "LGPL-2.1",
   "devDependencies": {
     "esbuild": "^0.17.17",
-    "jest": "^29.5.0"
+    "jest": "^29.5.0",
+    "liquidjs": "^10.7.1"
   },
   "dependencies": {
     "cross-dirname": "^0.1.0"

--- a/js/languages/solidity/package-lock.json
+++ b/js/languages/solidity/package-lock.json
@@ -13,7 +13,8 @@
       },
       "devDependencies": {
         "esbuild": "^0.17.17",
-        "jest": "^29.5.0"
+        "jest": "^29.5.0",
+        "liquidjs": "^10.7.1"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1783,6 +1784,15 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3025,6 +3035,26 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
+    },
+    "node_modules/liquidjs": {
+      "version": "10.7.1",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.7.1.tgz",
+      "integrity": "sha512-tl9nWBZrrKcC61yfih3lbtSjAn+k7e0HhwydPjQKI4+metLk927HYBfXfbf6yrCcYjnBnLzk8xMjUF83yknAQQ==",
+      "dev": true,
+      "dependencies": {
+        "commander": "^10.0.0"
+      },
+      "bin": {
+        "liquid": "bin/liquid.js",
+        "liquidjs": "bin/liquid.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/liquidjs"
+      }
     },
     "node_modules/locate-path": {
       "version": "5.0.0",
@@ -5098,6 +5128,12 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -6034,6 +6070,15 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
+    },
+    "liquidjs": {
+      "version": "10.7.1",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.7.1.tgz",
+      "integrity": "sha512-tl9nWBZrrKcC61yfih3lbtSjAn+k7e0HhwydPjQKI4+metLk927HYBfXfbf6yrCcYjnBnLzk8xMjUF83yknAQQ==",
+      "dev": true,
+      "requires": {
+        "commander": "^10.0.0"
+      }
     },
     "locate-path": {
       "version": "5.0.0",

--- a/js/languages/solidity/package.json
+++ b/js/languages/solidity/package.json
@@ -22,7 +22,8 @@
   "license": "LGPL-2.1",
   "devDependencies": {
     "esbuild": "^0.17.17",
-    "jest": "^29.5.0"
+    "jest": "^29.5.0",
+    "liquidjs": "^10.7.1"
   },
   "dependencies": {
     "cross-dirname": "^0.1.0"

--- a/js/languages/swift/package-lock.json
+++ b/js/languages/swift/package-lock.json
@@ -13,7 +13,8 @@
       },
       "devDependencies": {
         "esbuild": "^0.17.17",
-        "jest": "^29.5.0"
+        "jest": "^29.5.0",
+        "liquidjs": "^10.7.1"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1783,6 +1784,15 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3025,6 +3035,26 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
+    },
+    "node_modules/liquidjs": {
+      "version": "10.7.1",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.7.1.tgz",
+      "integrity": "sha512-tl9nWBZrrKcC61yfih3lbtSjAn+k7e0HhwydPjQKI4+metLk927HYBfXfbf6yrCcYjnBnLzk8xMjUF83yknAQQ==",
+      "dev": true,
+      "dependencies": {
+        "commander": "^10.0.0"
+      },
+      "bin": {
+        "liquid": "bin/liquid.js",
+        "liquidjs": "bin/liquid.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/liquidjs"
+      }
     },
     "node_modules/locate-path": {
       "version": "5.0.0",
@@ -5098,6 +5128,12 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -6034,6 +6070,15 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
+    },
+    "liquidjs": {
+      "version": "10.7.1",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.7.1.tgz",
+      "integrity": "sha512-tl9nWBZrrKcC61yfih3lbtSjAn+k7e0HhwydPjQKI4+metLk927HYBfXfbf6yrCcYjnBnLzk8xMjUF83yknAQQ==",
+      "dev": true,
+      "requires": {
+        "commander": "^10.0.0"
+      }
     },
     "locate-path": {
       "version": "5.0.0",

--- a/js/languages/swift/package.json
+++ b/js/languages/swift/package.json
@@ -22,7 +22,8 @@
   "license": "LGPL-2.1",
   "devDependencies": {
     "esbuild": "^0.17.17",
-    "jest": "^29.5.0"
+    "jest": "^29.5.0",
+    "liquidjs": "^10.7.1"
   },
   "dependencies": {
     "cross-dirname": "^0.1.0"

--- a/js/languages/terraform/package-lock.json
+++ b/js/languages/terraform/package-lock.json
@@ -13,7 +13,8 @@
       },
       "devDependencies": {
         "esbuild": "^0.17.17",
-        "jest": "^29.5.0"
+        "jest": "^29.5.0",
+        "liquidjs": "^10.7.1"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1783,6 +1784,15 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3025,6 +3035,26 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
+    },
+    "node_modules/liquidjs": {
+      "version": "10.7.1",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.7.1.tgz",
+      "integrity": "sha512-tl9nWBZrrKcC61yfih3lbtSjAn+k7e0HhwydPjQKI4+metLk927HYBfXfbf6yrCcYjnBnLzk8xMjUF83yknAQQ==",
+      "dev": true,
+      "dependencies": {
+        "commander": "^10.0.0"
+      },
+      "bin": {
+        "liquid": "bin/liquid.js",
+        "liquidjs": "bin/liquid.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/liquidjs"
+      }
     },
     "node_modules/locate-path": {
       "version": "5.0.0",
@@ -5098,6 +5128,12 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -6034,6 +6070,15 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
+    },
+    "liquidjs": {
+      "version": "10.7.1",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.7.1.tgz",
+      "integrity": "sha512-tl9nWBZrrKcC61yfih3lbtSjAn+k7e0HhwydPjQKI4+metLk927HYBfXfbf6yrCcYjnBnLzk8xMjUF83yknAQQ==",
+      "dev": true,
+      "requires": {
+        "commander": "^10.0.0"
+      }
     },
     "locate-path": {
       "version": "5.0.0",

--- a/js/languages/terraform/package.json
+++ b/js/languages/terraform/package.json
@@ -22,7 +22,8 @@
   "license": "LGPL-2.1",
   "devDependencies": {
     "esbuild": "^0.17.17",
-    "jest": "^29.5.0"
+    "jest": "^29.5.0",
+    "liquidjs": "^10.7.1"
   },
   "dependencies": {
     "cross-dirname": "^0.1.0"

--- a/js/languages/typescript/package-lock.json
+++ b/js/languages/typescript/package-lock.json
@@ -13,7 +13,8 @@
       },
       "devDependencies": {
         "esbuild": "^0.17.17",
-        "jest": "^29.5.0"
+        "jest": "^29.5.0",
+        "liquidjs": "^10.7.1"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1783,6 +1784,15 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3025,6 +3035,26 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
+    },
+    "node_modules/liquidjs": {
+      "version": "10.7.1",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.7.1.tgz",
+      "integrity": "sha512-tl9nWBZrrKcC61yfih3lbtSjAn+k7e0HhwydPjQKI4+metLk927HYBfXfbf6yrCcYjnBnLzk8xMjUF83yknAQQ==",
+      "dev": true,
+      "dependencies": {
+        "commander": "^10.0.0"
+      },
+      "bin": {
+        "liquid": "bin/liquid.js",
+        "liquidjs": "bin/liquid.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/liquidjs"
+      }
     },
     "node_modules/locate-path": {
       "version": "5.0.0",
@@ -5098,6 +5128,12 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -6034,6 +6070,15 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
+    },
+    "liquidjs": {
+      "version": "10.7.1",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.7.1.tgz",
+      "integrity": "sha512-tl9nWBZrrKcC61yfih3lbtSjAn+k7e0HhwydPjQKI4+metLk927HYBfXfbf6yrCcYjnBnLzk8xMjUF83yknAQQ==",
+      "dev": true,
+      "requires": {
+        "commander": "^10.0.0"
+      }
     },
     "locate-path": {
       "version": "5.0.0",

--- a/js/languages/typescript/package.json
+++ b/js/languages/typescript/package.json
@@ -22,7 +22,8 @@
   "license": "LGPL-2.1",
   "devDependencies": {
     "esbuild": "^0.17.17",
-    "jest": "^29.5.0"
+    "jest": "^29.5.0",
+    "liquidjs": "^10.7.1"
   },
   "dependencies": {
     "cross-dirname": "^0.1.0"


### PR DESCRIPTION
We've seen intermittent failures in the JS build because I forgot to add `liquidjs` as an explicit dev dependency, which results in races when multiple instances of npx try to globally install liquidjs at the same time.
