### PR TITLE
fix: Introduce type inference using Type.ml

### DIFF
--- a/changelog.d/inference.fixed
+++ b/changelog.d/inference.fixed
@@ -1,0 +1,1 @@
+Improve type inference for some simple arithmetic expressions

--- a/src/core/Type.ml
+++ b/src/core/Type.ml
@@ -1,0 +1,211 @@
+(* Yoann Padioleau
+ *
+ * Copyright (C) 2022, 2023 r2c
+ *
+ *)
+open Common
+module G = AST_generic
+
+let logger = Logging.get_logger [ __MODULE__ ]
+
+(*****************************************************************************)
+(* Prelude *)
+(*****************************************************************************)
+(* Types for type inference.
+ *
+ * Why not simply reuse AST_generic.type_ ? Because here we want to make
+ * sure type names are fully resolved! AST_generic is also meant to represent
+ * types that people could actually write as part of programs. This is a more
+ * abstract representation of types, divorced from the notion of a syntax tree.
+ * For example, we don't include tokens here. We may introduce types here that
+ * wouldn't appear as written types in a program. We might even introduce type
+ * variables here, which would not be appropriate to include in AST_generic.
+ *
+ * In the future, we may also want to apply more complex normalizations to
+ * simplify typing/naming.
+ *
+ * TODO: polymorphic types? type parameters are resolved names?
+ *
+ * These types are polymorphic to support the Pro Engine, which represents
+ * resolved names differently.
+ *)
+
+(*****************************************************************************)
+(* Types *)
+(*****************************************************************************)
+type todo_kind = string option [@@deriving show]
+
+(* Fully qualified name *)
+type 'resolved name = 'resolved * 'resolved type_argument list
+and 'resolved type_argument = TA of 'resolved t | OtherTypeArg of todo_kind
+
+and 'resolved t =
+  | N of 'resolved name * (* alt names *) G.alternate_name list
+  (* e.g. for unresolved types in core libraries
+   * TODO? generalize and have just NotYetHandled of G.type_?
+   * so at least we are as good as regular Semgrep for typing?
+   *)
+  | UnresolvedName of string * 'resolved type_argument list
+  | Builtin of builtin_type
+  | Null (* for null analysis, alt: TOption of t *)
+  (* TODO: generalize to other containers? But then use a TyContainer
+   * in SAST.ml? *)
+  (* int option for the cases where we know the size of the array *)
+  | Array of int option * 'resolved t
+  | Function of 'resolved function_type
+  | Pointer of 'resolved t
+  (* todos (bailout) *)
+  (* NoType is to avoid some Type.t option and use of let* everywhere.
+   * See also of_opt() below.
+   *)
+  | NoType
+  | Todo of todo_kind
+
+and builtin_type =
+  (* mimic SAST.literal *)
+  | Int
+  | Float
+  | String
+  | Bool
+  | OtherBuiltins of string
+
+and 'resolved function_type = 'resolved parameter list * 'resolved t
+
+and 'resolved parameter =
+  | Param of 'resolved parameter_classic
+  | OtherParam of todo_kind
+
+and 'resolved parameter_classic = {
+  (* the identifier can be useful to handle ArgKwd calls *)
+  pident : string option;
+  ptype : 'resolved t;
+}
+[@@deriving show { with_path = false }]
+
+(*****************************************************************************)
+(* Helpers *)
+(*****************************************************************************)
+
+(* TODO: should not be needed at some point *)
+let todo_parameter = OtherParam (Some "todo_paramter")
+
+let of_opt opt =
+  match opt with
+  | None -> NoType
+  | Some t -> t
+
+let rec to_name_opt lang ty =
+  match ty with
+  | N (n, _) -> Some n
+  (* Currently, this function is only used to resolve the LHS of a DotAccess. In
+   * go, DotAccess is overloaded to be both a field access (like `.` in C) and a
+   * dereference plus a field access (like `->` in C). In most languages, either
+   * all object types are implicitly pointers, or they require explicit
+   * disambiguation which makes this unnecessary. To address this ambiguity,
+   * look through a `Pointer` type when resolving the name. *)
+  | Pointer ty when lang =*= Lang.Go -> to_name_opt lang ty
+  | _else_ -> None
+
+(*****************************************************************************)
+(* Converters *)
+(*****************************************************************************)
+
+let todo_kind_to_ast_generic_todo_kind (x : todo_kind) : G.todo_kind =
+  match x with
+  | Some s -> (s, Tok.unsafe_fake_tok s)
+  | None -> ("TodoKind is None", Tok.unsafe_fake_tok "")
+
+(* There is no function of_ast_generic_type_. The closest is
+ * Naming_AST.type_of_expr  which converts an G.type_ to Type.t *)
+let rec to_ast_generic_type_ lang (f : 'a -> G.alternate_name list -> G.name)
+    (x : 'a t) : G.type_ option =
+  let mkt str =
+    G.TyN (G.Id ((str, Tok.unsafe_fake_tok str), G.empty_id_info ())) |> G.t
+  in
+  match x with
+  | N ((name, args), alts) -> (
+      let n = f name alts in
+      let t = G.TyN n |> G.t in
+      match args with
+      | [] -> Some t
+      | xs ->
+          let* targs = type_arguments lang f xs in
+          Some (G.TyApply (t, Tok.unsafe_fake_bracket targs) |> G.t))
+  | UnresolvedName (s, args) -> (
+      let t = mkt s in
+      match args with
+      | [] -> Some t
+      | xs ->
+          let* targs = type_arguments lang f xs in
+          Some (G.TyApply (t, Tok.unsafe_fake_bracket targs) |> G.t))
+  | Null -> Some (mkt "null")
+  | Builtin x -> (
+      (* Roughly the inverse of Type_generic.builtin_type_of_ident. TODO Unify
+       * *)
+      match x with
+      | Int -> Some (mkt "int")
+      | Float -> Some (mkt "float")
+      | String -> Some (mkt "string")
+      | Bool -> Some (mkt "bool")
+      | OtherBuiltins _ -> None)
+  | Array (size, ty) ->
+      let size =
+        Option.map
+          (fun n ->
+            G.L (G.Int (Some n, Tok.unsafe_fake_tok (string_of_int n))) |> G.e)
+          size
+      in
+      let* ty = to_ast_generic_type_ lang f ty in
+      Some (G.TyArray (Tok.unsafe_fake_bracket size, ty) |> G.t)
+  | Function (params, tret) ->
+      let params =
+        params
+        |> Common.map (function
+             | Param { pident; ptype } -> (
+                 let topt = to_ast_generic_type_ lang f ptype in
+                 match topt with
+                 | Some t ->
+                     let classic =
+                       {
+                         G.pname =
+                           pident
+                           |> Option.map (fun s -> (s, Tok.unsafe_fake_tok s));
+                         ptype = Some t;
+                         pattrs = [];
+                         pinfo = G.empty_id_info ();
+                         pdefault = None;
+                       }
+                     in
+                     G.Param classic
+                 | _else_ ->
+                     G.OtherParam
+                       ( ( "to_ast_generic_type for param",
+                           Tok.unsafe_fake_tok "" ),
+                         [] ))
+             | OtherParam x ->
+                 G.OtherParam (todo_kind_to_ast_generic_todo_kind x, []))
+      in
+      let* tret = to_ast_generic_type_ lang f tret in
+      Some (G.TyFun (params, tret) |> G.t)
+  | Pointer ty ->
+      let* ty = to_ast_generic_type_ lang f ty in
+      Some (G.TyPointer (Tok.unsafe_fake_tok "Pointer", ty) |> G.t)
+  | NoType
+  | Todo _ ->
+      None
+
+and type_arguments lang f (xs : 'a type_argument list) :
+    G.type_argument list option =
+  match xs with
+  | [] -> Some []
+  | x :: xs ->
+      let* x =
+        match x with
+        | TA t ->
+            let* t = to_ast_generic_type_ lang f t in
+            Some (G.TA t)
+        | OtherTypeArg x ->
+            Some (G.OtherTypeArg (todo_kind_to_ast_generic_todo_kind x, []))
+      in
+      let* xs = type_arguments lang f xs in
+      Some (x :: xs)

--- a/src/matching/Generic_vs_generic.ml
+++ b/src/matching/Generic_vs_generic.ml
@@ -1424,7 +1424,7 @@ and m_compatible_type lang typed_mvar t e =
           m_type_option_with_hook idb (Some t) !tb >>= fun () ->
           envf typed_mvar (MV.Id (idb, Some id_infob))
       | _ta, _eb -> (
-          match type_of_expr lang e with
+          match Typing.type_of_expr lang e with
           | tbopt, Some idb ->
               m_type_option_with_hook idb (Some t) tbopt >>= fun () ->
               envf typed_mvar (MV.E e)
@@ -1432,72 +1432,6 @@ and m_compatible_type lang typed_mvar t e =
               let* () = m_type_ t tb in
               envf typed_mvar (MV.E e)
           | None, None -> fail ()))
-
-(* returns possibly the inferred type of the expression,
- * as well as an ident option that can then be used to query LSP to get the
- * type of the ident.
- *)
-and type_of_expr lang e : G.type_ option * G.ident option =
-  match e.B.e with
-  (* TODO? or generate a fake "new" id for LSP to query on tk? *)
-  | B.New (_tk, t, _ii, _) -> (Some t, None)
-  (* this is covered by the basic type propagation done in Naming_AST.ml *)
-  | B.N
-      (B.IdQualified
-        { name_last = idb, None; name_info = { B.id_type = tb; _ }; _ })
-  | B.DotAccess
-      ({ e = IdSpecial (This, _); _ }, _, FN (Id (idb, { B.id_type = tb; _ })))
-    ->
-      (!tb, Some idb)
-  (* deep: those are usually resolved only in deep mode *)
-  | B.DotAccess (_, _, FN (Id (idb, { B.id_type = tb; _ }))) -> (!tb, Some idb)
-  (* deep: same *)
-  | B.Call
-      ( { e = B.DotAccess (_, _, FN (Id (idb, { B.id_type = tb; _ }))); _ },
-        _args ) -> (
-      match !tb with
-      (* less: in OCaml functions can be curried, so we need to match
-       * _params and _args to calculate the resulting type.
-       *)
-      | Some { t = TyFun (_params, tret); _ } -> (Some tret, Some idb)
-      | Some _
-      | None ->
-          (None, Some idb))
-  (* deep: in Java, there can be an implicit `this.`
-     so calculate the type in the same way as above
-     THINK: should we do this for all languages? Why not? *)
-  | B.Call ({ e = N (Id (idb, { B.id_type = tb; _ })); _ }, _args)
-    when lang =*= Lang.Java -> (
-      match !tb with
-      | Some { t = TyFun (_params, tret); _ } -> (Some tret, Some idb)
-      | Some _
-      | None ->
-          (None, Some idb))
-  | B.Conditional (_, e1, e2) ->
-      let ( let* ) = Option.bind in
-      let t1opt, id1opt = type_of_expr lang e1 in
-      let t2opt, id2opt = type_of_expr lang e2 in
-      (* LATER: we could also not enforce to have a type for both branches,
-       * but let's go simple for now and enforce both branches have
-       * a type and that the types are equal.
-       *)
-      let topt =
-        let* t1 = t1opt in
-        let* t2 = t2opt in
-        (* LATER: in theory we should look if the types are compatible,
-         * and take the lowest upper bound of the two types *)
-        if AST_utils.with_structural_equal G.equal_type_ t1 t2 then Some t1
-        else None
-      in
-      let idopt =
-        (* TODO? is there an Option.xxx or Common.xxx function for that? *)
-        match (id1opt, id2opt) with
-        | Some id1, _ -> Some id1
-        | _, Some id2 -> Some id2
-        | None, None -> None
-      in
-      (topt, idopt)
-  | _else_ -> (None, None)
 
 (*---------------------------------------------------------------------------*)
 (* XML *)

--- a/src/typing/Typing.ml
+++ b/src/typing/Typing.ml
@@ -1,0 +1,127 @@
+(* Nat Mote
+ *
+ * Copyright (C) 2019-2023 Semgrep, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * version 2.1 as published by the Free Software Foundation, with the
+ * special exception on linking described in file LICENSE.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
+ * LICENSE for more details.
+ *)
+
+open Common
+module G = AST_generic
+
+(* returns possibly the inferred type of the expression,
+ * as well as an ident option that can then be used to query LSP to get the
+ * type of the ident.
+ *
+ * Old type inference over `AST_generic.type_`. TODO Let's migrate all of this
+ * to the new type inference over `Type.t`.
+ *)
+let rec type_of_expr_old lang e : G.type_ option * G.ident option =
+  match e.G.e with
+  (* TODO? or generate a fake "new" id for LSP to query on tk? *)
+  | G.New (_tk, t, _ii, _) -> (Some t, None)
+  (* this is covered by the basic type propagation done in Naming_AST.ml *)
+  | G.N
+      (G.IdQualified
+        { name_last = idb, None; name_info = { G.id_type = tb; _ }; _ })
+  | G.DotAccess
+      ({ e = IdSpecial (This, _); _ }, _, FN (Id (idb, { G.id_type = tb; _ })))
+    ->
+      (!tb, Some idb)
+  (* deep: those are usually resolved only in deep mode *)
+  | G.DotAccess (_, _, FN (Id (idb, { G.id_type = tb; _ }))) -> (!tb, Some idb)
+  (* deep: same *)
+  | G.Call
+      ( { e = G.DotAccess (_, _, FN (Id (idb, { G.id_type = tb; _ }))); _ },
+        _args ) -> (
+      match !tb with
+      (* less: in OCaml functions can be curried, so we need to match
+       * _params and _args to calculate the resulting type.
+       *)
+      | Some { t = TyFun (_params, tret); _ } -> (Some tret, Some idb)
+      | Some _
+      | None ->
+          (None, Some idb))
+  (* deep: in Java, there can be an implicit `this.`
+     so calculate the type in the same way as above
+     THINK: should we do this for all languages? Why not? *)
+  | G.Call ({ e = N (Id (idb, { G.id_type = tb; _ })); _ }, _args)
+    when lang =*= Lang.Java -> (
+      match !tb with
+      | Some { t = TyFun (_params, tret); _ } -> (Some tret, Some idb)
+      | Some _
+      | None ->
+          (None, Some idb))
+  | G.Conditional (_, e1, e2) ->
+      let ( let* ) = Option.bind in
+      let t1opt, id1opt = type_of_expr lang e1 in
+      let t2opt, id2opt = type_of_expr lang e2 in
+      (* LATER: we could also not enforce to have a type for both branches,
+       * but let's go simple for now and enforce both branches have
+       * a type and that the types are equal.
+       *)
+      let topt =
+        let* t1 = t1opt in
+        let* t2 = t2opt in
+        (* LATER: in theory we should look if the types are compatible,
+         * and take the lowest upper bound of the two types *)
+        if AST_utils.with_structural_equal G.equal_type_ t1 t2 then Some t1
+        else None
+      in
+      let idopt =
+        (* TODO? is there an Option.xxx or Common.xxx function for that? *)
+        match (id1opt, id2opt) with
+        | Some id1, _ -> Some id1
+        | _, Some id2 -> Some id2
+        | None, None -> None
+      in
+      (topt, idopt)
+  | _else_ -> (None, None)
+
+(* returns possibly the inferred type of the expression,
+ * as well as an ident option that can then be used to query LSP to get the
+ * type of the ident.
+ *
+ * New Type inference over `Type.t`. Prefer this to the old type inference over
+ * `AST_generic.type_`. Eventually we'll do all the type inference here and
+ * delete the old. *)
+and type_of_expr_new lang e : G.name Type.t * G.ident option =
+  match e.G.e with
+  | G.L lit ->
+      let t =
+        match lit with
+        | G.Int _ -> Type.Builtin Type.Int
+        | _else_ -> Type.NoType
+      in
+      (t, None)
+  | G.Call ({ e = IdSpecial (Op op, _); _ }, (_l, [ Arg e1; Arg e2 ], _r)) ->
+      let t1, _id = type_of_expr_new lang e1 in
+      let t2, _id = type_of_expr_new lang e2 in
+      let t =
+        match (t1, op, t2) with
+        | ( Type.Builtin Type.Int,
+            (G.Plus | G.Minus (* TODO more *)),
+            Type.Builtin Type.Int ) ->
+            Type.Builtin Type.Int
+        | _else_ -> Type.NoType
+      in
+      (t, None)
+  | _else_ -> (Type.NoType, None)
+
+and type_of_expr lang e : G.type_ option * G.ident option =
+  let t, id = type_of_expr_new lang e in
+  match
+    Type.to_ast_generic_type_ lang
+      (fun name _alts ->
+        (* TODO Do something with alts? Or are they already there? *) name)
+      t
+  with
+  | None -> type_of_expr_old lang e
+  | Some t -> (Some t, id)

--- a/src/typing/Typing.mli
+++ b/src/typing/Typing.mli
@@ -1,0 +1,6 @@
+(* Returns possibly the inferred type of the expression, as well as an ident
+ * option that can then be used to query LSP to get the type of the ident. *)
+val type_of_expr :
+  Lang.t ->
+  AST_generic.expr ->
+  AST_generic.type_ option * AST_generic.ident option

--- a/src/typing/dune
+++ b/src/typing/dune
@@ -1,18 +1,14 @@
 (library
- (public_name semgrep.matching)
- (name semgrep_matching)
+ (public_name semgrep.typing)
+ (name semgrep_typing)
  (wrapped false)
  (libraries
-   yaml ppx_deriving.runtime re
+   ppx_deriving.runtime
 
    commons
    lib_parsing
-   pfff-lang_GENERIC-analyze
-   parser_javascript.ast ; for Ast_js.default_entity
 
    semgrep_core
-   semgrep_typing
-   semgrep_optimizing
    ; No dependencies to semgrep_parsing here!
    ; we use parsers in Unit_matcher.ml but they are passed in
    ; via a parameter in tests().

--- a/tests/patterns/java/metavar_typed_int.java
+++ b/tests/patterns/java/metavar_typed_int.java
@@ -1,0 +1,20 @@
+public class Main {
+  public static void main(String[] args) {
+    // MATCH:
+    System.out.println(1);
+    // MATCH:
+    System.out.println(1 + 1);
+    // MATCH:
+    System.out.println(1 - 1);
+    // TODO:
+    System.out.println(1 * 1);
+    // TODO:
+    System.out.println(1 / 1);
+    // TODO:
+    System.out.println(1 % 1);
+    // OK:
+    System.out.println("1");
+    // OK:
+    System.out.println("1" + "1");
+  }
+}

--- a/tests/patterns/java/metavar_typed_int.sgrep
+++ b/tests/patterns/java/metavar_typed_int.sgrep
@@ -1,0 +1,1 @@
+System.out.println((int $X))


### PR DESCRIPTION
Here, I bring `Type.ml` over from the Pro Engine, and use it to it to implement a couple cases of type inference, just enough to showcase the idea. I don't think that `AST_generic.type_` is suitable for use as a type representation for any sophisticated type inference.

This way, we can build out local type inference in OSS, improving matching for typed metavariables and possibly other things when local type inference is able to determine a type. We can also make use of the Pro Engine's resolved types for symbols defined outside of the local scope to further improve typed metavariable matching in the Pro Engine.

Test plan: Automated tests

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
