### PR TITLE
osemgrep: Find_target: support include/exclude patterns better

### DIFF
--- a/cli/tests/e2e/test_check.py
+++ b/cli/tests/e2e/test_check.py
@@ -456,6 +456,7 @@ def test_metavariable_multi_regex_rule(run_semgrep_in_tmp: RunSemgrep, snapshot)
 
 
 @pytest.mark.kinda_slow
+@pytest.mark.osempass
 def test_regex_with_any_language_rule(run_semgrep_in_tmp: RunSemgrep, snapshot):
     snapshot.assert_match(
         run_semgrep_in_tmp(
@@ -466,6 +467,7 @@ def test_regex_with_any_language_rule(run_semgrep_in_tmp: RunSemgrep, snapshot):
 
 
 @pytest.mark.kinda_slow
+@pytest.mark.osempass
 def test_regex_with_any_language_multiple_rule(
     run_semgrep_in_tmp: RunSemgrep, snapshot
 ):
@@ -490,6 +492,7 @@ def test_invalid_regex_with_any_language_rule(run_semgrep_in_tmp: RunSemgrep, sn
 
 
 @pytest.mark.kinda_slow
+@pytest.mark.osempass
 def test_regex_with_any_language_rule_none_alias(
     run_semgrep_in_tmp: RunSemgrep, snapshot
 ):
@@ -503,6 +506,7 @@ def test_regex_with_any_language_rule_none_alias(
 
 
 @pytest.mark.kinda_slow
+@pytest.mark.osempass
 def test_regex_with_any_language_multiple_rule_none_alias(
     run_semgrep_in_tmp: RunSemgrep, snapshot
 ):

--- a/src/targeting/Find_target.ml
+++ b/src/targeting/Find_target.ml
@@ -428,10 +428,16 @@ let get_targets conf scanning_roots =
 let create_cache () = Hashtbl.create 1000
 
 let match_glob_pattern ~pat path =
+  (* if pattern uses a * and no /, use filename  *)
   let regex = Glob.Parse.parse_string pat in
+  let path =
+    if String.contains pat '*' && not (String.contains pat '/') then
+      Fpath.filename path
+    else Fpath.to_string path
+  in
   Glob.Match.run
     Glob.Match.(compile ~source:(string_loc ~source_kind:None pat) regex)
-    (Fpath.to_string path)
+    path
 
 let match_a_path_pattern path_patterns path =
   match path_patterns with


### PR DESCRIPTION
Now, rule `paths` are matched the same as in pysemgrep.

There are various tests that pass now

test plan:
- make osempass

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
