### PR TITLE
osemgrep: NEW incremental display of match results in text mode

### DIFF
--- a/src/core_cli/Core_CLI.ml
+++ b/src/core_cli/Core_CLI.ml
@@ -366,6 +366,7 @@ let mk_config () =
     ncores = !ncores;
     parsing_cache_dir = !use_parsing_cache;
     target_source = !target_source;
+    file_match_results_hook = None;
     action = !action;
     version = Version.version;
     roots = [] (* This will be set later in main () *);

--- a/src/osemgrep/cli_scan/Cli_json_output.mli
+++ b/src/osemgrep/cli_scan/Cli_json_output.mli
@@ -20,3 +20,12 @@ val contents_of_file :
 
 (* internals used in Scan_subcommant.ml *)
 val exit_code_of_error_type : Semgrep_output_v1_j.core_error_kind -> Exit_code.t
+
+(* internals used also for incremental display of matches *)
+type env = { hrules : Rule.hrules }
+
+val cli_match_of_core_match :
+  env -> Semgrep_output_v1_t.core_match -> Semgrep_output_v1_t.cli_match
+
+val dedup_and_sort :
+  Semgrep_output_v1_t.cli_match list -> Semgrep_output_v1_t.cli_match list

--- a/src/osemgrep/cli_scan/Core_runner.ml
+++ b/src/osemgrep/cli_scan/Core_runner.ml
@@ -234,10 +234,12 @@ let runner_config_of_conf (conf : conf) : Runner_config.t =
 (*
    Take in rules and targets and return object with findings.
 *)
-let invoke_semgrep_core ?(respect_git_ignore = true) (conf : conf)
-    (all_rules : Rule.t list) (rule_errors : Rule.invalid_rule_error list)
-    (all_targets : Fpath.t list) : result =
+let invoke_semgrep_core ?(respect_git_ignore = true)
+    ?(file_match_results_hook = None) (conf : conf) (all_rules : Rule.t list)
+    (rule_errors : Rule.invalid_rule_error list) (all_targets : Fpath.t list) :
+    result =
   let config : Runner_config.t = runner_config_of_conf conf in
+  let config = { config with file_match_results_hook } in
 
   match rule_errors with
   (* with semgrep-python, semgrep-core is passed all the rules unparsed,
@@ -300,8 +302,7 @@ let invoke_semgrep_core ?(respect_git_ignore = true) (conf : conf)
       let _exnTODO = None in
       (* similar to Run_semgrep.semgrep_with_rules_and_formatted_output *)
       (* LATER: we want to avoid this intermediate data structure but
-       * for now that's what semgrep-python used to get so simpler to
-       * return it.
+       * for now that's what pysemgrep used to get so simpler to return it.
        *)
       let match_results =
         JSON_report.match_results_of_matches_and_errors

--- a/src/osemgrep/cli_scan/Core_runner.mli
+++ b/src/osemgrep/cli_scan/Core_runner.mli
@@ -26,6 +26,8 @@ type result = {
 *)
 val invoke_semgrep_core :
   ?respect_git_ignore:bool ->
+  ?file_match_results_hook:
+    (Fpath.t -> Report.partial_profiling Report.match_result -> unit) option ->
   conf ->
   (* LATER? use Config_resolve.rules_and_origin instead? *)
   Rule.rules ->

--- a/src/osemgrep/cli_scan/Output.ml
+++ b/src/osemgrep/cli_scan/Output.ml
@@ -137,6 +137,8 @@ let dispatch_output_format (output_format : Output_format.t)
       Matches_report.pp_cli_output ~max_chars_per_line:conf.max_chars_per_line
         ~max_lines_per_finding:conf.max_lines_per_finding
         ~color_output:conf.force_color Format.std_formatter cli_output
+  (* matches have already been displayed in a file_match_results_hook *)
+  | TextIncremental -> ()
   | Gitlab_sast
   | Gitlab_secrets
   | Junit_xml

--- a/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -9,6 +9,7 @@
 *)
 
 module Out = Semgrep_output_v1_t
+module RP = Report
 
 (*****************************************************************************)
 (* Logging/Profiling/Debugging *)
@@ -94,6 +95,51 @@ let exit_code_of_cli_errors (errors : Out.cli_error list) : Exit_code.t =
   match List.rev errors with
   | [] -> Exit_code.ok
   | x :: _ -> Exit_code.of_int x.Out.code
+
+(*****************************************************************************)
+(* Incremental display *)
+(*****************************************************************************)
+
+(* Note that this is run in parallel in Parmap at the end of processing
+ * a file.
+ * TODO: Using Format.std_formatter in parallel is not good; the output
+ * is interwinded. Need to find a way to synchronize them. At least
+ * it works with osemgrep -j 1
+ *)
+let file_match_results_hook (conf : Scan_CLI.conf) (rules : Rule.rules)
+    (_file : Fpath.t) (match_results : RP.partial_profiling RP.match_result) :
+    unit =
+  let (cli_matches : Out.cli_match list) =
+    (* need to go through a series of transformation so that we can
+     * get something that Matches_report.pp_text_outputs can operate on
+     *)
+    let (pms : Pattern_match.t list) = match_results.matches in
+    let (core_matches : Out.core_match list) =
+      pms |> Common.partition_either (JSON_report.match_to_match None) |> fst
+    in
+    let hrules = Rule.hrules_of_rules rules in
+    let env = { Cli_json_output.hrules } in
+    core_matches
+    |> Common.map (Cli_json_output.cli_match_of_core_match env)
+    |> Cli_json_output.dedup_and_sort
+  in
+  (* TODO? needed? given the call to dedup_and_sort above? I just imitate
+   * what we do in the regular code path
+   *)
+  let cli_matches = Matches_report.sort_matches cli_matches in
+  (* TODO? not sure why the order in sort_matches is wrong *)
+  let cli_matches = List.rev cli_matches in
+  let cli_matches =
+    cli_matches
+    |> Common.exclude (fun m ->
+           let to_ignore, _errs = Nosemgrep.rule_match_nosem ~strict:false m in
+           to_ignore)
+  in
+  if cli_matches <> [] then
+    (* coupling: similar to Output.dispatch_output_format for Text *)
+    Matches_report.pp_text_outputs ~max_chars_per_line:conf.max_chars_per_line
+      ~max_lines_per_finding:conf.max_lines_per_finding
+      ~color_output:conf.force_color Format.std_formatter cli_matches
 
 (*****************************************************************************)
 (* Skipped analysis *)
@@ -221,10 +267,18 @@ let run (conf : Scan_CLI.conf) : Exit_code.t =
                    x.Output_from_core_t.details));
 
       (* step3: running the engine *)
+      let output_format, file_match_results_hook =
+        match conf with
+        | { output_format = Output_format.Text; legacy = false; _ } ->
+            ( Output_format.TextIncremental,
+              Some (file_match_results_hook conf filtered_rules) )
+        | { output_format; _ } -> (output_format, None)
+      in
       let (res : Core_runner.result) =
         Core_runner.invoke_semgrep_core
           ~respect_git_ignore:conf.targeting_conf.respect_git_ignore
-          conf.core_runner_conf filtered_rules errors targets
+          ~file_match_results_hook conf.core_runner_conf filtered_rules errors
+          targets
       in
 
       (* step4: report matches *)
@@ -242,7 +296,7 @@ let run (conf : Scan_CLI.conf) : Exit_code.t =
       in
 
       (* outputting the result! in JSON/Text/... depending on conf *)
-      let cli_errors = Output.output_result conf res in
+      let cli_errors = Output.output_result { conf with output_format } res in
 
       Logs.info (fun m ->
           m "%a" Skipped_report.pp_skipped

--- a/src/osemgrep/reporting/Matches_report.ml
+++ b/src/osemgrep/reporting/Matches_report.ml
@@ -28,6 +28,19 @@ let group_titles = function
   | `Blocking -> "Blocking Code Finding"
   | `Merged -> "Code Finding"
 
+let sort_matches (matches : Out.cli_match list) =
+  matches
+  |> List.sort (fun (m1 : Out.cli_match) (m2 : Out.cli_match) ->
+         match String.compare m2.path m1.path with
+         | 0 -> (
+             match String.compare m2.check_id m1.check_id with
+             | 0 -> (
+                 match Int.compare m2.start.line m1.start.line with
+                 | 0 -> Int.compare m2.start.col m1.start.col
+                 | x -> x)
+             | x -> x)
+         | x -> x)
+
 let is_blocking (json : Yojson.Basic.t) =
   match Yojson.Basic.Util.member "dev.semgrep.actions" json with
   | `List stuff ->
@@ -135,51 +148,54 @@ let pp_finding ~max_chars_per_line ~max_lines_per_finding ~color_output
   in
   let start_line = m.start.line in
   let stripped, _ =
-    List.fold_left
-      (fun (stripped, line_number) line ->
-        let line, line_off, stripped' =
-          let ll = String.length line in
-          if max_chars_per_line > 0 && ll > max_chars_per_line then
-            if start_line = line_number then
-              let start_col = m.start.col - 1 - dedented in
-              let end_col = min (start_col + max_chars_per_line) ll in
-              let data = String.sub line start_col (end_col - start_col - 1) in
-              ( (if start_col > 0 then ellipsis_string else "")
-                ^ data ^ ellipsis_string,
-                m.start.col - 1,
-                true )
-            else
-              ( Str.first_chars line max_chars_per_line ^ ellipsis_string,
-                0,
-                true )
-          else (line, 0, false)
-        in
-        let line_number_str = string_of_int line_number in
-        let pad = String.make (11 - String.length line_number_str) ' ' in
-        let col c = max 0 (c - 1 - dedented - line_off) in
-        let ellipsis_len p =
-          if stripped' && p then String.length ellipsis_string else 0
-        in
-        let start_color =
-          if line_number > start_line then 0
-          else col m.start.col + ellipsis_len (line_off > 0)
-        in
-        let end_color =
-          max start_color
-            (if line_number >= m.end_.line then
-             min
-               (if m.start.line = m.end_.line then
-                start_color + (m.end_.col - m.start.col)
-               else col m.end_.col - ellipsis_len true)
-               (String.length line - 1 - ellipsis_len true)
-            else String.length line - 1)
-        in
-        let a, b, c = cut line start_color end_color in
-        Fmt.pf ppf "%s%s┆ %s%a%s@." pad line_number_str a
-          Fmt.(styled `Bold string)
-          b c;
-        (stripped' || stripped, succ line_number))
-      (false, start_line) lines
+    lines
+    |> List.fold_left
+         (fun (stripped, line_number) line ->
+           let line, line_off, stripped' =
+             let ll = String.length line in
+             if max_chars_per_line > 0 && ll > max_chars_per_line then
+               if start_line = line_number then
+                 let start_col = m.start.col - 1 - dedented in
+                 let end_col = min (start_col + max_chars_per_line) ll in
+                 let data =
+                   String.sub line start_col (end_col - start_col - 1)
+                 in
+                 ( (if start_col > 0 then ellipsis_string else "")
+                   ^ data ^ ellipsis_string,
+                   m.start.col - 1,
+                   true )
+               else
+                 ( Str.first_chars line max_chars_per_line ^ ellipsis_string,
+                   0,
+                   true )
+             else (line, 0, false)
+           in
+           let line_number_str = string_of_int line_number in
+           let pad = String.make (11 - String.length line_number_str) ' ' in
+           let col c = max 0 (c - 1 - dedented - line_off) in
+           let ellipsis_len p =
+             if stripped' && p then String.length ellipsis_string else 0
+           in
+           let start_color =
+             if line_number > start_line then 0
+             else col m.start.col + ellipsis_len (line_off > 0)
+           in
+           let end_color =
+             max start_color
+               (if line_number >= m.end_.line then
+                min
+                  (if m.start.line = m.end_.line then
+                   start_color + (m.end_.col - m.start.col)
+                  else col m.end_.col - ellipsis_len true)
+                  (String.length line - 1 - ellipsis_len true)
+               else String.length line - 1)
+           in
+           let a, b, c = cut line start_color end_color in
+           Fmt.pf ppf "%s%s┆ %s%a%s@." pad line_number_str a
+             Fmt.(styled `Bold string)
+             b c;
+           (stripped' || stripped, succ line_number))
+         (false, start_line)
   in
   if stripped then
     Fmt.pf ppf
@@ -241,13 +257,14 @@ let pp_text_outputs ~max_chars_per_line ~max_lines_per_finding ~color_output ppf
     Fmt.pf ppf "@."
   in
   let last, cur =
-    List.fold_left
-      (fun (last, cur) (next : Out.cli_match) ->
-        (match cur with
-        | None -> ()
-        | Some m -> print_one last m (Some next));
-        (cur, Some next))
-      (None, None) matches
+    matches
+    |> List.fold_left
+         (fun (last, cur) (next : Out.cli_match) ->
+           (match cur with
+           | None -> ()
+           | Some m -> print_one last m (Some next));
+           (cur, Some next))
+         (None, None)
   in
   match cur with
   | Some m -> print_one last m None
@@ -260,43 +277,32 @@ let pp_text_outputs ~max_chars_per_line ~max_lines_per_finding ~color_output ppf
 let pp_cli_output ~max_chars_per_line ~max_lines_per_finding ~color_output ppf
     (cli_output : Out.cli_output) =
   let groups =
-    Common.group_by
-      (fun (m : Out.cli_match) ->
-        (* TODO: python (text.py):
-           if match.product == RuleProduct.sast:
-             subgroup = "blocking" if match.is_blocking else "nonblocking"
-           else:
-             subgroup = match.exposure_type or "undetermined"
+    cli_output.results |> sort_matches
+    |> Common.group_by (fun (m : Out.cli_match) ->
+           (* TODO: python (text.py):
+              if match.product == RuleProduct.sast:
+                subgroup = "blocking" if match.is_blocking else "nonblocking"
+              else:
+                subgroup = match.exposure_type or "undetermined"
 
-           figuring out the product, python uses (rule.py):
-              RuleProduct.sca
-              if "r2c-internal-project-depends-on" in self._raw
-              else RuleProduct.sast
+              figuring out the product, python uses (rule.py):
+                 RuleProduct.sca
+                 if "r2c-internal-project-depends-on" in self._raw
+                 else RuleProduct.sast
 
-           and exposure_type (rule_match.py):
-           if "sca_info" not in self.extra:
-               return None
+              and exposure_type (rule_match.py):
+              if "sca_info" not in self.extra:
+                  return None
 
-           if self.metadata.get("sca-kind") == "upgrade-only":
-               return "reachable"
-           elif self.metadata.get("sca-kind") == "legacy":
-               return "undetermined"
-           else:
-               return "reachable" if self.extra["sca_info"].reachable else "unreachable"
-        *)
-        if is_blocking m.Out.extra.Out.metadata then `Blocking else `Nonblocking)
-      (List.sort
-         (fun (m1 : Out.cli_match) (m2 : Out.cli_match) ->
-           match String.compare m2.path m1.path with
-           | 0 -> (
-               match String.compare m2.check_id m1.check_id with
-               | 0 -> (
-                   match Int.compare m2.start.line m1.start.line with
-                   | 0 -> Int.compare m2.start.col m1.start.col
-                   | x -> x)
-               | x -> x)
-           | x -> x)
-         cli_output.results)
+              if self.metadata.get("sca-kind") == "upgrade-only":
+                  return "reachable"
+              elif self.metadata.get("sca-kind") == "legacy":
+                  return "undetermined"
+              else:
+                  return "reachable" if self.extra["sca_info"].reachable else "unreachable"
+           *)
+           if is_blocking m.Out.extra.Out.metadata then `Blocking
+           else `Nonblocking)
   in
   (* if not is_ci_invocation *)
   let groups =
@@ -312,13 +318,12 @@ let pp_cli_output ~max_chars_per_line ~max_lines_per_finding ~color_output ppf
          (fun (k, _) -> not (k = `Nonblocking || k = `Blocking))
          groups
   in
-  List.iter
-    (fun (group, matches) ->
-      (match matches with
-      | [] -> ()
-      | _non_empty ->
-          Fmt_helpers.pp_heading ppf
-            (string_of_int (List.length matches) ^ " " ^ group_titles group));
-      pp_text_outputs ~max_chars_per_line ~max_lines_per_finding ~color_output
-        ppf matches)
-    groups
+  groups
+  |> List.iter (fun (group, matches) ->
+         (match matches with
+         | [] -> ()
+         | _non_empty ->
+             Fmt_helpers.pp_heading ppf
+               (string_of_int (List.length matches) ^ " " ^ group_titles group));
+         pp_text_outputs ~max_chars_per_line ~max_lines_per_finding
+           ~color_output ppf matches)

--- a/src/osemgrep/reporting/Matches_report.mli
+++ b/src/osemgrep/reporting/Matches_report.mli
@@ -7,3 +7,15 @@ val pp_cli_output :
   Format.formatter ->
   Semgrep_output_v1_t.cli_output ->
   unit
+
+(* internals, used also for incremental display of matches *)
+val pp_text_outputs :
+  max_chars_per_line:int ->
+  max_lines_per_finding:int ->
+  color_output:'a ->
+  Format.formatter ->
+  Semgrep_output_v1_t.cli_match list ->
+  unit
+
+val sort_matches :
+  Semgrep_output_v1_t.cli_match list -> Semgrep_output_v1_t.cli_match list

--- a/src/osemgrep/reporting/Output_format.ml
+++ b/src/osemgrep/reporting/Output_format.ml
@@ -12,6 +12,10 @@ type t =
   | Sarif
   | Emacs
   | Vim
+  (* used to disable the final display of match results because
+   * we displayed them incrementally instead
+   *)
+  | TextIncremental
 [@@deriving show]
 
 let _output_format_is_json = function
@@ -23,5 +27,6 @@ let _output_format_is_json = function
   | Gitlab_secrets
   | Junit_xml
   | Emacs
-  | Vim ->
+  | Vim
+  | TextIncremental ->
       false

--- a/src/osemgrep/reporting/Output_format.mli
+++ b/src/osemgrep/reporting/Output_format.mli
@@ -7,4 +7,8 @@ type t =
   | Sarif
   | Emacs
   | Vim
+  (* used to disable the final display of match results because
+   * we displayed them incrementally instead
+   *)
+  | TextIncremental
 [@@deriving show]

--- a/src/reporting/Nosemgrep.mli
+++ b/src/reporting/Nosemgrep.mli
@@ -12,3 +12,15 @@ val process_ignores :
 val rule_id_re_str : string
 val nosem_inline_re : Pcre.regexp
 val nosem_previous_line_re : Pcre.regexp
+
+(* used for the incremental display of matches *)
+
+(*
+   Try to recognize a possible [nosem] tag into the given [match].
+   If [strict:true], we returns possible errors when [nosem] is used with an
+   ID which is not equal to the rule's ID.
+*)
+val rule_match_nosem :
+  strict:bool ->
+  Semgrep_output_v1_t.cli_match ->
+  bool (* to_ignore *) * Semgrep_output_v1_t.cli_error list

--- a/src/runner/Run_semgrep.ml
+++ b/src/runner/Run_semgrep.ml
@@ -781,6 +781,12 @@ let semgrep_with_rules config ((rules, invalid_rules), rules_parse_time) =
                }
              else matches
            in
+           (* So we can display matches incrementally in osemgrep!
+            * Note that this is run in a child process of Parmap, so
+            * the hook should not rely on shared memory.
+            *)
+           config.file_match_results_hook
+           |> Option.iter (fun hook -> hook (Fpath.v file) matches);
 
            update_cli_progress config;
 

--- a/src/runner/Run_semgrep.mli
+++ b/src/runner/Run_semgrep.mli
@@ -138,9 +138,8 @@ val semgrep_with_prepared_rules_and_targets :
 
 val semgrep_with_rules :
   Runner_config.t ->
-  (Rule.mode Rule.rule_info Common.stack * Rule.invalid_rule_error Common.stack)
-  * float ->
-  Report.final_result * Common.filename Common.stack
+  (Rule.t list * Rule.invalid_rule_error list) * float ->
+  Report.final_result * Common.filename list
 
 (* utilities functions used in tests or semgrep-core variants *)
 

--- a/src/runner/Runner_config.ml
+++ b/src/runner/Runner_config.ml
@@ -1,9 +1,5 @@
-(*
-   Type definitions, mostly.
-*)
-
 (* in JSON mode, we might need to display intermediate '.' in the
- * output for semgrep to track progress as well as extra targets
+ * output for pysemgrep to track progress as well as extra targets
  * found by extract rules.
  * LATER: osemgrep: not needed after osemgrep migration done
  *)
@@ -11,8 +7,8 @@ type output_format = Text | Json of bool (* dots *) [@@deriving show]
 
 (*
    'Rule_file' is for the semgrep-core CLI.
-   The 'Rules' case is for an invocation that bypasses the semgrep-core
-   command (osemgrep) or when for some reason the rules had to be preparsed.
+   'Rules' is for osemgrep or when for some reason the rules had to be
+    preparsed.
 *)
 type rule_source = Rule_file of Fpath.t | Rules of Rule.t list
 
@@ -28,7 +24,7 @@ type target_source =
   | Target_file of Fpath.t
   | Targets of Input_to_core_t.targets
 
-(* TODO: similar to osemgrep Scan_CLI.conf, should be merged in it *)
+(* TODO: similar to osemgrep Scan_CLI.conf; should be merged with it *)
 type t = {
   (* Debugging/profiling/logging flags *)
   log_config_file : Fpath.t;
@@ -62,7 +58,13 @@ type t = {
   ncores : int;
   parsing_cache_dir : Fpath.t option;
   filter_irrelevant_rules : bool;
-  (* Flag used by the semgrep-python wrapper *)
+  (* Hook to display match results incrementally, after a file has been fully
+   * processed. Note that this hook run in a child process of Parmap
+   * in Run_semgrep, so the hook should not rely on shared memory!
+   *)
+  file_match_results_hook :
+    (Fpath.t -> Report.partial_profiling Report.match_result -> unit) option;
+  (* Flag used by pysemgrep *)
   target_source : target_source option;
   (* Common.ml action for the -dump_xxx *)
   action : string;
@@ -116,6 +118,7 @@ let default =
     parsing_cache_dir = None;
     (* a.k.a -fast, on by default *)
     filter_irrelevant_rules = true;
+    file_match_results_hook = None;
     (* Flag used by the semgrep-python wrapper *)
     target_source = None;
     (* Common.ml action for the -dump_xxx *)


### PR DESCRIPTION


test plan:
$ osemgrep --legacy --no-ast-caching -l ocaml -e ': Common.filename' .
display the matches all at once

$ osemgrep --no-ast-caching -l ocaml -e ': Common.filename' .
display the matches gradually :)

and it takes almost the same time, so using Unix.lockf does not include a perf penality.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)