### PR TITLE
osemgrep: enable tests where there are no rules

### DIFF
--- a/cli/tests/e2e/test_rule_parser.py
+++ b/cli/tests/e2e/test_rule_parser.py
@@ -31,6 +31,9 @@ def test_rule_parser__failure(run_semgrep_in_tmp: RunSemgrep, snapshot, filename
     run_semgrep_in_tmp(f"rules/syntax/{filename}.yaml", assert_exit_code={2, 7, 8})
 
 
+# TODO: osemgrep does not return exit code 8 yet, since all errors are handled
+# by Core_runner, which returns invalid_code (3) or fatal (2), using
+# Cli_json_output.exit_code_of_error_type
 @pytest.mark.kinda_slow
 def test_regex_with_bad_language(run_semgrep_in_tmp: RunSemgrep, snapshot):
     run_semgrep_in_tmp("rules/syntax/badlanguage.yaml", assert_exit_code=8)

--- a/cli/tests/e2e/test_rule_parser.py
+++ b/cli/tests/e2e/test_rule_parser.py
@@ -31,11 +31,13 @@ def test_rule_parser__failure(run_semgrep_in_tmp: RunSemgrep, snapshot, filename
     run_semgrep_in_tmp(f"rules/syntax/{filename}.yaml", assert_exit_code={2, 7, 8})
 
 
+@pytest.mark.osempass
 @pytest.mark.kinda_slow
 def test_regex_with_bad_language(run_semgrep_in_tmp: RunSemgrep, snapshot):
     run_semgrep_in_tmp("rules/badlanguage.yaml", assert_exit_code=7)
 
 
+@pytest.mark.osempass
 @pytest.mark.kinda_slow
 def test_rule_parser__empty(run_semgrep_in_tmp: RunSemgrep, snapshot):
     run_semgrep_in_tmp(f"rules/syntax/empty.yaml", assert_exit_code=7)

--- a/cli/tests/e2e/test_rule_parser.py
+++ b/cli/tests/e2e/test_rule_parser.py
@@ -34,7 +34,12 @@ def test_rule_parser__failure(run_semgrep_in_tmp: RunSemgrep, snapshot, filename
 @pytest.mark.osempass
 @pytest.mark.kinda_slow
 def test_regex_with_bad_language(run_semgrep_in_tmp: RunSemgrep, snapshot):
-    run_semgrep_in_tmp("rules/badlanguage.yaml", assert_exit_code=7)
+    run_semgrep_in_tmp("rules/syntax/badlanguage.yaml", assert_exit_code=7)
+
+@pytest.mark.osempass
+@pytest.mark.kinda_slow
+def test_nonexisting_faile(run_semgrep_in_tmp: RunSemgrep, snapshot):
+    run_semgrep_in_tmp("rules/does_not_exist.yaml", assert_exit_code=7)
 
 
 @pytest.mark.osempass

--- a/cli/tests/e2e/test_rule_parser.py
+++ b/cli/tests/e2e/test_rule_parser.py
@@ -36,6 +36,7 @@ def test_rule_parser__failure(run_semgrep_in_tmp: RunSemgrep, snapshot, filename
 def test_regex_with_bad_language(run_semgrep_in_tmp: RunSemgrep, snapshot):
     run_semgrep_in_tmp("rules/syntax/badlanguage.yaml", assert_exit_code=7)
 
+
 @pytest.mark.osempass
 @pytest.mark.kinda_slow
 def test_nonexisting_faile(run_semgrep_in_tmp: RunSemgrep, snapshot):

--- a/cli/tests/e2e/test_rule_parser.py
+++ b/cli/tests/e2e/test_rule_parser.py
@@ -31,10 +31,9 @@ def test_rule_parser__failure(run_semgrep_in_tmp: RunSemgrep, snapshot, filename
     run_semgrep_in_tmp(f"rules/syntax/{filename}.yaml", assert_exit_code={2, 7, 8})
 
 
-@pytest.mark.osempass
 @pytest.mark.kinda_slow
 def test_regex_with_bad_language(run_semgrep_in_tmp: RunSemgrep, snapshot):
-    run_semgrep_in_tmp("rules/syntax/badlanguage.yaml", assert_exit_code=7)
+    run_semgrep_in_tmp("rules/syntax/badlanguage.yaml", assert_exit_code=8)
 
 
 @pytest.mark.osempass

--- a/cli/tests/e2e/test_rule_parser.py
+++ b/cli/tests/e2e/test_rule_parser.py
@@ -41,7 +41,7 @@ def test_regex_with_bad_language(run_semgrep_in_tmp: RunSemgrep, snapshot):
 
 @pytest.mark.osempass
 @pytest.mark.kinda_slow
-def test_nonexisting_faile(run_semgrep_in_tmp: RunSemgrep, snapshot):
+def test_nonexisting_file(run_semgrep_in_tmp: RunSemgrep, snapshot):
     run_semgrep_in_tmp("rules/does_not_exist.yaml", assert_exit_code=7)
 
 

--- a/src/osemgrep/configuring/Semgrep_dashdash_config.ml
+++ b/src/osemgrep/configuring/Semgrep_dashdash_config.ml
@@ -89,4 +89,4 @@ let parse_config_string config_str =
         (E.Semgrep_error
            ( spf "unable to find a config; path `%s` does not exist%s" str
                addendum,
-             None ))
+             Some Exit_code.missing_config ))

--- a/src/parsing/Parse_rule.ml
+++ b/src/parsing/Parse_rule.ml
@@ -1476,7 +1476,10 @@ let parse_generic_ast ?(error_recovery = false) (file : Fpath.t)
             let loc = Tok.first_loc_of_file !!file in
             yaml_error (Tok.tok_of_loc loc)
               "missing rules entry as top-level key")
-    | _ -> (Tok.(tok_of_loc (first_loc_of_file !!file)), [])
+    | [] ->
+        (* an empty rules file returns an empty list of rules *)
+        (Tok.(tok_of_loc (first_loc_of_file !!file)), [])
+    | _ -> assert false
     (* yaml_to_generic should always return a ExprStmt *)
   in
   let xs =

--- a/src/parsing/Parse_rule.ml
+++ b/src/parsing/Parse_rule.ml
@@ -1476,7 +1476,7 @@ let parse_generic_ast ?(error_recovery = false) (file : Fpath.t)
             let loc = Tok.first_loc_of_file !!file in
             yaml_error (Tok.tok_of_loc loc)
               "missing rules entry as top-level key")
-    | _ -> assert false
+    | _ -> (Tok.(tok_of_loc (first_loc_of_file !!file)), [])
     (* yaml_to_generic should always return a ExprStmt *)
   in
   let xs =


### PR DESCRIPTION
Two more tests are enabled, one is fixed (badlanguage.yaml file location); also a new one (does_not_exist.yaml) has been added.

osemgrep now exits with error code 7.

test plan:
 - make osempass

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
