### PR TITLE
osemgrep: NEW --registry-caching flag

### DIFF
--- a/cli/tests/semgrep_runner.py
+++ b/cli/tests/semgrep_runner.py
@@ -51,7 +51,7 @@ USE_OSEMGREP = get_env_bool("PYTEST_USE_OSEMGREP")
 # at the root of the git project to be taken into account when testing,
 # which is a new behavior in osemgrep.
 # The --legacy is to try to get the same behaviors/limitations/errors of pysemgrep
-OSEMGREP_COMPATIBILITY_ARGS = ["--project-root", ".", "--legacy", "--no-ast-caching"]
+OSEMGREP_COMPATIBILITY_ARGS = ["--project-root", ".", "--legacy"]
 
 # The semgrep command suitable to run semgrep as a separate process.
 # It's something like ["semgrep"] or ["python3"; -m; "semgrep"] or

--- a/src/matching/Match_patterns.ml
+++ b/src/matching/Match_patterns.ml
@@ -24,6 +24,7 @@ module Config = Config_semgrep_t
 module MG = Matching_generic
 
 let logger = Logging.get_logger [ __MODULE__ ]
+let profile_mini_rules = ref false
 
 (*****************************************************************************)
 (* Prelude *)
@@ -50,7 +51,10 @@ let set_last_matched_rule rule f =
   (* note that if this raise an exn, last_matched_rule will not be
    * reset to None and that's what we want!
    *)
-  let res = f () in
+  let res =
+    if !profile_mini_rules then Profiling.profile_code ("rule:" ^ rule.MR.id) f
+    else f ()
+  in
   last_matched_rule := None;
   res
 
@@ -59,83 +63,71 @@ let set_last_matched_rule rule f =
 (*****************************************************************************)
 
 let match_e_e rule a b env =
-  Profiling.profile_code ("rule:" ^ rule.MR.id) (fun () ->
-      set_last_matched_rule rule (fun () -> GG.m_expr_root a b env))
+  set_last_matched_rule rule (fun () -> GG.m_expr_root a b env)
   [@@profiling]
 
 let match_st_st rule a b env =
-  Profiling.profile_code ("rule:" ^ rule.MR.id) (fun () ->
-      set_last_matched_rule rule (fun () -> GG.m_stmt a b env))
+  set_last_matched_rule rule (fun () -> GG.m_stmt a b env)
   [@@profiling]
 
 let match_sts_sts rule a b env =
-  Profiling.profile_code ("rule:" ^ rule.MR.id) (fun () ->
-      set_last_matched_rule rule (fun () ->
-          (* When matching statements, we need not only to report whether
-           * there is match, but also the actual statements that were matched.
-           * Indeed, even if we want the implicit '...' at the end of
-           * a sequence of statements pattern (AST_generic.Ss) to match all
-           * the rest, we don't want to report the whole Ss as a match but just
-           * the actually matched subset.
-           *
-           * TODO? do we need to generate unique key? we don't want
-           * nested calls to m_stmts_deep to pollute our metavar? We need
-           * to pass the key to m_stmts_deep?
-           *)
-          let env =
-            match b with
-            | [] -> env
-            | stmt :: _ -> MG.extend_stmts_match_span stmt env
-          in
-          GG.m_stmts_deep ~inside:rule.MR.inside ~less_is_ok:true a b env))
+  set_last_matched_rule rule (fun () ->
+      (* When matching statements, we need not only to report whether
+       * there is match, but also the actual statements that were matched.
+       * Indeed, even if we want the implicit '...' at the end of
+       * a sequence of statements pattern (AST_generic.Ss) to match all
+       * the rest, we don't want to report the whole Ss as a match but just
+       * the actually matched subset.
+       *
+       * TODO? do we need to generate unique key? we don't want
+       * nested calls to m_stmts_deep to pollute our metavar? We need
+       * to pass the key to m_stmts_deep?
+       *)
+      let env =
+        match b with
+        | [] -> env
+        | stmt :: _ -> MG.extend_stmts_match_span stmt env
+      in
+      GG.m_stmts_deep ~inside:rule.MR.inside ~less_is_ok:true a b env)
   [@@profiling]
 
 (* for unit testing *)
 let match_any_any pattern e env = GG.m_any pattern e env
 
 let match_t_t rule a b env =
-  Profiling.profile_code ("rule:" ^ rule.MR.id) (fun () ->
-      set_last_matched_rule rule (fun () -> GG.m_type_ a b env))
+  set_last_matched_rule rule (fun () -> GG.m_type_ a b env)
   [@@profiling]
 
 let match_p_p rule a b env =
-  Profiling.profile_code ("rule:" ^ rule.MR.id) (fun () ->
-      set_last_matched_rule rule (fun () -> GG.m_pattern a b env))
+  set_last_matched_rule rule (fun () -> GG.m_pattern a b env)
   [@@profiling]
 
 let match_partial_partial rule a b env =
-  Profiling.profile_code ("rule:" ^ rule.MR.id) (fun () ->
-      set_last_matched_rule rule (fun () -> GG.m_partial a b env))
+  set_last_matched_rule rule (fun () -> GG.m_partial a b env)
   [@@profiling]
 
 let match_at_at rule a b env =
-  Profiling.profile_code ("rule:" ^ rule.MR.id) (fun () ->
-      set_last_matched_rule rule (fun () -> GG.m_attribute a b env))
+  set_last_matched_rule rule (fun () -> GG.m_attribute a b env)
   [@@profiling]
 
 let match_fld_fld rule a b env =
-  Profiling.profile_code ("rule:" ^ rule.MR.id) (fun () ->
-      set_last_matched_rule rule (fun () -> GG.m_field a b env))
+  set_last_matched_rule rule (fun () -> GG.m_field a b env)
   [@@profiling]
 
 let match_flds_flds rule a b env =
-  Profiling.profile_code ("rule:" ^ rule.MR.id) (fun () ->
-      set_last_matched_rule rule (fun () -> GG.m_fields a b env))
+  set_last_matched_rule rule (fun () -> GG.m_fields a b env)
   [@@profiling]
 
 let match_name_name rule a b env =
-  Profiling.profile_code ("rule:" ^ rule.MR.id) (fun () ->
-      set_last_matched_rule rule (fun () -> GG.m_name a b env))
+  set_last_matched_rule rule (fun () -> GG.m_name a b env)
   [@@profiling]
 
 let match_xml_attribute_xml_attribute rule a b env =
-  Profiling.profile_code ("rule:" ^ rule.MR.id) (fun () ->
-      set_last_matched_rule rule (fun () -> GG.m_xml_attr a b env))
+  set_last_matched_rule rule (fun () -> GG.m_xml_attr a b env)
   [@@profiling]
 
 let match_raw_raw rule a b env =
-  Profiling.profile_code ("rule:" ^ rule.MR.id) (fun () ->
-      set_last_matched_rule rule (fun () -> GG.m_raw_tree a b env))
+  set_last_matched_rule rule (fun () -> GG.m_raw_tree a b env)
   [@@profiling]
 
 (*****************************************************************************)

--- a/src/osemgrep/cli_scan/Dump_subcommand.ml
+++ b/src/osemgrep/cli_scan/Dump_subcommand.ml
@@ -95,7 +95,8 @@ let run (conf : conf) : Exit_code.t =
   | Config config_str ->
       let kind = Semgrep_dashdash_config.parse_config_string config_str in
       let rules_and_origins =
-        Rule_fetching.rules_from_dashdash_config ~token_opt kind
+        Rule_fetching.rules_from_dashdash_config ~token_opt
+          ~registry_caching:false kind
       in
       rules_and_origins
       |> List.iter (fun x ->

--- a/src/osemgrep/cli_scan/Rule_fetching.ml
+++ b/src/osemgrep/cli_scan/Rule_fetching.ml
@@ -1,6 +1,7 @@
 open Common
 open File.Operators
 module E = Error
+module Env = Semgrep_envvars
 module FT = File_type
 module C = Semgrep_dashdash_config
 module R = Rule
@@ -14,6 +15,10 @@ module XP = Xpattern
 
    TODO:
     - lots of stuff ...
+
+   osemgrep-only:
+    - can pass -e without -l (try all possible languages)
+    - use a registry cache to speedup things
  *)
 
 (*****************************************************************************)
@@ -34,7 +39,7 @@ type rules_and_origin = {
  *  or just put the Semgrep_dashdash_config.config_kind it comes from?
  * This type is used only for rules_rewrite_rule_ids().
  *)
-and origin = Fpath.t option (* None for remote files *) [@@deriving show]
+and origin = Fpath.t option (* None for remote config *) [@@deriving show]
 
 (*****************************************************************************)
 (* Helpers *)
@@ -47,6 +52,29 @@ let partition_rules_and_errors (xs : rules_and_origin list) :
     xs |> List.concat_map (fun x -> x.errors)
   in
   (rules, errors)
+
+let fetch_content_from_url ?(token_opt = None) (url : Uri.t) : string =
+  (* TOPORT? _nice_semgrep_url() *)
+  Logs.debug (fun m -> m "trying to download from %s" (Uri.to_string url));
+  let content =
+    let headers =
+      match token_opt with
+      | None -> None
+      | Some token -> Some [ ("authorization", "Bearer " ^ token) ]
+    in
+    match Http_helpers.get ?headers url with
+    | Ok body -> body
+    | Error msg ->
+        (* was raise Semgrep_error, but equivalent to abort now *)
+        Error.abort
+          (spf "Failed to download config from %s: %s" (Uri.to_string url) msg)
+  in
+  Logs.debug (fun m -> m "finished downloading from %s" (Uri.to_string url));
+  content
+
+(*****************************************************************************)
+(* Rewrite rule ids *)
+(*****************************************************************************)
 
 let prefix_for_fpath_opt (fpath : Fpath.t) : string option =
   assert (Fpath.is_file_path fpath);
@@ -93,6 +121,69 @@ let rules_rewrite_rule_ids ~rewrite_rule_ids (x : rules_and_origin) :
   | _else_ -> x
 
 (*****************************************************************************)
+(* Registry caching *)
+(*****************************************************************************)
+
+type cache_registry_value = float (* timestamp *) * Uri.t * string (* content *)
+
+let cache_file_of_url (cache_dir : Fpath.t) (url : Uri.t) : Fpath.t =
+  (* Better to obfuscate the cache files, like in Unison, to discourage
+   * people to play with it. Also simple way to escape special chars
+   * in a URL.
+   *)
+  let md5 = Digest.string (Uri.to_string url) in
+  (* TODO: this also assumes yaml registry content. We need an
+   * extension because Parse_rule.parse_file behaves differently depending
+   * on the extension.
+   *)
+  cache_dir // Fpath.(v (Digest.to_hex md5) + "yaml")
+
+(* We cache rules from the registry at the string content level.
+ * alt: we could cache directly the parsed rules, but Rule.t now contains
+ * closures (we now parse patterns lazily) which complicates things
+ * (the Marshall module does not like functional values).
+ * Anyway parsing a rule is now fast; what takes time is downloading
+ * the rules from the network, which we optimize here.
+ *)
+let fetch_content_from_registry_url ~registry_caching url =
+  let f () = fetch_content_from_url url in
+  if not registry_caching then f ()
+  else
+    let cache_dir =
+      let dir = Env.env.user_dot_semgrep_dir / "cache" / "registry" in
+      match Bos.OS.Dir.create ~path:true dir with
+      | Ok _ -> dir
+      | Error (`Msg err) -> failwith err
+    in
+    let cache_file = cache_file_of_url cache_dir url in
+
+    let compute_and_save_in_cache () =
+      let res = f () in
+      let (v : cache_registry_value) = (Unix.time (), url, res) in
+      Logs.debug (fun m ->
+          m "saving %s content in %s" (Uri.to_string url) !!cache_file);
+      Common2.write_value v !!cache_file;
+      res
+    in
+    if Sys.file_exists !!cache_file then
+      let (v : cache_registry_value) = Common2.get_value !!cache_file in
+      let time2, url2, content = v in
+      if
+        Uri.equal url url2 && Unix.time () -. time2 <= 3600. *. 24.
+        (* 24h hours caching *)
+      then (
+        Logs.debug (fun m ->
+            m "using the cache file %s for %s" !!cache_file (Uri.to_string url));
+        content)
+      else (
+        Logs.debug (fun m ->
+            m "invalid cache %s for %s (or too old)" !!cache_file
+              (Uri.to_string url));
+
+        compute_and_save_in_cache ())
+    else compute_and_save_in_cache ()
+
+(*****************************************************************************)
 (* Registry and yaml aware jsonnet *)
 (*****************************************************************************)
 
@@ -109,7 +200,7 @@ let parse_yaml_for_jsonnet (file : Common.filename) : AST_jsonnet.program =
    *)
   AST_generic_to_jsonnet.program gen
 
-let import_callback base str =
+let import_callback ~registry_caching base str =
   match str with
   | s when s =~ ".*\\.y[a]?ml$" ->
       (* On the fly conversion from yaml to jsonnet. We can do
@@ -126,11 +217,6 @@ let import_callback base str =
           | C.R rkind ->
               let url = Network_registry.url_of_registry_config_kind rkind in
               Some url
-          (* TODO: this assumes every URLs are for yaml, but maybe we could
-           * also import URLs to jsonnet files or gist! or look at the
-           * header mimetype when downloading the URL to decide how to
-           * convert it further?
-           *)
           | C.URL url -> Some url
           (* TODO? allow to import any config_str? even a directory?
            * factorize with rules_from_dashdash_config?
@@ -143,25 +229,20 @@ let import_callback base str =
       in
       url_opt
       |> Option.map (fun url ->
-             (* TODO? factorize with load_rules_from_url? but here we
+             (* similar to load_rules_from_url() but here we
               * must return some AST_jsonnet, not rules (yet).
-              *)
-             Logs.debug (fun m ->
-                 m "trying to download from %s" (Uri.to_string url));
-             (* TODO: ask for JSON in headers which improves performance
+              *
+              * TODO: ask for JSON in headers which improves performance
               * because Yaml rule parsing is slower than Json rule parsing.
               *)
              let content =
-               match Http_helpers.get url with
-               | Ok body -> body
-               | Error msg ->
-                   (* was raise Semgrep_error, but equivalent to abort now *)
-                   Error.abort
-                     (spf "Failed to download config from %s: %s"
-                        (Uri.to_string url) msg)
+               fetch_content_from_registry_url ~registry_caching url
              in
-             Logs.debug (fun m ->
-                 m "finished downloading from %s" (Uri.to_string url));
+             (* TODO: this assumes every URLs are for yaml, but maybe we could
+              * also import URLs to jsonnet files or gist! or look at the
+              * header mimetype when downloading the URL to decide how to
+              * convert it further?
+              *)
              Common2.with_tmp_file ~str:content ~ext:"yaml" (fun file ->
                  (* LATER: adjust locations so refer to registry URL *)
                  parse_yaml_for_jsonnet file))
@@ -169,8 +250,11 @@ let import_callback base str =
 
 (* similar to Parse_rule.parse_file but with special import callbacks
  * for a registry-aware jsonnet.
+ * We also pass a ~registry_caching so the registry-aware jsonnet is also
+ * registry-cache aware.
  *)
-let parse_rule (file : Fpath.t) : Rule.rules * Rule.invalid_rule_error list =
+let parse_rule ~registry_caching (file : Fpath.t) :
+    Rule.rules * Rule.invalid_rule_error list =
   match FT.file_type_of_file file with
   | FT.Config FT.Jsonnet ->
       Logs.warn (fun m ->
@@ -179,7 +263,11 @@ let parse_rule (file : Fpath.t) : Rule.rules * Rule.invalid_rule_error list =
              internal use only. The syntax may change or be removed at any \
              point.");
       let ast = Parse_jsonnet.parse_program file in
-      let core = Desugar_jsonnet.desugar_program ~import_callback file ast in
+      let core =
+        Desugar_jsonnet.desugar_program
+          ~import_callback:(import_callback ~registry_caching)
+          file ast
+      in
       let value_ = Eval_jsonnet.eval_program core in
       let gen = Manifest_jsonnet_to_AST_generic.manifest_value value_ in
       (* TODO: put to true at some point *)
@@ -190,17 +278,19 @@ let parse_rule (file : Fpath.t) : Rule.rules * Rule.invalid_rule_error list =
 (* Loading rules *)
 (*****************************************************************************)
 
-(* Note that we don't sanity check Parse_rule.is_valid_rule_filename,
+(* Note that we don't sanity check Parse_rule.is_valid_rule_filename(),
  * so if you explicitely pass a file that does not have the right
  * extension, we will still process it
  * (could be useful for .jsonnet, which is not recognized yet as a
  *  Parse_rule.is_valid_rule_filename, but we still need ojsonnet to
  *  be done).
+ * We pass a ~registry_caching parameter here because the rule file can
+ * be a jsonnet file importing rules from the registry.
  *)
-let load_rules_from_file (file : Fpath.t) : rules_and_origin =
+let load_rules_from_file ~registry_caching (file : Fpath.t) : rules_and_origin =
   Logs.debug (fun m -> m "loading local config from %s" !!file);
   if Sys.file_exists !!file then (
-    let rules, errors = parse_rule file in
+    let rules, errors = parse_rule ~registry_caching file in
     Logs.debug (fun m -> m "Done loading local config from %s" !!file);
     { origin = Some file; rules; errors })
   else
@@ -209,24 +299,8 @@ let load_rules_from_file (file : Fpath.t) : rules_and_origin =
      *)
     Error.abort (spf "file %s does not exist anymore" !!file)
 
-let load_rules_from_url ?(token_opt = None) ?(ext = "yaml") url :
-    rules_and_origin =
-  (* TOPORT? _nice_semgrep_url() *)
-  Logs.debug (fun m -> m "trying to download from %s" (Uri.to_string url));
-  let content =
-    let headers =
-      match token_opt with
-      | None -> None
-      | Some token -> Some [ ("authorization", "Bearer " ^ token) ]
-    in
-    match Http_helpers.get ?headers url with
-    | Ok body -> body
-    | Error msg ->
-        (* was raise Semgrep_error, but equivalent to abort now *)
-        Error.abort
-          (spf "Failed to download config from %s: %s" (Uri.to_string url) msg)
-  in
-  Logs.debug (fun m -> m "finished downloading from %s" (Uri.to_string url));
+let load_rules_from_url ?token_opt ?(ext = "yaml") url : rules_and_origin =
+  let content = fetch_content_from_url ?token_opt url in
   let ext, content =
     if ext = "policy" then
       (* project rule_config, from config_resolver.py in _make_config_request *)
@@ -243,13 +317,13 @@ let load_rules_from_url ?(token_opt = None) ?(ext = "yaml") url :
   in
   Common2.with_tmp_file ~str:content ~ext (fun file ->
       let file = Fpath.v file in
-      let res = load_rules_from_file file in
+      let res = load_rules_from_file ~registry_caching:false file in
       { res with origin = None })
 
-let rules_from_dashdash_config ~token_opt
-    (kind : Semgrep_dashdash_config.config_kind) : rules_and_origin list =
+let rules_from_dashdash_config ~token_opt ~registry_caching kind :
+    rules_and_origin list =
   match kind with
-  | C.File file -> [ load_rules_from_file file ]
+  | C.File file -> [ load_rules_from_file ~registry_caching file ]
   | C.Dir dir ->
       List_files.list dir
       (* TOPORT:
@@ -269,11 +343,16 @@ let rules_from_dashdash_config ~token_opt
          )
       *)
       |> List.filter Parse_rule.is_valid_rule_filename
-      |> Common.map load_rules_from_file
+      |> Common.map (load_rules_from_file ~registry_caching)
   | C.URL url -> [ load_rules_from_url url ]
   | C.R rkind ->
       let url = Network_registry.url_of_registry_config_kind rkind in
-      [ load_rules_from_url url ]
+      let content = fetch_content_from_registry_url ~registry_caching url in
+      (* TODO: this also assumes every registry URL is for yaml *)
+      Common2.with_tmp_file ~str:content ~ext:"yaml" (fun file ->
+          let file = Fpath.v file in
+          let res = load_rules_from_file ~registry_caching file in
+          [ { res with origin = None } ])
   | C.A Policy ->
       [
         load_rules_from_url ~token_opt ~ext:"policy"
@@ -286,14 +365,14 @@ let rules_from_dashdash_config ~token_opt
 (*****************************************************************************)
 
 (* python: mix of resolver_config.get_config() and get_rules() *)
-let rules_from_rules_source ~token_opt ~rewrite_rule_ids (src : Rules_source.t)
-    : rules_and_origin list =
+let rules_from_rules_source ~token_opt ~rewrite_rule_ids ~registry_caching
+    (src : Rules_source.t) : rules_and_origin list =
   match src with
   | Configs xs ->
       xs
       |> List.concat_map (fun str ->
              let kind = Semgrep_dashdash_config.parse_config_string str in
-             rules_from_dashdash_config ~token_opt kind)
+             rules_from_dashdash_config ~token_opt ~registry_caching kind)
       |> Common.map (rules_rewrite_rule_ids ~rewrite_rule_ids)
   (* better: '-e foo -l regex' was not handled in pysemgrep
    *  (got a weird 'invalid pattern clause' error)

--- a/src/osemgrep/cli_scan/Rule_fetching.mli
+++ b/src/osemgrep/cli_scan/Rule_fetching.mli
@@ -17,6 +17,7 @@ val partition_rules_and_errors :
 val rules_from_rules_source :
   token_opt:Auth.token option ->
   rewrite_rule_ids:bool ->
+  registry_caching:bool ->
   Rules_source.t ->
   rules_and_origin list
 
@@ -28,11 +29,12 @@ val rules_from_rules_source :
  *)
 val rules_from_dashdash_config :
   token_opt:Auth.token option ->
+  registry_caching:bool ->
   Semgrep_dashdash_config.config_kind ->
   rules_and_origin list
 
 (* low-level API *)
-val load_rules_from_file : Fpath.t -> rules_and_origin
+val load_rules_from_file : registry_caching:bool -> Fpath.t -> rules_and_origin
 
 val load_rules_from_url :
   ?token_opt:Auth.token option -> ?ext:string -> Uri.t -> rules_and_origin

--- a/src/osemgrep/cli_scan/Scan_CLI.mli
+++ b/src/osemgrep/cli_scan/Scan_CLI.mli
@@ -38,6 +38,7 @@ type conf = {
   max_lines_per_finding : int;
   (* Networking options *)
   metrics : Metrics_.config;
+  registry_caching : bool; (* similar to core_runner_conf.ast_caching *)
   version_check : bool;
   (* Ugly: should be in separate subcommands *)
   version : bool;

--- a/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -193,7 +193,8 @@ let run (conf : Scan_CLI.conf) : Exit_code.t =
       (* Rule_fetching.rules_and_origin record also contain errors *)
       let rules_and_origins =
         Rule_fetching.rules_from_rules_source ~token_opt:settings.api_token
-          ~rewrite_rule_ids:conf.rewrite_rule_ids conf.rules_source
+          ~rewrite_rule_ids:conf.rewrite_rule_ids
+          ~registry_caching:conf.registry_caching conf.rules_source
       in
       let rules, errors =
         Rule_fetching.partition_rules_and_errors rules_and_origins

--- a/src/osemgrep/cli_scan/Validate_subcommand.ml
+++ b/src/osemgrep/cli_scan/Validate_subcommand.ml
@@ -72,7 +72,7 @@ let run (conf : conf) : Exit_code.t =
    *)
   let rules_and_origin =
     Rule_fetching.rules_from_rules_source ~token_opt ~rewrite_rule_ids:true
-      conf.rules_source
+      ~registry_caching:false conf.rules_source
   in
   let rules, errors =
     Rule_fetching.partition_rules_and_errors rules_and_origin
@@ -93,6 +93,7 @@ let run (conf : conf) : Exit_code.t =
         in
         let metarules_and_origin =
           Rule_fetching.rules_from_dashdash_config ~token_opt
+            ~registry_caching:false
             (Semgrep_dashdash_config.parse_config_string metarules_pack)
         in
         let metarules, metaerrors =


### PR DESCRIPTION
Cache the content in the registry for 24 hours

test plan:
osemgrep --registry-caching --config p/default --profile
shows now 0.2s for rules_from_rule_source whether it's
5s without the registry cache


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)