### PR TITLE
Trim ids collected and remove remaining bytes at the end of them

### DIFF
--- a/src/reporting/Nosemgrep.ml
+++ b/src/reporting/Nosemgrep.ml
@@ -124,6 +124,9 @@ let rule_match_nosem ~strict (rule_match : Out.cli_match) :
           (Option.value ~default:[||] ids_previous_line)
       in
       let ids = Common.map_filter Fun.id (Array.to_list ids) in
+      let ids = Common.map (String.split_on_char ' ') ids in
+      let ids = Common.map List.hd (* nosemgrep: list-hd *) ids in
+      (* [String.split_on_char] can **not** return an empty list. *)
       (* check if the id specified by the user is the [rule_match]'s [rule_id]. *)
       List.fold_left
         (fun (result, errors) id ->


### PR DESCRIPTION
PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)

This PR trims `ids` collected by `Nosem.ml` and remove remaining bytes that are not a part of the `id`.