### PR TITLE
fix: Handle variables in type inference

### DIFF
--- a/src/typing/Typing.ml
+++ b/src/typing/Typing.ml
@@ -101,6 +101,9 @@ and type_of_expr_new lang e : G.name Type.t * G.ident option =
         | _else_ -> Type.NoType
       in
       (t, None)
+  | G.N (Id (ident, id_info)) ->
+      let t = resolved_type_of_id_info lang id_info in
+      (t, Some ident)
   | G.Call ({ e = IdSpecial (Op op, _); _ }, (_l, [ Arg e1; Arg e2 ], _r)) ->
       let t1, _id = type_of_expr_new lang e1 in
       let t2, _id = type_of_expr_new lang e2 in
@@ -125,3 +128,17 @@ and type_of_expr lang e : G.type_ option * G.ident option =
   with
   | None -> type_of_expr_old lang e
   | Some t -> (Some t, id)
+
+and resolved_type_of_id_info lang info : G.name Type.t =
+  match !(info.G.id_type) with
+  | Some t -> type_of_ast_generic_type lang t
+  | None -> Type.NoType
+
+and type_of_ast_generic_type lang t : G.name Type.t =
+  match t.G.t with
+  | G.TyN (Id ((str, _), _) as name) -> (
+      match Type.builtin_type_of_string lang str with
+      | Some t -> Type.Builtin t
+      | None -> Type.N ((name, []), []))
+  (* TODO *)
+  | _else_ -> Type.NoType

--- a/tests/patterns/java/metavar_typed_int.java
+++ b/tests/patterns/java/metavar_typed_int.java
@@ -16,5 +16,11 @@ public class Main {
     System.out.println("1");
     // OK:
     System.out.println("1" + "1");
+
+    int x = 5;
+    // MATCH:
+    System.out.println(x);
+    // MATCH:
+    System.out.println(x + 1);
   }
 }


### PR DESCRIPTION
Out of the two new test cases, previously only the first one matched. We already handled the special case where a typed metavariable was matching a variable with a resolved type. However, the second case did not match.

In many cases we can assume that the type of a variable has already been resolved. This is handled by `Naming_AST.ml` (and the equivalent in Pro Engine). In some languages, type annotations do not exist on all variables, so we might need to recurse on the `id_svalue` if it has one. For now, we assume that naming has been able to resolve the type of a variable.

Test plan: Automated tests

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
