### PR TITLE
yaml parsing is baked into the engine

### DIFF
--- a/js/engine/Main.ml
+++ b/js/engine/Main.ml
@@ -28,17 +28,32 @@ let _ =
        method setParsePattern (func : jbool -> jstring -> jstring -> 'a) =
          Parse_pattern.parse_pattern_ref :=
            fun print_error lang pattern ->
-             func (Js.bool print_error)
-               (Js.string (Lang.to_lowercase_alnum lang))
-               (Js.string pattern)
+             match lang with
+             (* The Yaml and JSON parsers are embedded in the engine because it's a
+                core component needed to parse rules *)
+             | Lang.Yaml -> Yaml_to_generic.any pattern
+             | _ ->
+                 func (Js.bool print_error)
+                   (Js.string (Lang.to_lowercase_alnum lang))
+                   (Js.string pattern)
 
        method setJustParseWithLang
            (func : jstring -> jstring -> Parsing_result2.t) =
          Parse_target.just_parse_with_lang_ref :=
            fun lang filename ->
-             func
-               (Js.string (Lang.to_lowercase_alnum lang))
-               (Js.string filename)
+             match lang with
+             (* The Yaml and JSON parsers are embedded in the engine because it's a
+                core component needed to parse rules *)
+             | Lang.Yaml ->
+                 {
+                   ast = Yaml_to_generic.program filename;
+                   skipped_tokens = [];
+                   stat = Parsing_stat.default_stat filename;
+                 }
+             | _ ->
+                 func
+                   (Js.string (Lang.to_lowercase_alnum lang))
+                   (Js.string filename)
 
        (*
           The following methods are part of the engine's public API.


### PR DESCRIPTION
Not worth creating a standalone parser for yaml -- it's already baked into the engine via semgrep.parsing