### PR TITLE
Makefile: in minimal-build target, only build semgrep-core and osemgrep

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -72,6 +72,10 @@ top.ml
 **/.hypothesis/
 **/.pytest_cache/
 
+# src/targeting/Unit_guess_lang.ml creates a top-level tmp folder
+# "We don't delete the files when we're done because it's easier when troubleshooting tests."
+tmp/
+
 # Translations
 **/*.mo
 **/*.pot

--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,10 @@ coverage.xml
 .hypothesis/
 .pytest_cache/
 
+# src/targeting/Unit_guess_lang.ml creates a top-level tmp folder
+# "We don't delete the files when we're done because it's easier when troubleshooting tests."
+/tmp/
+
 # Translations
 *.mo
 *.pot

--- a/Makefile
+++ b/Makefile
@@ -120,8 +120,8 @@ symlink-core-for-cli:
 
 # Minimal build of the semgrep-core executable. Intended for the docker build.
 # Requires the environment variables set by the included file above.
-# Builds only the two main binaries mainly needed for development. If you
-# need other binaries, look at the rules below.
+# Builds only the two main binaries needed for development.
+# If you need other binaries, look at the rules below.
 .PHONY: minimal-build
 minimal-build:
 	dune build _build/install/default/bin/semgrep-core _build/install/default/bin/osemgrep

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,6 @@ build:
 core:
 	rm -f bin
 	$(MAKE) minimal-build
-	dune build ./_build/default/tests/test.exe
 	# make executables easily accessible for manual testing:
 	test -e bin || ln -s _build/install/default/bin .
 
@@ -250,9 +249,8 @@ test:
 core-test: core
 	# The test executable has a few options that can be useful
 	# in some contexts.
-	# The following command ensures that we can call 'test.exe --help'
-	# without having to chdir into the test data folder.
-	./_build/default/tests/test.exe --show-errors --help 2>&1 >/dev/null
+	dune build ./_build/default/src/tests/test.exe
+	cd ./_build/default/src/tests/ && ./test.exe --show-errors --help 2>&1 >/dev/null
 	$(MAKE) -C libs/spacegrep test
 	dune runtest -f --no-buffer
 

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,6 @@ build:
 core:
 	rm -f bin
 	$(MAKE) minimal-build
-	dune build
 	dune build ./_build/default/tests/test.exe
 	# make executables easily accessible for manual testing:
 	test -e bin || ln -s _build/install/default/bin .
@@ -138,6 +137,34 @@ build-docker:
 build-otarzan:
 	rm -f bin
 	dune build _build/install/default/bin/otarzan
+	test -e bin || ln -s _build/install/default/bin .
+
+# Build just this executable
+.PHONY: build-pfff
+build-pfff:
+	rm -f bin
+	dune build _build/install/default/bin/pfff
+	test -e bin || ln -s _build/install/default/bin .
+
+# Build just this executable
+.PHONY: build-parse-cairo
+build-parse-cairo:
+	rm -f bin
+	dune build _build/install/default/bin/parse-cairo
+	test -e bin || ln -s _build/install/default/bin .
+
+# Build just this executable
+.PHONY: build-spacegrep
+build-spacegrep:
+	rm -f bin
+	dune build _build/install/default/bin/spacegrep
+	test -e bin || ln -s _build/install/default/bin .
+
+# Build just this executable
+.PHONY: build-oncall
+build-oncall:
+	rm -f bin
+	dune build _build/install/default/bin/oncall
 	test -e bin || ln -s _build/install/default/bin .
 
 # Build the js_of_ocaml portion of the semgrep javascript packages

--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,7 @@ build:
 core:
 	rm -f bin
 	$(MAKE) minimal-build
+	dune build
 	dune build ./_build/default/tests/test.exe
 	# make executables easily accessible for manual testing:
 	test -e bin || ln -s _build/install/default/bin .
@@ -123,7 +124,7 @@ symlink-core-for-cli:
 # Requires the environment variables set by the included file above.
 .PHONY: minimal-build
 minimal-build:
-	dune build
+	dune build _build/install/default/bin/semgrep-core _build/install/default/bin/osemgrep
 
 # It is better to run this from a fresh repo or after a 'make clean',
 # to not send too much data to the Docker daemon.

--- a/Makefile
+++ b/Makefile
@@ -246,7 +246,7 @@ test:
 # the cached file under _build/.../tests/ is still the old one.
 #coupling: this is run by .github/workflow/tests.yml
 .PHONY: core-test
-core-test: core
+core-test: core build-spacegrep
 	# The test executable has a few options that can be useful
 	# in some contexts.
 	dune build ./_build/default/src/tests/test.exe

--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,8 @@ symlink-core-for-cli:
 
 # Minimal build of the semgrep-core executable. Intended for the docker build.
 # Requires the environment variables set by the included file above.
+# Builds only the two main binaries mainly needed for development. If you
+# need other binaries, look at the rules below.
 .PHONY: minimal-build
 minimal-build:
 	dune build _build/install/default/bin/semgrep-core _build/install/default/bin/osemgrep

--- a/Makefile
+++ b/Makefile
@@ -250,7 +250,7 @@ core-test: core
 	# The test executable has a few options that can be useful
 	# in some contexts.
 	dune build ./_build/default/src/tests/test.exe
-	cd ./_build/default/src/tests/ && ./test.exe --show-errors --help 2>&1 >/dev/null
+	./_build/default/src/tests/test.exe --show-errors --help 2>&1 >/dev/null
 	$(MAKE) -C libs/spacegrep test
 	dune runtest -f --no-buffer
 

--- a/Makefile
+++ b/Makefile
@@ -250,6 +250,8 @@ core-test: core
 	# The test executable has a few options that can be useful
 	# in some contexts.
 	dune build ./_build/default/src/tests/test.exe
+	# The following command ensures that we can call 'test.exe --help'
+	# from the directory of the checkou
 	./_build/default/src/tests/test.exe --show-errors --help 2>&1 >/dev/null
 	$(MAKE) -C libs/spacegrep test
 	dune runtest -f --no-buffer

--- a/languages/cpp/menhir/unit_parsing_cpp.ml
+++ b/languages/cpp/menhir/unit_parsing_cpp.ml
@@ -15,8 +15,8 @@ let parse file =
 (* Unit tests *)
 (*****************************************************************************)
 
-(* ran from _build/default/tests/ hence the '..'s below *)
-let tests_path = "../../../../tests"
+(* ran from the root of the semgrep repository *)
+let tests_path = "tests"
 
 let tests =
   Testutil.pack_tests "parsing_cpp"

--- a/languages/cpp/menhir/unit_parsing_cpp.ml
+++ b/languages/cpp/menhir/unit_parsing_cpp.ml
@@ -16,7 +16,7 @@ let parse file =
 (*****************************************************************************)
 
 (* ran from _build/default/tests/ hence the '..'s below *)
-let tests_path = "../../../tests"
+let tests_path = "../../../../tests"
 
 let tests =
   Testutil.pack_tests "parsing_cpp"

--- a/languages/go/menhir/unit_parsing_go.ml
+++ b/languages/go/menhir/unit_parsing_go.ml
@@ -5,7 +5,7 @@ open Common
 (*****************************************************************************)
 
 (* ran from _build/default/tests/ hence the '..'s below *)
-let tests_path = "../../../tests"
+let tests_path = "../../../../tests"
 
 let tests =
   Testutil.pack_tests "parsing_go"

--- a/languages/go/menhir/unit_parsing_go.ml
+++ b/languages/go/menhir/unit_parsing_go.ml
@@ -4,8 +4,8 @@ open Common
 (* Unit tests *)
 (*****************************************************************************)
 
-(* ran from _build/default/tests/ hence the '..'s below *)
-let tests_path = "../../../../tests"
+(* ran from the root of the semgrep repository *)
+let tests_path = "tests"
 
 let tests =
   Testutil.pack_tests "parsing_go"

--- a/languages/java/menhir/unit_parsing_java.ml
+++ b/languages/java/menhir/unit_parsing_java.ml
@@ -6,8 +6,8 @@ module Vis = Visitor_java
 (* Unit tests *)
 (*****************************************************************************)
 
-(* ran from _build/default/tests/ hence the '..'s below *)
-let tests_path = "../../../../tests"
+(* ran from the root of the semgrep repository *)
+let tests_path = "tests"
 
 let tests =
   Testutil.pack_tests "parsing_java"

--- a/languages/java/menhir/unit_parsing_java.ml
+++ b/languages/java/menhir/unit_parsing_java.ml
@@ -7,7 +7,7 @@ module Vis = Visitor_java
 (*****************************************************************************)
 
 (* ran from _build/default/tests/ hence the '..'s below *)
-let tests_path = "../../../tests"
+let tests_path = "../../../../tests"
 
 let tests =
   Testutil.pack_tests "parsing_java"

--- a/languages/javascript/menhir/unit_parsing_js.ml
+++ b/languages/javascript/menhir/unit_parsing_js.ml
@@ -5,7 +5,7 @@ open Common
 (*****************************************************************************)
 
 (* ran from _build/default/tests/ hence the '..'s below *)
-let tests_path = "../../../tests"
+let tests_path = "../../../../tests"
 
 let tests =
   Testutil.pack_tests "parsing_js"

--- a/languages/javascript/menhir/unit_parsing_js.ml
+++ b/languages/javascript/menhir/unit_parsing_js.ml
@@ -4,8 +4,8 @@ open Common
 (* Unit tests *)
 (*****************************************************************************)
 
-(* ran from _build/default/tests/ hence the '..'s below *)
-let tests_path = "../../../../tests"
+(* ran from the root of the semgrep repository *)
+let tests_path = "tests"
 
 let tests =
   Testutil.pack_tests "parsing_js"

--- a/languages/json/menhir/unit_parsing_json.ml
+++ b/languages/json/menhir/unit_parsing_json.ml
@@ -4,8 +4,8 @@ open Common
 (* Unit tests *)
 (*****************************************************************************)
 
-(* ran from _build/default/tests/ hence the '..'s below *)
-let tests_path = "../../../../tests"
+(* ran from the root of the semgrep repository *)
+let tests_path = "tests"
 
 let tests =
   Testutil.pack_tests "parsing_json"

--- a/languages/json/menhir/unit_parsing_json.ml
+++ b/languages/json/menhir/unit_parsing_json.ml
@@ -5,7 +5,7 @@ open Common
 (*****************************************************************************)
 
 (* ran from _build/default/tests/ hence the '..'s below *)
-let tests_path = "../../../tests"
+let tests_path = "../../../../tests"
 
 let tests =
   Testutil.pack_tests "parsing_json"

--- a/languages/ocaml/menhir/unit_parsing_ml.ml
+++ b/languages/ocaml/menhir/unit_parsing_ml.ml
@@ -4,8 +4,8 @@ open Common
 (* Unit tests *)
 (*****************************************************************************)
 
-(* ran from _build/default/tests/ hence the '..'s below *)
-let tests_path = "../../../../tests"
+(* ran from the root of the semgrep repository *)
+let tests_path = "tests"
 
 let tests =
   Testutil.pack_tests "parsing_ml"

--- a/languages/ocaml/menhir/unit_parsing_ml.ml
+++ b/languages/ocaml/menhir/unit_parsing_ml.ml
@@ -5,7 +5,7 @@ open Common
 (*****************************************************************************)
 
 (* ran from _build/default/tests/ hence the '..'s below *)
-let tests_path = "../../../tests"
+let tests_path = "../../../../tests"
 
 let tests =
   Testutil.pack_tests "parsing_ml"

--- a/languages/php/menhir/unit_parsing_php.ml
+++ b/languages/php/menhir/unit_parsing_php.ml
@@ -25,8 +25,8 @@ module Flag = Flag_parsing
 (* Unit tests *)
 (*****************************************************************************)
 
-(* ran from _build/default/tests/ hence the '..'s below *)
-let tests_path = "../../../../tests"
+(* ran from the root of the semgrep repository *)
+let tests_path = "tests"
 
 let tests =
   Testutil.pack_tests "parsing_php"

--- a/languages/php/menhir/unit_parsing_php.ml
+++ b/languages/php/menhir/unit_parsing_php.ml
@@ -26,7 +26,7 @@ module Flag = Flag_parsing
 (*****************************************************************************)
 
 (* ran from _build/default/tests/ hence the '..'s below *)
-let tests_path = "../../../tests"
+let tests_path = "../../../../tests"
 
 let tests =
   Testutil.pack_tests "parsing_php"

--- a/languages/python/menhir/Unit_parsing_python.ml
+++ b/languages/python/menhir/Unit_parsing_python.ml
@@ -5,7 +5,7 @@ open Common
 (*****************************************************************************)
 
 (* ran from _build/default/tests/ hence the '..'s below *)
-let tests_path = "../../../tests"
+let tests_path = "../../../../tests"
 
 let tests =
   Testutil.pack_tests "parsing_python"

--- a/languages/python/menhir/Unit_parsing_python.ml
+++ b/languages/python/menhir/Unit_parsing_python.ml
@@ -4,8 +4,8 @@ open Common
 (* Unit tests *)
 (*****************************************************************************)
 
-(* ran from _build/default/tests/ hence the '..'s below *)
-let tests_path = "../../../../tests"
+(* ran from the root of the semgrep repository *)
+let tests_path = "tests"
 
 let tests =
   Testutil.pack_tests "parsing_python"

--- a/languages/regexp/Unit_parsing.ml
+++ b/languages/regexp/Unit_parsing.ml
@@ -5,7 +5,7 @@
 open Common
 
 (* ran from _build/default/tests/ hence the '..'s below *)
-let tests_path = "../../../tests"
+let tests_path = "../../../../tests"
 
 let test_valid_files dialect rel_path () =
   let dir = Filename.concat tests_path rel_path in

--- a/languages/regexp/Unit_parsing.ml
+++ b/languages/regexp/Unit_parsing.ml
@@ -4,8 +4,8 @@
 
 open Common
 
-(* ran from _build/default/tests/ hence the '..'s below *)
-let tests_path = "../../../../tests"
+(* ran from the root of the semgrep repository *)
+let tests_path = "tests"
 
 let test_valid_files dialect rel_path () =
   let dir = Filename.concat tests_path rel_path in

--- a/languages/ruby/dyp/unit_parsing_ruby.ml
+++ b/languages/ruby/dyp/unit_parsing_ruby.ml
@@ -4,7 +4,8 @@ open Common
 (* Unit tests *)
 (*****************************************************************************)
 
-let tests_path = "../../../../tests"
+(* ran from the root of the semgrep repository *)
+let tests_path = "tests"
 
 let tests =
   Testutil.pack_tests "parsing_ruby"

--- a/languages/ruby/dyp/unit_parsing_ruby.ml
+++ b/languages/ruby/dyp/unit_parsing_ruby.ml
@@ -4,7 +4,7 @@ open Common
 (* Unit tests *)
 (*****************************************************************************)
 
-let tests_path = "../../../tests"
+let tests_path = "../../../../tests"
 
 let tests =
   Testutil.pack_tests "parsing_ruby"

--- a/languages/scala/recursive_descent/Unit_parsing_scala.ml
+++ b/languages/scala/recursive_descent/Unit_parsing_scala.ml
@@ -4,8 +4,8 @@ open Common
 (* Unit tests *)
 (*****************************************************************************)
 
-(* ran from _build/default/tests/ hence the '..'s below *)
-let tests_path = "../../../../tests"
+(* ran from the root of the semgrep repository *)
+let tests_path = "tests"
 
 let tests =
   Testutil.pack_tests "parsing_scala"

--- a/languages/scala/recursive_descent/Unit_parsing_scala.ml
+++ b/languages/scala/recursive_descent/Unit_parsing_scala.ml
@@ -5,7 +5,7 @@ open Common
 (*****************************************************************************)
 
 (* ran from _build/default/tests/ hence the '..'s below *)
-let tests_path = "../../../tests"
+let tests_path = "../../../../tests"
 
 let tests =
   Testutil.pack_tests "parsing_scala"

--- a/libs/spacegrep/Makefile
+++ b/libs/spacegrep/Makefile
@@ -15,17 +15,18 @@ symlinks:
 	ln -sf spacegrep bin/spacecat
 
 .PHONY: test
-test: build
+test:
 	dune exec -- src/test/test.exe -e
+	$(MAKE) symlinks
 	$(MAKE) examples > /dev/null
 	$(MAKE) show-perf > /dev/null
 
 .PHONY: examples
-examples: build
+examples:
 	./scripts/run-examples
 
 .PHONY: show-perf
-show-perf: build
+show-perf:
 	./scripts/show-perf
 
 .PHONY: clean

--- a/libs/spacegrep/Makefile
+++ b/libs/spacegrep/Makefile
@@ -15,18 +15,17 @@ symlinks:
 	ln -sf spacegrep bin/spacecat
 
 .PHONY: test
-test:
+test: build
 	dune exec -- src/test/test.exe -e
-	$(MAKE) symlinks
 	$(MAKE) examples > /dev/null
 	$(MAKE) show-perf > /dev/null
 
 .PHONY: examples
-examples:
+examples: build
 	./scripts/run-examples
 
 .PHONY: show-perf
-show-perf:
+show-perf: build
 	./scripts/show-perf
 
 .PHONY: clean

--- a/src/analyzing/tests/Unit_dataflow.ml
+++ b/src/analyzing/tests/Unit_dataflow.ml
@@ -8,7 +8,7 @@ open File.Operators
 let timeout_secs = 1.0
 
 (* ran from _build/default/tests/ hence the '..'s below *)
-let tests_path = "../../../tests"
+let tests_path = "../../../../tests"
 
 let tests parse_program =
   Testutil.pack_tests "dataflow_python"

--- a/src/analyzing/tests/Unit_dataflow.ml
+++ b/src/analyzing/tests/Unit_dataflow.ml
@@ -7,8 +7,8 @@ open File.Operators
 
 let timeout_secs = 1.0
 
-(* ran from _build/default/tests/ hence the '..'s below *)
-let tests_path = "../../../../tests"
+(* ran from the root of the semgrep repository *)
+let tests_path = "tests"
 
 let tests parse_program =
   Testutil.pack_tests "dataflow_python"

--- a/src/engine/Unit_engine.ml
+++ b/src/engine/Unit_engine.ml
@@ -25,9 +25,9 @@ let logger = Logging.get_logger [ __MODULE__ ]
 (*****************************************************************************)
 
 (* TODO: move these to the "main" for the test suite. *)
-(* ran from _build/default/tests/ hence the '..'s below *)
-let tests_path = Fpath.v "../../../../tests"
-let tests_path_patterns = Fpath.v "../../../../tests/patterns"
+(* ran from the root of the semgrep repository *)
+let tests_path = Fpath.v "tests"
+let tests_path_patterns = tests_path / "patterns"
 let polyglot_pattern_path = tests_path_patterns / "POLYGLOT"
 
 (*****************************************************************************)

--- a/src/engine/Unit_engine.ml
+++ b/src/engine/Unit_engine.ml
@@ -26,8 +26,8 @@ let logger = Logging.get_logger [ __MODULE__ ]
 
 (* TODO: move these to the "main" for the test suite. *)
 (* ran from _build/default/tests/ hence the '..'s below *)
-let tests_path = Fpath.v "../../../tests"
-let tests_path_patterns = Fpath.v "../../../tests/patterns"
+let tests_path = Fpath.v "../../../../tests"
+let tests_path_patterns = Fpath.v "../../../../tests/patterns"
 let polyglot_pattern_path = tests_path_patterns / "POLYGLOT"
 
 (*****************************************************************************)

--- a/src/experiments/synthesizing/Unit_synthesizer.ml
+++ b/src/experiments/synthesizing/Unit_synthesizer.ml
@@ -7,7 +7,7 @@ module PPG = Pretty_print_AST
 (*****************************************************************************)
 (* Semgrep Unit tests *)
 (*****************************************************************************)
-let test_path = Fpath.v "../../../tests/synthesizing"
+let test_path = Fpath.v "../../../../tests/synthesizing"
 
 (* Format: file, range of code to infer, expected patterns *)
 let python_tests =

--- a/src/experiments/synthesizing/Unit_synthesizer.ml
+++ b/src/experiments/synthesizing/Unit_synthesizer.ml
@@ -7,7 +7,8 @@ module PPG = Pretty_print_AST
 (*****************************************************************************)
 (* Semgrep Unit tests *)
 (*****************************************************************************)
-let test_path = Fpath.v "../../../../tests/synthesizing"
+(* ran from the root of the semgrep repository *)
+let test_path = Fpath.v "tests/synthesizing"
 
 (* Format: file, range of code to infer, expected patterns *)
 let python_tests =

--- a/src/experiments/synthesizing/Unit_synthesizer_targets.ml
+++ b/src/experiments/synthesizing/Unit_synthesizer_targets.ml
@@ -4,7 +4,7 @@ module R = Rule
 module E = Semgrep_error_code
 module Out = Output_from_core_t
 
-let test_path = "../../../tests/synthesizing/targets/"
+let test_path = "../../../../tests/synthesizing/targets/"
 
 (* Format: file, list of target ranges, expected pattern line. *)
 let stmt_tests =

--- a/src/experiments/synthesizing/Unit_synthesizer_targets.ml
+++ b/src/experiments/synthesizing/Unit_synthesizer_targets.ml
@@ -4,7 +4,8 @@ module R = Rule
 module E = Semgrep_error_code
 module Out = Output_from_core_t
 
-let test_path = "../../../../tests/synthesizing/targets/"
+(* ran from the root of the semgrep repository *)
+let test_path = "tests/synthesizing/targets/"
 
 (* Format: file, list of target ranges, expected pattern line. *)
 let stmt_tests =

--- a/src/metachecking/Unit_metachecking.ml
+++ b/src/metachecking/Unit_metachecking.ml
@@ -14,7 +14,7 @@ module E = Semgrep_error_code
 (*****************************************************************************)
 
 (* ran from _build/default/tests/ hence the '..'s below *)
-let tests_path = Fpath.v "../../../tests"
+let tests_path = Fpath.v "../../../../tests"
 
 (*****************************************************************************)
 (* Helpers *)

--- a/src/metachecking/Unit_metachecking.ml
+++ b/src/metachecking/Unit_metachecking.ml
@@ -13,8 +13,8 @@ module E = Semgrep_error_code
 (* Constants *)
 (*****************************************************************************)
 
-(* ran from _build/default/tests/ hence the '..'s below *)
-let tests_path = Fpath.v "../../../../tests"
+(* ran from the root of the semgrep repository *)
+let tests_path = Fpath.v "tests"
 
 (*****************************************************************************)
 (* Helpers *)

--- a/src/naming/Unit_naming_generic.ml
+++ b/src/naming/Unit_naming_generic.ml
@@ -5,8 +5,8 @@ open File.Operators
 (* Unit tests *)
 (*****************************************************************************)
 
-(* ran from _build/default/tests/ hence the '..'s below *)
-let tests_path = "../../../../tests"
+(* ran from the root of the semgrep repository *)
+let tests_path = "tests"
 
 let tests parse_program =
   Testutil.pack_tests "naming generic"

--- a/src/naming/Unit_naming_generic.ml
+++ b/src/naming/Unit_naming_generic.ml
@@ -6,7 +6,7 @@ open File.Operators
 (*****************************************************************************)
 
 (* ran from _build/default/tests/ hence the '..'s below *)
-let tests_path = "../../../tests"
+let tests_path = "../../../../tests"
 
 let tests parse_program =
   Testutil.pack_tests "naming generic"

--- a/src/naming/Unit_typing_generic.ml
+++ b/src/naming/Unit_typing_generic.ml
@@ -6,8 +6,8 @@ module G = AST_generic
 (* Unit tests *)
 (*****************************************************************************)
 
-(* ran from _build/default/tests/ hence the '..'s below *)
-let tests_path = Fpath.v "../../../../tests"
+(* ran from the root of the semgrep repository *)
+let tests_path = Fpath.v "tests"
 let tests_path_typing = tests_path / "typing"
 
 let tests parse_program parse_pattern =

--- a/src/naming/Unit_typing_generic.ml
+++ b/src/naming/Unit_typing_generic.ml
@@ -7,7 +7,7 @@ module G = AST_generic
 (*****************************************************************************)
 
 (* ran from _build/default/tests/ hence the '..'s below *)
-let tests_path = Fpath.v "../../../tests"
+let tests_path = Fpath.v "../../../../tests"
 let tests_path_typing = tests_path / "typing"
 
 let tests parse_program parse_pattern =

--- a/src/parsing/Unit_parsing.ml
+++ b/src/parsing/Unit_parsing.ml
@@ -12,9 +12,9 @@ module E = Semgrep_error_code
 (* Constants *)
 (*****************************************************************************)
 
-(* ran from _build/default/tests/ hence the '..'s below *)
-let tests_path = Fpath.v "../../tests"
-let tests_path_parsing = Fpath.v "../../../../tests/parsing"
+(* ran from the root of the semgrep repository *)
+let tests_path = Fpath.v "tests"
+let tests_path_parsing = tests_path / "parsing"
 
 (*****************************************************************************)
 (* Helpers *)

--- a/src/parsing/Unit_parsing.ml
+++ b/src/parsing/Unit_parsing.ml
@@ -13,8 +13,8 @@ module E = Semgrep_error_code
 (*****************************************************************************)
 
 (* ran from _build/default/tests/ hence the '..'s below *)
-let tests_path = Fpath.v "../../../tests"
-let tests_path_parsing = Fpath.v "../../../tests/parsing"
+let tests_path = Fpath.v "../../tests"
+let tests_path_parsing = Fpath.v "../../../../tests/parsing"
 
 (*****************************************************************************)
 (* Helpers *)

--- a/src/reporting/Unit_reporting.ml
+++ b/src/reporting/Unit_reporting.ml
@@ -16,9 +16,9 @@ module Out = Output_from_core_j
 (*****************************************************************************)
 
 (* ran from _build/default/tests/ hence the '..'s below *)
-let tests_path = "../../../tests"
-let e2e_path = "../../../cli/tests/e2e/snapshots/"
-let e2e_ci_path = "../../../cli/tests/e2e/snapshots/test_ci/test_full_run"
+let tests_path = "../../../../tests"
+let e2e_path = "../../../../cli/tests/e2e/snapshots/"
+let e2e_ci_path = "../../../../cli/tests/e2e/snapshots/test_ci/test_full_run"
 
 (*****************************************************************************)
 (* Semgrep-core output *)

--- a/src/reporting/Unit_reporting.ml
+++ b/src/reporting/Unit_reporting.ml
@@ -15,10 +15,10 @@ module Out = Output_from_core_j
 (* Constants *)
 (*****************************************************************************)
 
-(* ran from _build/default/tests/ hence the '..'s below *)
-let tests_path = "../../../../tests"
-let e2e_path = "../../../../cli/tests/e2e/snapshots/"
-let e2e_ci_path = "../../../../cli/tests/e2e/snapshots/test_ci/test_full_run"
+(* ran from the root of the semgrep repository *)
+let tests_path = "tests"
+let e2e_path = "cli/tests/e2e/snapshots/"
+let e2e_ci_path = e2e_path ^ "test_ci/test_full_run"
 
 (*****************************************************************************)
 (* Semgrep-core output *)

--- a/src/tests/Test.ml
+++ b/src/tests/Test.ml
@@ -104,7 +104,6 @@ let main () =
       (Sys.chdir ".."; parent ())
   in
   parent ();
-  print_endline (Sys.getcwd ());
   Parsing_init.init ();
   Data_init.init ();
   Core_CLI.register_exception_printers ();

--- a/src/tests/Test.ml
+++ b/src/tests/Test.ml
@@ -97,13 +97,16 @@ let tests_with_delayed_error () =
       ]
 
 let main () =
-  let rec parent () =
+  (* find the root of the semgrep repo as many of our tests rely on
+     'let test_path = "tests/"' to find their test files *)
+  let rec parent changed =
     if Sys.getcwd () = "/" then invalid_arg "couldn't find semgrep root"
     else if not (Sys.file_exists ".git" && Sys.is_directory ".git") then (
       Sys.chdir "..";
-      parent ())
+      parent true)
+    else changed
   in
-  parent ();
+  if parent false then print_endline ("changed directory to " ^ Sys.getcwd ());
   Parsing_init.init ();
   Data_init.init ();
   Core_CLI.register_exception_printers ();

--- a/src/tests/Test.ml
+++ b/src/tests/Test.ml
@@ -1,4 +1,3 @@
-
 (*****************************************************************************)
 (* Purpose *)
 (*****************************************************************************)
@@ -41,45 +40,41 @@ let any_gen_of_string str =
    explicitly by calling a function. These functions are roughly those
    that call 'Common2.glob'.
 *)
-let tests () = List.flatten [
-  Unit_list_files.tests;
-  Glob.Unit_glob.tests;
-  Unit_semgrepignore.tests;
-  Unit_parsing.tests ();
-  Unit_reporting.tests ();
-
-  Unit_entropy.tests;
-  Unit_ReDoS.tests;
-
-  Unit_guess_lang.tests;
-  Unit_memory_limit.tests;
-  Unit_SPcre.tests;
-  Unit_regexp_engine.tests;
-  Unit_Rpath.tests;
-  Unit_immutable_buffer.tests;
-  Unit_ugly_print_AST.tests;
-  Unit_autofix_printer.tests;
-
-  Unit_synthesizer.tests;
-  Unit_synthesizer_targets.tests;
-
-  Unit_dataflow.tests Parse_target.parse_program;
-  Unit_typing_generic.tests
-    Parse_target.parse_program
-    (fun lang file -> Parse_pattern.parse_pattern lang file);
-  Unit_naming_generic.tests Parse_target.parse_program;
-
-  (* just expression vs expression testing for one language (Python) *)
-  Unit_matcher.tests ~any_gen_of_string;
-  (* TODO Unit_matcher.spatch_unittest ~xxx *)
-  (* TODO Unit_matcher_php.unittest; (* sgrep, spatch, refactoring, unparsing *) *)
-  Unit_engine.tests ();
-  Unit_metachecking.tests ();
-  Unit_LS.tests;
-  Aliengrep.Unit_tests.tests;
-  (* Inline tests *)
-  Testutil.get_registered_tests ();
-]
+let tests () =
+  List.flatten
+    [
+      Unit_list_files.tests;
+      Glob.Unit_glob.tests;
+      Unit_semgrepignore.tests;
+      Unit_parsing.tests ();
+      Unit_reporting.tests ();
+      Unit_entropy.tests;
+      Unit_ReDoS.tests;
+      Unit_guess_lang.tests;
+      Unit_memory_limit.tests;
+      Unit_SPcre.tests;
+      Unit_regexp_engine.tests;
+      Unit_Rpath.tests;
+      Unit_immutable_buffer.tests;
+      Unit_ugly_print_AST.tests;
+      Unit_autofix_printer.tests;
+      Unit_synthesizer.tests;
+      Unit_synthesizer_targets.tests;
+      Unit_dataflow.tests Parse_target.parse_program;
+      Unit_typing_generic.tests Parse_target.parse_program (fun lang file ->
+          Parse_pattern.parse_pattern lang file);
+      Unit_naming_generic.tests Parse_target.parse_program;
+      (* just expression vs expression testing for one language (Python) *)
+      Unit_matcher.tests ~any_gen_of_string;
+      (* TODO Unit_matcher.spatch_unittest ~xxx *)
+      (* TODO Unit_matcher_php.unittest; (* sgrep, spatch, refactoring, unparsing *) *)
+      Unit_engine.tests ();
+      Unit_metachecking.tests ();
+      Unit_LS.tests;
+      Aliengrep.Unit_tests.tests;
+      (* Inline tests *)
+      Testutil.get_registered_tests ();
+    ]
 
 (*****************************************************************************)
 (* Entry point *)
@@ -93,13 +88,12 @@ let tests () = List.flatten [
    to allow what we want without this workaround.
 *)
 let tests_with_delayed_error () =
-  try tests ()
-  with e ->
-     ["cannot load test data - not a real test", (fun () -> raise e)]
+  try tests () with
+  | e -> [ ("cannot load test data - not a real test", fun () -> raise e) ]
 
 let main () =
   Parsing_init.init ();
-  Data_init.init();
+  Data_init.init ();
   Core_CLI.register_exception_printers ();
   Logs_helpers.setup_logging ~force_color:false ~level:(Some Logs.Debug);
   let alcotest_tests = Testutil.to_alcotest (tests_with_delayed_error ()) in

--- a/src/tests/Test.ml
+++ b/src/tests/Test.ml
@@ -98,10 +98,10 @@ let tests_with_delayed_error () =
 
 let main () =
   let rec parent () =
-    if Sys.getcwd () = "/" then
-      invalid_arg "couldn't find semgrep root"
-    else if not (Sys.file_exists ".git" && Sys.is_directory ".git") then
-      (Sys.chdir ".."; parent ())
+    if Sys.getcwd () = "/" then invalid_arg "couldn't find semgrep root"
+    else if not (Sys.file_exists ".git" && Sys.is_directory ".git") then (
+      Sys.chdir "..";
+      parent ())
   in
   parent ();
   Parsing_init.init ();

--- a/src/tests/Test.ml
+++ b/src/tests/Test.ml
@@ -89,7 +89,12 @@ let tests () =
 *)
 let tests_with_delayed_error () =
   try tests () with
-  | e -> [ ("cannot load test data - not a real test", fun () -> raise e) ]
+  | e ->
+      let exn = Exception.catch e in
+      [
+        ( "cannot load test data - not a real test",
+          fun () -> Exception.reraise exn );
+      ]
 
 let main () =
   Parsing_init.init ();

--- a/src/tests/Test.ml
+++ b/src/tests/Test.ml
@@ -97,6 +97,14 @@ let tests_with_delayed_error () =
       ]
 
 let main () =
+  let rec parent () =
+    if Sys.getcwd () = "/" then
+      invalid_arg "couldn't find semgrep root"
+    else if not (Sys.file_exists ".git" && Sys.is_directory ".git") then
+      (Sys.chdir ".."; parent ())
+  in
+  parent ();
+  print_endline (Sys.getcwd ());
   Parsing_init.init ();
   Data_init.init ();
   Core_CLI.register_exception_printers ();

--- a/src/tests/dune
+++ b/src/tests/dune
@@ -29,5 +29,9 @@
    (pps
       ppx_deriving.show
    ))
+ ; inform dune that if ../tests or ../cli/tests/e2e/snapshots are changing,
+ ; the tests should be rerun
+ ; if your tests depend on data stored in a separate directory, add the
+ ; directory here, so 'dune runtest' will pick up the changes
  (deps (source_tree ../tests) (source_tree ../cli/tests/e2e/snapshots))
 )

--- a/src/tests/dune
+++ b/src/tests/dune
@@ -1,4 +1,4 @@
-(executable
+(test
  (name test)
  (libraries
     commons
@@ -29,8 +29,5 @@
    (pps
       ppx_deriving.show
    ))
+ (deps (source_tree ../tests) (source_tree ../cli/tests/e2e/snapshots))
 )
-
-(rule
- (alias runtest)
- (action (run ./test.exe -e)))

--- a/src/tests/test_lsp.ml
+++ b/src/tests/test_lsp.ml
@@ -10,7 +10,7 @@ let foo e =
   | AST_generic.Call (x, (_, [], _)) -> 1
   | G.Call (x, (_, [ _ ], _)) -> 1
   | Call (x, y) -> 1
-  | _ -> 2
+  | _else -> 2
 
 let bar () =
   AST_generic.fake_bracket [] |> ignore;

--- a/src/tests/test_lsp.ml
+++ b/src/tests/test_lsp.ml
@@ -8,12 +8,11 @@ let foo e =
   let res2 = Call (Int (None, fake ""), fb []) in
   match e.e with
   | AST_generic.Call (x, (_, [], _)) -> 1
-  | G.Call (x, (_, [_], _)) -> 1
+  | G.Call (x, (_, [ _ ], _)) -> 1
   | Call (x, y) -> 1
   | _ -> 2
-
 
 let bar () =
   AST_generic.fake_bracket [] |> ignore;
   G.fake_bracket [] |> ignore;
-  fake_bracket [] |> ignore;
+  fake_bracket [] |> ignore


### PR DESCRIPTION
in core target, build everything

This cuts a rebuild (the second "make minimal-build" in make minimal-build ; make minimal-build from 10s down to 2.5s)

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
