### PR TITLE
osemgrep: rule validation

### DIFF
--- a/cli/tests/e2e/test_rule_parser.py
+++ b/cli/tests/e2e/test_rule_parser.py
@@ -22,9 +22,7 @@ def test_rule_parser__success(run_semgrep_in_tmp: RunSemgrep, snapshot, filename
     run_semgrep_in_tmp(f"rules/syntax/{filename}.yaml")
 
 
-# TODO: Those are almost osempass, but 2 files are failing and then
-# the same rules/syntax/ files are used for test_rule_parser__failure__error_messages
-# where they all fail, so can't really split the test in 2 with an osemfail suffix
+@pytest.mark.osempass
 @pytest.mark.kinda_slow
 @pytest.mark.parametrize("filename", syntax_fails)
 def test_rule_parser__failure(run_semgrep_in_tmp: RunSemgrep, snapshot, filename):

--- a/src/parsing/Parse_rule.ml
+++ b/src/parsing/Parse_rule.ml
@@ -480,8 +480,10 @@ let parse_paths env key value =
     ( take_opt paths_dict env parse_string_list "include",
       take_opt paths_dict env parse_string_list "exclude" )
   in
+  (* alt: we could use report_unparsed_fields(), but better to raise an error for now
+     to be compatible with pysemgrep *)
   if Hashtbl.length paths_dict.h > 0 then
-    yaml_error paths_dict.first_tok
+    error_at_key env key
       "Additional properties are not allowed (only 'include' and 'exclude' are \
        supported)";
   { R.include_ = optlist_to_list inc_opt; exclude = optlist_to_list exc_opt }

--- a/src/parsing/Parse_rule.ml
+++ b/src/parsing/Parse_rule.ml
@@ -174,9 +174,6 @@ let read_string_wrap e =
   | G.L (String (_, (value, t), _)) ->
       (* should use the unescaped string *)
       Some (value, t)
-  | G.L (Float (Some n, t)) ->
-      if Float.is_integer n then Some (string_of_int (Float.to_int n), t)
-      else Some (string_of_float n, t)
   | G.N (Id ((value, t), _)) -> Some (value, t)
   | _ -> None
 

--- a/src/parsing/Parse_rule.ml
+++ b/src/parsing/Parse_rule.ml
@@ -483,6 +483,10 @@ let parse_paths env key value =
     ( take_opt paths_dict env parse_string_list "include",
       take_opt paths_dict env parse_string_list "exclude" )
   in
+  if Hashtbl.length paths_dict.h > 0 then
+    yaml_error paths_dict.first_tok
+      "Additional properties are not allowed (only 'include' and 'exclude' are \
+       supported)";
   { R.include_ = optlist_to_list inc_opt; exclude = optlist_to_list exc_opt }
 
 let parse_options env (key : key) value =

--- a/tests/rules/message_int.py
+++ b/tests/rules/message_int.py
@@ -1,3 +1,0 @@
-def foo():
-  #ruleid:test
-  return x

--- a/tests/rules/message_int.yaml
+++ b/tests/rules/message_int.yaml
@@ -1,6 +1,0 @@
-rules:
-- id: test
-  languages: [python]
-  pattern: x
-  message: 42
-  severity: ERROR

--- a/tests/rules/metavar_pattern_generic.yaml
+++ b/tests/rules/metavar_pattern_generic.yaml
@@ -7,6 +7,6 @@ rules:
     - metavariable-pattern:
         metavariable: $...ARGS
         language: generic
-        pattern: 2
+        pattern: "2"
   message: rule_template_message
   severity: ERROR

--- a/tests/rules/pattern_int.yaml
+++ b/tests/rules/pattern_int.yaml
@@ -1,6 +1,6 @@
 rules:
 - id: test
   languages: [python]
-  pattern: 1
+  pattern: "1"
   message: Test
   severity: ERROR


### PR DESCRIPTION
Now that #7774 is merged (and quoted strings aren't treat as Float anymore), we can leverage the `read_string_wrap` to disallow Float.

The other check in place is that `paths` may only contain `include` and `exclude` keys.

Test plan:
 - make osempass

The test test_rule_parser.py::test_rule_parser__failure now passes (and has been marked with osempass).

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
