### PR TITLE
osemgrep: last rule_id prefix refinment for absolute paths

### DIFF
--- a/cli/tests/e2e/test_check.py
+++ b/cli/tests/e2e/test_check.py
@@ -140,6 +140,7 @@ def test_extract(run_semgrep_in_tmp: RunSemgrep, snapshot):
     )
 
 
+@pytest.mark.osempass
 @pytest.mark.kinda_slow
 def test_basic_rule__absolute(run_semgrep_in_tmp: RunSemgrep, snapshot):
     snapshot.assert_match(

--- a/src/osemgrep/TOPORT/config_resolver.py
+++ b/src/osemgrep/TOPORT/config_resolver.py
@@ -248,21 +248,9 @@ class Config:
         )
 
     @staticmethod
-    def _safe_relative_to(a: Path, b: Path) -> Path:
-        try:
-            return a.relative_to(b)
-        except ValueError:
-            # paths had no common prefix; not possible to relativize
-            return a
-
-    @staticmethod
     def _convert_config_id_to_prefix(config_id: str) -> str:
         at_path = Path(config_id)
-        try:
-            at_path = Config._safe_relative_to(at_path, Path.cwd())
-        except FileNotFoundError:
-            pass
-
+        ...
         prefix = ".".join(at_path.parts[:-1]).lstrip("./").lstrip(".")
         if len(prefix):
             prefix += "."


### PR DESCRIPTION
test plan:
make osempass
78 passed now!


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)