### PR TITLE
cleanup: use Fpath in Parse_with_caching.ml and move it

### DIFF
--- a/libs/commons/File.ml
+++ b/libs/commons/File.ml
@@ -3,6 +3,10 @@
 
    For now, this is a thin layer on top of Common. Eventually, we want
    to get rid of the interface exposed by Common.
+
+   related libraries:
+    - Bos.OS.File, Bos.OS.Dir, Bos.OS.Path
+     (ex: https://erratique.ch/software/bos/doc/Bos/OS/Dir/index.html )
 *)
 
 module Path = struct

--- a/libs/commons/File.mli
+++ b/libs/commons/File.mli
@@ -59,6 +59,13 @@ module Operators : sig
 
   (* File.Path.(!!) = Fpath.to_string *)
   val ( !! ) : Fpath.t -> string
+
+  (* TODO? also add this one? or use ++ a bit like we have !! to
+   * avoid collision with known operators?
+   *)
+  (*
+  val ( + ) : Fpath.t -> Fpath.ext -> Fpath.t
+  *)
 end
 
 (* For realpath, use Unix.realpath in OCaml >= 4.13 *)

--- a/libs/commons/FilePath.ml
+++ b/libs/commons/FilePath.ml
@@ -17,23 +17,29 @@
 (* Prelude *)
 (*****************************************************************************)
 
-(* This module governs a path type, which can only produce values which
+(* Real paths.
+
+   This module governs a path type, which can only produce values which
    are for normalized paths to existent files or directories.
    These paths are always canonically kept at their absolute forms, in order to
-   maintain a canonicity property. Due to the `Path` constructor being private, we
-   can enforce this invariant at the type level.
+   maintain a canonicity property. Due to the `Path` constructor being
+   private, we can enforce this invariant at the type level.
 
-   This file was originally called `Path.ml`, but this conflicts with
+   history: this file was originally called `Path.ml`, but this conflicts with
    the OCaml compiler libraries. Then it was called FPath.ml but this
    was too close to the Fpath library by Daniel Buenzli.
+
+   TODO: rename this file to Rpath.ml, so we would have Fpath.ml, Ppath.ml,
+   and finally Rpath.ml. We could also have Dpath.ml for directories
+   and that would put us closer to the nice filenames library in Scala
+   with better types paths.
 *)
 
 (*****************************************************************************)
 (* Types *)
 (*****************************************************************************)
 
-type path = Path of string [@@deriving show, eq]
-type t = path [@@deriving show, eq]
+type t = Path of string [@@deriving show, eq]
 
 (*****************************************************************************)
 (* Main functions *)
@@ -41,6 +47,8 @@ type t = path [@@deriving show, eq]
 
 (* TODO: we should use Unix.realpath but it's available only in 4.13
  * and there is no unixcompat like we have stdcompat.
+ * alt: we could use Martin's Realpath.ml that used to be in
+ * osemgrep/src/tarteting/ (also in my ~/Dropbox/r2c/TODO-code) now.
  *)
 let of_string s = Path (Common.fullpath s)
 let to_string (Path s) = s

--- a/libs/commons/FilePath.mli
+++ b/libs/commons/FilePath.mli
@@ -7,7 +7,7 @@
 
    This means that a `path_special` can only be constructed via
    `Path.of_string` (below), but it can be freely destructed via
-   pattern-matching without needing to call `Path.to_string`.  This
+   pattern-matching without needing to call `Path.to_string`. This
    ensures that all values of the type `path_special` must go through
    `of_string`, and in particular, ensures that they all must be
    validated by `Unix.realpath`.
@@ -18,8 +18,7 @@
    yet exist. See some examples of this in
    `Unit_commons.test_path_conversion()`.
 *)
-type path = private Path of string [@@deriving show, eq]
-type t = path [@@deriving show, eq]
+type t = private Path of string [@@deriving show, eq]
 
 val of_string : string -> t
 val to_string : t -> string

--- a/src/core_cli/Core_CLI.ml
+++ b/src/core_cli/Core_CLI.ml
@@ -289,10 +289,10 @@ let generate_ast_binary lang file =
   let final =
     Parse_with_caching.versioned_parse_result_of_file Version.version lang file
   in
-  let file = file ^ Parse_with_caching.binary_suffix in
+  let file = Fpath.add_ext Parse_with_caching.binary_suffix file in
   assert (Parse_with_caching.is_binary_ast_filename file);
-  Common2.write_value final file;
-  pr2 (spf "saved marshalled generic AST in %s" file)
+  Common2.write_value final !!file;
+  pr2 (spf "saved marshalled generic AST in %s" !!file)
 
 let dump_ext_of_lang () =
   let lang_to_exts =
@@ -391,7 +391,7 @@ let all_actions () =
       Arg_helpers.mk_action_1_conv Fpath.v generate_ast_json );
     ( "-generate_ast_binary",
       " <file> save in file.ast.binary the marshalled generic AST of file",
-      Arg_helpers.mk_action_1_arg (fun file ->
+      Arg_helpers.mk_action_1_conv Fpath.v (fun file ->
           generate_ast_binary (Xlang.lang_of_opt_xlang_exn !lang) file) );
     ( "-prefilter_of_rules",
       " <file> dump the prefilter regexps of rules in JSON ",

--- a/src/parsing/Parse_with_caching.mli
+++ b/src/parsing/Parse_with_caching.mli
@@ -3,27 +3,27 @@ val parse_and_resolve_name :
   ?parsing_cache_dir:string (* "" means no parsing cache *) ->
   string (* semgrep or AST generic version *) ->
   Lang.t ->
-  Common.filename ->
+  Fpath.t ->
   AST_generic.program * Tok.location list
 
 (* We store the version and the original path as well as whether parsing the
  * file was generating an exn in the marshalled value on disk. That
  * way we can do extra check when we read it back (e.g., making sure
  * the version is the same than the current program, otherwise
- * we could get some segfaults (unmarshalling is not type-safe in OCaml).
+ * we could get some segfaults (unmarshalling is not type-safe in OCaml)).
  *)
 type versioned_parse_result =
-  string (* version *)
-  * Common.filename (* original path *)
+  string (* AST_generic.version *)
+  * Fpath.t (* original path *)
   * (AST_generic.program * Tok.location list, Exception.t) Common.either
 
 (* to add as a suffix to a filename *)
-val binary_suffix : string (* .ast.binary *)
-val is_binary_ast_filename : Common.filename -> bool
+val binary_suffix : Fpath.ext (* .ast.binary *)
+val is_binary_ast_filename : Fpath.t -> bool
 
-(* used by -generate_ast_binary *)
+(* used by semgrep-core -generate_ast_binary *)
 val versioned_parse_result_of_file :
   string (* semgrep or AST generic version *) ->
   Lang.t ->
-  Common.filename ->
+  Fpath.t ->
   versioned_parse_result

--- a/src/runner/Run_semgrep.ml
+++ b/src/runner/Run_semgrep.ml
@@ -542,7 +542,7 @@ let xtarget_of_file (config : Runner_config.t) (xlang : Xlang.t)
         lazy
           (Parse_with_caching.parse_and_resolve_name
              ~parsing_cache_dir:config.parsing_cache_dir AST_generic.version
-             lang file)
+             lang (Fpath.v file))
     | _ -> lazy (failwith "requesting generic AST for LRegex|LGeneric")
   in
 


### PR DESCRIPTION
This is first step before adding AST caching in osemgrep
in the next PR!

test plan:
make core


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)