### PR TITLE
fix flakey js tests

### DIFF
--- a/js/languages/shared/Makefile.include
+++ b/js/languages/shared/Makefile.include
@@ -59,8 +59,8 @@ WASM_DEP := dist/semgrep-parser.js
 WASM_NAME := semgrep-parser
 endif
 
-package.json: ../shared/package.json.liquid
-	npx liquidjs -t @$^ -o $@ --context '{"lang": "$(SEMGREP_LANG)", "wasm": "$(WASM_NAME)", "version": "$(VERSION)"}'
+package.json: ../shared/generate-package-json.sh
+	$< $(SEMGREP_LANG) $(VERSION) > $@
 
 package-lock.json: package.json
 	npm install

--- a/js/languages/shared/generate-package-json.sh
+++ b/js/languages/shared/generate-package-json.sh
@@ -1,12 +1,19 @@
+#!/usr/bin/env bash
+set -eu
+
+LANG=$1
+VERSION=$2
+
+cat <<EOF
 {
-  "name": "@semgrep/lang-{{ lang }}",
-  "version": "{{ version }}",
-  "description": "Semgrep {{ lang }} parser",
+  "name": "@semgrep/lang-${LANG}",
+  "version": "${VERSION}",
+  "description": "Semgrep ${LANG} parser",
   "files": [
     "dist/index.cjs",
     "dist/index.mjs",
-    "dist/index.d.ts"{% if wasm %},
-    "dist/semgrep-parser.wasm"{% endif %}
+    "dist/index.d.ts",
+    "dist/semgrep-parser.wasm"
   ],
   "types": "dist/index.d.ts",
   "exports": {
@@ -29,3 +36,4 @@
     "cross-dirname": "^0.1.0"
   }
 }
+EOF


### PR DESCRIPTION
(Similar issue to the one I fixed in https://github.com/returntocorp/semgrep/pull/7627)

tl;dr There was another spot where `liquidjs` was being installed many times in parallel.  Liquid is a bit overkill for `package.json` generation, so let's switch to a bash script that won't fight with itself.

test plan:
- confirm there's no flurry of `liquidjs` installs in a clean build
- ensure github checks pass