### PR TITLE
refactor: Remove custom visit_expr method

### DIFF
--- a/libs/ast_generic/AST_generic.ml
+++ b/libs/ast_generic/AST_generic.ml
@@ -2420,11 +2420,6 @@ class virtual ['self] map_legacy =
     inherit [_] map
     method! visit_tok _env v = v
 
-    method! visit_expr env x =
-      let ekind = self#visit_expr_kind env x.e in
-      (* TODO? reuse the e_id or create a new one? *)
-      e ekind
-
     (* For convenience, so clients don't need to override visit_arguments and
      * deal with the bracket type. *)
     method visit_argument_list env v = self#visit_list self#visit_argument env v


### PR DESCRIPTION
I migrated this behavior from `Map_AST.ml`. However, I've realized that we always just set `e_id` to `0` and then ignore it. So we don't actually need to be careful here.

I'm considering starting to use `e_id`, and I'd rather not have to keep this custom behavior in mind.

Test plan: Automated tests

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
