### PR TITLE
osemgrep: login and logout subcommands

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -388,6 +388,7 @@ For more information see https://semsgrep.dev
     ocamlgraph
     parmap
     uri
+    uuidm
     http-lwt-client ; this brings lots of dependencies. This is for osemgrep.
     terminal_size
     lwt

--- a/semgrep.opam
+++ b/semgrep.opam
@@ -41,6 +41,7 @@ depends: [
   "ocamlgraph"
   "parmap"
   "uri"
+  "uuidm"
   "http-lwt-client"
   "terminal_size"
   "lwt"

--- a/src/osemgrep/cli_login/Login_CLI.ml
+++ b/src/osemgrep/cli_login/Login_CLI.ml
@@ -1,0 +1,114 @@
+(* Provides the 'Arg', 'Cmd', 'Manpage', and 'Term' modules. *)
+open Cmdliner
+
+(*****************************************************************************)
+(* Prelude *)
+(*****************************************************************************)
+(*
+   'semgrep login' command-line arguments processing.
+*)
+
+(*****************************************************************************)
+(* Types *)
+(*****************************************************************************)
+type conf = { logging_level : Logs.level option } [@@deriving show]
+
+(*****************************************************************************)
+(* Helpers *)
+(*****************************************************************************)
+
+(*************************************************************************)
+(* Command-line flags *)
+(*************************************************************************)
+
+(* ------------------------------------------------------------------ *)
+(* "Verbosity options" (mutually exclusive) *)
+(* ------------------------------------------------------------------ *)
+(* alt: we could use Logs_cli.level(), but by defining our own flags
+ * we can give better ~doc:. We lose the --verbosity=Level though.
+ *)
+let o_quiet : bool Term.t =
+  let info = Arg.info [ "q"; "quiet" ] ~doc:{|Only output findings.|} in
+  Arg.value (Arg.flag info)
+
+let o_verbose : bool Term.t =
+  let info =
+    Arg.info [ "v"; "verbose" ]
+      ~doc:
+        {|Show more details about what rules are running, which files
+failed to parse, etc.
+|}
+  in
+  Arg.value (Arg.flag info)
+
+let o_debug : bool Term.t =
+  let info =
+    Arg.info [ "debug" ]
+      ~doc:{|All of --verbose, but with additional debugging information.|}
+  in
+  Arg.value (Arg.flag info)
+
+(*****************************************************************************)
+(* Turn argv into a conf *)
+(*****************************************************************************)
+
+let cmdline_term : conf Term.t =
+  let combine debug quiet verbose =
+    let logging_level =
+      match (verbose, debug, quiet) with
+      | false, false, false -> Some Logs.Warning
+      | true, false, false -> Some Logs.Info
+      | false, true, false -> Some Logs.Debug
+      | false, false, true -> None
+      | _else_ ->
+          (* TOPORT: list the possibilities *)
+          Error.abort "mutually exclusive options --quiet/--verbose/--debug"
+    in
+    { logging_level }
+  in
+  Term.(const combine $ o_debug $ o_quiet $ o_verbose)
+
+(*****************************************************************************)
+(* Login subcommand *)
+(*****************************************************************************)
+
+let login_doc = "Obtain and save credentials for semgrep.dev"
+
+let login_man : Manpage.block list =
+  [
+    `S Manpage.s_description;
+    `P
+      "Obtain and save credentials for semgrep.dev\n\n\
+      \    Looks for an semgrep.dev API token in the environment variable \
+       SEMGREP_APP_TOKEN.\n\
+      \    If not defined and running in a TTY, prompts interactively.\n\
+      \    Once token is found, saves it to global settings file";
+  ]
+  @ CLI_common.help_page_bottom
+
+let login_cmdline_info : Cmd.info =
+  Cmd.info "semgrep login" ~doc:login_doc ~man:login_man
+
+(*****************************************************************************)
+(* Logout subcommand *)
+(*****************************************************************************)
+
+let logout_doc = "Remove locally stored credentials to semgrep.dev"
+
+let logout_man : Manpage.block list =
+  [
+    `S Manpage.s_description;
+    `P "Remove locally stored credentials to semgrep.dev";
+  ]
+  @ CLI_common.help_page_bottom
+
+let logout_cmdline_info : Cmd.info =
+  Cmd.info "semgrep logout" ~doc:logout_doc ~man:logout_man
+
+(*****************************************************************************)
+(* Turn argv into a conf *)
+(*****************************************************************************)
+
+let parse_argv (cmd_info : Cmd.info) (argv : string array) : conf =
+  let cmd : conf Cmd.t = Cmd.v cmd_info cmdline_term in
+  CLI_common.eval_value ~argv cmd

--- a/src/osemgrep/cli_login/Login_CLI.mli
+++ b/src/osemgrep/cli_login/Login_CLI.mli
@@ -1,0 +1,25 @@
+(*
+   'semgrep login' (and also 'semgrep logout') command-line parsing.
+*)
+
+(*
+   The result of parsing a 'semgrep login' command.
+*)
+type conf = {
+  (* mix of --debug, --quiet, --verbose *)
+  logging_level : Logs.level option;
+}
+[@@deriving show]
+
+val login_cmdline_info : Cmdliner.Cmd.info
+val logout_cmdline_info : Cmdliner.Cmd.info
+
+(*
+   Usage: parse_argv cmd_info [| "semgrep-login"; <args> |]
+
+   Turn argv into a conf structure.
+
+   This function may raise an exn in case of an error parsing argv
+   but this should be caught by CLI.safe_run.
+*)
+val parse_argv : Cmdliner.Cmd.info -> string array -> conf

--- a/src/osemgrep/cli_login/Login_subcommand.ml
+++ b/src/osemgrep/cli_login/Login_subcommand.ml
@@ -32,7 +32,7 @@ let man : Manpage.block list =
     `P
       "Obtain and save credentials for semgrep.dev\n\n\
       \    Looks for an semgrep.dev API token in the environment variable \
-       SEMGREP_API_TOKEN_SETTINGS_KEY.\n\
+       SEMGREP_APP_TOKEN.\n\
       \    If not defined and running in a TTY, prompts interactively.\n\
       \    Once token is found, saves it to global settings file";
   ]
@@ -44,19 +44,130 @@ let parse_argv (argv : string array) : conf =
   let cmd : conf Cmd.t = Cmd.v cmdline_info cmdline_term in
   CLI_common.eval_value ~argv cmd
 
+let make_login_url () =
+  let session_id = Uuidm.v `V4 in
+  ( session_id,
+    Uri.(
+      add_query_params
+        (with_path Semgrep_envvars.env.semgrep_url "login")
+        [
+          ("cli-token", [ Uuidm.to_string session_id ]);
+          ( "docker",
+            [ (if Semgrep_envvars.env.in_docker then "True" else "False") ] );
+          ( "gha",
+            [ (if Semgrep_envvars.env.in_gh_action then "True" else "False") ]
+          );
+        ]) )
+
 (*****************************************************************************)
 (* Main logic *)
 (*****************************************************************************)
 
+let wait_between_retry_in_sec = 6 (* So every 10 retries is a minute *)
+let max_retries = 30 (* Give users 3 minutes to log in / open link *)
+
 (* All the business logic after command-line parsing. Return the desired
    exit code. *)
 let run (_conf : conf) : Exit_code.t =
-  (* TODO:
-     Setup_logging.setup config;
-     logger#info "Executed as: %s" (Sys.argv |> Array.to_list |> String.concat " ");
-     logger#info "Version: %s" config.version;
-  *)
-  Exit_code.ok
+  Logs_helpers.setup_logging ~force_color:false ~level:(Some Logs.Debug);
+  Logs.info (fun m -> m "Semgrep version: %s" Version.version);
+  Logs.info (fun m ->
+      m "Executed as: %s" (Sys.argv |> Array.to_list |> String.concat " "));
+  let settings = Semgrep_settings.get () in
+  match settings.Semgrep_settings.api_token with
+  | None -> (
+      match Semgrep_envvars.env.app_token with
+      | Some token when String.length token > 0 ->
+          let settings =
+            Semgrep_settings.{ settings with api_token = Some token }
+          in
+          Semgrep_settings.save settings;
+          Exit_code.ok
+      | None
+      | Some _ ->
+          (* if not auth.is_a_tty():
+             click.echo(
+                 f"Error: semgrep login is an interactive command: run in an interactive terminal (or define SEMGREP_APP_TOKEN)",
+                 err=True,
+             )
+             sys.exit(FATAL_EXIT_CODE)
+          *)
+          let session_id, url = make_login_url () in
+          Logs.app (fun m ->
+              m
+                "Login enables additional proprietary Semgrep Registry rules \
+                 and running custom policies from Semgrep App.");
+          Logs.app (fun m -> m "Login at: %s" (Uri.to_string url));
+          Logs.app (fun m ->
+              m
+                "@.Once you've logged in, return here and you'll be ready to \
+                 start using new Semgrep rules.");
+          let rec fetch = function
+            | 0 ->
+                Logs.err (fun m ->
+                    m
+                      "Failed to login: please check your internet connection \
+                       or contact support@r2c.dev");
+                Exit_code.fatal
+            | n -> (
+                let url =
+                  Uri.with_path Semgrep_envvars.env.semgrep_url
+                    "api/agent/tokens/requests"
+                in
+                let body =
+                  {|{"token_request_key": "|} ^ Uuidm.to_string session_id
+                  ^ {|"}|}
+                in
+                match Network.post ~body url with
+                | Ok body -> (
+                    try
+                      match Yojson.Basic.from_string body with
+                      | `Assoc e -> (
+                          match List.assoc_opt "token" e with
+                          | Some (`String token) ->
+                              let settings =
+                                Semgrep_settings.
+                                  { settings with api_token = Some token }
+                              in
+                              Semgrep_settings.save settings;
+                              (* TODO if save failed, Exit_code.fatal *)
+                              Exit_code.ok
+                          | None
+                          | Some _ ->
+                              Logs.debug (fun m ->
+                                  m "failed to decode json token %s" body);
+                              Exit_code.fatal)
+                      | _ ->
+                          Logs.debug (fun m ->
+                              m "failed to decode json %s" body);
+                          Exit_code.fatal
+                    with
+                    | Yojson.Json_error msg ->
+                        Logs.debug (fun m ->
+                            m "failed to parse json %s: %s" msg body);
+                        Exit_code.fatal)
+                | Error (status_code, msg) ->
+                    if status_code = 404 then (
+                      Unix.sleep wait_between_retry_in_sec;
+                      fetch (n - 1))
+                    else (
+                      Logs.err (fun m ->
+                          m
+                            "Unexpected failure from %s: status code %d; \
+                             please contact support@r2c.dev if this persists"
+                            (Uri.to_string Semgrep_envvars.env.semgrep_url)
+                            status_code);
+                      Logs.info (fun m -> m "HTTP error: %s" msg);
+                      Exit_code.fatal))
+          in
+          fetch max_retries)
+  | Some _ ->
+      Logs.app (fun m ->
+          m
+            "API token already exists in %s. To login with a different token \
+             logout use `semgrep logout`"
+            Semgrep_envvars.env.user_settings_file);
+      Exit_code.fatal
 
 (*****************************************************************************)
 (* Entry point *)

--- a/src/osemgrep/cli_login/Login_subcommand.ml
+++ b/src/osemgrep/cli_login/Login_subcommand.ml
@@ -70,9 +70,6 @@ let max_retries = 30 (* Give users 3 minutes to log in / open link *)
    exit code. *)
 let run (_conf : conf) : Exit_code.t =
   Logs_helpers.setup_logging ~force_color:false ~level:(Some Logs.Debug);
-  Logs.info (fun m -> m "Semgrep version: %s" Version.version);
-  Logs.info (fun m ->
-      m "Executed as: %s" (Sys.argv |> Array.to_list |> String.concat " "));
   let settings = Semgrep_settings.get () in
   match settings.Semgrep_settings.api_token with
   | None -> (
@@ -166,7 +163,7 @@ let run (_conf : conf) : Exit_code.t =
           m
             "API token already exists in %s. To login with a different token \
              logout use `semgrep logout`"
-            Semgrep_envvars.env.user_settings_file);
+            (Fpath.to_string Semgrep_envvars.env.user_settings_file));
       Exit_code.fatal
 
 (*****************************************************************************)

--- a/src/osemgrep/cli_login/Login_subcommand.mli
+++ b/src/osemgrep/cli_login/Login_subcommand.mli
@@ -7,8 +7,5 @@
 *)
 val main : string array -> Exit_code.t
 
-(* no parameters for now *)
-type conf = unit
-
 (* internal *)
-val run : conf -> Exit_code.t
+val run : Login_CLI.conf -> Exit_code.t

--- a/src/osemgrep/cli_login/Logout_subcommand.ml
+++ b/src/osemgrep/cli_login/Logout_subcommand.ml
@@ -46,11 +46,13 @@ let parse_argv (argv : string array) : conf =
 (* All the business logic after command-line parsing. Return the desired
    exit code. *)
 let run (_conf : conf) : Exit_code.t =
-  (* TODO:
-     Setup_logging.setup config;
-     logger#info "Executed as: %s" (Sys.argv |> Array.to_list |> String.concat " ");
-     logger#info "Version: %s" config.version;
-  *)
+  Logs_helpers.setup_logging ~force_color:false ~level:(Some Logs.Debug);
+  Logs.info (fun m -> m "Semgrep version: %s" Version.version);
+  Logs.info (fun m ->
+      m "Executed as: %s" (Sys.argv |> Array.to_list |> String.concat " "));
+  let settings = Semgrep_settings.get () in
+  let settings = Semgrep_settings.{ settings with api_token = None } in
+  Semgrep_settings.save settings;
   Exit_code.ok
 
 (*****************************************************************************)

--- a/src/osemgrep/cli_login/Logout_subcommand.ml
+++ b/src/osemgrep/cli_login/Logout_subcommand.ml
@@ -1,5 +1,3 @@
-open Cmdliner
-
 (*****************************************************************************)
 (* Prelude *)
 (*****************************************************************************)
@@ -10,43 +8,13 @@ open Cmdliner
 *)
 
 (*****************************************************************************)
-(* Types *)
-(*****************************************************************************)
-(* no CLI parameters for now *)
-type conf = unit
-
-(*****************************************************************************)
-(* Helpers *)
-(*****************************************************************************)
-
-(* this could be moved in a Login_CLI.ml file at some point if needed *)
-let cmdline_term : conf Term.t =
-  let combine = () in
-  Term.(const combine)
-
-let doc = "Remove locally stored credentials to semgrep.dev"
-
-let man : Manpage.block list =
-  [
-    `S Manpage.s_description;
-    `P "Remove locally stored credentials to semgrep.dev";
-  ]
-  @ CLI_common.help_page_bottom
-
-let cmdline_info : Cmd.info = Cmd.info "semgrep logout" ~doc ~man
-
-let parse_argv (argv : string array) : conf =
-  let cmd : conf Cmd.t = Cmd.v cmdline_info cmdline_term in
-  CLI_common.eval_value ~argv cmd
-
-(*****************************************************************************)
 (* Main logic *)
 (*****************************************************************************)
 
 (* All the business logic after command-line parsing. Return the desired
    exit code. *)
-let run (_conf : conf) : Exit_code.t =
-  Logs_helpers.setup_logging ~force_color:false ~level:(Some Logs.Debug);
+let run (conf : Login_CLI.conf) : Exit_code.t =
+  Logs_helpers.setup_logging ~force_color:false ~level:conf.logging_level;
   let settings = Semgrep_settings.get () in
   let settings = Semgrep_settings.{ settings with api_token = None } in
   Semgrep_settings.save settings;
@@ -57,5 +25,5 @@ let run (_conf : conf) : Exit_code.t =
 (*****************************************************************************)
 
 let main (argv : string array) : Exit_code.t =
-  let conf = parse_argv argv in
+  let conf = Login_CLI.parse_argv Login_CLI.logout_cmdline_info argv in
   run conf

--- a/src/osemgrep/cli_login/Logout_subcommand.ml
+++ b/src/osemgrep/cli_login/Logout_subcommand.ml
@@ -47,9 +47,6 @@ let parse_argv (argv : string array) : conf =
    exit code. *)
 let run (_conf : conf) : Exit_code.t =
   Logs_helpers.setup_logging ~force_color:false ~level:(Some Logs.Debug);
-  Logs.info (fun m -> m "Semgrep version: %s" Version.version);
-  Logs.info (fun m ->
-      m "Executed as: %s" (Sys.argv |> Array.to_list |> String.concat " "));
   let settings = Semgrep_settings.get () in
   let settings = Semgrep_settings.{ settings with api_token = None } in
   Semgrep_settings.save settings;

--- a/src/osemgrep/cli_login/Logout_subcommand.mli
+++ b/src/osemgrep/cli_login/Logout_subcommand.mli
@@ -7,8 +7,5 @@
 *)
 val main : string array -> Exit_code.t
 
-(* no parameters for now *)
-type conf = unit
-
 (* internal *)
-val run : conf -> Exit_code.t
+val run : Login_CLI.conf -> Exit_code.t

--- a/src/osemgrep/cli_login/dune
+++ b/src/osemgrep/cli_login/dune
@@ -7,6 +7,9 @@
     cmdliner
     commons
 
+    semgrep_core_cli
+
+    osemgrep_configuring
     osemgrep_core
     osemgrep_networking
   )

--- a/src/osemgrep/cli_login/dune
+++ b/src/osemgrep/cli_login/dune
@@ -7,8 +7,6 @@
     cmdliner
     commons
 
-    semgrep_core_cli
-
     osemgrep_configuring
     osemgrep_core
     osemgrep_networking

--- a/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -381,33 +381,6 @@ let o_nosem : bool Term.t =
           a 'nosem' comment at the end. Enabled by default.|}
 
 (* ------------------------------------------------------------------ *)
-(* TOPORT "Verbosity options" (mutually exclusive) *)
-(* ------------------------------------------------------------------ *)
-(* alt: we could use Logs_cli.level(), but by defining our own flags
- * we can give better ~doc:. We lose the --verbosity=Level though.
- *)
-let o_quiet : bool Term.t =
-  let info = Arg.info [ "q"; "quiet" ] ~doc:{|Only output findings.|} in
-  Arg.value (Arg.flag info)
-
-let o_verbose : bool Term.t =
-  let info =
-    Arg.info [ "v"; "verbose" ]
-      ~doc:
-        {|Show more details about what rules are running, which files
-failed to parse, etc.
-|}
-  in
-  Arg.value (Arg.flag info)
-
-let o_debug : bool Term.t =
-  let info =
-    Arg.info [ "debug" ]
-      ~doc:{|All of --verbose, but with additional debugging information.|}
-  in
-  Arg.value (Arg.flag info)
-
-(* ------------------------------------------------------------------ *)
 (* TOPORT "Output formats" (mutually exclusive) *)
 (* ------------------------------------------------------------------ *)
 let o_json : bool Term.t =
@@ -642,30 +615,20 @@ let o_project_root : string option Term.t =
 let cmdline_term : conf Term.t =
   (* !The parameters must be in alphabetic orders to match the order
    * of the corresponding '$ o_xx $' further below! *)
-  let combine autofix baseline_commit config debug dryrun dump_ast dump_config
-      emacs error exclude exclude_rule_ids force_color include_ json lang
-      max_chars_per_line max_lines_per_finding max_memory_mb max_target_bytes
-      metrics num_jobs nosem optimizations pattern profile project_root quiet
-      replacement respect_git_ignore rewrite_rule_ids scan_unknown_extensions
-      severity show_supported_languages strict target_roots test
-      test_ignore_todo time_flag timeout timeout_threshold validate verbose
-      version version_check vim =
+  let combine logging_level autofix baseline_commit config dryrun dump_ast
+      dump_config emacs error exclude exclude_rule_ids force_color include_ json
+      lang max_chars_per_line max_lines_per_finding max_memory_mb
+      max_target_bytes metrics num_jobs nosem optimizations pattern profile
+      project_root replacement respect_git_ignore rewrite_rule_ids
+      scan_unknown_extensions severity show_supported_languages strict
+      target_roots test test_ignore_todo time_flag timeout timeout_threshold
+      validate version version_check vim =
     let include_ =
       match include_ with
       | [] -> None
       | nonempty -> Some nonempty
     in
     let target_roots = target_roots |> File.Path.of_strings in
-    let logging_level =
-      match (verbose, debug, quiet) with
-      | false, false, false -> Some Logs.Warning
-      | true, false, false -> Some Logs.Info
-      | false, true, false -> Some Logs.Debug
-      | false, false, true -> None
-      | _else_ ->
-          (* TOPORT: list the possibilities *)
-          Error.abort "mutually exclusive options --quiet/--verbose/--debug"
-    in
     (* ugly: call setup_logging ASAP so the Logs.xxx below are displayed
      * correctly *)
     Logs_helpers.setup_logging ~force_color ~level:logging_level;
@@ -890,16 +853,16 @@ let cmdline_term : conf Term.t =
   Term.(
     (* !the o_xxx must be in alphabetic orders to match the parameters of
      * combine above! *)
-    const combine $ o_autofix $ o_baseline_commit $ o_config $ o_debug
-    $ o_dryrun $ o_dump_ast $ o_dump_config $ o_emacs $ o_error $ o_exclude
-    $ o_exclude_rule_ids $ o_force_color $ o_include $ o_json $ o_lang
-    $ o_max_chars_per_line $ o_max_lines_per_finding $ o_max_memory_mb
+    const combine $ CLI_common.logging_term $ o_autofix $ o_baseline_commit
+    $ o_config $ o_dryrun $ o_dump_ast $ o_dump_config $ o_emacs $ o_error
+    $ o_exclude $ o_exclude_rule_ids $ o_force_color $ o_include $ o_json
+    $ o_lang $ o_max_chars_per_line $ o_max_lines_per_finding $ o_max_memory_mb
     $ o_max_target_bytes $ o_metrics $ o_num_jobs $ o_nosem $ o_optimizations
-    $ o_pattern $ o_profile $ o_project_root $ o_quiet $ o_replacement
+    $ o_pattern $ o_profile $ o_project_root $ o_replacement
     $ o_respect_git_ignore $ o_rewrite_rule_ids $ o_scan_unknown_extensions
     $ o_severity $ o_show_supported_languages $ o_strict $ o_target_roots
     $ o_test $ o_test_ignore_todo $ o_time $ o_timeout $ o_timeout_threshold
-    $ o_validate $ o_verbose $ o_version $ o_version_check $ o_vim)
+    $ o_validate $ o_version $ o_version_check $ o_vim)
 
 let doc = "run semgrep rules on files"
 

--- a/src/osemgrep/configuring/Semgrep_settings.ml
+++ b/src/osemgrep/configuring/Semgrep_settings.ml
@@ -1,0 +1,97 @@
+type t = {
+  has_shown_metrics_notification : bool option;
+  api_token : string option;
+  anonymous_user_id : Uuidm.t;
+}
+
+let default_settings =
+  {
+    has_shown_metrics_notification = None;
+    api_token = None;
+    anonymous_user_id = Uuidm.v `V4;
+  }
+
+let _t = ref default_settings
+let ( let* ) = Result.bind
+
+let of_yaml = function
+  | `O data ->
+      let has_shown_metrics_notification =
+        List.assoc_opt "has_shown_metrics_notification" data
+      and api_token = List.assoc_opt "api_token" data
+      and anonymous_user_id = List.assoc_opt "anonymous_user_id" data in
+      let* has_shown_metrics_notification =
+        Option.fold ~none:(Ok None)
+          ~some:(function
+            | `Bool b -> Ok (Some b)
+            | _else -> Error (`Msg "has shown metrics notification not a bool"))
+          has_shown_metrics_notification
+      in
+      let* api_token =
+        Option.fold ~none:(Ok None)
+          ~some:(function
+            | `String s -> Ok (Some s)
+            | _else -> Error (`Msg "api token not a string"))
+          api_token
+      in
+      let* anonymous_user_id =
+        Option.fold
+          ~none:(Error (`Msg "no anonymous user id"))
+          ~some:(function
+            | `String s ->
+                Option.to_result ~none:(`Msg "not a valid UUID")
+                  (Uuidm.of_string s)
+            | _else -> Error (`Msg "anonymous user id is not a string"))
+          anonymous_user_id
+      in
+      Ok { has_shown_metrics_notification; api_token; anonymous_user_id }
+  | _else -> Error (`Msg "YAML not an object")
+
+let to_yaml { has_shown_metrics_notification; api_token; anonymous_user_id } =
+  `O
+    ((match has_shown_metrics_notification with
+     | None -> []
+     | Some v -> [ ("has_shown_metrics_notification", `Bool v) ])
+    @ (match api_token with
+      | None -> []
+      | Some v -> [ ("api_token", `String v) ])
+    @ [ ("anonymous_user_id", `String (Uuidm.to_string anonymous_user_id)) ])
+
+let settings = Fpath.v Semgrep_envvars.env.user_settings_file
+
+let get_contents () =
+  lazy
+    (_t :=
+       try
+         let _ = File.fullpath settings in
+         let data = File.read_file settings in
+         match Yaml.of_string data with
+         | Error _ ->
+             Logs.warn (fun m ->
+                 m "Bad settings format; %s will be overriden. Contents:\n%s"
+                   (Fpath.to_string settings) data);
+             default_settings
+         | Ok value -> (
+             match of_yaml value with
+             | Error (`Msg msg) ->
+                 Logs.warn (fun m ->
+                     m
+                       "Bad settings format; %s will be overriden. Contents:\n\
+                        %s"
+                       (Fpath.to_string settings) data);
+                 Logs.info (fun m -> m "Decode error: %s" msg);
+                 default_settings
+             | Ok s -> s)
+       with
+       | Failure _ -> default_settings)
+
+let save t =
+  let yaml = to_yaml t in
+  let str = Yaml.to_string_exn yaml in
+  Sys.mkdir Fpath.(to_string (parent settings)) 0o755;
+  File.write_file settings str;
+  _t := t
+
+let get () =
+  Lazy.force (get_contents ());
+  !_t

--- a/src/osemgrep/configuring/Semgrep_settings.mli
+++ b/src/osemgrep/configuring/Semgrep_settings.mli
@@ -1,0 +1,8 @@
+type t = {
+  has_shown_metrics_notification : bool option;
+  api_token : string option;
+  anonymous_user_id : Uuidm.t;
+}
+
+val save : t -> unit
+val get : unit -> t

--- a/src/osemgrep/configuring/Semgrep_settings.mli
+++ b/src/osemgrep/configuring/Semgrep_settings.mli
@@ -1,3 +1,4 @@
+(* content of the the ~/.semgrep/settings.yml file. See also Semgrep_envvars.user_settings_file *)
 type t = {
   has_shown_metrics_notification : bool option;
   api_token : string option;

--- a/src/osemgrep/configuring/dune
+++ b/src/osemgrep/configuring/dune
@@ -9,6 +9,7 @@
   (wrapped false)
   (libraries
    uri
+   uuidm
    commons
 
    osemgrep_core ; for Error.ml

--- a/src/osemgrep/core/CLI_common.ml
+++ b/src/osemgrep/core/CLI_common.ml
@@ -3,6 +3,50 @@
 *)
 open Cmdliner
 
+(*************************************************************************)
+(* Command-line flags *)
+(*************************************************************************)
+
+(* ------------------------------------------------------------------ *)
+(* "Verbosity options" (mutually exclusive) *)
+(* ------------------------------------------------------------------ *)
+(* alt: we could use Logs_cli.level(), but by defining our own flags
+ * we can give better ~doc:. We lose the --verbosity=Level though.
+ *)
+let o_quiet : bool Term.t =
+  let info = Arg.info [ "q"; "quiet" ] ~doc:{|Only output findings.|} in
+  Arg.value (Arg.flag info)
+
+let o_verbose : bool Term.t =
+  let info =
+    Arg.info [ "v"; "verbose" ]
+      ~doc:
+        {|Show more details about what rules are running, which files
+failed to parse, etc.
+|}
+  in
+  Arg.value (Arg.flag info)
+
+let o_debug : bool Term.t =
+  let info =
+    Arg.info [ "debug" ]
+      ~doc:{|All of --verbose, but with additional debugging information.|}
+  in
+  Arg.value (Arg.flag info)
+
+let logging_term : Logs.level option Term.t =
+  let combine debug quiet verbose =
+    match (verbose, debug, quiet) with
+    | false, false, false -> Some Logs.Warning
+    | true, false, false -> Some Logs.Info
+    | false, true, false -> Some Logs.Debug
+    | false, false, true -> None
+    | _else_ ->
+        (* TOPORT: list the possibilities *)
+        Error.abort "mutually exclusive options --quiet/--verbose/--debug"
+  in
+  Term.(const combine $ o_debug $ o_quiet $ o_verbose)
+
 let help_page_bottom =
   [
     `S Manpage.s_authors;

--- a/src/osemgrep/core/CLI_common.mli
+++ b/src/osemgrep/core/CLI_common.mli
@@ -8,6 +8,9 @@ val help_page_bottom : Cmdliner.Manpage.block list
 (* small wrapper around Cmdliner.Cmd.eval_value *)
 val eval_value : argv:string array -> 'a Cmdliner.Cmd.t -> 'a
 
+(* handles logging arguments (--quiet/--verbose/--debug) *)
+val logging_term : Logs.level option Cmdliner.Term.t
+
 (* TODO: parser+printer for file path so we can write things like:
 
         Arg.value (Arg.opt (Arg.some CLI_common.fpath) None info)

--- a/src/osemgrep/networking/Network.ml
+++ b/src/osemgrep/networking/Network.ml
@@ -14,3 +14,19 @@ let get url =
         ^ Status.to_string response.status)
   | Error (`Msg msg) -> Error ("HTTP request failed: " ^ msg)
   [@@profiling]
+
+let post ~body ?(headers = [ ("Content-type", "application/json") ]) url =
+  let bodyf _ acc data = Lwt.return (acc ^ data) in
+  let promise =
+    request ~meth:`POST ~headers ~body (Uri.to_string url) bodyf ""
+  in
+  let r = Lwt_main.run promise in
+  match r with
+  | Ok (response, content) when Status.is_successful response.status ->
+      Ok content
+  | Ok (response, _) ->
+      Error
+        ( Status.to_code response.status,
+          "HTTP request failed, server response "
+          ^ Status.to_string response.status )
+  | Error (`Msg msg) -> Error (-1, "HTTP request failed: " ^ msg)

--- a/src/osemgrep/networking/Network.mli
+++ b/src/osemgrep/networking/Network.mli
@@ -1,1 +1,7 @@
 val get : Uri.t -> (string, string) result
+
+val post :
+  body:string ->
+  ?headers:(string * string) list ->
+  Uri.t ->
+  (string, int * string) result


### PR DESCRIPTION
test plan:
  make core
  osemgrep login
  osemgrep logout

Only the login and logout commands are now ported, the api_token is not (yet) used in http requests (this will be done in a followup PR).

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
