### PR TITLE
fix(error messages): Improve message when Apex is used without --pro

### DIFF
--- a/src/parsing/Parsing_plugin.ml
+++ b/src/parsing/Parsing_plugin.ml
@@ -32,7 +32,9 @@ let make lang =
     match !parsers with
     | None ->
         let msg =
-          spf "Missing Semgrep extension needed for parsing %s target."
+          spf
+            "Missing Semgrep extension needed for parsing %s target. Try \
+             adding `--pro` to your command."
             (Lang.to_string lang)
         in
         raise (Missing_plugin msg)
@@ -42,7 +44,9 @@ let make lang =
     match !parsers with
     | None ->
         let msg =
-          spf "Missing Semgrep extension needed for parsing %s pattern."
+          spf
+            "Missing Semgrep extension needed for parsing %s pattern. Try \
+             adding `--pro` to your command."
             (Lang.to_string lang)
         in
         raise (Missing_plugin msg)


### PR DESCRIPTION
Test plan:
```
➜  apex git:(emma/improve-kotlin-translation) ✗ pwd
/Users/emma/workspace/semgrep-proprietary/tests/rules/apex
➜  apex git:(emma/improve-kotlin-translation) ✗ semgrep --config cp_class_attribute.yaml cp_class_attribute.cls
               
               
┌─────────────┐
│ Scan Status │
└─────────────┘
  Scanning 1 file tracked by git with 1 Code rule:
  Scanning 1 file.
  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━   0% 0:00:00                                                                                                     
[ERROR] Pattern parse error in rule test:
 Invalid pattern for Apex:
--- pattern ---
req.setHeader('Authorization', ...)

--- end pattern ---
Pattern error: Parsing_plugin.Missing_plugin("Missing Semgrep extension needed for parsing Apex target. Try adding `--pro` to your command.")
```

Still not a great error message but at least it includes the suggestion.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
