### PR TITLE
osemgrep interactive: support --profile

### DIFF
--- a/src/osemgrep/cli_interactive/Interactive_CLI.ml
+++ b/src/osemgrep/cli_interactive/Interactive_CLI.ml
@@ -19,6 +19,7 @@ type conf = {
   core_runner_conf : Core_runner.conf;
   (* nosem? *)
   logging_level : Logs.level option;
+  profile : bool;
 }
 [@@deriving show]
 
@@ -27,7 +28,10 @@ type conf = {
 (*************************************************************************)
 
 let cmdline_term : conf Term.t =
-  let combine exclude include_ lang target_roots logging_level =
+  (* those parameters must be in alphabetic order, like in the 'const combine'
+   * further below, so it's easy to add new options.
+   *)
+  let combine exclude include_ lang logging_level profile target_roots =
     let lang =
       match lang with
       (* TODO? we could omit the language like for -e and try all languages?*)
@@ -50,11 +54,12 @@ let cmdline_term : conf Term.t =
         { Scan_CLI.default.targeting_conf with include_; exclude };
       core_runner_conf = Scan_CLI.default.core_runner_conf;
       logging_level;
+      profile;
     }
   in
   Term.(
     const combine $ Scan_CLI.o_exclude $ Scan_CLI.o_include $ Scan_CLI.o_lang
-    $ Scan_CLI.o_target_roots $ CLI_common.logging_term)
+    $ CLI_common.o_logging $ CLI_common.o_profile $ Scan_CLI.o_target_roots)
 
 let doc = "Interactive mode!!"
 

--- a/src/osemgrep/cli_interactive/Interactive_CLI.mli
+++ b/src/osemgrep/cli_interactive/Interactive_CLI.mli
@@ -14,6 +14,7 @@ type conf = {
   core_runner_conf : Core_runner.conf;
   (* nosem? *)
   logging_level : Logs.level option;
+  profile : bool;
 }
 [@@deriving show]
 

--- a/src/osemgrep/cli_interactive/Interactive_subcommand.ml
+++ b/src/osemgrep/cli_interactive/Interactive_subcommand.ml
@@ -426,6 +426,7 @@ let interactive_loop xlang xtargets =
       (* TODO: change *)
       if true then update t state)
     (fun () -> Term.release t)
+  [@@profiling]
 
 (*****************************************************************************)
 (* Main logic *)

--- a/src/osemgrep/cli_login/Login_CLI.ml
+++ b/src/osemgrep/cli_login/Login_CLI.ml
@@ -56,7 +56,7 @@ let logout_cmdline_info : Cmd.info =
 
 let term =
   let combine logging_level = { logging_level } in
-  Term.(const combine $ CLI_common.logging_term)
+  Term.(const combine $ CLI_common.o_logging)
 
 let parse_argv (cmd_info : Cmd.info) (argv : string array) : conf =
   let cmd : conf Cmd.t = Cmd.v cmd_info term in

--- a/src/osemgrep/cli_lsp/Lsp_CLI.ml
+++ b/src/osemgrep/cli_lsp/Lsp_CLI.ml
@@ -19,7 +19,7 @@ type conf = { logging_level : Logs.level option } [@@deriving show]
 
 let cmdline_term : conf Term.t =
   let combine logging_level = { logging_level } in
-  Term.(const combine $ CLI_common.logging_term)
+  Term.(const combine $ CLI_common.o_logging)
 
 let doc = "Language server mode!!"
 

--- a/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -145,6 +145,7 @@ let default : conf =
 (*************************************************************************)
 (* Command-line flags *)
 (*************************************************************************)
+(* The o_ below stands for option (as in command-line argument option) *)
 
 (* ------------------------------------------------------------------ *)
 (* Networking related options (New) *)
@@ -606,11 +607,6 @@ let o_legacy : bool Term.t =
     ~default:default.legacy
     ~doc:{|Keep the pysemgrep behaviors/limitations/errors|}
 
-(* alt: could be put in Display options, next to o_time *)
-let o_profile : bool Term.t =
-  let info = Arg.info [ "profile" ] ~doc:{|<undocumented>|} in
-  Arg.value (Arg.flag info)
-
 let o_dump_config : string option Term.t =
   let info = Arg.info [ "dump-config" ] ~doc:{|<undocumented>|} in
   Arg.value (Arg.opt Arg.(some string) None info)
@@ -904,9 +900,9 @@ let cmdline_term : conf Term.t =
     const combine $ o_ast_caching $ o_autofix $ o_baseline_commit $ o_config
     $ o_dryrun $ o_dump_ast $ o_dump_config $ o_emacs $ o_error $ o_exclude
     $ o_exclude_rule_ids $ o_force_color $ o_include $ o_json $ o_lang
-    $ o_legacy $ CLI_common.logging_term $ o_max_chars_per_line
+    $ o_legacy $ CLI_common.o_logging $ o_max_chars_per_line
     $ o_max_lines_per_finding $ o_max_memory_mb $ o_max_target_bytes $ o_metrics
-    $ o_num_jobs $ o_nosem $ o_optimizations $ o_pattern $ o_profile
+    $ o_num_jobs $ o_nosem $ o_optimizations $ o_pattern $ CLI_common.o_profile
     $ o_project_root $ o_registry_caching $ o_replacement $ o_respect_git_ignore
     $ o_rewrite_rule_ids $ o_scan_unknown_extensions $ o_severity
     $ o_show_supported_languages $ o_strict $ o_target_roots $ o_test

--- a/src/osemgrep/core/CLI_common.ml
+++ b/src/osemgrep/core/CLI_common.ml
@@ -4,7 +4,8 @@ open Cmdliner
 (* Prelude *)
 (*************************************************************************)
 (*
-   Shared parameters, options, and help messages for the semgrep CLI.
+   Shared CLI flags, CLI processing helpers, and help messages for the
+   semgrep CLI.
 
    TODO: parser+printer for file path so we can write things like:
 
@@ -22,7 +23,7 @@ open Cmdliner
 *)
 
 (*************************************************************************)
-(* "Verbosity options" (mutually exclusive) *)
+(* Verbosity options (mutually exclusive) *)
 (*************************************************************************)
 
 (* alt: we could use Logs_cli.level(), but by defining our own flags
@@ -49,7 +50,7 @@ let o_debug : bool Term.t =
   in
   Arg.value (Arg.flag info)
 
-let logging_term : Logs.level option Term.t =
+let o_logging : Logs.level option Term.t =
   let combine debug quiet verbose =
     match (verbose, debug, quiet) with
     | false, false, false -> Some Logs.Warning
@@ -101,6 +102,15 @@ let setup_logging ~force_color ~level =
     ~log_config_file:(Fpath.v "log_config.json")
     ~log_to_file:None;
   ()
+
+(*************************************************************************)
+(* Profiling options *)
+(*************************************************************************)
+
+(* osemgrep-only:  *)
+let o_profile : bool Term.t =
+  let info = Arg.info [ "profile" ] ~doc:{|<undocumented>|} in
+  Arg.value (Arg.flag info)
 
 (*************************************************************************)
 (* Misc *)

--- a/src/osemgrep/core/CLI_common.mli
+++ b/src/osemgrep/core/CLI_common.mli
@@ -1,6 +1,8 @@
 (*
    Shared utilities to help with command-line parsing and handling
    (relies on the cmdliner library)
+
+   The o_ below stands for option (as in command-line argument option).
 *)
 
 val help_page_bottom : Cmdliner.Manpage.block list
@@ -9,7 +11,10 @@ val help_page_bottom : Cmdliner.Manpage.block list
 val eval_value : argv:string array -> 'a Cmdliner.Cmd.t -> 'a
 
 (* handles logging arguments (--quiet/--verbose/--debug) *)
-val logging_term : Logs.level option Cmdliner.Term.t
+val o_logging : Logs.level option Cmdliner.Term.t
 
 (* small wrapper around Logs_helper.setup_logging and Logging_helpers.setup *)
 val setup_logging : force_color:bool -> level:Logs.level option -> unit
+
+(* for --profile *)
+val o_profile : bool Cmdliner.Term.t


### PR DESCRIPTION
test plan:
```
$ osemgrep interactive -l ocaml --profile
...
exit
...
Error: bye bye
---------------------
profiling result
---------------------
*CLI.dispatch_subcommand                 :      3.083 sec          1 count
Find_targets.get_targets                 :      1.993 sec          1 count
Gitignore_filter.select                  :      1.973 sec       8781 count
Glob.Match.run                           :      1.241 sec    9898813 count
Gitignores_cache.load                    :      0.006 sec      33781 count
...
```


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)