### PR TITLE
fix(test): update snapshot test which should work now

### DIFF
--- a/cli/tests/e2e/snapshots/test_metrics/test_metrics_payload/pro_flag0/metrics-payload.json
+++ b/cli/tests/e2e/snapshots/test_metrics/test_metrics_payload/pro_flag0/metrics-payload.json
@@ -5,15 +5,66 @@
     "configNamesHash": "d3e03c9938537c0a0668cec7204f37f1e9da87d03e18e8cc444dd7454b36c4d5",
     "isAuthenticated": false,
     "projectHash": null,
+    "rulesHash": "e9641bba77ccfc7908dd80437de848365e2508233b7b42ca197d17fcc0eb0402",
     "version": "x.x.x"
   },
   "errors": {
-    "returnCode": 2
+    "errors": [],
+    "returnCode": 0
   },
   "event_id": "00000000-0000-0000-0000-000000000000",
   "extension": {},
-  "parse_rate": {},
-  "performance": {},
+  "parse_rate": {
+    "python": {
+      "bytes_parsed": 6,
+      "num_bytes": 6,
+      "num_targets": 1,
+      "targets_parsed": 1
+    }
+  },
+  "performance": {
+    "fileStats": [
+      {
+        "matchTime": 0.0,
+        "numTimesScanned": 0,
+        "parseTime": 0.0,
+        "runTime": 0.0,
+        "size": 6
+      }
+    ],
+    "maxMemoryBytes": null,
+    "numRules": 4,
+    "numTargets": 1,
+    "profilingTimes": {
+      "config_time": 0.0,
+      "core_time": 0.0,
+      "ignores_time": 0.0,
+      "total_time": 0.0
+    },
+    "ruleStats": [
+      {
+        "bytesScanned": 0,
+        "matchTime": 0.0,
+        "ruleHash": "0c9be123b69d289f1b0fa65faefade9c76479bae63006869f3ecacd8ffe8b0a8"
+      },
+      {
+        "bytesScanned": 0,
+        "matchTime": 0.0,
+        "ruleHash": "c3f79a06bc39dcd0d7ed1e1b676934d1d9fa628d5631ecd666fc204e3d811089"
+      },
+      {
+        "bytesScanned": 0,
+        "matchTime": 0.0,
+        "ruleHash": "f19cada0143903df62f6b421917d325fbbcc5ff6a7c423818030cdf64c828731"
+      },
+      {
+        "bytesScanned": 0,
+        "matchTime": 0.0,
+        "ruleHash": "f4692285ae22ee62c58c95675c490c445348fdf6d8bce37b696c75f868c8ae40"
+      }
+    ],
+    "totalBytesScanned": 6
+  },
   "sent_at": "2017-03-03T00:00:00+09:00",
   "started_at": "2017-03-03T00:00:00+09:00",
   "value": {
@@ -26,6 +77,14 @@
       "config/local",
       "language/python",
       "subcommand/scan"
-    ]
+    ],
+    "numFindings": 1,
+    "numIgnored": 0,
+    "ruleHashesWithFindings": {
+      "0c9be123b69d289f1b0fa65faefade9c76479bae63006869f3ecacd8ffe8b0a8": 0,
+      "c3f79a06bc39dcd0d7ed1e1b676934d1d9fa628d5631ecd666fc204e3d811089": 0,
+      "f19cada0143903df62f6b421917d325fbbcc5ff6a7c423818030cdf64c828731": 0,
+      "f4692285ae22ee62c58c95675c490c445348fdf6d8bce37b696c75f868c8ae40": 1
+    }
   }
 }


### PR DESCRIPTION
## What:
This PR updates a snapshot test which is now working, which is supposed to work after #7606.

## Why:
#7606 made it such that `--pro` can now take in a single file. We had a metrics payload test which used `--pro`, with a single file, that used to crash. After that PR, however, it no longer crashes, so we should update the test.

It's not clear to me why it seems it's only failing locally. CI passed on the relevant PR, and on PRs past it, so for some reason CI wasn't complaining earlier. Let's see if it does now.

## How:
I just updated the snapshot. We see that the file is correctly parsed, and a result returned now.

## Test plan:
I ascertained that this was the case by bisecting, and seeing how far back I had to go until the snapshot stopped changing. I then got that it was introduced by #7606.

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
