### PR TITLE
osemgrep: fix typos remarked by @aryx

### DIFF
--- a/libs/commons/Logs_helpers.ml
+++ b/libs/commons/Logs_helpers.ml
@@ -1,11 +1,12 @@
-(* ansii escape sequences for colored output, depending on log level *)
+(* ANSI escape sequences for colored output, depending on log level *)
 let color level =
   match level with
   | Logs.Warning -> Some "33" (*yellow*)
   | Logs.Error -> Some "31" (*red*)
   | _else -> None
 
-(* print an ansi escape sequence *)
+(* print an ANSI escape sequence - not worth to use an extra library
+   (such as ANSIterminal) for this *)
 let pp_sgr ppf style =
   Format.pp_print_as ppf 0 "\027[";
   Format.pp_print_as ppf 0 style;


### PR DESCRIPTION
PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
