### PR TITLE
osemgrep: output tweaks for test_terminal_output

### DIFF
--- a/cli/tests/e2e/test_check.py
+++ b/cli/tests/e2e/test_check.py
@@ -202,6 +202,7 @@ def test_terminal_output(run_semgrep_in_tmp: RunSemgrep, snapshot):
     snapshot.assert_match(results.as_snapshot(), "results_second.txt")
 
 
+@pytest.mark.osempass
 @pytest.mark.kinda_slow
 def test_terminal_output_quiet(run_semgrep_in_tmp: RunSemgrep, snapshot):
     """
@@ -369,6 +370,7 @@ def test_regex_rule__utf8(run_semgrep_in_tmp: RunSemgrep, snapshot):
 
 
 @pytest.mark.kinda_slow
+@pytest.mark.osempass
 def test_regex_rule__utf8_on_image(run_semgrep_in_tmp: RunSemgrep, snapshot):
     # https://github.com/returntocorp/semgrep/issues/4258
     snapshot.assert_match(

--- a/cli/tests/e2e/test_check.py
+++ b/cli/tests/e2e/test_check.py
@@ -178,6 +178,7 @@ def test_basic_rule__absolute(run_semgrep_in_tmp: RunSemgrep, snapshot):
     )
 
 
+@pytest.mark.osempass
 @pytest.mark.slow
 def test_terminal_output(run_semgrep_in_tmp: RunSemgrep, snapshot):
     # Have shared settings file to test second run doesnt show metric output

--- a/cli/tests/e2e/test_cli_test.py
+++ b/cli/tests/e2e/test_cli_test.py
@@ -28,6 +28,7 @@ def test_cli_test_basic(run_semgrep_in_tmp: RunSemgrep, snapshot):
     )
 
 
+@pytest.mark.osempass
 @pytest.mark.kinda_slow
 def test_cli_test_verbose(run_semgrep_in_tmp: RunSemgrep, snapshot):
     results, _ = run_semgrep_in_tmp(

--- a/cli/tests/e2e/test_output.py
+++ b/cli/tests/e2e/test_output.py
@@ -41,6 +41,7 @@ def _etree_to_dict(t):
     return d
 
 
+@pytest.mark.osempass
 @pytest.mark.kinda_slow
 def test_output_highlighting(run_semgrep_in_tmp: RunSemgrep, snapshot):
     results, _errors = run_semgrep_in_tmp(
@@ -72,6 +73,7 @@ def test_output_highlighting__no_color(run_semgrep_in_tmp: RunSemgrep, snapshot)
     )
 
 
+@pytest.mark.osempass
 @pytest.mark.kinda_slow
 def test_output_highlighting__force_color_and_no_color(
     run_semgrep_in_tmp: RunSemgrep, snapshot

--- a/libs/commons/Fmt_helpers.ml
+++ b/libs/commons/Fmt_helpers.ml
@@ -12,11 +12,7 @@ let line width =
         | 2 -> 0x80
         | _not_possible -> assert false))
 
-(*****************************************************************************)
-(* Entry point *)
-(*****************************************************************************)
-
-let pp_table (h1, heading) ppf entries =
+let layout_table (h1, heading) entries =
   let int_size i =
     let rec dec acc = function
       | 0 -> acc
@@ -39,19 +35,57 @@ let pp_table (h1, heading) ppf entries =
     let to_pad = len - str_size in
     String.make to_pad ' '
   in
-  Fmt.pf ppf "  %s%s" h1 (pad (String.length h1) len1);
-  List.iter2
-    (fun h l -> Fmt.pf ppf "%s%s" (pad (String.length h) l) h)
-    heading lengths;
-  Fmt.pf ppf "@. %s@." line;
-  List.iter
-    (fun (e1, entries) ->
-      Fmt.pf ppf "  %s%s" e1 (pad (String.length e1) len1);
-      List.iter2
-        (fun e l -> Fmt.pf ppf "%s%u" (pad (int_size e) l) e)
-        entries lengths;
-      Fmt.pf ppf "@.")
-    entries;
+  String.concat ""
+    (List.flatten
+       ([ h1; pad (String.length h1) len1 ]
+       :: Common.map2
+            (fun h l -> [ pad (String.length h) l; h ])
+            heading lengths))
+  :: line
+  :: Common.map
+       (fun (e1, entries) ->
+         String.concat ""
+           (List.flatten
+              ([ e1; pad (String.length e1) len1 ]
+              :: Common.map2
+                   (fun e l -> [ pad (int_size e) l; string_of_int e ])
+                   entries lengths)))
+       entries
+
+(*****************************************************************************)
+(* Entry point *)
+(*****************************************************************************)
+
+let pp_table (h1, heading) ppf entries =
+  let lines = layout_table (h1, heading) entries in
+  List.iteri
+    (fun idx line -> Fmt.pf ppf "%s%s@." (if idx = 1 then " " else "  ") line)
+    lines;
+  Fmt.pf ppf "@."
+
+let pp_tables ppf (h1, heading1, entries1) (h2, heading2, entries2) =
+  let lines1 = layout_table (h1, heading1) entries1
+  and lines2 = layout_table (h2, heading2) entries2 in
+  let l1_space = String.make (String.length (List.hd lines1)) ' ' in
+  let space = String.make 10 ' ' in
+  let rec one idx a b =
+    match (a, b) with
+    | [], [] -> ()
+    | a :: ra, b :: rb ->
+        Fmt.pf ppf "%s%s%s%s@."
+          (if idx = 1 then " " else "  ")
+          a
+          (if idx = 1 then String.make 8 ' ' else space)
+          b;
+        one (idx + 1) ra rb
+    | a :: ra, [] ->
+        Fmt.pf ppf "  %s@." a;
+        one (idx + 1) ra []
+    | [], b :: rb ->
+        Fmt.pf ppf "  %s%s%s@." l1_space space b;
+        one (idx + 1) [] rb
+  in
+  one 0 lines1 lines2;
   Fmt.pf ppf "@."
 
 let pp_heading ppf txt =

--- a/libs/commons/Fmt_helpers.ml
+++ b/libs/commons/Fmt_helpers.ml
@@ -85,8 +85,7 @@ let pp_tables ppf (h1, heading1, entries1) (h2, heading2, entries2) =
         Fmt.pf ppf "  %s%s%s@." l1_space space b;
         one (idx + 1) [] rb
   in
-  one 0 lines1 lines2;
-  Fmt.pf ppf "@."
+  one 0 lines1 lines2
 
 let pp_heading ppf txt =
   let line = line (String.length txt + 2) in

--- a/libs/commons/Fmt_helpers.ml
+++ b/libs/commons/Fmt_helpers.ml
@@ -66,7 +66,11 @@ let pp_table (h1, heading) ppf entries =
 let pp_tables ppf (h1, heading1, entries1) (h2, heading2, entries2) =
   let lines1 = layout_table (h1, heading1) entries1
   and lines2 = layout_table (h2, heading2) entries2 in
-  let l1_space = String.make (String.length (List.hd lines1)) ' ' in
+  let l1_space =
+    String.make
+      (String.length (Common.hd_exn "unexpected empty list" lines1))
+      ' '
+  in
   let space = String.make 10 ' ' in
   let rec one idx a b =
     match (a, b) with

--- a/libs/commons/Fmt_helpers.ml
+++ b/libs/commons/Fmt_helpers.ml
@@ -33,23 +33,20 @@ let pp_table (h1, heading) ppf entries =
       (String.length h1, acc)
       entries
   in
-  let len1, lengths = (len1 + 3, Common.map (fun i -> i + 3) lengths) in
+  let lengths = Common.map (fun i -> i + 3) lengths in
   let line = List.fold_left (fun acc w -> acc + w) (len1 + 2) lengths |> line in
   let pad str_size len =
     let to_pad = len - str_size in
     String.make to_pad ' '
   in
-  Fmt.pf ppf "  %a%s" Fmt.(styled `Bold string) h1 (pad (String.length h1) len1);
+  Fmt.pf ppf "  %s%s" h1 (pad (String.length h1) len1);
   List.iter2
-    (fun h l ->
-      Fmt.pf ppf "%s%a" (pad (String.length h) l) Fmt.(styled `Bold string) h)
+    (fun h l -> Fmt.pf ppf "%s%s" (pad (String.length h) l) h)
     heading lengths;
   Fmt.pf ppf "@. %s@." line;
   List.iter
     (fun (e1, entries) ->
-      Fmt.pf ppf "  %s%s"
-        (String.capitalize_ascii e1)
-        (pad (String.length e1) len1);
+      Fmt.pf ppf "  %s%s" e1 (pad (String.length e1) len1);
       List.iter2
         (fun e l -> Fmt.pf ppf "%s%u" (pad (int_size e) l) e)
         entries lengths;
@@ -58,11 +55,7 @@ let pp_table (h1, heading) ppf entries =
   Fmt.pf ppf "@."
 
 let pp_heading ppf txt =
-  let chars = String.length txt + 2 in
-  let line = line chars in
-  Fmt.pf ppf "%s@.%s@."
-    (String.make (chars + 2) ' ')
-    (String.make (chars + 2) ' ');
-  Fmt.pf ppf "┌%s┐@." line;
+  let line = line (String.length txt + 2) in
+  Fmt.pf ppf "@.@.┌%s┐@." line;
   Fmt.pf ppf "│ %s │@." txt;
   Fmt.pf ppf "└%s┘@." line

--- a/libs/commons/Fmt_helpers.mli
+++ b/libs/commons/Fmt_helpers.mli
@@ -18,3 +18,11 @@ val pp_table : string * string list -> (string * int list) list Fmt.t
       A    1  2
       B  100 20
     ]} *)
+
+val pp_tables :
+  Format.formatter ->
+  string * string list * (string * int list) list ->
+  string * string list * (string * int list) list ->
+  unit
+(** Pretty-prints two tables with headings side by side, with some spacing in between.
+    Look at [pp_table] for the individual arguments. *)

--- a/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -211,7 +211,6 @@ let run (conf : Scan_CLI.conf) : Exit_code.t =
                \"--metrics=off\".@.Using configs only from local files (like \
                --config=xyz.yml) does not enable metrics.@.@.More information: \
                https://semgrep.dev/docs/metrics");
-        Logs.app (fun m -> m "@.");
         let settings =
           {
             settings with

--- a/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -297,9 +297,11 @@ let run (conf : Scan_CLI.conf) : Exit_code.t =
                 other_ignored,
                 errors_skipped ));
         Logs.app (fun m ->
-            m "Ran %s on %s: %s@."
+            m "Ran %s on %s: %s."
               (String_utils.unit_str (List.length filtered_rules) "rule")
-              (String_utils.unit_str (List.length targets) "file")
+              (String_utils.unit_str
+                 (List.length cli_output.paths.scanned)
+                 "file")
               (String_utils.unit_str (List.length cli_output.results) "finding"));
 
         (* TOPORT? was in formater/base.py

--- a/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -202,15 +202,19 @@ let run (conf : Scan_CLI.conf) : Exit_code.t =
       (* --------------------------------------------------------- *)
       (* step0: potentially notify user about metrics *)
       if not (settings.has_shown_metrics_notification = Some true) then (
-        (* the 22m 24m is just for python compatibility *)
+        (* python compatibility: the 22m and 24m are "normal color or intensity", and "underline off" *)
+        let esc =
+          if Fmt.style_renderer Fmt.stderr = `Ansi_tty then "\027[22m\027[24m"
+          else ""
+        in
         Logs.warn (fun m ->
             m
-              "\027[22m\027[24mMETRICS: Using configs from the Registry (like \
-               --config=p/ci) reports pseudonymous rule metrics to \
-               semgrep.dev.@.To disable Registry rule metrics, use \
-               \"--metrics=off\".@.Using configs only from local files (like \
-               --config=xyz.yml) does not enable metrics.@.@.More information: \
-               https://semgrep.dev/docs/metrics");
+              "%sMETRICS: Using configs from the Registry (like --config=p/ci) \
+               reports pseudonymous rule metrics to semgrep.dev.@.To disable \
+               Registry rule metrics, use \"--metrics=off\".@.Using configs \
+               only from local files (like --config=xyz.yml) does not enable \
+               metrics.@.@.More information: https://semgrep.dev/docs/metrics"
+              esc);
         Logs.app (fun m -> m "");
         let settings =
           {

--- a/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -211,6 +211,7 @@ let run (conf : Scan_CLI.conf) : Exit_code.t =
                \"--metrics=off\".@.Using configs only from local files (like \
                --config=xyz.yml) does not enable metrics.@.@.More information: \
                https://semgrep.dev/docs/metrics");
+        Logs.info (fun m -> m "");
         let settings =
           {
             settings with

--- a/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -211,7 +211,7 @@ let run (conf : Scan_CLI.conf) : Exit_code.t =
                \"--metrics=off\".@.Using configs only from local files (like \
                --config=xyz.yml) does not enable metrics.@.@.More information: \
                https://semgrep.dev/docs/metrics");
-        Logs.info (fun m -> m "");
+        Logs.app (fun m -> m "");
         let settings =
           {
             settings with

--- a/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -202,14 +202,16 @@ let run (conf : Scan_CLI.conf) : Exit_code.t =
       (* --------------------------------------------------------- *)
       (* step0: potentially notify user about metrics *)
       if not (settings.has_shown_metrics_notification = Some true) then (
+        (* the 22m 24m is just for python compatibility *)
         Logs.warn (fun m ->
             m
-              "METRICS: Using configs from the Registry (like --config=p/ci) \
-               reports pseudonymous rule metrics to semgrep.dev.@.To disable \
-               Registry rule metrics, use \"--metrics=off\".@.Using configs \
-               only from local files (like --config=xyz.yml) does not enable \
-               metrics.@.@.More information: \
-               https://semgrep.dev/docs/metrics@.");
+              "\027[22m\027[24mMETRICS: Using configs from the Registry (like \
+               --config=p/ci) reports pseudonymous rule metrics to \
+               semgrep.dev.@.To disable Registry rule metrics, use \
+               \"--metrics=off\".@.Using configs only from local files (like \
+               --config=xyz.yml) does not enable metrics.@.@.More information: \
+               https://semgrep.dev/docs/metrics");
+        Logs.app (fun m -> m "@.");
         let settings =
           {
             settings with

--- a/src/osemgrep/configuring/Semgrep_settings.ml
+++ b/src/osemgrep/configuring/Semgrep_settings.ml
@@ -78,7 +78,7 @@ let to_yaml { has_shown_metrics_notification; api_token; anonymous_user_id } =
 (* Entry points *)
 (*****************************************************************************)
 
-let load () =
+let load ?(legacy = false) () =
   try
     if
       Sys.file_exists (Fpath.to_string settings)
@@ -101,9 +101,10 @@ let load () =
               default_settings
           | Ok s -> s)
     else (
-      Logs.warn (fun m ->
-          m "Settings file %a does not exist or is not a regular file" Fpath.pp
-            settings);
+      if not legacy then
+        Logs.warn (fun m ->
+            m "Settings file %a does not exist or is not a regular file"
+              Fpath.pp settings);
       default_settings)
   with
   | Failure _ -> default_settings
@@ -118,7 +119,8 @@ let save setting =
     if Sys.file_exists (Fpath.to_string tmp) then
       Sys.remove (Fpath.to_string tmp);
     File.write_file tmp str;
-    (* TODO: Why this tmp and rename? Why not write directly to the file? *)
+    (* Create a termporary file and rename to have a consisting settings file,
+       even if the power fails (or a Ctrl-C happens) during the write_file. *)
     Unix.rename (Fpath.to_string tmp) (Fpath.to_string settings);
     true
   with

--- a/src/osemgrep/configuring/Semgrep_settings.mli
+++ b/src/osemgrep/configuring/Semgrep_settings.mli
@@ -8,7 +8,7 @@ type t = {
 }
 
 (* loading the ~/.semgrep/settings.yml in memory *)
-val load : unit -> t
+val load : ?legacy:bool -> unit -> t
 
 (* returns whether the save was successful *)
 val save : t -> bool

--- a/src/osemgrep/reporting/Matches_report.ml
+++ b/src/osemgrep/reporting/Matches_report.ml
@@ -102,7 +102,7 @@ let wrap ~indent ~width s =
   let pre = String.make indent ' ' in
   let rec go indent width pre s acc =
     let real_width = width - indent in
-    if String.length s <= real_width then List.rev ((pre ^ s) :: acc)
+    if String.length s <= real_width then List.rev ((pre, s) :: acc)
     else
       let cut =
         let prev_ws =
@@ -118,7 +118,7 @@ let wrap ~indent ~width s =
       let e, s =
         (Str.first_chars s cut, String.(trim (sub s cut (length s - cut))))
       in
-      go indent width pre s ((pre ^ e) :: acc)
+      go indent width pre s ((pre, e) :: acc)
   in
   go indent width pre s []
 
@@ -240,10 +240,10 @@ let pp_text_outputs ~max_chars_per_line ~max_lines_per_finding ~color_output ppf
     in
     if print then (
       List.iter
-        (fun l -> Fmt.pf ppf "%a@." Fmt.(styled `Bold string) l)
+        (fun (sp, l) -> Fmt.pf ppf "%s%a@." sp Fmt.(styled `Bold string) l)
         (wrap ~indent:7 ~width:text_width cur.check_id);
       List.iter
-        (fun l -> Fmt.pf ppf "%s@." l)
+        (fun (sp, l) -> Fmt.pf ppf "%s%s@." sp l)
         (wrap ~indent:10 ~width:text_width cur.extra.message);
       (match Yojson.Basic.Util.member "shortlink" cur.extra.metadata with
       | `String s -> Fmt.pf ppf "%sDetails: %s@." base_indent s

--- a/src/osemgrep/reporting/Matches_report.ml
+++ b/src/osemgrep/reporting/Matches_report.ml
@@ -187,12 +187,13 @@ let pp_finding ~max_chars_per_line ~max_lines_per_finding ~color_output
                   (if m.start.line = m.end_.line then
                    start_color + (m.end_.col - m.start.col)
                   else col m.end_.col - ellipsis_len true)
-                  (String.length line - 1 - ellipsis_len true)
-               else String.length line - 1)
+                  (String.length line - ellipsis_len true)
+               else String.length line)
            in
            let a, b, c = cut line start_color end_color in
            Fmt.pf ppf "%s%s┆ %s%a%s@." pad line_number_str a
-             Fmt.(styled `Bold string)
+             (* The 24m is "no underline", and for python compatibility *)
+             Fmt.(styled `Bold (any "\027[24m" ++ string))
              b c;
            (stripped' || stripped, succ line_number))
          (false, start_line)
@@ -226,8 +227,9 @@ let pp_text_outputs ~max_chars_per_line ~max_lines_per_finding ~color_output ppf
             else (true, None)
       in
       if print then
+        (* python compatibility: the 22m and 24m are "normal color or intensity", and "underline off" *)
         Fmt.pf ppf "  %a@."
-          Fmt.(styled (`Fg `Cyan) (any "  " ++ string ++ any " "))
+          Fmt.(styled (`Fg `Cyan) (any "\027[22m\027[24m  " ++ string ++ any " "))
           cur.path;
       msg
     in
@@ -240,7 +242,8 @@ let pp_text_outputs ~max_chars_per_line ~max_lines_per_finding ~color_output ppf
     in
     if print then (
       List.iter
-        (fun (sp, l) -> Fmt.pf ppf "%s%a@." sp Fmt.(styled `Bold string) l)
+        (* The 24m is "no underline", and for python compatibility *)
+        (fun (sp, l) -> Fmt.pf ppf "%s%a@." sp Fmt.(styled `Bold (any "\027[24m" ++ string)) l)
         (wrap ~indent:7 ~width:text_width cur.check_id);
       List.iter
         (fun (sp, l) -> Fmt.pf ppf "%s%s@." sp l)

--- a/src/osemgrep/reporting/Matches_report.ml
+++ b/src/osemgrep/reporting/Matches_report.ml
@@ -229,7 +229,8 @@ let pp_text_outputs ~max_chars_per_line ~max_lines_per_finding ~color_output ppf
       if print then
         (* python compatibility: the 22m and 24m are "normal color or intensity", and "underline off" *)
         Fmt.pf ppf "  %a@."
-          Fmt.(styled (`Fg `Cyan) (any "\027[22m\027[24m  " ++ string ++ any " "))
+          Fmt.(
+            styled (`Fg `Cyan) (any "\027[22m\027[24m  " ++ string ++ any " "))
           cur.path;
       msg
     in
@@ -243,7 +244,8 @@ let pp_text_outputs ~max_chars_per_line ~max_lines_per_finding ~color_output ppf
     if print then (
       List.iter
         (* The 24m is "no underline", and for python compatibility *)
-        (fun (sp, l) -> Fmt.pf ppf "%s%a@." sp Fmt.(styled `Bold (any "\027[24m" ++ string)) l)
+          (fun (sp, l) ->
+          Fmt.pf ppf "%s%a@." sp Fmt.(styled `Bold (any "\027[24m" ++ string)) l)
         (wrap ~indent:7 ~width:text_width cur.check_id);
       List.iter
         (fun (sp, l) -> Fmt.pf ppf "%s%s@." sp l)

--- a/src/osemgrep/reporting/Status_report.ml
+++ b/src/osemgrep/reporting/Status_report.ml
@@ -29,8 +29,9 @@ let pp_status ~num_rules ~num_targets ~respect_git_ignore lang_jobs ppf =
   if num_rules = 0 then Fmt.pf ppf "  Nothing to scan."
   else if num_rules = 1 then
     Fmt.pf ppf "  Scanning %s." (String_utils.unit_str num_targets "file")
-  else
+  else (
     (* TODO origin table [Origin Rules] [Community N] *)
+    Fmt.pf ppf "@.";
     let xlang_label = function
       | Xlang.LGeneric
       | Xlang.LRegex ->
@@ -50,5 +51,4 @@ let pp_status ~num_rules ~num_targets ~respect_git_ignore lang_jobs ppf =
              | [ (_, [ r1; t1 ]) ], others ->
                  (lang, [ rules + r1; targets + t1 ]) :: others
              | _ -> assert false)
-           []
-      |> List.rev)
+           []))

--- a/src/osemgrep/reporting/Status_report.ml
+++ b/src/osemgrep/reporting/Status_report.ml
@@ -30,6 +30,7 @@ let origin rule =
 (*****************************************************************************)
 
 let pp_status ~num_rules ~num_targets ~respect_git_ignore lang_jobs ppf =
+  Fmt.pf ppf "@.";
   Fmt_helpers.pp_heading ppf "Scan Status";
   Fmt.pf ppf "  Scanning %s%s with %s"
     (String_utils.unit_str num_targets "file")

--- a/src/osemgrep/reporting/Status_report.ml
+++ b/src/osemgrep/reporting/Status_report.ml
@@ -7,6 +7,25 @@
 *)
 
 (*****************************************************************************)
+(* Helpers *)
+(*****************************************************************************)
+
+let origin rule =
+  Option.value ~default:"unknown"
+    (match rule.Rule.metadata with
+    | Some meta -> (
+        match Yojson.Basic.Util.member "semgrep.dev" (JSON.to_yojson meta) with
+        | `Assoc _ as things -> (
+            match Yojson.Basic.Util.member "rule" things with
+            | `Assoc _ as things -> (
+                match Yojson.Basic.Util.member "origin" things with
+                | `String s -> Some s
+                | _else -> None)
+            | _else -> None)
+        | _else -> None)
+    | _else -> None)
+
+(*****************************************************************************)
 (* Entry point *)
 (*****************************************************************************)
 
@@ -29,8 +48,16 @@ let pp_status ~num_rules ~num_targets ~respect_git_ignore lang_jobs ppf =
   if num_rules = 0 then Fmt.pf ppf "  Nothing to scan."
   else if num_rules = 1 then
     Fmt.pf ppf "  Scanning %s." (String_utils.unit_str num_targets "file")
-  else (
-    (* TODO origin table [Origin Rules] [Community N] *)
+  else
+    let rule_origins =
+      lang_jobs
+      |> List.fold_left
+           (fun acc Lang_job.{ rules; _ } -> Common.map origin rules @ acc)
+           []
+      |> Common.group_by Fun.id
+      |> Common.map (fun (src, xs) ->
+             (String.capitalize_ascii src, [ List.length xs ]))
+    in
     Fmt.pf ppf "@.";
     let xlang_label = function
       | Xlang.LGeneric
@@ -38,17 +65,18 @@ let pp_status ~num_rules ~num_targets ~respect_git_ignore lang_jobs ppf =
           "<multilang>"
       | Xlang.L (l, _) -> Lang.to_lowercase_alnum l
     in
-    Fmt_helpers.pp_table
-      ("Language", [ "Rules"; "Files" ])
-      ppf
-      (lang_jobs
-      |> Common.map (fun Lang_job.{ xlang; targets; rules } ->
-             (xlang_label xlang, List.length rules, List.length targets))
-      |> List.fold_left
-           (fun acc (lang, rules, targets) ->
-             match List.partition (fun (l, _) -> l = lang) acc with
-             | [], others -> (lang, [ rules; targets ]) :: others
-             | [ (_, [ r1; t1 ]) ], others ->
-                 (lang, [ rules + r1; targets + t1 ]) :: others
-             | _ -> assert false)
-           []))
+    Fmt_helpers.pp_tables ppf
+      ( "Language",
+        [ "Rules"; "Files" ],
+        lang_jobs
+        |> Common.map (fun Lang_job.{ xlang; targets; rules } ->
+               (xlang_label xlang, List.length rules, List.length targets))
+        |> List.fold_left
+             (fun acc (lang, rules, targets) ->
+               match List.partition (fun (l, _) -> l = lang) acc with
+               | [], others -> (lang, [ rules; targets ]) :: others
+               | [ (_, [ r1; t1 ]) ], others ->
+                   (lang, [ rules + r1; targets + t1 ]) :: others
+               | _ -> assert false)
+             [] )
+      ("Origin", [ "Rules" ], rule_origins)

--- a/src/osemgrep/reporting/Status_report.ml
+++ b/src/osemgrep/reporting/Status_report.ml
@@ -30,7 +30,6 @@ let origin rule =
 (*****************************************************************************)
 
 let pp_status ~num_rules ~num_targets ~respect_git_ignore lang_jobs ppf =
-  Fmt.pf ppf "@.";
   Fmt_helpers.pp_heading ppf "Scan Status";
   Fmt.pf ppf "  Scanning %s%s with %s"
     (String_utils.unit_str num_targets "file")

--- a/src/osemgrep/reporting/Status_report.ml
+++ b/src/osemgrep/reporting/Status_report.ml
@@ -35,7 +35,7 @@ let pp_status ~num_rules ~num_targets ~respect_git_ignore lang_jobs ppf =
       | Xlang.LGeneric
       | Xlang.LRegex ->
           "<multilang>"
-      | xlang -> Xlang.to_string xlang
+      | Xlang.L (l, _) -> Lang.to_lowercase_alnum l
     in
     Fmt_helpers.pp_table
       ("Language", [ "Rules"; "Files" ])


### PR DESCRIPTION
I'm proud this PR finally makes test_terminal_output check pass with osemgrep

test plan:
 - make osempass

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
