### PR TITLE
osemgrep: fix performance bug when one deletes a file

### DIFF
--- a/libs/commons/common2.mli
+++ b/libs/commons/common2.mli
@@ -991,7 +991,11 @@ val nblines_file : filename -> int
 val filesize : filename -> int
 val filemtime : filename -> float
 val lfile_exists : filename -> bool
+
+(* raise Unix_error if the directory does not exist *)
 val is_directory : path -> bool
+
+(* raise Unix_error if the file does not exist *)
 val is_file : path -> bool
 val is_symlink : filename -> bool
 val is_executable : filename -> bool

--- a/src/targeting/Find_target.mli
+++ b/src/targeting/Find_target.mli
@@ -11,15 +11,24 @@
  *)
 
 type conf = {
+  (* osemgrep-only option (see Git_project.ml and the force_root parameter) *)
   project_root : Fpath.t option;
+  (* global exclude list, passed via semgrep --exclude *)
   exclude : string list;
-  (* [!] include_ = None is the opposite of Some [].
-     If a list of include patterns is specified, a path must match
-     at least of the patterns to be selected. *)
+  (* global include list, passed via semgrep --include
+   * [!] include_ = None is the opposite of Some [].
+   * If a list of include patterns is specified, a path must match
+   * at least of the patterns to be selected.
+   *)
   include_ : string list option;
   max_target_bytes : int;
+  (* whether or not follow what is specified in the .gitignore
+   * TODO? what about .semgrepignore?
+   *)
   respect_git_ignore : bool;
+  (* TODO: not used for now *)
   baseline_commit : string option;
+  (* TODO: not used for now *)
   scan_unknown_extensions : bool;
 }
 [@@deriving show]


### PR DESCRIPTION
test plan:
rm setup.py
osemgrep -l ocaml -e ': Common.filename' . --verbose
returns quickly and does not say anymore
git ls-files could not be used


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)