### PR TITLE
Use Rpath for Parse_with_caching.ml to reduce cache misses

### DIFF
--- a/libs/paths/Realpath.ml
+++ b/libs/paths/Realpath.ml
@@ -1,13 +1,16 @@
 (*
-   OCaml implementation of realpath. Remove once we depend on ocaml >= 4.13.
+   OCaml implementation of realpath.
+
+   Remove once we depend on ocaml >= 4.13? Or just reduce
+   the code to a simple calls to Unix.realpath.
+   Unfortunately there is no unixcompat like we have stdcompat.
 
    related functions:
     - Unix.realpath(), but available only since OCaml 4.13
-    - Common.fullpath()
+    - Common.fullpath(), but not as good as Realpath
     - efuns/c/realpath.ml (an OCaml binding to the C library realpath(3))
       but Unix.realpath() should be the same
 *)
-
 open Printf
 
 (**********************************************************)
@@ -93,6 +96,7 @@ let realpath path =
     | _ -> abs_path
   in
   resolve (lazy (Unix.getcwd () |> Fpath.v)) path
+  [@@profiling]
 
 let realpath_str s =
   match Fpath.of_string s with

--- a/libs/paths/Rpath.ml
+++ b/libs/paths/Rpath.ml
@@ -21,7 +21,7 @@
    This module governs a path type, which can only produce values which
    are for normalized paths to existent files or directories.
    These paths are always canonically kept at their absolute forms, in order to
-   maintain a canonicity property. Due to the `Path` constructor being
+   maintain a canonicity property. Due to the `Rpath` constructor being
    private, we can enforce this invariant at the type level.
 
    history: this file was originally called `Path.ml`, but this conflicts with
@@ -38,34 +38,27 @@
 (* Types *)
 (*****************************************************************************)
 
-(* TODO? use Path of Fpath.t instead? *)
-type t = Path of string [@@deriving show, eq]
+(* TODO? use of Fpath.t instead? or too confusing? *)
+type t = Rpath of string [@@deriving show, eq]
 
 (*****************************************************************************)
 (* Main functions *)
 (*****************************************************************************)
 
-(* TODO: we should use Unix.realpath but it's available only in 4.13
- * and there is no unixcompat like we have stdcompat.
- * alt: use Common.fullpath, but not as good as Unix.realpath
- *)
-let of_fpath p = Path (Realpath.realpath p |> Fpath.to_string)
-let of_string s = Path (Realpath.realpath_str s)
-let to_fpath (Path s) = Fpath.v s
-let to_string (Path s) = s
+let of_fpath p = Rpath (Realpath.realpath p |> Fpath.to_string)
+let of_string s = Rpath (Realpath.realpath_str s)
+let to_fpath (Rpath s) = Fpath.v s
+let to_string (Rpath s) = s
 let canonical s = to_string (of_string s)
-let ( / ) (Path s1) s2 = of_string (Filename.concat s1 s2)
+let ( / ) (Rpath s1) s2 = of_string (Filename.concat s1 s2)
 let concat = ( / )
-let apply ~f (Path s) = f s
-let file_exists (Path s) = Sys.file_exists s
+let apply ~f (Rpath s) = f s
+let basename (Rpath s) = Filename.basename s
+let dirname (Rpath s) = Filename.dirname s |> of_string
+let extension (Rpath s) = Filename.extension s
 
 (* TODO: probably better to direct people to the File module, and remove those
  * functions. People just have to use 'rpath |> Rpath.to_fpath |> xxx'
  *)
-let cat = apply ~f:Common.cat
-let read_file ?max_len = apply ~f:(Common.read_file ?max_len)
-let write_file ~file:(Path s1) = Common.write_file ~file:s1
 let is_directory = apply ~f:Sys.is_directory
-let basename (Path s) = Filename.basename s
-let dirname (Path s) = Filename.dirname s |> of_string
-let extension (Path s) = Filename.extension s
+let file_exists = apply ~f:Sys.file_exists

--- a/libs/paths/Rpath.mli
+++ b/libs/paths/Rpath.mli
@@ -22,9 +22,11 @@
 
    Also note that even though it's tempting to use Rpath.t inside your
    program, because they provide a canonical representation of a path,
-   you should prefer in general to use Ppath.t because users want
-   error messages, findings, etc. that refer to paths relative to the
-   root of their project (and not /home/pad/my/long/project/foo/bar).
+   you should prefer in general to use Fpath.t because users want
+   error messages, findings, etc. that contain paths derived from
+   what was passed on the command line, or Ppath.t if users want
+   findings relative to the root of their project (and not real paths like
+   /home/pad/my/long/project/foo/bar).
 
    The name of the module imitates Fpath.ml, and Ppath.ml, but use Rpath.ml
    for Real path.
@@ -40,14 +42,16 @@
    `of_string`, and in particular, ensures that they all must be
    validated by `realpath()`.
 *)
-type t = private Path of string [@@deriving show, eq]
+type t = private Rpath of string [@@deriving show, eq]
 
 (* only way to build an Rpath *)
 val of_fpath : Fpath.t -> t
 val of_string : string -> t
+
+(* converters *)
 val to_fpath : t -> Fpath.t
 
-(* Deprecated: should use Fpath.t instead of string *)
+(* Deprecated: you should use to_fpath (and then Fpath.to_string if needed) *)
 val to_string : t -> string
 
 (* <=> to_string (of_string s) *)
@@ -63,11 +67,13 @@ val basename : t -> string
 val dirname : t -> t
 val extension : t -> string
 
-(* Deprecated: Similar to functions in File.mli. You should
+(* Deprecated? Similar to functions in File.mli. You should
  * instead use directly the File module with 'File.xxx (Rpath.to_fpath rpath)'
  *)
-val cat : t -> string list
-val write_file : file:t -> string -> unit
-val read_file : ?max_len:int -> t -> string
-val file_exists : t -> bool
 val is_directory : t -> bool
+
+(* This should always return true because you normally can't build an Rpath
+ * from a nonexistent file. However, the underlying FS can change, or you may
+ * have used concat() above which may lead to a nonexistent file.
+ *)
+val file_exists : t -> bool

--- a/libs/paths/Unit_Rpath.ml
+++ b/libs/paths/Unit_Rpath.ml
@@ -26,9 +26,11 @@ let test_path_conversion () =
       let path = Rpath.of_string file in
       let max_len = 24 in
       assert (Rpath.to_string path = realpath file);
-      assert (Rpath.read_file path = data);
-      assert (Rpath.cat path = [ data ]);
-      assert (Rpath.read_file ~max_len path = Str.first_chars data max_len);
+      assert (Rpath.to_fpath path |> File.read_file = data);
+      assert (Rpath.to_fpath path |> File.cat = [ data ]);
+      assert (
+        File.read_file ~max_len (Rpath.to_fpath path)
+        = Str.first_chars data max_len);
       assert (Rpath.file_exists path);
       assert (not (Rpath.is_directory path)));
   assert (

--- a/libs/paths/dune
+++ b/libs/paths/dune
@@ -7,6 +7,7 @@
      fpath
 
      commons
+     profiling
   )
   (preprocess (pps
      ppx_deriving.show

--- a/src/osemgrep/cli_scan/Rule_fetching.ml
+++ b/src/osemgrep/cli_scan/Rule_fetching.ml
@@ -148,6 +148,7 @@ type _registry_cached_value =
     float (* timestamp *) * Uri.t )
   Cache_disk.cached_value_on_disk
 
+(* better: faster fetching by using a cache *)
 let fetch_content_from_registry_url ~registry_caching url =
   if not registry_caching then fetch_content_from_url url
   else

--- a/src/parsing/Parse_with_caching.ml
+++ b/src/parsing/Parse_with_caching.ml
@@ -20,7 +20,7 @@ let logger = Logging.get_logger [ __MODULE__ ]
 (*****************************************************************************)
 (* Purpose *)
 (*****************************************************************************)
-(* Cache parsed generic ASTs between runs to speedup things.
+(* Cache parsed generic ASTs between two runs of Semgrep to speedup things.
  *
  * On some big repositories (e.g., elasticsearch), the speedup can be
  * very important (e.g., 10x). Indeed:
@@ -50,13 +50,15 @@ let logger = Logging.get_logger [ __MODULE__ ]
  * The extra data is to double check the cached AST correspond
  * to the file, to check it has the right AST_generic.version, and
  * to check if the cache is stale.
- * alt: we could add Lang.t in it, but instead it is part of the input
- * and used to generate the cache file.
+ * We use Rpath below instead of Fpath which reduces cache miss if
+ * some people are running Semgrep from different places or through
+ * symlinks.
  *)
 type ast_cached_value =
   ( (AST_generic.program * Tok.location list, Exception.t) Common.either,
     string (* AST_generic.version *)
-    * Fpath.t (* original file *)
+    * Lang.t
+    * Rpath.t (* original file *)
     * float (* mtime of the original file *) )
   Cache_disk.cached_value_on_disk
 
@@ -87,8 +89,8 @@ let ast_or_exn_of_file (lang, file) =
       Right e
 
 (* Cache_disk methods reused in a few places *)
-let cache_extra_for_input version (_lang, file) =
-  (version, file, File.filemtime file)
+let cache_extra_for_input version (lang, file) =
+  (version, lang, Rpath.of_fpath file, File.filemtime file)
 
 (* this is used for semgrep-core -generate_ast_binary done for Snowflake *)
 let binary_suffix : Fpath.ext = ".ast.binary"
@@ -115,7 +117,10 @@ let parse_and_resolve_name ?(parsing_cache_dir = None) version lang
     logger#info "%s is already an AST binary file, unmarshalling its value"
       !!file;
     let (v : ast_cached_value) = Common2.get_value !!file in
-    let { Cache_disk.value = either; extra = version2, _file2, _mtime2 } = v in
+    let { Cache_disk.value = either; extra = version2, _lang2, _file2, _mtime2 }
+        =
+      v
+    in
     (* coupling: similar to check_extra() method below, but we're not
      * checking it's the same file here
      *)
@@ -137,16 +142,19 @@ let parse_and_resolve_name ?(parsing_cache_dir = None) version lang
           {
             Cache_disk.cache_file_for_input =
               (fun (lang, file) ->
+                (* canonicalize to reduce cache misses *)
+                let file = Rpath.of_fpath file in
                 (* we may use different parsers for the same file
-                 * (e.g., in Python3 or Python2 mode), so we put the lang as part
-                 * of the cache "dependency".
+                 * (e.g., in Python3 or Python2 mode), so we put the lang as
+                 * part of the cache "dependency".
                  * We also add version here so bumping the version will not
                  * try to use the old cache file.
-                 * TODO? do we need version here since anyway we would generate an
-                 * exception when reading the cache and regenerate it.
+                 * TODO? do we need version here since anyway we would
+                 * generate an exn when reading the cache and regenerate it.
                  *)
                 let str =
-                  spf "%s__%s__%s" !!file (Lang.to_string lang) version
+                  spf "%s__%s__%s" (Rpath.to_string file) (Lang.to_string lang)
+                    version
                 in
                 (* Better to obfuscate the cache files, like in Unison, to
                  * discourage people to play with it. Also simple way to escape
@@ -158,13 +166,15 @@ let parse_and_resolve_name ?(parsing_cache_dir = None) version lang
                 parsing_cache_dir // Fpath.(v md5_hex + binary_suffix));
             cache_extra_for_input = cache_extra_for_input version;
             check_extra =
-              (fun (version2, file2, mtime2) ->
+              (fun (version2, lang2, file2, mtime2) ->
                 (* TODO: better logging for the different reason the cache is
                  * invalid?
                  * - "Version mismatch! Clean the cache file"
                  * - "Not the same file! Md5sum collision! Clean the cache file"
                  *)
-                version = version2 && Fpath.equal file file2
+                version = version2
+                && Rpath.equal (Rpath.of_fpath file) file2
+                && Lang.equal lang lang2
                 && File.filemtime file =*= mtime2);
             input_to_string =
               (fun (lang, file) ->

--- a/src/parsing/Parse_with_caching.mli
+++ b/src/parsing/Parse_with_caching.mli
@@ -18,7 +18,8 @@ val parse_and_resolve_name :
 type ast_cached_value =
   ( (AST_generic.program * Tok.location list, Exception.t) Common.either,
     string (* AST_generic.version *)
-    * Fpath.t (* original file *)
+    * Lang.t
+    * Rpath.t (* original file *)
     * float (* mtime of the original file *) )
   Cache_disk.cached_value_on_disk
 

--- a/src/parsing/dune
+++ b/src/parsing/dune
@@ -8,6 +8,7 @@
    yaml pcre
 
    commons
+   paths
    lib_parsing
    process_limits
    spacegrep


### PR DESCRIPTION
Real paths are better for this kind of things.

test plan:
$ osemgrep --config semgrep.jsonnet /home/pad/github/semgrep/
$ osemgrep --config semgrep.jsonnet /home/pad/github/semgrep/
$ ls -1 ~/.semgrep/asts/
1699
$ osemgrep --config semgrep.jsonnet /home/pad/yy/
$ ls -1 ~/.semgrep/asts/
1699


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)