### PR TITLE
bugfix: generate regular filenames in ~/.semgrep/cache/asts

### DIFF
--- a/src/parsing/Parse_with_caching.ml
+++ b/src/parsing/Parse_with_caching.ml
@@ -153,9 +153,9 @@ let parse_and_resolve_name ?(parsing_cache_dir = None) version lang
                  * special chars in a file path.
                  * hopefully there will be no collision
                  *)
-                let md5 = Digest.string str in
+                let md5_hex = Digest.string str |> Digest.to_hex in
                 (* TODO: create parsing_cache_dir in Cache_disk.ml, factorize *)
-                parsing_cache_dir // Fpath.(v md5 + binary_suffix));
+                parsing_cache_dir // Fpath.(v md5_hex + binary_suffix));
             cache_extra_for_input = cache_extra_for_input version;
             check_extra =
               (fun (version2, file2, mtime2) ->


### PR DESCRIPTION
Digest.string was returning a binary string with possible special
chars in it, which was causing issues in certain filesystems
(Nat is using Btrfs), and was actually causing also issues in
osemgrep.

test plan:
from semgrep repo
```
$ osemgrep -e ': Common.filename' .
...
188 findings
$ ls -1 ~/.semgrep/cache/asts
77031cab83d2f56ebb703c289cb97dc5.ast.binary
fea82fddbd7bd0cdbc5403edce286f2f.ast.binary
...
```

Before this PR, running osemgrep with --no-ast-caching
or --ast-caching was producing a different number of findings
(no idea why, maybe some weird errors were propagated when trying
to read the cache file).


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)