### PR TITLE
osemgrep: Filter rules (esp. generic & regex)

### DIFF
--- a/src/osemgrep/reporting/Matches_report.ml
+++ b/src/osemgrep/reporting/Matches_report.ml
@@ -110,7 +110,7 @@ let wrap ~indent ~width s =
   go indent width pre s []
 
 let cut s idx1 idx2 =
-  Logs.info (fun m -> m "cut %d (idx1 %d idx2 %d)" (String.length s) idx1 idx2);
+  Logs.debug (fun m -> m "cut %d (idx1 %d idx2 %d)" (String.length s) idx1 idx2);
   ( Str.first_chars s idx1,
     String.sub s idx1 (idx2 - idx1),
     Str.string_after s idx2 )

--- a/src/osemgrep/reporting/Status_report.ml
+++ b/src/osemgrep/reporting/Status_report.ml
@@ -27,13 +27,24 @@ let pp_status ~num_rules ~num_targets ~respect_git_ignore lang_jobs ppf =
   *)
   Fmt.pf ppf ":@.@.";
   (* TODO origin table [Origin Rules] [Community N] *)
+  let lan_label = function
+    | Xlang.LGeneric
+    | Xlang.LRegex ->
+        "<multilang>"
+    | lang -> Xlang.to_string lang
+  in
   Fmt_helpers.pp_table
     ("Language", [ "Rules"; "Files" ])
     ppf
     (lang_jobs
+    |> List.map (fun Lang_job.{ lang; targets; rules } ->
+           (lan_label lang, List.length rules, List.length targets))
     |> List.fold_left
-         (fun acc Lang_job.{ lang; targets; rules } ->
-           (Xlang.to_string lang, [ List.length rules; List.length targets ])
-           :: acc)
+         (fun acc (lang, rules, targets) ->
+           match List.partition (fun (l, _) -> l = lang) acc with
+           | [], others -> (lang, [ rules; targets ]) :: others
+           | [ (_, [ r1; t1 ]) ], others ->
+               (lang, [ rules + r1; targets + t1 ]) :: others
+           | _ -> assert false)
          []
     |> List.rev)

--- a/src/osemgrep/reporting/Status_report.ml
+++ b/src/osemgrep/reporting/Status_report.ml
@@ -37,7 +37,7 @@ let pp_status ~num_rules ~num_targets ~respect_git_ignore lang_jobs ppf =
     ("Language", [ "Rules"; "Files" ])
     ppf
     (lang_jobs
-    |> List.map (fun Lang_job.{ lang; targets; rules } ->
+    |> Common.map (fun Lang_job.{ lang; targets; rules } ->
            (lan_label lang, List.length rules, List.length targets))
     |> List.fold_left
          (fun acc (lang, rules, targets) ->


### PR DESCRIPTION
test plan: make core && osemgrep --config r/python src/osemgrep

before: 
```
  Language      Rules   Files
 ─────────────────────────────
  Generic           8     151
  Python          385      55
  Regex             4     151
```

now:
```
  Language         Rules   Files
 ────────────────────────────────
  <multilang>          4     161
  Python             385      55
```

pysemgrep:
```
  Language      Rules   Files
 ─────────────────────────────
  <multilang>       5     150
  python          385      55                                                                
```

Not clear to me why the difference is there (4 vs 5)

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
