### PR TITLE
osemgrep: restart from scratch Find_targets.get_targets (part 1)

### DIFF
--- a/cli/tests/e2e/test_check.py
+++ b/cli/tests/e2e/test_check.py
@@ -340,6 +340,7 @@ def test_regex_rule__utf8(run_semgrep_in_tmp: RunSemgrep, snapshot):
 
 
 @pytest.mark.kinda_slow
+@pytest.mark.osempass
 def test_regex_rule__utf8_on_image(run_semgrep_in_tmp: RunSemgrep, snapshot):
     # https://github.com/returntocorp/semgrep/issues/4258
     snapshot.assert_match(

--- a/cli/tests/e2e/test_ignores.py
+++ b/cli/tests/e2e/test_ignores.py
@@ -8,7 +8,6 @@ from ..conftest import TESTS_PATH
 
 
 @pytest.mark.kinda_slow
-@pytest.mark.osempass
 def test_semgrepignore(run_semgrep_in_tmp: RunSemgrep, tmp_path, snapshot):
     (tmp_path / ".semgrepignore").symlink_to(
         Path(TESTS_PATH / "e2e" / "targets" / "ignores" / ".semgrepignore").resolve()

--- a/cli/tests/e2e/test_match_based_id.py
+++ b/cli/tests/e2e/test_match_based_id.py
@@ -19,17 +19,14 @@ def test_duplicate_matches_indexing(run_semgrep_in_tmp: RunSemgrep, snapshot):
     snapshot.assert_match(results, "results.json")
 
 
+@pytest.mark.osempass
 @pytest.mark.kinda_slow
 @pytest.mark.parametrize(
     "rule,target_name,expect_change",
     [
-        # ("rules/match_based_id/","",True)
         ("rules/match_based_id/formatting.yaml", "formatting.c", False),
         ("rules/match_based_id/formatting.yaml", "ellipse.c", False),
         ("rules/taint.yaml", "taint.py", False),
-        ("rules/match_based_id/operator.yaml", "operator.c", True),
-        ("rules/match_based_id/formatting.yaml", "meta-change.c", True),
-        ("rules/match_based_id/join.yaml", "join.py", True),
     ],
 )
 def test_id_change(
@@ -72,3 +69,21 @@ def test_id_change(
     after_id = run_on_target("after")
 
     assert (after_id != before_id) == expect_change
+
+
+@pytest.mark.kinda_slow
+@pytest.mark.parametrize(
+    "rule,target_name,expect_change",
+    [
+        # ("rules/match_based_id/","",True)
+        ("rules/match_based_id/operator.yaml", "operator.c", True),
+        ("rules/match_based_id/formatting.yaml", "meta-change.c", True),
+        ("rules/match_based_id/join.yaml", "join.py", True),
+    ],
+)
+def test_id_change_osemfail(
+    run_semgrep_on_copied_files: RunSemgrep, tmp_path, rule, target_name, expect_change
+):
+    test_id_change(
+        run_semgrep_on_copied_files, tmp_path, rule, target_name, expect_change
+    )

--- a/src/targeting/Find_targets.ml
+++ b/src/targeting/Find_targets.ml
@@ -133,7 +133,7 @@ let files_from_git_ls ~cwd:scan_root =
   (* tracked files *)
   let tracked_output = Git_wrapper.files_from_git_ls ~cwd:scan_root in
   tracked_output
-  |> Common.map (fun x -> scan_root // x)
+  |> Common.map (fun x -> if !!scan_root = "." then x else scan_root // x)
   |> List.filter is_valid_file
   [@@profiling]
 
@@ -177,6 +177,31 @@ let list_regular_files (conf : conf) (scan_root : Fpath.t) : Fpath.t list =
   | S_BLK
   | S_SOCK ->
       []
+  [@@profiling]
+
+(*************************************************************************)
+(* Entry point (new) *)
+(*************************************************************************)
+
+(* This does almost nothing and is not as complete as get_targets2() below.
+ * For example, it does not handle .semgrepignore; it handles .gitignore
+ * but just because we use git ls-files really.
+ * BUT, at least it returns "readable" fpaths as opposed to absolute
+ * path in get_targets2, which currently leads to less e2e failures
+ * TODO:
+ *  - handle .semgrepignore but by doing it in a more efficient way
+ *    than get_targets2
+ *  - handle file size? e2e tests testing that?
+ *)
+let get_targets conf scanning_roots =
+  scanning_roots
+  |> Common.map (fun scan_root ->
+         let xs = list_regular_files conf scan_root in
+         let skipped = [] in
+         (xs, skipped))
+  |> List.split
+  |> fun (paths_list, skipped_paths_list) ->
+  (List.flatten paths_list, List.flatten skipped_paths_list)
   [@@profiling]
 
 (*************************************************************************)
@@ -290,7 +315,7 @@ let group_roots_by_project conf paths =
            ((Project.Other_project, root), Ppath.to_fpath root git_path))
 
 (*************************************************************************)
-(* Entry point *)
+(* Entry point (old) *)
 (*************************************************************************)
 
 (* python: mix of Target_manager(), target_manager.get_files_for_rule(),
@@ -303,7 +328,7 @@ let group_roots_by_project conf paths =
    See the documentation for the conf object for the various filters
    that we apply.
 *)
-let get_targets conf scanning_roots =
+let get_targets2 conf scanning_roots =
   (* python: =~ Target_manager.get_all_files() *)
   group_roots_by_project conf scanning_roots
   |> Common.map (fun ((proj_kind, project_root), scanning_roots) ->

--- a/src/targeting/Find_targets.mli
+++ b/src/targeting/Find_targets.mli
@@ -47,6 +47,14 @@ val get_targets :
   Fpath.t list (* scanning roots *) ->
   Fpath.t list * Output_from_core_t.skipped_target list
 
+(* old implementation, more complete for ignoring paths, but returning
+ * bad absolute fpaths instead of "readable" fpaths
+ *)
+val get_targets2 :
+  conf ->
+  Fpath.t list (* scanning roots *) ->
+  Fpath.t list * Output_from_core_t.skipped_target list
+
 (*
    [legacy implementation used in semgrep-core]
 


### PR DESCRIPTION
test plan:
make osempass
114 from 111

also osemgrep --config semgrep.jsonnet .
now displays findings relative to the current directory, not anymore
absolute paths


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)