### PR TITLE
semgrep.js: more missing language methods + tests + update types

### DIFF
--- a/js/engine/src/index.d.ts
+++ b/js/engine/src/index.d.ts
@@ -16,5 +16,8 @@ export interface Engine {
   ) => string;
   writeFile: (filename: string, content: string) => void;
   deleteFile: (filename: string) => void;
+  isMissingLanguages: () => boolean;
+  getMissingLanguages: () => string[];
+  clearMissingLanguages: () => void;
 }
 export declare const EngineFactory: (wasmUri?: string) => Promise<Engine>;

--- a/js/engine/src/index.js
+++ b/js/engine/src/index.js
@@ -69,7 +69,9 @@ export const EngineFactory = async (wasmUri) => {
       });
     },
     hasParser: (lang) => languages.has(lang),
+    isMissingLanguages: () => missingLanguages.size > 0,
     getMissingLanguages: () => Array.from(missingLanguages),
+    clearMissingLanguages: () => missingLanguages.clear(),
     execute,
     writeFile,
     deleteFile,

--- a/js/engine/tests/index.test.js
+++ b/js/engine/tests/index.test.js
@@ -2,8 +2,8 @@ const { EngineFactory } = require("../dist/index.cjs");
 
 const enginePromise = EngineFactory("./dist/semgrep-engine.wasm");
 
-describe("lookupParserName", () => {
-  test("handles base case", async () => {
+describe("engine", () => {
+  test("handles valid language", async () => {
     const engine = await enginePromise;
     expect(engine.lookupLang("java")).toEqual("java");
   });
@@ -22,6 +22,9 @@ describe("lookupParserName", () => {
       `${__dirname}/test-rule-python.json`,
       `${__dirname}/../../languages/python/tests/test.py`
     );
+    expect(engine.isMissingLanguages()).toBe(true);
     expect(engine.getMissingLanguages()).toEqual(["python"]);
+    engine.clearMissingLanguages();
+    expect(engine.isMissingLanguages()).toBe(false);
   });
 });


### PR DESCRIPTION
- need a way to clear the `missingLanguages` set so that we're not constantly attempting to load unloadable parsers in the frontend
- forgot to update types file in previous PR (will automate generation of this file in the near future)
- update tests

test plan:
- test suite
- tested against this branch with a local playground instance
