### PR TITLE
osemgrep: NEW --ast-caching option, on by default!

### DIFF
--- a/cli/tests/semgrep_runner.py
+++ b/cli/tests/semgrep_runner.py
@@ -50,7 +50,8 @@ USE_OSEMGREP = get_env_bool("PYTEST_USE_OSEMGREP")
 # The --project-root option is used to prevent the .semgrepignore
 # at the root of the git project to be taken into account when testing,
 # which is a new behavior in osemgrep.
-OSEMGREP_COMPATIBILITY_ARGS = ["--project-root", "."]
+# The --legacy is to try to get the same behaviors/limitations/errors of pysemgrep
+OSEMGREP_COMPATIBILITY_ARGS = ["--project-root", ".", "--legacy", "--no-ast-caching"]
 
 # The semgrep command suitable to run semgrep as a separate process.
 # It's something like ["semgrep"] or ["python3"; -m; "semgrep"] or

--- a/libs/ast_generic/AST_generic.ml
+++ b/libs/ast_generic/AST_generic.ml
@@ -163,15 +163,15 @@
  *    of a VarDef, as done in Python for example).
  *)
 
-(* !! Modify version below each time you modify the generic AST!! There are
- * now a few places where we cache the generic AST in a marshalled binary
- * form on disk (e.g., in src/runner/Parsing_with_cache.ml) and reading back
+(* !! Modify version below each time you modify the generic AST!!
+ * There are now a few places where we cache the generic AST in a marshalled
+ * form on disk (e.g., in src/parsing/Parsing_with_cache.ml) and reading back
  * old version of this AST can lead to segfaults in OCaml.
- * Note that this number below could be independent of the versioning scheme of
+ * Note that the number below could be independent of the versioning scheme of
  * Semgrep; we don't have to update version below for each version of
- * Semgrep, just when we actually modify the generic AST. However it's convenient
- * to correspond mostly to Semgrep versions. So version below can jump from
- * "1.12.1" to "1.20.0" and that's fine.
+ * Semgrep, just when we actually modify the generic AST. However it's
+ * convenient to correspond mostly to Semgrep versions. So version below
+ * can jump from "1.12.1" to "1.20.0" and that's fine.
  *)
 let version = "1.20.0"
 

--- a/src/osemgrep/cli_scan/Core_runner.ml
+++ b/src/osemgrep/cli_scan/Core_runner.ml
@@ -1,5 +1,7 @@
+open File.Operators
 module Out = Semgrep_output_v1_t
 module RP = Report
+module Env = Semgrep_envvars
 
 (*************************************************************************)
 (* Prelude *)
@@ -51,6 +53,8 @@ type conf = {
   max_memory_mb : int;
   timeout : float;
   timeout_threshold : int;
+  (* osemgrep-only: *)
+  ast_caching : bool;
 }
 [@@deriving show]
 
@@ -184,7 +188,14 @@ let split_jobs_by_language all_rules all_targets : Lang_job.t list =
 
 let runner_config_of_conf (conf : conf) : Runner_config.t =
   match conf with
-  | { num_jobs; timeout; timeout_threshold; max_memory_mb; optimizations }
+  | {
+   num_jobs;
+   timeout;
+   timeout_threshold;
+   max_memory_mb;
+   optimizations;
+   ast_caching;
+  }
   (* TODO: time_flag = _;
   *) ->
       (* We should default to Json because we do not want the same text
@@ -196,6 +207,14 @@ let runner_config_of_conf (conf : conf) : Runner_config.t =
        *)
       let output_format = Runner_config.Json false (* no dots *) in
       let filter_irrelevant_rules = optimizations in
+      let parsing_cache_dir =
+        if ast_caching then
+          let dir = Env.env.user_dot_semgrep_dir / "cache" / "asts" in
+          match Bos.OS.Dir.create ~path:true dir with
+          | Ok _ -> !!dir
+          | Error (`Msg err) -> failwith err
+        else ""
+      in
       {
         Runner_config.default with
         ncores = num_jobs;
@@ -204,6 +223,7 @@ let runner_config_of_conf (conf : conf) : Runner_config.t =
         timeout_threshold;
         max_memory_mb;
         filter_irrelevant_rules;
+        parsing_cache_dir;
         version = Version.version;
       }
 

--- a/src/osemgrep/cli_scan/Core_runner.mli
+++ b/src/osemgrep/cli_scan/Core_runner.mli
@@ -5,6 +5,8 @@ type conf = {
   max_memory_mb : int;
   timeout : float;
   timeout_threshold : int;
+  (* osemgrep-only: *)
+  ast_caching : bool;
 }
 [@@deriving show]
 

--- a/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -99,6 +99,8 @@ let default : conf =
         timeout_threshold = 3;
         max_memory_mb = 0;
         optimizations = true;
+        (* like legacy, should maybe be set to false when we release osemgrep*)
+        ast_caching = true;
       };
     autofix = false;
     dryrun = false;
@@ -617,6 +619,11 @@ let o_project_root : string option Term.t =
   in
   Arg.value (Arg.opt Arg.(some string) None info)
 
+let o_ast_caching : bool Term.t =
+  H.negatable_flag [ "ast-caching" ] ~neg_options:[ "no-ast-caching" ]
+    ~default:default.core_runner_conf.ast_caching
+    ~doc:{|Store in ~/.semgrep/cache/asts/ the parsed ASTs to speedup things.|}
+
 (*****************************************************************************)
 (* Turn argv into a conf *)
 (*****************************************************************************)
@@ -624,14 +631,14 @@ let o_project_root : string option Term.t =
 let cmdline_term : conf Term.t =
   (* !The parameters must be in alphabetic orders to match the order
    * of the corresponding '$ o_xx $' further below! *)
-  let combine autofix baseline_commit config dryrun dump_ast dump_config emacs
-      error exclude exclude_rule_ids force_color include_ json lang legacy
-      logging_level max_chars_per_line max_lines_per_finding max_memory_mb
-      max_target_bytes metrics num_jobs nosem optimizations pattern profile
-      project_root replacement respect_git_ignore rewrite_rule_ids
-      scan_unknown_extensions severity show_supported_languages strict
-      target_roots test test_ignore_todo time_flag timeout timeout_threshold
-      validate version version_check vim =
+  let combine ast_caching autofix baseline_commit config dryrun dump_ast
+      dump_config emacs error exclude exclude_rule_ids force_color include_ json
+      lang legacy logging_level max_chars_per_line max_lines_per_finding
+      max_memory_mb max_target_bytes metrics num_jobs nosem optimizations
+      pattern profile project_root replacement respect_git_ignore
+      rewrite_rule_ids scan_unknown_extensions severity show_supported_languages
+      strict target_roots test test_ignore_todo time_flag timeout
+      timeout_threshold validate version version_check vim =
     let include_ =
       match include_ with
       | [] -> None
@@ -704,6 +711,7 @@ let cmdline_term : conf Term.t =
         timeout;
         timeout_threshold;
         max_memory_mb;
+        ast_caching;
       }
     in
     let targeting_conf =
@@ -867,8 +875,8 @@ let cmdline_term : conf Term.t =
   Term.(
     (* !the o_xxx must be in alphabetic orders to match the parameters of
      * combine above! *)
-    const combine $ o_autofix $ o_baseline_commit $ o_config $ o_dryrun
-    $ o_dump_ast $ o_dump_config $ o_emacs $ o_error $ o_exclude
+    const combine $ o_ast_caching $ o_autofix $ o_baseline_commit $ o_config
+    $ o_dryrun $ o_dump_ast $ o_dump_config $ o_emacs $ o_error $ o_exclude
     $ o_exclude_rule_ids $ o_force_color $ o_include $ o_json $ o_lang
     $ o_legacy $ CLI_common.logging_term $ o_max_chars_per_line
     $ o_max_lines_per_finding $ o_max_memory_mb $ o_max_target_bytes $ o_metrics

--- a/src/osemgrep/cli_scan/dune
+++ b/src/osemgrep/cli_scan/dune
@@ -6,6 +6,7 @@
   (libraries
     cmdliner
     logs
+    bos
     commons
 
     semgrep_core_cli

--- a/src/osemgrep/configuring/Semgrep_envvars.ml
+++ b/src/osemgrep/configuring/Semgrep_envvars.ml
@@ -55,7 +55,7 @@ type t = {
   version_check_cache_path : Fpath.t;
   git_command_timeout : int;
   src_directory : Fpath.t;
-  user_data_folder : Fpath.t;
+  user_dot_semgrep_dir : Fpath.t;
   user_log_file : Fpath.t;
   user_settings_file : Fpath.t;
   in_docker : bool;
@@ -69,7 +69,7 @@ type t = {
 
 (* less: make it Lazy? *)
 let env : t =
-  let user_data_folder =
+  let user_dot_semgrep_dir =
     let parent_dir =
       match Sys.getenv_opt "XDG_CONFIG_HOME" with
       | Some x when Sys.is_directory x -> Fpath.v x
@@ -98,12 +98,12 @@ let env : t =
         (Fpath.v (Sys.getcwd ()) / ".cache" / "semgrep_version");
     git_command_timeout = env_or int_of_string "SEMGREP_GIT_COMMAND_TIMEOUT" 300;
     src_directory = env_or Fpath.v "SEMGREP_SRC_DIRECTORY" (Fpath.v "/src");
-    user_data_folder;
+    user_dot_semgrep_dir;
     user_log_file =
-      env_or Fpath.v "SEMGREP_LOG_FILE" (user_data_folder / "semgrep.log");
+      env_or Fpath.v "SEMGREP_LOG_FILE" (user_dot_semgrep_dir / "semgrep.log");
     user_settings_file =
       env_or Fpath.v "SEMGREP_SETTINGS_FILE"
-        (user_data_folder / settings_filename);
+        (user_dot_semgrep_dir / settings_filename);
     in_docker = in_env "SEMGREP_IN_DOCKER";
     in_gh_action = in_env "GITHUB_WORKSPACE";
     in_agent = in_env "SEMGREP_AGENT";

--- a/src/osemgrep/configuring/Semgrep_envvars.mli
+++ b/src/osemgrep/configuring/Semgrep_envvars.mli
@@ -22,7 +22,7 @@ type t = {
   (* "/src" *)
   src_directory : Fpath.t;
   (* $XDG_CONFIG_HOME/.semgrep or ~/.semgrep *)
-  user_data_folder : Fpath.t;
+  user_dot_semgrep_dir : Fpath.t;
   (* $SEMGREP_LOG_FILE or ~/.semgrep/semgrep.log  *)
   user_log_file : Fpath.t;
   (* $SEMGREP_SETTINGS_FILE ~/.semgrep/settings.yml *)


### PR DESCRIPTION
Turn on AST caching by default in osemgrep!
On the semgrep repo itself this does not change
a lot the time, but still from 1.2s to 0.7s

Can probably improve things even more

test plan:
```
$ time osemgrep --no-ast-caching -e ': Common.filename'
...
Ran 5 rules on 2071 files: 185 findings
...
real	0m1.265s
$ time osemgrep --ast-caching -e ': Common.filename'
...
Ran 5 rules on 2071 files: 185 findings
...
real	0m0.795s
```


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)