### PR TITLE
osemgrep scan: support "--config policy"

### DIFF
--- a/src/osemgrep/cli_login/Login_subcommand.ml
+++ b/src/osemgrep/cli_login/Login_subcommand.ml
@@ -27,7 +27,7 @@ let make_login_url () =
 let get_deployment_from_token token =
   match
     Network.get
-      ~headers:[ ("Authorization", "Bearer " ^ token) ]
+      ~headers:[ ("authorization", "Bearer " ^ token) ]
       (Uri.with_path Semgrep_envvars.env.semgrep_url
          "api/agent/deployments/current")
   with

--- a/src/osemgrep/cli_login/Logout_subcommand.ml
+++ b/src/osemgrep/cli_login/Logout_subcommand.ml
@@ -17,8 +17,7 @@ let run (conf : Login_CLI.conf) : Exit_code.t =
   Logs_helpers.setup_logging ~force_color:false ~level:conf.logging_level;
   let settings = Semgrep_settings.get () in
   let settings = Semgrep_settings.{ settings with api_token = None } in
-  Semgrep_settings.save settings;
-  Exit_code.ok
+  if Semgrep_settings.save settings then Exit_code.ok else Exit_code.fatal
 
 (*****************************************************************************)
 (* Entry point *)

--- a/src/osemgrep/cli_scan/Rule_fetching.mli
+++ b/src/osemgrep/cli_scan/Rule_fetching.mli
@@ -37,4 +37,4 @@ val rules_from_dashdash_config :
 
 (* low-level API *)
 val load_rules_from_file : Fpath.t -> rules_and_origin
-val load_rules_from_url : Uri.t -> rules_and_origin
+val load_rules_from_url : ?ext:string -> Uri.t -> rules_and_origin

--- a/src/osemgrep/configuring/Semgrep_settings.ml
+++ b/src/osemgrep/configuring/Semgrep_settings.ml
@@ -102,11 +102,13 @@ let save setting =
   try
     Sys.mkdir Fpath.(to_string (parent settings)) 0o755;
     File.write_file settings str;
-    t := setting
+    t := setting;
+    true
   with
   | Sys_error _ ->
       Logs.warn (fun m ->
-          m "Could not write settings file at %a" Fpath.pp settings)
+          m "Could not write settings file at %a" Fpath.pp settings);
+      false
 
 let get () =
   Lazy.force (get_contents ());

--- a/src/osemgrep/configuring/Semgrep_settings.mli
+++ b/src/osemgrep/configuring/Semgrep_settings.mli
@@ -5,5 +5,5 @@ type t = {
   anonymous_user_id : Uuidm.t;
 }
 
-val save : t -> unit
+val save : t -> bool
 val get : unit -> t

--- a/src/osemgrep/core/Constants.ml
+++ b/src/osemgrep/core/Constants.ml
@@ -14,7 +14,6 @@ let _please_file_issue_text =
 let default_semgrep_config_name = "semgrep"
 let _default_config_file = spf ".%s.yml" default_semgrep_config_name
 let _default_config_folder = spf ".%s" default_semgrep_config_name
-let _default_semgrep_app_config_url = "api/agent/deployments/scans/config"
 
 let _returntocorp_lever_url =
   "https://api.lever.co/v0/postings/returntocorp?mode=json"

--- a/src/osemgrep/networking/Network.ml
+++ b/src/osemgrep/networking/Network.ml
@@ -1,9 +1,9 @@
 open Http_lwt_client
 
 (* TODO: extend to allow to curl with JSON as answer *)
-let get url =
+let get ?headers url =
   let bodyf _ acc data = Lwt.return (acc ^ data) in
-  let promise = request (Uri.to_string url) bodyf "" in
+  let promise = request ?headers (Uri.to_string url) bodyf "" in
   let r = Lwt_main.run promise in
   match r with
   | Ok (response, content) when Status.is_successful response.status ->
@@ -13,7 +13,6 @@ let get url =
         ("HTTP request failed, server response "
         ^ Status.to_string response.status)
   | Error (`Msg msg) -> Error ("HTTP request failed: " ^ msg)
-  [@@profiling]
 
 let post ~body ?(headers = [ ("Content-type", "application/json") ]) url =
   let bodyf _ acc data = Lwt.return (acc ^ data) in

--- a/src/osemgrep/networking/Network.mli
+++ b/src/osemgrep/networking/Network.mli
@@ -1,4 +1,4 @@
-val get : Uri.t -> (string, string) result
+val get : ?headers:(string * string) list -> Uri.t -> (string, string) result
 
 val post :
   body:string ->


### PR DESCRIPTION
test plan:
```
   make core
   osemgrep login
   osemgrep --config policy . (needs `SEMGREP_REPO_NAME` being set)
```

Previously, `--config=policy` failed (no authentication, ...).

Further notes:
- Semgrep_settings: save returns a bool now whether the write was successful
- Login_subcommand: feature parity with python code, check received token (whether {semgrep_url}/api/agent/deployments/current returns something sensible)
- Rule_fetching: support "--config policy", which requests the rules from the logged in session, downloads json with "rule_config"
- Network: allow passing headers for get as well

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
