### PR TITLE
osemgrep: NEW support -e without requiring -l

### DIFF
--- a/src/osemgrep/cli_scan/Scan_CLI.mli
+++ b/src/osemgrep/cli_scan/Scan_CLI.mli
@@ -8,7 +8,7 @@
 type conf = {
   (* Main configuration options *)
   (* mix of --pattern/--lang/--replacement, --config *)
-  rules_source : Rule_fetching.rules_source;
+  rules_source : Rules_source.t;
   (* can be a list of files or directories *)
   target_roots : Fpath.t list;
   (* Rules/targets refinements *)

--- a/src/osemgrep/core/Rules_source.ml
+++ b/src/osemgrep/core/Rules_source.ml
@@ -1,7 +1,9 @@
 type t =
-  (* -e/-l/--replacement. In theory we could even parse the string to get
-   * a XPattern.t *)
-  | Pattern of string * Xlang.t * string option (* replacement *)
+  (* For --pattern/--lang/--replacement (also -e/-l/--replacement).
+   * In theory we could even parse the string to get a XPattern.t
+   * Xlang.t is now an option to allow to use -e without -l in osemgrep
+   *)
+  | Pattern of string * Xlang.t option * string option (* replacement *)
   (* --config. In theory we could even parse the string to get
    * some Semgrep_dashdash_config.config_kind list *)
   | Configs of string (* Semgrep_dashdash_config.config_str *) list

--- a/src/parsing/Parse_rule.ml
+++ b/src/parsing/Parse_rule.ml
@@ -530,6 +530,7 @@ let parse_xpattern env (str, tok) =
       let src = Spacegrep.Src_file.of_string str in
       match Spacegrep.Parse_pattern.of_src src with
       | Ok ast -> XP.mk_xpat (XP.Spacegrep ast) (str, tok)
+      (* TODO: use R.Err exn instead? *)
       | Error err -> failwith err.msg)
 
 (* TODO: note that the [pattern] string and token location [t] given to us

--- a/src/parsing/Parse_rule.mli
+++ b/src/parsing/Parse_rule.mli
@@ -1,4 +1,4 @@
-(* Parse a rule file, either in YAML or JSON (or even JSONNET) format
+(* Parse a rule file, either in YAML or JSON (or even Jsonnet) format
  * depending on the filename extension.
  *
  * The parser accepts invalid rules, skips them, and returns them in
@@ -23,8 +23,13 @@ val parse_and_filter_invalid_rules :
  *)
 val is_valid_rule_filename : Fpath.t -> bool
 
-(* this can be used for parsing -e/-f extended patterns in Run_semgrep.ml
+(* This is used for parsing -e/-f extended patterns in Run_semgrep.ml
  * and now also in osemgrep Config_resolver.ml.
+ * This can raise Failure for spacegrep parsing errors, and
+ * Rule.InvalidRegexp for regexp errors.
+ * For lang.t, we now parse the pattern lazily, so if you want
+ * to get the possible Rule.InvalidPattern exn, you need to
+ * force evaluate XPattern.Sem (lpat_lazy, _).
  *)
 val parse_xpattern : Xlang.t -> string Rule.wrap -> Xpattern.t
 


### PR DESCRIPTION
We just try all the languages!

Note that we could have added this feature to pysemgrep but it would
have been far more tedious to implement. You would need:
 - change commands/scan.py to accept -e without -l
 - add a new way for pysemgrep to call semgrep-core just to
   get parsing results of a pattern
   (knowledge about parsing languages is in semgrep-core)
   * either add new flags in semgrep-core to parse a pattern
     and agree on some special exit code that pysemgrep will interpret
   * either use ATD and extend interfaces/Input_to_core.atd and
     Semgrep_core_v1.atd for this new way to communicate
 - modify core_runner.py
 - add some new code in semgrep-core to just parse a pattern
Note that it's an extra fork.

With osemgrep we just call the parsing function directly; that's it.

We're now competing with 'git grep'. With this PR that's 9 letters
less to type in
sg -e ': Common.filename'
vs
sg -e ': Common.filename' -l ocaml
vs
git grep Common.filename

test plan:
```
osemgrep -e ': Common.filename'
┌─────────────┐
│ Scan status │
└─────────────┘
Scanning 2077 files tracked by git with 5 Code rules:

  Language        Rules   Files
 ───────────────────────────────
  Dockerfile          1       5
  OCaml               1     915
  Bash                1      31
  Lua                 1       1
...
  /home/pad/github/semgrep/tools/otarzan/lib/Parse.mli
     -

          5┆ Common.filename -> Ast_ml.type_declaration list list
          ⋮┆----------------------------------------
          8┆ val parse : Common.filename -> Ast_ml.program

┌──────────────┐
│ Scan summary │
└──────────────┘
Some files were skipped or only partially analyzed.
  Scan skipped: 1 files larger than 1 MB, 4650 files matching .semgrepignore patterns, 19 other files ignored
  For a full list of skipped files, run semgrep with the --verbose flag.

Ran 5 rules on 2077 files: 190 findings

```


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)