### PR TITLE
osemgrep: support --debug in osemgrep interactive

### DIFF
--- a/src/osemgrep/cli_ci/Ci_subcommand.ml
+++ b/src/osemgrep/cli_ci/Ci_subcommand.ml
@@ -21,12 +21,12 @@
 
 (* All the business logic after command-line parsing. Return the desired
    exit code. *)
-let run (_conf : Ci_CLI.conf) : Exit_code.t =
-  (* TODO:
-     Setup_logging.setup config;
-     logger#info "Executed as: %s" (Sys.argv |> Array.to_list |> String.concat " ");
-     logger#info "Version: %s" config.version;
-  *)
+let run (conf : Ci_CLI.conf) : Exit_code.t =
+  CLI_common.setup_logging ~force_color:conf.force_color
+    ~level:conf.logging_level;
+  (* TODO: lots of work here!! lots of things to port, but also lots of code
+   * from Scan_subcommand.ml to reuse.
+   *)
   Exit_code.ok
 
 (*****************************************************************************)

--- a/src/osemgrep/cli_interactive/Interactive_subcommand.ml
+++ b/src/osemgrep/cli_interactive/Interactive_subcommand.ml
@@ -176,6 +176,7 @@ let semgrep_with_interactive_mode (config : Runner_config.t) =
 (* All the business logic after command-line parsing. Return the desired
    exit code. *)
 let run (conf : Interactive_CLI.conf) : Exit_code.t =
+  CLI_common.setup_logging ~force_color:false ~level:conf.logging_level;
   let config = Core_runner.runner_config_of_conf conf.core_runner_conf in
   let config =
     {

--- a/src/osemgrep/cli_login/Login_subcommand.ml
+++ b/src/osemgrep/cli_login/Login_subcommand.ml
@@ -53,7 +53,7 @@ let max_retries = 30 (* Give users 3 minutes to log in / open link *)
 (* All the business logic after command-line parsing. Return the desired
    exit code. *)
 let run (conf : Login_CLI.conf) : Exit_code.t =
-  Logs_helpers.setup_logging ~force_color:false ~level:conf.logging_level;
+  CLI_common.setup_logging ~force_color:false ~level:conf.logging_level;
   let settings = Semgrep_settings.load () in
   match settings.Semgrep_settings.api_token with
   | None -> (

--- a/src/osemgrep/cli_login/Logout_subcommand.ml
+++ b/src/osemgrep/cli_login/Logout_subcommand.ml
@@ -14,7 +14,7 @@
 (* All the business logic after command-line parsing. Return the desired
    exit code. *)
 let run (conf : Login_CLI.conf) : Exit_code.t =
-  Logs_helpers.setup_logging ~force_color:false ~level:conf.logging_level;
+  CLI_common.setup_logging ~force_color:false ~level:conf.logging_level;
   let settings = Semgrep_settings.load () in
   let settings = Semgrep_settings.{ settings with api_token = None } in
   if Semgrep_settings.save settings then (

--- a/src/osemgrep/cli_lsp/Lsp_subcommand.ml
+++ b/src/osemgrep/cli_lsp/Lsp_subcommand.ml
@@ -20,7 +20,9 @@
 
 (* All the business logic after command-line parsing. Return the desired
    exit code. *)
-let run (_conf : Lsp_CLI.conf) : Exit_code.t = Exit_code.ok
+let run (conf : Lsp_CLI.conf) : Exit_code.t =
+  CLI_common.setup_logging ~force_color:false ~level:conf.logging_level;
+  Exit_code.ok
 
 (*****************************************************************************)
 (* Entry point *)

--- a/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -15,46 +15,10 @@ module RP = Report
 (* Logging/Profiling/Debugging *)
 (*****************************************************************************)
 
-(* ugly: also partially done in CLI.ml *)
 let setup_logging (conf : Scan_CLI.conf) =
-  (* For osemgrep we use the Logs library instead of the Logger
-   * library in pfff. We had a few issues with Logger (which is a small
-   * wrapper around the easy_logging library), and we don't really want
-   * the logging in semgrep-core to interfere with the proper
-   * logging/output we want in osemgrep, so this is a good opportunity
-   * to evaluate a new logging library.
-   *)
-  Logs_helpers.setup_logging ~force_color:conf.force_color
+  CLI_common.setup_logging ~force_color:conf.force_color
     ~level:conf.logging_level;
-  (* TOPORT
-        # Setup file logging
-        # env.user_log_file dir must exist
-        env.user_log_file.parent.mkdir(parents=True, exist_ok=True)
-        file_handler = logging.FileHandler(env.user_log_file, "w")
-        file_formatter = logging.Formatter(
-            "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
-        )
-        file_handler.setLevel(logging.DEBUG)
-        file_handler.setFormatter(file_formatter)
-        logger.addHandler(file_handler)
-  *)
-  Logs.debug (fun m -> m "Logging setup for semgrep scan");
   Logs.debug (fun m -> m "Semgrep version: %s" Version.version);
-  Logs.debug (fun m ->
-      m "Executed as: %s" (Sys.argv |> Array.to_list |> String.concat " "));
-
-  (* Easy_logging setup. We should avoid to use Logger in osemgrep/
-   * and use Logs instead, but it is still useful to get the semgrep-core
-   * logging information at runtime, hence this call.
-   *)
-  let debug =
-    match conf.logging_level with
-    | Some Logs.Debug -> true
-    | _else_ -> false
-  in
-  Logging_helpers.setup ~debug
-    ~log_config_file:(Fpath.v "log_config.json")
-    ~log_to_file:None;
   ()
 
 (* ugly: also partially done in CLI.ml *)

--- a/src/osemgrep/core/CLI_common.ml
+++ b/src/osemgrep/core/CLI_common.ml
@@ -1,15 +1,30 @@
-(*
-   Shared parameters, options, and help messages for the semgrep CLI.
-*)
 open Cmdliner
 
 (*************************************************************************)
-(* Command-line flags *)
+(* Prelude *)
+(*************************************************************************)
+(*
+   Shared parameters, options, and help messages for the semgrep CLI.
+
+   TODO: parser+printer for file path so we can write things like:
+
+        Arg.value (Arg.opt (Arg.some CLI_common.fpath) None info)
+
+      instead of
+
+        Arg.value (Arg.opt (Arg.some Arg.string) None info)
+        (* + having to convert the string to an fpath by hand *)
+
+      The main benefit would be to clarify error messages by having Fpath.t
+      instead of string.
+
+   val fpath : Fpath.t Cmdliner.conv????
+*)
+
+(*************************************************************************)
+(* "Verbosity options" (mutually exclusive) *)
 (*************************************************************************)
 
-(* ------------------------------------------------------------------ *)
-(* "Verbosity options" (mutually exclusive) *)
-(* ------------------------------------------------------------------ *)
 (* alt: we could use Logs_cli.level(), but by defining our own flags
  * we can give better ~doc:. We lose the --verbosity=Level though.
  *)
@@ -46,6 +61,50 @@ let logging_term : Logs.level option Term.t =
         Error.abort "mutually exclusive options --quiet/--verbose/--debug"
   in
   Term.(const combine $ o_debug $ o_quiet $ o_verbose)
+
+(* ugly: also partially done in CLI.ml *)
+let setup_logging ~force_color ~level =
+  (* For osemgrep we use the Logs library instead of the Logger
+   * library in pfff. We had a few issues with Logger (which is a small
+   * wrapper around the easy_logging library), and we don't really want
+   * the logging in semgrep-core to interfere with the proper
+   * logging/output we want in osemgrep, so this is a good opportunity
+   * to evaluate a new logging library.
+   *)
+  Logs_helpers.setup_logging ~force_color ~level;
+  (* TOPORT
+        # Setup file logging
+        # env.user_log_file dir must exist
+        env.user_log_file.parent.mkdir(parents=True, exist_ok=True)
+        file_handler = logging.FileHandler(env.user_log_file, "w")
+        file_formatter = logging.Formatter(
+            "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+        )
+        file_handler.setLevel(logging.DEBUG)
+        file_handler.setFormatter(file_formatter)
+        logger.addHandler(file_handler)
+  *)
+  Logs.debug (fun m -> m "Logging setup for osemgrep");
+  Logs.debug (fun m ->
+      m "Executed as: %s" (Sys.argv |> Array.to_list |> String.concat " "));
+
+  (* Easy_logging setup. We should avoid to use Logger in osemgrep/
+   * and use Logs instead, but it is still useful to get the semgrep-core
+   * logging information at runtime, hence this call.
+   *)
+  let debug =
+    match level with
+    | Some Logs.Debug -> true
+    | _else_ -> false
+  in
+  Logging_helpers.setup ~debug
+    ~log_config_file:(Fpath.v "log_config.json")
+    ~log_to_file:None;
+  ()
+
+(*************************************************************************)
+(* Misc *)
+(*************************************************************************)
 
 let help_page_bottom =
   [

--- a/src/osemgrep/core/CLI_common.mli
+++ b/src/osemgrep/core/CLI_common.mli
@@ -11,17 +11,5 @@ val eval_value : argv:string array -> 'a Cmdliner.Cmd.t -> 'a
 (* handles logging arguments (--quiet/--verbose/--debug) *)
 val logging_term : Logs.level option Cmdliner.Term.t
 
-(* TODO: parser+printer for file path so we can write things like:
-
-        Arg.value (Arg.opt (Arg.some CLI_common.fpath) None info)
-
-      instead of
-
-        Arg.value (Arg.opt (Arg.some Arg.string) None info)
-        (* + having to convert the string to an fpath by hand *)
-
-      The main benefit would be to clarify error messages by having Fpath.t
-      instead of string.
-
-   val fpath : Fpath.t Cmdliner.conv????
-*)
+(* small wrapper around Logs_helper.setup_logging and Logging_helpers.setup *)
+val setup_logging : force_color:bool -> level:Logs.level option -> unit


### PR DESCRIPTION
And factorize code between the subcommand related to logging

test plan:
```
$ osemgrep interactive -l ocaml . --debug
Logging setup for osemgrep
Executed as: /home/pad/yy/_build/default/src/osemgrep/main/Main.exe interactive -l ocaml src/ --debug
>
```


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)