### PR TITLE
fix: ensure pro tests run on develop and on non-fork PRs

### DIFF
--- a/.github/workflows/test-semgrep-pro-latest.yaml
+++ b/.github/workflows/test-semgrep-pro-latest.yaml
@@ -10,10 +10,13 @@ name: test-semgrep-pro-latest
 on:
   workflow_dispatch:
   pull_request:
+  push:
+    branches:
+      - "develop"
 jobs:
   test-semgrep-pro-latest:
     name: Test Semgrep Pro Engine (latest release)
-    if: github.event.pull_request.head.repo.full_name == github.repository # only returntocorp has the necessary credentials to access semgrep pro
+    if: github.ref == 'refs/heads/develop' || github.event.pull_request.head.repo.full_name == github.repository # only returntocorp has the necessary credentials to access semgrep pro
     runs-on: ubuntu-22.04
     permissions:
       id-token: write

--- a/.github/workflows/test-semgrep-pro.yaml
+++ b/.github/workflows/test-semgrep-pro.yaml
@@ -29,7 +29,7 @@ jobs:
     outputs:
       docker-tag: ${{ steps.setup-docker-tag.outputs.docker-tag }}
     steps:
-      - name:
+      - name: Setup Docker Tag
         id: setup-docker-tag
         run: |
           echo "Github event is ${{ github.event_name }}"
@@ -42,7 +42,6 @@ jobs:
           fi
   test-semgrep-pro:
     name: Test Semgrep Pro Engine
-    if: github.event.pull_request.head.repo.full_name == github.repository # only returntocorp has the necessary credentials to access semgrep pro
     runs-on: ubuntu-22.04
     permissions:
       id-token: write

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -321,6 +321,7 @@ jobs:
   test-semgrep-pro:
     needs: [build-test-docker, push-docker]
     uses: ./.github/workflows/test-semgrep-pro.yaml
+    if: github.ref == 'refs/heads/develop' || github.event.pull_request.head.repo.full_name == github.repository # only returntocorp has the necessary credentials to access semgrep pro
     secrets: inherit
     with:
       artifact-name: image-test


### PR DESCRIPTION
With PR #7658, we've started opting some PRs out of checks for semgrep pro. To counteract this, we want to run these checks on develop as well as on a PR, so as to enforce correctness on develop. There was also some logic that needed adjustment, which this PR addresses.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
