### PR TITLE
test: Mark test_git_url_parser test as quick

### DIFF
--- a/cli/tests/e2e/test_meta.py
+++ b/cli/tests/e2e/test_meta.py
@@ -1,6 +1,9 @@
+import pytest
+
 from semgrep.meta import get_url_from_sstp_url
 
 
+@pytest.mark.quick
 def test_git_url_parser():
     tests = [
         # This used to cause the URL parser to crash.


### PR DESCRIPTION
`make` was failing because it checks that all the tests are marked with their quickness. I'm not sure why this never gets checked in CI.

Test plan: `make`

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
