### PR TITLE
feat(scala): parse if expr `then` better

### DIFF
--- a/languages/scala/ast/AST_scala.ml
+++ b/languages/scala/ast/AST_scala.ml
@@ -355,6 +355,7 @@ and block_stat =
   | D of definition
   | I of import
   | Ex of import
+  | Ext of extension
   | E of expr
   (* just at the beginning of top_stat *)
   | Package of package
@@ -466,6 +467,19 @@ and definition_kind =
   | TypeDef of type_definition
   (* class/traits/objects *)
   | Template of template_definition
+
+(*****************************************************************************)
+(* Extensions *)
+(*****************************************************************************)
+and extension = {
+  ext_tok : tok; (* extension *)
+  ext_tparams : type_parameters;
+  ext_using : bindings list;
+  ext_param : binding;
+  ext_methods : ext_method list;
+}
+
+and ext_method = ExtDef of definition | ExtExport of import
 
 (* ------------------------------------------------------------------------- *)
 (* Enums *)

--- a/languages/scala/generic/scala_to_generic.ml
+++ b/languages/scala/generic/scala_to_generic.ml
@@ -755,6 +755,7 @@ and v_block_stat x : G.item list =
   | E v1 ->
       let v1 = v_expr_for_stmt v1 in
       [ v1 ]
+  | Ext v1 -> v_extension v1
   | Package v1 ->
       let ipak, ids = v_package v1 in
       [ G.DirectiveStmt (G.Package (ipak, ids) |> G.d) |> G.s ]
@@ -911,6 +912,27 @@ and v_given_definition { gsig; gkind } =
     ( { name = G.OtherEntity (todo_kind, []); attrs = []; tparams = [] },
       G.OtherDef (todo_kind, v1 @ [ G.Anys v2 ]) );
   ]
+
+and v_extension { ext_tok = _; ext_tparams; ext_using; ext_param; ext_methods }
+    : G.stmt list =
+  let tparams =
+    G.Anys (v_type_parameters ext_tparams |> Common.map (fun tp -> G.Tp tp))
+  in
+  let using =
+    G.Anys
+      (v_list v_bindings ext_using |> Common.map (fun params -> G.Params params))
+  in
+  let params = G.Pa (v_binding None ext_param) in
+  let methods = G.Anys (List.concat_map v_ext_method ext_methods) in
+  (* Extensions are definitions and methods that extend an existing class. It's not
+     super important for semantic analysis right now.
+  *)
+  [ G.OtherStmt (OS_Extension, [ tparams; using; params; methods ]) |> G.s ]
+
+and v_ext_method ext_method : G.any list =
+  match ext_method with
+  | ExtDef def -> v_definition def |> Common.map (fun def -> G.Def def)
+  | ExtExport import -> v_import import |> Common.map (fun dir -> G.Dir dir)
 
 and v_constr_app (ty, args) = (v_type_ ty, v_list v_arguments args)
 

--- a/languages/scala/recursive_descent/Token_helpers_scala.ml
+++ b/languages/scala/recursive_descent/Token_helpers_scala.ml
@@ -339,6 +339,16 @@ let isStatSep = function
 let isStatSeqEnd = function
   | RBRACE _
   | DEDENT _
+  (* This is here so we know how to end a blockStatSeq which is the "then"
+     expression in an if-then-else, like
+     if (true)
+       val x = 2
+       val y = 3
+     else
+       4
+     It should be safe to put this here, because there shouldn't be another reason
+     to see an `else`.
+  *)
   | Kelse _
   | EOF _ ->
       true

--- a/languages/scala/recursive_descent/Token_helpers_scala.ml
+++ b/languages/scala/recursive_descent/Token_helpers_scala.ml
@@ -339,6 +339,7 @@ let isStatSep = function
 let isStatSeqEnd = function
   | RBRACE _
   | DEDENT _
+  | Kelse _
   | EOF _ ->
       true
   | _ -> false

--- a/languages/scala/recursive_descent/Token_helpers_scala.ml
+++ b/languages/scala/recursive_descent/Token_helpers_scala.ml
@@ -393,7 +393,8 @@ let isTemplateIntro = function
   | Kclass _
   | Kenum _
   | Ktrait _
-  | ID_LOWER ("given", _) ->
+  | ID_LOWER ("given", _)
+  | ID_LOWER ("extension", _) ->
       true
   (*TODO | Kcaseobject | | Kcaseclass *)
   | Kcase _ -> true

--- a/languages/scala/recursive_descent/Token_scala.ml
+++ b/languages/scala/recursive_descent/Token_scala.ml
@@ -89,6 +89,7 @@ type token =
   | BANG of Tok.t
   | AT of Tok.t
   | ARROW of Tok.t
+  (* emitted only via lexing tricks *)
   | DEDENT of (* line *) int * (* width *) int
 [@@deriving show { with_path = false }]
 

--- a/libs/ast_generic/AST_generic.ml
+++ b/libs/ast_generic/AST_generic.ml
@@ -1355,6 +1355,8 @@ and other_stmt_operator =
   | OS_Retry
   (* OCaml *)
   | OS_ExprStmt2
+  (* Scala *)
+  | OS_Extension
   (* Other: Leave/Emit in Solidity *)
   | OS_Todo
 
@@ -1362,7 +1364,7 @@ and other_stmt_operator =
 (* Pattern *)
 (*****************************************************************************)
 (* This is quite similar to expr. A few constructs in expr have
- * equivalent here prefixed with Pat (e.g., PaLiteral, PatId). We could
+* equivalent here prefixed with Pat (e.g., PaLiteral, PatId). We could
  * maybe factorize with expr, and this may help semgrep, but I think it's
  * cleaner to have a separate type because the scoping rules for a pattern and
  * an expr are quite different and not any expr is allowed here.

--- a/libs/ast_generic/AST_generic_to_v1.ml
+++ b/libs/ast_generic/AST_generic_to_v1.ml
@@ -814,6 +814,7 @@ and map_other_stmt_operator = function
   | OS_Redo -> "Redo"
   | OS_Retry -> "Retry"
   | OS_ExprStmt2 -> "ExprStmt2"
+  | OS_Extension -> "Extension"
   | OS_Todo -> "Todo"
 
 and map_other_stmt_with_stmt_operator = function

--- a/libs/ast_generic/Meta_AST.ml
+++ b/libs/ast_generic/Meta_AST.ml
@@ -1018,6 +1018,7 @@ and vof_other_stmt_operator = function
   | OS_Asm -> OCaml.VSum ("OS_Asm", [])
   | OS_Go -> OCaml.VSum ("OS_Go", [])
   | OS_Defer -> OCaml.VSum ("OS_Defer", [])
+  | OS_Extension -> OCaml.VSum ("OS_Extension", [])
   | OS_Fallthrough -> OCaml.VSum ("OS_Fallthrough", [])
 
 and vof_pattern = function

--- a/tests/parsing/scala/extensions.scala
+++ b/tests/parsing/scala/extensions.scala
@@ -1,0 +1,23 @@
+
+
+extension (a: T) def x = 2 
+
+object IsProxy:
+  extension (a: T) def x = 2 
+  extension[T] (a: T) def x = 2 
+  extension[T] (using x: A) (a: T) def x = 2 
+  extension[T] (using x: A) (a: T) def x = 2 
+  extension[T] (using x: A) (a: T) (using y: B) def x = 2 
+  extension[T] (using x: A) (a: T) (using y: B) 
+    def x = 2
+    val y = 3
+    export this
+  extension[T] (using x: A) (a: T) (using y: B) {
+    def x = 2
+    val y = 3
+    export this
+  }
+
+val x = {
+  extension (a: T) def x = 2
+}

--- a/tests/parsing/scala/if_expr.scala
+++ b/tests/parsing/scala/if_expr.scala
@@ -7,3 +7,51 @@ val y =
     4
   else
     5
+
+val x = 
+  if (true) 1 else 3
+
+// this test case demonstrates the necessity of 
+// indentedExprOrBlockStatSeq...
+// it's an indented expr, but it doesn't start a
+// blockStatSeq, and it doesn't even have a closing
+// DEDENT 
+val x = 
+  if (true) 
+    1 else 3
+
+val x = 
+  if (true) 
+    1 
+  else 3
+
+val x = 
+  if (true) 
+    1 
+  else 
+    3
+
+val x = 
+  if (true) 
+    val x = 2 
+    val y = 3 
+  else 3
+
+val x = 
+  if true then 
+    val x = 2 
+    val y = 3 
+  else 3
+
+val x = 
+  if true then 
+    x.foo(); 
+    val y = 3 
+  else 3
+
+
+
+
+
+ 
+    


### PR DESCRIPTION
## What:
This PR makes it so that we parse the `then` expression in a Scala if-then-else better.

## Why:
Previously, we were unable to parse things such as 
```
if (true)
  x.foo();
  val x = 2
else
  4
```
because our `blockStatSeq` parser is limited to things which do not start with expressions. This was so we had a distinction between blockStatSeq's and just regular `expr`s, which would otherwise conflate, and cause us to incorrectly parse things as a `blockExpr` when it's too general.

In addition, there are difficulties with parsing it as such, because we have things such as
```
if (true)
  3 else 4
```
where the expression is indented, which would ordinarily start an indentation region, but there is no corresponding 
DEDENT at the end of the expression. This messes with things like `inBracesOrIndented` and friends, which expect to parse a single nonterminal, and then parse the DEDENT. Here, however, there's not just a single nonterminal before the DEDENT, because we have the `else 4` in addition to the `3`.

## How:
We added the `indentexExprOrBlackStatSeqUntil` function, which means to parse something which is an indented expression, or a block stat seq. In addition, there is the possibility of a terminating token, which is cnotextual. In the case of a `then` expression, this is `else`. In the case of the terminating token, we don't require a DEDENT, so we can't use a normal parsing combinator.

## Test plan:
Included tests, and parse rate `0.9785559783011464` -> `0.9800450983204928`


PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
