### PR TITLE
feat(scala): parse end markers

### DIFF
--- a/languages/scala/ast/AST_scala.ml
+++ b/languages/scala/ast/AST_scala.ml
@@ -356,6 +356,7 @@ and block_stat =
   | I of import
   | Ex of import
   | Ext of extension
+  | End of end_marker
   | E of expr
   (* just at the beginning of top_stat *)
   | Package of package
@@ -467,6 +468,11 @@ and definition_kind =
   | TypeDef of type_definition
   (* class/traits/objects *)
   | Template of template_definition
+
+(*****************************************************************************)
+(* End Marker *)
+(*****************************************************************************)
+and end_marker = { end_tok : tok; end_kind : tok }
 
 (*****************************************************************************)
 (* Extensions *)

--- a/languages/scala/generic/scala_to_generic.ml
+++ b/languages/scala/generic/scala_to_generic.ml
@@ -755,6 +755,9 @@ and v_block_stat x : G.item list =
   | E v1 ->
       let v1 = v_expr_for_stmt v1 in
       [ v1 ]
+  | End v1 ->
+      let v1 = v_end_marker v1 in
+      [ v1 ]
   | Ext v1 -> v_extension v1
   | Package v1 ->
       let ipak, ids = v_package v1 in
@@ -912,6 +915,9 @@ and v_given_definition { gsig; gkind } =
     ( { name = G.OtherEntity (todo_kind, []); attrs = []; tparams = [] },
       G.OtherDef (todo_kind, v1 @ [ G.Anys v2 ]) );
   ]
+
+and v_end_marker { end_tok; end_kind } : G.stmt =
+  G.OtherStmt (OS_Todo, [ G.Tk end_tok; G.Tk end_kind ]) |> G.s
 
 and v_extension { ext_tok = _; ext_tparams; ext_using; ext_param; ext_methods }
     : G.stmt list =

--- a/languages/scala/recursive_descent/Parser_scala_recursive_descent.ml
+++ b/languages/scala/recursive_descent/Parser_scala_recursive_descent.ml
@@ -3652,6 +3652,27 @@ let localDef implicitMod in_ : definition =
          (* AST: if RBRACE | CASE defs :+ literalUnit *))
 
 (* ------------------------------------------------------------------------- *)
+(* End Marker *)
+(* ------------------------------------------------------------------------- *)
+
+(** {{{
+ *  EndMarker         ::=  ‘end’ EndMarkerTag    -- when followed by EOL
+ *  EndMarkerTag      ::=  id | ‘if’ | ‘while’ | ‘for’ | ‘match’ | ‘try’
+                        |  ‘new’ | ‘this’ | ‘given’ | ‘extension’ | ‘val’
+ *  }}}
+*)
+
+let endMarker in_ : end_marker =
+  let end_tok = TH.info_of_tok in_.token in
+  accept (ID_LOWER ("end", ab)) in_;
+  let end_kind = TH.info_of_tok in_.token in
+  (* We could dispatch on the various cases, but every single case ends up
+     with some kind of token. So let's just say that it's a single token.
+  *)
+  skipToken in_;
+  { end_tok; end_kind }
+
+(* ------------------------------------------------------------------------- *)
 (* Extension *)
 (* ------------------------------------------------------------------------- *)
 
@@ -3777,6 +3798,7 @@ let statSeq ?(errorMsg = "illegal start of definition") ?(rev = false) stat in_
   *                 | Annotations [implicit] [lazy] Def
   *                 | Annotations LocalModifiers TmplDef
   *                 | Expr1
+  *                 | EndMarker
   *                 | Extension
   *                 |
   *  }}}
@@ -3795,6 +3817,9 @@ let blockStatSeqInner in_ : top_stat option =
     if not (TH.isCaseDefEnd in_.token) then acceptStatSepOpt in_
   in
   match in_.token with
+  | ID_LOWER ("end", _) ->
+      let x = endMarker in_ in
+      Some (End x)
   | ID_LOWER ("extension", _) ->
       let x = extension in_ in
       Some (Ext x)
@@ -3915,6 +3940,7 @@ let indentedExprOrBlockStatSeqUntil ?(until = None) in_ =
  *                     | Annotations Modifiers Dcl
  *                     | Expr1
  *                     | super ArgumentExprs {ArgumentExprs}
+ *                     | EndMarker
  *                     | Extension
  *                     |
  *                     | Annotations Modifiers EnumCase
@@ -3929,6 +3955,9 @@ let templateStat in_ : template_stat option =
   | Kexport _ ->
       let x = exportClause in_ in
       Some (Ex x)
+  | ID_LOWER ("end", _) ->
+      let x = endMarker in_ in
+      Some (End x)
   | ID_LOWER ("extension", _) ->
       let x = extension in_ in
       Some (Ext x)
@@ -3953,6 +3982,7 @@ let templateStats in_ : template_stat list = statSeq templateStat in_
  *            | package object ObjectDef
  *            | Import
  *            | Export
+ *            | EndMarker
  *            | Extension
  *            |
  *  }}}
@@ -3969,6 +3999,9 @@ let topStat in_ : top_stat option =
   | Kexport _ ->
       let x = exportClause in_ in
       Some (Ex x)
+  | ID_LOWER ("end", _) ->
+      let x = endMarker in_ in
+      Some (End x)
   | ID_LOWER ("extension", _) ->
       let x = extension in_ in
       Some (Ext x)
@@ -4011,7 +4044,7 @@ let templateStatSeq ~isPre in_ : self_type option * block =
     if
       TH.isExprIntro in_.token
       && (not (is_modifier in_))
-      && not (in_.token =~= ID_LOWER ("extension", ab))
+      && not (TH.isTemplateIntro in_.token)
     then (
       let first = expr ~location:InTemplate in_ in
       match in_.token with

--- a/languages/scala/recursive_descent/Parser_scala_recursive_descent.ml
+++ b/languages/scala/recursive_descent/Parser_scala_recursive_descent.ml
@@ -4044,6 +4044,11 @@ let templateStatSeq ~isPre in_ : self_type option * block =
     if
       TH.isExprIntro in_.token
       && (not (is_modifier in_))
+      (* We add this here, because there are some "soft" modifiers that can start
+         a templateIntro, such as "extension", "end", etc.
+         If we did not do this, template stats that start with those would always
+         enter this expression case, even though they denote something else.
+      *)
       && not (TH.isTemplateIntro in_.token)
     then (
       let first = expr ~location:InTemplate in_ in

--- a/languages/scala/recursive_descent/Token_helpers_scala.ml
+++ b/languages/scala/recursive_descent/Token_helpers_scala.ml
@@ -394,6 +394,7 @@ let isTemplateIntro = function
   | Kenum _
   | Ktrait _
   | ID_LOWER ("given", _)
+  | ID_LOWER ("end", _)
   | ID_LOWER ("extension", _) ->
       true
   (*TODO | Kcaseobject | | Kcaseclass *)

--- a/tests/parsing/scala/end_markers.scala
+++ b/tests/parsing/scala/end_markers.scala
@@ -1,0 +1,10 @@
+
+object A:
+  extension (a: File)
+    inline def x: String = "hi" 
+  end extension
+
+  def foo(x: T) = x
+  end def
+
+end foo


### PR DESCRIPTION
## What:
This PR lets us parse end markers, which are stat seq members that look like
```
end def
```
for instance.

## Why:
Scala 3, baby.

## How:
Just added code which parses the `end` in the `blockStat`, `templateStat`, and `topStat` cases.

It's gotten to the point where I've had to whitelist a few soft idents as being able to start a template stat without
degenerating to the `exp` case, so I made it so we only enter the `expr` case if the starting identifier is not a 
`TemplateIntro`, so we don't mangle the soft identifiers.

I injected the end markers into `OS_Todo`, because I figured that it was time to stop making a bunch of useless variants. Let me know if that's not the right thing to do, though.

## Test plan:
Included tests, parse rate `0.9802102190211246` -> `0.9806002679202549`

I also checked that
```
object A:
  extension (a: File)
    inline def x: String = "hi" 
  end extension

  def foo(x: T) = x
  end def

end foo
```
parses to
```
Pr(
  [DefStmt(
     ({
       name=EN(
              Id(("A", ()),
                {id_info_id=1; id_hidden=false; id_resolved=Ref(None); id_type=Ref(None); id_svalue=Ref(None); }));
       attrs=[]; tparams=[]; },
      ClassDef(
        {ckind=(Object, ()); cextends=[]; cimplements=[]; cmixins=[]; cparams=[
         ];
         cbody=[F(
                  OtherStmt(OS_Extension,
                    [Anys([]); Anys([]);
                     Pa(
                       Param(
                         {pname=Some(("a", ())); pdefault=None;
                          ptype=Some({t_attrs=[];
                                      t=TyN(
                                          Id(("File", ()),
                                            {id_info_id=3; id_hidden=false; id_resolved=Ref(
                                             None); id_type=Ref(None); id_svalue=Ref(
                                             None); }));
                                      });
                          pattrs=[];
                          pinfo={id_info_id=2; id_hidden=false; id_resolved=Ref(
                                 Some((Parameter, -1))); id_type=Ref(
                                 None); id_svalue=Ref(None); };
                          }));
                     Anys(
                       [D(
                          ({
                            name=EN(
                                   Id(("x", ()),
                                     {id_info_id=4; id_hidden=false; id_resolved=Ref(
                                      None); id_type=Ref(None); id_svalue=Ref(
                                      None); }));
                            attrs=[OtherAttribute(("inline", ()), [])]; tparams=[
                            ]; },
                           FuncDef(
                             {fkind=(Method, ()); fparams=[];
                              frettype=Some({t_attrs=[];
                                             t=TyN(
                                                 Id(("String", ()),
                                                   {id_info_id=5; id_hidden=false; id_resolved=Ref(
                                                    None); id_type=Ref(
                                                    None); id_svalue=Ref(
                                                    None); }));
                                             });
                              fbody=FBExpr(L(String(("hi", ())))); })))])]));
                F(OtherStmt(OS_Todo, [Tk(()); Tk(())]));
                F(
                  DefStmt(
                    ({
                      name=EN(
                             Id(("foo", ()),
                               {id_info_id=6; id_hidden=false; id_resolved=Ref(
                                None); id_type=Ref(None); id_svalue=Ref(
                                None); }));
                      attrs=[]; tparams=[]; },
                     FuncDef(
                       {fkind=(Method, ());
                        fparams=[Param(
                                   {pname=Some(("x", ())); pdefault=None;
                                    ptype=Some({t_attrs=[];
                                                t=TyN(
                                                    Id(("T", ()),
                                                      {id_info_id=8; id_hidden=false; id_resolved=Ref(
                                                       None); id_type=Ref(
                                                       None); id_svalue=Ref(
                                                       None); }));
                                                });
                                    pattrs=[];
                                    pinfo={id_info_id=7; id_hidden=false; id_resolved=Ref(
                                           Some((Parameter, -1))); id_type=Ref(
                                           None); id_svalue=Ref(None); };
                                    })];
                        frettype=None;
                        fbody=FBExpr(
                                N(
                                  Id(("x", ()),
                                    {id_info_id=9; id_hidden=false; id_resolved=Ref(
                                     None); id_type=Ref(None); id_svalue=Ref(
                                     None); })));
                        })))); F(OtherStmt(OS_Todo, [Tk(()); Tk(())]))];
         }))); OtherStmt(OS_Todo, [Tk(()); Tk(())])])
```
which correctly places the end markers on the level they're supposed to be on.

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
