### PR TITLE
osemgrep, match report: fix highlighting (otherwise out of bounds)

### DIFF
--- a/src/osemgrep/reporting/Matches_report.ml
+++ b/src/osemgrep/reporting/Matches_report.ml
@@ -165,11 +165,14 @@ let pp_finding ~max_chars_per_line ~max_lines_per_finding ~color_output
           else col m.start.col + ellipsis_len (line_off > 0)
         in
         let end_color =
-          if line_number >= m.end_.line then
-            min
-              (start_color + (m.end_.col - m.start.col))
-              (String.length line - 1 - ellipsis_len true)
-          else String.length line - 1
+          max start_color
+            (if line_number >= m.end_.line then
+             min
+               (if m.start.line = m.end_.line then
+                start_color + (m.end_.col - m.start.col)
+               else col m.end_.col - ellipsis_len true)
+               (String.length line - 1 - ellipsis_len true)
+            else String.length line - 1)
         in
         let a, b, c = cut line start_color end_color in
         Fmt.pf ppf "%s%s┆ %s%a%s@." pad line_number_str a


### PR DESCRIPTION
test plan:
make core
osemgrep --config r/python src/osemgrep/TOPORT/util.py

previously, there was an out of bounds error, since the assumption was that start line and end line was the same (and thus the cut point was negative).

now, the issue was solved, and for safety there's a "max start ..", so idx2 will always be >= idx1 in cut

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
