### PR TITLE
osemgrep: Output.output_result (which runs nosemgrep) returns now Out.cli_output

### DIFF
--- a/src/osemgrep/cli_scan/Output.ml
+++ b/src/osemgrep/cli_scan/Output.ml
@@ -156,7 +156,7 @@ let dispatch_output_format (output_format : Output_format.t)
  * TODO: take a more precise conf than Scan_CLI.conf at some point
  *)
 let output_result (conf : Scan_CLI.conf) (res : Core_runner.result) :
-    Out.cli_error list =
+    Out.cli_output =
   (* In theory, we should build the JSON CLI output only for the
    * Json conf.output_format, but cli_output contains lots of data-structures
    * that are useful for the other formats (e.g., Vim, Emacs), so we build
@@ -178,5 +178,5 @@ let output_result (conf : Scan_CLI.conf) (res : Core_runner.result) :
   (* ugly: but see the comment above why we do it here *)
   if conf.autofix then apply_fixes_and_warn conf cli_output;
   dispatch_output_format conf.output_format conf cli_output;
-  cli_output.errors
+  cli_output
   [@@profiling]

--- a/src/osemgrep/cli_scan/Output.mli
+++ b/src/osemgrep/cli_scan/Output.mli
@@ -11,4 +11,4 @@ module Out = Semgrep_output_v1_j
  *
  * ugly: this also apply autofixes depending on the configuration.
  *)
-val output_result : Scan_CLI.conf -> Core_runner.result -> Out.cli_error list
+val output_result : Scan_CLI.conf -> Core_runner.result -> Out.cli_output

--- a/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -306,7 +306,7 @@ let run (conf : Scan_CLI.conf) : Exit_code.t =
         in
 
         (* outputting the result! in JSON/Text/... depending on conf *)
-        let cli_errors = Output.output_result { conf with output_format } res in
+        let cli_output = Output.output_result { conf with output_format } res in
 
         Logs.info (fun m ->
             m "%a" Skipped_report.pp_skipped
@@ -334,7 +334,7 @@ let run (conf : Scan_CLI.conf) : Exit_code.t =
             m "Ran %s on %s: %s@."
               (String_utils.unit_str (List.length filtered_rules) "rule")
               (String_utils.unit_str (List.length targets) "file")
-              (String_utils.unit_str (List.length res.core.matches) "finding"));
+              (String_utils.unit_str (List.length cli_output.results) "finding"));
 
         (* TOPORT? was in formater/base.py
            def keep_ignores(self) -> bool:
@@ -347,7 +347,7 @@ let run (conf : Scan_CLI.conf) : Exit_code.t =
         *)
 
         (* step5: exit with the right exit code *)
-        match cli_errors with
+        match cli_output.Out.errors with
         | [] ->
             (* final result for the shell *)
             exit_code_of_errors ~strict:conf.strict res.core.errors


### PR DESCRIPTION
use the findings from output_result for the summary line

test plan: make core ; osemgrep --config semgrep.jsonnet . --> now returns:

```
┌─────────────────┐
│ 3 Code Findings │
└─────────────────┘

..and..

Ran 56 rules on 2085 files: 3 findings
```


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
