### PR TITLE
osemgrep: do not print the rule id if interactive

### DIFF
--- a/src/osemgrep/cli_scan/Output.ml
+++ b/src/osemgrep/cli_scan/Output.ml
@@ -101,7 +101,7 @@ let dispatch_output_format (output_format : Output_format.t)
              } ->
                  let severity = String.lowercase_ascii severity in
                  let severity_and_ruleid =
-                   if check_id = Constants.cli_rule_id then severity
+                   if check_id = Constants.rule_id_for_dash_e then severity
                    else
                      let xs =
                        check_id |> Str.split (Str.regexp_string ".") |> List.rev

--- a/src/osemgrep/cli_scan/Rule_fetching.ml
+++ b/src/osemgrep/cli_scan/Rule_fetching.ml
@@ -383,7 +383,7 @@ let rules_from_rules_source ~token_opt ~rewrite_rule_ids ~registry_caching
         | XP.Regexp _ ->
             ());
         let rule = Rule.rule_of_xpattern xlang xpat in
-        let rule = { rule with id = (Constants.cli_rule_id, fk); fix } in
+        let rule = { rule with id = (Constants.rule_id_for_dash_e, fk); fix } in
         { origin = None; rules = [ rule ]; errors = [] }
       in
 

--- a/src/osemgrep/core/Constants.ml
+++ b/src/osemgrep/core/Constants.ml
@@ -5,7 +5,7 @@ open Common
 
 let _rules_key = "rules"
 let _id_key = "id"
-let cli_rule_id = "-"
+let rule_id_for_dash_e = "-"
 
 let _please_file_issue_text =
   "An error occurred while invoking the Semgrep engine. Please help us fix \

--- a/src/osemgrep/core/Constants.mli
+++ b/src/osemgrep/core/Constants.mli
@@ -1,2 +1,2 @@
 (* "-", the rule id for interactive rule? via -e ? *)
-val cli_rule_id : string
+val rule_id_for_dash_e : string

--- a/src/osemgrep/reporting/Matches_report.ml
+++ b/src/osemgrep/reporting/Matches_report.ml
@@ -213,6 +213,8 @@ let pp_text_outputs ~max_chars_per_line ~max_lines_per_finding ~color_output ppf
       msg
     in
     let print =
+      cur.check_id <> "-"
+      &&
       match last_message with
       | None -> true
       | Some m -> m <> cur.extra.message

--- a/src/osemgrep/reporting/Matches_report.ml
+++ b/src/osemgrep/reporting/Matches_report.ml
@@ -213,7 +213,7 @@ let pp_text_outputs ~max_chars_per_line ~max_lines_per_finding ~color_output ppf
       msg
     in
     let print =
-      cur.check_id <> "-"
+      cur.check_id <> Constants.rule_id_for_dash_e
       &&
       match last_message with
       | None -> true


### PR DESCRIPTION
test plan:
 - osemgrep -e ': Common.filename' -l ocaml src/

compare output to pysemgrep

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
