### PR TITLE
osemgrep: some more output tweaks

### DIFF
--- a/libs/commons/Cmdliner_helpers.ml
+++ b/libs/commons/Cmdliner_helpers.ml
@@ -28,14 +28,34 @@ let add_option_dashes option_names =
    backward compatibility with the Python CLI.
    See https://github.com/dbuenzli/cmdliner/issues/164
 *)
-let negatable_flag ?(default = false) ?env ~neg_options ~doc options =
+let negatable_flag ?(default = false) ~neg_options ~doc options =
   let neg_doc =
     let options_str = add_option_dashes options |> String.concat "/" in
     Printf.sprintf "negates %s" options_str
   in
-  let enable = (true, Arg.info options ~doc ?env) in
+  let enable = (true, Arg.info options ~doc) in
   let disable = (false, Arg.info neg_options ~doc:neg_doc) in
   Arg.value (Arg.vflag default [ enable; disable ])
+
+(* Cmdliner.Arg.vflag does not support environment variables, thus we use
+   Arg.value manually if we need supporting environment variables as well *)
+let negatable_flag_with_env ?(default = false) ?env ~neg_options ~doc options =
+  let neg_doc =
+    let options_str = add_option_dashes options |> String.concat "/" in
+    Printf.sprintf "negates %s" options_str
+  in
+  let enable = Arg.(value (flag (info options ~doc ?env))) in
+  let disable = Arg.(value (flag (info neg_options ~doc:neg_doc))) in
+  let combine yes no =
+    match yes, no with
+    | true, false -> true
+    | false, true -> false
+    | false, false -> default
+    | true, true ->
+      invalid_arg ("mutually exclusive options: " ^ String.concat ", "
+                     (options @ neg_options))
+  in
+  Term.(const combine $ enable $ disable)
 
 (* Parse command-line arguments representing a number of bytes, such as
  * '5 mb' or '3.2GiB'

--- a/libs/commons/Cmdliner_helpers.ml
+++ b/libs/commons/Cmdliner_helpers.ml
@@ -47,13 +47,14 @@ let negatable_flag_with_env ?(default = false) ?env ~neg_options ~doc options =
   let enable = Arg.(value (flag (info options ~doc ?env))) in
   let disable = Arg.(value (flag (info neg_options ~doc:neg_doc))) in
   let combine yes no =
-    match yes, no with
+    match (yes, no) with
     | true, false -> true
     | false, true -> false
     | false, false -> default
     | true, true ->
-      invalid_arg ("mutually exclusive options: " ^ String.concat ", "
-                     (options @ neg_options))
+        invalid_arg
+          ("mutually exclusive options: "
+          ^ String.concat ", " (options @ neg_options))
   in
   Term.(const combine $ enable $ disable)
 

--- a/libs/commons/Cmdliner_helpers.mli
+++ b/libs/commons/Cmdliner_helpers.mli
@@ -4,6 +4,18 @@
 *)
 val negatable_flag :
   ?default:bool ->
+  neg_options:string list ->
+  doc:string ->
+  string list ->
+  bool Cmdliner.Term.t
+
+(* Define a flag that can be negated e.g. --foo and --no-foo, and being able to
+   specify an environment variable.
+   It's not supported out-of-the-box by cmdliner but we want it for
+   backward compatibility with the Python CLI.
+*)
+val negatable_flag_with_env :
+  ?default:bool ->
   ?env:Cmdliner.Cmd.Env.info ->
   neg_options:string list ->
   doc:string ->

--- a/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -162,7 +162,7 @@ environment variable, defaults to 'auto'.
 
 (* alt: was in "Performance and memory options" before *)
 let o_version_check : bool Term.t =
-  H.negatable_flag [ "enable-version-check" ]
+  H.negatable_flag_with_env [ "enable-version-check" ]
     ~neg_options:[ "disable-version-check" ]
     ~default:default.version_check
     ~env:(Cmd.Env.info "SEMGREP_ENABLE_VERSION_CHECK")
@@ -338,7 +338,7 @@ the file is skipped. If set to 0 will not have limit. Defaults to 3.
  * better be backward compatible with how semgrep was doing it before
  *)
 let o_force_color : bool Term.t =
-  H.negatable_flag [ "force-color" ] ~neg_options:[ "no-force-color" ]
+  H.negatable_flag_with_env [ "force-color" ] ~neg_options:[ "no-force-color" ]
     ~default:default.force_color
       (* TOPORT? need handle SEMGREP_COLOR_NO_COLOR or NO_COLOR
        * # https://no-color.org/

--- a/src/osemgrep/reporting/Status_report.ml
+++ b/src/osemgrep/reporting/Status_report.ml
@@ -12,8 +12,7 @@
 
 let pp_status ~num_rules ~num_targets ~respect_git_ignore lang_jobs ppf =
   Fmt_helpers.pp_heading ppf "Scan Status";
-  (* TODO indentation of the body *)
-  Fmt.pf ppf "Scanning %s%s with %s"
+  Fmt.pf ppf "  Scanning %s%s with %s"
     (String_utils.unit_str num_targets "file")
     (if respect_git_ignore then " tracked by git" else "")
     (String_utils.unit_str num_rules "Code rule");
@@ -27,9 +26,9 @@ let pp_status ~num_rules ~num_targets ~respect_git_ignore lang_jobs ppf =
          summary_line += f", {unit_str(pro_rule_count, 'Pro rule')}"
   *)
   Fmt.pf ppf ":@.";
-  if num_rules = 0 then Fmt.pf ppf "Nothing to scan."
+  if num_rules = 0 then Fmt.pf ppf "  Nothing to scan."
   else if num_rules = 1 then
-    Fmt.pf ppf "Scanning %s." (String_utils.unit_str num_targets "file")
+    Fmt.pf ppf "  Scanning %s." (String_utils.unit_str num_targets "file")
   else
     (* TODO origin table [Origin Rules] [Community N] *)
     let xlang_label = function


### PR DESCRIPTION
for one, it is indentation of the scan status section

on the other note, this respects the environment variables for negetable flags

test plan:
- make osempass

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
