### PR TITLE
fix to_lowercase_alnum, update current users to to_capitalized_alnum

### DIFF
--- a/src/core/Lang.ml.j2
+++ b/src/core/Lang.ml.j2
@@ -122,7 +122,7 @@ let to_lowercase_alnum = function
 {% for item in langs %}  | {{ item.id }} -> "{{ item.id | lower }}"
 {% endfor %}
 
-(* must match [a-z][a-z0-9]* *)
+(* must match [A-Z][a-z0-9]* *)
 let to_capitalized_alnum = function
 {% for item in langs %}  | {{ item.id }} -> "{{ item.id }}"
 {% endfor %}

--- a/src/core/Lang.ml.j2
+++ b/src/core/Lang.ml.j2
@@ -119,6 +119,11 @@ let to_string = function
 
 (* must match [a-z][a-z0-9]* *)
 let to_lowercase_alnum = function
+{% for item in langs %}  | {{ item.id }} -> "{{ item.id | lower }}"
+{% endfor %}
+
+(* must match [a-z][a-z0-9]* *)
+let to_capitalized_alnum = function
 {% for item in langs %}  | {{ item.id }} -> "{{ item.id }}"
 {% endfor %}
 

--- a/src/core/Lang.mli.j2
+++ b/src/core/Lang.mli.j2
@@ -33,6 +33,16 @@ val to_string : t -> string
 val to_lowercase_alnum : t -> string
 
 (*
+   Convert to the most standard and unambiguous representation of the
+   language name of form [A-Z][a-z0-9]*
+   e.g. 'Python3' or 'Csharp'.
+
+   This is meant to be URL-friendly, filesystem-friendly, and generally
+   programmer-friendly. Furthermore, it matches the type name.
+*)
+val to_capitalized_alnum : t -> string
+
+(*
    Return a list of extensions for a language such that a file with that
    extension can reasonably be expected to be in that language.
 

--- a/src/parsing/tests/Test_parsing.ml
+++ b/src/parsing/tests/Test_parsing.ml
@@ -341,7 +341,7 @@ let parsing_common ?(verbose = true) lang files_or_dirs =
     |> List.rev_map (fun file ->
            pr2
              (spf "%05.1fs: [%s] processing %s" (Sys.time ())
-                (Lang.to_lowercase_alnum lang)
+                (Lang.to_capitalized_alnum lang)
                 file);
            let stat =
              try
@@ -401,7 +401,7 @@ let parse_project ~verbose lang name files_or_dirs =
   in
   pr2
     (spf "%05.1fs: [%s] done parsing %s" (Sys.time ())
-       (Lang.to_lowercase_alnum lang)
+       (Lang.to_capitalized_alnum lang)
        name);
   (name, stat_list)
 
@@ -493,7 +493,11 @@ let aggregate_project_stats lang
       acc project_stats
   in
   let global = update_parsing_rate acc in
-  { language = Lang.to_lowercase_alnum lang; global; projects = project_stats }
+  {
+    language = Lang.to_capitalized_alnum lang;
+    global;
+    projects = project_stats;
+  }
 
 let print_json lang results =
   let project_stats = aggregate_file_stats results in


### PR DESCRIPTION
`Lang.to_lowercase_alnum` does not do what it claims 😞 

This PR:
- updates `to_lowercase_alnum` to do the correct thing
- adds `to_capitalized_alnum` with the original functionality
- migrates current usage from `to_lowercase_alnum` to `to_capitalized_alnum` to ensure nothing changes for folks

I'll make a companion PR for Semgprep Pro once this is merged.

test plan:
- [ ] `make test`
