### PR TITLE
Prevent uses of (==) because folks don't know what it means

### DIFF
--- a/languages/php/menhir/parsing_hacks_php.ml
+++ b/languages/php/menhir/parsing_hacks_php.ml
@@ -182,7 +182,7 @@ let find_typehint toks =
         | TCBRACE _ ->
             ([], []) (* absolutely will not be in a typehint *)
         | TCOLON _ ->
-            if depth == 0 then (List.rev (x :: acc), xs)
+            if depth =|= 0 then (List.rev (x :: acc), xs)
             else aux xs (x :: acc) depth
         | _ -> aux xs (x :: acc) depth)
   in

--- a/languages/php/menhir/parsing_hacks_php.ml
+++ b/languages/php/menhir/parsing_hacks_php.ml
@@ -128,10 +128,10 @@ let find_paren_tokens toks replace =
     | x :: xs -> (
         match x with
         | TCPAR t ->
-            let x' = if depth == 0 && replace then T_LAMBDA_CPAR t else x in
+            let x' = if depth =|= 0 && replace then T_LAMBDA_CPAR t else x in
             aux xs (x' :: acc) (depth + 1)
         | TOPAR t ->
-            if depth == 1 then
+            if depth =|= 1 then
               let x' = if replace then T_LAMBDA_OPAR t else x in
               (List.rev (x' :: acc), xs)
             else aux xs (x :: acc) (depth - 1)

--- a/languages/ruby/dyp/il_ruby_build.ml
+++ b/languages/ruby/dyp/il_ruby_build.ml
@@ -35,7 +35,7 @@ let acc_append acc1 acc2 =
     q = DQueue.append acc1.q acc2.q;
     seen = StrSet.union acc1.seen acc2.seen;
     super_args =
-      (assert (acc1.super_args == acc2.super_args);
+      (assert (phys_equal acc1.super_args acc2.super_args);
        acc1.super_args);
   }
 

--- a/languages/ruby/dyp/lexer_ruby.mll
+++ b/languages/ruby/dyp/lexer_ruby.mll
@@ -145,7 +145,7 @@ let push_back str lexbuf =
       Bytes.of_string (Bytes.to_string pre_str ^ str ^ Bytes.to_string post_str);
     lexbuf.Lexing.lex_buffer_len <- lexbuf.Lexing.lex_buffer_len + (String.length str);
     lexbuf.Lexing.lex_curr_p <- update_pos str lexbuf.Lexing.lex_curr_p;
-    assert ((Bytes.length lexbuf.Lexing.lex_buffer) == lexbuf.Lexing.lex_buffer_len)
+    assert ((Bytes.length lexbuf.Lexing.lex_buffer) =|= lexbuf.Lexing.lex_buffer_len)
 
 (* ---------------------------------------------------------------------- *)
 (* Misc *)
@@ -632,7 +632,7 @@ and percent state = parse
          else interp_string_lexer d
        in
          if modifier = "r"
-         then regexp_delim ((==)d) ((==)d) (Buffer.create 31) state lexbuf
+         then regexp_delim (phys_equal d) (phys_equal d) (Buffer.create 31) state lexbuf
          else emit_extra (T_USER_BEG(modifier, (tk lexbuf))) f state lexbuf
       }
 
@@ -649,7 +649,7 @@ and percent state = parse
            then (incr level; false)
            else false
        in
-       let chk d = d == d_start || d == d_end in
+       let chk d = phys_equal d d_start || phys_equal d d_end in
        let f =
          if modifier_is_single modifier
          then non_interp_string d_end (Buffer.create 31) (tk lexbuf)
@@ -800,7 +800,7 @@ and non_interp_string delim buf t state = parse
       { Buffer.add_string buf (str lexbuf);
         non_interp_string delim buf (add_to_tok lexbuf t) state lexbuf }
   | _ as c
-      { if c == delim
+      { if phys_equal c delim
         then T_SINGLE_STRING(Buffer.contents buf, add_to_tok lexbuf t)
         else begin
           Buffer.add_char buf c;
@@ -824,7 +824,7 @@ and tick_string t state = parse
 
 and interp_string_lexer delim state = parse
   | e { let chk x =
-          x == delim
+          phys_equal x delim
         in
         let t  = tk lexbuf in
         interp_lexer fail_eof chk chk (Buffer.create 31) t state lexbuf
@@ -884,7 +884,7 @@ and interp_code start cont state = parse
                incr level;
                tok
            | T_RBRACE _ as tok ->
-               if !level == 0 then begin
+               if phys_equal !level 0 then begin
                  pop_lexer state; (* abort k *)
                  cont state lexbuf
                end else begin
@@ -906,7 +906,7 @@ and regexp state = parse
   | e { regexp_string (Buffer.create 31) state lexbuf }
 
 and regexp_string buf state = parse
-  | e { regexp_delim ((==)'/') ((==)'/') buf state lexbuf }
+  | e { regexp_delim (phys_equal '/') (phys_equal '/') buf state lexbuf }
 
 and regexp_delim delim_f escape_f buf state = parse
   | e { let k state lexbuf =

--- a/languages/ruby/dyp/lexer_ruby.mll
+++ b/languages/ruby/dyp/lexer_ruby.mll
@@ -75,7 +75,7 @@ let emit_extra tok k = fun state lexbuf ->
 
 (* helper for transitioning between states *)
 let beg_choose want yes no = fun state lexbuf ->
-  if state.S.state == want
+  if phys_equal state.S.state want
   then yes state lexbuf
   else no state lexbuf
 

--- a/libs/commons/Common.ml
+++ b/libs/commons/Common.ml
@@ -1279,14 +1279,28 @@ module SMap = Map.Make (String)
 type 'a smap = 'a SMap.t
 
 (*****************************************************************************)
+(* Disable physical equality/inequality operators *)
+(*****************************************************************************)
+
+let phys_equal = Stdlib.( == )
+let phys_not_equal = Stdlib.( != )
+
+type hidden_by_your_nanny = unit
+
+let ( == ) : hidden_by_your_nanny = ()
+let ( != ) : hidden_by_your_nanny = ()
+
+(*****************************************************************************)
 (* Operators *)
 (*****************************************************************************)
 
 module Operators = struct
   let ( =~ ) = ( =~ )
-  let ( = ) = ( = )
+  let ( = ) = ( = ) (* already shadowed *)
   let ( =|= ) = ( =|= )
   let ( =$= ) = ( =$= )
   let ( =:= ) = ( =:= )
   let ( =*= ) = ( =*= )
+  let ( == ) = ( == ) (* already shadowed *)
+  let ( != ) = ( != ) (* already shadowed *)
 end

--- a/libs/commons/Common.mli
+++ b/libs/commons/Common.mli
@@ -466,8 +466,30 @@ val pr_time : string -> (unit -> 'a) -> 'a
 val pr2_time : string -> (unit -> 'a) -> 'a
 
 (*****************************************************************************)
+(* Disable physical equality/inequality operators *)
+(*****************************************************************************)
+
+(*
+   Disable the use of (==) since some people confuse it with structural
+   equality. We do this here since we're disabling in with semgrep anyway
+   and it's quicker if the compiler can report it.
+*)
+
+(* Physical (shallow) equality, normally available as (==) *)
+val phys_equal : 'a -> 'a -> bool
+
+(* Physical (shallow) inequality, normally available as (!=) *)
+val phys_not_equal : 'a -> 'a -> bool
+
+type hidden_by_your_nanny
+
+val ( == ) : hidden_by_your_nanny
+val ( != ) : hidden_by_your_nanny
+
+(*****************************************************************************)
 (* Operators *)
 (*****************************************************************************)
+
 (* if you just want to use the operators *)
 module Operators : sig
   val ( =~ ) : string -> string -> bool
@@ -476,6 +498,8 @@ module Operators : sig
   val ( =$= ) : char -> char -> bool
   val ( =:= ) : bool -> bool -> bool
   val ( =*= ) : 'a -> 'a -> bool
+  val ( == ) : hidden_by_your_nanny
+  val ( != ) : hidden_by_your_nanny
 end
 
 (*****************************************************************************)

--- a/src/analyzing/Dataflow_svalue.ml
+++ b/src/analyzing/Dataflow_svalue.ml
@@ -604,7 +604,7 @@ let update_svalue (flow : F.cfg) mapping =
           (fun ii ->
             (* Note the use of physical equality, we are looking for the *same*
              * id_svalue ref, that tells us it's the same variable occurrence. *)
-            var.id_info.id_svalue != (* nosemgrep *) ii.id_svalue)
+            phys_not_equal var.id_info.id_svalue ii.id_svalue)
           (G.E e)
     | G.NotCst
     | G.Cst _

--- a/src/experiments/synthesizing/Pattern_from_Targets.ml
+++ b/src/experiments/synthesizing/Pattern_from_Targets.ml
@@ -200,7 +200,7 @@ let check_equal_length (targets : 'a list list) : bool =
   | _ ->
       let lengths = Common.map List.length targets in
       let hdlen = Common.hd_exn "unexpected empty list" lengths in
-      List.for_all (( == ) hdlen) lengths
+      List.for_all (phys_equal hdlen) lengths
 
 (*****************************************************************************)
 (* Pattern generation *)

--- a/src/matching/Generic_vs_generic.ml
+++ b/src/matching/Generic_vs_generic.ml
@@ -365,12 +365,8 @@ let m_with_symbolic_propagation ~is_root f b tin =
            * we do, we shouldn't crash. This simple check will not protect
            * against complicated paths through which a symbol could resolve to
            * itself, but if it directly resolves to itself, we can easily catch
-           * it.
-           *
-           * Yes, Semgrep, I want physical equality.
-           *
-           * nosemgrep *)
-          if b1 == b then (
+           * it. *)
+          if phys_equal b1 b then (
             logger#error
               "Aborting symbolic propagation: Circular reference encountered \
                (\"%s\")"


### PR DESCRIPTION
We should investigate why semgrep didn't detect these uses. I thought https://semgrep.dev/playground/r/ocaml.lang.correctness.physical-vs-structural.physical-equal and https://semgrep.dev/playground/r/ocaml.lang.correctness.physical-vs-structural.physical-not-equal were supposed to catch this.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
