### PR TITLE
osemgrep: minimize diff of text output with pysemgrep

### DIFF
--- a/libs/commons/Fmt_helpers.ml
+++ b/libs/commons/Fmt_helpers.ml
@@ -60,6 +60,6 @@ let pp_table (h1, heading) ppf entries =
 let pp_heading ppf txt =
   let chars = String.length txt + 2 in
   let line = line chars in
-  Fmt.pf ppf "┌%s┐@." line;
+  Fmt.pf ppf "@.@.┌%s┐@." line;
   Fmt.pf ppf "│ %s │@." txt;
   Fmt.pf ppf "└%s┘@." line

--- a/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -331,10 +331,10 @@ let run (conf : Scan_CLI.conf) : Exit_code.t =
                 other_ignored,
                 errors_skipped ));
         Logs.app (fun m ->
-            m "Ran %d rules on %d files: %d findings@."
-              (List.length filtered_rules)
-              (List.length targets)
-              (List.length res.core.matches));
+            m "Ran %s on %s: %s@."
+              (String_utils.unit_str (List.length filtered_rules) "rule")
+              (String_utils.unit_str (List.length targets) "file")
+              (String_utils.unit_str (List.length res.core.matches) "finding"));
 
         (* TOPORT? was in formater/base.py
            def keep_ignores(self) -> bool:

--- a/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -322,6 +322,7 @@ let run (conf : Scan_CLI.conf) : Exit_code.t =
         Logs.app (fun m ->
             m "%a" Summary_report.pp_summary
               ( conf.targeting_conf.respect_git_ignore,
+                conf.legacy,
                 conf.targeting_conf.max_target_bytes,
                 semgrepignored,
                 included,

--- a/src/osemgrep/reporting/Status_report.ml
+++ b/src/osemgrep/reporting/Status_report.ml
@@ -2,7 +2,8 @@
 (* Prelude *)
 (*****************************************************************************)
 (*
-  Partially translated from semgrep_main.py (print_scan_status())
+  Partially translated from semgrep_main.py (print_scan_status()) and from
+  core_runner.py (print()).
 *)
 
 (*****************************************************************************)
@@ -12,10 +13,14 @@
 let pp_status ~num_rules ~num_targets ~respect_git_ignore lang_jobs ppf =
   Fmt_helpers.pp_heading ppf "Scan status";
   (* TODO indentation of the body *)
-  Fmt.pf ppf "Scanning %s%s with %s"
-    (String_utils.unit_str num_targets "file")
-    (if respect_git_ignore then " tracked by git" else "")
-    (String_utils.unit_str num_rules "Code rule");
+  if num_rules = 0 then Fmt.pf ppf "Nothing to scan."
+  else if num_rules = 1 then
+    Fmt.pf ppf "Scanning %s." (String_utils.unit_str num_targets "file")
+  else
+    Fmt.pf ppf "Scanning %s%s with %s"
+      (String_utils.unit_str num_targets "file")
+      (if respect_git_ignore then " tracked by git" else "")
+      (String_utils.unit_str num_rules "Code rule");
   (* TODO if sca_rules ...
      Fmt.(option ~none:(any "") (any ", " ++ int ++ any "Supply Chain rule" *)
   (* TODO pro_rule

--- a/src/osemgrep/reporting/Status_report.ml
+++ b/src/osemgrep/reporting/Status_report.ml
@@ -11,16 +11,12 @@
 (*****************************************************************************)
 
 let pp_status ~num_rules ~num_targets ~respect_git_ignore lang_jobs ppf =
-  Fmt_helpers.pp_heading ppf "Scan status";
+  Fmt_helpers.pp_heading ppf "Scan Status";
   (* TODO indentation of the body *)
-  if num_rules = 0 then Fmt.pf ppf "Nothing to scan."
-  else if num_rules = 1 then
-    Fmt.pf ppf "Scanning %s." (String_utils.unit_str num_targets "file")
-  else
-    Fmt.pf ppf "Scanning %s%s with %s"
-      (String_utils.unit_str num_targets "file")
-      (if respect_git_ignore then " tracked by git" else "")
-      (String_utils.unit_str num_rules "Code rule");
+  Fmt.pf ppf "Scanning %s%s with %s"
+    (String_utils.unit_str num_targets "file")
+    (if respect_git_ignore then " tracked by git" else "")
+    (String_utils.unit_str num_rules "Code rule");
   (* TODO if sca_rules ...
      Fmt.(option ~none:(any "") (any ", " ++ int ++ any "Supply Chain rule" *)
   (* TODO pro_rule
@@ -29,26 +25,30 @@ let pp_status ~num_rules ~num_targets ~respect_git_ignore lang_jobs ppf =
      if pro_rule_count:
          summary_line += f", {unit_str(pro_rule_count, 'Pro rule')}"
   *)
-  Fmt.pf ppf ":@.@.";
-  (* TODO origin table [Origin Rules] [Community N] *)
-  let lan_label = function
-    | Xlang.LGeneric
-    | Xlang.LRegex ->
-        "<multilang>"
-    | lang -> Xlang.to_string lang
-  in
-  Fmt_helpers.pp_table
-    ("Language", [ "Rules"; "Files" ])
-    ppf
-    (lang_jobs
-    |> Common.map (fun Lang_job.{ lang; targets; rules } ->
-           (lan_label lang, List.length rules, List.length targets))
-    |> List.fold_left
-         (fun acc (lang, rules, targets) ->
-           match List.partition (fun (l, _) -> l = lang) acc with
-           | [], others -> (lang, [ rules; targets ]) :: others
-           | [ (_, [ r1; t1 ]) ], others ->
-               (lang, [ rules + r1; targets + t1 ]) :: others
-           | _ -> assert false)
-         []
-    |> List.rev)
+  Fmt.pf ppf ":@.";
+  if num_rules = 0 then Fmt.pf ppf "Nothing to scan."
+  else if num_rules = 1 then
+    Fmt.pf ppf "Scanning %s." (String_utils.unit_str num_targets "file")
+  else
+    (* TODO origin table [Origin Rules] [Community N] *)
+    let lan_label = function
+      | Xlang.LGeneric
+      | Xlang.LRegex ->
+          "<multilang>"
+      | lang -> Xlang.to_string lang
+    in
+    Fmt_helpers.pp_table
+      ("Language", [ "Rules"; "Files" ])
+      ppf
+      (lang_jobs
+      |> Common.map (fun Lang_job.{ lang; targets; rules } ->
+             (lan_label lang, List.length rules, List.length targets))
+      |> List.fold_left
+           (fun acc (lang, rules, targets) ->
+             match List.partition (fun (l, _) -> l = lang) acc with
+             | [], others -> (lang, [ rules; targets ]) :: others
+             | [ (_, [ r1; t1 ]) ], others ->
+                 (lang, [ rules + r1; targets + t1 ]) :: others
+             | _ -> assert false)
+           []
+      |> List.rev)

--- a/src/osemgrep/reporting/Status_report.ml
+++ b/src/osemgrep/reporting/Status_report.ml
@@ -12,11 +12,10 @@
 let pp_status ~num_rules ~num_targets ~respect_git_ignore lang_jobs ppf =
   Fmt_helpers.pp_heading ppf "Scan status";
   (* TODO indentation of the body *)
-  let pp_s ppf x = if x = 1 then Fmt.string ppf "" else Fmt.string ppf "s" in
-
-  Fmt.pf ppf "Scanning %d files%s with %d Code rule%a" num_targets
+  Fmt.pf ppf "Scanning %s%s with %s"
+    (String_utils.unit_str num_targets "file")
     (if respect_git_ignore then " tracked by git" else "")
-    num_rules pp_s num_rules;
+    (String_utils.unit_str num_rules "Code rule");
   (* TODO if sca_rules ...
      Fmt.(option ~none:(any "") (any ", " ++ int ++ any "Supply Chain rule" *)
   (* TODO pro_rule

--- a/src/osemgrep/reporting/Summary_report.ml
+++ b/src/osemgrep/reporting/Summary_report.ml
@@ -34,7 +34,7 @@ let pp_summary ppf
       * Out.skipped_target list
       * Out.skipped_target list
       * Out.skipped_target list) =
-  Fmt_helpers.pp_heading ppf "Scan summary";
+  Fmt_helpers.pp_heading ppf "Scan Summary";
   (* TODO
         if self.target_manager.baseline_handler:
             limited_fragments.append(

--- a/src/osemgrep/reporting/Summary_report.ml
+++ b/src/osemgrep/reporting/Summary_report.ml
@@ -17,6 +17,7 @@ module Out = Semgrep_output_v1_t
 
 let pp_summary ppf
     (( _respect_git_ignore,
+       legacy,
        max_target_bytes,
        semgrep_ignored,
        include_ignored,
@@ -25,6 +26,7 @@ let pp_summary ppf
        other_ignored,
        errors ) :
       bool
+      * bool
       * int
       * Out.skipped_target list
       * Out.skipped_target list
@@ -69,7 +71,7 @@ let pp_summary ppf
         opt_msg "files matching --exclude patterns" exclude_ignored;
         opt_msg ("files larger than " ^ mb ^ " MB") file_size_ignored;
         opt_msg "files matching .semgrepignore patterns" semgrep_ignored;
-        opt_msg "other files ignored" other_ignored;
+        (if legacy then None else opt_msg "other files ignored" other_ignored);
       ]
   in
   let out_partial =

--- a/src/osemgrep/reporting/Summary_report.mli
+++ b/src/osemgrep/reporting/Summary_report.mli
@@ -1,6 +1,7 @@
 val pp_summary :
   Format.formatter ->
   bool
+  * bool
   * int
   * Semgrep_output_v1_t.skipped_target list
   * Semgrep_output_v1_t.skipped_target list


### PR DESCRIPTION
test plan:
- make osempass
since there are still some differences, the test_check.py::test_terminal_output does still not pass.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
