### PR TITLE
core: Disable matching cache by default

### DIFF
--- a/changelog.d/cleanup-2.changed
+++ b/changelog.d/cleanup-2.changed
@@ -1,0 +1,3 @@
+engine: The use of a matching cache for statements is now disabled by default,
+please let us know if you notice any performance degradation. We plan to remove
+this optimization in a few weeks.

--- a/src/configuring/Flag_semgrep.ml
+++ b/src/configuring/Flag_semgrep.ml
@@ -20,9 +20,13 @@ let pfff_only = ref false
 (* look if identifiers in pattern intersect with file using simple regexps *)
 let filter_irrelevant_patterns = ref false
 
+(* TODO: This was turned off by default in 1.22.0, the matching-cache's code
+ * should be removed after a few releases once we confirm that disabling it
+ * has no major impact on performance for our community users and customers. *)
 (* opt = optimization *)
-let with_opt_cache = ref true
+let with_opt_cache = ref false
 
+(* TODO: To be removed with `with_opt_cache` a few releases after 1.22.0. *)
 (* Improves performance on some patterns, degrades performance on others. *)
 let max_cache = ref false
 


### PR DESCRIPTION
Ran p/default on about ~30~ 20 repos from stress-tests-monorepo, the average speedup was ~1.02 so basically no change, a couple of repos were faster with caching disabled although not super meaningful. However, we get two more timeouts errors analyzing Kubernetes compared to having caching enabled, happing on two large Go source files of 5 and 15 kLOC. After investigation those timeouts were a bit special, I could only reproduce them when running with Docker but they didn't happen if I ran a native macOS Semgrep binary... Nonetheless I could fix both of them by fixing two rules. For one rule I already opened PR returntocorp/semgrep-rules#2909. For the other rule I started a discussion with SR since I need to be sure that my proposed alternative rule works as they wished (but I'm confident we can find an alternative rule that causes no timeout).

test plan:
make test
and run on some stress-test-monorepo repos to compare perf

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
