### PR TITLE
osemgrep: Fix login logout

### DIFF
--- a/src/osemgrep/configuring/Semgrep_settings.ml
+++ b/src/osemgrep/configuring/Semgrep_settings.ml
@@ -101,8 +101,7 @@ let save setting =
   let str = Yaml.to_string_exn yaml in
   try
     let dir = Fpath.(to_string (parent settings)) in
-    if not (Sys.file_exists dir) then
-      Sys.mkdir dir 0o755;
+    if not (Sys.file_exists dir) then Sys.mkdir dir 0o755;
     let tmp = Fpath.(settings + "tmp") in
     if Sys.file_exists (Fpath.to_string tmp) then
       Sys.remove (Fpath.to_string tmp);

--- a/src/osemgrep/networking/Network.ml
+++ b/src/osemgrep/networking/Network.ml
@@ -14,7 +14,7 @@ let get ?headers url =
         ^ Status.to_string response.status)
   | Error (`Msg msg) -> Error ("HTTP request failed: " ^ msg)
 
-let post ~body ?(headers = [ ("Content-type", "application/json") ]) url =
+let post ~body ?(headers = [ ("content-type", "application/json") ]) url =
   let bodyf _ acc data = Lwt.return (acc ^ data) in
   let promise =
     request ~meth:`POST ~headers ~body (Uri.to_string url) bodyf ""


### PR DESCRIPTION
test plan:
  make core
  osemgrep logout
  osemgrep login

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
