### PR TITLE
feat(scala): parse anonymous types

### DIFF
--- a/languages/scala/ast/AST_scala.ml
+++ b/languages/scala/ast/AST_scala.ml
@@ -175,6 +175,7 @@ and type_ =
   | TyProj of type_ * tok (* '#' *) * ident
   (* ast_orig: AppliedType *)
   | TyApplied of type_ * type_ list bracket
+  | TyAnon of tok (* '?' *) * type_bounds
   | TyInfix of type_ * ident * type_
   | TyFunction1 of type_ * tok (* '=>' *) * type_
   | TyFunction2 of type_ list bracket * tok (* '=>' *) * type_

--- a/languages/scala/generic/scala_to_generic.ml
+++ b/languages/scala/generic/scala_to_generic.ml
@@ -252,6 +252,12 @@ and v_type_kind = function
           todo_type "TyAppliedComplex"
             (G.T v1 :: (xs |> Common.map (fun x -> G.T x))))
   | TyAnon (v1, v2) ->
+      (* We'd prefer to see type bounds in a `type_parameter`, but this
+         nonterminal needs to become a `type_` argument anyways, and we
+         don't really have a way of embedding `type_parameter` into a
+         `type`. This won't matter semantically, so let's just keep it
+         as an `OtherType`.
+      *)
       let bound1, bound2 = v_type_bounds v2 in
       let bound1 =
         match bound1 with

--- a/languages/scala/generic/scala_to_generic.ml
+++ b/languages/scala/generic/scala_to_generic.ml
@@ -251,6 +251,19 @@ and v_type_kind = function
       | _ ->
           todo_type "TyAppliedComplex"
             (G.T v1 :: (xs |> Common.map (fun x -> G.T x))))
+  | TyAnon (v1, v2) ->
+      let bound1, bound2 = v_type_bounds v2 in
+      let bound1 =
+        match bound1 with
+        | None -> []
+        | Some (_tok, ty) -> [ G.T ty ]
+      in
+      let bound2 =
+        match bound2 with
+        | None -> []
+        | Some (_tok, ty) -> [ G.T ty ]
+      in
+      G.OtherType (("?", v1), bound1 @ bound2)
   | TyInfix (v1, v2, v3) ->
       let v1 = v_type_ v1 and v2 = v_ident v2 and v3 = v_type_ v3 in
       G.TyApply (G.TyN (H.name_of_ids [ v2 ]) |> G.t, fb [ G.TA v1; G.TA v3 ])

--- a/languages/scala/recursive_descent/Parser_scala_recursive_descent.ml
+++ b/languages/scala/recursive_descent/Parser_scala_recursive_descent.ml
@@ -1294,6 +1294,7 @@ and tupleInfixType in_ : type_ =
  *                     |  StableId
  *                     |  Path `.` type
  *                     |  Literal
+ *                     |  `?` TypeBounds
  *                     |  `(` Types `)`
  *                     |  WildcardType
  *  }}}
@@ -1313,6 +1314,12 @@ and simpleType in_ : type_ =
              let x = literal ~isNegated:(Some ii) in_ in
              (* ast: SingletonTypeTree(x) *)
              TyLiteral x
+         (* See https://docs.scala-lang.org/scala3/reference/changed-features/wildcards.html *)
+         | OP ("?", _) ->
+             let ii = TH.info_of_tok in_.token in
+             skipToken in_;
+             let bounds = typeBounds in_ in
+             TyAnon (ii, bounds)
          | _ ->
              let start =
                match in_.token with

--- a/tests/parsing/scala/anonymous_types.scala
+++ b/tests/parsing/scala/anonymous_types.scala
@@ -1,0 +1,5 @@
+trait Test { self =>
+  def foo[T](x: A[? >: T] => T2): Int =
+  { (x: A[? >: T]) => 3 
+  }
+}


### PR DESCRIPTION
## What:
This PR adds in the "anonymous type", or "wildcard type parameter" variant into `simpleType`.

## Why:
Scala 3!!

## How:
Added the relevant logic in parsing.

An anonymous type is really more of a type parameter thing, but I doubt this will matter semantically, and I thought it would be an unnecessary amount of work to restrict it to the type argument position. Since these are bounds, we would prefer to see them in `type_parameter`, but the Generic AST doesn't currently support embedding `type_parameter` into a `type_` in a first-class way anyways, so it's probably fine. We'll keep it as an `OtherType`.

## Test plan:
Included test, and parse rate `0.9824967723453597 ` -> `0.9834194546856357`

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
