### PR TITLE
refactor: Avoid conversion from Type.t for matching

### DIFF
--- a/src/core/Type.ml
+++ b/src/core/Type.ml
@@ -110,6 +110,12 @@ let rec to_name_opt lang ty =
 let mkt str =
   G.TyN (G.Id ((str, Tok.unsafe_fake_tok str), G.empty_id_info ())) |> G.t
 
+let is_real_type = function
+  | NoType
+  | Todo _ ->
+      false
+  | _else_ -> true
+
 (*****************************************************************************)
 (* Converters *)
 (*****************************************************************************)
@@ -119,7 +125,8 @@ let todo_kind_to_ast_generic_todo_kind (x : todo_kind) : G.todo_kind =
   | Some s -> (s, Tok.unsafe_fake_tok s)
   | None -> ("TodoKind is None", Tok.unsafe_fake_tok "")
 
-(* less: should sanity check things by looking at [lang]
+(* less: should sanity check things by looking at [lang]. but maybe users like
+ * to write `bool` in a language that uses `boolean`, and we should allow that?
  *
  * coupling: Inverse of ast_generic_type_of_builtin_type *)
 let builtin_type_of_string _langTODO str =

--- a/src/matching/Generic_vs_generic.ml
+++ b/src/matching/Generic_vs_generic.ml
@@ -1392,53 +1392,36 @@ and m_container_ordered_elements a b =
  *    style as typechecking could also bind metavariables in the process
  *)
 and m_compatible_type lang typed_mvar t e =
-  match (Type.builtin_type_of_type lang t, e.G.e) with
-  | Some builtin, B.L lit -> (
-      match (builtin, lit) with
-      | Type.Int, B.Int _
-      | Type.Float, B.Float _
-      | Type.Number, (B.Int _ | B.Float _)
-      | Type.Bool, B.Bool _
-      | Type.String, B.String _ ->
-          envf typed_mvar (MV.E e)
-      | _ -> fail ())
-  | _else_ -> (
-      match (t.G.t, e.G.e) with
-      (* for C specific literals *)
-      | ( G.TyPointer (_, { t = TyN (G.Id (("char", _), _)); _ }),
-          B.L (B.String _) ) ->
-          envf typed_mvar (MV.E e)
-      | G.TyPointer (_, _), B.L (B.Null _) -> envf typed_mvar (MV.E e)
-      (* for C strings to match metavariable pointer types *)
-      | ( G.TyPointer (t1, { t = G.TyN (G.Id ((_, tok), id_info)); _ }),
-          B.L (B.String _) ) ->
-          m_type_ t
-            (G.TyPointer (t1, G.TyN (G.Id (("char", tok), id_info)) |> G.t)
-            |> G.t)
-          >>= fun () -> envf typed_mvar (MV.E e)
-      (* for matching ids *)
-      (* this is covered by the basic type propagation done in Naming_AST.ml *)
-      | _ta, B.N (B.Id (idb, ({ B.id_type = tb; _ } as id_infob))) ->
-          (* NOTE: Name values must be represented with MV.Id! *)
-          m_type_option_with_hook idb (Some t) !tb >>= fun () ->
-          envf typed_mvar (MV.Id (idb, Some id_infob))
-      | _ta, _eb -> (
-          let tb, idopt = Typing.type_of_expr lang e in
-          let tbopt =
-            tb
-            |> Type.to_ast_generic_type_ lang (fun name _alts ->
-                   (* TODO Do something with the alts? Or are they already in
-                    * `name`? *)
-                   name)
-          in
-          match (tbopt, idopt) with
-          | _, Some idb ->
-              m_type_option_with_hook idb (Some t) tbopt >>= fun () ->
-              envf typed_mvar (MV.E e)
-          | Some tb, None ->
-              let* () = m_type_ t tb in
-              envf typed_mvar (MV.E e)
-          | None, None -> fail ()))
+  match (t.G.t, e.G.e) with
+  (* for C specific literals *)
+  | G.TyPointer (_, { t = TyN (G.Id (("char", _), _)); _ }), B.L (B.String _) ->
+      envf typed_mvar (MV.E e)
+  | G.TyPointer (_, _), B.L (B.Null _) -> envf typed_mvar (MV.E e)
+  (* for C strings to match metavariable pointer types *)
+  | ( G.TyPointer (t1, { t = G.TyN (G.Id ((_, tok), id_info)); _ }),
+      B.L (B.String _) ) ->
+      m_type_ t
+        (G.TyPointer (t1, G.TyN (G.Id (("char", tok), id_info)) |> G.t) |> G.t)
+      >>= fun () -> envf typed_mvar (MV.E e)
+  (* for matching ids *)
+  (* this is covered by the basic type propagation done in Naming_AST.ml *)
+  | _ta, B.N (B.Id (idb, ({ B.id_type = tb; _ } as id_infob))) ->
+      (* NOTE: Name values must be represented with MV.Id! *)
+      m_type_option_with_hook idb (Some t) !tb >>= fun () ->
+      envf typed_mvar (MV.Id (idb, Some id_infob))
+  | _ta, _eb -> (
+      let tb, idopt = Typing.type_of_expr lang e in
+      (* If we can infer the type, then match against it. Otherwise, fall back
+       * on LSP type matching *)
+      if Type.is_real_type tb then
+        let* () = m_generic_type_vs_type_t lang t tb in
+        envf typed_mvar (MV.E e)
+      else
+        match idopt with
+        | Some idb ->
+            m_type_option_with_hook idb (Some t) None >>= fun () ->
+            envf typed_mvar (MV.E e)
+        | None -> fail ())
 
 (*---------------------------------------------------------------------------*)
 (* XML *)
@@ -2004,6 +1987,129 @@ and m_todo_kind a b = m_ident a b
 and m_wildcard (a1, a2) (b1, b2) =
   let* () = m_wrap m_bool a1 b1 in
   m_type_ a2 b2
+
+(******************************************************************************)
+(* Type.t, constructed during type inference and matched for typed metavariables
+ * *)
+(******************************************************************************)
+
+(* The AST_generic.type_ written in a pattern vs an inferred Type.t
+ *
+ * Checks if the pattern `a` describes any supertype of the type `b`. Currently,
+ * subtype analysis is fairly limited (I believe it only happens with
+ * inheritance for nominal types when used with the Pro Engine) but it may be
+ * extended at some point.
+ * *)
+and m_generic_type_vs_type_t lang a b =
+  match (a.G.t, b) with
+  | G.TyN name1, Type.N ((name2, (* targs *) []), _alts) ->
+      (* TODO: Alternate names should actually be part of the 'resolved type
+       * param in Type.t. They are actually stored in the name, so we ignore
+       * them here. *)
+      m_name name1 name2
+  | G.TyApply ({ t = G.TyN name1; _ }, targs1), Type.N ((name2, targs2), _alts)
+    ->
+      let* () = m_name name1 name2 in
+      m_generic_targs_vs_type_targs lang targs1 targs2
+  (* TODO: Handle IdQualified matching unresolved name? *)
+  | G.TyN (Id ((str1, _), _)), Type.UnresolvedName (str2, (* targs *) []) ->
+      m_string str1 str2
+  | ( G.TyApply ({ t = G.TyN (Id ((str1, _), _)); _ }, targs1),
+      Type.UnresolvedName (str2, targs2) ) ->
+      let* () = m_string str1 str2 in
+      m_generic_targs_vs_type_targs lang targs1 targs2
+  | G.TyN (Id ((str, _), _)), Type.Builtin builtin2 -> (
+      (* Convert the string in the pattern to a Type.builtin_type. Currently,
+       * this lets users write, for example `str` in Java and have it
+       * interpreted as `String`. We could make this a bit stricter, but some
+       * tests rely on this behavior and real rules probably do as well. It's
+       * probably fine to be a bit generous here when we're attempting a match
+       * against a builtin, as this will not preclude matches elsewhere against
+       * named types that happen to collide. *)
+      match (Type.builtin_type_of_string lang str, builtin2) with
+      | Some Type.Int, Type.Int
+      | Some Type.Float, Type.Float
+      | Some Type.String, Type.String
+      | Some Type.Bool, Type.Bool
+      (* Type.Number used for JS/TS. We still infer more specific types for
+       * literals, however. *)
+      | Some Type.Number, (Type.Number | Type.Int | Type.Float) ->
+          return ()
+      | Some Type.Int, _
+      | Some Type.Float, _
+      | Some Type.String, _
+      | Some Type.Bool, _
+      | Some Type.Number, _
+      | Some (Type.OtherBuiltins _), _
+      | None, _ ->
+          fail ())
+  (* coupling: we also match on "null" etc. in Typing.type_of_ast_generic_type.
+   * Pull out into util? *)
+  | G.TyN (Id ((("null" | "nil"), _), _)), Type.Null -> return ()
+  (* An array type pattern with no size specified should still match an array
+   * type where we know the size. *)
+  | G.TyArray ((_l, None, _r), t1), Type.Array (_size, t2) ->
+      (* THINK: Should be an invariant match rather than covariant? *)
+      m_generic_type_vs_type_t lang t1 t2
+  | ( G.TyArray ((_l, Some { e = G.L (G.Int (Some size1, _)); _ }, _r), t1),
+      Type.Array (Some size2, t2) ) ->
+      let* () = m_int size1 size2 in
+      (* THINK: Should be an invariant match rather than covariant? *)
+      m_generic_type_vs_type_t lang t1 t2
+  | G.TyFun (params1, tret1), Type.Function (params2, tret2) ->
+      let* () = m_generic_params_vs_params lang params1 params2 in
+      m_generic_type_vs_type_t lang tret1 tret2
+  | G.TyPointer (_tok, t1), Type.Pointer t2 ->
+      m_generic_type_vs_type_t lang t1 t2
+  | G.TyExpr { e = G.N name1; _ }, _ ->
+      m_generic_type_vs_type_t lang (G.TyN name1 |> G.t) b
+  | _, Type.N _
+  | _, Type.UnresolvedName _
+  | _, Type.Builtin _
+  | _, Type.Null
+  | _, Type.Array _
+  | _, Type.Function _
+  | _, Type.Pointer _
+  | _, Type.NoType
+  | _, Type.Todo _ ->
+      fail ()
+
+and m_generic_targs_vs_type_targs lang (_l, a, _r) b =
+  (* TODO Handle ellipses? *)
+  m_list (m_generic_targ_vs_type_targ lang) a b
+
+and m_generic_targ_vs_type_targ lang a b =
+  match (a, b) with
+  | G.TA t1, Type.TA t2 ->
+      (* Technically this isn't quite right. m_generic_type_vs_type_t checks if
+       * t1 is a supertype of t2. Typically, type parameters must be invariant,
+       * and this will assume covariance. But it's probably not a big deal, and
+       * they don't have to be invariant in all cases anyway. *)
+      m_generic_type_vs_type_t lang t1 t2
+  | G.TA _, Type.OtherTypeArg _
+  (* TODO Represent more typearg kinds in Type.t? *)
+  | G.TAWildcard _, _
+  | G.TAExpr _, _
+  (* THINK: Should G.OtherTypeArg match Type.OtherTypeArg? *)
+  | G.OtherTypeArg _, _ ->
+      fail ()
+
+and m_generic_params_vs_params lang a b =
+  (* TODO Handle ellipses? *)
+  m_list (m_generic_param_vs_param lang) a b
+
+and m_generic_param_vs_param lang a b =
+  match (a, b) with
+  | ( G.Param { G.pname = name1; ptype = t1; _ },
+      Type.Param { Type.pident = name2; ptype = t2 } ) -> (
+      let name1 = Option.map fst name1 in
+      let* () = m_option m_string name1 name2 in
+      match t1 with
+      | Some t1 -> m_generic_type_vs_type_t lang t1 t2
+      | None -> (* THINK: Is this right? *) return ())
+  | _, Type.Param _
+  | _, Type.OtherParam _ ->
+      fail ()
 
 (*****************************************************************************)
 (* Attribute *)

--- a/src/matching/Matching_generic.mli
+++ b/src/matching/Matching_generic.mli
@@ -101,7 +101,7 @@ val m_option_ellipsis_ok :
   AST_generic.expr matcher -> AST_generic.expr option matcher
 
 val m_option_none_can_match_some : 'a matcher -> 'a option matcher
-val m_list : 'a matcher -> 'a list matcher
+val m_list : ('a, 'b) general_matcher -> ('a list, 'b list) general_matcher
 val m_list_prefix : 'a matcher -> 'a list matcher
 
 (*

--- a/src/typing/Typing.ml
+++ b/src/typing/Typing.ml
@@ -28,8 +28,14 @@ let rec type_of_expr lang e : G.name Type.t * G.ident option =
   | G.L lit ->
       let t =
         match lit with
+        (* NB: We could infer Type.Number for JS int/float literals, but we can
+         * handle that relationship in matching and we can be more precise for
+         * now. One actual rule uses `float` for a typed metavariable in JS so
+         * let's avoid breaking that for now at least. *)
         | G.Int _ -> Type.Builtin Type.Int
+        | G.Float _ -> Type.Builtin Type.Float
         | G.Bool _ -> Type.Builtin Type.Bool
+        | G.String _ -> Type.Builtin Type.String
         | _else_ -> Type.NoType
       in
       (t, None)


### PR DESCRIPTION
I've been gradually increasing the longevity of `Type.t` in our naming, type inference, and matching process. Before this PR, we did type inference over `Type.t` but then converted it back to `AST_generic.type_` for matching. We can avoid that lossy conversion and write more precise matching code if we match patterns directly against inferred types. That is what I've done in this PR. I've also removed the special-case literal matching. That was difficult before for reasons that I'm omitting here to keep things brief. Feel free to ask.

I've deleted the only use in this codebase of
`Type.to_ast_generic_type_` and I'd like to delete that function itself, but it is still in use in the Pro Engine. I'd like to change `id_type` to use `Type.t` at which point that function will no longer be needed.

Test plan: Automated tests including `make test` in pro

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
