### PR TITLE
added: more informative error message for unsupported language

### DIFF
--- a/cli/src/semgrep/semgrep_types.py
+++ b/cli/src/semgrep/semgrep_types.py
@@ -85,7 +85,7 @@ class _LanguageData:
             spans = [span.with_context(before=1, after=1)] if span else []
             raise UnknownLanguageError(
                 short_msg=f"invalid language: {normalized}",
-                long_msg=f"unsupported language: {normalized}. {self.show_suppported_languages_message()}",
+                long_msg=f"unsupported language: {normalized}. {self.show_suppported_languages_message()}\n\nYou may need to update your version of Semgrep, if you are on an old version that does not yet support this language.",
                 spans=spans,
             )
 

--- a/cli/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badlanguage/error-in-color.txt
+++ b/cli/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badlanguage/error-in-color.txt
@@ -5,5 +5,7 @@
 [94m[22m[24m  | [0m               [31m[22m[24m^^^^^^^^^^[0m
 [94m[22m[24m8 | [0m    severity: WARNING
 
-[31m[22m[24munsupported language: intercal. supported languages are: apex, bash, c, c#, c++, clojure, cpp, csharp, dart, docker, dockerfile, elixir, ex, generic, go, golang, hack, hcl, html, java, javascript, js, json, jsonnet, julia, kotlin, kt, lisp, lua, none, ocaml, php, py, python, python2, python3, r, regex, ruby, rust, scala, scheme, sh, sol, solidity, swift, terraform, tf, ts, typescript, vue, xml, yaml[0m
+[31m[22m[24munsupported language: intercal. supported languages are: apex, bash, c, c#, c++, clojure, cpp, csharp, dart, docker, dockerfile, elixir, ex, generic, go, golang, hack, hcl, html, java, javascript, js, json, jsonnet, julia, kotlin, kt, lisp, lua, none, ocaml, php, py, python, python2, python3, r, regex, ruby, rust, scala, scheme, sh, sol, solidity, swift, terraform, tf, ts, typescript, vue, xml, yaml
+
+You may need to update your version of Semgrep, if you are on an old version that does not yet support this language.[0m
 

--- a/cli/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badlanguage/error.json
+++ b/cli/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badlanguage/error.json
@@ -3,7 +3,7 @@
     {
       "code": 8,
       "level": "error",
-      "long_msg": "unsupported language: intercal. supported languages are: apex, bash, c, c#, c++, clojure, cpp, csharp, dart, docker, dockerfile, elixir, ex, generic, go, golang, hack, hcl, html, java, javascript, js, json, jsonnet, julia, kotlin, kt, lisp, lua, none, ocaml, php, py, python, python2, python3, r, regex, ruby, rust, scala, scheme, sh, sol, solidity, swift, terraform, tf, ts, typescript, vue, xml, yaml",
+      "long_msg": "unsupported language: intercal. supported languages are: apex, bash, c, c#, c++, clojure, cpp, csharp, dart, docker, dockerfile, elixir, ex, generic, go, golang, hack, hcl, html, java, javascript, js, json, jsonnet, julia, kotlin, kt, lisp, lua, none, ocaml, php, py, python, python2, python3, r, regex, ruby, rust, scala, scheme, sh, sol, solidity, swift, terraform, tf, ts, typescript, vue, xml, yaml\n\nYou may need to update your version of Semgrep, if you are on an old version that does not yet support this language.",
       "short_msg": "invalid language: intercal",
       "spans": [
         {


### PR DESCRIPTION
## What:
This PR makes it so when running Semgrep CLI on a rule with an unsupported language, we emit an error that suggests updating Semgrep version.

## Why:
People running an older version of Semgrep will occasionally be unable to do scans due to rulepacks updating with languages only added in later versions. They should update their version to run the rulepacks.

## How:
Added an error message.

## Alternatives considered:
I considered making it so we try to run the rules as best as we can, but I'd need to add a message about all the rules we skipped, and the logic for consolidating all of that seemed annoying, as language parsing happens a good deal away from there. Additionally, @bmahe said it was fine to have a more informative error message.

## Test plan:
<img width="1728" alt="image" src="https://user-images.githubusercontent.com/49291449/234941036-82ce7987-0101-491f-bc7d-0a112b415cc6.png">

Closes PA-2731
Closes PA-2728

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
