### PR TITLE
const-prop #6780: Allow symbolic propagation for rvals in lhs of assignments

### DIFF
--- a/changelog.d/gh-6780.fixed
+++ b/changelog.d/gh-6780.fixed
@@ -1,0 +1,1 @@
+Allow symbolic propagation for rvals in lhs of assignments.

--- a/src/il/IL_helpers.ml
+++ b/src/il/IL_helpers.ml
@@ -30,6 +30,8 @@ let exp_of_arg arg =
 
 let rexps_of_instr x =
   match x.i with
+  | Assign (({ base = Var _; rev_offset = _ :: _ } as lval), exp) ->
+      [ { e = Fetch { lval with rev_offset = [] }; eorig = NoOrig }; exp ]
   | Assign (_, exp) -> [ exp ]
   | AssignAnon _ -> []
   | Call (_, e1, args) -> e1 :: Common.map exp_of_arg args
@@ -74,7 +76,7 @@ and lvals_in_lval lval =
 
 and lvals_of_exps xs = xs |> List.concat_map lvals_of_exp
 
-(** The lvals in the RHS of the instruction. *)
+(** The lvals in the rvals of the instruction. *)
 let rlvals_of_instr x =
   let exps = rexps_of_instr x in
   lvals_of_exps exps

--- a/tests/patterns/python/cp_label.py
+++ b/tests/patterns/python/cp_label.py
@@ -11,8 +11,8 @@ a =\
     #ERROR:
     "foo"
 
-#ERROR: a is foo by constant propagation
-a[b] = 1
+#OK:
+a = "bar"
 
 def f():
     #OK:

--- a/tests/patterns/python/cp_label.py
+++ b/tests/patterns/python/cp_label.py
@@ -11,7 +11,7 @@ a =\
     #ERROR:
     "foo"
 
-#OK:
+#ERROR: a is foo by constant propagation
 a[b] = 1
 
 def f():

--- a/tests/rules/sym_prop_lhs_exp.py
+++ b/tests/rules/sym_prop_lhs_exp.py
@@ -1,0 +1,14 @@
+def foo():
+    # ruleid: test
+    foo.Bar.alice = 2 * my_module.UNIT
+
+def bar():
+    x = foo.Bar
+    # ruleid: test
+    x.alice = 3 * my_module.UNIT
+
+def alice():
+    x = foo.Bar
+    y = x
+    # ruleid: test
+    y.alice = 4 * my_module.UNIT

--- a/tests/rules/sym_prop_lhs_exp.yaml
+++ b/tests/rules/sym_prop_lhs_exp.yaml
@@ -1,0 +1,9 @@
+rules:
+  - id: test
+    message: sym prop test
+    severity: ERROR
+    languages:
+      - python
+    pattern: foo.Bar.$X
+    options:
+      symbolic_propagation: true


### PR DESCRIPTION
Closes #6780 

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
