### PR TITLE
osemgrep: uniquify rules before applying them (fixes test_deduplication)

### DIFF
--- a/cli/tests/e2e/test_check.py
+++ b/cli/tests/e2e/test_check.py
@@ -67,6 +67,7 @@ def test_basic_jsonnet_rule(
 
 
 @pytest.mark.kinda_slow
+@pytest.mark.osempass
 def test_deduplication(run_semgrep_in_tmp: RunSemgrep, snapshot):
     """
     Check that semgrep runs a rule only once even when different in the metadata

--- a/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -199,6 +199,11 @@ let run (conf : Scan_CLI.conf) : Exit_code.t =
       let rules, errors =
         Rule_fetching.partition_rules_and_errors rules_and_origins
       in
+      let rules =
+        Common.uniq_by
+          (fun r1 r2 -> String.equal (fst r1.Rule.id) (fst r2.Rule.id))
+          rules
+      in
       let filtered_rules =
         Rule_filtering.filter_rules conf.rule_filtering_conf rules
       in

--- a/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -199,6 +199,7 @@ let run (conf : Scan_CLI.conf) : Exit_code.t =
       let rules, errors =
         Rule_fetching.partition_rules_and_errors rules_and_origins
       in
+      (* TODO: we should probably warn the user about rules using the same id *)
       let rules =
         Common.uniq_by
           (fun r1 r2 -> String.equal (fst r1.Rule.id) (fst r2.Rule.id))

--- a/src/parsing/yaml_to_generic.ml
+++ b/src/parsing/yaml_to_generic.ml
@@ -221,49 +221,51 @@ let scalar (_tag, pos, value, style) env : G.expr * E.pos =
   else
     let token = mk_tok ~style pos value env in
     let expr =
-      (match value with
-      | "__sgrep_ellipses__" -> G.Ellipsis (Tok.fake_tok token "...")
-      (* TODO: emma: I will put "" back to Null and have either a warning or
-       * an error when we try to parse a string and get Null in another PR.
-       *)
-      | "null"
-      | "NULL"
-      | "Null"
-      | "~" ->
-          G.L (G.Null token)
-      | "y"
-      | "Y"
-      | "yes"
-      | "Yes"
-      | "YES"
-      | "true"
-      | "True"
-      | "TRUE"
-      | "on"
-      | "On"
-      | "ON" ->
-          G.L (G.Bool (true, token))
-      | "n"
-      | "N"
-      | "no"
-      | "No"
-      | "NO"
-      | "false"
-      | "False"
-      | "FALSE"
-      | "off"
-      | "Off"
-      | "OFF" ->
-          G.L (G.Bool (false, token))
-      | "-.inf" -> G.L (G.Float (Some neg_infinity, token))
-      | ".inf" -> G.L (G.Float (Some neg_infinity, token))
-      | ".nan"
-      | ".NaN"
-      | ".NAN" ->
-          G.L (G.Float (Some nan, token))
-      | _ -> (
-          try G.L (G.Float (Some (float_of_string value), token)) with
-          | _ -> G.L (G.String (fb (value, token)))))
+      (if quoted then G.L (G.String (fb (value, token)))
+      else
+        match value with
+        | "__sgrep_ellipses__" -> G.Ellipsis (Tok.fake_tok token "...")
+        (* TODO: emma: I will put "" back to Null and have either a warning or
+         * an error when we try to parse a string and get Null in another PR.
+         *)
+        | "null"
+        | "NULL"
+        | "Null"
+        | "~" ->
+            G.L (G.Null token)
+        | "y"
+        | "Y"
+        | "yes"
+        | "Yes"
+        | "YES"
+        | "true"
+        | "True"
+        | "TRUE"
+        | "on"
+        | "On"
+        | "ON" ->
+            G.L (G.Bool (true, token))
+        | "n"
+        | "N"
+        | "no"
+        | "No"
+        | "NO"
+        | "false"
+        | "False"
+        | "FALSE"
+        | "off"
+        | "Off"
+        | "OFF" ->
+            G.L (G.Bool (false, token))
+        | "-.inf" -> G.L (G.Float (Some neg_infinity, token))
+        | ".inf" -> G.L (G.Float (Some neg_infinity, token))
+        | ".nan"
+        | ".NaN"
+        | ".NAN" ->
+            G.L (G.Float (Some nan, token))
+        | _ -> (
+            try G.L (G.Float (Some (float_of_string value), token)) with
+            | _ -> G.L (G.String (fb (value, token)))))
       |> G.e
     in
     (expr, pos)


### PR DESCRIPTION
To uniquify the rules, derive equality for the `type rule`.

test plan:
  make osempass

Now, the test_check::test_deduplication passes

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
