### PR TITLE
fix: hilarious semgrep and test version clash

### DIFF
--- a/cli/tests/e2e/rules/dependency_aware/ruby-sca.yaml
+++ b/cli/tests/e2e/rules/dependency_aware/ruby-sca.yaml
@@ -4,7 +4,10 @@ rules:
     r2c-internal-project-depends-on:
         namespace: gem
         package: parallel
-        version: "== 1.21.0"
+        # hilarious anecdote, please never make this version
+        # a version of semgrep to be released or CI will break
+        # from masking the test output
+        version: "== 1.20.0"
     message: oh no
     languages: [ruby]
     severity: WARNING

--- a/cli/tests/e2e/rules/dependency_aware/ruby-sca.yaml
+++ b/cli/tests/e2e/rules/dependency_aware/ruby-sca.yaml
@@ -7,7 +7,7 @@ rules:
         # hilarious anecdote, please never make this version
         # a version of semgrep to be released or CI will break
         # from masking the test output
-        version: "== 1.20.0"
+        version: "== 1.19.0"
     message: oh no
     languages: [ruby]
     severity: WARNING

--- a/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awareruby-sca.yaml-dependency_awareruby-with-multiple-remotes/results.txt
+++ b/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awareruby-sca.yaml-dependency_awareruby-with-multiple-remotes/results.txt
@@ -37,7 +37,7 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
             "dependency_pattern": {
               "ecosystem": "gem",
               "package": "parallel",
-              "semver_range": "== 1.21.0"
+              "semver_range": "== 1.19.0"
             },
             "found_dependency": {
               "allowed_hashes": {},
@@ -45,7 +45,7 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
               "line_number": 21,
               "package": "parallel",
               "transitivity": "transitive",
-              "version": "1.21.0"
+              "version": "1.19.0"
             },
             "lockfile": "targets/dependency_aware/ruby-with-multiple-remotes/Gemfile.lock"
           },

--- a/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awareruby-sca.yaml-dependency_awareruby/results.txt
+++ b/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awareruby-sca.yaml-dependency_awareruby/results.txt
@@ -37,7 +37,7 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
             "dependency_pattern": {
               "ecosystem": "gem",
               "package": "parallel",
-              "semver_range": "== 1.21.0"
+              "semver_range": "== 1.19.0"
             },
             "found_dependency": {
               "allowed_hashes": {},
@@ -45,7 +45,7 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
               "line_number": 19,
               "package": "parallel",
               "transitivity": "transitive",
-              "version": "1.21.0"
+              "version": "1.19.0"
             },
             "lockfile": "targets/dependency_aware/ruby/Gemfile.lock"
           },

--- a/cli/tests/e2e/targets/dependency_aware/perf/100k/Gemfile.lock
+++ b/cli/tests/e2e/targets/dependency_aware/perf/100k/Gemfile.lock
@@ -99946,7 +99946,7 @@ GEM
     json (2.3.0)
     method_source (1.0.0)
     minitest (5.15.0)
-    parallel (1.21.0)
+    parallel (1.19.0)
     parser (3.1.0.0)
       ast (~> 2.4.1)
     power_assert (2.0.1)

--- a/cli/tests/e2e/targets/dependency_aware/perf/10k/Gemfile.lock
+++ b/cli/tests/e2e/targets/dependency_aware/perf/10k/Gemfile.lock
@@ -9946,7 +9946,7 @@ GEM
     json (2.3.0)
     method_source (1.0.0)
     minitest (5.15.0)
-    parallel (1.21.0)
+    parallel (1.19.0)
     parser (3.1.0.0)
       ast (~> 2.4.1)
     power_assert (2.0.1)

--- a/cli/tests/e2e/targets/dependency_aware/perf/50k/Gemfile.lock
+++ b/cli/tests/e2e/targets/dependency_aware/perf/50k/Gemfile.lock
@@ -49946,7 +49946,7 @@ GEM
     json (2.3.0)
     method_source (1.0.0)
     minitest (5.15.0)
-    parallel (1.21.0)
+    parallel (1.19.0)
     parser (3.1.0.0)
       ast (~> 2.4.1)
     power_assert (2.0.1)

--- a/cli/tests/e2e/targets/dependency_aware/ruby-with-multiple-remotes/Gemfile.lock
+++ b/cli/tests/e2e/targets/dependency_aware/ruby-with-multiple-remotes/Gemfile.lock
@@ -18,7 +18,7 @@ GEM
     json (2.3.0)
     method_source (1.0.0)
     minitest (5.15.0)
-    parallel (1.21.0)
+    parallel (1.19.0)
     parser (3.1.0.0)
       ast (~> 2.4.1)
     power_assert (2.0.1)

--- a/cli/tests/e2e/targets/dependency_aware/ruby/Gemfile.lock
+++ b/cli/tests/e2e/targets/dependency_aware/ruby/Gemfile.lock
@@ -16,7 +16,7 @@ GEM
     json (2.3.0)
     method_source (1.0.0)
     minitest (5.15.0)
-    parallel (1.20.0)
+    parallel (1.19.0)
     parser (3.1.0.0)
       ast (~> 2.4.1)
     power_assert (2.0.1)

--- a/cli/tests/e2e/targets/dependency_aware/ruby/Gemfile.lock
+++ b/cli/tests/e2e/targets/dependency_aware/ruby/Gemfile.lock
@@ -16,7 +16,7 @@ GEM
     json (2.3.0)
     method_source (1.0.0)
     minitest (5.15.0)
-    parallel (1.21.0)
+    parallel (1.20.0)
     parser (3.1.0.0)
       ast (~> 2.4.1)
     power_assert (2.0.1)


### PR DESCRIPTION
## What:
This test fixes a hilarious bug where masking the Semgrep version might mask the output of a Semgrep SCA test with versions attached, making CI fail on release, due to masking the to-be-released version.

## Why:
I want to release.

## How:
Made it a version of Semgrep that will never be released again. I also checked the other rules, and I rate them at "very low probability" of ever being released, unless we end up with Semgrep v8.

## Test plan:
`make test`

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
