### PR TITLE
osemgrep: new --legacy flag to imitate pysemgrep

### DIFF
--- a/src/osemgrep/cli_scan/Scan_CLI.mli
+++ b/src/osemgrep/cli_scan/Scan_CLI.mli
@@ -21,6 +21,10 @@ type conf = {
   error_on_findings : bool;
   strict : bool;
   rewrite_rule_ids : bool;
+  time_flag : bool;
+  profile : bool;
+  (* osemgrep-only: whether to keep pysemgrep behavior/limitations/errors *)
+  legacy : bool;
   (* Performance options *)
   core_runner_conf : Core_runner.conf;
   (* Display options *)
@@ -32,8 +36,6 @@ type conf = {
   (* text output config (TODO: make a separate type gathering all of them) *)
   max_chars_per_line : int;
   max_lines_per_finding : int;
-  time_flag : bool;
-  profile : bool;
   (* Networking options *)
   metrics : Metrics_.config;
   version_check : bool;

--- a/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -245,6 +245,7 @@ let run (conf : Scan_CLI.conf) : Exit_code.t =
       Logs.info (fun m ->
           m "%a" Skipped_report.pp_skipped
             ( conf.targeting_conf.respect_git_ignore,
+              conf.legacy,
               conf.targeting_conf.max_target_bytes,
               semgrepignored,
               included,

--- a/src/osemgrep/reporting/Skipped_report.ml
+++ b/src/osemgrep/reporting/Skipped_report.ml
@@ -16,22 +16,15 @@ module Out = Semgrep_output_v1_t
 (*****************************************************************************)
 
 let pp_skipped ppf
-    (( respect_git_ignore,
-       max_target_bytes,
-       semgrep_ignored,
-       include_ignored,
-       exclude_ignored,
-       file_size_ignored,
-       other_ignored,
-       errors ) :
-      bool
-      * int
-      * Out.skipped_target list
-      * Out.skipped_target list
-      * Out.skipped_target list
-      * Out.skipped_target list
-      * Out.skipped_target list
-      * Out.skipped_target list) =
+    ( respect_git_ignore,
+      legacy,
+      max_target_bytes,
+      semgrep_ignored,
+      include_ignored,
+      exclude_ignored,
+      file_size_ignored,
+      other_ignored,
+      errors ) =
   (* not sure why but pysemgrep does not use the classic heading for skipped*)
   Fmt.pf ppf "%s@.Files skipped:@.%s@." (String.make 40 '=')
     (String.make 40 '=');
@@ -94,12 +87,13 @@ let pp_skipped ppf
   pp_list file_size_ignored;
   Fmt.pf ppf "@.";
 
-  Fmt.pf ppf " %a@.@." Fmt.(styled `Bold string) "Skipped for other reasons:";
-  pp_list other_ignored;
-  Fmt.pf ppf "@.";
+  if not legacy then (
+    Fmt.pf ppf " %a@.@." Fmt.(styled `Bold string) "Skipped for other reasons:";
+    pp_list other_ignored;
+    Fmt.pf ppf "@.");
 
   Fmt.pf ppf " %a@.@."
     Fmt.(styled `Bold string)
-    "Skipped by analysis failure due to parsing or internal Semgrep error";
+    "Partially analyzed due to parsing or internal Semgrep errors";
   pp_list errors;
   Fmt.pf ppf "@."

--- a/src/osemgrep/reporting/Skipped_report.mli
+++ b/src/osemgrep/reporting/Skipped_report.mli
@@ -1,6 +1,8 @@
+(* TODO: this is an ugly signature. Should define a record to hold the data *)
 val pp_skipped :
   Format.formatter ->
   bool
+  * bool
   * int
   * Semgrep_output_v1_t.skipped_target list
   * Semgrep_output_v1_t.skipped_target list

--- a/src/targeting/Find_target.ml
+++ b/src/targeting/Find_target.ml
@@ -47,15 +47,25 @@ module Resp = Output_from_core_t
 (*************************************************************************)
 
 type conf = {
-  project_root : Fpath.t option;
+  (* global exclude list, passed via semgrep --exclude *)
   exclude : string list;
+  (* global include list, passed via semgrep --include
+   * [!] include_ = None is the opposite of Some [].
+   * If a list of include patterns is specified, a path must match
+   * at least of the patterns to be selected.
+   *)
   include_ : string list option;
   max_target_bytes : int;
+  (* whether or not follow what is specified in the .gitignore
+   * TODO? what about .semgrepignore?
+   *)
   respect_git_ignore : bool;
   (* TODO? use, and better parsing of the string? a Git.version type? *)
   baseline_commit : string option;
   (* TODO: use *)
   scan_unknown_extensions : bool;
+  (* osemgrep-only: option (see Git_project.ml and the force_root parameter) *)
+  project_root : Fpath.t option;
 }
 [@@deriving show]
 

--- a/src/targeting/Find_target.mli
+++ b/src/targeting/Find_target.mli
@@ -11,8 +11,6 @@
  *)
 
 type conf = {
-  (* osemgrep-only option (see Git_project.ml and the force_root parameter) *)
-  project_root : Fpath.t option;
   (* global exclude list, passed via semgrep --exclude *)
   exclude : string list;
   (* global include list, passed via semgrep --include
@@ -30,6 +28,8 @@ type conf = {
   baseline_commit : string option;
   (* TODO: not used for now *)
   scan_unknown_extensions : bool;
+  (* osemgrep-only: option (see Git_project.ml and the force_root parameter) *)
+  project_root : Fpath.t option;
 }
 [@@deriving show]
 


### PR DESCRIPTION
Keep the same behavior/limitations/error messages than pysemgrep,
even if they are not great.

The flag will also be useful to guard new features that
are osemgrep-only!

test plan:
make core
make core-install
make osempass


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)