### PR TITLE
fix: Handle boolean operators in new type inference

### DIFF
--- a/tests/patterns/java/metavar_typed_bool.java
+++ b/tests/patterns/java/metavar_typed_bool.java
@@ -1,0 +1,71 @@
+public class metavar_typed_bool {
+  public static void main(String[] args) {
+    boolean x = true;
+    // OK:
+    System.out.println(5);
+    // MATCH:
+    System.out.println(x);
+    // MATCH:
+    System.out.println(true);
+    // MATCH:
+    System.out.println(1 == 2);
+    // MATCH:
+    System.out.println(true == true);
+    // MATCH:
+    System.out.println(true != false);
+    // Even though we can't resolve this name, we can still conclude that the
+    // result of a comparison is a boolean. If you comment out this case, and
+    // the others with unresolved names, you can run this test file.
+    // MATCH:
+    System.out.println(unresolved != 3);
+    // MATCH:
+    System.out.println(3 > 4);
+    // MATCH:
+    System.out.println(3 >= 4);
+    // MATCH:
+    System.out.println(3 < 4);
+    // MATCH:
+    System.out.println(3 <= 4);
+    // MATCH:
+    System.out.println(true && false);
+    // MATCH:
+    System.out.println(true || false);
+    // MATCH:
+    System.out.println(!(1 == 2));
+
+    metavar_typed_bool.overloaded();
+  }
+
+  public static void overloaded() {
+    // Overloaded operators, where the type of the operands determines whether
+    // they are boolean operators or bitwise operators
+
+    boolean x = true;
+
+    // When operands are booleans, this is xor
+    // MATCH:
+    System.out.println(x ^ false);
+    // When one operand is unresolved but the other is a boolean, we can assume
+    // that the result is a boolean.
+    // MATCH:
+    System.out.println(unresolved ^ false);
+    // MATCH:
+    System.out.println(false ^ unresolved);
+    // When operands are ints, this is bitwise xor
+    // OK:
+    System.out.println(1 ^ 2);
+    // OK:
+    System.out.println(unresolved1 ^ unresolved2);
+
+    // When operands are boolean, these are non-short-circuiting and/or
+    // MATCH:
+    System.out.println(x | false);
+    // MATCH:
+    System.out.println(x & false);
+    // When operands are ints, thse are bitwise and/or
+    // OK:
+    System.out.println(3 | 4);
+    // OK:
+    System.out.println(3 & 4);
+  }
+}

--- a/tests/patterns/java/metavar_typed_bool.sgrep
+++ b/tests/patterns/java/metavar_typed_bool.sgrep
@@ -1,0 +1,1 @@
+System.out.println((boolean $X))


### PR DESCRIPTION
This includes some which are overloaded in Java. See the explanations inline and in the tests.

Test plan: Automated tests

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
