### PR TITLE
osemgrep: add right prefix to rule id for local configs

### DIFF
--- a/cli/tests/e2e/test_check.py
+++ b/cli/tests/e2e/test_check.py
@@ -264,6 +264,7 @@ def test_multiline(run_semgrep_in_tmp: RunSemgrep, snapshot):
     )
 
 
+@pytest.mark.osempass
 @pytest.mark.slow
 def test_url_rule(run_semgrep_in_tmp: RunSemgrep, snapshot):
     snapshot.assert_match(
@@ -283,6 +284,7 @@ def test_auto_config(run_semgrep_in_tmp: RunSemgrep, mocker):
     assert True
 
 
+@pytest.mark.osempass
 @pytest.mark.kinda_slow
 def test_hidden_rule__explicit(run_semgrep_in_tmp: RunSemgrep, snapshot):
     snapshot.assert_match(

--- a/cli/tests/e2e/test_metavariable_pattern.py
+++ b/cli/tests/e2e/test_metavariable_pattern.py
@@ -2,6 +2,7 @@ import pytest
 from tests.fixtures import RunSemgrep
 
 
+@pytest.mark.osempass
 @pytest.mark.kinda_slow
 def test1(run_semgrep_in_tmp: RunSemgrep, snapshot):
     # https://github.com/returntocorp/semgrep/issues/7271
@@ -15,8 +16,8 @@ def test1(run_semgrep_in_tmp: RunSemgrep, snapshot):
     )
 
 
-@pytest.mark.kinda_slow
 @pytest.mark.osempass
+@pytest.mark.kinda_slow
 def test2(run_semgrep_in_tmp: RunSemgrep, snapshot):
     # https://linear.app/r2c/issue/PA-2696
     snapshot.assert_match(

--- a/src/osemgrep/TOPORT/config_resolver.py
+++ b/src/osemgrep/TOPORT/config_resolver.py
@@ -232,12 +232,6 @@ class Config:
         return cls(valid), errors
 
     def get_rules(self, no_rewrite_rule_ids: bool) -> List[Rule]:
-        """
-        Return list of rules
-
-        If no_rewrite_rule_ids is True will not add
-        path to config file to start of rule_ids
-        """
         configs = self.valid
         if not no_rewrite_rule_ids:
             # re-write the configs to have the hierarchical rule ids
@@ -273,14 +267,6 @@ class Config:
         if len(prefix):
             prefix += "."
         return prefix
-
-    @staticmethod
-    def _rename_rule_ids(valid_configs: Mapping[str, Sequence[Rule]]) -> None:
-        for config_id, rules in valid_configs.items():
-            for rule in rules:
-                rule.rename_id(
-                    f"{Config._convert_config_id_to_prefix(config_id)}{rule.id or MISSING_RULE_ID}"
-                )
 
     @staticmethod
     def _validate(

--- a/src/osemgrep/TOPORT/rule.py
+++ b/src/osemgrep/TOPORT/rule.py
@@ -110,10 +110,6 @@ class Rule:
             return self._yaml.value["languages"].span
         return EmptySpan
 
-    def rename_id(self, new_id: str) -> None:
-        self._id = new_id
-        self._raw["id"] = new_id
-
     @property
     def full_hash(self) -> str:
         """

--- a/src/osemgrep/cli_scan/Cli_json_output.ml
+++ b/src/osemgrep/cli_scan/Cli_json_output.ml
@@ -30,14 +30,7 @@ module Out = Semgrep_output_v1_j
 (*****************************************************************************)
 
 (* environment to pass to the JSON cli_output generator *)
-type env = {
-  hrules : Rule.hrules;
-  (* string to prefix all rule_id with
-   * (e.g., "xxx.tests." if the --config argument
-    * was xxx/tests/osemgrep.yml)
-   *)
-  config_prefix : string;
-}
+type env = { hrules : Rule.hrules }
 
 (* LATER: use Metavariable.bindings directly ! *)
 type metavars = (string * Out.metavar_value) list
@@ -83,20 +76,6 @@ let contents_of_file (range : Out.position * Out.position) (file : filename) :
 (*****************************************************************************)
 (* Helpers *)
 (*****************************************************************************)
-
-(* TODO: probably want to use Config_resolver.rules_and_origin to
- * get the prefix
- *)
-let config_prefix_of_rules_source (src : Rule_fetching.rules_source) : string =
-  (* TODO: what if it's a registry rule?
-   * call Semgrep_dashdash_config.config_kind_of_config_str
-   *)
-  match src with
-  | Rules_source.Configs (path :: _TODO) ->
-      (*  need to prefix with the dotted path of the config file *)
-      let dir = Filename.dirname path in
-      Str.global_replace (Str.regexp "/") "." dir ^ "."
-  | _else_ -> ""
 
 (* Substitute the metavariables mentioned in a message to their
  * matched content.
@@ -355,8 +334,7 @@ let cli_match_of_core_match (env : env) (m : Out.core_match) : Out.cli_match =
         | None -> ""
       in
       let fix = render_fix env m in
-      (*  need to prefix with the dotted path of the config file *)
-      let check_id = env.config_prefix ^ rule_id in
+      let check_id = rule_id in
       let metavars = Some metavars in
       (* LATER: this should be a variant in semgrep_output_v1.atd
        * and merged with Constants.rule_severity
@@ -446,8 +424,8 @@ let cli_skipped_targets ~(skipped_targets : Out.skipped_target list) :
 (* Entry point *)
 (*****************************************************************************)
 
-let cli_output_of_core_results ~logging_level ~rules_source
-    (res : Core_runner.result) : Out.cli_output =
+let cli_output_of_core_results ~logging_level (res : Core_runner.result) :
+    Out.cli_output =
   match res.core with
   | {
    matches;
@@ -461,12 +439,7 @@ let cli_output_of_core_results ~logging_level ~rules_source
    rules_by_engine = _;
    engine_requested = _;
   } ->
-      let env =
-        {
-          hrules = res.hrules;
-          config_prefix = config_prefix_of_rules_source rules_source;
-        }
-      in
+      let env = { hrules = res.hrules } in
       (* TODO: not sure how it's sorted. Look at rule_match.py keys? *)
       let matches =
         matches

--- a/src/osemgrep/cli_scan/Cli_json_output.mli
+++ b/src/osemgrep/cli_scan/Cli_json_output.mli
@@ -1,8 +1,6 @@
 (* entry point *)
 val cli_output_of_core_results :
   logging_level:Logs.level option ->
-  (* TODO: should not be needed at some point *)
-  rules_source:Rule_fetching.rules_source ->
   Core_runner.result ->
   Semgrep_output_v1_j.cli_output
 

--- a/src/osemgrep/cli_scan/Output.ml
+++ b/src/osemgrep/cli_scan/Output.ml
@@ -162,7 +162,7 @@ let output_result (conf : Scan_CLI.conf) (res : Core_runner.result) :
    *)
   let cli_output : Out.cli_output =
     Cli_json_output.cli_output_of_core_results ~logging_level:conf.logging_level
-      ~rules_source:conf.rules_source res
+      res
   in
   let cli_output =
     let keep_ignored =

--- a/src/osemgrep/cli_scan/Rule_fetching.mli
+++ b/src/osemgrep/cli_scan/Rule_fetching.mli
@@ -13,10 +13,12 @@ and origin = Fpath.t option (* None for remote files *) [@@deriving show]
 val partition_rules_and_errors :
   rules_and_origin list -> Rule.rules * Rule.invalid_rule_error list
 
-(* [rules_from_rules_source] returns rules from --config or -e
- * TODO: does it rewrite the rule_id?
+(* [rules_from_rules_source] returns rules from --config or -e.
+ * If [rewrite_rule_ids] is true, it will add the path to the config
+ * file to the start of rule_ids.
  *)
-val rules_from_rules_source : rules_source -> rules_and_origin list
+val rules_from_rules_source :
+  rewrite_rule_ids:bool -> rules_source -> rules_and_origin list
 
 (* internals *)
 

--- a/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -191,7 +191,8 @@ let run (conf : Scan_CLI.conf) : Exit_code.t =
 
       (* Rule_fetching.rules_and_origin record also contain errors *)
       let rules_and_origins =
-        Rule_fetching.rules_from_rules_source conf.rules_source
+        Rule_fetching.rules_from_rules_source
+          ~rewrite_rule_ids:conf.rewrite_rule_ids conf.rules_source
       in
       let rules, errors =
         Rule_fetching.partition_rules_and_errors rules_and_origins

--- a/src/osemgrep/cli_scan/Validate_subcommand.ml
+++ b/src/osemgrep/cli_scan/Validate_subcommand.ml
@@ -68,7 +68,8 @@ let run (conf : conf) : Exit_code.t =
    * in Config_resolver.errors.
    *)
   let rules_and_origin =
-    Rule_fetching.rules_from_rules_source conf.rules_source
+    Rule_fetching.rules_from_rules_source ~rewrite_rule_ids:true
+      conf.rules_source
   in
   let rules, errors =
     Rule_fetching.partition_rules_and_errors rules_and_origin
@@ -105,8 +106,7 @@ let run (conf : conf) : Exit_code.t =
         (* TODO? sanity check errors below too? *)
         let { Out.results; errors = _; _ } =
           Cli_json_output.cli_output_of_core_results
-            ~logging_level:conf.logging_level ~rules_source:conf.rules_source
-            res
+            ~logging_level:conf.logging_level res
         in
         (* TOPORT?
                 ... run -check_rules in semgrep-core ...


### PR DESCRIPTION
test plan:
make osempass
from 74 to 77


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)