### PR TITLE
fix: sym-prop: Make sure we perform cycle checks

### DIFF
--- a/changelog.d/pa-2740.fixed
+++ b/changelog.d/pa-2740.fixed
@@ -1,0 +1,1 @@
+Fixed bug introduced in 1.19.0 that was causing some stack overflows.

--- a/semgrep.yml
+++ b/semgrep.yml
@@ -381,3 +381,17 @@ rules:
     fix: Metavariable.Structural.$F
     languages: [ocaml]
     severity: WARNING
+
+  - id: no-direct-assign-to-id_svalue
+    patterns:
+      - pattern-not-inside: |
+          if no_cycles_in_svalue ... then
+            ...
+      # FIXME: This doesn't work: $X.id_svalue := Some $E
+      - pattern-regex: \s([a-z0-5_]+)\.id_svalue\s+:=\s+Some\s+([a-z0-5_]+)
+    message: >-
+      Dot not set '$1.id_svalue' directly, instead use
+      'Dataflow_svalue.set_svalue_ref' which performs a cycle check.
+    fix: Dataflow_svalue.set_svalue_ref $1 $2
+    languages: [ocaml]
+    severity: WARNING

--- a/src/analyzing/Constant_propagation.ml
+++ b/src/analyzing/Constant_propagation.ml
@@ -117,6 +117,34 @@ let rec lvars_in_lhs expr =
   | Container ((Tuple | Array), (_, es, _)) -> List.concat_map lvars_in_lhs es
   | __else__ -> []
 
+let no_cycles_in_sym_prop sid exp =
+  let for_all_sid : (G.sid -> bool) -> G.any -> bool =
+    (* Check that all sid's satisfy a given condition. We use refs so that
+     * we can have a single visitor for all calls, given that the old
+     * `mk_visitor` was kind of expensive, and constructing a visitor object
+     * may be as well. *)
+    let ff = ref (fun _ -> true) in
+    let ok = ref true in
+    let vout =
+      object
+        inherit [_] G.iter
+
+        method! visit_resolved_name _env (_, sid) =
+          ok := !ok && !ff sid;
+          if not !ok then raise Exit
+      end
+    in
+    fun f ast ->
+      ff := f;
+      ok := true;
+      try
+        vout#visit_any () ast;
+        !ok
+      with
+      | Exit -> false
+  in
+  for_all_sid (fun sid' -> sid' <> sid) (E exp)
+
 (*****************************************************************************)
 (* Environment Helpers *)
 (*****************************************************************************)
@@ -401,9 +429,23 @@ let var_stats prog : var_stats =
             super#visit_definition env x
         | _ -> super#visit_definition env x
 
-      (* TODO An `ExprStmt` method call (probably returning 'void') should count as
-       * a potential assignment too... We need a visit_stmt here. E.g. in Ruby
-       * `a.concat(b)` is going to update `a`. *)
+      (* TODO: An `ExprStmt` method call (probably returning 'void') should count as a
+       * potential assignment too... E.g. in Ruby `a.concat(b)` is going to update `a`. *)
+      method! visit_stmt env x =
+        (match x.s with
+        | For
+            ( _,
+              ForEach
+                ( PatId
+                    (id, { id_resolved = { contents = Some (_kind, sid) }; _ }),
+                  _,
+                  _ ),
+              _ ) ->
+            let var = (H.str_of_ident id, sid) in
+            let stat = get_stat_or_create var h in
+            incr stat.lvalue
+        | _ -> ());
+        super#visit_stmt env x
 
       method! visit_expr env x =
         match x.e with
@@ -626,7 +668,9 @@ let propagate_basic lang prog =
                 Although we may propagate expressions with identifiers in them, those identifiers
                 will simply not have an `svalue` if they are non-propagated as well.
              *)
-             | None, _ when Dataflow_svalue.is_symbolic_expr e ->
+             | None, _
+               when Dataflow_svalue.is_symbolic_expr e
+                    && no_cycles_in_sym_prop sid e ->
                  add_constant_env id (sid, Sym e) env
              | None, _ -> ());
             super#visit_definition venv x
@@ -708,8 +752,10 @@ let propagate_basic lang prog =
                match opt_svalue with
                | Some svalue -> add_constant_env id (sid, svalue) env
                | None ->
-                   if Dataflow_svalue.is_symbolic_expr rexp then
-                     add_constant_env id (sid, Sym rexp) env;
+                   if
+                     Dataflow_svalue.is_symbolic_expr rexp
+                     && no_cycles_in_sym_prop sid rexp
+                   then add_constant_env id (sid, Sym rexp) env;
                    ());
             self#visit_expr venv rexp
         | Assign (e1, _, e2)

--- a/src/analyzing/Constant_propagation.ml
+++ b/src/analyzing/Constant_propagation.ml
@@ -123,7 +123,7 @@ let no_cycles_in_sym_prop sid exp =
      * we can have a single visitor for all calls, given that the old
      * `mk_visitor` was kind of expensive, and constructing a visitor object
      * may be as well. *)
-    let ff = ref (fun _ -> true) in
+    let ff = ref (fun _ -> assert false) in
     let ok = ref true in
     let vout =
       object

--- a/src/analyzing/Constant_propagation.ml
+++ b/src/analyzing/Constant_propagation.ml
@@ -693,19 +693,19 @@ let propagate_basic lang prog =
               (_, [ Arg { e = N (Id (id, id_info)); _ } ], _) )
           when not !(env.in_lvalue) ->
             let/ svalue = find_id env id id_info in
-            id_info.id_svalue := Some svalue
+            Dataflow_svalue.set_svalue_ref id_info svalue
         (* ugly: dockerfile specific *)
         | Call
             ( { e = N (Id (("!dockerfile_expand!", _), _)); _ },
               (_, [ Arg { e = N (Id (id, id_info)); _ } ], _) )
           when not !(env.in_lvalue) ->
             let/ svalue = find_id env id id_info in
-            id_info.id_svalue := Some svalue
+            Dataflow_svalue.set_svalue_ref id_info svalue
         | DotAccess
             ({ e = IdSpecial ((This | Self), _); _ }, _, FN (Id (id, id_info)))
           when not !(env.in_lvalue) ->
             let/ svalue = find_id env id id_info in
-            id_info.id_svalue := Some svalue
+            Dataflow_svalue.set_svalue_ref id_info svalue
         (* ugly: terraform specific.
          * coupling: with eval() above
          *)
@@ -716,7 +716,7 @@ let propagate_basic lang prog =
           when lang = Lang.Terraform && not !(env.in_lvalue) ->
             let var = (prefix ^ "." ^ str, terraform_sid) in
             let/ svalue = Hashtbl.find_opt env.constants var in
-            id_info.id_svalue := Some svalue
+            Dataflow_svalue.set_svalue_ref id_info svalue
         | ArrayAccess (e1, (_, e2, _)) ->
             self#visit_expr venv e1;
             Common.save_excursion env.in_lvalue false (fun () ->

--- a/src/analyzing/Dataflow_svalue.ml
+++ b/src/analyzing/Dataflow_svalue.ml
@@ -174,11 +174,6 @@ let refine c1 c2 =
   | G.Sym _, G.Cst _ ->
       c2
 
-let refine_svalue_ref c_ref c' =
-  match !c_ref with
-  | None -> c_ref := Some c'
-  | Some c -> c_ref := Some (refine c c')
-
 (*****************************************************************************)
 (* Constness evaluation *)
 (*****************************************************************************)
@@ -400,6 +395,59 @@ let eval_or_sym_prop env exp =
   | G.NotCst -> sym_prop exp.eorig
   | c -> c
 
+let no_cycles_in_svalue (id_info : G.id_info) svalue =
+  let for_all_id_info : (G.id_info -> bool) -> G.any -> bool =
+    (* Check that all id_info's satisfy a given condition. We use refs so that
+     * we can have a single visitor for all calls, given that the old
+     * `mk_visitor` was pretty expensive, and constructing a visitor object may
+     * be as well. *)
+    let ff = ref (fun _ -> true) in
+    let ok = ref true in
+    let vout =
+      object
+        inherit [_] G.iter
+
+        method! visit_id_info _env ii =
+          ok := !ok && !ff ii;
+          if not !ok then raise Exit
+      end
+    in
+    fun f ast ->
+      ff := f;
+      ok := true;
+      try
+        vout#visit_any () ast;
+        !ok
+      with
+      | Exit -> false
+  in
+  (* Check that `c' contains no reference to `var'. It can contain references
+   * to other occurrences of `var', but not to the same occurrence (that would
+   * be a cycle), and each occurence must have its own `id_svalue` ref. This
+   * is not supposed to happen, but if it does happen by accident then it would
+   * cause an infinite loop, stack overflow, or segfault later on. *)
+  match svalue with
+  | G.Sym e ->
+      for_all_id_info
+        (fun ii ->
+          (* Note the use of physical equality, we are looking for the *same*
+           * id_svalue ref, that tells us it's the same variable occurrence. *)
+          not (phys_equal id_info.id_svalue ii.id_svalue))
+        (G.E e)
+  | G.NotCst
+  | G.Cst _
+  | G.Lit _ ->
+      true
+
+let set_svalue_ref id_info c' =
+  if no_cycles_in_svalue id_info c' then
+    match !(id_info.id_svalue) with
+    | None -> id_info.id_svalue := Some c'
+    | Some c -> id_info.id_svalue := Some (refine c c')
+  else
+    logger#error "Cycle check failed for %s := %s" (G.show_id_info id_info)
+      (G.show_svalue c')
+
 (*****************************************************************************)
 (* Transfer *)
 (*****************************************************************************)
@@ -569,50 +617,6 @@ let (fixpoint : Lang.t -> IL.name list -> F.cfg -> mapping) =
     ~forward:true ~flow
 
 let update_svalue (flow : F.cfg) mapping =
-  let for_all_id_info : (G.id_info -> bool) -> G.any -> bool =
-    (* Check that all id_info's satisfy a given condition. We use refs so that
-     * we can have a single visitor for all calls, given that the old
-     * `mk_visitor` was pretty expensive, and constructing a visitor object may
-     * be as well. *)
-    let ff = ref (fun _ -> true) in
-    let ok = ref true in
-    let vout =
-      object
-        inherit [_] G.iter
-
-        method! visit_id_info _env ii =
-          ok := !ok && !ff ii;
-          if not !ok then raise Exit
-      end
-    in
-    fun f ast ->
-      ff := f;
-      ok := true;
-      try
-        vout#visit_any () ast;
-        !ok
-      with
-      | Exit -> false
-  in
-  let no_cycles var c =
-    (* Check that `c' contains no reference to `var'. It can contain references
-     * to other occurrences of `var', but not to the same occurrence (that would
-     * be a cycle), and each occurence must have its own `id_svalue` ref. This
-     * is not supposed to happen, but if it does happen by accident then it would
-     * cause an infinite loop, stack overflow, or segfault later on. *)
-    match c with
-    | G.Sym e ->
-        for_all_id_info
-          (fun ii ->
-            (* Note the use of physical equality, we are looking for the *same*
-             * id_svalue ref, that tells us it's the same variable occurrence. *)
-            phys_not_equal var.id_info.id_svalue ii.id_svalue)
-          (G.E e)
-    | G.NotCst
-    | G.Cst _
-    | G.Lit _ ->
-        true
-  in
   flow.graph#nodes#keys
   |> List.iter (fun ni ->
          let ni_info = mapping.(ni) in
@@ -625,12 +629,7 @@ let update_svalue (flow : F.cfg) mapping =
               | { base = Var var; _ } -> (
                   match VarMap.find_opt (str_of_name var) ni_info.D.in_env with
                   | None -> ()
-                  | Some c ->
-                      if no_cycles var c then
-                        refine_svalue_ref var.id_info.id_svalue c
-                      else
-                        logger#error "Cycle check failed for %s -> %s"
-                          (str_of_name var) (G.show_svalue c))
+                  | Some c -> set_svalue_ref var.id_info c)
               | ___else___ -> ())
          (* Should not update the LHS svalue since in x = E, x is a "ref",
           * and it should not be substituted for the value it holds. *))

--- a/src/analyzing/Dataflow_svalue.ml
+++ b/src/analyzing/Dataflow_svalue.ml
@@ -401,7 +401,7 @@ let no_cycles_in_svalue (id_info : G.id_info) svalue =
      * we can have a single visitor for all calls, given that the old
      * `mk_visitor` was pretty expensive, and constructing a visitor object may
      * be as well. *)
-    let ff = ref (fun _ -> true) in
+    let ff = ref (fun _ -> assert false) in
     let ok = ref true in
     let vout =
       object

--- a/src/analyzing/Dataflow_svalue.mli
+++ b/src/analyzing/Dataflow_svalue.mli
@@ -19,6 +19,8 @@ val fixpoint : Lang.t -> IL.name list -> IL.cfg -> mapping
  * !Note that this assumes Naming_AST.resolve has been called before!
 *)
 
+val set_svalue_ref : AST_generic.id_info -> AST_generic.svalue -> unit
+
 val update_svalue : IL.cfg -> mapping -> unit
 (**
  * Updates the [IL.lval.svalue] refs according to the mapping.

--- a/src/runner/Run_semgrep.ml
+++ b/src/runner/Run_semgrep.ml
@@ -889,7 +889,7 @@ let semgrep_with_rules_and_formatted_output config =
         |> List.iter (fun explain -> Matching_explanation.print explain);
       (* the match has already been printed above. We just print errors here *)
       if not (null res.errors) then (
-        pr "WARNING: some files were skipped on only partially analyzed:";
+        pr "WARNING: some files were skipped or only partially analyzed:";
         res.errors |> List.iter (fun err -> pr (E.string_of_error err)))
 
 (*****************************************************************************)

--- a/tests/rules/sym_prop_no_cycle.py
+++ b/tests/rules/sym_prop_no_cycle.py
@@ -1,0 +1,3 @@
+for p in FOO:
+    #ruleid: test
+    p = p

--- a/tests/rules/sym_prop_no_cycle.yaml
+++ b/tests/rules/sym_prop_no_cycle.yaml
@@ -1,0 +1,11 @@
+rules:
+  - id: test
+    languages:
+      - python
+    options:
+      symbolic_propagation: true
+    pattern: |
+      p = ...
+      ... 
+    severity: ERROR
+    message: Test


### PR DESCRIPTION
Fixes stack overflows that started to happen in 1.19.0.

In eeaecf7a9b4 we extended flow-insensitive sym-prop to work for global variables that are assigned just once in the file, but we forgot about cycle checks... and we allowed assignments like `p = p` to be propagated introducing a cycle in the `id_svalue` relation.

Part of the problem is also that sometimes we wrongly infer that something is assigned just once, for example,  we were not considering that in `for p in FOO` the `p` is being assigned, so `p` is assigned more than once to start with. So now we forbid propagating any assignment where the defined variable occurs in the defining expression, because that is a hint that the variable may be assigned more than once.

Also added some safeguard to (hopefully) prevent this from happening again.

Fixes: eeaecf7a9b4 ("const-prop: Private static variables set once in a static block (#7527)")
Closes PA-2740

test plan:
make test # test added

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
