### PR TITLE
feat(scala): parse whitespace indented packages

### DIFF
--- a/languages/scala/recursive_descent/Parser_scala_recursive_descent.ml
+++ b/languages/scala/recursive_descent/Parser_scala_recursive_descent.ml
@@ -4228,12 +4228,12 @@ let packageOrPackageObject ipackage in_ : top_stat =
     let x = packageObjectDef ipackage in_ in
     (* ast: joinComment(x::Nil).head *)
     D x
-  else (
+  else
     let x = pkgQualId in_ in
     let body = inBracesOrColonIndented topStatSeq in_ in
     (* ast: makePackaging(x, body) *)
     let pack = (ipackage, x) in
-    Packaging (pack, body))
+    Packaging (pack, body)
 
 (* ------------------------------------------------------------------------- *)
 (* Class/trait *)

--- a/languages/scala/recursive_descent/Parser_scala_recursive_descent.ml
+++ b/languages/scala/recursive_descent/Parser_scala_recursive_descent.ml
@@ -155,8 +155,6 @@ type indent_status =
   | Dedent of (* line *) int * (* width *) int
   | Indent of (* same *) int * int
 
-let report in_ s = Common.(pr2 (spf "%s: %s" s ([%show: token] in_.token)))
-
 (*****************************************************************************)
 (* Logging/Dumpers  *)
 (*****************************************************************************)
@@ -3963,7 +3961,6 @@ let topStat in_ : top_stat option =
   match in_.token with
   | Kpackage ii ->
       skipToken in_;
-      report in_ "after package";
       let x = !packageOrPackageObject_ ii in_ in
       Some x
   | Kimport _ ->
@@ -4232,7 +4229,6 @@ let packageOrPackageObject ipackage in_ : top_stat =
     (* ast: joinComment(x::Nil).head *)
     D x
   else (
-    report in_ "package or package obj in id case";
     let x = pkgQualId in_ in
     let body = inBracesOrColonIndented topStatSeq in_ in
     (* ast: makePackaging(x, body) *)

--- a/tests/parsing/scala/indented_package.scala
+++ b/tests/parsing/scala/indented_package.scala
@@ -1,0 +1,4 @@
+package foo.bar 
+
+package A:
+  case class B(x: T1, y: T2)

--- a/tests/parsing/scala/indented_package.scala
+++ b/tests/parsing/scala/indented_package.scala
@@ -1,4 +1,6 @@
 package foo.bar 
 
+import foo.*
+
 package A:
   case class B(x: T1, y: T2)


### PR DESCRIPTION
## What:
This PR permits parsing Scala packages that are indented, like
```
package foo:
  case class x(y : T)
```

## Why:
Scala 3 things.

## How:
Just added a combinator for parsing the `:<<< >>>` grammar things.

## Test plan:
Included test, parse rate `0.9800663343161121 ` -> `0.9802102190211246`

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
