### PR TITLE
feat(scala): emit newlines in fors

### DIFF
--- a/languages/scala/recursive_descent/Parser_scala_recursive_descent.ml
+++ b/languages/scala/recursive_descent/Parser_scala_recursive_descent.ml
@@ -503,6 +503,7 @@ let nextToken in_ =
    && (match in_.sepRegions with
       | []
       | RBRACE _ :: _
+      (* See "note: sepFor" below. *)
       | Kfor _ :: _
       | DEDENT _ :: _ ->
           true
@@ -2553,6 +2554,11 @@ and parseFor in_ : stmt =
   let ii = TH.info_of_tok in_.token in
   skipToken in_;
   let enums =
+    (* note: sepFor
+       This is so that we can emit newlines specifically within a `for`.
+       Don't blame me, blame Dotty:
+       https://github.com/lampepfl/dotty/blob/865aa639c98e0a8771366b3ebc9580cc8b61bfeb/compiler/src/dotty/tools/dotc/parsing/Scanners.scala#L505
+    *)
     inSepRegion (Kfor ii)
       (fun () ->
         match in_.token with

--- a/tests/parsing/scala/newline_in_for.scala
+++ b/tests/parsing/scala/newline_in_for.scala
@@ -1,0 +1,14 @@
+
+// this example is weird because the parens surround the
+// generators of the `for`
+// if we don't explicitly whitelist a `for` as a sepRegion
+// where we can emit newlines, we're not going to be able to
+// separate the two generators, because we won't emit a NEWLINE
+// before the `_`
+def foo() =
+  foo { x =>
+    bar (for
+      y <- 2 
+      _ <- 3 
+    yield ())
+  } 


### PR DESCRIPTION
## What:
This PR adds in a new `sepRegion` specifically for `for` expressions, because we need to be able to emit newlines in them, per the Dotty source: https://github.com/lampepfl/dotty/blob/865aa639c98e0a8771366b3ebc9580cc8b61bfeb/compiler/src/dotty/tools/dotc/parsing/Scanners.scala#L505

## Why:
SCALA 3

## How:
Just added a new sepRegion and added the proper handling in `nextToken`

## Test plan:
Included test, and parse rate `0.9814874124719436` -> `0.9824967723453597`

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
