### PR TITLE
tainting: pro: Java: Field-sensitive analysis of constructors

### DIFF
--- a/changelog.d/pa-2570.added
+++ b/changelog.d/pa-2570.added
@@ -1,0 +1,3 @@
+Pro: Java: Taint-mode can now do field-sensitive analysis of class constructors.
+For example, if the default constructor of a class `C` sets its field `x` to a
+tainted value, given `o = new C()`, Semgrep will know that `o.getX()` is tainted.

--- a/src/analyzing/Dataflow_svalue.ml
+++ b/src/analyzing/Dataflow_svalue.ml
@@ -513,6 +513,8 @@ let transfer :
                * call itself as a symbolic expression. *)
               let ccall = sym_prop instr.iorig in
               update_env_with inp' var ccall
+        | New ({ base = Var var; rev_offset = [] }, _ty, _ii, _args) ->
+            update_env_with inp' var (sym_prop instr.iorig)
         | CallSpecial
             (Some { base = Var var; rev_offset = [] }, (special, _), args) ->
             let args = Common.map IL_helpers.exp_of_arg args in

--- a/src/engine/Match_tainting_mode.ml
+++ b/src/engine/Match_tainting_mode.ml
@@ -542,7 +542,7 @@ let rec convert_taint_call_trace = function
 
 let pm_of_finding finding =
   match finding with
-  | T.ArgToArg _
+  | T.ToArg _
   | T.ToReturn _ ->
       None
   | ToSink

--- a/src/il/Display_IL.ml
+++ b/src/il/Display_IL.ml
@@ -4,6 +4,11 @@ open IL
 let string_of_name name =
   Common.spf "%s:%s" (fst name.ident) (AST_generic.SId.show name.sid)
 
+let string_of_type (ty : IL.type_) =
+  match ty.type_.t with
+  | TyN (Id (id, _)) -> fst id
+  | __else__ -> "<TYPE>"
+
 let string_of_base base =
   match base with
   | Var x -> string_of_name x
@@ -70,6 +75,9 @@ let short_string_of_node_kind nkind =
             | Some lval -> string_of_lval lval ^ " = "
           in
           lval_str ^ string_of_exp exp ^ "(" ^ string_of_arguments args ^ ")"
+      | New (lval, ty, _cons, args) ->
+          Common.spf "%s = new %s(%s)" (string_of_lval lval) (string_of_type ty)
+            (string_of_arguments args)
       | CallSpecial (lval_opt, (call_special, _tok), args) ->
           let lval_str =
             match lval_opt with

--- a/src/il/IL.ml
+++ b/src/il/IL.ml
@@ -255,14 +255,15 @@ and 'a argument = Unnamed of 'a | Named of ident * 'a
 (* Types *)
 (*****************************************************************************)
 
-(* THINK: Types contain expressions that we want to check, but right now we don't
- * need to duplicate the type 'type_' just for this (perhaps we could parameterize it?). *)
+(* THINK: Types contain expressions that we want to check (see e.g. 'TyExpr'), but
+ * right now we don't need/want to duplicate the type 'type_' just for this
+ * (perhaps we could parameterize it?). *)
 type type_ = {
   type_ : G.type_;
   exps : exp list;
       (* IL translation of the expressions in `type_`, we want to check them because
-       * these could be sinks! E.g. in `new E(args)` the class/constructor E could be
-       * a sink. *)
+       * these could be sinks! E.g. in PHP you can have `new $cons(args)` and the
+       * constructor $cons could be a sink. See 'tests/rules/misc_php_new_taint.php'. *)
 }
 [@@deriving show { with_path = false }]
 

--- a/src/il/IL.ml
+++ b/src/il/IL.ml
@@ -252,6 +252,21 @@ and 'a argument = Unnamed of 'a | Named of ident * 'a
 [@@deriving show { with_path = false }]
 
 (*****************************************************************************)
+(* Types *)
+(*****************************************************************************)
+
+(* THINK: Types contain expressions that we want to check, but right now we don't
+ * need to duplicate the type 'type_' just for this (perhaps we could parameterize it?). *)
+type type_ = {
+  type_ : G.type_;
+  exps : exp list;
+      (* IL translation of the expressions in `type_`, we want to check them because
+       * these could be sinks! E.g. in `new E(args)` the class/constructor E could be
+       * a sink. *)
+}
+[@@deriving show { with_path = false }]
+
+(*****************************************************************************)
 (* Instruction *)
 (*****************************************************************************)
 
@@ -266,13 +281,13 @@ and instr_kind =
   | AssignAnon of lval * anonymous_entity
   | Call of lval option * exp (* less: enforce lval? *) * exp argument list
   | CallSpecial of lval option * call_special wrap * exp argument list
+  | New of lval * type_ * exp option (* constructor *) * exp argument list
   (* todo: PhiSSA! *)
   | FixmeInstr of fixme_kind * G.any
 
 and call_special =
   | Eval
   (* TODO: lift up like in AST_generic *)
-  | New
   | Typeof
   | Instanceof
   | Sizeof

--- a/src/il/IL_helpers.ml
+++ b/src/il/IL_helpers.ml
@@ -33,7 +33,9 @@ let rexps_of_instr x =
   | Assign (_, exp) -> [ exp ]
   | AssignAnon _ -> []
   | Call (_, e1, args) -> e1 :: Common.map exp_of_arg args
-  | CallSpecial (_, _, args) -> Common.map exp_of_arg args
+  | New (_, _, _, args)
+  | CallSpecial (_, _, args) ->
+      Common.map exp_of_arg args
   | FixmeInstr _ -> []
 
 (* opti: could use a set *)
@@ -81,6 +83,13 @@ let rlvals_of_instr x =
 (* Public *)
 (*****************************************************************************)
 
+let is_pro_resolved_global name =
+  match !(name.id_info.id_resolved) with
+  | Some (GlobalName _, _sid) -> true
+  | Some _
+  | None ->
+      false
+
 let lval_of_var var = { IL.base = Var var; rev_offset = [] }
 
 let is_dots_offset offset =
@@ -95,6 +104,7 @@ let lval_of_instr_opt x =
   | Assign (lval, _)
   | AssignAnon (lval, _)
   | Call (Some lval, _, _)
+  | New (lval, _, _, _)
   | CallSpecial (Some lval, _, _) ->
       Some lval
   | Call _

--- a/src/il/IL_helpers.mli
+++ b/src/il/IL_helpers.mli
@@ -1,3 +1,6 @@
+val is_pro_resolved_global : IL.name -> bool
+(** Test whether a name is global and has been resolved by Pro-naming. *)
+
 val exp_of_arg : IL.exp IL.argument -> IL.exp
 
 (** Lvalue/Rvalue helpers working on the IL *)

--- a/src/tainting/Dataflow_tainting.ml
+++ b/src/tainting/Dataflow_tainting.ml
@@ -234,6 +234,14 @@ let ( let+ ) x f =
   | None -> []
   | Some x -> f x
 
+let _show_fun_exp fun_exp =
+  match fun_exp with
+  | { e = Fetch { base = Var func; rev_offset = [] }; _ } -> fst func.ident
+  | { e = Fetch { base = Var obj; rev_offset = [ { o = Dot method_; _ } ] }; _ }
+    ->
+      Printf.sprintf "%s.%s" (fst obj.ident) (fst method_.ident)
+  | _ -> "<FUNC>"
+
 let status_to_taints = function
   | `None (* no info *)
   | `Clean (* clean, from previous sanitization *)
@@ -308,6 +316,11 @@ let top_level_sinks_in_nodes config flow =
                Seq.cons instr.iorig
                  (match instr.i with
                  | Call (_, c, args) -> Seq.cons c.eorig (origs_of_args args)
+                 | New (_, ty, _, args) ->
+                     let ty_origs =
+                       ty.exps |> List.to_seq |> Seq.map (fun e -> e.eorig)
+                     in
+                     Seq.append ty_origs (origs_of_args args)
                  | CallSpecial (_, _, args) -> origs_of_args args
                  | Assign (_, e) -> List.to_seq [ e.eorig ]
                  | AssignAnon _
@@ -719,14 +732,10 @@ let propagate_taint_via_java_setter env e args all_args_taints =
       else env.lval_env
   | __else__ -> env.lval_env
 
-let resolve_poly_taint_for_java_getters env lval st =
-  (* NOTE: This is a hack and it doesn't handle all cases, but it's mean to handle
-   * the most basic ones. It does work for more than just getters. However, it
-   * needs some testing and for now it's safer to restrict it to Java and getX. *)
+let fix_poly_taint_with_field env lval st =
   if env.lang =*= Java then
     match lval.rev_offset with
-    | { o = Dot n; _ } :: _
-      when Stdcompat.String.starts_with ~prefix:"get" (fst n.ident) -> (
+    | { o = Dot n; _ } :: _ -> (
         match st with
         | `Sanitized
         | `Clean
@@ -889,8 +898,11 @@ let find_lval_taint_sources env ~labels lval =
   let lval_env = Lval_env.add env.lval_env lval taints_sources_mut in
   (Taints.union taints_sources_reg taints_sources_mut, lval_env)
 
-let rec check_tainted_lval env (lval : IL.lval) : Taints.t * Lval_env.t =
-  let new_taints, lval_in_env, lval_env = check_tainted_lval_aux env lval in
+let rec check_tainted_lval env ?(fix_poly_field = false) (lval : IL.lval) :
+    Taints.t * Lval_env.t =
+  let new_taints, lval_in_env, lval_env =
+    check_tainted_lval_aux env ~fix_poly_field lval
+  in
   let taints_from_env = status_to_taints lval_in_env in
   let taints = Taints.union new_taints taints_from_env in
   let sinks =
@@ -902,7 +914,7 @@ let rec check_tainted_lval env (lval : IL.lval) : Taints.t * Lval_env.t =
   report_findings { env with lval_env } findings;
   (taints, lval_env)
 
-and check_tainted_lval_aux env (lval : IL.lval) :
+and check_tainted_lval_aux env ~fix_poly_field (lval : IL.lval) :
     Taints.t
     (* `Sanitized means that the lval matched a sanitizer "right now", whereas
      * `Clean means that the lval has been _previously_ sanitized. They are
@@ -951,7 +963,8 @@ and check_tainted_lval_aux env (lval : IL.lval) :
             (taints, `None, lval_env)
         | { base = _; rev_offset = _ :: rev_offset' } ->
             (* Recursive case, given `x.a.b` we must first check `x.a`. *)
-            check_tainted_lval_aux env { lval with rev_offset = rev_offset' }
+            check_tainted_lval_aux env ~fix_poly_field
+              { lval with rev_offset = rev_offset' }
       in
       (* Check the status of lval in the environemnt. *)
       let lval_in_env =
@@ -963,11 +976,13 @@ and check_tainted_lval_aux env (lval : IL.lval) :
             match Lval_env.dumb_find lval_env lval with
             | (`Clean | `Tainted _) as st' -> st'
             | `None ->
-                (* HACK(field-sensitivity): Java: If we encounter `obj.getX` and `obj` has
-                   * polymorphic taint,  and we know nothing specific about `obj.getX`, then
-                   * we add the same offset `.getX` to the polymorphic taint coming from `obj`.
-                   * See also 'propagate_taint_via_java_setter'. *)
-                resolve_poly_taint_for_java_getters env lval st)
+                if fix_poly_field then
+                  (* HACK(field-sensitivity): If we encounter `obj.x` and `obj` has
+                     * polymorphic taint,  and we know nothing specific about `obj.x`, then
+                     * we add the same offset `.x` to the polymorphic taint coming from `obj`.
+                     * See also 'propagate_taint_via_java_setter'. *)
+                  fix_poly_taint_with_field env lval st
+                else st)
       in
       let taints_from_env = status_to_taints lval_in_env in
       (* Find taint sources matching lval. *)
@@ -1181,7 +1196,9 @@ let taints_of_sig_arg env fparams fun_exp args_exps args_taints
   | __else__ ->
       (* We want to know what's the taint carried by 'arg_exp.x1. ... .xN'. *)
       let* lval, _obj = lval_of_sig_arg fun_exp fparams args_exps sig_arg in
-      let arg_taints = check_tainted_lval env lval |> fst in
+      let arg_taints =
+        check_tainted_lval env ~fix_poly_field:true lval |> fst
+      in
       Some arg_taints
 
 (* This function is consuming the taint signature of a function to determine
@@ -1292,23 +1309,28 @@ let check_function_signature env fun_exp args args_taints =
             findings_of_tainted_sink env incoming_taints sink
             |> report_findings env;
             []
-        | T.ArgToArg (src_arg, tokens, dst_arg) ->
-            let+ src_taints =
-              taints_of_sig_arg env fparams fun_exp args args_taints src_arg
-            in
-            let+ dst_lval, dst_obj =
-              lval_of_sig_arg fun_exp fparams args dst_arg
-            in
-            let dst_taints =
-              src_taints
-              |> Taints.map (fun taint ->
-                     let tokens =
-                       List.rev_append tokens (snd dst_obj.ident :: taint.tokens)
-                     in
-                     { taint with tokens })
-            in
-            if Taints.is_empty dst_taints then []
-            else [ `UpdateEnv (dst_lval, dst_taints) ]
+        | T.ToArg (taints, dst_arg) ->
+            taints
+            |> List.concat_map (fun t ->
+                   let+ dst_lval, dst_obj =
+                     lval_of_sig_arg fun_exp fparams args dst_arg
+                   in
+                   let+ dst_taints =
+                     match t.T.orig with
+                     | Src _ -> Some (Taints.singleton t)
+                     | Arg src_arg ->
+                         taints_of_sig_arg env fparams fun_exp args args_taints
+                           src_arg
+                         |> Option.map
+                              (Taints.map (fun taint ->
+                                   let tokens =
+                                     List.rev_append t.tokens
+                                       (snd dst_obj.ident :: taint.tokens)
+                                   in
+                                   { taint with tokens }))
+                   in
+                   if Taints.is_empty dst_taints then []
+                   else [ `UpdateEnv (dst_lval, dst_taints) ])
       in
       Some
         (fun_sig
@@ -1324,6 +1346,44 @@ let check_function_signature env fun_exp args args_taints =
   | Some _, _ ->
       None
 
+let check_function_callee env e =
+  match e with
+  | {
+   e =
+     Fetch
+       ({ base = Var _obj; rev_offset = [ { o = Dot method_; _ } ] } as e_lval);
+   _;
+  }
+  (* HACK(field-sensitivity):
+   * For Java `getX` methods for which we have no definition available
+   * (or could not be resolved) we just assume that they are getter methods
+   * and we use `fix_poly_field` to add the `.getX` offset in case `_obj`
+   * were a parameter. *)
+    when env.lang =*= Lang.Java
+         && (not (LV.is_pro_resolved_global method_))
+         && Stdcompat.String.starts_with ~prefix:"get" (fst method_.ident) ->
+      check_tainted_lval env ~fix_poly_field:true e_lval
+  | __else__ -> check_tainted_expr env e
+
+let check_function_arguments env args =
+  let args_taints, (lval_env, all_taints) =
+    args
+    |> List.fold_left_map
+         (fun (lval_env, all_taints) arg ->
+           let taints, lval_env =
+             check_tainted_expr { env with lval_env }
+               (IL_helpers.exp_of_arg arg)
+           in
+           let new_acc = (lval_env, taints :: all_taints) in
+           match arg with
+           | Unnamed _ -> (new_acc, Unnamed taints)
+           | Named (id, _) -> (new_acc, Named (id, taints)))
+         (env.lval_env, [])
+    |> Common2.swap
+  in
+  let all_args_taints = List.fold_left Taints.union Taints.empty all_taints in
+  (args_taints, all_args_taints, lval_env)
+
 (* Test whether an instruction is tainted, and if it is also a sink,
  * report the finding too (by side effect). *)
 (* TODO: This should return a new var_env rather than just taint, it
@@ -1335,23 +1395,11 @@ let check_tainted_instr env instr : Taints.t * Lval_env.t =
     | Assign (_, e) -> check_expr env e
     | AssignAnon _ -> (Taints.empty, env.lval_env) (* TODO *)
     | Call (_, e, args) ->
-        let args_taints, (lval_env, all_taints) =
-          args
-          |> List.fold_left_map
-               (fun (lval_env, all_taints) arg ->
-                 let taints, lval_env =
-                   check_expr { env with lval_env } (IL_helpers.exp_of_arg arg)
-                 in
-                 let new_acc = (lval_env, taints :: all_taints) in
-                 match arg with
-                 | Unnamed _ -> (new_acc, Unnamed taints)
-                 | Named (id, _) -> (new_acc, Named (id, taints)))
-               (env.lval_env, [])
-          |> Common2.swap
+        let args_taints, all_args_taints, lval_env =
+          check_function_arguments env args
         in
-        let e_taints, lval_env = check_expr { env with lval_env } e in
-        let all_args_taints =
-          List.fold_left Taints.union Taints.empty all_taints
+        let e_taints, lval_env =
+          check_function_callee { env with lval_env } e
         in
         (* After we introduced Top_sinks, we need to explicitly support sinks like
          * `sink(...)` by considering that all of the parameters are sinks. To make
@@ -1385,6 +1433,21 @@ let check_tainted_instr env instr : Taints.t * Lval_env.t =
          * when `x` is tainted, because the call is represented in IL as `(x.foo)()`.
          * TODO: Properly track taint through objects. *)
         (Taints.union e_taints call_taints, lval_env)
+    | New (_lval, _ty, Some constructor, args) -> (
+        (* 'New' with reference to constructor, although it doesn't mean it has been resolved. *)
+        let args_taints, all_args_taints, lval_env =
+          check_function_arguments env args
+        in
+        match
+          check_function_signature { env with lval_env } constructor args
+            args_taints
+        with
+        | Some (call_taints, lval_env) -> (call_taints, lval_env)
+        | None -> (all_args_taints, lval_env))
+    | New (_, ty, None, args) ->
+        (* 'New' without reference to constructor *)
+        let exps = ty.exps @ (args |> Common.map IL_helpers.exp_of_arg) in
+        exps |> union_map_taints_and_vars env check_expr
     | CallSpecial (_, _, args) ->
         args
         |> Common.map IL_helpers.exp_of_arg
@@ -1453,11 +1516,9 @@ let findings_from_arg_updates_at_exit enter_env exit_env : T.finding list =
              in
              let new_taints = Taints.diff exit_taints enter_taints in
              (* TODO: Also report if taints are _cleaned_. *)
-             new_taints |> Taints.elements
-             |> Common.map_filter (fun taint ->
-                    match taint.T.orig with
-                    | T.Arg t -> Some (T.ArgToArg (t, taint.tokens, arg))
-                    | T.Src _ -> None (* TODO SrcToArg *)))
+             if not (Taints.is_empty new_taints) then
+               [ T.ToArg (new_taints |> Taints.elements, arg) ]
+             else [])
 
 (*****************************************************************************)
 (* Transfer *)
@@ -1517,7 +1578,7 @@ let transfer :
         let lval_env' =
           let has_taints = not (Taints.is_empty taints) in
           match opt_lval with
-          | Some lval ->
+          | Some lval -> (
               if has_taints then
                 (* Instruction returns tainted data, add taints to lval.
                  * See [Taint_lval_env] for details. *)
@@ -1525,7 +1586,14 @@ let transfer :
               else
                 (* Instruction returns safe data, remove taints from lval.
                  * See [Taint_lval_env] for details. *)
-                Lval_env.clean lval_env' lval
+                match x.i with
+                | New _ ->
+                    (* Pro:`x = new T(args)` is interpreted as `x.T(args)` where `T` is the
+                     * constructor. But `x.T` does not return any taint, taint is propagated
+                     * to `x` by side-effect. If clean `x` here, then we would that taint.
+                     * TODO: `new T(args)` should return an "object taint signature". *)
+                    lval_env'
+                | _ -> Lval_env.clean lval_env' lval)
           | None ->
               (* Instruction returns 'void' or its return value is ignored. *)
               lval_env'

--- a/src/tainting/Taint.ml
+++ b/src/tainting/Taint.ml
@@ -178,7 +178,7 @@ type taints_to_sink = {
 type finding =
   | ToSink of taints_to_sink
   | ToReturn of taint list * G.tok
-  | ArgToArg of arg * tainted_tokens * arg (* TODO: CleanArg ? *)
+  | ToArg of taint list * arg (* TODO: CleanArg ? *)
 [@@deriving show]
 
 type signature = finding list
@@ -190,8 +190,10 @@ let _show_finding = function
   | ToSink x -> _show_taints_to_sink x
   | ToReturn (taints, _) ->
       Printf.sprintf "return (%s)" (Common2.string_of_list _show_taint taints)
-  | ArgToArg (a1, _, a2) ->
-      Printf.sprintf "%s ----> %s" (_show_arg a1) (_show_arg a2)
+  | ToArg (taints, a2) ->
+      Printf.sprintf "%s ----> %s"
+        (Common2.string_of_list _show_taint taints)
+        (_show_arg a2)
 
 (*****************************************************************************)
 (* Taint sets *)

--- a/src/tainting/Taint.mli
+++ b/src/tainting/Taint.mli
@@ -67,7 +67,7 @@ type finding =
   | ToReturn of taint list * AST_generic.tok
       (** Taint sources or potentially-tainted arguments
           would reach a `return` statement. *)
-  | ArgToArg of arg * tainted_tokens * arg
+  | ToArg of taint list * arg
 [@@deriving show]
 
 type signature = finding list


### PR DESCRIPTION
Helps PA-2570

test plan:
See returntocorp/semgrep-proprietary#709

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
