### PR TITLE
fix(perf): set better limits on analyze_rule

### DIFF
--- a/changelog.d/gh-7839.fixed
+++ b/changelog.d/gh-7839.fixed
@@ -1,0 +1,2 @@
+Fix for very long runtimes that could happen due to one of our optimizations. We now detect when that might
+happen and skip the optimization.

--- a/src/optimizing/Analyze_rule.ml
+++ b/src/optimizing/Analyze_rule.ml
@@ -205,13 +205,20 @@ let rec (cnf : Rule.formula -> cnf_step0) =
       let zs = Common.map (fun (_t, cond) -> And [ Or [ LCond cond ] ]) conds in
       And (ys @ zs |> List.concat_map (function And ors -> ors))
   | R.Or (_, xs) ->
-      let is_dangerously_large l = List.compare_length_with l 1_000_000 > 0 in
+      let is_dangerously_large p q =
+        List.compare_length_with p 1_000_000 > 0
+        || List.compare_length_with q 1_000_000 > 0
+        ||
+        let p_len = List.length p in
+        let q_len = List.length q in
+        (* Divide rather than multiply to avoid integer overflow *)
+        p_len > Int.div 10_000_000 q_len
+      in
       let ys = Common.map cnf xs in
       List.fold_left
         (fun (And ps) (And qs) ->
           (* Abort before this starts consuming insane amounts of memory. *)
-          if is_dangerously_large ps || is_dangerously_large qs then
-            raise CNF_exploded;
+          if is_dangerously_large ps qs then raise CNF_exploded;
           (* Distributive law *)
           And
             (ps

--- a/src/optimizing/Analyze_rule.ml
+++ b/src/optimizing/Analyze_rule.ml
@@ -603,7 +603,8 @@ let regexp_prefilter_of_rule (r : R.rule) =
             regexp_prefilter_of_formula f
         | `Taint spec -> regexp_prefilter_of_taint_rule r.R.id spec
       with
-      (* TODO: see tests/rules/tainted-filename.yaml *)
+      (* TODO: see tests/rules/tainted-filename.yaml,
+                   tests/rules/kotlin_slow_import.yaml *)
       | CNF_exploded ->
           logger#error "CNF size exploded on rule id %s" rule_id;
           None

--- a/tests/rules/kotlin_slow_import.kt
+++ b/tests/rules/kotlin_slow_import.kt
@@ -51,8 +51,8 @@ fun Route.customerRouting() {
                     // "userAgent (raw): ${req.userAgent()} \n" +
                     // "userAgent (decoded): ${URLDecoder.decode(req.userAgent())} \n"
 
-            // ruleid: ktor_request_xss_2
             call.respondBytes(
+                // ruleid: ktor_request_xss_2
                 bytes="hi! ${resp}",
                 contentType = ContentType.Text.Html,
             )

--- a/tests/rules/kotlin_slow_import.kt
+++ b/tests/rules/kotlin_slow_import.kt
@@ -1,0 +1,61 @@
+package com.example.routes
+
+import com.example.models.Customer
+import com.example.models.customerStorage
+import io.ktor.http.*
+import io.ktor.server.application.*
+import io.ktor.server.logging.*
+import io.ktor.server.request.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import java.io.StringWriter
+import java.net.URLDecoder
+
+fun Route.customerRouting() {
+    route("/customer") {
+        get("hi/{asdf?}") {
+            val req = call.request
+            val local = req.local
+            val resp = "Customer stored correctly. \n" +
+                    "accept: ${req.accept()} \n"
+                    // "acceptCharset: ${req.acceptCharset()} \n" +
+                    // "acceptCharsetItems: ${req.acceptCharsetItems()} \n" +
+                    // "acceptEncoding: ${req.acceptEncoding()} \n" +
+                    // "acceptEncodingItems: ${req.acceptEncodingItems()} \n" +
+                    // "acceptItems: ${req.acceptItems()} \n" +
+                    // "acceptLanguage: ${req.acceptLanguage()} \n" +
+                    // "acceptLanguageItems: ${req.acceptLanguageItems()} \n" +
+                    // "cacheControl: ${req.cacheControl()} \n" +
+                    // "cookies: ${req.cookies["asdf"]} \n" +
+                    // "rawCookies: ${req.cookies.rawCookies["asdf"]} \n" +
+                    // "document (raw): ${req.document()} \n" +
+                    // "document (decoded): ${URLDecoder.decode(req.document())} \n" +
+                    // "header (asdf): ${req.header("asdf")} \n" +
+//                        "host: ${req.host()} \n" +
+                    // "location: ${req.location()} \n" +
+                    // "local.localAddress: ${local.localAddress} \n" +
+                    // "local.localHost: ${local.localHost} \n" +
+                    // "local.remoteAddress: ${local.remoteAddress} \n" +
+                    // "local.remoteHost: ${local.remoteHost} \n" +
+                    // "local.serverHost: ${local.serverHost} \n" +
+                    // "local.uri: ${local.uri} \n" +
+                    // "path (raw): ${req.path()} \n" +
+                    // "path (decoded): ${URLDecoder.decode(req.path())} \n" +
+                    // "queryString (raw): ${req.queryString()} \n" +
+                    // "queryString (decoded): ${URLDecoder.decode(req.queryString())} \n" +
+                    // "queryParameters: ${req.queryParameters["hi"]} \n" +
+                    // "rawQueryParameters (raw): ${req.rawQueryParameters["hi"]} \n" +
+                    // "rawQueryParameters (decoded): ${URLDecoder.decode(req.rawQueryParameters["hi"])} \n" +
+                    // "toLogString: ${req.toLogString()} \n" +
+                    // "uri: ${req.uri} \n" +
+                    // "userAgent (raw): ${req.userAgent()} \n" +
+                    // "userAgent (decoded): ${URLDecoder.decode(req.userAgent())} \n"
+
+            // ruleid: ktor_request_xss_2
+            call.respondBytes(
+                bytes="hi! ${resp}",
+                contentType = ContentType.Text.Html,
+            )
+        }
+    }
+}

--- a/tests/rules/kotlin_slow_import.yaml
+++ b/tests/rules/kotlin_slow_import.yaml
@@ -1,0 +1,308 @@
+# From https://github.com/returntocorp/semgrep/pull/7845
+# This used to take a very long time when running with `-filter_irrelevant_rules` due
+# to the CNF getting very large
+rules:
+  - id: ktor_request_xss_2
+    languages:
+      - kotlin
+    message: >
+      Untrusted, unsanitized user input enters `$RESPFUNC()` with `contentType =
+      ContentType.Text.Html`, which can lead to a Cross-site scripting (XSS)
+      vulnerability.
+
+      XSS vulnerabilities occur when untrusted input executes malicious JavaScript code, leading to issues such as account compromise and sensitive information leakage.
+
+      To prevent this vulnerability, validate the user input, perform contextual output encoding or sanitize the input.
+
+      For more information, see: [XSS prevention in Go](https://semgrep.dev/docs/cheat-sheets/go-xss/).
+    metadata:
+      category: security
+      confidence: HIGH
+      cwe:
+        - "CWE-79: Improper Neutralization of Input During Web Page Generation
+          ('Cross-site Scripting')"
+      cwe2020-top25: true
+      cwe2021-top25: true
+      cwe2022-top25: true
+      impact: MEDIUM
+      likelihood: MEDIUM
+      owasp:
+        - A07:2017 - Cross-Site Scripting (XSS)
+        - A03:2021 - Injection
+      references:
+        - https://owasp.org/Top10/A03_2021-Injection
+      subcategory:
+        - vuln
+      technology:
+        - kotlin
+    mode: taint
+    options:
+      symbolic_propagation: true
+    pattern-sinks:
+      - label: sink
+        patterns:
+          - patterns:
+              - pattern-either:
+                  - patterns:
+                      - pattern: call.$RESPFUNC($INPUT, ContentType.Text.Html, ...)
+                      - metavariable-regex:
+                          metavariable: $RESPFUNC
+                          regex: ^(respond(Text|Bytes))$
+                  - patterns:
+                      - pattern: call.$RESPFUNC(message = $INPUT, contentType = ContentType.Text.Html,
+                          ...)
+                      - metavariable-regex:
+                          metavariable: $RESPFUNC
+                          regex: ^(respondText)$
+                  - patterns:
+                      - pattern: call.$RESPFUNC(bytes = $INPUT, contentType = ContentType.Text.Html,
+                          ...)
+                      - metavariable-regex:
+                          metavariable: $RESPFUNC
+                          regex: ^(respondBytes)$
+              - focus-metavariable: $INPUT
+        requires: urldecode or list_access or no_processing_needed
+    pattern-sources:
+      - label: no_processing_needed
+        patterns:
+          - pattern-either:
+              - patterns:
+                  - pattern-either:
+                      - pattern-inside: |
+                          import io.ktor.*
+                          ...
+                      - pattern-inside: |
+                          import io.ktor.server
+                          ...
+                  - pattern-either:
+                      - patterns:
+                          - pattern: server.application.call.request.$F(...)
+                          - metavariable-regex:
+                              metavariable: $F
+                              regex: ^(accept|acceptCharset|acceptEncoding|acceptLanguage|cacheControl|header|location|userAgent)$
+                      - patterns:
+                          - pattern: server.application.call.request.local.$F
+                          - metavariable-regex:
+                              metavariable: $F
+                              regex: ^(uri)$
+                      - patterns:
+                          - patterns:
+                              - pattern-either:
+                                  - pattern: server.application.call.request.$F["..."]
+                                  - pattern: server.application.call.request.$F.get("...", ...)
+                              - metavariable-regex:
+                                  metavariable: $F
+                                  regex: ^(cookies|queryParameters)$
+              - patterns:
+                  - pattern-either:
+                      - pattern-inside: |
+                          import io.ktor.server.*
+                          ...
+                      - pattern-inside: |
+                          import io.ktor.server.application
+                          ...
+                  - pattern-either:
+                      - patterns:
+                          - pattern: application.call.request.$F(...)
+                          - metavariable-regex:
+                              metavariable: $F
+                              regex: ^(accept|acceptCharset|acceptEncoding|acceptLanguage|cacheControl|header|location|userAgent)$
+                      - patterns:
+                          - pattern: application.call.request.local.$F
+                          - metavariable-regex:
+                              metavariable: $F
+                              regex: ^(uri)$
+                      - patterns:
+                          - patterns:
+                              - pattern-either:
+                                  - pattern: application.call.request.$F["..."]
+                                  - pattern: application.call.request.$F.get("...", ...)
+                              - metavariable-regex:
+                                  metavariable: $F
+                                  regex: ^(cookies|queryParameters)$
+              - patterns:
+                  - pattern-either:
+                      - pattern-inside: |
+                          import io.ktor.server.application.*
+                          ...
+                      - pattern-inside: |
+                          import io.ktor.server.application.call
+                          ...
+                  - pattern-either:
+                      - patterns:
+                          - pattern: call.request.$F(...)
+                          - metavariable-regex:
+                              metavariable: $F
+                              regex: ^(accept|acceptCharset|acceptEncoding|acceptLanguage|cacheControl|header|location|userAgent)$
+                      - patterns:
+                          - pattern: call.request.local.$F
+                          - metavariable-regex:
+                              metavariable: $F
+                              regex: ^(uri)$
+                      - patterns:
+                          - patterns:
+                              - pattern-either:
+                                  - pattern: call.request.$F["..."]
+                                  - pattern: call.request.$F.get("...", ...)
+                              - metavariable-regex:
+                                  metavariable: $F
+                                  regex: ^(cookies|queryParameters)$
+      - label: returns_list
+        patterns:
+          - pattern-either:
+              - patterns:
+                  - pattern-either:
+                      - pattern-inside: |
+                          import io.ktor.*
+                          ...
+                      - pattern-inside: |
+                          import io.ktor.server
+                          ...
+                  - patterns:
+                      - pattern: server.application.call.request.$F(...)
+                      - metavariable-regex:
+                          metavariable: $F
+                          regex: ^(acceptCharsetItems|acceptEncodingItems|acceptItems|acceptLanguageItems)$
+              - patterns:
+                  - pattern-either:
+                      - pattern-inside: |
+                          import io.ktor.server.*
+                          ...
+                      - pattern-inside: |
+                          import io.ktor.server.application
+                          ...
+                  - patterns:
+                      - pattern: application.call.request.$F(...)
+                      - metavariable-regex:
+                          metavariable: $F
+                          regex: ^(acceptCharsetItems|acceptEncodingItems|acceptItems|acceptLanguageItems)$
+              - patterns:
+                  - pattern-either:
+                      - pattern-inside: |
+                          import io.ktor.server.application.*
+                          ...
+                      - pattern-inside: |
+                          import io.ktor.server.application.call
+                          ...
+                  - patterns:
+                      - pattern: call.request.$F(...)
+                      - metavariable-regex:
+                          metavariable: $F
+                          regex: ^(acceptCharsetItems|acceptEncodingItems|acceptItems|acceptLanguageItems)$
+      - label: returns_url_encoded
+        patterns:
+          - pattern-either:
+              - patterns:
+                  - pattern-either:
+                      - pattern-inside: |
+                          import io.ktor.*
+                          ...
+                      - pattern-inside: |
+                          import io.ktor.server
+                          ...
+                  - patterns:
+                      - pattern-either:
+                          - patterns:
+                              - pattern: server.application.call.request.$F
+                              - metavariable-regex:
+                                  metavariable: $F
+                                  regex: ^(rawQueryParameters|uri)$
+                          - patterns:
+                              - pattern: server.application.call.request.$F(...)
+                              - metavariable-regex:
+                                  metavariable: $F
+                                  regex: ^(document|path|queryString|toLogString)$
+                          - patterns:
+                              - pattern: server.application.call.request.cookies.$F
+                              - metavariable-regex:
+                                  metavariable: $F
+                                  regex: ^(rawCookies)$
+              - patterns:
+                  - pattern-either:
+                      - pattern-inside: |
+                          import io.ktor.server.*
+                          ...
+                      - pattern-inside: |
+                          import io.ktor.server.application
+                          ...
+                  - patterns:
+                      - pattern-either:
+                          - patterns:
+                              - pattern: application.call.request.$F
+                              - metavariable-regex:
+                                  metavariable: $F
+                                  regex: ^(rawQueryParameters|uri)$
+                          - patterns:
+                              - pattern: application.call.request.$F(...)
+                              - metavariable-regex:
+                                  metavariable: $F
+                                  regex: ^(document|path|queryString|toLogString)$
+                          - patterns:
+                              - pattern: application.call.request.cookies.$F
+                              - metavariable-regex:
+                                  metavariable: $F
+                                  regex: ^(rawCookies)$
+              - patterns:
+                  - pattern-either:
+                      - pattern-inside: |
+                          import io.ktor.server.application.*
+                          ...
+                      - pattern-inside: |
+                          import io.ktor.server.application.call
+                          ...
+                  - patterns:
+                      - pattern-either:
+                          - patterns:
+                              - pattern: call.request.$F
+                              - metavariable-regex:
+                                  metavariable: $F
+                                  regex: ^(rawQueryParameters|uri)$
+                          - patterns:
+                              - pattern: call.request.$F(...)
+                              - metavariable-regex:
+                                  metavariable: $F
+                                  regex: ^(document|path|queryString|toLogString)$
+                          - patterns:
+                              - pattern: call.request.cookies.$F
+                              - metavariable-regex:
+                                  metavariable: $F
+                                  regex: ^(rawCookies)$
+      - label: list_access
+        patterns:
+          - patterns:
+              - pattern-either:
+                  - pattern: for (... in $LIST) { ... }
+                  - pattern: for (... in $LIST.size) { ... }
+                  - pattern: $LIST.forEach { ... }
+                  - pattern: $LIST.forEachIndexed { ... }
+                  - pattern: $LIST.listIterator(...)
+                  - pattern: $LIST.iterator(...)
+                  - pattern: $LIST.get(...)
+                  - pattern: $LIST[...]
+                  - pattern: $LIST.subList(...)
+                  - pattern: $LIST.slice(...)
+              - focus-metavariable: $LIST
+        requires: returns_list
+      - label: urldecode
+        patterns:
+          - pattern-either:
+              - patterns:
+                  - pattern-inside: |
+                      import java.net
+                      ...
+                  - patterns:
+                      - pattern: net.URLDecoder.decode($INPUT, ...)
+                      - focus-metavariable: $INPUT
+              - patterns:
+                  - pattern-either:
+                      - pattern-inside: |
+                          import java.net.*
+                          ...
+                      - pattern-inside: |
+                          import java.net.URLDecoder
+                          ...
+                  - patterns:
+                      - pattern: URLDecoder.decode($INPUT, ...)
+                      - focus-metavariable: $INPUT
+        requires: returns_url_encoded
+    severity: WARNING


### PR DESCRIPTION
Closes https://github.com/returntocorp/semgrep/issues/7839

In Analyze_rule, we distribute out formulas like `(x0 ^ x1) v (y0 ^ y1)` into cnf. Let's call `x0 ^ x1` p and `y0 ^ y1` q. Currently, we check that `p` and `q` are individually under 1,000,000 elements to prevent memory blowup. However, `p` and `q` produce a formula that is `p * q` elements long. So, even under these constraints, if `p` and `q` are both large, this step can still take too long.

Instead, what we need to do is guard the result. This PR currently requires that that result be under 10,000,000 elements. It leaves the `p` and `q` restrictions intact just in case. This allows us to take advantage of `List.compare_length` in case we get an incredibly long `p` or `q`.

To consider: do we still need the gates for `p` and `q`? Is it possible to get a list for `p` or `q` so large that traversing it is a problem?

Test plan: will add tests

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
