### PR TITLE
interactive: extract Pointed_zipper.ml from Interactive_subcommand

### DIFF
--- a/src/osemgrep/cli_interactive/Pointed_zipper.ml
+++ b/src/osemgrep/cli_interactive/Pointed_zipper.ml
@@ -1,0 +1,63 @@
+(*****************************************************************************)
+(* Prelude *)
+(*****************************************************************************)
+(* A pointed zipper.
+
+   See the .mli for more information
+*)
+
+(*****************************************************************************)
+(* Types *)
+(*****************************************************************************)
+type 'a t = {
+  before_rev : 'a list;
+  pointer : int;
+  max_len : int;
+  after : 'a list;
+}
+
+(*****************************************************************************)
+(* Helpers *)
+(*****************************************************************************)
+
+let shift_frame_left m =
+  match (m.before_rev, m.after) with
+  | [], _ -> m
+  | x :: xs, after -> { m with before_rev = xs; after = x :: after }
+
+let shift_frame_right m =
+  match (m.before_rev, m.after) with
+  | _, [] -> m
+  | before_rev, x :: xs -> { m with before_rev = x :: before_rev; after = xs }
+
+(*****************************************************************************)
+(* API *)
+(*****************************************************************************)
+
+(* A move necessitates a pointer move, which may or may
+   not cause a frame move, depending on if the pointer is
+   at the boundaries of the frame.
+*)
+let move_left m =
+  if m.pointer <= 0 then { (shift_frame_left m) with pointer = 0 }
+  else { m with pointer = m.pointer - 1 }
+
+let move_right m =
+  if m.pointer >= m.max_len - 1 then
+    { (shift_frame_right m) with pointer = m.max_len - 1 }
+  else if m.pointer >= List.length m.after - 1 then
+    (* This is the case where we move the pointer
+       down, but we don't have enough entries left.
+       In this case, don't move the pointer.
+    *)
+    m
+  else { m with pointer = m.pointer + 1 }
+
+let take n m = Common2.take_safe n m.after
+let of_list max_len l = { before_rev = []; after = l; pointer = 0; max_len }
+let position m = m.pointer
+let get_current m = List.nth m.after (position m)
+let is_empty m = List.length m.after + List.length m.before_rev = 0
+
+let empty_with_max_len max_len =
+  { before_rev = []; after = []; pointer = 0; max_len }

--- a/src/osemgrep/cli_interactive/Pointed_zipper.mli
+++ b/src/osemgrep/cli_interactive/Pointed_zipper.mli
@@ -1,0 +1,50 @@
+(* This module implements something I call a "pointed zipper".
+
+   A zipper is, of course, the classic data structure for a
+   list's "one hole context", of traversing a list via being located
+   at a single point.
+
+   A "pointed zipper" is a zipper which also has a "frame", which
+   is of a certain size, and a pointer which can move around the
+   frame freely. Essentially, a pointed zipper is not just located
+   at a single element in the list, but a frame of many such
+   elements.
+
+   The main use case here is for scrolling purposes on a list of
+   n entries with a frame of length m. In this case, we want to
+   keep a pointer around so we can move around on the entries we
+   already see, but we also want to be able to move elements
+   through the zipper, for when the elements in our frame change.
+
+   So for instance, we might have a zipper like:
+
+   A
+   B <- only these
+   C <- are in
+   D <- our frame
+   E
+
+   Our pointer moves freely between B,C,D, but if we try to go
+   up, the whole zipper moves, and we get:
+
+   A <- only these
+   B <- are in
+   C <- our frame
+   D
+   E
+*)
+
+type 'a t
+
+(* A move necessitates a pointer move, which may or may
+   not cause a frame move, depending on if the pointer is
+   at the boundaries of the frame.
+*)
+val move_left : 'a t -> 'a t
+val move_right : 'a t -> 'a t
+val take : int -> 'a t -> 'a list
+val of_list : int -> 'a list -> 'a t
+val empty_with_max_len : int -> 'a t
+val get_current : 'a t -> 'a
+val is_empty : 'a t -> bool
+val position : 'a t -> int


### PR DESCRIPTION
test plan:
make core
osemgrep interactive -i python cli/
still works


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)