### PR TITLE
feat(scala): parse interpolated strings without newlines

### DIFF
--- a/languages/scala/recursive_descent/Parser_scala_recursive_descent.ml
+++ b/languages/scala/recursive_descent/Parser_scala_recursive_descent.ml
@@ -4885,7 +4885,6 @@ let try_rule toks frule =
   x
 
 let parse toks =
-  Common.(pr2 (spf "toks %s" ([%show: token list] toks)));
   try try_rule toks compilationUnit with
   | Parsing_error.Syntax_error _ as err1 -> (
       let e1 = Exception.catch err1 in

--- a/languages/scala/recursive_descent/Parser_scala_recursive_descent.ml
+++ b/languages/scala/recursive_descent/Parser_scala_recursive_descent.ml
@@ -2256,39 +2256,53 @@ and interpolatedString ~inPattern in_ =
   (* ast: let interpolater = in.name.encoded,  *)
   (* ast: let partsBuf = ref [] in let exprsBuf = ref [] in *)
   let xs = ref [] in
+  let ii = TH.info_of_tok in_.token in
   nextToken in_;
-  (* T_INTERPOLATED_START(s,info) *)
-  while TH.is_stringpart in_.token do
-    (* pad: in original code, but the interpolated string can start with
-     * a non string literal like $f, so I've commented this code.
-     * let x = literal in_ in
-     * if inPattern
-     * then todo "interpolatedString: inPattern (dropAnyBraces(pattern))" in_
-     * else
-     *)
-    match in_.token with
-    (* pad: the original code  uses IDENTIFIER but Lexer_scala.mll
-     * introduces a new token for $xxx.
-     * STILL? the original code also allow 'this', but ID_DOLLAR should cover
-     * that?
-     *)
-    | ID_DOLLAR _ ->
-        let x = ident in_ in
-        (* ast: Ident(x) *)
-        xs += EncapsDollarIdent x
-    (* actually a ${, but using LBRACE allows to reuse blockExpr *)
-    | LBRACE _ ->
-        let x = expr in_ in
-        (* ast: x *)
-        xs += EncapsExpr x
-    (* pad: not in original code, but the way Lexer_scala.mll is written
-     * we can have multiple consecutive StringLiteral *)
-    | StringLiteral x ->
-        nextToken in_;
-        xs += EncapsStr x
-    | _ ->
-        error "error in interpolated string: identifier or block expected" in_
-  done;
+  (* While parsing interpolated string components, we don't want
+     to emit NEWLINEs or DEDENTs.
+
+     This helps us in cases like:
+
+     object Foo:
+       val x = s"""
+     hi there"""
+  *)
+  inSepRegion (T_INTERPOLATED_END ii)
+    (fun () ->
+      (* T_INTERPOLATED_START(s,info) *)
+      while TH.is_stringpart in_.token do
+        (* pad: in original code, but the interpolated string can start with
+         * a non string literal like $f, so I've commented this code.
+         * let x = literal in_ in
+         * if inPattern
+         * then todo "interpolatedString: inPattern (dropAnyBraces(pattern))" in_
+         * else
+         *)
+        match in_.token with
+        (* pad: the original code  uses IDENTIFIER but Lexer_scala.mll
+         * introduces a new token for $xxx.
+         * STILL? the original code also allow 'this', but ID_DOLLAR should cover
+         * that?
+         *)
+        | ID_DOLLAR _ ->
+            let x = ident in_ in
+            (* ast: Ident(x) *)
+            xs += EncapsDollarIdent x
+        (* actually a ${, but using LBRACE allows to reuse blockExpr *)
+        | LBRACE _ ->
+            let x = expr in_ in
+            (* ast: x *)
+            xs += EncapsExpr x
+        (* pad: not in original code, but the way Lexer_scala.mll is written
+         * we can have multiple consecutive StringLiteral *)
+        | StringLiteral x ->
+            nextToken in_;
+            xs += EncapsStr x
+        | _ ->
+            error "error in interpolated string: identifier or block expected"
+              in_
+      done)
+    in_;
   (* pad: not in original code *)
   let ii = TH.info_of_tok in_.token in
   accept (T_INTERPOLATED_END ab) in_;
@@ -4871,6 +4885,7 @@ let try_rule toks frule =
   x
 
 let parse toks =
+  Common.(pr2 (spf "toks %s" ([%show: token list] toks)));
   try try_rule toks compilationUnit with
   | Parsing_error.Syntax_error _ as err1 -> (
       let e1 = Exception.catch err1 in

--- a/tests/parsing/scala/interpolated_string_no_dedent.scala
+++ b/tests/parsing/scala/interpolated_string_no_dedent.scala
@@ -1,0 +1,10 @@
+
+// We don't want a DEDENT or a NEWLINE to be posted before
+// this $z. If it is, it will mess up our string interpolation
+// parsing.
+
+def foo(): String =
+  val x = 2 
+
+  s"""foo: $x (bar: $y)
+$z"""

--- a/tests/parsing/scala/interpolated_string_no_dedent.scala
+++ b/tests/parsing/scala/interpolated_string_no_dedent.scala
@@ -8,3 +8,10 @@ def foo(): String =
 
   s"""foo: $x (bar: $y)
 $z"""
+
+def foo(): String =
+  val x = 2 
+
+  s"""foo: $x (bar: $y)
+$z"""
+  val y = 3


### PR DESCRIPTION
## What:
This PR suppresses the output of NEWLINEs while parsing interpolated strings.

## Why:
If you had a program like 
```
def foo(): String =
  val x = 2 

  s"""foo: $x (bar: $y)
$z"""
```
the parser could emit a NEWLINE before the `$z`, because it's inside of a blockStatSeq. This is bad, because this will completely mess up the interpolated string parsing. We want to suppress them while parsing an interpolated string, because the contents of a string could have whatever spacing.

## How:
We just add a `sepRegion` while we are parsing the interpolated string contents. This guarantees we do not emit NEWLINEs or DEDENTs.

## Test plan:
Included test, and parse rate `0.98381817133808` -> `0.9841003067084511`

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
