### PR TITLE
osemgrep: semgrep interactive v0

### DIFF
--- a/src/osemgrep/cli_interactive/Interactive_CLI.ml
+++ b/src/osemgrep/cli_interactive/Interactive_CLI.ml
@@ -11,15 +11,44 @@ open Cmdliner
 (* Types and constants *)
 (*****************************************************************************)
 
-type conf = { logging_level : Logs.level option } [@@deriving show]
+(* a subset of Scan_CLI.conf *)
+type conf = {
+  lang : Lang.t; (* use Xlang.t at some point? or even Xlang option? *)
+  target_roots : Fpath.t list;
+  targeting_conf : Find_targets.conf;
+  core_runner_conf : Core_runner.conf;
+  (* nosem? *)
+  logging_level : Logs.level option;
+}
+[@@deriving show]
 
 (*************************************************************************)
 (* Command-line parsing: turn argv into conf *)
 (*************************************************************************)
 
 let cmdline_term : conf Term.t =
-  let combine logging_level = { logging_level } in
-  Term.(const combine $ CLI_common.logging_term)
+  let combine lang target_roots logging_level =
+    let lang =
+      match lang with
+      (* TODO? we could omit the language like for -e and try all languages?*)
+      | None -> Error.abort "-l is required for the interactive subcommand"
+      | Some s ->
+          (* may raise unsupported language exn *)
+          Lang.of_string s
+    in
+    let target_roots = File.Path.of_strings target_roots in
+    {
+      lang;
+      target_roots;
+      (* TODO: accept CLI args at some point *)
+      targeting_conf = Scan_CLI.default.targeting_conf;
+      core_runner_conf = Scan_CLI.default.core_runner_conf;
+      logging_level;
+    }
+  in
+  Term.(
+    const combine $ Scan_CLI.o_lang $ Scan_CLI.o_target_roots
+    $ CLI_common.logging_term)
 
 let doc = "Interactive mode!!"
 

--- a/src/osemgrep/cli_interactive/Interactive_CLI.mli
+++ b/src/osemgrep/cli_interactive/Interactive_CLI.mli
@@ -6,7 +6,16 @@
    The result of parsing a 'semgrep interactive' command.
 *)
 
-type conf = { logging_level : Logs.level option } [@@deriving show]
+(* a subset of Scan_CLI.conf *)
+type conf = {
+  lang : Lang.t; (* use Xlang.t at some point? or even Xlang option? *)
+  target_roots : Fpath.t list;
+  targeting_conf : Find_targets.conf;
+  core_runner_conf : Core_runner.conf;
+  (* nosem? *)
+  logging_level : Logs.level option;
+}
+[@@deriving show]
 
 (*
    Usage: parse_argv [| "semgrep-interactive"; <args> |]

--- a/src/osemgrep/cli_interactive/Interactive_subcommand.ml
+++ b/src/osemgrep/cli_interactive/Interactive_subcommand.ml
@@ -148,6 +148,9 @@ let check_interactive f xlang xtargets =
   done;
   ()
 
+(* TODO: we should rewrite this to use the osemgrep file targeting instead
+ * of the deprecated (and possibly slow) files_of_dirs_or_files() below
+ *)
 let semgrep_with_interactive_mode (config : Runner_config.t) =
   (* TODO: support generic and regex patterns as well. See code in Deep.
    * Just use Parse_rule.parse_xpattern xlang (str, fk)
@@ -172,7 +175,17 @@ let semgrep_with_interactive_mode (config : Runner_config.t) =
 
 (* All the business logic after command-line parsing. Return the desired
    exit code. *)
-let run (_conf : Interactive_CLI.conf) : Exit_code.t = Exit_code.ok
+let run (conf : Interactive_CLI.conf) : Exit_code.t =
+  let config = Core_runner.runner_config_of_conf conf.core_runner_conf in
+  let config =
+    {
+      config with
+      roots = conf.target_roots;
+      lang = Some (Xlang.L (conf.lang, []));
+    }
+  in
+  semgrep_with_interactive_mode config;
+  Exit_code.ok
 
 (*****************************************************************************)
 (* Entry point *)

--- a/src/osemgrep/cli_interactive/dune
+++ b/src/osemgrep/cli_interactive/dune
@@ -14,6 +14,7 @@
 
     osemgrep_core
     osemgrep_configuring
+    osemgrep_cli_scan
   )
  (preprocess
    (pps

--- a/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -24,6 +24,10 @@ module H = Cmdliner_helpers
 (*****************************************************************************)
 (*
    The result of parsing a 'semgrep scan' command.
+
+   LATER: we could actually define this structure in ATD, so people could
+   programmatically set the command-line arguments they want if they
+   want to programmatically call Semgrep.
 *)
 type conf = {
   (* Main configuration options *)
@@ -68,6 +72,10 @@ type conf = {
 }
 [@@deriving show]
 
+(* We could split the content of this variable in different files, e.g.,
+ * targeting_conf default could be move in a Find_targets.default, but
+ * it's also nice to have everything in one place.
+ *)
 let default : conf =
   {
     (* alt: Configs [ "auto" ]? *)

--- a/src/osemgrep/cli_scan/Scan_CLI.mli
+++ b/src/osemgrep/cli_scan/Scan_CLI.mli
@@ -64,3 +64,7 @@ val parse_argv : string array -> conf
 
 (* exported because used by Ci_CLI.ml too *)
 val cmdline_term : conf Cmdliner.Term.t
+
+(* exported because used by Interactive_CLI.ml too *)
+val o_lang : string option Cmdliner.Term.t
+val o_target_roots : string list Cmdliner.Term.t


### PR DESCRIPTION
Connect the CLI args to Brandon's file targeting code.

test plan:
```
$ osemgrep interactive -l ocaml src/metachecking
> foo $X
Found 0 total findings
```

Note that running it from the toplevel crash because of a syntax
error in one of the osemgrep files. It's also pretty slow,
at least 20s before I can see the prompt.


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)