### PR TITLE
osemgrep interactive: leverage AST caching and -fast

### DIFF
--- a/src/engine/Match_rules.mli
+++ b/src/engine/Match_rules.mli
@@ -15,3 +15,7 @@ val check :
   Rule.rules ->
   Xtarget.t ->
   Report.partial_profiling Report.match_result
+
+(* for osemgrep interactive *)
+val is_relevant_rule_for_xtarget :
+  Rule.t -> Match_env.xconfig -> Xtarget.t -> bool

--- a/src/osemgrep/cli_interactive/Interactive_CLI.ml
+++ b/src/osemgrep/cli_interactive/Interactive_CLI.ml
@@ -16,8 +16,8 @@ type conf = {
   lang : Lang.t; (* use Xlang.t at some point? or even Xlang option? *)
   target_roots : Fpath.t list;
   targeting_conf : Find_targets.conf;
+  (* LATER: nosem *)
   core_runner_conf : Core_runner.conf;
-  (* nosem? *)
   logging_level : Logs.level option;
   profile : bool;
 }
@@ -31,7 +31,8 @@ let cmdline_term : conf Term.t =
   (* those parameters must be in alphabetic order, like in the 'const combine'
    * further below, so it's easy to add new options.
    *)
-  let combine exclude include_ lang logging_level profile target_roots =
+  let combine ast_caching exclude include_ lang logging_level profile
+      target_roots =
     let lang =
       match lang with
       (* TODO? we could omit the language like for -e and try all languages?*)
@@ -41,6 +42,7 @@ let cmdline_term : conf Term.t =
           Lang.of_string s
     in
     let target_roots = File.Path.of_strings target_roots in
+    (* like in Scan_CLI.combine *)
     let include_ =
       match include_ with
       | [] -> None
@@ -52,14 +54,15 @@ let cmdline_term : conf Term.t =
       (* LATER: accept all CLI args *)
       targeting_conf =
         { Scan_CLI.default.targeting_conf with include_; exclude };
-      core_runner_conf = Scan_CLI.default.core_runner_conf;
+      core_runner_conf = { Scan_CLI.default.core_runner_conf with ast_caching };
       logging_level;
       profile;
     }
   in
   Term.(
-    const combine $ Scan_CLI.o_exclude $ Scan_CLI.o_include $ Scan_CLI.o_lang
-    $ CLI_common.o_logging $ CLI_common.o_profile $ Scan_CLI.o_target_roots)
+    const combine $ Scan_CLI.o_ast_caching $ Scan_CLI.o_exclude
+    $ Scan_CLI.o_include $ Scan_CLI.o_lang $ CLI_common.o_logging
+    $ CLI_common.o_profile $ Scan_CLI.o_target_roots)
 
 let doc = "Interactive mode!!"
 

--- a/src/osemgrep/cli_interactive/Interactive_CLI.mli
+++ b/src/osemgrep/cli_interactive/Interactive_CLI.mli
@@ -8,11 +8,10 @@
 
 (* a subset of Scan_CLI.conf *)
 type conf = {
-  lang : Lang.t; (* use Xlang.t at some point? or even Xlang option? *)
+  lang : Lang.t;
   target_roots : Fpath.t list;
   targeting_conf : Find_targets.conf;
   core_runner_conf : Core_runner.conf;
-  (* nosem? *)
   logging_level : Logs.level option;
   profile : bool;
 }

--- a/src/osemgrep/cli_interactive/Interactive_subcommand.ml
+++ b/src/osemgrep/cli_interactive/Interactive_subcommand.ml
@@ -1,10 +1,21 @@
 (*****************************************************************************)
 (* Prelude *)
 (*****************************************************************************)
-(*
-   Parse a semgrep-interactive command, execute it and exit.
-
-*)
+(* Parse a semgrep-interactive command, execute it and exit.
+ *
+ * TODO:
+ *  - turbo/live mode, show results as you type, using threads for a v0
+ *    (not waiting until you have typed the whole thing)
+ *  - turbo/live mode with displaying incremental matches
+ *    (not waiting until we have found all the matches)
+ *  - code highlighting using Highlight_AST.ml in codemap/efuns
+ *  - leverage multicore (switch to OCaml 5.0 or find a way to use
+ *    Parmap like in Run_semgrep.map_targets)
+ *  - support more complex iformula (where, inside, etc.)
+ *  - readline-like input with history
+ *  - completion on function names in the project! (or maybe put this in
+ *    osemgrep-pro interactive)
+ *)
 
 open Notty
 open Notty_unix

--- a/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -108,8 +108,11 @@ let default : conf =
         timeout_threshold = 3;
         max_memory_mb = 0;
         optimizations = true;
-        (* like legacy, should maybe be set to false when we release osemgrep*)
-        ast_caching = true;
+        (* better to set to false for now; annoying to add --ast-caching to
+         * each command, but while we're still developing osemgrep it is
+         * better to eliminate some source of complexity by default.
+         *)
+        ast_caching = false;
       };
     autofix = false;
     dryrun = false;

--- a/src/osemgrep/cli_scan/Scan_CLI.mli
+++ b/src/osemgrep/cli_scan/Scan_CLI.mli
@@ -70,3 +70,4 @@ val o_lang : string option Cmdliner.Term.t
 val o_target_roots : string list Cmdliner.Term.t
 val o_include : string list Cmdliner.Term.t
 val o_exclude : string list Cmdliner.Term.t
+val o_ast_caching : bool Cmdliner.Term.t

--- a/src/parsing/Parse_with_caching.ml
+++ b/src/parsing/Parse_with_caching.ml
@@ -187,3 +187,4 @@ let parse_and_resolve_name ?(parsing_cache_dir = None) version lang
         match either with
         | Left x -> x
         | Right exn -> Exception.reraise exn)
+  [@@profiling]


### PR DESCRIPTION
For the example in the scope doc, we go for django from
a few seconds of intialization and 9s for the foo query
to instant initialization and 0.6s for the foo query.

For the semgrep repo we go from 20s for foo query
to 0.1s (and 1.6s of init time, but we should be able to improve that too)

test plan:
```
$ cd django
$ osemgrep interactive -l python --ast-caching --profile
> foo
> exit
Error: bye bye
---------------------
profiling result
---------------------
*CLI.dispatch_subcommand                 :      2.595 sec          1 count
*Interactive_subcommand.interactive_loop :      2.274 sec          1 count
Match_search_mode.matches_of_xpatterns   :      0.676 sec        250 count
Match_patterns.check                     :      0.426 sec        250 count
Find_targets.get_targets                 :      0.319 sec          1 count
Gitignore_filter.select                  :      0.277 sec       9869 count
Match_search_mode.lazy_force             :      0.249 sec        250 count
Parse_with_caching.parse_and_resolve_name :      0.248 sec        250 count
Glob.Match.run                           :      0.136 sec    1359615 count
Match_patterns.match_e_e                 :      0.116 sec     525837 count
AST_generic_helpers.range_of_any_opt     :      0.086 sec     529060 count
Analyze_rule.run_cnf_step2               :      0.020 sec       2750 count
Gitignores_cache.load                    :      0.019 sec      50255 count
Analyze_rule.compute_final_cnf           :      0.004 sec          1 count
...
```


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)