### PR TITLE
fix(pro): fix looping dataflow from get methods

### DIFF
--- a/changelog.d/pro-56.fixed
+++ b/changelog.d/pro-56.fixed
@@ -1,0 +1,3 @@
+Pro Engine: Fixed a bug where dataflow analysis would sometimes
+loop when analyzing interprocedural `get<name>` methods in a
+loop.

--- a/src/tainting/Dataflow_tainting.ml
+++ b/src/tainting/Dataflow_tainting.ml
@@ -738,10 +738,16 @@ let resolve_poly_taint_for_java_getters env lval st =
               taints
               |> Taints.map (fun taint ->
                      match taint.orig with
-                     | Arg arg ->
+                     | Arg ({ offset; _ } as arg) when not (List.mem n offset)
+                       ->
+                         (* If the offset we are trying to take is already in the
+                            list of offsets, don't append it! This is so we don't
+                            never-endingly loop the dataflow and make it think the
+                            Arg taint is never-endingly changing.
+                         *)
                          let arg' = { arg with offset = arg.offset @ [ n ] } in
                          { taint with orig = Arg arg' }
-                     | Src _ -> taint)
+                     | _ -> taint)
             in
             `Tainted taints')
     | _ :: _

--- a/src/tainting/Dataflow_tainting.ml
+++ b/src/tainting/Dataflow_tainting.ml
@@ -744,10 +744,16 @@ let resolve_poly_taint_for_java_getters env lval st =
                             list of offsets, don't append it! This is so we don't
                             never-endingly loop the dataflow and make it think the
                             Arg taint is never-endingly changing.
+
+                            For instance, this code example would previously loop,
+                            if `x` started with an `Arg` taint:
+                            while (true) { x = x.getX(); }
                          *)
                          let arg' = { arg with offset = arg.offset @ [ n ] } in
                          { taint with orig = Arg arg' }
-                     | _ -> taint)
+                     | Arg _
+                     | Src _ ->
+                         taint)
             in
             `Tainted taints')
     | _ :: _


### PR DESCRIPTION
## What:
This PR makes it so that dataflow does not occasionally loop when analyzing `getX` methods in a loop.

## Why:
We want analysis to terminate.

## How:
We were appending infinitely to the `Arg` taint's `offset`, making the dataflow analysis think the in-and-out-sets were constantly changing.

This PR enforces that we eventually always reach a cap, by ensuring we never append the same offset more than once, to the same arg.

## Test plan:
No longer loops on `examples-annotations/repos/java/SQLi/fp-scanner-repos/aws-doc-sdk-examples/java/example_code/kms/src/main/java/aws/example/kms/ListKeyPolicies.java` using `deepsemgrep-sqli-rules.yaml`.

See https://github.com/returntocorp/semgrep-proprietary/pull/692 for tests.

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
