### PR TITLE
feat(scala): parse new function types

### DIFF
--- a/languages/scala/ast/AST_scala.ml
+++ b/languages/scala/ast/AST_scala.ml
@@ -179,6 +179,10 @@ and type_ =
   | TyInfix of type_ * ident * type_
   | TyFunction1 of type_ * tok (* '=>' *) * type_
   | TyFunction2 of type_ list bracket * tok (* '=>' *) * type_
+  (* https://docs.scala-lang.org/scala3/reference/new-types/polymorphic-function-types.html *)
+  | TyPoly of binding list * tok (* '=>' *) * type_
+  (* https://docs.scala-lang.org/scala3/reference/new-types/dependent-function-types.html *)
+  | TyDependent of (ident * type_) list * tok (* '=>' *) * type_
   | TyTuple of type_ list bracket
   | TyRepeated of type_ * tok (* '*' *)
   | TyByName of tok (* => *) * type_

--- a/languages/scala/generic/scala_to_generic.ml
+++ b/languages/scala/generic/scala_to_generic.ml
@@ -284,6 +284,19 @@ and v_type_kind = function
         v1 |> Tok.unbracket |> Common.map (fun t -> G.Param (G.param_of_type t))
       in
       G.TyFun (ts, v3)
+  | TyPoly (v1, _v2, v3) ->
+      let v1 = v_list (v_binding None) v1 in
+      let v3 = v_type_ v3 in
+      G.TyFun (v1, v3)
+  | TyDependent (v1, _v2, v3) ->
+      let v1 =
+        v_list
+          (fun (v1, v2) ->
+            G.Param (G.param_of_type ~pname:(Some (v_ident v1)) (v_type_ v2)))
+          v1
+      in
+      let v3 = v_type_ v3 in
+      G.TyFun (v1, v3)
   | TyTuple v1 ->
       let v1 = v_bracket (v_list v_type_) v1 in
       G.TyTuple v1

--- a/tests/parsing/scala/function_types.scala
+++ b/tests/parsing/scala/function_types.scala
@@ -1,0 +1,8 @@
+
+val x: T => T2 = 1
+val x: () => T2 = 1
+val x: (=> T) => T2 = 1
+val x: (c: Char) => T = 1
+val x: (c: Char, y: Int) => T = 1
+val x: [X] => T = 1
+val x: [X] => (c: Char) => T = 1


### PR DESCRIPTION
## What:
This PR adds the ability to parse Scala 3's new dependent and polymorphic function types.

## Why:
Scala 3

## How:
I added in the `FunType` nonterminal, which subsumes the previous function type nonterminal. 

In doing so, I had to change `param` to be OK with no annotations (which it should have been, from the grammar specification, anyways). I'm overloading `param` for a lot of things, including `HKClauseParam`, but that's OK, it should suffice for most cases.

## Test plan:
Included test, and parse rate `0.9837808999988299 ` -> `0.98381817133808`

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
