### PR TITLE
osemgrep: move more reporting stuff out of Scan_subcommand.ml

### DIFF
--- a/src/osemgrep/TOPORT/semgrep_main.py
+++ b/src/osemgrep/TOPORT/semgrep_main.py
@@ -239,7 +239,6 @@ def main(
     pattern: Optional[str],
     lang: Optional[str],
     configs: Sequence[str],
-    no_rewrite_rule_ids: bool = False,
     jobs: int = 1,
     include: Optional[Sequence[str]] = None,
     exclude: Optional[Sequence[str]] = None,

--- a/src/osemgrep/cli_scan/Cli_json_output.ml
+++ b/src/osemgrep/cli_scan/Cli_json_output.ml
@@ -92,7 +92,7 @@ let config_prefix_of_rules_source (src : Rule_fetching.rules_source) : string =
    * call Semgrep_dashdash_config.config_kind_of_config_str
    *)
   match src with
-  | Rule_fetching.Configs (path :: _TODO) ->
+  | Rules_source.Configs (path :: _TODO) ->
       (*  need to prefix with the dotted path of the config file *)
       let dir = Filename.dirname path in
       Str.global_replace (Str.regexp "/") "." dir ^ "."

--- a/src/osemgrep/cli_scan/Rule_fetching.ml
+++ b/src/osemgrep/cli_scan/Rule_fetching.ml
@@ -19,15 +19,8 @@ module C = Semgrep_dashdash_config
 (*****************************************************************************)
 
 (* input *)
-type rules_source =
-  (* -e/-l/--replacement. In theory we could even parse the string to get
-   * a XPattern.t *)
-  | Pattern of string * Xlang.t * string option (* replacement *)
-  (* --config. In theory we could even parse the string to get
-   * some Semgrep_dashdash_config.config_kind list *)
-  | Configs of string list
-(* TODO? | ProjectUrl of Uri.t? or just use Configs for it? *)
-[@@deriving show]
+(* moved in a core/Rules_source.ml so it can also be used in reporting/ *)
+type rules_source = Rules_source.t [@@deriving show]
 
 (* output *)
 (* python: was called ConfigFile, and called a 'config' in text output *)

--- a/src/osemgrep/cli_scan/Rule_fetching.mli
+++ b/src/osemgrep/cli_scan/Rule_fetching.mli
@@ -1,13 +1,5 @@
 (* input *)
-type rules_source =
-  (* -e/-l/--replacement. In theory we could even parse the string to get
-   * a XPattern.t *)
-  | Pattern of string * Xlang.t * string option (* replacement *)
-  (* --config. In theory we could even parse the string to get
-   * some Semgrep_dashdash_config.config_kind list *)
-  | Configs of Semgrep_dashdash_config.config_str list
-(* TODO? | ProjectUrl of Uri.t? or just use Configs for it? *)
-[@@deriving show]
+type rules_source = Rules_source.t [@@deriving show]
 
 (* output *)
 type rules_and_origin = {

--- a/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -654,7 +654,7 @@ let cmdline_term : conf Term.t =
       | [], (None, _, _)
         when dump_ast || dump_config <> None || validate || test || version
              || show_supported_languages ->
-          Rule_fetching.Configs []
+          Rules_source.Configs []
       (* TOPORT: handle get_project_url() if empty Configs? *)
       | [], (None, _, _) ->
           (* alt: default.rules_source *)
@@ -668,7 +668,7 @@ let cmdline_term : conf Term.t =
       | [], (Some pat, Some str, fix) ->
           (* may raise a Failure (will be caught in CLI.safe_run) *)
           let xlang = Xlang.of_string str in
-          Rule_fetching.Pattern (pat, xlang, fix)
+          Rules_source.Pattern (pat, xlang, fix)
       | _, (Some _, None, _) ->
           (* alt: "language must be specified when a pattern is passed" *)
           Error.abort "-e/--pattern and -l/--lang must both be specified"
@@ -680,7 +680,7 @@ let cmdline_term : conf Term.t =
             "command-line replacement flag can only be used with command-line \
              pattern; when using a config file add the fix: key instead"
       (* TOPORT? handle [x], _ and rule passed inline, python: util.is_rules*)
-      | xs, (None, None, None) -> Rule_fetching.Configs xs
+      | xs, (None, None, None) -> Rules_source.Configs xs
       | _ :: _, (Some _, _, _) ->
           Error.abort "Mutually exclusive options --config/--pattern"
     in

--- a/src/osemgrep/cli_scan/Validate_subcommand.ml
+++ b/src/osemgrep/cli_scan/Validate_subcommand.ml
@@ -76,8 +76,8 @@ let run (conf : conf) : Exit_code.t =
   (* Checking (3) *)
   let metacheck_errors =
     match conf.rules_source with
-    | Rule_fetching.Pattern _ -> []
-    | Rule_fetching.Configs _xs ->
+    | Rules_source.Pattern _ -> []
+    | Rules_source.Configs _xs ->
         (* In a validate context, rules are actually targets of metarules.
          * alt: could also process Configs to compute the targets.
          *)

--- a/src/osemgrep/core/Rules_source.ml
+++ b/src/osemgrep/core/Rules_source.ml
@@ -1,0 +1,9 @@
+type t =
+  (* -e/-l/--replacement. In theory we could even parse the string to get
+   * a XPattern.t *)
+  | Pattern of string * Xlang.t * string option (* replacement *)
+  (* --config. In theory we could even parse the string to get
+   * some Semgrep_dashdash_config.config_kind list *)
+  | Configs of string (* Semgrep_dashdash_config.config_str *) list
+(* TODO? | ProjectUrl of Uri.t? or just use Configs for it? *)
+[@@deriving show]

--- a/src/osemgrep/reporting/Rules_report.ml
+++ b/src/osemgrep/reporting/Rules_report.ml
@@ -1,0 +1,40 @@
+(*****************************************************************************)
+(* Prelude *)
+(*****************************************************************************)
+(* Reporting the config and rules used to the user *)
+
+(*****************************************************************************)
+(* Helpers *)
+(*****************************************************************************)
+
+let pp_rule_sources ppf = function
+  | Rules_source.Pattern _ -> Format.pp_print_string ppf "pattern"
+  | Configs [ x ] -> Format.fprintf ppf "1 config %s" x
+  | Configs xs -> Format.fprintf ppf "%d configs" (List.length xs)
+
+(*****************************************************************************)
+(* Entry point *)
+(*****************************************************************************)
+
+let pp_rules ppf (rules_source, filtered_rules) =
+  Fmt.pf ppf "running %d rules from %a@."
+    (List.length filtered_rules)
+    pp_rule_sources rules_source;
+  (* TODO should output whether .semgrepignore is found and used
+     (as done in semgrep_main.py get_file_ignore()) *)
+  Fmt.pf ppf "Rules:@.";
+  let exp, normal =
+    filtered_rules
+    |> List.partition (fun rule -> rule.Rule.severity = Rule.Experiment)
+  in
+
+  let rule_id r = fst r.Rule.id in
+  let sorted =
+    List.sort (fun r1 r2 -> String.compare (rule_id r1) (rule_id r2))
+  in
+  sorted normal |> List.iter (fun rule -> Fmt.pf ppf "- %s@." (rule_id rule));
+  match exp with
+  | [] -> ()
+  | __non_empty__ ->
+      Fmt.pf ppf "Experimental rules:@.";
+      sorted exp |> List.iter (fun rule -> Fmt.pf ppf "- %s@." (rule_id rule))

--- a/src/osemgrep/reporting/Rules_report.mli
+++ b/src/osemgrep/reporting/Rules_report.mli
@@ -1,0 +1,1 @@
+val pp_rules : Format.formatter -> Rules_source.t * Rule.t list -> unit

--- a/src/osemgrep/reporting/Skipped_report.ml
+++ b/src/osemgrep/reporting/Skipped_report.ml
@@ -32,9 +32,10 @@ let pp_skipped ppf
       * Out.skipped_target list
       * Out.skipped_target list
       * Out.skipped_target list) =
+  (* not sure why but pysemgrep does not use the classic heading for skipped*)
   Fmt.pf ppf "%s@.Files skipped:@.%s@." (String.make 40 '=')
     (String.make 40 '=');
-  Fmt_helpers.pp_heading ppf "Files skipped";
+  (* nope: Fmt_helpers.pp_heading ppf "Files skipped"; *)
   (* TODO: always skipped *)
   Fmt.pf ppf " %a@." Fmt.(styled `Bold string) "Skipped by .gitignore:";
   if respect_git_ignore then (

--- a/src/osemgrep/reporting/Targets_report.ml
+++ b/src/osemgrep/reporting/Targets_report.ml
@@ -1,0 +1,15 @@
+open File.Operators
+
+let pp_targets_debug ppf (target_roots, semgrepignored_targets, targets) =
+  Fmt.pf ppf "target roots: [@.";
+  target_roots |> List.iter (fun root -> Fmt.pf ppf "  %s@." !!root);
+  Fmt.pf ppf "]@.";
+  Fmt.pf ppf "skipped targets: [@.";
+  semgrepignored_targets
+  |> List.iter (fun x ->
+         Fmt.pf ppf "  %s" (Output_from_core_t.show_skipped_target x));
+  Fmt.pf ppf "]@.";
+  Fmt.pf ppf "selected targets: [@.";
+  targets |> List.iter (fun file -> Fmt.pf ppf "target = %s@." !!file);
+  Fmt.pf ppf "]@.";
+  ()

--- a/src/osemgrep/reporting/Targets_report.mli
+++ b/src/osemgrep/reporting/Targets_report.mli
@@ -1,0 +1,6 @@
+val pp_targets_debug :
+  Format.formatter ->
+  Fpath.t list (* target roots *)
+  * Semgrep_output_v1_t.skipped_target list
+  * Fpath.t list (* final targets *) ->
+  unit

--- a/src/osemgrep/reporting/dune
+++ b/src/osemgrep/reporting/dune
@@ -6,6 +6,7 @@
    commons
    fmt
    terminal_size
+   osemgrep_core
    semgrep.reporting
  )
  (preprocess


### PR DESCRIPTION
The main algorithm should not be obfuscated by reporting

test plan:
make core


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)