### PR TITLE
add(env): increae timeout for semgrep.dev network calls

### DIFF
--- a/changelog.d/timeout.added
+++ b/changelog.d/timeout.added
@@ -1,0 +1,2 @@
+Increase timeout of `semgrep ci` upload findings network calls
+and make said timeout configurable with env var SEMGREP_UPLOAD_FINDINGS_TIMEOUT

--- a/cli/src/semgrep/app/scans.py
+++ b/cli/src/semgrep/app/scans.py
@@ -365,6 +365,7 @@ class ScanHandler:
 
         response = state.app_session.post(
             f"{state.env.semgrep_url}/api/agent/scans/{self.scan_id}/findings_and_ignores",
+            timeout=state.env.upload_findings_timeout,
             json=findings_and_ignores,
         )
 
@@ -382,6 +383,7 @@ class ScanHandler:
         # mark as complete
         response = state.app_session.post(
             f"{state.env.semgrep_url}/api/agent/scans/{self.scan_id}/complete",
+            timeout=state.env.upload_findings_timeout,
             json=complete,
         )
 

--- a/cli/src/semgrep/env.py
+++ b/cli/src/semgrep/env.py
@@ -90,6 +90,8 @@ class Env:
     shouldafound_no_email: bool = field()
     min_fetch_depth: int = field()
 
+    upload_findings_timeout: int = field()
+
     r2c_internal_jsonnet_lib: Path = field()
 
     @version_check_timeout.default
@@ -166,3 +168,8 @@ class Env:
             return Path(value)
         # TODO what should the default path be?
         return Path.home()
+
+    @upload_findings_timeout.default
+    def upload_findings_timeout_default(self) -> int:
+        value = os.getenv("SEMGREP_UPLOAD_FINDINGS_TIMEOUT", "300")
+        return int(value)


### PR DESCRIPTION
Increase timeout of `semgrep ci` upload findings network calls
and make said timeout configurable with env var SEMGREP_UPLOAD_FINDINGS_TIMEOUT

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
