### PR TITLE
Set LSP defaults to be sensible

### DIFF
--- a/cli/src/semgrep/lsp/config.py
+++ b/cli/src/semgrep/lsp/config.py
@@ -10,6 +10,8 @@ from typing import Union
 from semgrep.app import auth
 from semgrep.app.scans import ScanHandler
 from semgrep.config_resolver import get_config
+from semgrep.constants import DEFAULT_MAX_TARGET_SIZE
+from semgrep.constants import DEFAULT_TIMEOUT
 from semgrep.engine import EngineType
 from semgrep.meta import generate_meta_from_environment
 from semgrep.meta import GitMeta
@@ -59,7 +61,15 @@ class LSPConfig:
 
     @property
     def max_target_bytes(self) -> int:
-        return self._settings["scan"].get("maxTargetBytes", 0)
+        return self._settings["scan"].get("maxTargetBytes", DEFAULT_MAX_TARGET_SIZE)
+
+    @property
+    def timeout(self) -> int:
+        return self._settings["scan"].get("timeout", DEFAULT_TIMEOUT)
+
+    @property
+    def timeout_threshold(self) -> int:
+        return self._settings["scan"].get("timeoutThreshold", 3)
 
     @property
     def project_url(self) -> Union[str, None]:

--- a/cli/src/semgrep/lsp/schema.json
+++ b/cli/src/semgrep/lsp/schema.json
@@ -40,8 +40,18 @@
     },
     "semgrep.scan.maxTargetBytes": {
       "type": "integer",
-      "default": 0,
+      "default": 1000000,
       "description": "Maximum size of target in bytes to scan."
+    },
+    "semgrep.scan.timeout": {
+      "type": "integer",
+      "default": 30,
+      "description": "Maximum time to scan in seconds."
+    },
+    "semgrep.scan.timeoutThreshold": {
+      "type": "integer",
+      "default": 3,
+      "description": "Maximum number of rules that can timeout on a file before the file is skipped. If set to 0 will not have limit. Defaults to 3."
     },
     "semgrep.scan.onlyGitDirty": {
       "type": "boolean",

--- a/cli/src/semgrep/lsp/server.py
+++ b/cli/src/semgrep/lsp/server.py
@@ -77,6 +77,10 @@ class SemgrepCoreLSServer:
             self.target_file.name,
             "-max_memory",
             str(self.config.max_memory),
+            "-timeout",
+            str(self.config.timeout),
+            "-timeout_threshold",
+            str(self.config.timeout_threshold),
             "-fast",
             "-ls",
         ]


### PR DESCRIPTION
We never set some defaults to sensible values, and now we do.
PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
