### PR TITLE
osemgrep: Cleanup Semgrep_settings.yml and pass ~token_opt more

### DIFF
--- a/src/osemgrep/cli_login/Login_subcommand.ml
+++ b/src/osemgrep/cli_login/Login_subcommand.ml
@@ -54,7 +54,7 @@ let max_retries = 30 (* Give users 3 minutes to log in / open link *)
    exit code. *)
 let run (conf : Login_CLI.conf) : Exit_code.t =
   Logs_helpers.setup_logging ~force_color:false ~level:conf.logging_level;
-  let settings = Semgrep_settings.get () in
+  let settings = Semgrep_settings.load () in
   match settings.Semgrep_settings.api_token with
   | None -> (
       match Semgrep_envvars.env.app_token with

--- a/src/osemgrep/cli_login/Logout_subcommand.ml
+++ b/src/osemgrep/cli_login/Logout_subcommand.ml
@@ -15,7 +15,7 @@
    exit code. *)
 let run (conf : Login_CLI.conf) : Exit_code.t =
   Logs_helpers.setup_logging ~force_color:false ~level:conf.logging_level;
-  let settings = Semgrep_settings.get () in
+  let settings = Semgrep_settings.load () in
   let settings = Semgrep_settings.{ settings with api_token = None } in
   if Semgrep_settings.save settings then (
     Logs.app (fun m -> m "Logged out (log back in with `semgrep login`)");

--- a/src/osemgrep/cli_scan/Dump_subcommand.ml
+++ b/src/osemgrep/cli_scan/Dump_subcommand.ml
@@ -67,6 +67,9 @@ let dump_v_to_format ~json (v : OCaml.v) =
 (*****************************************************************************)
 
 let run (conf : conf) : Exit_code.t =
+  let settings = Semgrep_settings.load () in
+  let token_opt = settings.api_token in
+
   (* TODO? error management? improve error message for parse errors?
    * or let CLI.safe_run do the right thing?
    *)
@@ -92,7 +95,7 @@ let run (conf : conf) : Exit_code.t =
   | Config config_str ->
       let kind = Semgrep_dashdash_config.parse_config_string config_str in
       let rules_and_origins =
-        Rule_fetching.rules_from_dashdash_config ~token_opt:None kind
+        Rule_fetching.rules_from_dashdash_config ~token_opt kind
       in
       rules_and_origins
       |> List.iter (fun x ->

--- a/src/osemgrep/cli_scan/Dump_subcommand.ml
+++ b/src/osemgrep/cli_scan/Dump_subcommand.ml
@@ -91,7 +91,9 @@ let run (conf : conf) : Exit_code.t =
       Exit_code.ok
   | Config config_str ->
       let kind = Semgrep_dashdash_config.parse_config_string config_str in
-      let rules_and_origins = Rule_fetching.rules_from_dashdash_config kind in
+      let rules_and_origins =
+        Rule_fetching.rules_from_dashdash_config ~token_opt:None kind
+      in
       rules_and_origins
       |> List.iter (fun x ->
              Logs.app (fun m -> m "%s" (Rule_fetching.show_rules_and_origin x)));

--- a/src/osemgrep/cli_scan/Rule_fetching.mli
+++ b/src/osemgrep/cli_scan/Rule_fetching.mli
@@ -4,27 +4,35 @@ type rules_and_origin = {
   errors : Rule.invalid_rule_error list;
 }
 
-and origin = Fpath.t option (* None for remote files *) [@@deriving show]
+and origin = Fpath.t option (* None for remote config *) [@@deriving show]
 
 val partition_rules_and_errors :
   rules_and_origin list -> Rule.rules * Rule.invalid_rule_error list
 
 (* [rules_from_rules_source] returns rules from --config or -e.
- * If [rewrite_rule_ids] is true, it will add the path to the config
+ * If [rewrite_rule_ids] is true, it will add the path of the config
  * file to the start of rule_ids.
+ * The token is used to fetch App rules (e.g., from --config policy).
  *)
 val rules_from_rules_source :
-  rewrite_rule_ids:bool -> Rules_source.t -> rules_and_origin list
+  token_opt:Auth.token option ->
+  rewrite_rule_ids:bool ->
+  Rules_source.t ->
+  rules_and_origin list
 
 (* internals *)
 
-(* [rules_from_dashdash_config config] returns a list of rules_and_origin
- * because the string can correspond to a folder, in which case we return
- * one rules_and_origin per files in this folder.
+(* [rules_from_dashdash_config] returns a list of rules_and_origin
+ * because the [config_kind] can be a [Dir], in which case we return one
+ * rules_and_origin per files in this folder.
  *)
 val rules_from_dashdash_config :
-  Semgrep_dashdash_config.config_kind -> rules_and_origin list
+  token_opt:Auth.token option ->
+  Semgrep_dashdash_config.config_kind ->
+  rules_and_origin list
 
 (* low-level API *)
 val load_rules_from_file : Fpath.t -> rules_and_origin
-val load_rules_from_url : ?ext:string -> Uri.t -> rules_and_origin
+
+val load_rules_from_url :
+  ?token_opt:Auth.token option -> ?ext:string -> Uri.t -> rules_and_origin

--- a/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -157,6 +157,7 @@ let run (conf : Scan_CLI.conf) : Exit_code.t =
   let conf = setup_profiling conf in
   Logs.debug (fun m -> m "conf = %s" (Scan_CLI.show_conf conf));
   Metrics_.configure conf.metrics;
+  let settings = Semgrep_settings.load () in
 
   match () with
   (* "alternate modes" where no search is performed.
@@ -191,7 +192,7 @@ let run (conf : Scan_CLI.conf) : Exit_code.t =
 
       (* Rule_fetching.rules_and_origin record also contain errors *)
       let rules_and_origins =
-        Rule_fetching.rules_from_rules_source
+        Rule_fetching.rules_from_rules_source ~token_opt:settings.api_token
           ~rewrite_rule_ids:conf.rewrite_rule_ids conf.rules_source
       in
       let rules, errors =

--- a/src/osemgrep/cli_scan/Validate_subcommand.ml
+++ b/src/osemgrep/cli_scan/Validate_subcommand.ml
@@ -63,8 +63,8 @@ let metarules_pack = "p/semgrep-rule-lints"
 (*****************************************************************************)
 
 let run (conf : conf) : Exit_code.t =
-  (* Do we need to load the settings in a validate context? *)
-  let token_opt = None in
+  let settings = Semgrep_settings.load () in
+  let token_opt = settings.api_token in
   (* Checking (1) and (2). Parsing the rules is already a form of validation.
    * Before running metachecks on those rules, we make sure we can parse them.
    * TODO: report not only Rule.invalid_rule_errors but all Rule.error for (1)

--- a/src/osemgrep/cli_scan/Validate_subcommand.ml
+++ b/src/osemgrep/cli_scan/Validate_subcommand.ml
@@ -63,13 +63,15 @@ let metarules_pack = "p/semgrep-rule-lints"
 (*****************************************************************************)
 
 let run (conf : conf) : Exit_code.t =
+  (* Do we need to load the settings in a validate context? *)
+  let token_opt = None in
   (* Checking (1) and (2). Parsing the rules is already a form of validation.
    * Before running metachecks on those rules, we make sure we can parse them.
    * TODO: report not only Rule.invalid_rule_errors but all Rule.error for (1)
    * in Config_resolver.errors.
    *)
   let rules_and_origin =
-    Rule_fetching.rules_from_rules_source ~rewrite_rule_ids:true
+    Rule_fetching.rules_from_rules_source ~token_opt ~rewrite_rule_ids:true
       conf.rules_source
   in
   let rules, errors =
@@ -90,7 +92,7 @@ let run (conf : conf) : Exit_code.t =
                  x.Rule_fetching.origin)
         in
         let metarules_and_origin =
-          Rule_fetching.rules_from_dashdash_config
+          Rule_fetching.rules_from_dashdash_config ~token_opt
             (Semgrep_dashdash_config.parse_config_string metarules_pack)
         in
         let metarules, metaerrors =

--- a/src/osemgrep/configuring/Semgrep_settings.mli
+++ b/src/osemgrep/configuring/Semgrep_settings.mli
@@ -3,9 +3,12 @@
  *)
 type t = {
   has_shown_metrics_notification : bool option;
-  api_token : string option;
+  api_token : Auth.token option;
   anonymous_user_id : Uuidm.t;
 }
 
+(* loading the ~/.semgrep/settings.yml in memory *)
+val load : unit -> t
+
+(* returns whether the save was successful *)
 val save : t -> bool
-val get : unit -> t

--- a/src/osemgrep/core/Auth.ml
+++ b/src/osemgrep/core/Auth.ml
@@ -1,0 +1,1 @@
+type token = string

--- a/src/osemgrep/networking/Network_app.ml
+++ b/src/osemgrep/networking/Network_app.ml
@@ -13,8 +13,8 @@ open Common
 (*****************************************************************************)
 
 (* from auth.py *)
-let get_deployment_id () =
-  match Semgrep_settings.((get ()).api_token) with
+let get_deployment_id ~token_opt =
+  match token_opt with
   | None -> None
   | Some token -> (
       match
@@ -43,7 +43,7 @@ let get_deployment_id () =
               None))
 
 (* from auth.py *)
-let get_deployment_from_token token =
+let get_deployment_from_token ~token =
   match
     Http_helpers.get
       ~headers:[ ("authorization", "Bearer " ^ token) ]
@@ -71,8 +71,8 @@ let get_deployment_from_token token =
 
 let default_semgrep_app_config_url = "api/agent/deployments/scans/config"
 
-let url_for_policy () =
-  match get_deployment_id () with
+let url_for_policy ~token_opt =
+  match get_deployment_id ~token_opt with
   | None ->
       Error.abort
         (spf "Invalid API Key. Run `semgrep logout` and `semgrep login` again.")

--- a/src/osemgrep/networking/Network_app.mli
+++ b/src/osemgrep/networking/Network_app.mli
@@ -1,7 +1,5 @@
 (* internally rely on api_token in ~/.settings and SEMGREP_REPO_NAME *)
-val url_for_policy : unit -> Uri.t
+val url_for_policy : token_opt:Auth.token option -> Uri.t
 
-(* auth *)
-
-(* ?? *)
-val get_deployment_from_token : string -> string option
+(* *)
+val get_deployment_from_token : token:Auth.token -> string option


### PR DESCRIPTION
Not a huge fan of this lazy trick to get the semgrep settings.
In any case I think it's better to be explicit that rely on
this global and so passing around a token seems better,
in which case there's no point anymore in optimizing Semgrep_settings
using Lazy.

test plan:
make osempass


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)