### PR TITLE
feat(scala): parse extensions

### DIFF
--- a/languages/scala/ast/AST_scala.ml
+++ b/languages/scala/ast/AST_scala.ml
@@ -355,6 +355,7 @@ and block_stat =
   | D of definition
   | I of import
   | Ex of import
+  | Ext of extension
   | E of expr
   (* just at the beginning of top_stat *)
   | Package of package
@@ -466,6 +467,19 @@ and definition_kind =
   | TypeDef of type_definition
   (* class/traits/objects *)
   | Template of template_definition
+
+(*****************************************************************************)
+(* Extensions *)
+(*****************************************************************************)
+and extension = {
+  ext_tok : tok; (* extension *)
+  ext_tparams : type_parameters;
+  ext_using : bindings list;
+  ext_param : binding;
+  ext_methods : ext_method list;
+}
+
+and ext_method = ExtDef of definition | ExtExport of import
 
 (* ------------------------------------------------------------------------- *)
 (* Enums *)

--- a/languages/scala/generic/scala_to_generic.ml
+++ b/languages/scala/generic/scala_to_generic.ml
@@ -755,6 +755,7 @@ and v_block_stat x : G.item list =
   | E v1 ->
       let v1 = v_expr_for_stmt v1 in
       [ v1 ]
+  | Ext v1 -> v_extension v1
   | Package v1 ->
       let ipak, ids = v_package v1 in
       [ G.DirectiveStmt (G.Package (ipak, ids) |> G.d) |> G.s ]
@@ -911,6 +912,27 @@ and v_given_definition { gsig; gkind } =
     ( { name = G.OtherEntity (todo_kind, []); attrs = []; tparams = [] },
       G.OtherDef (todo_kind, v1 @ [ G.Anys v2 ]) );
   ]
+
+and v_extension { ext_tok = _; ext_tparams; ext_using; ext_param; ext_methods }
+    : G.stmt list =
+  let tparams =
+    G.Anys (v_type_parameters ext_tparams |> Common.map (fun tp -> G.Tp tp))
+  in
+  let using =
+    G.Anys
+      (v_list v_bindings ext_using |> Common.map (fun params -> G.Params params))
+  in
+  let params = G.Pa (v_binding None ext_param) in
+  let methods = G.Anys (List.concat_map v_ext_method ext_methods) in
+  (* Extensions are definitions and methods that extend an existing class. It's not
+     super important for semantic analysis right now.
+  *)
+  [ G.OtherStmt (OS_Extension, [ tparams; using; params; methods ]) |> G.s ]
+
+and v_ext_method ext_method : G.any list =
+  match ext_method with
+  | ExtDef def -> v_definition def |> Common.map (fun def -> G.Def def)
+  | ExtExport import -> v_import import |> Common.map (fun dir -> G.Dir dir)
 
 and v_constr_app (ty, args) = (v_type_ ty, v_list v_arguments args)
 

--- a/languages/scala/recursive_descent/Token_helpers_scala.ml
+++ b/languages/scala/recursive_descent/Token_helpers_scala.ml
@@ -393,7 +393,8 @@ let isTemplateIntro = function
   | Kclass _
   | Kenum _
   | Ktrait _
-  | ID_LOWER ("given", _) ->
+  | ID_LOWER ("given", _)
+  | ID_LOWER ("extension", _) ->
       true
   (*TODO | Kcaseobject | | Kcaseclass *)
   | Kcase _ -> true

--- a/languages/scala/recursive_descent/Token_scala.ml
+++ b/languages/scala/recursive_descent/Token_scala.ml
@@ -89,6 +89,7 @@ type token =
   | BANG of Tok.t
   | AT of Tok.t
   | ARROW of Tok.t
+  (* emitted only via lexing tricks *)
   | DEDENT of (* line *) int * (* width *) int
 [@@deriving show { with_path = false }]
 

--- a/libs/ast_generic/AST_generic.ml
+++ b/libs/ast_generic/AST_generic.ml
@@ -1355,6 +1355,8 @@ and other_stmt_operator =
   | OS_Retry
   (* OCaml *)
   | OS_ExprStmt2
+  (* Scala *)
+  | OS_Extension
   (* Other: Leave/Emit in Solidity *)
   | OS_Todo
 
@@ -1362,7 +1364,7 @@ and other_stmt_operator =
 (* Pattern *)
 (*****************************************************************************)
 (* This is quite similar to expr. A few constructs in expr have
- * equivalent here prefixed with Pat (e.g., PaLiteral, PatId). We could
+* equivalent here prefixed with Pat (e.g., PaLiteral, PatId). We could
  * maybe factorize with expr, and this may help semgrep, but I think it's
  * cleaner to have a separate type because the scoping rules for a pattern and
  * an expr are quite different and not any expr is allowed here.

--- a/libs/ast_generic/AST_generic_to_v1.ml
+++ b/libs/ast_generic/AST_generic_to_v1.ml
@@ -814,6 +814,7 @@ and map_other_stmt_operator = function
   | OS_Redo -> "Redo"
   | OS_Retry -> "Retry"
   | OS_ExprStmt2 -> "ExprStmt2"
+  | OS_Extension -> "Extension"
   | OS_Todo -> "Todo"
 
 and map_other_stmt_with_stmt_operator = function

--- a/libs/ast_generic/Meta_AST.ml
+++ b/libs/ast_generic/Meta_AST.ml
@@ -1018,6 +1018,7 @@ and vof_other_stmt_operator = function
   | OS_Asm -> OCaml.VSum ("OS_Asm", [])
   | OS_Go -> OCaml.VSum ("OS_Go", [])
   | OS_Defer -> OCaml.VSum ("OS_Defer", [])
+  | OS_Extension -> OCaml.VSum ("OS_Extension", [])
   | OS_Fallthrough -> OCaml.VSum ("OS_Fallthrough", [])
 
 and vof_pattern = function

--- a/tests/parsing/scala/extensions.scala
+++ b/tests/parsing/scala/extensions.scala
@@ -1,0 +1,23 @@
+
+
+extension (a: T) def x = 2 
+
+object IsProxy:
+  extension (a: T) def x = 2 
+  extension[T] (a: T) def x = 2 
+  extension[T] (using x: A) (a: T) def x = 2 
+  extension[T] (using x: A) (a: T) def x = 2 
+  extension[T] (using x: A) (a: T) (using y: B) def x = 2 
+  extension[T] (using x: A) (a: T) (using y: B) 
+    def x = 2
+    val y = 3
+    export this
+  extension[T] (using x: A) (a: T) (using y: B) {
+    def x = 2
+    val y = 3
+    export this
+  }
+
+val x = {
+  extension (a: T) def x = 2
+}


### PR DESCRIPTION
## What:
This PR adds in the ability to parse `extension` definitions.

## Why:
This is Scala 3 stuff.

## How:
Added in all the necessary constructs. `extension` is a soft keyword, so some hackery was necessary to ensure that we would properly enter the `extension` cases when necessary. 

I didn't have a good enough construct for the `OtherStmt`, so I added in a `OS_Extension` variant, for Scala extensions. Perhaps we will leverage this in the future.

## Test plan:
Included test, and parse rate `0.9800450983204928` -> `0.9800663343161121`.

Parse rate didn't really go up, but this change needs to happen, and its probably correlated with some other Scala 3 stuff I didn't get around to yet.


PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
