### PR TITLE
Fix cleanup of opam files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,9 +156,10 @@ clean:
 core-clean:
 	dune clean
 	rm -f bin
-	# we still need to keep the nonempty opam files in git for
+	# We still need to keep the nonempty opam files in git for
 	# 'make setup', so we should only remove the empty opam files.
-	#rm -f *.opam
+	# This removes the gitignored opam files.
+	git clean -fX *.opam
 
 ###############################################################################
 # Install targets


### PR DESCRIPTION
test plan:
```
make
ls *.opam
make clean
```
Check that most of the *.opam files are gone after `make clean`.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
