### PR TITLE
interactive: use the file targeting of osemgrep

### DIFF
--- a/.semgrepignore
+++ b/.semgrepignore
@@ -33,3 +33,6 @@
 # rules being tested for performance
 /perf/rules/
 /perf/r2c-rules/
+
+#TODO: fix, can't parse currently, weird
+/src/osemgrep/cli_scan/Cli_json_output.ml

--- a/src/osemgrep/cli_interactive/Interactive_CLI.ml
+++ b/src/osemgrep/cli_interactive/Interactive_CLI.ml
@@ -27,7 +27,7 @@ type conf = {
 (*************************************************************************)
 
 let cmdline_term : conf Term.t =
-  let combine lang target_roots logging_level =
+  let combine exclude include_ lang target_roots logging_level =
     let lang =
       match lang with
       (* TODO? we could omit the language like for -e and try all languages?*)
@@ -37,18 +37,24 @@ let cmdline_term : conf Term.t =
           Lang.of_string s
     in
     let target_roots = File.Path.of_strings target_roots in
+    let include_ =
+      match include_ with
+      | [] -> None
+      | nonempty -> Some nonempty
+    in
     {
       lang;
       target_roots;
-      (* TODO: accept CLI args at some point *)
-      targeting_conf = Scan_CLI.default.targeting_conf;
+      (* LATER: accept all CLI args *)
+      targeting_conf =
+        { Scan_CLI.default.targeting_conf with include_; exclude };
       core_runner_conf = Scan_CLI.default.core_runner_conf;
       logging_level;
     }
   in
   Term.(
-    const combine $ Scan_CLI.o_lang $ Scan_CLI.o_target_roots
-    $ CLI_common.logging_term)
+    const combine $ Scan_CLI.o_exclude $ Scan_CLI.o_include $ Scan_CLI.o_lang
+    $ Scan_CLI.o_target_roots $ CLI_common.logging_term)
 
 let doc = "Interactive mode!!"
 

--- a/src/osemgrep/cli_scan/Scan_CLI.mli
+++ b/src/osemgrep/cli_scan/Scan_CLI.mli
@@ -68,3 +68,5 @@ val cmdline_term : conf Cmdliner.Term.t
 (* exported because used by Interactive_CLI.ml too *)
 val o_lang : string option Cmdliner.Term.t
 val o_target_roots : string list Cmdliner.Term.t
+val o_include : string list Cmdliner.Term.t
+val o_exclude : string list Cmdliner.Term.t


### PR DESCRIPTION
Find_targets_old.files_of_dirs_or_files is deprecated and old and bad.
The new file targeting in osemgrep handles the .gitignore and
.semgrepignore which reduces the size we need to consider.

test plan:
osemgrep interactive -l ocaml
> 1 ENTER

does not crash anymore, because the OCaml file with the parse
error is mentioned in the .semgrepignore


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)