### PR TITLE
Parse globs in paths: include: and exclude: fields

### DIFF
--- a/cli/tests/e2e/test_check.py
+++ b/cli/tests/e2e/test_check.py
@@ -505,6 +505,7 @@ def test_regex_with_any_language_rule_none_alias(
     )
 
 
+@pytest.mark.osempass
 @pytest.mark.kinda_slow
 def test_regex_with_any_language_multiple_rule_none_alias(
     run_semgrep_in_tmp: RunSemgrep, snapshot

--- a/src/core/Rule.ml
+++ b/src/core/Rule.ml
@@ -274,9 +274,13 @@ type 'mode rule_info = {
 }
 
 and paths = {
-  (* not regexp but globs *)
-  include_ : string list;
-  exclude : string list;
+  (* If not empty, list of file path patterns (globs) that
+   * the file path must at least match once to be considered for the rule.
+   * Called 'include' in our doc but really it is a 'require'.
+   *)
+  require : Glob.Pattern.t list;
+  (* List of file path patterns we want to exclude. *)
+  exclude : Glob.Pattern.t list;
 }
 
 (* TODO? just reuse Error_code.severity *)

--- a/src/core/dune
+++ b/src/core/dune
@@ -11,6 +11,7 @@
    atdgen-runtime
 
    commons
+   glob
    lib_parsing ; Parse_info.ml
    ast_generic
    parser_javascript.ast ; TODO remove this, ugly dependency to Ast_js.default_entity in Pattern.ml

--- a/src/targeting/Filter_target.mli
+++ b/src/targeting/Filter_target.mli
@@ -1,1 +1,2 @@
+(* Select the file if it belongs to the language using Guess_lang.ml *)
 val filter_target_for_xlang : Xlang.t -> Fpath.t -> bool

--- a/src/targeting/Find_targets.mli
+++ b/src/targeting/Find_targets.mli
@@ -1,13 +1,6 @@
 (*
-   Find target files suitable to be analyzed by semgrep.
-
-   A file tree is a mix of files in different languages. Different rules
-   will target different files. We provide two main operations:
-
-   1. Select global targets: obtain all the files that Semgrep accepts to
-      scan regardless of rules or languages.
-   2. Filter suitable targets for a language or for a rule
-      (multiple languages).
+   Find target files suitable to be analyzed by semgrep,
+   regardless of rules or languages.
  *)
 
 type conf = {
@@ -46,8 +39,6 @@ type conf = {
    The order of the files isn't guaranteed to be anything special
    at the moment but we could obey some ordering if it makes sense to do it
    here.
-
-   Usage: let possible_targets = get_files scanning_roots
 
    This may raise Unix.Unix_error if the scanning root does not exist.
 *)

--- a/src/targeting/Skip_target.ml
+++ b/src/targeting/Skip_target.ml
@@ -1,9 +1,6 @@
 (*
-   Filter targets.
+   Skip targets.
 
-   TODO: note that some of the functions below are also present in
-   semgrep-python so we might want to move all file-filtering in one
-   place.
 *)
 open Common
 open File.Operators


### PR DESCRIPTION
First step is to parse them. Second step (next PR) is
to use the information to filter target files
in Run_semgrep.ml, for osemgrep

test plan:
```
$ make core
$ osemgrep --dump-config tests/rules/compare-exposed-port.yaml
...
     "Detected an invalid port number. Valid ports are 0 through 65535.";
     severity = Rule.Error; languages = (Xlang.L (Dockerfile, []));
     options = None; equivalences = None; fix = None; fix_regexp = None;
     paths =
     (Some { Rule.require =
             [[(Pattern.Segment
                  [Pattern.Star; (Pattern.Char 'd'); (Pattern.Char 'o');
                    (Pattern.Char 'c'); (Pattern.Char 'k');
                    (Pattern.Char 'e'); (Pattern.Char 'r');
                    (Pattern.Char 'f'); (Pattern.Char 'i');
                    (Pattern.Char 'l'); (Pattern.Char 'e'); Pattern.Star])
                ];
               [(Pattern.Segment
                   [Pattern.Star; (Pattern.Char 'D'); (Pattern.Char 'o');
                     (Pattern.Char 'c'); (Pattern.Char 'k');
                     (Pattern.Char 'e'); (Pattern.Char 'r');
                     (Pattern.Char 'f'); (Pattern.Char 'i');
                     (Pattern.Char 'l'); (Pattern.Char 'e'); Pattern.Star])
                 ]
               ];
             exclude = [] });
     metadata =
     (Some (JSON.Object
              [("source-rule-url",
                (JSON.String
                   "https://github.com/hadolint/hadolint/wiki/DL3011"));
                ("references",
                 (JSON.Array
                    [(JSON.String
                        "https://github.com/hadolint/hadolint/wiki/DL3011")
                      ]));
                ("category", (JSON.String "correctness"));
                ("technology", (JSON.Array [(JSON.String "dockerfile")]))]))
     }
    ];
  errors = [] }
```


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)