### PR TITLE
osemgrep: move the old file targeting code in Find_targets_old.ml

### DIFF
--- a/src/parsing/tests/Test_parsing.ml
+++ b/src/parsing/tests/Test_parsing.ml
@@ -218,7 +218,7 @@ let dump_tree_sitter_cst lang file =
 let test_parse_tree_sitter lang root_paths =
   let paths = Common.map Common.fullpath root_paths |> File.Path.of_strings in
   let paths, _skipped_paths =
-    Find_targets.files_of_dirs_or_files (Some lang) paths
+    Find_targets_old.files_of_dirs_or_files (Some lang) paths
   in
   let stat_list = ref [] in
   paths |> File.Path.to_strings
@@ -335,7 +335,9 @@ let parsing_common ?(verbose = true) lang files_or_dirs =
     (* = absolute paths *)
     Common.map Common.fullpath files_or_dirs |> File.Path.of_strings
   in
-  let paths, skipped = Find_targets.files_of_dirs_or_files (Some lang) paths in
+  let paths, skipped =
+    Find_targets_old.files_of_dirs_or_files (Some lang) paths
+  in
   let stats =
     paths |> File.Path.to_strings
     |> List.rev_map (fun file ->
@@ -550,7 +552,7 @@ let diff_pfff_tree_sitter xs =
 let test_parse_rules roots =
   let roots = File.Path.of_strings roots in
   let targets, _skipped_paths =
-    Find_targets.files_of_dirs_or_files (Some Lang.Yaml) roots
+    Find_targets_old.files_of_dirs_or_files (Some Lang.Yaml) roots
   in
   targets
   |> List.iter (fun file ->

--- a/src/targeting/Filter_target.ml
+++ b/src/targeting/Filter_target.ml
@@ -90,3 +90,4 @@ let filter_paths (paths : Rule.paths) (path : Fpath.t) : bool =
       | _xs -> require |> List.exists (fun pat -> match_glob pat path)
     in
     is_required
+  [@@profiling]

--- a/src/targeting/Find_targets.ml
+++ b/src/targeting/Find_targets.ml
@@ -103,7 +103,7 @@ let get_reason_for_exclusion sel_events =
       (* shouldn't happen *) fallback
 
 (*************************************************************************)
-(* Finding (new) *)
+(* Finding *)
 (*************************************************************************)
 
 (* We used to call 'git ls-files' when conf.respect_git_ignore was true,
@@ -214,7 +214,7 @@ let walk_skip_and_collect (conf : conf) (ign : Semgrepignore.t)
   (!res, !skipped)
 
 (*************************************************************************)
-(* Grouping (new) *)
+(* Grouping *)
 (*************************************************************************)
 
 (*
@@ -248,7 +248,7 @@ let group_scanning_roots_by_project (conf : conf)
          { project; scanning_roots = xs |> Common.map snd })
 
 (*************************************************************************)
-(* Entry point (new) *)
+(* Entry point *)
 (*************************************************************************)
 
 let get_targets conf scanning_roots =
@@ -266,6 +266,17 @@ let get_targets conf scanning_roots =
          (* step2: filter also the --include and --exclude from the CLI args
           * (the paths: exclude: include: in a rule are handled elsewhere, in
           * Run_semgrep.ml by calling Filter_target.filter_paths
+          *
+          * We currently handle gitignores by creating this
+          * ign below that then will internally use some cache and complex
+          * logic to select files in walk_skip_and_collect().
+          * TODO? we could instead change strategy and accumulate the
+          * current set of applicable gitignore as we walk down the FS
+          * hierarchy. We would not need then to look at each element
+          * in the ppath and look for the present of a .gitignore there;
+          * the job would have already been done as we walked!
+          * We would still need to intialize at the beginning with
+          * the .gitignore of all the parents of the scan_root.
           *)
          let ign =
            Semgrepignore.create ?include_patterns:conf.include_
@@ -301,347 +312,3 @@ let get_targets conf scanning_roots =
   |> fun (paths_list, skipped_paths_list) ->
   (List.flatten paths_list, List.flatten skipped_paths_list)
   [@@profiling]
-
-(*************************************************************************)
-(* Dedup *)
-(*************************************************************************)
-
-(* TODO? use Common2.uniq_eff *)
-let deduplicate_list l =
-  let tbl = Hashtbl.create 1000 in
-  List.filter
-    (fun x ->
-      if Hashtbl.mem tbl x then false
-      else (
-        Hashtbl.add tbl x ();
-        true))
-    l
-
-(*************************************************************************)
-(* Sorting *)
-(*************************************************************************)
-
-let sort_targets_by_decreasing_size targets =
-  targets
-  |> Common.map (fun target -> (target, Common2.filesize target.In.path))
-  |> List.sort (fun (_, (a : int)) (_, b) -> compare b a)
-  |> Common.map fst
-
-let sort_files_by_decreasing_size files =
-  files
-  |> Common.map (fun file -> (file, File.filesize file))
-  |> List.sort (fun (_, (a : int)) (_, b) -> compare b a)
-  |> Common.map fst
-
-(*************************************************************************)
-(* Filtering *)
-(*************************************************************************)
-
-(*
-   Filter files can make suitable targets, independently from specific
-   rules or languages.
-
-   'sort_by_decr_size' should always be true but we keep it as an option
-   for compatibility with the legacy implementation 'files_of_dirs_or_files'.
-
-   '?lang' is a legacy option that shouldn't be used in
-   the language-independent 'select_global_targets'.
-*)
-let global_filter ~opt_lang ~sort_by_decr_size paths =
-  let paths, skipped1 =
-    match opt_lang with
-    | None -> (paths, [])
-    | Some lang -> Guess_lang.inspect_files lang paths
-  in
-  let paths, skipped2 = Skip_target.exclude_big_files paths in
-  let paths, skipped3 = Skip_target.exclude_minified_files paths in
-  let skipped = Common.flatten [ skipped1; skipped2; skipped3 ] in
-  let sorted_paths =
-    if sort_by_decr_size then sort_files_by_decreasing_size paths else paths
-  in
-  let sorted_skipped =
-    List.sort
-      (fun (a : Out.skipped_target) b -> String.compare a.path b.path)
-      skipped
-  in
-  (sorted_paths, sorted_skipped)
-  [@@profiling]
-
-(*************************************************************************)
-(* Grouping (old) *)
-(*************************************************************************)
-
-(*
-   func must return:
-     ((project_kind, project_root), path)
-*)
-let group_by_project_root func paths =
-  Common.map func paths |> Common.group_by fst
-  |> Common.map (fun (k, kv_list) -> (k, Common.map snd kv_list))
-
-(*
-   Identify the project root for each scanning root and group them
-   by project root. If the project_root is specified, then we use that.
-
-   This is important to avoid reading the gitignore and semgrepignore files
-   twice when multiple scanning roots that belong to the same project.
-
-   LATER: use Ppaths rather than full paths as scanning roots
-   when we switch to Semgrepignore.list to list project files.
-
-   TODO? move in paths/Project.ml?
-*)
-let group_roots_by_project conf paths =
-  let force_root =
-    match conf.project_root with
-    | None -> None
-    | Some proj_root -> Some (Project.Git_project, proj_root)
-  in
-  if conf.respect_git_ignore then
-    paths
-    |> group_by_project_root (fun path ->
-           match Git_project.find_any_project_root ?force_root path with
-           | (Project.Other_project as kind), root, git_path ->
-               ((kind, root), Ppath.to_fpath root git_path)
-           | (Project.Git_project as kind), root, git_path ->
-               ((kind, root), Ppath.to_fpath ~root git_path))
-  else
-    (* ignore gitignore files but respect semgrepignore files *)
-    paths
-    |> group_by_project_root (fun path ->
-           let root, git_path = Git_project.force_project_root path in
-           ((Project.Other_project, root), Ppath.to_fpath root git_path))
-
-(*************************************************************************)
-(* Finding (old) *)
-(*************************************************************************)
-
-(* Check if file is a readable regular file.
-
-   This eliminates files that should never be semgrep targets. Among
-   others, this takes care of excluding symbolic links (because we don't
-   want to scan the target twice), directories (which may be returned by
-   globbing or by 'git ls-files' e.g. submodules), and
-   TODO files missing the read permission.
-
-   bugfix: we were using Common2.is_file but it is throwing an exn when a
-   file does exist
-   (which could happen when a file tracked by git was deleted, in which
-   case files_from_git_ls() below would still return it but Common2.is_file()
-   would fail).
-
-   TODO: we could return a skipped_target if the valid is not valid, adding
-   a new Unreadable_file and Inexistent_file to semgrep_output_v1.atd
-   skip_reason type.
-*)
-let is_valid_file file =
-  (* TOPORT: return self._is_valid_file_or_dir(path) and path.is_file() *)
-  try
-    let stat = Unix.stat !!file in
-    stat.Unix.st_kind =*= Unix.S_REG
-  with
-  | Unix.Unix_error (Unix.ENOENT, _, _) -> false
-
-(* python: 'git ls-files' is significantly faster than os.walk when performed
- * on a git project, so identify the git files first, then filter those later.
- *)
-let files_from_git_ls ~cwd:scan_root =
-  (* TOPORT:
-      # Untracked but not ignored files
-      untracked_output = run_git_command([
-              "git",
-              "ls-files",
-              "--other",
-              "--exclude-standard",
-          ])
-      deleted_output = run_git_command(["git", "ls-files", "--deleted"])
-      tracked = self._parse_git_output(tracked_output)
-      untracked_unignored = self._parse_git_output(untracked_output)
-      deleted = self._parse_git_output(deleted_output)
-      return frozenset(tracked | untracked_unignored - deleted)
-  *)
-  (* tracked files *)
-  let tracked_output = Git_wrapper.files_from_git_ls ~cwd:scan_root in
-  tracked_output
-  |> Common.map (fun x -> if !!scan_root = "." then x else scan_root // x)
-  |> List.filter is_valid_file
-  [@@profiling]
-
-(* python: mostly Target.files() method in target_manager.py *)
-let list_regular_files (conf : conf) (scan_root : Fpath.t) : Fpath.t list =
-  (* This may raise Unix.Unix_error.
-   * better: Note that I use Unix.stat below, not Unix.lstat, so we can
-   * actually analyze symlink to dirs!
-   * TODO? improve Unix.Unix_error in Find_targets specific exn?
-   *)
-  match (Unix.stat !!scan_root).st_kind with
-  (* TOPORT? make sure has right permissions (readable) *)
-  | S_REG -> [ scan_root ]
-  | S_DIR ->
-      (* LATER: maybe we should first check whether scan_root is inside
-       * a git repository because respect_git_ignore is set to true by default
-       * and so it does not really mean the user want to use git (and
-       * a possible .gitignore) to list files.
-       *)
-      if conf.respect_git_ignore then (
-        try files_from_git_ls ~cwd:scan_root with
-        | (Git_wrapper.Error _ | Common.CmdError _ | Unix.Unix_error _) as exn
-          ->
-            Logs.info (fun m ->
-                m
-                  "Unable to ignore files ignored by git (%s is not a git \
-                   directory or git is not installed). Running on all files \
-                   instead..."
-                  !!scan_root);
-            Logs.debug (fun m -> m "exn = %s" (Common.exn_to_s exn));
-            List_files.list_regular_files ~keep_root:true scan_root)
-      else
-        (* python: was called Target.files_from_filesystem () *)
-        List_files.list_regular_files ~keep_root:true scan_root
-  | S_LNK ->
-      (* already dereferenced by Unix.stat *)
-      assert false
-  (* TODO? use write_pipe_to_disk? *)
-  | S_FIFO -> []
-  | S_CHR
-  | S_BLK
-  | S_SOCK ->
-      []
-  [@@profiling]
-
-(*************************************************************************)
-(* Entry point (old) *)
-(*************************************************************************)
-
-(* python: mix of Target_manager(), target_manager.get_files_for_rule(),
-   target_manager.get_all_files(), Target(), and Target.files()
-
-   This takes a list of scanning roots which are either regular files
-   or directories. Directories are scanned and we return files discovered
-   in this directories.
-
-   See the documentation for the conf object for the various filters
-   that we apply.
-*)
-let get_targets2 conf scanning_roots =
-  (* python: =~ Target_manager.get_all_files() *)
-  group_roots_by_project conf scanning_roots
-  |> Common.map (fun ((proj_kind, project_root), scanning_roots) ->
-         (* step0: starting point (git ls-files or List_files) *)
-         let paths =
-           scanning_roots
-           |> List.concat_map (fun scan_root ->
-                  list_regular_files conf scan_root)
-           |> deduplicate_list
-         in
-
-         (* step1: filter with .gitignore and .semgrepignore *)
-         let exclusion_mechanism : Semgrepignore.exclusion_mechanism =
-           match (proj_kind : Project.kind) with
-           | Project.Git_project -> Gitignore_and_semgrepignore
-           | Project.Other_project -> Only_semgrepignore
-         in
-         let ign =
-           Semgrepignore.create ?include_patterns:conf.include_
-             ~cli_patterns:conf.exclude ~exclusion_mechanism ~project_root ()
-         in
-         let paths, skipped_paths1 =
-           paths
-           |> Common.partition_either (fun path ->
-                  Logs.debug (fun m -> m "Considering path %s" !!path);
-                  let rel_path =
-                    match Fpath.relativize ~root:project_root path with
-                    | Some x -> x
-                    | None ->
-                        (* we're supposed to be working with clean paths by now *)
-                        assert false
-                  in
-                  let git_path = Ppath.(of_fpath rel_path |> make_absolute) in
-                  let status, selection_events =
-                    Semgrepignore.select ign git_path
-                  in
-                  match status with
-                  | Not_ignored -> Left path
-                  | Ignored ->
-                      Logs.debug (fun m ->
-                          m "Ignoring path %s:\n%s" !!path
-                            (Gitignore.show_selection_events selection_events));
-                      let reason = get_reason_for_exclusion selection_events in
-                      let skipped =
-                        {
-                          Resp.path = !!path;
-                          reason;
-                          details =
-                            "excluded by --include/--exclude, gitignore, or \
-                             semgrepignore";
-                          rule_id = None;
-                        }
-                      in
-                      Right skipped)
-         in
-         (* step2: other filters (big files, minified files) *)
-         let paths, skipped_paths2 =
-           global_filter ~opt_lang:None ~sort_by_decr_size:true paths
-         in
-         (* step3: filter big files (again).
-          * TODO: factorize with Skip_target.exlude_big_files which
-          * uses Flag_semgrep.max_target_bytes instead of the osemgrep CLI
-          * --max-target-bytes flag.
-          *)
-         let paths, skipped_paths3 =
-           paths
-           |> Common.partition_result (fun path ->
-                  let size = File.filesize path in
-                  if conf.max_target_bytes > 0 && size > conf.max_target_bytes
-                  then
-                    Error
-                      {
-                        Resp.path = !!path;
-                        reason = Too_big;
-                        details =
-                          spf "target file size exceeds %i bytes at %i bytes"
-                            conf.max_target_bytes size;
-                        rule_id = None;
-                      }
-                  else Ok path)
-         in
-
-         (* TODO: respect_git_ignore, baseline_handler, etc. *)
-         (paths, skipped_paths1 @ skipped_paths2 @ skipped_paths3))
-  |> (* flatten results that were grouped by project *)
-  List.split
-  |> fun (paths_list, skipped_paths_list) ->
-  (List.flatten paths_list, List.flatten skipped_paths_list)
-  [@@profiling]
-
-(*************************************************************************)
-(* Legacy *)
-(*************************************************************************)
-
-(* Legacy semgrep-core implementation, used when receiving targets from
-   the Python wrapper. *)
-let files_of_dirs_or_files ?(keep_root_files = true)
-    ?(sort_by_decr_size = false) opt_lang roots =
-  let explicit_targets, paths =
-    if keep_root_files then
-      roots
-      |> List.partition (fun path ->
-             Sys.file_exists !!path && not (Sys.is_directory !!path))
-    else (roots, [])
-  in
-  let paths =
-    paths |> File.Path.to_strings
-    |> Common.files_of_dir_or_files_no_vcs_nofilter |> File.Path.of_strings
-  in
-  let paths, skipped = global_filter ~opt_lang ~sort_by_decr_size paths in
-  let paths = explicit_targets @ paths in
-  let sorted_paths =
-    if sort_by_decr_size then sort_files_by_decreasing_size paths
-    else List.sort Fpath.compare paths
-  in
-  let sorted_skipped =
-    List.sort
-      (fun (a : Out.skipped_target) b -> String.compare a.path b.path)
-      skipped
-  in
-  (sorted_paths, sorted_skipped)

--- a/src/targeting/Find_targets.mli
+++ b/src/targeting/Find_targets.mli
@@ -45,46 +45,6 @@ val get_targets :
   Fpath.t list (* scanning roots *) ->
   Fpath.t list * Output_from_core_t.skipped_target list
 
-(* old implementation, more complete for ignoring paths, but returning
- * bad absolute fpaths instead of "readable" fpaths
- *)
-val get_targets2 :
-  conf ->
-  Fpath.t list (* scanning roots *) ->
-  Fpath.t list * Output_from_core_t.skipped_target list
-
-(*
-   [legacy implementation used in semgrep-core]
-
-   Scan a list of folders or files recursively and return a list of files
-   in the requested language. This takes care of ignoring undesirable
-   files, which are returned in the semgrep-core response format.
-
-   Reasons for skipping a file include currently:
-   - the file looks like it's the wrong language.
-   - a 'skip_list.txt' file was found at a conventional location (see
-     skip_list.ml in pfff).
-   - files over a certain size.
-   See Skip_target.ml for more information.
-
-   If keep_root_files is true (the default), regular files passed directly
-   to this function are considered ok and bypass the other filters.
-
-   By default files are sorted alphabetically. Setting
-   'sort_by_decr_size' will sort them be decreasing size instead.
-
-   This is a replacement for Lang.files_of_dirs_or_files.
-*)
-val files_of_dirs_or_files :
-  ?keep_root_files:bool ->
-  ?sort_by_decr_size:bool ->
-  Lang.t option ->
-  Fpath.t list ->
-  Fpath.t list * Output_from_core_t.skipped_target list
-
-(*
-   Sort targets by decreasing size. This is meant for optimizing
-   CPU usage when processing targets in parallel on a fixed number of cores.
-*)
-val sort_targets_by_decreasing_size :
-  Input_to_core_t.target list -> Input_to_core_t.target list
+(* internals used also in Find_targets_old.ml *)
+val get_reason_for_exclusion :
+  Gitignore.selection_event list -> Output_from_core_t.skip_reason

--- a/src/targeting/Find_targets_old.ml
+++ b/src/targeting/Find_targets_old.ml
@@ -1,0 +1,352 @@
+open Common
+open File.Operators
+module In = Input_to_core_t
+module Out = Output_from_core_t
+module Resp = Output_from_core_t
+open Find_targets (* conf type *)
+
+(*************************************************************************)
+(* Prelude *)
+(*************************************************************************)
+(* Deprecated: use Find_targets.ml instead. *)
+
+(*************************************************************************)
+(* Dedup *)
+(*************************************************************************)
+
+(* TODO? use Common2.uniq_eff *)
+let deduplicate_list l =
+  let tbl = Hashtbl.create 1000 in
+  List.filter
+    (fun x ->
+      if Hashtbl.mem tbl x then false
+      else (
+        Hashtbl.add tbl x ();
+        true))
+    l
+
+(*************************************************************************)
+(* Sorting *)
+(*************************************************************************)
+
+(* similar to Run_semgrep.sort_targets_by_decreasing_size, could factorize *)
+let sort_files_by_decreasing_size files =
+  files
+  |> Common.map (fun file -> (file, File.filesize file))
+  |> List.sort (fun (_, (a : int)) (_, b) -> compare b a)
+  |> Common.map fst
+
+(*************************************************************************)
+(* Filtering *)
+(*************************************************************************)
+
+(*
+   Filter files can make suitable targets, independently from specific
+   rules or languages.
+
+   'sort_by_decr_size' should always be true but we keep it as an option
+   for compatibility with the legacy implementation 'files_of_dirs_or_files'.
+
+   '?lang' is a legacy option that shouldn't be used in
+   the language-independent 'select_global_targets'.
+*)
+let global_filter ~opt_lang ~sort_by_decr_size paths =
+  let paths, skipped1 =
+    match opt_lang with
+    | None -> (paths, [])
+    | Some lang -> Guess_lang.inspect_files lang paths
+  in
+  let paths, skipped2 = Skip_target.exclude_big_files paths in
+  let paths, skipped3 = Skip_target.exclude_minified_files paths in
+  let skipped = Common.flatten [ skipped1; skipped2; skipped3 ] in
+  let sorted_paths =
+    if sort_by_decr_size then sort_files_by_decreasing_size paths else paths
+  in
+  let sorted_skipped =
+    List.sort
+      (fun (a : Out.skipped_target) b -> String.compare a.path b.path)
+      skipped
+  in
+  (sorted_paths, sorted_skipped)
+  [@@profiling]
+
+(*************************************************************************)
+(* Grouping (old) *)
+(*************************************************************************)
+
+(*
+   func must return:
+     ((project_kind, project_root), path)
+*)
+let group_by_project_root func paths =
+  Common.map func paths |> Common.group_by fst
+  |> Common.map (fun (k, kv_list) -> (k, Common.map snd kv_list))
+
+(*
+   Identify the project root for each scanning root and group them
+   by project root. If the project_root is specified, then we use that.
+
+   This is important to avoid reading the gitignore and semgrepignore files
+   twice when multiple scanning roots that belong to the same project.
+
+   LATER: use Ppaths rather than full paths as scanning roots
+   when we switch to Semgrepignore.list to list project files.
+
+   TODO? move in paths/Project.ml?
+*)
+let group_roots_by_project conf paths =
+  let force_root =
+    match conf.project_root with
+    | None -> None
+    | Some proj_root -> Some (Project.Git_project, proj_root)
+  in
+  if conf.respect_git_ignore then
+    paths
+    |> group_by_project_root (fun path ->
+           match Git_project.find_any_project_root ?force_root path with
+           | (Project.Other_project as kind), root, git_path ->
+               ((kind, root), Ppath.to_fpath root git_path)
+           | (Project.Git_project as kind), root, git_path ->
+               ((kind, root), Ppath.to_fpath ~root git_path))
+  else
+    (* ignore gitignore files but respect semgrepignore files *)
+    paths
+    |> group_by_project_root (fun path ->
+           let root, git_path = Git_project.force_project_root path in
+           ((Project.Other_project, root), Ppath.to_fpath root git_path))
+
+(*************************************************************************)
+(* Finding (old) *)
+(*************************************************************************)
+
+(* Check if file is a readable regular file.
+
+   This eliminates files that should never be semgrep targets. Among
+   others, this takes care of excluding symbolic links (because we don't
+   want to scan the target twice), directories (which may be returned by
+   globbing or by 'git ls-files' e.g. submodules), and
+   TODO files missing the read permission.
+
+   bugfix: we were using Common2.is_file but it is throwing an exn when a
+   file does exist
+   (which could happen when a file tracked by git was deleted, in which
+   case files_from_git_ls() below would still return it but Common2.is_file()
+   would fail).
+
+   TODO: we could return a skipped_target if the valid is not valid, adding
+   a new Unreadable_file and Inexistent_file to semgrep_output_v1.atd
+   skip_reason type.
+*)
+let is_valid_file file =
+  (* TOPORT: return self._is_valid_file_or_dir(path) and path.is_file() *)
+  try
+    let stat = Unix.stat !!file in
+    stat.Unix.st_kind =*= Unix.S_REG
+  with
+  | Unix.Unix_error (Unix.ENOENT, _, _) -> false
+
+(* python: 'git ls-files' is significantly faster than os.walk when performed
+ * on a git project, so identify the git files first, then filter those later.
+ *)
+let files_from_git_ls ~cwd:scan_root =
+  (* TOPORT:
+      # Untracked but not ignored files
+      untracked_output = run_git_command([
+              "git",
+              "ls-files",
+              "--other",
+              "--exclude-standard",
+          ])
+      deleted_output = run_git_command(["git", "ls-files", "--deleted"])
+      tracked = self._parse_git_output(tracked_output)
+      untracked_unignored = self._parse_git_output(untracked_output)
+      deleted = self._parse_git_output(deleted_output)
+      return frozenset(tracked | untracked_unignored - deleted)
+  *)
+  (* tracked files *)
+  let tracked_output = Git_wrapper.files_from_git_ls ~cwd:scan_root in
+  tracked_output
+  |> Common.map (fun x -> if !!scan_root = "." then x else scan_root // x)
+  |> List.filter is_valid_file
+  [@@profiling]
+
+(* python: mostly Target.files() method in target_manager.py *)
+let list_regular_files (conf : conf) (scan_root : Fpath.t) : Fpath.t list =
+  (* This may raise Unix.Unix_error.
+   * better: Note that I use Unix.stat below, not Unix.lstat, so we can
+   * actually analyze symlink to dirs!
+   * TODO? improve Unix.Unix_error in Find_targets specific exn?
+   *)
+  match (Unix.stat !!scan_root).st_kind with
+  (* TOPORT? make sure has right permissions (readable) *)
+  | S_REG -> [ scan_root ]
+  | S_DIR ->
+      (* LATER: maybe we should first check whether scan_root is inside
+       * a git repository because respect_git_ignore is set to true by default
+       * and so it does not really mean the user want to use git (and
+       * a possible .gitignore) to list files.
+       *)
+      if conf.respect_git_ignore then (
+        try files_from_git_ls ~cwd:scan_root with
+        | (Git_wrapper.Error _ | Common.CmdError _ | Unix.Unix_error _) as exn
+          ->
+            Logs.info (fun m ->
+                m
+                  "Unable to ignore files ignored by git (%s is not a git \
+                   directory or git is not installed). Running on all files \
+                   instead..."
+                  !!scan_root);
+            Logs.debug (fun m -> m "exn = %s" (Common.exn_to_s exn));
+            List_files.list_regular_files ~keep_root:true scan_root)
+      else
+        (* python: was called Target.files_from_filesystem () *)
+        List_files.list_regular_files ~keep_root:true scan_root
+  | S_LNK ->
+      (* already dereferenced by Unix.stat *)
+      assert false
+  (* TODO? use write_pipe_to_disk? *)
+  | S_FIFO -> []
+  | S_CHR
+  | S_BLK
+  | S_SOCK ->
+      []
+  [@@profiling]
+
+(*************************************************************************)
+(* Entry point (old) *)
+(*************************************************************************)
+
+(* python: mix of Target_manager(), target_manager.get_files_for_rule(),
+   target_manager.get_all_files(), Target(), and Target.files()
+
+   This takes a list of scanning roots which are either regular files
+   or directories. Directories are scanned and we return files discovered
+   in this directories.
+
+   See the documentation for the conf object for the various filters
+   that we apply.
+*)
+let get_targets conf scanning_roots =
+  (* python: =~ Target_manager.get_all_files() *)
+  group_roots_by_project conf scanning_roots
+  |> Common.map (fun ((proj_kind, project_root), scanning_roots) ->
+         (* step0: starting point (git ls-files or List_files) *)
+         let paths =
+           scanning_roots
+           |> List.concat_map (fun scan_root ->
+                  list_regular_files conf scan_root)
+           |> deduplicate_list
+         in
+
+         (* step1: filter with .gitignore and .semgrepignore *)
+         let exclusion_mechanism : Semgrepignore.exclusion_mechanism =
+           match (proj_kind : Project.kind) with
+           | Project.Git_project -> Gitignore_and_semgrepignore
+           | Project.Other_project -> Only_semgrepignore
+         in
+         let ign =
+           Semgrepignore.create ?include_patterns:conf.include_
+             ~cli_patterns:conf.exclude ~exclusion_mechanism ~project_root ()
+         in
+         let paths, skipped_paths1 =
+           paths
+           |> Common.partition_either (fun path ->
+                  Logs.debug (fun m -> m "Considering path %s" !!path);
+                  let rel_path =
+                    match Fpath.relativize ~root:project_root path with
+                    | Some x -> x
+                    | None ->
+                        (* we're supposed to be working with clean paths by now *)
+                        assert false
+                  in
+                  let git_path = Ppath.(of_fpath rel_path |> make_absolute) in
+                  let status, selection_events =
+                    Semgrepignore.select ign git_path
+                  in
+                  match status with
+                  | Not_ignored -> Left path
+                  | Ignored ->
+                      Logs.debug (fun m ->
+                          m "Ignoring path %s:\n%s" !!path
+                            (Gitignore.show_selection_events selection_events));
+                      let reason =
+                        Find_targets.get_reason_for_exclusion selection_events
+                      in
+                      let skipped =
+                        {
+                          Resp.path = !!path;
+                          reason;
+                          details =
+                            "excluded by --include/--exclude, gitignore, or \
+                             semgrepignore";
+                          rule_id = None;
+                        }
+                      in
+                      Right skipped)
+         in
+         (* step2: other filters (big files, minified files) *)
+         let paths, skipped_paths2 =
+           global_filter ~opt_lang:None ~sort_by_decr_size:true paths
+         in
+         (* step3: filter big files (again).
+          * TODO: factorize with Skip_target.exlude_big_files which
+          * uses Flag_semgrep.max_target_bytes instead of the osemgrep CLI
+          * --max-target-bytes flag.
+          *)
+         let paths, skipped_paths3 =
+           paths
+           |> Common.partition_result (fun path ->
+                  let size = File.filesize path in
+                  if conf.max_target_bytes > 0 && size > conf.max_target_bytes
+                  then
+                    Error
+                      {
+                        Resp.path = !!path;
+                        reason = Too_big;
+                        details =
+                          spf "target file size exceeds %i bytes at %i bytes"
+                            conf.max_target_bytes size;
+                        rule_id = None;
+                      }
+                  else Ok path)
+         in
+
+         (* TODO: respect_git_ignore, baseline_handler, etc. *)
+         (paths, skipped_paths1 @ skipped_paths2 @ skipped_paths3))
+  |> (* flatten results that were grouped by project *)
+  List.split
+  |> fun (paths_list, skipped_paths_list) ->
+  (List.flatten paths_list, List.flatten skipped_paths_list)
+  [@@profiling]
+
+(*************************************************************************)
+(* Legacy *)
+(*************************************************************************)
+
+(* Legacy semgrep-core implementation, used when receiving targets from
+   the Python wrapper. *)
+let files_of_dirs_or_files ?(keep_root_files = true)
+    ?(sort_by_decr_size = false) opt_lang roots =
+  let explicit_targets, paths =
+    if keep_root_files then
+      roots
+      |> List.partition (fun path ->
+             Sys.file_exists !!path && not (Sys.is_directory !!path))
+    else (roots, [])
+  in
+  let paths =
+    paths |> File.Path.to_strings
+    |> Common.files_of_dir_or_files_no_vcs_nofilter |> File.Path.of_strings
+  in
+  let paths, skipped = global_filter ~opt_lang ~sort_by_decr_size paths in
+  let paths = explicit_targets @ paths in
+  let sorted_paths =
+    if sort_by_decr_size then sort_files_by_decreasing_size paths
+    else List.sort Fpath.compare paths
+  in
+  let sorted_skipped =
+    List.sort
+      (fun (a : Out.skipped_target) b -> String.compare a.path b.path)
+      skipped
+  in
+  (sorted_paths, sorted_skipped)

--- a/src/targeting/Find_targets_old.mli
+++ b/src/targeting/Find_targets_old.mli
@@ -1,0 +1,36 @@
+(* old implementation, returning bad absolute fpaths instead of
+ * "readable" fpaths
+ *)
+val get_targets :
+  Find_targets.conf ->
+  Fpath.t list (* scanning roots *) ->
+  Fpath.t list * Output_from_core_t.skipped_target list
+
+(*
+   [legacy implementation used in semgrep-core]
+
+   Scan a list of folders or files recursively and return a list of files
+   in the requested language. This takes care of ignoring undesirable
+   files, which are returned in the semgrep-core response format.
+
+   Reasons for skipping a file include currently:
+   - the file looks like it's the wrong language.
+   - a 'skip_list.txt' file was found at a conventional location (see
+     skip_list.ml in pfff).
+   - files over a certain size.
+   See Skip_target.ml for more information.
+
+   If keep_root_files is true (the default), regular files passed directly
+   to this function are considered ok and bypass the other filters.
+
+   By default files are sorted alphabetically. Setting
+   'sort_by_decr_size' will sort them be decreasing size instead.
+
+   This is a replacement for Lang.files_of_dirs_or_files.
+*)
+val files_of_dirs_or_files :
+  ?keep_root_files:bool ->
+  ?sort_by_decr_size:bool ->
+  Lang.t option ->
+  Fpath.t list ->
+  Fpath.t list * Output_from_core_t.skipped_target list


### PR DESCRIPTION
test plan:
make core
make osempass


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)