### PR TITLE
fix js build

### DIFF
--- a/.github/workflows/build-test-javascript.yaml
+++ b/.github/workflows/build-test-javascript.yaml
@@ -39,7 +39,7 @@ jobs:
           # TODO: figure out why we need to do this
           ln -s $TREESITTER_INCDIR/tree_sitter /usr/include/tree_sitter
 
-          opam install -y --deps-only ./libs/ocaml-tree-sitter-core
+          opam install -vv -y --deps-only ./libs/ocaml-tree-sitter-core
           opam install -y --deps-only ./
 
           dune build js --profile=release

--- a/.github/workflows/build-test-javascript.yaml
+++ b/.github/workflows/build-test-javascript.yaml
@@ -39,6 +39,9 @@ jobs:
           # TODO: figure out why we need to do this
           ln -s $TREESITTER_INCDIR/tree_sitter /usr/include/tree_sitter
 
+          opam install -y --deps-only ./libs/ocaml-tree-sitter-core
+          opam install -y --deps-only ./
+
           dune build js --profile=release
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build-test-javascript.yaml
+++ b/.github/workflows/build-test-javascript.yaml
@@ -39,8 +39,8 @@ jobs:
           # TODO: figure out why we need to do this
           ln -s $TREESITTER_INCDIR/tree_sitter /usr/include/tree_sitter
 
-          opam install -vv -y --deps-only ./libs/ocaml-tree-sitter-core
-          opam install -y --deps-only ./
+          opam install -y --deps-only ./libs/ocaml-tree-sitter-core
+          opam install -vv -y --deps-only ./
 
           dune build js --profile=release
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/build-test-javascript.yaml
+++ b/.github/workflows/build-test-javascript.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   build-semgrep-js-ocaml:
     runs-on: ubuntu-latest-16-core
-    container: returntocorp/ocaml:ubuntu-2023-04-17
+    container: returntocorp/ocaml:alpine-2023-04-17
     # We need this hack because GHA tampers with the HOME in container
     # and this does not play well with 'opam' installed in /root
     env:
@@ -31,9 +31,7 @@ jobs:
         run: |
           eval $(opam env)
 
-          # TODO: figure out why we need to do this
-          git config --global --add safe.directory $(pwd)
-
+          make install-deps-ALPINE-for-semgrep-core
           make install-deps-for-semgrep-core
 
           dune build js --profile=release

--- a/.github/workflows/build-test-javascript.yaml
+++ b/.github/workflows/build-test-javascript.yaml
@@ -31,16 +31,10 @@ jobs:
         run: |
           eval $(opam env)
 
-          # TODO: figure out why the opam install fails on ubuntu
-          #make install-deps-for-semgrep-core
-
-          . libs/ocaml-tree-sitter-core/tree-sitter-config.sh
-
           # TODO: figure out why we need to do this
-          ln -s $TREESITTER_INCDIR/tree_sitter /usr/include/tree_sitter
+          git config --global --add safe.directory $(pwd)
 
-          opam install -y --deps-only ./libs/ocaml-tree-sitter-core
-          opam install -vv -y --deps-only ./
+          make install-deps-for-semgrep-core
 
           dune build js --profile=release
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/build-test-javascript.yaml
+++ b/.github/workflows/build-test-javascript.yaml
@@ -33,6 +33,13 @@ jobs:
 
           make install-deps-ALPINE-for-semgrep-core
           make install-deps-for-semgrep-core
+
+          # This symlink seems to be necessary because our tree-sitter langs don't
+          # explicitly include the $TREESITTER_INCDIR folder when building c++ files.
+          # I'm puzzled why we haven't hit this issue elsewhere.
+          . libs/ocaml-tree-sitter-core/tree-sitter-config.sh
+          ln -s $TREESITTER_INCDIR/tree_sitter /usr/include/tree_sitter
+
           make build-semgrep-jsoo
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build-test-javascript.yaml
+++ b/.github/workflows/build-test-javascript.yaml
@@ -34,6 +34,8 @@ jobs:
           make install-deps-ALPINE-for-semgrep-core
           make install-deps-for-semgrep-core
 
+          . libs/ocaml-tree-sitter-core/tree-sitter-config.sh
+
           dune build js --profile=release
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build-test-javascript.yaml
+++ b/.github/workflows/build-test-javascript.yaml
@@ -33,7 +33,7 @@ jobs:
 
           make install-deps-ALPINE-for-semgrep-core
           make install-deps-for-semgrep-core
-          make build-jsoo
+          make build-semgrep-jsoo
       - uses: actions/upload-artifact@v3
         with:
           name: semgrep-js-ocaml-build

--- a/.github/workflows/build-test-javascript.yaml
+++ b/.github/workflows/build-test-javascript.yaml
@@ -33,10 +33,7 @@ jobs:
 
           make install-deps-ALPINE-for-semgrep-core
           make install-deps-for-semgrep-core
-
-          . libs/ocaml-tree-sitter-core/tree-sitter-config.sh
-
-          dune build js --profile=release
+          make build-jsoo
       - uses: actions/upload-artifact@v3
         with:
           name: semgrep-js-ocaml-build

--- a/Makefile
+++ b/Makefile
@@ -139,6 +139,11 @@ build-otarzan:
 	dune build _build/install/default/bin/otarzan
 	test -e bin || ln -s _build/install/default/bin .
 
+# Build the js_of_ocaml portion of the semgrep javascript packages
+.PHONY: build-semgrep-jsoo
+build-semgrep-jsoo:
+	dune build js --profile=release
+
 # Remove from the project tree everything that's not under source control
 # and was not created by 'make setup'.
 .PHONY: clean


### PR DESCRIPTION
The JS build wasn't installing opam deps, which was fine until `ocaml-layer` fell out of sync.

~This is just a quick fix to unblock the release; I'll submit a better fix (i.e. figure out why `make install-deps-for-semgrep-core` wasnt working (see [comment](https://github.com/returntocorp/semgrep/blob/develop/.github/workflows/build-test-javascript.yaml#L34))) later today.~ <-- got this working