### PR TITLE
feat(scala): parse `then` after newline

### DIFF
--- a/languages/scala/recursive_descent/Parser_scala_recursive_descent.ml
+++ b/languages/scala/recursive_descent/Parser_scala_recursive_descent.ml
@@ -2467,6 +2467,12 @@ and parseIf in_ : stmt =
         cond
     | _ ->
         let e = expr in_ in
+        (* So we can parse things like
+           if true
+           then 2
+           else 3
+        *)
+        newLinesOpt in_;
         accept (ID_LOWER ("then", ab)) in_;
         newLinesOpt in_;
         fb (Tok.unsafe_fake_tok "") e

--- a/tests/parsing/scala/if_expr.scala
+++ b/tests/parsing/scala/if_expr.scala
@@ -49,6 +49,10 @@ val x =
     val y = 3 
   else 3
 
+val x =
+  if true 
+  then 1 
+  else 2 
 
 
 


### PR DESCRIPTION
## What:
This PR makes it so we can parse things like
```
if true
then 2
else 3
```

## Why:
Scala 3

## How:
We previously didn't allow an optional newline before the `then`. We need that so we consume the newline, so we can continue parsing.

## Test plan:
Included test, parse rate `0.9834194546856357` -> `0.9837808999988299`

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
