### PR TITLE
feat: add Alex as codeowner on workflows

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 
 # Matches all files in the .github/ dir, recursively.
-.github/ @spencerdrak @cgdolan @aryx @bmahe
+.github/ @spencerdrak @cgdolan @aryx @bmahe @apt-itude
 src/analyzing @IagoAbal
 src/tainting @IagoAbal


### PR DESCRIPTION
Alex has joined us on infra, and should also be a codeowner on the workflows here.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
