### PR TITLE
Extension metrics compatibility bug

### DIFF
--- a/cli/src/semgrep/lsp/config.py
+++ b/cli/src/semgrep/lsp/config.py
@@ -1,6 +1,7 @@
 import json
 import urllib
 from typing import Any
+from typing import Dict
 from typing import List
 from typing import Mapping
 from typing import Optional
@@ -100,8 +101,21 @@ class LSPConfig:
     # Semgrep LSP settings
     # =====================
     @property
+    def extension_metrics(self) -> Dict[str, Any]:
+        extension_metrics = self._settings.get("extensionMetrics", {})
+        if isinstance(extension_metrics, dict):
+            return extension_metrics
+        elif isinstance(extension_metrics, str):
+            # for backwards compatibility, older versions of the extension may send metrics: "on" or "off"
+            return {
+                "enabled": extension_metrics == "on",
+            }
+        else:
+            return {}
+
+    @property
     def metrics_state(self) -> MetricsState:
-        choice = self._settings.get("metrics", {}).get("enabled", True)
+        choice = self.extension_metrics.get("enabled", True)
         if choice:
             return MetricsState.ON
         else:
@@ -187,7 +201,7 @@ class LSPConfig:
         metrics.add_engine_type(self.engine_type)
         metrics.add_project_url(self.project_url)
         metrics.add_token(self.token)
-        extension_metrics = self._settings.get("metrics", {})
+        extension_metrics = self.extension_metrics
         machine_id = extension_metrics.get("machineId")
         new_install = extension_metrics.get("isNewAppInstall")
         session_id = extension_metrics.get("sessionId")


### PR DESCRIPTION
In another PR, I changed the settings schema so that way users wouldn't have to type on/off, and instead could check a box to enable metrics. This resulted in a backwards compatibility issue that this PR fixes.

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
