### PR TITLE
refactor: Migrate src/autofix/ off of mk_visitor

### DIFF
--- a/src/fixing/Autofix_metavar_replacement.ml
+++ b/src/fixing/Autofix_metavar_replacement.ml
@@ -46,101 +46,86 @@ let replace metavar_tbl pattern_ast =
    * metavariable bound to an argument, and if so, do the replacement at that
    * point in the tree traversal. *)
   let mapper =
-    Map_AST.(
-      mk_visitor
-        {
-          default_visitor with
-          (* TODO handle:
-           * [x] ident
-           * [ ] name
-           * [x] expr
-           * [ ] stmt
-           * [ ] type_
-           * [ ] pattern
-           * [ ] stmt list
-           * [x] argument list
-           * [ ] parameter list
-           * [ ] xml_body list
-           * [x] text
-           *)
-          kargs =
-            (fun (k, _) args ->
-              (* A metavariable can appear as a single argument, but can be
-               * bound to zero or more arguments, so we have to handle this case
-               * by looking at an argument list as a whole. For example,
-               * `foo(1, $...X)` matches `foo(1)` *)
-              let map_arg arg =
-                match arg with
-                | Arg { e = N (Id ((id_str, _), _)); _ } -> (
-                    match Hashtbl.find_opt metavar_tbl id_str with
-                    | Some (MV.Args args) -> args
-                    | _ -> [ arg ])
-                | _ -> [ arg ]
-              in
-              let args = List.concat_map map_arg args in
-              k args);
-          kexpr =
-            (fun (k, _) orig ->
-              let replacement =
-                match orig.e with
-                | N (Id ((id_str, _), _)) -> (
-                    match Hashtbl.find_opt metavar_tbl id_str with
-                    | Some (MV.E e) -> Some e
-                    | _ -> None)
-                | _ -> None
-              in
-              match replacement with
-              | None ->
-                  (* The mapper changes the ID of expressions. This stymies the
-                   * print-avoidance implemented later in the autofix process,
-                   * because the resulting AST nodes cannot be recognized as the
-                   * same as the original ones.
-                   *
-                   * To work around this, we use the original expression, except
-                   * for the mapped kind.
-                   *
-                   * There is a note in the mapper expressing uncertainty about
-                   * whether the ID should be reused or not. We should consider
-                   * changing that behavior in the mapper, in which case this
-                   * workaround would no longer be necessary. *)
-                  { orig with e = (k orig).e }
-              | Some e ->
-                  (* We found a matching metavariable binding. There is no point
-                   * searching through the metavariable value that came from the
-                   * target file for more metavariables, so we won't call `k`
-                   * here. *)
-                  e);
-          klit =
-            (fun (k, _) lit ->
-              match lit with
-              | String (_l, (str, _), _r) -> (
-                  (* TODO handle the case where the metavar appears within the
-                   * string but is not the entire contents of the string *)
-                  match Hashtbl.find_opt metavar_tbl str with
-                  | Some (MV.Text (str, _info, originfo)) ->
-                      (* Don't use `Metavariable.mvalue_to_any` here. It uses
-                       * the modified token info, which drops the quotes. *)
-                      (* TODO? reuse l and r from String above? *)
-                      String (fb (str, originfo))
-                  | _ -> k lit)
-              | _ -> k lit);
-          kname =
-            (fun (k, _) name ->
-              match name with
-              | Id ((id_str, _), _) -> (
-                  match Hashtbl.find_opt metavar_tbl id_str with
-                  | Some (MV.Id (id, info)) ->
-                      let info =
-                        match info with
-                        | Some x -> x
-                        | None -> G.empty_id_info ()
-                      in
-                      Id (id, info)
-                  | _ -> k name)
-              | _ -> k name);
-        })
+    object (_self : 'self)
+      inherit [_] AST_generic.map as super
+
+      (* TODO handle:
+       * [x] ident
+       * [ ] name
+       * [x] expr
+       * [ ] stmt
+       * [ ] type_
+       * [ ] pattern
+       * [ ] stmt list
+       * [x] argument list
+       * [ ] parameter list
+       * [ ] xml_body list
+       * [x] text
+       *)
+      method! visit_arguments env (l, args, r) =
+        (* A metavariable can appear as a single argument, but can be
+         * bound to zero or more arguments, so we have to handle this case
+         * by looking at an argument list as a whole. For example,
+         * `foo(1, $...X)` matches `foo(1)` *)
+        let map_arg arg =
+          match arg with
+          | Arg { e = N (Id ((id_str, _), _)); _ } -> (
+              match Hashtbl.find_opt metavar_tbl id_str with
+              | Some (MV.Args args) -> args
+              | _ -> [ arg ])
+          | _ -> [ arg ]
+        in
+        let args = List.concat_map map_arg args in
+        super#visit_arguments env (l, args, r)
+
+      method! visit_expr env orig =
+        let replacement =
+          match orig.e with
+          | N (Id ((id_str, _), _)) -> (
+              match Hashtbl.find_opt metavar_tbl id_str with
+              | Some (MV.E e) -> Some e
+              | _ -> None)
+          | _ -> None
+        in
+        match replacement with
+        | None -> super#visit_expr env orig
+        | Some e ->
+            (* We found a matching metavariable binding. There is no point
+             * searching through the metavariable value that came from the
+             * target file for more metavariables, so we won't call `k`
+             * here. *)
+            e
+
+      method! visit_literal env lit =
+        match lit with
+        | String (_l, (str, _), _r) -> (
+            (* TODO handle the case where the metavar appears within the
+             * string but is not the entire contents of the string *)
+            match Hashtbl.find_opt metavar_tbl str with
+            | Some (MV.Text (str, _info, originfo)) ->
+                (* Don't use `Metavariable.mvalue_to_any` here. It uses
+                 * the modified token info, which drops the quotes. *)
+                (* TODO? reuse l and r from String above? *)
+                String (fb (str, originfo))
+            | _ -> super#visit_literal env lit)
+        | _ -> super#visit_literal env lit
+
+      method! visit_name env name =
+        match name with
+        | Id ((id_str, _), _) -> (
+            match Hashtbl.find_opt metavar_tbl id_str with
+            | Some (MV.Id (id, info)) ->
+                let info =
+                  match info with
+                  | Some x -> x
+                  | None -> G.empty_id_info ()
+                in
+                Id (id, info)
+            | _ -> super#visit_name env name)
+        | _ -> super#visit_name env name
+    end
   in
-  mapper.Map_AST.vany pattern_ast
+  mapper#visit_any () pattern_ast
 
 (* Check for remaining metavars in the fixed pattern AST. If there are any, that
  * indicates a failure to properly replace them in the previous step, and the


### PR DESCRIPTION
Note that for both of these visitors, we no longer need to work around the expression mapping behavior that was the default in the old visitor. We inherit from the plain `map` visitor, so we don't get any of the nonstandard behavior.

Test plan: Automated tests

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
