### PR TITLE
Fix ppx_profiling to handle labels and add more [@@profiling]

### DIFF
--- a/languages/php/menhir/parse_php.ml
+++ b/languages/php/menhir/parse_php.ml
@@ -38,7 +38,7 @@ let error_msg_tok tok = Parsing_helpers.error_message_info (TH.info_of_tok tok)
 (*****************************************************************************)
 (* Lexing only *)
 (*****************************************************************************)
-let tokens2 ?(init_state = Lexer_php.INITIAL) input_source =
+let tokens ?(init_state = Lexer_php.INITIAL) input_source =
   Lexer_php.reset ();
   Lexer_php._mode_stack := [ init_state ];
 
@@ -70,9 +70,7 @@ let tokens2 ?(init_state = Lexer_php.INITIAL) input_source =
   in
   Parsing_helpers.tokenize_all_and_adjust_pos input_source token
     TH.visitor_info_of_tok TH.is_eof
-
-let tokens ?init_state a =
-  Profiling.profile_code "Parse_php.tokens" (fun () -> tokens2 ?init_state a)
+  [@@profiling]
 
 let is_comment v =
   TH.is_comment v
@@ -87,7 +85,7 @@ let is_comment v =
 (* Main entry point *)
 (*****************************************************************************)
 
-let parse2 ?(pp = !Flag_php.pp_default) filename =
+let parse ?(pp = !Flag_php.pp_default) filename =
   let orig_filename = filename in
   let filename =
     (* note that now that pfff support XHP constructs directly,
@@ -191,9 +189,7 @@ let parse2 ?(pp = !Flag_php.pp_default) filename =
         tokens = info_item;
         stat;
       }
-
-let parse ?pp a =
-  Profiling.profile_code "Parse_php.parse" (fun () -> parse2 ?pp a)
+  [@@profiling]
 
 let parse_program ?pp file =
   let res = parse ?pp file in

--- a/languages/python/menhir/Parse_python.ml
+++ b/languages/python/menhir/Parse_python.ml
@@ -93,7 +93,7 @@ let tokens parsing_mode input_source =
 (* Main entry point *)
 (*****************************************************************************)
 
-let rec parse_basic ?(parsing_mode = Python) filename =
+let rec parse ?(parsing_mode = Python) filename =
   let stat = Parsing_stat.default_stat filename in
 
   (* this can throw Parse_info.Lexical_error *)
@@ -143,7 +143,7 @@ let rec parse_basic ?(parsing_mode = Python) filename =
         (* note that we cant use tokens as the tokens are actually different
          * in Python2 mode, but we could optimize things a bit and just
          * transform those tokens here *)
-        parse_basic ~parsing_mode:Python2 filename
+        parse ~parsing_mode:Python2 filename
       else
         let cur = tr.Parsing_helpers.current in
         if not !Flag.error_recovery then
@@ -158,10 +158,7 @@ let rec parse_basic ?(parsing_mode = Python) filename =
           Parsing_helpers.print_bad line_error (0, checkpoint2) filelines);
         stat.PS.error_line_count <- stat.PS.total_line_count;
         { Parsing_result.ast = []; tokens = toks; stat }
-
-let parse ?parsing_mode a =
-  Profiling.profile_code "Parse_python.parse" (fun () ->
-      parse_basic ?parsing_mode a)
+  [@@profiling]
 
 let parse_program ?parsing_mode file =
   let res = parse ?parsing_mode file in

--- a/libs/gitignore/Gitignore_filter.ml
+++ b/libs/gitignore/Gitignore_filter.ml
@@ -118,3 +118,4 @@ let select t sel_events (full_git_path : Ppath.t) =
       select_path None sel_events t.lower_priority_levels rel_segments
     in
     result_of_selection_events sel_events
+  [@@profiling]

--- a/libs/gitignore/Gitignores_cache.ml
+++ b/libs/gitignore/Gitignores_cache.ml
@@ -42,3 +42,4 @@ let load t dir_path =
       in
       Hashtbl.add tbl key res;
       res
+  [@@profiling]

--- a/libs/gitignore/Parse_gitignore.ml
+++ b/libs/gitignore/Parse_gitignore.ml
@@ -102,3 +102,4 @@ let from_string ~anchor ~name ~kind str =
 let from_file ~anchor ~kind path =
   Fpath.to_string path |> Common.read_file
   |> from_string ~anchor ~name:(Fpath.to_string path) ~kind
+  [@@profiling]

--- a/libs/gitignore/dune
+++ b/libs/gitignore/dune
@@ -5,7 +5,11 @@
   (wrapped false)
   (libraries
     glob
+    profiling
     ppath
   )
-  (preprocess (pps ppx_deriving.show))
+  (preprocess (pps
+    ppx_deriving.show
+    profiling.ppx
+  ))
 )

--- a/libs/glob/Match.ml
+++ b/libs/glob/Match.ml
@@ -93,6 +93,7 @@ let map_root pat = Re.seq (Re.bos :: map pat)
 let compile ~source pat =
   let re = map_root pat |> Re.compile in
   { source; re }
+  [@@profiling "Glob.Match.compile"]
 
 (* This is used during unit testing. *)
 let debug = ref false
@@ -104,6 +105,7 @@ let run matcher path =
     Printf.printf "** pattern: %S  path: %S  matches: %B\n"
       matcher.source.line_contents path res;
   res
+  [@@profiling "Glob.Match.run"]
 
 let source matcher = matcher.source
 

--- a/libs/glob/Parse.ml
+++ b/libs/glob/Parse.ml
@@ -1,3 +1,4 @@
 let parse_string str =
   let lexbuf = Lexing.from_string str in
   Parser.segments Lexer.token lexbuf
+  [@@profiling "Glob.Parse.parse_string"]

--- a/libs/glob/dune
+++ b/libs/glob/dune
@@ -5,8 +5,12 @@
   (libraries
     stdcompat
     commons
+    profiling
   )
-  (preprocess (pps ppx_deriving.show))
+  (preprocess (pps
+     ppx_deriving.show
+     profiling.ppx
+  ))
 )
 
 (ocamllex Lexer)

--- a/libs/profiling/ppx/tests/basic.ml
+++ b/libs/profiling/ppx/tests/basic.ml
@@ -1,0 +1,1 @@
+let foo a b = a + b [@@profiling]

--- a/libs/profiling/ppx/tests/label.ml
+++ b/libs/profiling/ppx/tests/label.ml
@@ -1,0 +1,1 @@
+let foo ~a b = a + b [@@profiling]

--- a/libs/profiling/ppx/tests/optional_param.ml
+++ b/libs/profiling/ppx/tests/optional_param.ml
@@ -1,0 +1,1 @@
+let foo ?a b = a + b [@@profiling]

--- a/src/osemgrep/cli_scan/Core_runner.ml
+++ b/src/osemgrep/cli_scan/Core_runner.ml
@@ -326,3 +326,4 @@ let invoke_semgrep_core ?(respect_git_ignore = true) (conf : conf)
           | None -> ())
       *)
       { core = match_results; hrules = Rule.hrules_of_rules all_rules; scanned }
+  [@@profiling]

--- a/src/osemgrep/cli_scan/Output.ml
+++ b/src/osemgrep/cli_scan/Output.ml
@@ -177,3 +177,4 @@ let output_result (conf : Scan_CLI.conf) (res : Core_runner.result) :
   if conf.autofix then apply_fixes_and_warn conf cli_output;
   dispatch_output_format conf.output_format conf cli_output;
   cli_output.errors
+  [@@profiling]

--- a/src/osemgrep/cli_scan/Rule_fetching.ml
+++ b/src/osemgrep/cli_scan/Rule_fetching.ml
@@ -397,3 +397,4 @@ let rules_from_rules_source ~rewrite_rule_ids (src : Rules_source.t) :
                  | R.Err _
                  | Failure _ ->
                      None))
+  [@@profiling]

--- a/src/osemgrep/targeting/Semgrepignore.ml
+++ b/src/osemgrep/targeting/Semgrepignore.ml
@@ -101,3 +101,4 @@ let select t path =
   | Ignored -> (Gitignore.Ignored, sel_events)
   | Not_ignored ->
       Gitignore_filter.select t.gitignore_filter sel_events git_path
+  [@@profiling]

--- a/src/parsing/Parse_pattern.ml
+++ b/src/parsing/Parse_pattern.ml
@@ -75,7 +75,4 @@ let parse_pattern ?(print_errors = false) lang str =
   Caching.prepare_pattern any;
   Check_pattern.check lang any;
   any
-
-let parse_pattern ?print_errors a b =
-  Profiling.profile_code "Parse_pattern.parse_pattern" (fun () ->
-      parse_pattern ?print_errors a b)
+  [@@profiling]

--- a/src/targeting/Find_target.ml
+++ b/src/targeting/Find_target.ml
@@ -160,6 +160,7 @@ let files_from_git_ls ~cwd:scan_root =
   tracked_output
   |> Common.map (fun x -> scan_root // x)
   |> List.filter is_valid_file
+  [@@profiling]
 
 (* python: mostly Target.files() method in target_manager.py *)
 let list_regular_files (conf : conf) (scan_root : Fpath.t) : Fpath.t list =
@@ -201,6 +202,7 @@ let list_regular_files (conf : conf) (scan_root : Fpath.t) : Fpath.t list =
   | S_BLK
   | S_SOCK ->
       []
+  [@@profiling]
 
 (*************************************************************************)
 (* Dedup *)
@@ -265,6 +267,7 @@ let global_filter ~opt_lang ~sort_by_decr_size paths =
       skipped
   in
   (sorted_paths, sorted_skipped)
+  [@@profiling]
 
 (*************************************************************************)
 (* Grouping *)
@@ -416,6 +419,7 @@ let get_targets conf scanning_roots =
   List.split
   |> fun (paths_list, skipped_paths_list) ->
   (List.flatten paths_list, List.flatten skipped_paths_list)
+  [@@profiling]
 
 (*************************************************************************)
 (* Target cache *)


### PR DESCRIPTION
This also shows the main bottleneck now on big repos
(and also on small one) is Find_target.get_targets
and especially Gitignore_filter.select which is too slow.
Takes 10s on big repo like elasticsearch

test plan:
```
$ pwd
/home/pad/github/stress-test-monorepo/repos/elasticsearch
$ osemgrep -l java --ast-caching -e 'Common.filename' --profile
┌─────────────┐
│ Scan status │
└─────────────┘
Scanning 21331 files tracked by git with 1 Code rule:

  Language      Rules   Files
 ─────────────────────────────
  Java              1   15333

┌──────────────┐
│ Scan summary │
└──────────────┘
Some files were skipped or only partially analyzed.
  Partially scanned: 1 files only partially analyzed due to a parsing or internal Semgrep error
  Scan skipped: 7 files matching .semgrepignore patterns, 1260 other files ignored
  For a full list of skipped files, run semgrep with the --verbose flag.

Ran 1 rules on 21331 files: 0 findings

---------------------
profiling result
---------------------
CLI.dispatch_subcommand                  :     13.703 sec          1 count
Find_target.get_targets                  :     12.901 sec          1 count
Gitignore_filter.select                  :     12.237 sec      22598 count
Glob.Match.run                           :     10.339 sec   22422630 count
Core_runner.invoke_semgrep_core          :      0.800 sec          1 count
Parse_with_caching.cache_computation     :      0.780 sec       1001 count
Find_target.global_filter                :      0.480 sec          1 count
Gitignores_cache.load                    :      0.086 sec     267584 count
Find_target.list_regular_files           :      0.052 sec          1 count
Find_target.files_from_git_ls            :      0.052 sec          1 count
Rule_fetching.rules_from_rules_source    :      0.001 sec          1 count
Parse_pattern.parse_pattern              :      0.001 sec          1 count
Parse_gitignore.from_file                :      0.000 sec          6 count
Glob.Match.compile                       :      0.000 sec         60 count
Glob.Parse.parse_string                  :      0.000 sec         60 count
*Parse_with_caching.cache_computation    :      0.000 sec          1 count
Output.output_result                     :      0.000 sec          1 count
JSON_report.match_results_of_matches_and_errors :      0.000 sec          1 count
Pos.full_charpos_to_pos_str              :      0.000 sec          1 count
```

But it is also slow on small repo like semgrep:
```
$ pwd
/home/pad/github/semgrep
$ osemgrep -e ': Common.filename' --profile
...
---------------------
profiling result
---------------------
CLI.dispatch_subcommand                  :      1.502 sec          1 count
Find_target.get_targets                  :      0.936 sec          1 count
Gitignore_filter.select                  :      0.857 sec       6747 count
Core_runner.invoke_semgrep_core          :      0.537 sec          1 count
Glob.Match.run                           :      0.534 sec    4374058 count
Parse_with_caching.cache_computation     :      0.443 sec       1906 count
Find_target.global_filter                :      0.046 sec          1 count
real_rule:-                              :      0.043 sec        182 count
Match_search_mode.matches_of_xpatterns   :      0.042 sec        182 count
Match_patterns.check                     :      0.042 sec        182 count
Parse_target.parse_and_resolve_name      :      0.022 sec         17 count
Rule_fetching.rules_from_rules_source    :      0.017 sec          1 count
Find_target.list_regular_files           :      0.016 sec          1 count
Find_target.files_from_git_ls            :      0.016 sec          1 count
*Parse_pattern.parse_pattern             :      0.016 sec         32 count
Analyze_rule.run_cnf_step2               :      0.015 sec        953 count
Output.output_result                     :      0.011 sec          1 count
Parse_target.just_parse_with_lang        :      0.006 sec         17 count
Cli_json_output.lines_of_file            :      0.005 sec        186 count
Match_patterns.match_t_t                 :      0.005 sec      16139 count
Gitignores_cache.load                    :      0.005 sec      15821 count
Constant_propagation.propagate_basic     :      0.004 sec         17 count
Naming_AST.resolve                       :      0.003 sec         17 count
Analyze_rule.compute_final_cnf           :      0.003 sec          1 count
rule:21                                  :      0.002 sec      16139 count
Parse_gitignore.from_file                :      0.002 sec         11 count
Apply_equivalences.apply                 :      0.001 sec        182 count
Parse_pattern.parse_pattern              :      0.001 sec          5 count
Glob.Match.compile                       :      0.001 sec        180 count
AST_generic_helpers.ii_of_any            :      0.001 sec        352 count
Pos.full_charpos_to_pos_large            :      0.001 sec         17 count
Pattern_match.uniq                       :      0.001 sec        364 count
Parser_ml.main                           :      0.001 sec         17 count
AST_generic_helpers.range_of_any_opt     :      0.000 sec        186 count
Glob.Parse.parse_string                  :      0.000 sec        180 count
JSON_report.match_results_of_matches_and_errors :      0.000 sec          1 count
Run_semgrep.filter_too_many_matches      :      0.000 sec          4 count
Run_semgrep.parse_equivalences           :      0.000 sec        953 count
Xpattern_match_regexp.matches_of_regexs  :      0.000 sec        182 count
JSON_report.match_to_match               :      0.000 sec        186 count
Xpattern_match_spacegrep.matches_of_spacegrep :      0.000 sec        182 count
Parse_js.tokens                          :      0.000 sec          4 count
C++ parsing.fix_tokens                   :      0.000 sec          2 count
Pos.full_charpos_to_pos_str              :      0.000 sec         15 count
Match_search_mode.lazy_force             :      0.000 sec        182 count
Parse_python.tokens                      :      0.000 sec          3 count
Parse_scala.tokens                       :      0.000 sec          1 count
C parsing.lex_ident                      :      0.000 sec          4 count
Analyze_rule.prefilter_formula_of_cnf_step2 :      0.000 sec          1 count
```


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)