### PR TITLE
feat(scala): indent expr case clause blocks

### DIFF
--- a/tests/parsing/scala/expr_case_clause.scala
+++ b/tests/parsing/scala/expr_case_clause.scala
@@ -2,3 +2,15 @@
 val x = 
   try 2
   catch case _ => 4
+
+val x = 
+  try 
+    3
+  catch
+    case _ =>
+      // we need to properly emit an indentRegion here, because we're
+      // not just parsing a block, we're parsing an expr 
+      // (which results in a <<< block >>>, actually)
+      var x = 2
+
+private val y = 3


### PR DESCRIPTION
## What:
This PR makes it so that blocks inside an `exprCaseClause` (so, for instance, under a `catch`) properly emit indentation
regions for blocks.

## Why:
This would otherwise mess up programs like
```
val x = 
  try 
    3
  catch
    case _ =>
      var x = 2

private val y = 3
```
because failing to emit the `INDENT` on the `var` would cause us to be unable to emit the `DEDENT` on the `private`, meaning we wouldn't know where to end the block.

## How:
Changed it so we went through `expr` instead of straight through `block`, which will take care of the necessary indentation-region logic.

To reuse code, I factorized out `caseClause` by the RHS in question. This allows us to use it for both the `block` and `expr` case, for the RHS.

## Test plan:
Included test, and parse rate `0.9811493700926973` -> `0.9814874124719436`

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
