### PR TITLE
fix: ensure that semgrep pro won't be failing when PR is from a fork

### DIFF
--- a/.github/workflows/test-semgrep-pro-latest.yaml
+++ b/.github/workflows/test-semgrep-pro-latest.yaml
@@ -13,7 +13,7 @@ on:
 jobs:
   test-semgrep-pro-latest:
     name: Test Semgrep Pro Engine (latest release)
-    if: github.repository_owner == 'returntocorp' # only returntocorp has the necessary credentials to access semgrep pro
+    if: github.event.pull_request.head.repo.full_name != github.repository # only returntocorp has the necessary credentials to access semgrep pro
     runs-on: ubuntu-22.04
     permissions:
       id-token: write

--- a/.github/workflows/test-semgrep-pro-latest.yaml
+++ b/.github/workflows/test-semgrep-pro-latest.yaml
@@ -13,7 +13,7 @@ on:
 jobs:
   test-semgrep-pro-latest:
     name: Test Semgrep Pro Engine (latest release)
-    if: github.event.pull_request.head.repo.full_name != github.repository # only returntocorp has the necessary credentials to access semgrep pro
+    if: github.event.pull_request.head.repo.full_name == github.repository # only returntocorp has the necessary credentials to access semgrep pro
     runs-on: ubuntu-22.04
     permissions:
       id-token: write

--- a/.github/workflows/test-semgrep-pro.yaml
+++ b/.github/workflows/test-semgrep-pro.yaml
@@ -42,7 +42,7 @@ jobs:
           fi
   test-semgrep-pro:
     name: Test Semgrep Pro Engine
-    if: github.repository_owner == 'returntocorp' # only returntocorp has the necessary credentials to access semgrep pro
+    if: github.event.pull_request.head.repo.full_name != github.repository # only returntocorp has the necessary credentials to access semgrep pro
     runs-on: ubuntu-22.04
     permissions:
       id-token: write

--- a/.github/workflows/test-semgrep-pro.yaml
+++ b/.github/workflows/test-semgrep-pro.yaml
@@ -42,7 +42,7 @@ jobs:
           fi
   test-semgrep-pro:
     name: Test Semgrep Pro Engine
-    if: github.event.pull_request.head.repo.full_name != github.repository # only returntocorp has the necessary credentials to access semgrep pro
+    if: github.event.pull_request.head.repo.full_name == github.repository # only returntocorp has the necessary credentials to access semgrep pro
     runs-on: ubuntu-22.04
     permissions:
       id-token: write


### PR DESCRIPTION
PRs from forked repositories were showing CI failures because they were attempting to run workflows that used AWS steps. This PR changes how we are excluding these workflows so that it is more reliable. 

@brandonspark I believe you were heading up the work here - since we're no longer running these checks on all of our PRs, do we want to also run these checks on merges to develop? I think it would be tough to debug if a PR fails on this step for unrelated reasons due to a past PR not being checked. I can open a subsequent PR to fix that if we want to go that direction.

Test plan: 

Opened this PR from a fork.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
