### PR TITLE
Cache_disk: generalize the registry cache in Rule_fetching.ml

### DIFF
--- a/libs/commons/Cache_disk.mli
+++ b/libs/commons/Cache_disk.mli
@@ -1,5 +1,42 @@
 (* Caching computation (e.g., parsed ASTs, network data) on disk *)
 
+(* this record is marshalled on disk *)
+type ('v, 'x) cached_value_on_disk = {
+  (* Extra data useful for checking the cache (e.g., a version).
+   * This is useful because the Marshall module is not type-safe;
+   * if the OCaml data structure types change between the moment the
+   * value was cached and the moment it is retrieved, you can
+   * get a segmentation fault after when starting to use the value.
+   *)
+  extra : 'x;
+  (* the actual cached value *)
+  value : 'v;
+}
+
+type ('input, 'value, 'extra) cache_methods = {
+  (* the containing directory will *not* be automatically created *)
+  cache_file_for_input : 'input -> Fpath.t;
+  (* add some extra information with the value to enable certain checks
+   * when getting back the value from the cache (e.g., version check).
+   *)
+  cache_extra_for_input : 'input -> 'extra;
+  (* Returns true if everything is fine and the cached value is valid.
+   * Otherwise the value will be recomputed and saved again in the cache.
+   *)
+  check_extra : 'extra -> bool;
+  (* for debugging purpose, to add the input in the logs *)
+  input_to_string : 'input -> string;
+}
+
+(* The first parameter is the actual computation we want to cache *)
+val cache :
+  ('input -> 'value) ->
+  ('input, 'value, 'extra) cache_methods ->
+  'input ->
+  'value
+
+(* deprecated old functions, less flexible than cache() above. *)
+
 (* take file from which computation is done, an extension, and the function
  * and will compute the function only once and then save result in
  * file ^ extension.

--- a/libs/commons/dune
+++ b/libs/commons/dune
@@ -3,12 +3,12 @@
  (wrapped false)
  (libraries
    str
-   uri
    unix
    fpath
+   uri
    yojson
-   ANSITerminal
    fmt
+   ANSITerminal
    logs logs.fmt
    easy_logging easy_logging_yojson
    alcotest
@@ -18,6 +18,7 @@
    parmap
    digestif.c
  )
+ ; can't use profiling.ppx because of circular dependencies :(
  (preprocess
    (pps
      ppx_deriving.show


### PR DESCRIPTION
This will help factorize code between Rule_fetching.ml and
Parse_with_caching.ml

test plan:
make core
rm -rf ~/.semgrep/cache
osemgrep --config semgrep.jsonnet .
osemgrep --config semgrep.jsonnet .

the second one is fast


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)