### PR TITLE
osemgrep: output white spaces, adjust white spacing in findings

### DIFF
--- a/libs/commons/Fmt_helpers.ml
+++ b/libs/commons/Fmt_helpers.ml
@@ -60,7 +60,9 @@ let pp_table (h1, heading) ppf entries =
 let pp_heading ppf txt =
   let chars = String.length txt + 2 in
   let line = line chars in
-  Fmt.pf ppf "%s@.%s@." (String.make (chars + 2) ' ') (String.make (chars + 2) ' ');
+  Fmt.pf ppf "%s@.%s@."
+    (String.make (chars + 2) ' ')
+    (String.make (chars + 2) ' ');
   Fmt.pf ppf "┌%s┐@." line;
   Fmt.pf ppf "│ %s │@." txt;
   Fmt.pf ppf "└%s┘@." line

--- a/libs/commons/Fmt_helpers.ml
+++ b/libs/commons/Fmt_helpers.ml
@@ -60,6 +60,7 @@ let pp_table (h1, heading) ppf entries =
 let pp_heading ppf txt =
   let chars = String.length txt + 2 in
   let line = line chars in
-  Fmt.pf ppf "@.@.┌%s┐@." line;
+  Fmt.pf ppf "%s@.%s@." (String.make (chars + 2) ' ') (String.make (chars + 2) ' ');
+  Fmt.pf ppf "┌%s┐@." line;
   Fmt.pf ppf "│ %s │@." txt;
   Fmt.pf ppf "└%s┘@." line

--- a/src/osemgrep/reporting/Matches_report.ml
+++ b/src/osemgrep/reporting/Matches_report.ml
@@ -12,8 +12,8 @@ module Out = Semgrep_output_v1_t
 (*****************************************************************************)
 
 let ellipsis_string = " ... "
-let base_indent = String.make 8 ' '
-let findings_indent_depth = String.make 10 ' '
+let base_indent = String.make 10 ' '
+let findings_indent_depth = String.make 12 ' '
 
 let text_width =
   let max_text_width = 120 in
@@ -171,7 +171,7 @@ let pp_finding ~max_chars_per_line ~max_lines_per_finding ~color_output
              else (line, 0, false)
            in
            let line_number_str = string_of_int line_number in
-           let pad = String.make (11 - String.length line_number_str) ' ' in
+           let pad = String.make (13 - String.length line_number_str) ' ' in
            let col c = max 0 (c - 1 - dedented - line_off) in
            let ellipsis_len p =
              if stripped' && p then String.length ellipsis_string else 0
@@ -225,7 +225,7 @@ let pp_text_outputs ~max_chars_per_line ~max_lines_per_finding ~color_output ppf
             if m.path = cur.path then (false, Some m.extra.message)
             else (true, None)
       in
-      if print then Fmt.pf ppf "  %a@." Fmt.(styled (`Fg `Cyan) string) cur.path;
+      if print then Fmt.pf ppf "  %a@." Fmt.(styled (`Fg `Cyan) (any "  " ++ string ++ any " ")) cur.path;
       msg
     in
     let print =
@@ -238,10 +238,10 @@ let pp_text_outputs ~max_chars_per_line ~max_lines_per_finding ~color_output ppf
     if print then (
       List.iter
         (fun l -> Fmt.pf ppf "%a@." Fmt.(styled `Bold string) l)
-        (wrap ~indent:5 ~width:text_width cur.check_id);
+        (wrap ~indent:7 ~width:text_width cur.check_id);
       List.iter
         (fun l -> Fmt.pf ppf "%s@." l)
-        (wrap ~indent:8 ~width:text_width cur.extra.message);
+        (wrap ~indent:10 ~width:text_width cur.extra.message);
       (match Yojson.Basic.Util.member "shortlink" cur.extra.metadata with
       | `String s -> Fmt.pf ppf "%sDetails: %s@." base_indent s
       | _else -> ());

--- a/src/osemgrep/reporting/Matches_report.ml
+++ b/src/osemgrep/reporting/Matches_report.ml
@@ -225,7 +225,10 @@ let pp_text_outputs ~max_chars_per_line ~max_lines_per_finding ~color_output ppf
             if m.path = cur.path then (false, Some m.extra.message)
             else (true, None)
       in
-      if print then Fmt.pf ppf "  %a@." Fmt.(styled (`Fg `Cyan) (any "  " ++ string ++ any " ")) cur.path;
+      if print then
+        Fmt.pf ppf "  %a@."
+          Fmt.(styled (`Fg `Cyan) (any "  " ++ string ++ any " "))
+          cur.path;
       msg
     in
     let print =


### PR DESCRIPTION
Slightly daunting, but let's keep the pysemgrep semantics for now:
- a path is output with "  " then "  " (in cyan then <path>, then " " in cyan
- findings used 2 spaces less than pysemgrep
- before a heading, two empty lines with <box-chars> of whitespaces are emitted

test plan:
- make osempass

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
