### PR TITLE
feat(scala): soft `export`, fix template intro

### DIFF
--- a/languages/scala/recursive_descent/Lexer_scala.mll
+++ b/languages/scala/recursive_descent/Lexer_scala.mll
@@ -395,6 +395,16 @@ rule token = parse
         | "package"     -> Kpackage t
         | "import"   -> Kimport t
 
+        (* Scala 3: There are more keywords, but they are "soft" keywords,
+           meaning that we cannot lex them here as keywords!
+
+           Soft keywords behave like keywords only in certain contextual
+           situations, and otherwise behave as normal identifiers.
+
+           We just case on them as `ID_LOWER` in `Parser_scala_recursive_descent`,
+           such as `accept (ID_LOWER ("export", ab)) in_`.
+         *)
+
         | "abstract"       -> Kabstract t
         | "final"       -> Kfinal t
         | "private"       -> Kprivate t

--- a/languages/scala/recursive_descent/Lexer_scala.mll
+++ b/languages/scala/recursive_descent/Lexer_scala.mll
@@ -394,7 +394,6 @@ rule token = parse
 
         | "package"     -> Kpackage t
         | "import"   -> Kimport t
-        | "export"   -> Kexport t
 
         | "abstract"       -> Kabstract t
         | "final"       -> Kfinal t

--- a/languages/scala/recursive_descent/Parser_scala_recursive_descent.ml
+++ b/languages/scala/recursive_descent/Parser_scala_recursive_descent.ml
@@ -3106,7 +3106,7 @@ let importClause in_ : import =
 *)
 let exportClause in_ : import =
   let ii = TH.info_of_tok in_.token in
-  accept (Kexport ab) in_;
+  accept (ID_LOWER ("export", ab)) in_;
   let xs = commaSeparated importExpr in_ in
   (ii, xs)
 
@@ -3865,7 +3865,7 @@ let usingParamClauses ~owner in_ =
 
 let extMethod in_ : ext_method =
   match in_.token with
-  | Kexport _ -> ExtExport (exportClause in_)
+  | ID_LOWER ("export", _) -> ExtExport (exportClause in_)
   | _ ->
       let annots = annotations ~skipNewLines:true in_ in
       let mods = modifiers in_ in
@@ -4119,7 +4119,8 @@ let templateStat in_ : template_stat option =
   | Kimport _ ->
       let x = importClause in_ in
       Some (I x)
-  | Kexport _ ->
+  | ID_LOWER ("export", _)
+    when lookingAhead (fun in_ -> TH.isPathStart in_.token) in_ ->
       let x = exportClause in_ in
       Some (Ex x)
   | ID_LOWER ("end", _) ->
@@ -4163,7 +4164,8 @@ let topStat in_ : top_stat option =
   | Kimport _ ->
       let x = importClause in_ in
       Some (I x)
-  | Kexport _ ->
+  | ID_LOWER ("export", _)
+    when lookingAhead (fun in_ -> TH.isPathStart in_.token) in_ ->
       let x = exportClause in_ in
       Some (Ex x)
   | ID_LOWER ("end", _) ->
@@ -4216,7 +4218,7 @@ let templateStatSeq ~isPre in_ : self_type option * block =
          If we did not do this, template stats that start with those would always
          enter this expression case, even though they denote something else.
       *)
-      && not (TH.isTemplateIntro in_.token)
+      && not (TH.isTemplateStatIntroSoftKeyword in_.token)
     then (
       let first = expr ~location:InTemplate in_ in
       match in_.token with

--- a/languages/scala/recursive_descent/Token_helpers_scala.ml
+++ b/languages/scala/recursive_descent/Token_helpers_scala.ml
@@ -408,9 +408,9 @@ let isLocalModifier = function
    but contextually may act as keywords.
    When deciding if we want to parse a templateStat, we first check for
    expressions. This would incorrectly flag these soft keywords, which can
-   otherwise start a templateStat, so this function whitelists them to not 
+   otherwise start a templateStat, so this function whitelists them to not
    enter the `expr` case, in favor of parsing them as templateStat keywords.
- *)
+*)
 let isTemplateStatIntroSoftKeyword = function
   | ID_LOWER ("given", _)
   | ID_LOWER ("end", _)

--- a/languages/scala/recursive_descent/Token_helpers_scala.ml
+++ b/languages/scala/recursive_descent/Token_helpers_scala.ml
@@ -249,6 +249,12 @@ let inLastOfStat x =
 (* Used in the parser *)
 (* ------------------------------------------------------------------------- *)
 
+(* This function is for using a token of lookahead to check whether we should
+   enter an exportClause.
+   Since an `export` used as a keyword is always followed by an `id`, we can
+   prevent more false positives of `export` used as a keyword when it shouldn't,
+   by looking ahead a token.
+*)
 let isPathStart = function
   | ID_LOWER _
   | ID_UPPER _
@@ -398,14 +404,19 @@ let isLocalModifier = function
 (* Construct Intro *)
 (* ------------------------------------------------------------------------- *)
 
+(* Some keywords are "soft keywords", which means they are lexed as identifiers,
+   but contextually may act as keywords.
+   When deciding if we want to parse a templateStat, we first check for
+   expressions. This would incorrectly flag these soft keywords, which can
+   otherwise start a templateStat, so this function whitelists them to not 
+   enter the `expr` case, in favor of parsing them as templateStat keywords.
+ *)
 let isTemplateStatIntroSoftKeyword = function
   | ID_LOWER ("given", _)
   | ID_LOWER ("end", _)
   | ID_LOWER ("export", _)
   | ID_LOWER ("extension", _) ->
       true
-  (*TODO | Kcaseobject | | Kcaseclass *)
-  | Kcase _ -> true
   | _ -> false
 
 let isDclIntro = function

--- a/languages/scala/recursive_descent/Token_helpers_scala.ml
+++ b/languages/scala/recursive_descent/Token_helpers_scala.ml
@@ -135,7 +135,6 @@ let visitor_info_of_tok f = function
   | Kmatch ii -> Kmatch (f ii)
   | Klazy ii -> Klazy (f ii)
   | Kimport ii -> Kimport (f ii)
-  | Kexport ii -> Kexport (f ii)
   | Kimplicit ii -> Kimplicit (f ii)
   | Kif ii -> Kif (f ii)
   | KforSome ii -> KforSome (f ii)
@@ -249,6 +248,17 @@ let inLastOfStat x =
 (* ------------------------------------------------------------------------- *)
 (* Used in the parser *)
 (* ------------------------------------------------------------------------- *)
+
+let isPathStart = function
+  | ID_LOWER _
+  | ID_UPPER _
+  | ID_BACKQUOTED _
+  | OP _
+  | ID_DOLLAR _
+  | Kthis _
+  | Ksuper _ ->
+      true
+  | _ -> false
 
 let isIdent = function
   | ID_LOWER ("given", _) -> None
@@ -388,13 +398,10 @@ let isLocalModifier = function
 (* Construct Intro *)
 (* ------------------------------------------------------------------------- *)
 
-let isTemplateIntro = function
-  | Kobject _
-  | Kclass _
-  | Kenum _
-  | Ktrait _
+let isTemplateStatIntroSoftKeyword = function
   | ID_LOWER ("given", _)
   | ID_LOWER ("end", _)
+  | ID_LOWER ("export", _)
   | ID_LOWER ("extension", _) ->
       true
   (*TODO | Kcaseobject | | Kcaseclass *)
@@ -435,7 +442,17 @@ let isExprIntro x =
       true
   | _ -> false
 
-let isDefIntro x = isTemplateIntro x || isDclIntro x
+let isTemplateDefIntro x =
+  match x with
+  | Kobject _
+  | Kclass _
+  | Ktrait _
+  | Kenum _
+  | ID_LOWER ("given", _) ->
+      true
+  | _ -> false
+
+let isDefIntro x = isDclIntro x || isTemplateDefIntro x
 
 let isTypeIntroToken x =
   (isLiteral x && not (isNull x))

--- a/languages/scala/recursive_descent/Token_scala.ml
+++ b/languages/scala/recursive_descent/Token_scala.ml
@@ -53,7 +53,6 @@ type token =
   | Kmatch of Tok.t
   | Klazy of Tok.t
   | Kimport of Tok.t
-  | Kexport of Tok.t
   | Kimplicit of Tok.t
   | Kif of Tok.t
   | KforSome of Tok.t

--- a/tests/parsing/scala/soft_keywords.scala
+++ b/tests/parsing/scala/soft_keywords.scala
@@ -1,0 +1,8 @@
+
+val x = foo { export =>
+  // here, we scan one token ahead and see "export" is not followed by
+  // an ident... so we treat it as an expr
+  export match {
+    case _ => 2
+  }
+}


### PR DESCRIPTION
## What:
This PR makes it so that `export` is now properly a soft keyword again, as well as fixing `isDefIntro` to not incorrectly
flag things which start `TmplStat`, as opposed to `TmplDef` (which is correct)

## Why:
Before, when implementing `export`, I took the path of least resistance and just made it a keyword, with the logic that it would be easier to see whether or not this had a significant effect on parse rate later. It turns out, it does, so we need to not do that.

## How:
In addition, our `isDefIntro` function relies on `isTemplateIntro`. Unfortunately, this is only correct if `isTemplateIntro` corresponds to tokens that start template _defs_, but not template _stats_, which includes other things like end markers, extensions, and exports (which have only been added recently). This means that we enter the `Def` case even in cases where we shouldn't, so I fixed it (and gave it a more descriptive name) so we don't conflate the two.

I also just deleted the `export` keyword, and added proper handling for exports elsewhere. The machinery for making sure we don't use `export` as an identifier in places we shouldn't is fairly streamlined, so I just added it to the (newly named) function `isTemplateIntroSoftKeyword`.

Oh yeah, making `export` soft also makes it so we might spuriously enter the `exportClause` nonterminal when `export` starts a `templateStat` or similar, so I also added a token of lookahead, so we only enter `exportClause` when it's followed by an `id`.

## Test plan:
Included test, and parse rate `0.9841003067084511` -> `0.9883969120262044`

Closes PA-2748

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
