### PR TITLE
Add check for file existence in size filter (fixes #6890)

### DIFF
--- a/cli/src/semgrep/target_manager.py
+++ b/cli/src/semgrep/target_manager.py
@@ -678,7 +678,9 @@ class TargetManager:
             return FilteredFiles(candidates)
 
         kept, removed = partition(
-            candidates, lambda path: os.path.isfile(path) and os.path.getsize(path) <= max_target_bytes
+            candidates,
+            lambda path: os.path.isfile(path)
+            and os.path.getsize(path) <= max_target_bytes,
         )
 
         return FilteredFiles(frozenset(kept), frozenset(removed))

--- a/cli/src/semgrep/target_manager.py
+++ b/cli/src/semgrep/target_manager.py
@@ -678,7 +678,7 @@ class TargetManager:
             return FilteredFiles(candidates)
 
         kept, removed = partition(
-            candidates, lambda path: os.path.getsize(path) <= max_target_bytes
+            candidates, lambda path: os.path.isfile(path) and os.path.getsize(path) <= max_target_bytes
         )
 
         return FilteredFiles(frozenset(kept), frozenset(removed))


### PR DESCRIPTION
# What
Adds a check for whether `os.path.isfile(path)` to the file size filter. This filters a file out if it doesn't exist (as it vacuously has no size). If we would like to include it instead, the condition can be inverted.

# Why
Closes #6890.

# PR checklist

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
