### PR TITLE
feat(scala): parse starred arrow param types

### DIFF
--- a/languages/scala/ast/AST_scala.ml
+++ b/languages/scala/ast/AST_scala.ml
@@ -546,7 +546,7 @@ and parameter_classic = {
 
 and param_type =
   | PT of type_
-  | PTByNameApplication of tok (* => *) * type_
+  | PTByNameApplication of tok (* => *) * type_ * (* * *) tok option
   | PTRepeatedApplication of type_ * tok (* * *)
 
 (* ------------------------------------------------------------------------- *)

--- a/languages/scala/generic/scala_to_generic.ml
+++ b/languages/scala/generic/scala_to_generic.ml
@@ -1092,14 +1092,18 @@ and v_binding using_opt v : G.parameter =
       | Some (PT v1) ->
           let v1 = v_type_ v1 in
           G.Param { pclassic with ptype = Some v1 }
-      | Some (PTByNameApplication (v1, v2)) ->
+      | Some (PTByNameApplication (v1, v2, v3)) -> (
           let v1 = v_tok v1 and v2 = v_type_ v2 in
-          G.Param
+          let pclassic =
             {
               pclassic with
               ptype = Some v2;
               pattrs = G.KeywordAttr (G.Lazy, v1) :: pclassic.pattrs;
             }
+          in
+          match v3 with
+          | Some ii -> G.ParamRest (ii, pclassic)
+          | _ -> G.Param pclassic)
       | Some (PTRepeatedApplication (v1, v2)) ->
           let v1 = v_type_ v1 and v2 = v_tok v2 in
           G.ParamRest (v2, { pclassic with ptype = Some v1 }))

--- a/tests/parsing/scala/starred_arrow_param_type.scala
+++ b/tests/parsing/scala/starred_arrow_param_type.scala
@@ -1,0 +1,3 @@
+trait Foo {
+  def bar(x: => T*): Int = 3
+}


### PR DESCRIPTION
## What:
This PR allows us to parse param types that are arrow types, but with a suffixing `*`, such as:
```
=> T*
```
which previously only allowed `=> T`.

## Why:
SCALA 3

## How:
Added the star to the named arrow type variant. This should be strictly more permissive than the actual grammar.

## Test plan:
Included test, and parse rate `0.9810696267622084` -> `0.9811003972864731`

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
