### PR TITLE
tainting: Do not use `Metavariable.equal_mvalue` directly

### DIFF
--- a/changelog.d/gh-7694.fixed
+++ b/changelog.d/gh-7694.fixed
@@ -1,0 +1,2 @@
+taint-mode: Fixed bug in taint labels that was causing some fatal errors:
+> Failure "Call AST_utils.with_xxx_equal to avoid this error."

--- a/semgrep.yml
+++ b/semgrep.yml
@@ -365,3 +365,19 @@ rules:
     fix: Common.tl_exn "unexpected empty list"
     languages: [ocaml]
     severity: WARNING
+
+  - id: no-metavariable-equal-xyz
+    patterns:
+      - pattern: Metavariable.$F
+      - pattern-not: Metavariable.equal_mvar
+      - metavariable-regex:
+          metavariable: $F
+          regex: equal_.*
+    message: >-
+      Don't use 'Metavariable.$F' directly, see 'AST_utils'. Instead use
+      either 'Metavariable.Structural.$F' or 'Metavariable.Referential.$F'.
+      You can also consider replacing `equal_mvalue` with
+      'Matching_generic.equal_ast_bound_code'.
+    fix: Metavariable.Structural.$F
+    languages: [ocaml]
+    severity: WARNING

--- a/src/tainting/Dataflow_tainting.ml
+++ b/src/tainting/Dataflow_tainting.ml
@@ -367,7 +367,7 @@ let is_func_sink_with_focus taint_sink =
       true
   | __else__ -> false
 
-let unify_mvars_sets mvars1 mvars2 =
+let unify_mvars_sets env mvars1 mvars2 =
   let xs =
     List.fold_left
       (fun xs (mvar, mval) ->
@@ -375,7 +375,7 @@ let unify_mvars_sets mvars1 mvars2 =
         match List.assoc_opt mvar mvars2 with
         | None -> Some ((mvar, mval) :: xs)
         | Some mval' ->
-            if Metavariable.equal_mvalue mval mval' then
+            if Matching_generic.equal_ast_bound_code env.options mval mval' then
               Some ((mvar, mval) :: xs)
             else None)
       (Some []) mvars1
@@ -393,7 +393,10 @@ let sink_biased_union_mvars source_mvars sink_mvars =
   in
   Some (source_mvars' @ sink_mvars)
 
-let merge_source_mvars bindings =
+(* Takes the bindings of multiple taint sources and filters the bindings ($MVAR, MVAL)
+ * such that either $MVAR is bound by a single source, or all MVALs bounds to $MVAR
+ * can be unified. *)
+let merge_source_mvars env bindings =
   let flat_bindings = List.concat bindings in
   let bindings_tbl =
     flat_bindings
@@ -415,8 +418,10 @@ let merge_source_mvars bindings =
              *)
              Hashtbl.replace bindings_tbl mvar (Some mval)
          | Some (Some mval') ->
-             if not (Metavariable.equal_mvalue mval mval') then
-               Hashtbl.remove bindings_tbl mvar);
+             if
+               not
+                 (Matching_generic.equal_ast_bound_code env.options mval mval')
+             then Hashtbl.remove bindings_tbl mvar);
   (* After this, the only surviving bindings should be those where
      there was no conflict between bindings in different sources.
   *)
@@ -438,7 +443,7 @@ let merge_source_sink_mvars env source_mvars sink_mvars =
      * `pattern-sinks` as independent. We keep this option mainly for
      * backwards compatibility, it may be removed later on if no real use
      * is found. *)
-    unify_mvars_sets source_mvars sink_mvars
+    unify_mvars_sets env source_mvars sink_mvars
   else
     (* The union of both sets, but taking the sink mvars in case of collision. *)
     sink_biased_union_mvars source_mvars sink_mvars
@@ -560,7 +565,7 @@ let findings_of_tainted_sink env taints_with_traces (sink : T.sink) :
                     }))
       else
         match
-          taints_and_bindings |> Common.map snd |> merge_source_mvars
+          taints_and_bindings |> Common.map snd |> merge_source_mvars env
           |> merge_source_sink_mvars env sink_pm.PM.env
         with
         | None -> []

--- a/src/tainting/dune
+++ b/src/tainting/dune
@@ -5,6 +5,7 @@
  (libraries
    pfff-lang_GENERIC-analyze
    semgrep_core
+   semgrep.matching
  )
  (preprocess (pps ppx_deriving.show ppx_profiling))
 )

--- a/tests/rules/no_fatal_error_with_xxx_equal.js
+++ b/tests/rules/no_fatal_error_with_xxx_equal.js
@@ -1,0 +1,8 @@
+// https://github.com/returntocorp/semgrep/issues/7694
+// We don't want to get: "Fatal error": (Failure "Call AST_utils.with_xxx_equal to avoid this error.")
+$('.invalid', c).foobar(
+  function() {
+      //ruleid: test
+      $l = $t.baz('<foo for="' + id + '"></foo>');
+  }
+);

--- a/tests/rules/no_fatal_error_with_xxx_equal.yaml
+++ b/tests/rules/no_fatal_error_with_xxx_equal.yaml
@@ -1,0 +1,22 @@
+rules:
+  - id: test
+    message: Test
+    languages:
+      - javascript
+      - typescript
+    severity: WARNING
+    mode: taint
+    pattern-sources:
+      - label: TEST
+        by-side-effect: true
+        patterns:
+          - pattern-either:
+              - pattern: $A($SOURCE)
+              - pattern: $A.$SANITIZE($SOURCE)
+          - focus-metavariable: $SOURCE
+          - metavariable-regex:
+              metavariable: $A
+              regex: (?i)(.*valid)
+    pattern-sinks:
+      - requires: TEST
+        pattern: '"$HTMLSTR" + $EXPR'


### PR DESCRIPTION
If the `mvalue`s being compared happen to contain `stmt`s, then this will raise a fatal error:

    Failure "Call AST_utils.with_xxx_equal to avoid this error."

We already had a use of `Metavariable.equal_mvalue` previously but this did not cause much trouble because it was only used if option `taint_unify_mvars` was set. But then we started using `equal_mvalue` for essentially all taint-labels rules at the same time as SR was adding more taint-labels rules... making this fatal error more likely.

Replaced `equal_mvalue` with `Matching_generic.equal_ast_bound_code` given that it's actually what we use when unifying metavariables.

Also added a Semgrep rule to prevent this in the future.

Fixes: 8588460 ("feat(taint): multiple source traces (#7291)")

Closes #7694

test plan:
make test # test added

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
