### PR TITLE
tainting: Fix crash while generating JSON report

### DIFF
--- a/tests/rules/taint_labels_empty.go
+++ b/tests/rules/taint_labels_empty.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+    "crypto/tls"
+    "encoding/json"
+    "encoding/hex"
+    "fmt"
+    "io/ioutil"
+    "net/http"
+    "net/url"
+)
+
+func (s *server) handlerBadFmt (w http.ResponseWriter, r *http.Request) {
+    urls, ok := r.URL.Query()["url"] // extract url from query params
+
+    if !ok {
+		http.Error(w, "url missing", 500)
+		return
+	}
+
+	if len(urls) != 1 {
+		http.Error(w, "url missing", 500)
+		return
+	}
+
+    url := fmt.Sprintf("//%s/path", urls[0])
+
+    // ruleid: test
+    resp, err := http.Get(url) // sink
+    if err != nil {
+		http.Error(w, err.Error(), 500)
+		return
+	}
+
+    // ok: test
+	_, err3 := http.Get("https://semgrep.dev")
+	if err3 != nil {
+		http.Error(w, err.Error(), 500)
+		return
+    }
+
+    url4 := fmt.Sprintf("ftps://%s/path/to/%s", "test", r.URL.Path)
+    // ok: test
+	_, err4 := http.Get("https://semgrep.dev")
+	if err3 != nil {
+		http.Error(w, err.Error(), 500)
+		return
+	}
+
+    defer resp.Body.Close()
+
+    bytes, err := ioutil.ReadAll(resp.Body)
+    if err != nil {
+		http.Error(w, err.Error(), 500)
+		return
+	}
+
+    // Write out the hexdump of the bytes as plaintext.
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	fmt.Fprint(w, hex.Dump(bytes))
+}

--- a/tests/rules/taint_labels_empty.yaml
+++ b/tests/rules/taint_labels_empty.yaml
@@ -1,0 +1,16 @@
+rules:
+- id: test
+  languages:
+  - go
+  message: Test
+  mode: taint
+  pattern-sources:
+  - label: INPUT
+    pattern: |
+      ($REQUEST : *http.Request).URL
+  pattern-sinks:
+  - requires: INPUT or not INPUT # could lead to findings with empty sources
+    patterns:
+    - pattern: http.$METHOD($URL, ...)
+    - focus-metavariable: $URL
+  severity: WARNING


### PR DESCRIPTION
If a sink had a trivially satisfiable 'requires' then the taint engine could generate a finding with no taint sources, and that caused a crash in `JSON_report.taint_trace_to_dataflow_trace`.

Fixes 85884600514 ("feat(taint): multiple source traces (#7291)")
Fixes bug causing PR returntocorp/semgrep-rules#2881 to fail.
Closes PA-2774

test plan:
make test # one test added

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
