### PR TITLE
refer to langs by string instead of number

### DIFF
--- a/js/engine/Main.ml
+++ b/js/engine/Main.ml
@@ -56,12 +56,7 @@ let _ =
               |> Js.string)
                (Js.string pattern)
 
-       method isValidLang lang =
-         match Lang.of_string_opt (Js.to_string lang) with
-         | Some _ -> true
-         | None -> false
-
-       method lookupParserName lang_js_str =
+       method getParserForLang lang_js_str =
          let lang_str = Js.to_string lang_js_str in
          match Hashtbl.find_opt parser_lang_overrides lang_str with
          | Some parser -> Js.some (Js.string parser)
@@ -72,8 +67,6 @@ let _ =
                    (Js.string
                       (String.lowercase_ascii (Lang.to_lowercase_alnum lang)))
              | None -> Js.null)
-
-       method lookupLang lang = Lang.of_string (Js.to_string lang)
 
        method execute (language : Js.js_string Js.t)
            (rule_file : Js.js_string Js.t) (source_file : Js.js_string Js.t)

--- a/js/engine/Main.ml
+++ b/js/engine/Main.ml
@@ -9,7 +9,14 @@ external get_jsoo_mount_point : unit -> 'any list = "get_jsoo_mount_point"
    For example, the Python parser handles all of the Python Langs *)
 let parser_lang_overrides =
   Common.hash_of_list
-    [ ("python2", "python"); ("python3", "python"); ("py", "python") ]
+    [
+      ("python2", "python");
+      ("python3", "python");
+      ("py", "python");
+      ("xml", "html");
+      ("scheme", "lisp");
+      ("clojure", "lisp");
+    ]
 
 let _ =
   Common.jsoo := true;
@@ -30,12 +37,24 @@ let _ =
 
        method deleteFile filename = Sys.remove (Js.to_string filename)
 
-       method setParsePattern (func : bool -> Lang.t -> string -> 'a) =
-         Parse_pattern.parse_pattern_ref := func
+       method setParsePattern
+           (func : bool -> Js.js_string Js.t -> Js.js_string Js.t -> 'a) =
+         Parse_pattern.parse_pattern_ref :=
+           fun print_error lang target ->
+             func print_error
+               (lang |> Lang.to_lowercase_alnum |> String.lowercase_ascii
+              |> Js.string)
+               (Js.string target)
 
        method setJustParseWithLang
-           (func : Lang.t -> string -> Parsing_result2.t) =
-         Parse_target.just_parse_with_lang_ref := func
+           (func : Js.js_string Js.t -> Js.js_string Js.t -> Parsing_result2.t)
+           =
+         Parse_target.just_parse_with_lang_ref :=
+           fun lang pattern ->
+             func
+               (lang |> Lang.to_lowercase_alnum |> String.lowercase_ascii
+              |> Js.string)
+               (Js.string pattern)
 
        method isValidLang lang =
          match Lang.of_string_opt (Js.to_string lang) with

--- a/js/engine/src/index.d.ts
+++ b/js/engine/src/index.d.ts
@@ -6,7 +6,7 @@ export interface Parser {
   parsePattern: (printErrors: boolean, lang: string, pattern: string) => any;
 }
 export interface Engine {
-  getParserForLang: (name: string) => string | null;
+  lookupLang: (name: string) => string | null;
   addParser: (parser: Parser) => void;
   hasParser: (lang: string) => boolean;
   execute: (

--- a/js/engine/src/index.d.ts
+++ b/js/engine/src/index.d.ts
@@ -1,15 +1,14 @@
 export type Mountpoint = object;
-export type Lang = number;
 export interface Parser {
-  getLangs: () => Lang[];
+  getLangs: () => string[];
   setMountpoints: (mountpoints: Mountpoint[]) => void;
-  parseTarget: (lang: Lang, filename: string) => any;
-  parsePattern: (printErrors: boolean, lang: Lang, pattern: string) => any;
+  parseTarget: (lang: string, filename: string) => any;
+  parsePattern: (printErrors: boolean, lang: string, pattern: string) => any;
 }
 export interface Engine {
-  lookupLang: (name: string) => Lang;
+  getParserForLang: (name: string) => string | null;
   addParser: (parser: Parser) => void;
-  hasParser: (lang: Lang) => boolean;
+  hasParser: (lang: string) => boolean;
   execute: (
     language: string,
     rulesFilename: string,

--- a/js/engine/src/index.js
+++ b/js/engine/src/index.js
@@ -20,7 +20,7 @@ export const EngineFactory = async (wasmUri) => {
     setParsePattern,
     setJustParseWithLang,
     execute,
-    getParserForLang,
+    lookupLang,
     writeFile,
     deleteFile,
   } = require("../../../_build/default/js/engine/Main.bc");
@@ -49,7 +49,7 @@ export const EngineFactory = async (wasmUri) => {
   setJustParseWithLang(parseFile);
 
   return {
-    getParserForLang,
+    lookupLang,
     addParser: (parser) => {
       parser.setMountpoints(getMountpoints());
       parser.getLangs().forEach((lang) => {

--- a/js/engine/src/index.js
+++ b/js/engine/src/index.js
@@ -54,7 +54,7 @@ export const EngineFactory = async (wasmUri) => {
     lookupParserName,
     addParser: (parser) => {
       parser.setMountpoints(getMountpoints());
-      parser.getLangs().forEach((lang) => {
+      parser.getLangKeys().forEach((lang) => {
         languages.set(lang, parser);
       });
     },

--- a/js/engine/src/index.js
+++ b/js/engine/src/index.js
@@ -20,8 +20,7 @@ export const EngineFactory = async (wasmUri) => {
     setParsePattern,
     setJustParseWithLang,
     execute,
-    lookupLang,
-    lookupParserName,
+    getParserForLang,
     writeFile,
     deleteFile,
   } = require("../../../_build/default/js/engine/Main.bc");
@@ -50,11 +49,10 @@ export const EngineFactory = async (wasmUri) => {
   setJustParseWithLang(parseFile);
 
   return {
-    lookupLang,
-    lookupParserName,
+    getParserForLang,
     addParser: (parser) => {
       parser.setMountpoints(getMountpoints());
-      parser.getLangKeys().forEach((lang) => {
+      parser.getLangs().forEach((lang) => {
         languages.set(lang, parser);
       });
     },

--- a/js/engine/src/index.js
+++ b/js/engine/src/index.js
@@ -21,6 +21,7 @@ export const EngineFactory = async (wasmUri) => {
     setJustParseWithLang,
     execute,
     lookupLang,
+    lookupParserName,
     writeFile,
     deleteFile,
   } = require("../../../_build/default/js/engine/Main.bc");
@@ -50,6 +51,7 @@ export const EngineFactory = async (wasmUri) => {
 
   return {
     lookupLang,
+    lookupParserName,
     addParser: (parser) => {
       parser.setMountpoints(getMountpoints());
       parser.getLangs().forEach((lang) => {

--- a/js/engine/src/index.test.js
+++ b/js/engine/src/index.test.js
@@ -1,6 +1,21 @@
 const { EngineFactory } = require("../dist/index");
 
-test("it loads the engine", async () => {
-  const engine = await EngineFactory("./dist/semgrep-engine.wasm");
-  expect(engine.lookupLang("python")).toBe(24);
+const enginePromise = EngineFactory("./dist/semgrep-engine.wasm");
+
+describe("lookupParserName", () => {
+  test("handles base case", async () => {
+    const engine = await enginePromise;
+    expect(engine.lookupParserName("java")).toEqual("java");
+  });
+  test("handles invalid languages", async () => {
+    const engine = await enginePromise;
+    expect(engine.lookupParserName("fake-language")).toBeNull();
+  });
+  test("handles overridden languages", async () => {
+    const engine = await enginePromise;
+    expect(engine.lookupParserName("python")).toEqual("python");
+    expect(engine.lookupParserName("python2")).toEqual("python");
+    expect(engine.lookupParserName("python3")).toEqual("python");
+    expect(engine.lookupParserName("py")).toEqual("python");
+  });
 });

--- a/js/engine/src/index.test.js
+++ b/js/engine/src/index.test.js
@@ -5,17 +5,17 @@ const enginePromise = EngineFactory("./dist/semgrep-engine.wasm");
 describe("lookupParserName", () => {
   test("handles base case", async () => {
     const engine = await enginePromise;
-    expect(engine.lookupParserName("java")).toEqual("java");
+    expect(engine.getParserForLang("java")).toEqual("java");
   });
   test("handles invalid languages", async () => {
     const engine = await enginePromise;
-    expect(engine.lookupParserName("fake-language")).toBeNull();
+    expect(engine.getParserForLang("fake-language")).toBeNull();
   });
   test("handles overridden languages", async () => {
     const engine = await enginePromise;
-    expect(engine.lookupParserName("python")).toEqual("python");
-    expect(engine.lookupParserName("python2")).toEqual("python");
-    expect(engine.lookupParserName("python3")).toEqual("python");
-    expect(engine.lookupParserName("py")).toEqual("python");
+    expect(engine.getParserForLang("python")).toEqual("python");
+    expect(engine.getParserForLang("python2")).toEqual("python");
+    expect(engine.getParserForLang("python3")).toEqual("python");
+    expect(engine.getParserForLang("py")).toEqual("python");
   });
 });

--- a/js/engine/src/index.test.js
+++ b/js/engine/src/index.test.js
@@ -5,17 +5,10 @@ const enginePromise = EngineFactory("./dist/semgrep-engine.wasm");
 describe("lookupParserName", () => {
   test("handles base case", async () => {
     const engine = await enginePromise;
-    expect(engine.getParserForLang("java")).toEqual("java");
+    expect(engine.lookupLang("java")).toEqual("java");
   });
   test("handles invalid languages", async () => {
     const engine = await enginePromise;
-    expect(engine.getParserForLang("fake-language")).toBeNull();
-  });
-  test("handles overridden languages", async () => {
-    const engine = await enginePromise;
-    expect(engine.getParserForLang("python")).toEqual("python");
-    expect(engine.getParserForLang("python2")).toEqual("python");
-    expect(engine.getParserForLang("python3")).toEqual("python");
-    expect(engine.getParserForLang("py")).toEqual("python");
+    expect(engine.lookupLang("fake-language")).toBeNull();
   });
 });

--- a/js/languages/bash/tests/index.test.js
+++ b/js/languages/bash/tests/index.test.js
@@ -2,17 +2,22 @@ const { ParserFactory } = require("../dist/index.cjs");
 
 const parserPromise = ParserFactory();
 
-test("it has a lang value", async () => {
+const LANG = "bash";
+const EXPECTED_LANGS = [LANG];
+
+test("getLangKeys", async () => {
   const parser = await parserPromise;
-  expect(parser.getLangs()).toEqual([1]);
+  expect(parser.getLangKeys()).toEqual(EXPECTED_LANGS);
 });
 
 test("it parses a pattern", async () => {
   const parser = await parserPromise;
-  parser.parsePattern(false, 1, "echo $X");
+  const pattern = parser.parsePattern(false, LANG, "echo $X");
+  expect(typeof pattern).toEqual("object");
 });
 
 test("it parses a file", async () => {
   const parser = await parserPromise;
-  parser.parseTarget(1, "tests/test.sh");
+  const target = parser.parseTarget(LANG, "tests/test.sh");
+  expect(typeof target).toEqual("object");
 });

--- a/js/languages/bash/tests/index.test.js
+++ b/js/languages/bash/tests/index.test.js
@@ -5,9 +5,9 @@ const parserPromise = ParserFactory();
 const LANG = "bash";
 const EXPECTED_LANGS = [LANG];
 
-test("getLangKeys", async () => {
+test("getLangs", async () => {
   const parser = await parserPromise;
-  expect(parser.getLangKeys()).toEqual(EXPECTED_LANGS);
+  expect(parser.getLangs()).toEqual(EXPECTED_LANGS);
 });
 
 test("it parses a pattern", async () => {

--- a/js/languages/c/tests/index.test.js
+++ b/js/languages/c/tests/index.test.js
@@ -2,17 +2,22 @@ const { ParserFactory } = require("../dist/index.cjs");
 
 const parserPromise = ParserFactory();
 
-test("it has a lang value", async () => {
+const LANG = "c";
+const EXPECTED_LANGS = [LANG];
+
+test("getLangKeys", async () => {
   const parser = await parserPromise;
-  expect(parser.getLangs()).toEqual([2]);
+  expect(parser.getLangKeys()).toEqual(EXPECTED_LANGS);
 });
 
 test("it parses a pattern", async () => {
   const parser = await parserPromise;
-  parser.parsePattern(false, "printf(...)");
+  const pattern = parser.parsePattern(false, LANG, "printf(...)");
+  expect(typeof pattern).toEqual("object");
 });
 
 test("it parses a file", async () => {
   const parser = await parserPromise;
-  parser.parseTarget("tests/test.c");
+  const target = parser.parseTarget(LANG, "tests/test.c");
+  expect(typeof target).toEqual("object");
 });

--- a/js/languages/c/tests/index.test.js
+++ b/js/languages/c/tests/index.test.js
@@ -5,9 +5,9 @@ const parserPromise = ParserFactory();
 const LANG = "c";
 const EXPECTED_LANGS = [LANG];
 
-test("getLangKeys", async () => {
+test("getLangs", async () => {
   const parser = await parserPromise;
-  expect(parser.getLangKeys()).toEqual(EXPECTED_LANGS);
+  expect(parser.getLangs()).toEqual(EXPECTED_LANGS);
 });
 
 test("it parses a pattern", async () => {

--- a/js/languages/cpp/tests/index.test.js
+++ b/js/languages/cpp/tests/index.test.js
@@ -5,9 +5,9 @@ const parserPromise = ParserFactory();
 const LANG = "cpp";
 const EXPECTED_LANGS = [LANG];
 
-test("getLangKeys", async () => {
+test("getLangs", async () => {
   const parser = await parserPromise;
-  expect(parser.getLangKeys()).toEqual(EXPECTED_LANGS);
+  expect(parser.getLangs()).toEqual(EXPECTED_LANGS);
 });
 
 test("it parses a pattern", async () => {

--- a/js/languages/cpp/tests/index.test.js
+++ b/js/languages/cpp/tests/index.test.js
@@ -2,17 +2,22 @@ const { ParserFactory } = require("../dist/index.cjs");
 
 const parserPromise = ParserFactory();
 
-test("it has a lang value", async () => {
+const LANG = "cpp";
+const EXPECTED_LANGS = [LANG];
+
+test("getLangKeys", async () => {
   const parser = await parserPromise;
-  expect(parser.getLangs()).toEqual([4]);
+  expect(parser.getLangKeys()).toEqual(EXPECTED_LANGS);
 });
 
 test("it parses a pattern", async () => {
   const parser = await parserPromise;
-  parser.parsePattern(false, "std::cout << $X");
+  const pattern = parser.parsePattern(false, LANG, "std::cout << $X");
+  expect(typeof pattern).toEqual("object");
 });
 
 test("it parses a file", async () => {
   const parser = await parserPromise;
-  parser.parseTarget("tests/test.cpp");
+  const target = parser.parseTarget(LANG, "tests/test.cpp");
+  expect(typeof target).toEqual("object");
 });

--- a/js/languages/csharp/tests/index.test.js
+++ b/js/languages/csharp/tests/index.test.js
@@ -2,17 +2,22 @@ const { ParserFactory } = require("../dist/index.cjs");
 
 const parserPromise = ParserFactory();
 
-test("it has a lang value", async () => {
+const LANG = "csharp";
+const EXPECTED_LANGS = [LANG];
+
+test("getLangKeys", async () => {
   const parser = await parserPromise;
-  expect(parser.getLangs()).toEqual([5]);
+  expect(parser.getLangKeys()).toEqual(EXPECTED_LANGS);
 });
 
 test("it parses a pattern", async () => {
   const parser = await parserPromise;
-  parser.parsePattern(false, "Console.WriteLine($X)");
+  const pattern = parser.parsePattern(false, LANG, "Console.WriteLine($X)");
+  expect(typeof pattern).toEqual("object");
 });
 
 test("it parses a file", async () => {
   const parser = await parserPromise;
-  parser.parseTarget("tests/test.cs");
+  const target = parser.parseTarget(LANG, "tests/test.cs");
+  expect(typeof target).toEqual("object");
 });

--- a/js/languages/csharp/tests/index.test.js
+++ b/js/languages/csharp/tests/index.test.js
@@ -5,9 +5,9 @@ const parserPromise = ParserFactory();
 const LANG = "csharp";
 const EXPECTED_LANGS = [LANG];
 
-test("getLangKeys", async () => {
+test("getLangs", async () => {
   const parser = await parserPromise;
-  expect(parser.getLangKeys()).toEqual(EXPECTED_LANGS);
+  expect(parser.getLangs()).toEqual(EXPECTED_LANGS);
 });
 
 test("it parses a pattern", async () => {

--- a/js/languages/dockerfile/tests/index.test.js
+++ b/js/languages/dockerfile/tests/index.test.js
@@ -7,17 +7,21 @@ const parserPromise = (async () => {
   return ParserFactory();
 })();
 
-test("it has a lang value", async () => {
+const LANG = "dockerfile";
+const EXPECTED_LANGS = [LANG];
+
+test("getLangKeys", async () => {
   const parser = await parserPromise;
-  expect(parser.getLangs()).toEqual([7]);
+  expect(parser.getLangKeys()).toEqual(EXPECTED_LANGS);
 });
 
 test("it parses a pattern", async () => {
   const parser = await parserPromise;
-  parser.parsePattern(false, "COPY $X $Y");
+  const pattern = parser.parsePattern(false, LANG, "COPY $X $Y");
+  expect(typeof pattern).toEqual("object");
 });
 
 test("it parses a file", async () => {
   const parser = await parserPromise;
-  parser.parseTarget("tests/Dockerfile");
+  parser.parseTarget(LANG, "tests/Dockerfile");
 });

--- a/js/languages/dockerfile/tests/index.test.js
+++ b/js/languages/dockerfile/tests/index.test.js
@@ -10,9 +10,9 @@ const parserPromise = (async () => {
 const LANG = "dockerfile";
 const EXPECTED_LANGS = [LANG];
 
-test("getLangKeys", async () => {
+test("getLangs", async () => {
   const parser = await parserPromise;
-  expect(parser.getLangKeys()).toEqual(EXPECTED_LANGS);
+  expect(parser.getLangs()).toEqual(EXPECTED_LANGS);
 });
 
 test("it parses a pattern", async () => {

--- a/js/languages/elixir/tests/index.test.js
+++ b/js/languages/elixir/tests/index.test.js
@@ -2,17 +2,22 @@ const { ParserFactory } = require("../dist/index.cjs");
 
 const parserPromise = ParserFactory();
 
-test("it has a lang value", async () => {
+const LANG = "elixir";
+const EXPECTED_LANGS = [LANG];
+
+test("getLangKeys", async () => {
   const parser = await parserPromise;
-  expect(parser.getLangs()).toEqual([8]);
+  expect(parser.getLangKeys()).toEqual(EXPECTED_LANGS);
 });
 
 test("it parses a pattern", async () => {
   const parser = await parserPromise;
-  parser.parsePattern(false, "IO.puts($X)");
+  const pattern = parser.parsePattern(false, LANG, "IO.puts($X)");
+  expect(typeof pattern).toEqual("object");
 });
 
 test("it parses a file", async () => {
   const parser = await parserPromise;
-  parser.parseTarget("tests/test.exs");
+  const target = parser.parseTarget(LANG, "tests/test.exs");
+  expect(typeof target).toEqual("object");
 });

--- a/js/languages/elixir/tests/index.test.js
+++ b/js/languages/elixir/tests/index.test.js
@@ -5,9 +5,9 @@ const parserPromise = ParserFactory();
 const LANG = "elixir";
 const EXPECTED_LANGS = [LANG];
 
-test("getLangKeys", async () => {
+test("getLangs", async () => {
   const parser = await parserPromise;
-  expect(parser.getLangKeys()).toEqual(EXPECTED_LANGS);
+  expect(parser.getLangs()).toEqual(EXPECTED_LANGS);
 });
 
 test("it parses a pattern", async () => {

--- a/js/languages/go/tests/index.test.js
+++ b/js/languages/go/tests/index.test.js
@@ -2,17 +2,22 @@ const { ParserFactory } = require("../dist/index.cjs");
 
 const parserPromise = ParserFactory();
 
-test("it has a lang value", async () => {
+const LANG = "go";
+const EXPECTED_LANGS = [LANG];
+
+test("getLangKeys", async () => {
   const parser = await parserPromise;
-  expect(parser.getLangs()).toEqual([9]);
+  expect(parser.getLangKeys()).toEqual(EXPECTED_LANGS);
 });
 
 test("it parses a pattern", async () => {
   const parser = await parserPromise;
-  parser.parsePattern(false, "fmt.Printf($X)");
+  const pattern = parser.parsePattern(false, LANG, "fmt.Printf($X)");
+  expect(typeof pattern).toEqual("object");
 });
 
 test("it parses a file", async () => {
   const parser = await parserPromise;
-  parser.parseTarget("tests/test.go");
+  const target = parser.parseTarget(LANG, "tests/test.go");
+  expect(typeof target).toEqual("object");
 });

--- a/js/languages/go/tests/index.test.js
+++ b/js/languages/go/tests/index.test.js
@@ -5,9 +5,9 @@ const parserPromise = ParserFactory();
 const LANG = "go";
 const EXPECTED_LANGS = [LANG];
 
-test("getLangKeys", async () => {
+test("getLangs", async () => {
   const parser = await parserPromise;
-  expect(parser.getLangKeys()).toEqual(EXPECTED_LANGS);
+  expect(parser.getLangs()).toEqual(EXPECTED_LANGS);
 });
 
 test("it parses a pattern", async () => {

--- a/js/languages/html/tests/index.test.js
+++ b/js/languages/html/tests/index.test.js
@@ -5,9 +5,9 @@ const parserPromise = ParserFactory();
 const LANG = "html";
 const EXPECTED_LANGS = [LANG, "xml"];
 
-test("getLangKeys", async () => {
+test("getLangs", async () => {
   const parser = await parserPromise;
-  expect(parser.getLangKeys()).toEqual(EXPECTED_LANGS);
+  expect(parser.getLangs()).toEqual(EXPECTED_LANGS);
 });
 
 test("it parses a pattern", async () => {

--- a/js/languages/html/tests/index.test.js
+++ b/js/languages/html/tests/index.test.js
@@ -2,17 +2,22 @@ const { ParserFactory } = require("../dist/index.cjs");
 
 const parserPromise = ParserFactory();
 
-test("it has a lang value", async () => {
+const LANG = "html";
+const EXPECTED_LANGS = [LANG, "xml"];
+
+test("getLangKeys", async () => {
   const parser = await parserPromise;
-  expect(parser.getLangs()).toEqual([11, 35]);
+  expect(parser.getLangKeys()).toEqual(EXPECTED_LANGS);
 });
 
 test("it parses a pattern", async () => {
   const parser = await parserPromise;
-  parser.parsePattern(false, "<body>$X</body>");
+  const pattern = parser.parsePattern(false, LANG, "<body>$X</body>");
+  expect(typeof pattern).toEqual("object");
 });
 
 test("it parses a file", async () => {
   const parser = await parserPromise;
-  parser.parseTarget("tests/test.html");
+  const target = parser.parseTarget(LANG, "tests/test.html");
+  expect(typeof target).toEqual("object");
 });

--- a/js/languages/java/tests/index.test.js
+++ b/js/languages/java/tests/index.test.js
@@ -2,17 +2,22 @@ const { ParserFactory } = require("../dist/index.cjs");
 
 const parserPromise = ParserFactory();
 
-test("it has a lang value", async () => {
+const LANG = "java";
+const EXPECTED_LANGS = [LANG];
+
+test("getLangKeys", async () => {
   const parser = await parserPromise;
-  expect(parser.getLangs()).toEqual([12]);
+  expect(parser.getLangKeys()).toEqual(EXPECTED_LANGS);
 });
 
 test("it parses a pattern", async () => {
   const parser = await parserPromise;
-  parser.parsePattern(false, "System.out.println($X)");
+  const pattern = parser.parsePattern(false, LANG, "System.out.println($X)");
+  expect(typeof pattern).toEqual("object");
 });
 
 test("it parses a file", async () => {
   const parser = await parserPromise;
-  parser.parseTarget("tests/test.java");
+  const target = parser.parseTarget(LANG, "tests/test.java");
+  expect(typeof target).toEqual("object");
 });

--- a/js/languages/java/tests/index.test.js
+++ b/js/languages/java/tests/index.test.js
@@ -5,9 +5,9 @@ const parserPromise = ParserFactory();
 const LANG = "java";
 const EXPECTED_LANGS = [LANG];
 
-test("getLangKeys", async () => {
+test("getLangs", async () => {
   const parser = await parserPromise;
-  expect(parser.getLangKeys()).toEqual(EXPECTED_LANGS);
+  expect(parser.getLangs()).toEqual(EXPECTED_LANGS);
 });
 
 test("it parses a pattern", async () => {

--- a/js/languages/json/tests/index.test.js
+++ b/js/languages/json/tests/index.test.js
@@ -2,17 +2,22 @@ const { ParserFactory } = require("../dist/index.cjs");
 
 const parserPromise = ParserFactory();
 
-test("it has a lang value", async () => {
+const LANG = "json";
+const EXPECTED_LANGS = [LANG];
+
+test("getLangKeys", async () => {
   const parser = await parserPromise;
-  expect(parser.getLangs()).toEqual([14]);
+  expect(parser.getLangKeys()).toEqual(EXPECTED_LANGS);
 });
 
 test("it parses a pattern", async () => {
   const parser = await parserPromise;
-  parser.parsePattern(false, '{"foo": $X}');
+  const pattern = parser.parsePattern(false, LANG, '{"foo": $X}');
+  expect(typeof pattern).toEqual("object");
 });
 
 test("it parses a file", async () => {
   const parser = await parserPromise;
-  parser.parseTarget("tests/test.json");
+  const target = parser.parseTarget(LANG, "tests/test.json");
+  expect(typeof target).toEqual("object");
 });

--- a/js/languages/json/tests/index.test.js
+++ b/js/languages/json/tests/index.test.js
@@ -5,9 +5,9 @@ const parserPromise = ParserFactory();
 const LANG = "json";
 const EXPECTED_LANGS = [LANG];
 
-test("getLangKeys", async () => {
+test("getLangs", async () => {
   const parser = await parserPromise;
-  expect(parser.getLangKeys()).toEqual(EXPECTED_LANGS);
+  expect(parser.getLangs()).toEqual(EXPECTED_LANGS);
 });
 
 test("it parses a pattern", async () => {

--- a/js/languages/jsonnet/tests/index.test.js
+++ b/js/languages/jsonnet/tests/index.test.js
@@ -5,9 +5,9 @@ const parserPromise = ParserFactory();
 const LANG = "jsonnet";
 const EXPECTED_LANGS = [LANG];
 
-test("getLangKeys", async () => {
+test("getLangs", async () => {
   const parser = await parserPromise;
-  expect(parser.getLangKeys()).toEqual(EXPECTED_LANGS);
+  expect(parser.getLangs()).toEqual(EXPECTED_LANGS);
 });
 
 test("it parses a pattern", async () => {

--- a/js/languages/jsonnet/tests/index.test.js
+++ b/js/languages/jsonnet/tests/index.test.js
@@ -2,17 +2,22 @@ const { ParserFactory } = require("../dist/index.cjs");
 
 const parserPromise = ParserFactory();
 
-test("it has a lang value", async () => {
+const LANG = "jsonnet";
+const EXPECTED_LANGS = [LANG];
+
+test("getLangKeys", async () => {
   const parser = await parserPromise;
-  expect(parser.getLangs()).toEqual([15]);
+  expect(parser.getLangKeys()).toEqual(EXPECTED_LANGS);
 });
 
 test("it parses a pattern", async () => {
   const parser = await parserPromise;
-  parser.parsePattern(false, "$X + $Y");
+  const pattern = parser.parsePattern(false, LANG, "$X + $Y");
+  expect(typeof pattern).toEqual("object");
 });
 
 test("it parses a file", async () => {
   const parser = await parserPromise;
-  parser.parseTarget("tests/test.jsonnet");
+  const target = parser.parseTarget(LANG, "tests/test.jsonnet");
+  expect(typeof target).toEqual("object");
 });

--- a/js/languages/kotlin/tests/index.test.js
+++ b/js/languages/kotlin/tests/index.test.js
@@ -2,17 +2,22 @@ const { ParserFactory } = require("../dist/index.cjs");
 
 const parserPromise = ParserFactory();
 
-test("it has a lang value", async () => {
+const LANG = "kotlin";
+const EXPECTED_LANGS = [LANG];
+
+test("getLangKeys", async () => {
   const parser = await parserPromise;
-  expect(parser.getLangs()).toEqual([17]);
+  expect(parser.getLangKeys()).toEqual(EXPECTED_LANGS);
 });
 
 test("it parses a pattern", async () => {
   const parser = await parserPromise;
-  parser.parsePattern(false, "println($X)");
+  const pattern = parser.parsePattern(false, LANG, "println($X)");
+  expect(typeof pattern).toEqual("object");
 });
 
 test("it parses a file", async () => {
   const parser = await parserPromise;
-  parser.parseTarget("tests/test.kt");
+  const target = parser.parseTarget(LANG, "tests/test.kt");
+  expect(typeof target).toEqual("object");
 });

--- a/js/languages/kotlin/tests/index.test.js
+++ b/js/languages/kotlin/tests/index.test.js
@@ -5,9 +5,9 @@ const parserPromise = ParserFactory();
 const LANG = "kotlin";
 const EXPECTED_LANGS = [LANG];
 
-test("getLangKeys", async () => {
+test("getLangs", async () => {
   const parser = await parserPromise;
-  expect(parser.getLangKeys()).toEqual(EXPECTED_LANGS);
+  expect(parser.getLangs()).toEqual(EXPECTED_LANGS);
 });
 
 test("it parses a pattern", async () => {

--- a/js/languages/lisp/tests/index.test.js
+++ b/js/languages/lisp/tests/index.test.js
@@ -5,9 +5,9 @@ const parserPromise = ParserFactory();
 const LANG = "lisp";
 const EXPECTED_LANGS = [LANG, "scheme", "clojure"];
 
-test("getLangKeys", async () => {
+test("getLangs", async () => {
   const parser = await parserPromise;
-  expect(parser.getLangKeys()).toEqual(EXPECTED_LANGS);
+  expect(parser.getLangs()).toEqual(EXPECTED_LANGS);
 });
 
 test("it parses a pattern", async () => {

--- a/js/languages/lisp/tests/index.test.js
+++ b/js/languages/lisp/tests/index.test.js
@@ -2,17 +2,22 @@ const { ParserFactory } = require("../dist/index.cjs");
 
 const parserPromise = ParserFactory();
 
-test("it has a lang value", async () => {
+const LANG = "lisp";
+const EXPECTED_LANGS = [LANG, "scheme", "clojure"];
+
+test("getLangKeys", async () => {
   const parser = await parserPromise;
-  expect(parser.getLangs()).toEqual([18, 29, 3]);
+  expect(parser.getLangKeys()).toEqual(EXPECTED_LANGS);
 });
 
 test("it parses a pattern", async () => {
   const parser = await parserPromise;
-  parser.parsePattern(false, "(ns $X)");
+  const pattern = parser.parsePattern(false, LANG, "(ns $X)");
+  expect(typeof pattern).toEqual("object");
 });
 
 test("it parses a file", async () => {
   const parser = await parserPromise;
-  parser.parseTarget("tests/test.clj");
+  const target = parser.parseTarget(LANG, "tests/test.clj");
+  expect(typeof target).toEqual("object");
 });

--- a/js/languages/lua/tests/index.test.js
+++ b/js/languages/lua/tests/index.test.js
@@ -5,9 +5,9 @@ const parserPromise = ParserFactory();
 const LANG = "lua";
 const EXPECTED_LANGS = [LANG];
 
-test("getLangKeys", async () => {
+test("getLangs", async () => {
   const parser = await parserPromise;
-  expect(parser.getLangKeys()).toEqual(EXPECTED_LANGS);
+  expect(parser.getLangs()).toEqual(EXPECTED_LANGS);
 });
 
 test("it parses a pattern", async () => {

--- a/js/languages/lua/tests/index.test.js
+++ b/js/languages/lua/tests/index.test.js
@@ -2,17 +2,22 @@ const { ParserFactory } = require("../dist/index.cjs");
 
 const parserPromise = ParserFactory();
 
-test("it has a lang value", async () => {
+const LANG = "lua";
+const EXPECTED_LANGS = [LANG];
+
+test("getLangKeys", async () => {
   const parser = await parserPromise;
-  expect(parser.getLangs()).toEqual([19]);
+  expect(parser.getLangKeys()).toEqual(EXPECTED_LANGS);
 });
 
 test("it parses a pattern", async () => {
   const parser = await parserPromise;
-  parser.parsePattern(false, "print($X)");
+  const pattern = parser.parsePattern(false, LANG, "print($X)");
+  expect(typeof pattern).toEqual("object");
 });
 
 test("it parses a file", async () => {
   const parser = await parserPromise;
-  parser.parseTarget("tests/test.lua");
+  const target = parser.parseTarget(LANG, "tests/test.lua");
+  expect(typeof target).toEqual("object");
 });

--- a/js/languages/ocaml/tests/index.test.js
+++ b/js/languages/ocaml/tests/index.test.js
@@ -2,17 +2,22 @@ const { ParserFactory } = require("../dist/index.cjs");
 
 const parserPromise = ParserFactory();
 
-test("it has a lang value", async () => {
+const LANG = "ocaml";
+const EXPECTED_LANGS = [LANG];
+
+test("getLangKeys", async () => {
   const parser = await parserPromise;
-  expect(parser.getLangs()).toEqual([20]);
+  expect(parser.getLangKeys()).toEqual(EXPECTED_LANGS);
 });
 
 test("it parses a pattern", async () => {
   const parser = await parserPromise;
-  parser.parsePattern(false, "(print_endline $X)");
+  const pattern = parser.parsePattern(false, LANG, "(print_endline $X)");
+  expect(typeof pattern).toEqual("object");
 });
 
 test("it parses a file", async () => {
   const parser = await parserPromise;
-  parser.parseTarget("tests/test.ml");
+  const target = parser.parseTarget(LANG, "tests/test.ml");
+  expect(typeof target).toEqual("object");
 });

--- a/js/languages/ocaml/tests/index.test.js
+++ b/js/languages/ocaml/tests/index.test.js
@@ -5,9 +5,9 @@ const parserPromise = ParserFactory();
 const LANG = "ocaml";
 const EXPECTED_LANGS = [LANG];
 
-test("getLangKeys", async () => {
+test("getLangs", async () => {
   const parser = await parserPromise;
-  expect(parser.getLangKeys()).toEqual(EXPECTED_LANGS);
+  expect(parser.getLangs()).toEqual(EXPECTED_LANGS);
 });
 
 test("it parses a pattern", async () => {

--- a/js/languages/php/tests/index.test.js
+++ b/js/languages/php/tests/index.test.js
@@ -5,9 +5,9 @@ const parserPromise = ParserFactory();
 const LANG = "php";
 const EXPECTED_LANGS = [LANG];
 
-test("getLangKeys", async () => {
+test("getLangs", async () => {
   const parser = await parserPromise;
-  expect(parser.getLangKeys()).toEqual(EXPECTED_LANGS);
+  expect(parser.getLangs()).toEqual(EXPECTED_LANGS);
 });
 
 test("it parses a pattern", async () => {

--- a/js/languages/php/tests/index.test.js
+++ b/js/languages/php/tests/index.test.js
@@ -2,17 +2,22 @@ const { ParserFactory } = require("../dist/index.cjs");
 
 const parserPromise = ParserFactory();
 
-test("it has a lang value", async () => {
+const LANG = "php";
+const EXPECTED_LANGS = [LANG];
+
+test("getLangKeys", async () => {
   const parser = await parserPromise;
-  expect(parser.getLangs()).toEqual([21]);
+  expect(parser.getLangKeys()).toEqual(EXPECTED_LANGS);
 });
 
 test("it parses a pattern", async () => {
   const parser = await parserPromise;
-  parser.parsePattern(true, "echo $X;");
+  const pattern = parser.parsePattern(true, LANG, "echo $X;");
+  expect(typeof pattern).toEqual("object");
 });
 
 test("it parses a file", async () => {
   const parser = await parserPromise;
-  parser.parseTarget("tests/test.php");
+  const target = parser.parseTarget(LANG, "tests/test.php");
+  expect(typeof target).toEqual("object");
 });

--- a/js/languages/python/tests/index.test.js
+++ b/js/languages/python/tests/index.test.js
@@ -2,17 +2,22 @@ const { ParserFactory } = require("../dist/index.cjs");
 
 const parserPromise = ParserFactory();
 
-test("it has a lang value", async () => {
+const LANG = "python";
+const EXPECTED_LANGS = [LANG, "python2", "python3"];
+
+test("getLangKeys", async () => {
   const parser = await parserPromise;
-  expect(parser.getLangs()).toEqual([24, 22, 23]);
+  expect(parser.getLangKeys()).toEqual(EXPECTED_LANGS);
 });
 
 test("it parses a pattern", async () => {
   const parser = await parserPromise;
-  parser.parsePattern(false, "print($X)");
+  const pattern = parser.parsePattern(false, LANG, "print($X)");
+  expect(typeof pattern).toEqual("object");
 });
 
 test("it parses a file", async () => {
   const parser = await parserPromise;
-  parser.parseTarget("tests/test.py");
+  const target = parser.parseTarget(LANG, "tests/test.py");
+  expect(typeof target).toEqual("object");
 });

--- a/js/languages/python/tests/index.test.js
+++ b/js/languages/python/tests/index.test.js
@@ -5,9 +5,9 @@ const parserPromise = ParserFactory();
 const LANG = "python";
 const EXPECTED_LANGS = [LANG, "python2", "python3"];
 
-test("getLangKeys", async () => {
+test("getLangs", async () => {
   const parser = await parserPromise;
-  expect(parser.getLangKeys()).toEqual(EXPECTED_LANGS);
+  expect(parser.getLangs()).toEqual(EXPECTED_LANGS);
 });
 
 test("it parses a pattern", async () => {

--- a/js/languages/r/tests/index.test.js
+++ b/js/languages/r/tests/index.test.js
@@ -2,17 +2,22 @@ const { ParserFactory } = require("../dist/index.cjs");
 
 const parserPromise = ParserFactory();
 
-test("it has a lang value", async () => {
+const LANG = "r";
+const EXPECTED_LANGS = [LANG];
+
+test("getLangKeys", async () => {
   const parser = await parserPromise;
-  expect(parser.getLangs()).toEqual([25]);
+  expect(parser.getLangKeys()).toEqual(EXPECTED_LANGS);
 });
 
 test("it parses a pattern", async () => {
   const parser = await parserPromise;
-  parser.parsePattern(false, "print($X)");
+  const pattern = parser.parsePattern(false, LANG, "print($X)");
+  expect(typeof pattern).toEqual("object");
 });
 
 test("it parses a file", async () => {
   const parser = await parserPromise;
-  parser.parseTarget("tests/test.r");
+  const target = parser.parseTarget(LANG, "tests/test.r");
+  expect(typeof target).toEqual("object");
 });

--- a/js/languages/r/tests/index.test.js
+++ b/js/languages/r/tests/index.test.js
@@ -5,9 +5,9 @@ const parserPromise = ParserFactory();
 const LANG = "r";
 const EXPECTED_LANGS = [LANG];
 
-test("getLangKeys", async () => {
+test("getLangs", async () => {
   const parser = await parserPromise;
-  expect(parser.getLangKeys()).toEqual(EXPECTED_LANGS);
+  expect(parser.getLangs()).toEqual(EXPECTED_LANGS);
 });
 
 test("it parses a pattern", async () => {

--- a/js/languages/ruby/tests/index.test.js
+++ b/js/languages/ruby/tests/index.test.js
@@ -2,17 +2,22 @@ const { ParserFactory } = require("../dist/index.cjs");
 
 const parserPromise = ParserFactory();
 
-test("it has a lang value", async () => {
+const LANG = "ruby";
+const EXPECTED_LANGS = [LANG];
+
+test("getLangKeys", async () => {
   const parser = await parserPromise;
-  expect(parser.getLangs()).toEqual([26]);
+  expect(parser.getLangKeys()).toEqual(EXPECTED_LANGS);
 });
 
 test("it parses a pattern", async () => {
   const parser = await parserPromise;
-  parser.parsePattern(false, "print $X");
+  const pattern = parser.parsePattern(false, LANG, "print $X");
+  expect(typeof pattern).toEqual("object");
 });
 
 test("it parses a file", async () => {
   const parser = await parserPromise;
-  parser.parseTarget("tests/test.rb");
+  const target = parser.parseTarget(LANG, "tests/test.rb");
+  expect(typeof target).toEqual("object");
 });

--- a/js/languages/ruby/tests/index.test.js
+++ b/js/languages/ruby/tests/index.test.js
@@ -5,9 +5,9 @@ const parserPromise = ParserFactory();
 const LANG = "ruby";
 const EXPECTED_LANGS = [LANG];
 
-test("getLangKeys", async () => {
+test("getLangs", async () => {
   const parser = await parserPromise;
-  expect(parser.getLangKeys()).toEqual(EXPECTED_LANGS);
+  expect(parser.getLangs()).toEqual(EXPECTED_LANGS);
 });
 
 test("it parses a pattern", async () => {

--- a/js/languages/rust/tests/index.test.js
+++ b/js/languages/rust/tests/index.test.js
@@ -2,17 +2,22 @@ const { ParserFactory } = require("../dist/index.cjs");
 
 const parserPromise = ParserFactory();
 
-test("it has a lang value", async () => {
+const LANG = "rust";
+const EXPECTED_LANGS = [LANG];
+
+test("getLangKeys", async () => {
   const parser = await parserPromise;
-  expect(parser.getLangs()).toEqual([27]);
+  expect(parser.getLangKeys()).toEqual(EXPECTED_LANGS);
 });
 
 test("it parses a pattern", async () => {
   const parser = await parserPromise;
-  parser.parsePattern(false, "println!($X)");
+  const pattern = parser.parsePattern(false, LANG, "println!($X)");
+  expect(typeof pattern).toEqual("object");
 });
 
 test("it parses a file", async () => {
   const parser = await parserPromise;
-  parser.parseTarget("tests/test.rs");
+  const target = parser.parseTarget(LANG, "tests/test.rs");
+  expect(typeof target).toEqual("object");
 });

--- a/js/languages/rust/tests/index.test.js
+++ b/js/languages/rust/tests/index.test.js
@@ -5,9 +5,9 @@ const parserPromise = ParserFactory();
 const LANG = "rust";
 const EXPECTED_LANGS = [LANG];
 
-test("getLangKeys", async () => {
+test("getLangs", async () => {
   const parser = await parserPromise;
-  expect(parser.getLangKeys()).toEqual(EXPECTED_LANGS);
+  expect(parser.getLangs()).toEqual(EXPECTED_LANGS);
 });
 
 test("it parses a pattern", async () => {

--- a/js/languages/scala/tests/index.test.js
+++ b/js/languages/scala/tests/index.test.js
@@ -2,17 +2,22 @@ const { ParserFactory } = require("../dist/index.cjs");
 
 const parserPromise = ParserFactory();
 
-test("it has a lang value", async () => {
+const LANG = "scala";
+const EXPECTED_LANGS = [LANG];
+
+test("getLangKeys", async () => {
   const parser = await parserPromise;
-  expect(parser.getLangs()).toEqual([28]);
+  expect(parser.getLangKeys()).toEqual(EXPECTED_LANGS);
 });
 
 test("it parses a pattern", async () => {
   const parser = await parserPromise;
-  parser.parsePattern(false, "println($X)");
+  const pattern = parser.parsePattern(false, LANG, "println($X)");
+  expect(typeof pattern).toEqual("object");
 });
 
 test("it parses a file", async () => {
   const parser = await parserPromise;
-  parser.parseTarget("tests/test.scala");
+  const target = parser.parseTarget(LANG, "tests/test.scala");
+  expect(typeof target).toEqual("object");
 });

--- a/js/languages/scala/tests/index.test.js
+++ b/js/languages/scala/tests/index.test.js
@@ -5,9 +5,9 @@ const parserPromise = ParserFactory();
 const LANG = "scala";
 const EXPECTED_LANGS = [LANG];
 
-test("getLangKeys", async () => {
+test("getLangs", async () => {
   const parser = await parserPromise;
-  expect(parser.getLangKeys()).toEqual(EXPECTED_LANGS);
+  expect(parser.getLangs()).toEqual(EXPECTED_LANGS);
 });
 
 test("it parses a pattern", async () => {

--- a/js/languages/solidity/tests/index.test.js
+++ b/js/languages/solidity/tests/index.test.js
@@ -2,17 +2,22 @@ const { ParserFactory } = require("../dist/index.cjs");
 
 const parserPromise = ParserFactory();
 
-test("it has a lang value", async () => {
+const LANG = "solidity";
+const EXPECTED_LANGS = [LANG];
+
+test("getLangKeys", async () => {
   const parser = await parserPromise;
-  expect(parser.getLangs()).toEqual([30]);
+  expect(parser.getLangKeys()).toEqual(EXPECTED_LANGS);
 });
 
 test("it parses a pattern", async () => {
   const parser = await parserPromise;
-  parser.parsePattern(false, "$X = $Y;");
+  const pattern = parser.parsePattern(false, LANG, "$X = $Y;");
+  expect(typeof pattern).toEqual("object");
 });
 
 test("it parses a file", async () => {
   const parser = await parserPromise;
-  parser.parseTarget("tests/test.sol");
+  const target = parser.parseTarget(LANG, "tests/test.sol");
+  expect(typeof target).toEqual("object");
 });

--- a/js/languages/solidity/tests/index.test.js
+++ b/js/languages/solidity/tests/index.test.js
@@ -5,9 +5,9 @@ const parserPromise = ParserFactory();
 const LANG = "solidity";
 const EXPECTED_LANGS = [LANG];
 
-test("getLangKeys", async () => {
+test("getLangs", async () => {
   const parser = await parserPromise;
-  expect(parser.getLangKeys()).toEqual(EXPECTED_LANGS);
+  expect(parser.getLangs()).toEqual(EXPECTED_LANGS);
 });
 
 test("it parses a pattern", async () => {

--- a/js/languages/swift/tests/index.test.js
+++ b/js/languages/swift/tests/index.test.js
@@ -2,17 +2,22 @@ const { ParserFactory } = require("../dist/index.cjs");
 
 const parserPromise = ParserFactory();
 
-test("it has a lang value", async () => {
+const LANG = "swift";
+const EXPECTED_LANGS = [LANG];
+
+test("getLangKeys", async () => {
   const parser = await parserPromise;
-  expect(parser.getLangs()).toEqual([31]);
+  expect(parser.getLangKeys()).toEqual(EXPECTED_LANGS);
 });
 
 test("it parses a pattern", async () => {
   const parser = await parserPromise;
-  parser.parsePattern(false, "print($X)");
+  const pattern = parser.parsePattern(false, LANG, "print($X)");
+  expect(typeof pattern).toEqual("object");
 });
 
 test("it parses a file", async () => {
   const parser = await parserPromise;
-  parser.parseTarget("tests/test.swift");
+  const target = parser.parseTarget(LANG, "tests/test.swift");
+  expect(typeof target).toEqual("object");
 });

--- a/js/languages/swift/tests/index.test.js
+++ b/js/languages/swift/tests/index.test.js
@@ -5,9 +5,9 @@ const parserPromise = ParserFactory();
 const LANG = "swift";
 const EXPECTED_LANGS = [LANG];
 
-test("getLangKeys", async () => {
+test("getLangs", async () => {
   const parser = await parserPromise;
-  expect(parser.getLangKeys()).toEqual(EXPECTED_LANGS);
+  expect(parser.getLangs()).toEqual(EXPECTED_LANGS);
 });
 
 test("it parses a pattern", async () => {

--- a/js/languages/terraform/tests/index.test.js
+++ b/js/languages/terraform/tests/index.test.js
@@ -5,9 +5,9 @@ const parserPromise = ParserFactory();
 const LANG = "terraform";
 const EXPECTED_LANGS = [LANG];
 
-test("getLangKeys", async () => {
+test("getLangs", async () => {
   const parser = await parserPromise;
-  expect(parser.getLangKeys()).toEqual(EXPECTED_LANGS);
+  expect(parser.getLangs()).toEqual(EXPECTED_LANGS);
 });
 
 test("it parses a pattern", async () => {

--- a/js/languages/terraform/tests/index.test.js
+++ b/js/languages/terraform/tests/index.test.js
@@ -2,17 +2,22 @@ const { ParserFactory } = require("../dist/index.cjs");
 
 const parserPromise = ParserFactory();
 
-test("it has a lang value", async () => {
+const LANG = "terraform";
+const EXPECTED_LANGS = [LANG];
+
+test("getLangKeys", async () => {
   const parser = await parserPromise;
-  expect(parser.getLangs()).toEqual([32]);
+  expect(parser.getLangKeys()).toEqual(EXPECTED_LANGS);
 });
 
 test("it parses a pattern", async () => {
   const parser = await parserPromise;
-  parser.parsePattern(false, "value = $X");
+  const pattern = parser.parsePattern(false, LANG, "value = $X");
+  expect(typeof pattern).toEqual("object");
 });
 
 test("it parses a file", async () => {
   const parser = await parserPromise;
-  parser.parseTarget("tests/test.tf");
+  const target = parser.parseTarget(LANG, "tests/test.tf");
+  expect(typeof target).toEqual("object");
 });

--- a/js/languages/typescript/tests/index.test.js
+++ b/js/languages/typescript/tests/index.test.js
@@ -2,27 +2,33 @@ const { ParserFactory } = require("../dist/index.cjs");
 
 const parserPromise = ParserFactory();
 
-test("it has a lang", async () => {
+const EXPECTED_LANGS = ["js", "ts"];
+
+test("getLangKeys", async () => {
   const parser = await parserPromise;
-  expect(parser.getLangs()).toEqual([13, 33]);
+  expect(parser.getLangKeys()).toEqual(EXPECTED_LANGS);
 });
 
 test("it successfully parses a pattern", async () => {
   const parser = await parserPromise;
-  parser.parsePattern(false, "console.log($X)");
+  const pattern = parser.parsePattern(false, "js", "console.log($X)");
+  expect(typeof pattern).toEqual("object");
 });
 
 test("it parses a js file", async () => {
   const parser = await parserPromise;
-  parser.parseTarget(13, "tests/example.ts");
+  const target = parser.parseTarget("js", "tests/example.ts");
+  expect(typeof target).toEqual("object");
 });
 
 test("it parses a ts file", async () => {
   const parser = await parserPromise;
-  parser.parseTarget(33, "tests/example.ts");
+  const target = parser.parseTarget("ts", "tests/example.ts");
+  expect(typeof target).toEqual("object");
 });
 
 test("it parses a tsx file", async () => {
   const parser = await parserPromise;
-  parser.parseTarget(33, "tests/example.tsx");
+  const target = parser.parseTarget("ts", "tests/example.tsx");
+  expect(typeof target).toEqual("object");
 });

--- a/js/languages/typescript/tests/index.test.js
+++ b/js/languages/typescript/tests/index.test.js
@@ -4,9 +4,9 @@ const parserPromise = ParserFactory();
 
 const EXPECTED_LANGS = ["js", "ts"];
 
-test("getLangKeys", async () => {
+test("getLangs", async () => {
   const parser = await parserPromise;
-  expect(parser.getLangKeys()).toEqual(EXPECTED_LANGS);
+  expect(parser.getLangs()).toEqual(EXPECTED_LANGS);
 });
 
 test("it successfully parses a pattern", async () => {

--- a/js/libpcre/Makefile.include
+++ b/js/libpcre/Makefile.include
@@ -1,1 +1,1 @@
-PCRE_EXPORTED_METHODS := _pcre_version,_pcre_config,_pcre_compile,_pcre_study,_pcre_fullinfo
+PCRE_EXPORTED_METHODS := _pcre_version,_pcre_config,_pcre_compile,_pcre_study,_pcre_fullinfo,_pcre_exec

--- a/js/shared/Semgrep_js_shared.ml
+++ b/js/shared/Semgrep_js_shared.ml
@@ -13,10 +13,7 @@ external set_parser_wasm_module : 'any -> unit = "set_parser_wasm_module"
 let make_js_module (langs : Lang.t list) parse_target parse_pattern =
   let lang_names =
     Array.of_list
-      (Common.map
-         (fun x ->
-           x |> Lang.to_lowercase_alnum |> String.lowercase_ascii |> Js.string)
-         langs)
+      (Common.map (fun x -> Js.string (Lang.to_lowercase_alnum x)) langs)
   in
   Js.export "createParser" (fun wasm_module ->
       set_parser_wasm_module wasm_module;
@@ -25,12 +22,10 @@ let make_js_module (langs : Lang.t list) parse_target parse_pattern =
         method setMountpoints = set_jsoo_mount_point
 
         method parseTarget lang file =
-          parse_target
-            (lang |> Js.to_string |> Lang.of_string)
-            (Js.to_string file)
+          parse_target (Lang.of_string (Js.to_string lang)) (Js.to_string file)
 
         method parsePattern print_errors lang str =
           parse_pattern (Js.to_bool print_errors)
-            (lang |> Js.to_string |> Lang.of_string)
+            (Lang.of_string (Js.to_string lang))
             (Js.to_string str)
       end)

--- a/js/shared/Semgrep_js_shared.ml
+++ b/js/shared/Semgrep_js_shared.ml
@@ -11,7 +11,7 @@ external set_jsoo_mount_point : 'any Js.js_array -> unit
 external set_parser_wasm_module : 'any -> unit = "set_parser_wasm_module"
 
 let make_js_module (langs : Lang.t list) parse_target parse_pattern =
-  let lang_keys =
+  let lang_names =
     Array.of_list
       (Common.map
          (fun x ->
@@ -21,8 +21,7 @@ let make_js_module (langs : Lang.t list) parse_target parse_pattern =
   Js.export "createParser" (fun wasm_module ->
       set_parser_wasm_module wasm_module;
       object%js
-        method getLangs = Js.array (Array.of_list langs)
-        method getLangKeys = Js.array lang_keys
+        method getLangs = Js.array lang_names
         method setMountpoints = set_jsoo_mount_point
 
         method parseTarget lang file =

--- a/js/shared/Semgrep_js_shared.ml
+++ b/js/shared/Semgrep_js_shared.ml
@@ -11,13 +11,27 @@ external set_jsoo_mount_point : 'any Js.js_array -> unit
 external set_parser_wasm_module : 'any -> unit = "set_parser_wasm_module"
 
 let make_js_module (langs : Lang.t list) parse_target parse_pattern =
+  let lang_keys =
+    Array.of_list
+      (Common.map
+         (fun x ->
+           x |> Lang.to_lowercase_alnum |> String.lowercase_ascii |> Js.string)
+         langs)
+  in
   Js.export "createParser" (fun wasm_module ->
       set_parser_wasm_module wasm_module;
       object%js
         method getLangs = Js.array (Array.of_list langs)
+        method getLangKeys = Js.array lang_keys
         method setMountpoints = set_jsoo_mount_point
-        method parseTarget lang file = parse_target lang (Js.to_string file)
+
+        method parseTarget lang file =
+          parse_target
+            (lang |> Js.to_string |> Lang.of_string)
+            (Js.to_string file)
 
         method parsePattern print_errors lang str =
-          parse_pattern (Js.to_bool print_errors) lang (Js.to_string str)
+          parse_pattern (Js.to_bool print_errors)
+            (lang |> Js.to_string |> Lang.of_string)
+            (Js.to_string str)
       end)


### PR DESCRIPTION
jsoo internally represents `Lang.t` by its ordinal number, which means that adding a language requires rolling out a new version of the engine and *all* parsers. This PR updates the code to use the language's name instead, which should be more stable.

Also, added support for parser name overrides (e.g. `python3` is parsed by the `python` parser) since we don't have a perfect 1:1 mapping between langs and parsers.

There's a lot of copypasta in the tests -- I need to factor out some stuff in a future PR.

test plan:
- [x] full test suite
- [x] local playground testing