### PR TITLE
osemgrep: start to use osemgrep in 'make check' for dogfooding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -447,25 +447,21 @@ report-perf-matching:
 SEMGREP_ARGS=--config semgrep.jsonnet --error --exclude tests
 # you can add --verbose for debugging
 
-DOCKER_IMAGE=returntocorp/semgrep:develop
-
-# You need to have semgrep in your PATH! do 'cd cli; pipenv shell' before
-# if needed.
+#Dogfooding osemgrep!
 .PHONY: check
 check:
-	semgrep $(SEMGREP_ARGS)
+	./bin/osemgrep $(SEMGREP_ARGS)
+
+check_for_emacs:
+	./bin/osemgrep $(SEMGREP_ARGS) --emacs --quiet
+
+DOCKER_IMAGE=returntocorp/semgrep:develop
 
 # If you get semgrep-core parsing errors while running this command, maybe you
 # have an old cached version of the docker image.
 # You can invalidate the cache with 'docker rmi returntocorp/semgrep:develop`
 check_with_docker:
 	docker run --rm -v "${PWD}:/src" $(DOCKER_IMAGE) semgrep $(SEMGREP_ARGS)
-
-# I use the docker here instead of directly semgrep, because semgrep is not always
-# in my PATH.
-#TODO: this will be less needed once we run semgrep with semgrep.jsonnet in pre-commit
-check_for_emacs:
-	docker run --rm -v "${PWD}:/src" $(DOCKER_IMAGE) semgrep $(SEMGREP_ARGS) --emacs --quiet
 
 ###############################################################################
 # Martin's targets


### PR DESCRIPTION
Let's switch to osemgrep now that we get 0 finding
with osemgrep --config semgrep.jsonnet

test plan:
add a List.map in src/main/Main.ml, run 'make check', or
'make check_for_emacs' and get the (single) finding


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)