### PR TITLE
feat(scala): parse indented tuple pattern in for

### DIFF
--- a/languages/scala/recursive_descent/Parser_scala_recursive_descent.ml
+++ b/languages/scala/recursive_descent/Parser_scala_recursive_descent.ml
@@ -2507,12 +2507,43 @@ and parseDo in_ : stmt =
   (* ast: makeDoWhile(lname.toTermName, body, cond) *)
   DoWhile (ido, body, iwhile, cond)
 
+(* Is the following sequence the generators of a for-expression enclosed in (...)? *)
+(* As implemented in Dotty:
+   https://github.com/lampepfl/dotty/blob/865aa639c98e0a8771366b3ebc9580cc8b61bfeb/compiler/src/dotty/tools/dotc/parsing/Parsers.scala#L857
+*)
+and followingIsEnclosedGenerators in_ =
+  let parens = ref 1 in
+  lookingAhead
+    (fun in_ ->
+      while !parens != 0 && not (in_.token =~= EOF ab) do
+        if in_.token =~= LPAREN ab then incr parens
+        else if in_.token =~= RPAREN ab then decr parens;
+        nextToken in_
+      done;
+      if in_.token =~= LARROW ab then false
+        (* it's a pattern *)
+        (* nosemgrep *)
+      else if TH.isIdentBool in_.token then true
+        (* it's not a pattern since token cannot be an infix operator *)
+      else
+        (* followedByToken(LARROW) // `<-` comes before possible statement starts
+           In the Scala compiler, this is what it says ^
+
+           Except this function is actually like, quite complicated, and relies on
+           other functions we haven't yet ported.
+
+           So let's just not do that for now.
+        *)
+        true)
+    in_
+
 and parseFor in_ : stmt =
   let ii = TH.info_of_tok in_.token in
   skipToken in_;
   let enums =
     match in_.token with
-    | LPAREN _ -> inParens enumerators in_
+    | LPAREN _ when followingIsEnclosedGenerators in_ ->
+        inParens enumerators in_
     | LBRACE _ -> inBraces enumerators in_
     | _ ->
         (* Deliberately not `inBracesOrIndented`, to combine the last two cases!

--- a/languages/scala/recursive_descent/Parser_scala_recursive_descent.ml
+++ b/languages/scala/recursive_descent/Parser_scala_recursive_descent.ml
@@ -2515,7 +2515,7 @@ and followingIsEnclosedGenerators in_ =
   let parens = ref 1 in
   lookingAhead
     (fun in_ ->
-      while !parens != 0 && not (in_.token =~= EOF ab) do
+      while !parens <> 0 && not (in_.token =~= EOF ab) do
         if in_.token =~= LPAREN ab then incr parens
         else if in_.token =~= RPAREN ab then decr parens;
         nextToken in_

--- a/tests/parsing/scala/indented_tuple_for_pattern.scala
+++ b/tests/parsing/scala/indented_tuple_for_pattern.scala
@@ -1,0 +1,5 @@
+val x = for
+  (a, b) <- 1 
+  c      <- 2 
+  d      <- 3 
+yield (a, b)


### PR DESCRIPTION
## What:
This PR lets us parse an indented `for` expression in Scala, when the first pattern is a Tuple.

## Why:
This had some ambiguity, because we were assuming an LPAREN meant it must be an enclosed generator. This is actually not the case, because a pattern might itself start with an LPAREN, so we might not be in the enclosed generator case.

## How:
Implemented the `followingIsEnclosedGenerators` function, as in Dotty: 
https://github.com/lampepfl/dotty/blob/865aa639c98e0a8771366b3ebc9580cc8b61bfeb/compiler/src/dotty/tools/dotc/parsing/Parsers.scala#L857

## Test plan:
Enclosed test, and `0.9811003972864731` to `0.9811493700926973`

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
