### PR TITLE
refactor: Remove ParenExpr

### DIFF
--- a/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixocaml_paren_expr.yaml-autofixocaml_paren_expr.ml-dryrun/results.json
+++ b/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixocaml_paren_expr.yaml-autofixocaml_paren_expr.ml-dryrun/results.json
@@ -59,9 +59,9 @@
       "extra": {
         "engine_kind": "OSS",
         "fingerprint": "0x42",
-        "fix": "a_function_call (wrap ((the_argument)))",
+        "fix": "a_function_call (wrap (the_argument))",
         "fixed_lines": [
-          "let two = a_function_call (wrap ((the_argument)))"
+          "let two = a_function_call (wrap (the_argument))"
         ],
         "is_ignored": false,
         "lines": "let two = a_function_call (the_argument)",
@@ -69,16 +69,16 @@
         "metadata": {},
         "metavars": {
           "$X": {
-            "abstract_content": "(the_argument)",
+            "abstract_content": "the_argument",
             "end": {
-              "col": 41,
+              "col": 40,
               "line": 3,
-              "offset": 80
+              "offset": 79
             },
             "start": {
-              "col": 27,
+              "col": 28,
               "line": 3,
-              "offset": 66
+              "offset": 67
             }
           }
         },
@@ -111,7 +111,7 @@
         "metadata": {},
         "metavars": {
           "$X": {
-            "abstract_content": "(another_func the_argument)",
+            "abstract_content": "another_func the_argument",
             "end": {
               "col": 56,
               "line": 5,

--- a/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixocaml_paren_expr.yaml-autofixocaml_paren_expr.ml-not-dryrun/autofix/ocaml_paren_expr.ml-fixed
+++ b/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixocaml_paren_expr.yaml-autofixocaml_paren_expr.ml-not-dryrun/autofix/ocaml_paren_expr.ml-fixed
@@ -1,6 +1,6 @@
 let one = a_function_call (wrap (the_argument))
 
-let two = a_function_call (wrap ((the_argument)))
+let two = a_function_call (wrap (the_argument))
 
 let three = a_function_call (wrap ((another_func the_argument)))
 

--- a/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixocaml_paren_expr.yaml-autofixocaml_paren_expr.ml-not-dryrun/results.json
+++ b/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixocaml_paren_expr.yaml-autofixocaml_paren_expr.ml-not-dryrun/results.json
@@ -56,23 +56,23 @@
       "extra": {
         "engine_kind": "OSS",
         "fingerprint": "0x42",
-        "fix": "a_function_call (wrap ((the_argument)))",
+        "fix": "a_function_call (wrap (the_argument))",
         "is_ignored": false,
         "lines": "let two = a_function_call (the_argument)",
         "message": "Wrap the arguments to `a_function_call` with `wrap` first",
         "metadata": {},
         "metavars": {
           "$X": {
-            "abstract_content": "(the_argument)",
+            "abstract_content": "the_argument",
             "end": {
-              "col": 41,
+              "col": 40,
               "line": 3,
-              "offset": 80
+              "offset": 79
             },
             "start": {
-              "col": 27,
+              "col": 28,
               "line": 3,
-              "offset": 66
+              "offset": 67
             }
           }
         },
@@ -102,7 +102,7 @@
         "metadata": {},
         "metavars": {
           "$X": {
-            "abstract_content": "(another_func the_argument)",
+            "abstract_content": "another_func the_argument",
             "end": {
               "col": 56,
               "line": 5,

--- a/languages/elixir/generic/Parse_elixir_tree_sitter.ml
+++ b/languages/elixir/generic/Parse_elixir_tree_sitter.ml
@@ -859,7 +859,8 @@ and map_capture_expression (env : env) (x : CST.capture_expression) : expr =
       let v1 = (* "(" *) token env v1 in
       let v2 = map_expression env v2 in
       let v3 = (* ")" *) token env v3 in
-      ParenExpr (v1, v2, v3) |> G.e
+      AST_generic_helpers.set_e_range v1 v3 v2;
+      v2
   | `Exp x -> map_expression env x
 
 and map_catch_block (env : env) ((v1, v2, v3) : CST.catch_block) =

--- a/languages/go/generic/go_to_generic.ml
+++ b/languages/go/generic/go_to_generic.ml
@@ -249,10 +249,10 @@ let top_func () =
     | Cast (t, (l, e, r)) ->
         let t = type_ t and e = expr e in
         (* for semgrep and autofix to get the right range by including
-         * 'r' in the AST.
+         * 'r' in the range.
          * alt: change G.Cast to take a bracket
          *)
-        let e = G.ParenExpr (l, e, r) |> G.e in
+        AST_generic_helpers.set_e_range l r e;
         G.Cast (t, l, e)
     | Deref (v1, v2) ->
         let v1 = tok v1 and v2 = expr v2 in

--- a/languages/ocaml/generic/ml_to_generic.ml
+++ b/languages/ocaml/generic/ml_to_generic.ml
@@ -230,87 +230,86 @@ and option_expr_to_ctor_arguments v =
       fb [ e ]
 
 and expr e =
-  (match e with
+  match e with
   | ParenExpr (l, e, r) -> (
       let e = expr e in
       match e.G.e with
       (* replace fake brackets with real one *)
-      | G.Container (G.Tuple, (_, xs, _)) -> G.Container (G.Tuple, (l, xs, r))
-      (* actually, always keep the ParenExpr for now, so that autofix does not
-       * have dangling parenthesis
-       * TODO: this may prevent some matching in generic_vs_generic.
-       * Maybe we should have a pre-phase that set the e_range correctly and
-       * remove the extra ParenExpr.
-       *)
-      | _kind -> G.ParenExpr (l, e, r))
+      | G.Container (G.Tuple, (_, xs, _)) ->
+          G.Container (G.Tuple, (l, xs, r)) |> G.e
+      | _kind ->
+          AST_generic_helpers.set_e_range l r e;
+          e)
   | TypedExpr (v1, v2, v3) -> (
       let v1 = expr v1 in
       let v2 = tok v2 in
       let v3 = type_ v3 in
       match v1.G.e with
       | G.N (G.Id (id, _idinfo)) when AST_generic.is_metavar_name (fst id) ->
-          G.TypedMetavar (id, v2, v3)
-      | _ -> G.Cast (v3, v2, v1))
+          G.TypedMetavar (id, v2, v3) |> G.e
+      | _ -> G.Cast (v3, v2, v1) |> G.e)
   | Ellipsis v1 ->
       let v1 = tok v1 in
-      G.Ellipsis v1
+      G.Ellipsis v1 |> G.e
   | DeepEllipsis (v1, v2, v3) ->
       let v1 = tok v1 in
       let v2 = expr v2 in
       let v3 = tok v3 in
-      G.DeepEllipsis (v1, v2, v3)
+      G.DeepEllipsis (v1, v2, v3) |> G.e
   | L v1 ->
       let v1 = literal v1 in
-      G.L v1
-  | Name v1 -> G.N (name v1)
+      G.L v1 |> G.e
+  | Name v1 -> G.N (name v1) |> G.e
   | Constructor (v1, v2) ->
       let v1 = name v1 in
       let v2 = option_expr_to_ctor_arguments v2 in
-      G.Constructor (v1, v2)
+      G.Constructor (v1, v2) |> G.e
   | PolyVariant ((v0, v1), v2) ->
       let v0 = tok v0 in
       let v1 = ident v1 in
       let v2 = option_expr_to_ctor_arguments v2 in
       let name = H.name_of_ids [ ("`", v0); v1 ] in
       (* TODO: introduce a new construct in AST_generic instead? *)
-      G.Constructor (name, v2)
+      G.Constructor (name, v2) |> G.e
   | Tuple v1 ->
       let v1 = (list expr) v1 in
       (* the fake brackets might be replaced in the caller if there
        * was a ParenExpr around
        *)
-      G.Container (G.Tuple, fb v1)
+      G.Container (G.Tuple, fb v1) |> G.e
   | List v1 ->
       let v1 = bracket (list expr) v1 in
-      G.Container (G.List, v1)
+      G.Container (G.List, v1) |> G.e
   | Prefix (v1, v2) ->
       let v1 = wrap string v1 and v2 = expr v2 in
       G.Call (G.N (G.Id (v1, G.empty_id_info ())) |> G.e, fb [ G.Arg v2 ])
+      |> G.e
   (* todo? convert some v2 in IdSpecial Op? *)
   | Infix (v1, v2, v3) ->
       let v1 = expr v1 and v3 = expr v3 in
       G.Call
         (G.N (G.Id (v2, G.empty_id_info ())) |> G.e, fb [ G.Arg v1; G.Arg v3 ])
+      |> G.e
   | Call (v1, v2) ->
       let v1 = expr v1 and v2 = list argument v2 in
-      G.Call (v1, fb v2)
+      G.Call (v1, fb v2) |> G.e
   | RefAccess (v1, v2) ->
       let v1 = tok v1 and v2 = expr v2 in
-      G.DeRef (v1, v2)
+      G.DeRef (v1, v2) |> G.e
   | RefAssign (v1, v2, v3) ->
       let v1 = expr v1 and v2 = tok v2 and v3 = expr v3 in
-      G.Assign (G.DeRef (v2, v1) |> G.e, v2, v3)
+      G.Assign (G.DeRef (v2, v1) |> G.e, v2, v3) |> G.e
   | FieldAccess (v1, vtok, v2) ->
       let v1 = expr v1 in
       let vtok = tok vtok in
       let v2 = name v2 in
-      G.DotAccess (v1, vtok, G.FN v2)
+      G.DotAccess (v1, vtok, G.FN v2) |> G.e
   | FieldAssign (v1, t1, v2, t2, v3) ->
       let v1 = expr v1 and v3 = expr v3 in
       let t1 = tok t1 in
       let t2 = tok t2 in
       let v2 = name v2 in
-      G.Assign (G.DotAccess (v1, t1, G.FN v2) |> G.e, t2, v3)
+      G.Assign (G.DotAccess (v1, t1, G.FN v2) |> G.e, t2, v3) |> G.e
   | Record (v1, v2) -> (
       let v1 = option expr v1
       and v2 =
@@ -328,18 +327,17 @@ and expr e =
                    G.fld (ent, def)))
           v2
       in
-      let obj = G.Record v2 in
+      let obj = G.Record v2 |> G.e in
       match v1 with
       | None -> obj
-      | Some e -> G.OtherExpr (("With", G.fake ""), [ G.E e; G.E (obj |> G.e) ])
-      )
+      | Some e -> G.OtherExpr (("With", G.fake ""), [ G.E e; G.E obj ]) |> G.e)
   | New (v1, v2) ->
       let v1 = tok v1 and v2 = name v2 in
-      G.New (v1, G.TyN v2 |> G.t, G.empty_id_info (), fb [])
+      G.New (v1, G.TyN v2 |> G.t, G.empty_id_info (), fb []) |> G.e
   | ObjAccess (v1, t, v2) ->
       let v1 = expr v1 and v2 = ident v2 in
       let t = tok t in
-      G.DotAccess (v1, t, G.FN (G.Id (v2, G.empty_id_info ())))
+      G.DotAccess (v1, t, G.FN (G.Id (v2, G.empty_id_info ()))) |> G.e
   | LetIn (tlet, v1, v2, v3) ->
       let _v1 = rec_opt v1 in
       let v2 = list let_binding v2 in
@@ -347,7 +345,7 @@ and expr e =
       let defs = defs_of_bindings tlet [] v2 in
       let st = G.Block (fb (defs @ [ G.exprstmt v3 ])) |> G.s in
       let x = G.stmt_to_expr st in
-      x.G.e
+      x.G.e |> G.e
   | Fun (t, v1, v2) ->
       let v1 = list parameter v1 and v2 = expr v2 in
       let def =
@@ -358,7 +356,7 @@ and expr e =
           fbody = G.FBExpr v2;
         }
       in
-      G.Lambda def
+      G.Lambda def |> G.e
   | Function (t, xs) ->
       let xs = list (fun a -> a |> match_case |> G.case_of_pat_and_expr) xs in
       let id = G.implicit_param_id t in
@@ -375,10 +373,11 @@ and expr e =
           fkind = (G.Function, t);
           fbody = G.FBStmt body_stmt;
         }
+      |> G.e
   | ExprTodo (t, xs) ->
       let t = todo_category t in
       let xs = list expr xs in
-      G.OtherExpr (t, Common.map (fun x -> G.E x) xs)
+      G.OtherExpr (t, Common.map (fun x -> G.E x) xs) |> G.e
   | If _
   | Try _
   | For _
@@ -387,8 +386,7 @@ and expr e =
   | Match _ ->
       let s = stmt e in
       let x = G.stmt_to_expr s in
-      x.G.e)
-  |> G.e
+      x.G.e |> G.e
 
 and literal = function
   | Int v1 ->

--- a/libs/ast_generic/AST_generic.ml
+++ b/libs/ast_generic/AST_generic.ml
@@ -741,13 +741,6 @@ and expr_kind =
      Revisit when symbolic propagation is more stable
   *)
   | Alias of string wrap * expr
-  (* In some rare cases, we need to keep the parenthesis around an expression
-   * otherwise in autofix semgrep could produce incorrect code. For example,
-   * in Go a cast int(3.0) requires the parenthesis.
-   * alt: change cast to take a expr bracket, but this is used only for Go.
-   * Note that this data structure is really becoming more a CST than an AST.
-   *)
-  | ParenExpr of expr bracket
   (* sgrep: ... in expressions, args, stmts, items, and fields
    * (and unfortunately also in types in Python) *)
   | Ellipsis of tok (* '...' *)

--- a/libs/ast_generic/AST_generic_to_v1.ml
+++ b/libs/ast_generic/AST_generic_to_v1.ml
@@ -219,9 +219,6 @@ and map_qualifier = function
 
 and map_expr x : B.expr =
   match x.e with
-  | ParenExpr v1 ->
-      let v1 = map_bracket map_expr v1 in
-      `ParenExpr v1
   | N v1 ->
       let v1 = map_name v1 in
       `N v1

--- a/libs/ast_generic/Meta_AST.ml
+++ b/libs/ast_generic/Meta_AST.ml
@@ -282,9 +282,6 @@ and vof_name = function
 and vof_expr e =
   (* TODO: also dump e_id? *)
   match e.e with
-  | ParenExpr v1 ->
-      let v1 = vof_bracket vof_expr v1 in
-      OCaml.VSum ("ParenExpr", [ v1 ])
   | DotAccessEllipsis (v1, v2) ->
       let v1 = vof_expr v1 in
       let v2 = vof_tok v2 in

--- a/src/analyzing/AST_to_IL.ml
+++ b/src/analyzing/AST_to_IL.ml
@@ -740,7 +740,6 @@ and expr_aux env ?(void = false) e_gen =
       mk_e (Composite (Constructor cname, (tok1, es, tok2))) eorig
   | G.RegexpTemplate ((l, e, r), _opt) ->
       mk_e (Composite (Regexp, (l, [ expr env e ], r))) NoOrig
-  | G.ParenExpr (_, e, _) -> expr env e
   | G.Xml xml -> xml_expr env xml
   | G.Cast (typ, _, e) ->
       let e = expr env e in

--- a/src/analyzing/Dataflow_svalue.ml
+++ b/src/analyzing/Dataflow_svalue.ml
@@ -370,7 +370,6 @@ let rec is_symbolic_expr expr =
   | G.L _ -> true
   | G.N _ -> true
   | G.IdSpecial _ -> true
-  | G.ParenExpr (_, e, _)
   | G.Cast (_, _, e)
   | G.DotAccess (e, _, FN _) ->
       is_symbolic_expr e

--- a/src/matching/Generic_vs_generic.ml
+++ b/src/matching/Generic_vs_generic.ml
@@ -923,10 +923,6 @@ and m_expr ?(is_root = false) ?(arguments_have_changed = true) a b =
   | ( G.Call ({ e = G.IdSpecial (G.Op aop, toka); _ }, aargs),
       B.Call ({ e = B.IdSpecial (B.Op bop, tokb); _ }, bargs) ) ->
       m_call_op aop toka aargs bop tokb bargs
-  (* TODO? should probably do some equivalence like allowing extra
-   * paren in the pattern to still match code without parens
-   *)
-  | G.ParenExpr a1, B.ParenExpr b1 -> m_bracket m_expr a1 b1
   (* boilerplate *)
   | G.Call (a1, a2), B.Call (b1, b2) ->
       m_expr a1 b1 >>= fun () -> m_arguments a2 b2
@@ -1053,7 +1049,6 @@ and m_expr ?(is_root = false) ?(arguments_have_changed = true) a b =
   | G.N _, _
   | G.New _, _
   | G.IdSpecial _, _
-  | G.ParenExpr _, _
   | G.Xml _, _
   | G.Assign _, _
   | G.AssignOp _, _
@@ -1507,7 +1502,6 @@ and type_of_expr lang e : G.type_ option * G.ident option =
       | Some _
       | None ->
           (None, Some idb))
-  | B.ParenExpr (_, e, _) -> type_of_expr lang e
   | B.Conditional (_, e1, e2) ->
       let ( let* ) = Option.bind in
       let t1opt, id1opt = type_of_expr lang e1 in

--- a/src/matching/SubAST_generic.ml
+++ b/src/matching/SubAST_generic.ml
@@ -160,8 +160,6 @@ let subexprs_of_expr with_symbolic_propagation e =
   | RawExpr x -> Raw_tree.anys x |> subexprs_of_any_list
   | Alias (_, e1) -> [ e1 ]
   | Lambda def -> subexprs_of_stmt (H.funcbody_to_stmt def.fbody)
-  (* TODO? or call recursively on e? *)
-  | ParenExpr (_, e, _) -> [ e ]
   | Xml { xml_attrs; xml_body; _ } ->
       Common.map_filter
         (function
@@ -218,7 +216,6 @@ let subexprs_of_expr_implicit with_symbolic_propagation e =
        *)
       e :: subexprs_of_args args
   | Cast (_, _, e)
-  | ParenExpr (_, e, _)
   | Await (_, e) ->
       [ e ]
   | Yield (_, eopt, _) -> Option.to_list eopt

--- a/src/parsing/Parse_rule.ml
+++ b/src/parsing/Parse_rule.ml
@@ -1082,7 +1082,6 @@ let parse_taint_requires env key x =
         | G.Or ->
             ()
         | _ -> parse_error ())
-    | G.ParenExpr (_, e, _) -> check e
     | ___else__ -> parse_error ()
   and check_arg = function
     | G.Arg e -> check e

--- a/src/tainting/Dataflow_tainting.ml
+++ b/src/tainting/Dataflow_tainting.ml
@@ -459,7 +459,6 @@ let rec eval_label_requires ~labels e =
       | __else__ ->
           logger#error "Unexpected Boolean operator";
           false)
-  | G.ParenExpr (_, e, _) -> eval_label_requires ~labels e
   | ___else__ ->
       logger#error "Unexpected `requires' expression";
       false


### PR DESCRIPTION
I believe that this was only added to make sure the ranges were correct for expressions surrounded by parentheses, especially for autofix. However, I ran into correctness issues when I tried to use it for Python in #7437. I assume that this is because there are places that should match and recurse on `ParenExpr` that were not doing so. It would be difficult to make sure that we are handling it correctly throughout Semgrep.

Instead, I set `e_range` to include the locations of the parentheses. This worked well, and I followed up by doing the same for JS in #7686. I think it's time to take this approach for other languages, and simplify the generic AST and analyses that run on it by removing this node.

Test plan: Automated tests

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
