### PR TITLE
chore: create Homebrew PRs in standard format

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -268,7 +268,9 @@ jobs:
     steps:
       - name: Get the version
         id: get-version
-        run: echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
+        run: |
+          echo "TAG=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
+          echo "VERSION=${TAG#v}" >> $GITHUB_OUTPUT
       - uses: actions/setup-python@v4
         id: python-setup
         with:
@@ -290,7 +292,7 @@ jobs:
         if: ${{ contains(github.ref, '-test-release') || needs.dry-run.outputs.dry-run == 'true' }}
         run: |
           brew bump-formula-pr --force --no-audit --no-browse --write-only \
-            --message="Bump semgrep to version v99.99.99" \
+            --message="semgrep 99.99.99" \
             --tag="v99.99.99" --revision="${GITHUB_SHA}" semgrep --python-exclude-packages semgrep
       - name: Open Brew PR
         if: ${{ !contains(github.ref, '-test-release') && needs.dry-run.outputs.dry-run != 'true' }}
@@ -298,8 +300,8 @@ jobs:
           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.SEMGREP_HOMEBREW_RELEASE_PAT }}
         run: |
           brew bump-formula-pr --force --no-audit --no-browse --write-only \
-            --message="Bump semgrep to version ${{ steps.get-version.outputs.VERSION }}" \
-            --tag="${{ steps.get-version.outputs.VERSION }}" semgrep
+            --message="semgrep ${{ steps.get-version.outputs.VERSION }}" \
+            --tag="${{ steps.get-version.outputs.TAG }}" semgrep
       - name: Prepare Branch
         env:
           GITHUB_TOKEN: ${{ secrets.SEMGREP_HOMEBREW_RELEASE_PAT }}
@@ -314,7 +316,7 @@ jobs:
           git remote add r2c "${R2C_HOMEBREW_CORE_FORK_HTTPS_URL}"
           git checkout -b bump-semgrep-${{ steps.get-version.outputs.VERSION }}
           git add Formula/semgrep.rb
-          git commit -m "Bump semgrep to version ${{ steps.get-version.outputs.VERSION }}"
+          git commit -m "semgrep ${{ steps.get-version.outputs.VERSION }}"
       - name: Push Branch to Fork
         env:
           GITHUB_TOKEN: ${{ secrets.SEMGREP_HOMEBREW_RELEASE_PAT }}


### PR DESCRIPTION
PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)

---

This patch modifies semgrep's release workflow to create Homebrew PRs in the standard format (https://docs.brew.sh/Formula-Cookbook#commit).

Commits not in this standard format are rejected. For example, https://github.com/Homebrew/homebrew-core/pull/131054 is replaced by https://github.com/Homebrew/homebrew-core/pull/131058.
