### PR TITLE
osemgrep: handle the paths: include: and exclude:

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,6 @@
 .git/
 # dune
-**/_build
+**/_build/
 # starting from dune 2.8.2, those are actually not generated anymore
 **/.merlin
 
@@ -11,7 +11,7 @@
 !semgrep.opam
 
 # bisect_ppx
-**/_coverage
+**/_coverage/
 **/*.coverage
 
 # pad's stuff (but better to put in ~pad/config/commons/gitignore)

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # dune
-_build
+_build/
 # starting from dune 2.8.2, those are actually not generated anymore
 .merlin
 
@@ -10,7 +10,7 @@ _build
 !/semgrep.opam
 
 # bisect_ppx
-_coverage
+_coverage/
 *.coverage
 
 # pad's stuff (but better to put in ~pad/config/commons/gitignore)

--- a/semgrep.jsonnet
+++ b/semgrep.jsonnet
@@ -8,7 +8,7 @@ local ocaml = import "p/ocaml";
 
 # this is useful to factorize exclude
 local test_code_globs = ["Unit_*.ml", "Test_*.ml"];
-local less_important_code_globs = ["spacegrep/*", "experiments/*", "scripts/*"];
+local less_important_code_globs = ["spacegrep/", "experiments/", "scripts/"];
 
 local semgrep_rules = [
 #TODO: does not parse anymore!!
@@ -72,12 +72,12 @@ local semgrep_rules = [
         "Parse_rule.ml",
         "yaml_to_generic.ml",
 	#skipping more stuff
-        "parsing/tree_sitter/*",
-        "metachecking/*",
+        "parsing/tree_sitter/",
+        "metachecking/",
 	# outside src/, not really semgrep code
-	"libs/*",
-	"languages/*",
-	"tools/*",
+	"libs/",
+	"languages/",
+	"tools/",
         ] + test_code_globs + less_important_code_globs,
     }
   }

--- a/src/core/Rule.ml
+++ b/src/core/Rule.ml
@@ -277,11 +277,18 @@ and paths = {
   (* If not empty, list of file path patterns (globs) that
    * the file path must at least match once to be considered for the rule.
    * Called 'include' in our doc but really it is a 'require'.
+   * TODO? use wrap? to also get location of include/require field?
    *)
-  require : Glob.Pattern.t list;
+  require : glob list;
   (* List of file path patterns we want to exclude. *)
-  exclude : Glob.Pattern.t list;
+  exclude : glob list;
 }
+
+(* TODO? store also the compiled glob directly? but we preprocess the pattern
+ * in Filter_target.filter_paths, so we would need to recompile it anyway,
+ * or call Filter_target.filter_paths preprocessing in Parse_rule.ml
+ *)
+and glob = string (* original string *) * Glob.Pattern.t (* parsed glob *)
 
 (* TODO? just reuse Error_code.severity *)
 and severity = Error | Warning | Info | Inventory | Experiment

--- a/src/osemgrep/cli_scan/Core_runner.ml
+++ b/src/osemgrep/cli_scan/Core_runner.ml
@@ -131,21 +131,15 @@ let runner_config_of_conf (conf : conf) : Runner_config.t =
   }
   (* TODO: time_flag = _;
   *) ->
-      (* We should default to Json because we do not want the same text
-       * displayed in osemgrep than in semgrep-core.
-       * We also don't want the current incremental matches output.
-       * LATER: probably provide a mechanism to display match as
-       * we process files, but probably need different text output
-       * of what semgrep-core match_hook currently provides.
+      (* We default to Json because we do not want the current text
+       * displayed in semgrep-core, and we don't want either the
+       * current semgrep-core incremental matches text output.
        *)
       let output_format = Runner_config.Json false (* no dots *) in
       let filter_irrelevant_rules = optimizations in
       let parsing_cache_dir =
         if ast_caching then
-          let dir = Env.env.user_dot_semgrep_dir / "cache" / "asts" in
-          match Bos.OS.Dir.create ~path:true dir with
-          | Ok _ -> Some dir
-          | Error (`Msg err) -> failwith err
+          Some (Env.env.user_dot_semgrep_dir / "cache" / "asts")
         else None
       in
       {
@@ -160,25 +154,18 @@ let runner_config_of_conf (conf : conf) : Runner_config.t =
         version = Version.version;
       }
 
-(* Same as semgrep_with_raw_results_and_exn_handler but takes rules
+(* Similar to semgrep_with_raw_results_and_exn_handler but takes rules
    and targets already filtered for a specific language.
    All other options are read from the runner_config object.
    TODO: we should not need this function because
    semgrep_with_raw_results_and_exn_handler can take a list of targets
    in different language (via config.targets set via --targets)
-*)
-(*
-val semgrep_with_prepared_rules_and_targets :
-  Runner_config.t ->
-  Lang_job.t ->
-  Exception.t option * Report.final_result * Common.filename list
-*)
-(* This is ugly, with potentially some filtering operations being done twice.
-   It should get simplified when we get rid of the Python wrapper.
-   For now, we avoid code duplication.
+   This is ugly, with potentially some filtering operations being done twice.
+   It should get simplified when we get rid of the pysemgrep completely.
 *)
 let semgrep_with_prepared_rules_and_targets (config : Runner_config.t)
-    (x : Lang_job.t) =
+    (x : Lang_job.t) :
+    Exception.t option * Report.final_result * Common.filename list =
   let lang_str = Xlang.to_string x.xlang in
   (* compute the rule idx and rule_nums for target_mappings
    * (see Input_to_core.atd)
@@ -223,7 +210,7 @@ let invoke_semgrep_core ?(respect_git_ignore = true)
   let config = { config with file_match_results_hook } in
 
   match rule_errors with
-  (* with semgrep-python, semgrep-core is passed all the rules unparsed,
+  (* with pysemgrep, semgrep-core is passed all the rules unparsed,
    * and as soon as semgrep-core detects an error in a rule, it raises
    * InvalidRule which is caught and translated to JSON before exiting.
    * Here we emulate the same behavior, even though the rules

--- a/src/parsing/Parse_rule.ml
+++ b/src/parsing/Parse_rule.ml
@@ -470,7 +470,7 @@ let parse_paths env key value =
   let parse_glob_list env (key : key) e =
     let extract_string env = function
       | { G.e = G.L (String (_, (value, _), _)); _ } -> (
-          try Glob.Parse.parse_string value with
+          try (value, Glob.Parse.parse_string value) with
           | Glob.Lexer.Syntax_error _ ->
               error_at_key env key ("Invalid glob for " ^ fst key))
       | _ ->

--- a/src/runner/Run_semgrep.ml
+++ b/src/runner/Run_semgrep.ml
@@ -739,6 +739,15 @@ let semgrep_with_rules config ((rules, invalid_rules), rules_parse_time) =
                     | `Search _
                     | `Taint _ ->
                         true)
+             |> List.filter (fun r ->
+                    (* TODO: some of this is already done in pysemgrep, so maybe
+                     * we should guard with a flag that only osemgrep set
+                     * like Runner_config.paths_processing: bool?
+                     *)
+                    match r.R.paths with
+                    | None -> true
+                    | Some paths ->
+                        Filter_target.filter_paths paths (Fpath.v file))
            in
 
            let xtarget = xtarget_of_file config xlang file in

--- a/src/targeting/Filter_target.ml
+++ b/src/targeting/Filter_target.ml
@@ -3,14 +3,12 @@
 (*************************************************************************)
 (* Filter target candidates.
 
-   TODO: Handles the paths: include/exclude
-
    Filtering each (rule, target) pair can become problematic since the number
    of such pairs is O(number of targets * number of rules).
    TODO? This is why we should cache the results of this step.
    This allows reducing the number of rules to the number of different
    languages and patterns used by the rules.
-   update: there used to be such an opti, but I removed it, because
+   update: there used to be such an opti, but Pad removed it, because
    it was not clear that was the actual bottleneck. Gitignore
    seems currently to be the thing to optimize.
 
@@ -18,18 +16,14 @@
 *)
 
 (*************************************************************************)
-(* Types *)
-(*************************************************************************)
-
-(*************************************************************************)
 (* Helpers *)
 (*************************************************************************)
 
 (*************************************************************************)
-(* Entry point *)
+(* Entry points *)
 (*************************************************************************)
 
-(* Used by Core_runner.split_jobs_by_language *)
+(* Used by Core_runner.split_jobs_by_language() *)
 let filter_target_for_xlang (xlang : Xlang.t) (path : Fpath.t) : bool =
   match xlang with
   | L (lang, langs) ->
@@ -39,3 +33,60 @@ let filter_target_for_xlang (xlang : Xlang.t) (path : Fpath.t) : bool =
   | LRegex
   | LGeneric ->
       true
+
+(* Used by Run_semgrep.semgrep_with_rules().
+ * See also https://semgrep.dev/docs/writing-rules/rule-syntax/#paths
+ * TODO: according to the doc,
+ * "Paths [in include: and exclude: patterns] are relative to the root
+ * directory of the scanned project" but it seems pysemgrep does not honor
+ * this thing because adding an exclude such as "metachecking/*" will
+ * filter code even in subdirs calls metachecking. The glob is not anchored,
+ * even when it contains a '/'.
+ * LESS: there used to be a time where semgrep-core was handling the
+ * include/exclude too. Can we find back this code?
+ *)
+let filter_paths (paths : Rule.paths) (path : Fpath.t) : bool =
+  let match_glob (pat : Rule.glob) (path : Fpath.t) : bool =
+    (* ugly: pysemgrep adds a leading **/ and a suffix /** to each pattern.
+     * See target_manager.py preprocess_path_patterns()
+     * python:
+     *    Convert semgrep's path include/exclude patterns to wcmatch's glob
+     *    patterns. In semgrep, pattern "foo/bar" should match paths
+     *    "x/foo/bar", "foo/bar/x", and "x/foo/bar/x". It implicitly matches
+     *    zero or more directories at the beginning and the end
+     *    of the pattern. In contrast, we have to explicitly specify the
+     *    globstar (**) patterns in wcmatch. This function will converts
+     *    a pattern "foo/bar" into "**/foo/bar" and "**/foo/bar/**". We need
+     *    the pattern without the trailing "/**" because "foo/bar.py/**"
+     *    won't match "foo/bar.py".
+     * LATER? compute the ppath instead? and use a Gitignore like semantic?
+     *)
+    let pat1 = Glob.Pattern.(append [ Any_subpath ] (snd pat)) in
+    let pat2 =
+      Glob.Pattern.(append [ Any_subpath ] (append (snd pat) [ Any_subpath ]))
+    in
+
+    let cpat1 =
+      Glob.Match.(compile ~source:(string_loc ~source_kind:None (fst pat)) pat1)
+    in
+    let cpat2 =
+      Glob.Match.(compile ~source:(string_loc ~source_kind:None (fst pat)) pat2)
+    in
+    Glob.Match.run cpat1 (Fpath.to_string path)
+    || Glob.Match.run cpat2 (Fpath.to_string path)
+  in
+
+  let { Rule.require; exclude } = paths in
+  let is_excluded = exclude |> List.exists (fun pat -> match_glob pat path) in
+  (* from the doc: "when mixing inclusion and exclusion filters,
+   * the exclusion ones take precedence."
+   *)
+  if is_excluded then false
+  else
+    let is_required =
+      match require with
+      (* no require patterns means no constraints *)
+      | [] -> true
+      | _xs -> require |> List.exists (fun pat -> match_glob pat path)
+    in
+    is_required

--- a/src/targeting/Filter_target.mli
+++ b/src/targeting/Filter_target.mli
@@ -1,2 +1,6 @@
 (* Select the file if it belongs to the language using Guess_lang.ml *)
 val filter_target_for_xlang : Xlang.t -> Fpath.t -> bool
+
+(* Select the file if it satisfies the include: exclude: constraints
+ * in a rule paths: field *)
+val filter_paths : Rule.paths -> Fpath.t -> bool


### PR DESCRIPTION
Do it in semgrep-core, simpler.

test plan:
osemgrep --config semgrep.jsonnet returns now only 3 findings
(all due to FPs in nosemgrep handling), and terminates quickly!

Dogfooding progress!


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)