### PR TITLE
Fix progress bar stuck on 0%

### DIFF
--- a/changelog.d/zero-progress.fixed
+++ b/changelog.d/zero-progress.fixed
@@ -1,0 +1,1 @@
+The scan progress bar no longer gets stuck displaying 0%

--- a/cli/src/semgrep/core_runner.py
+++ b/cli/src/semgrep/core_runner.py
@@ -443,7 +443,7 @@ class StreamingSemgrepCore:
                 "", total=self._total, start=False
             )
 
-        rc = asyncio.run(self._stream_exec_subprocess())
+            rc = asyncio.run(self._stream_exec_subprocess())
 
         open_and_ignore("/tmp/core-runner-semgrep-END")
         return rc


### PR DESCRIPTION
The code that runs core was accidentally deindented outside the context where the progress bar is active, here: https://github.com/returntocorp/semgrep/commit/a64535d68d095f59a71217a3d36bea3a79d1909f

PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
