### PR TITLE
feat(interactive): allow optional turbo

### DIFF
--- a/src/osemgrep/cli_interactive/Interactive_CLI.ml
+++ b/src/osemgrep/cli_interactive/Interactive_CLI.ml
@@ -1,4 +1,5 @@
 open Cmdliner
+module H = Cmdliner_helpers
 
 (*****************************************************************************)
 (* Prelude *)
@@ -20,8 +21,18 @@ type conf = {
   core_runner_conf : Core_runner.conf;
   logging_level : Logs.level option;
   profile : bool;
+  turbo : bool;
 }
 [@@deriving show]
+
+(*************************************************************************)
+(* Command-line flags *)
+(*************************************************************************)
+(* The o_ below stands for option (as in command-line argument option) *)
+
+let o_turbo : bool Term.t =
+  H.negatable_flag [ "turbo" ] ~neg_options:[ "no-turbo" ] ~default:false
+    ~doc:{|Automatically search as you type in Interactive Mode.|}
 
 (*************************************************************************)
 (* Command-line parsing: turn argv into conf *)
@@ -32,7 +43,7 @@ let cmdline_term : conf Term.t =
    * further below, so it's easy to add new options.
    *)
   let combine ast_caching exclude include_ lang logging_level profile
-      target_roots =
+      target_roots turbo =
     let lang =
       match lang with
       (* TODO? we could omit the language like for -e and try all languages?*)
@@ -57,12 +68,13 @@ let cmdline_term : conf Term.t =
       core_runner_conf = { Scan_CLI.default.core_runner_conf with ast_caching };
       logging_level;
       profile;
+      turbo;
     }
   in
   Term.(
     const combine $ Scan_CLI.o_ast_caching $ Scan_CLI.o_exclude
     $ Scan_CLI.o_include $ Scan_CLI.o_lang $ CLI_common.o_logging
-    $ CLI_common.o_profile $ Scan_CLI.o_target_roots)
+    $ CLI_common.o_profile $ Scan_CLI.o_target_roots $ o_turbo)
 
 let doc = "Interactive mode!!"
 

--- a/src/osemgrep/cli_interactive/Interactive_CLI.mli
+++ b/src/osemgrep/cli_interactive/Interactive_CLI.mli
@@ -14,6 +14,7 @@ type conf = {
   core_runner_conf : Core_runner.conf;
   logging_level : Logs.level option;
   profile : bool;
+  turbo : bool;
 }
 [@@deriving show]
 


### PR DESCRIPTION
## What:
This PR makes it so that we have the `--turbo` flag, which allows Turbo Interactive Mode to be optional, because in the other case, we might want to explicitly build up other queries. Later, we can combine these two ideas.

Right now, by default Turbo is off, but we can change that back later. I just want it this way for the demo.

## Test plan:
 https://asciinema.org/a/hEgAXkxOp0cTpzqzQqX7u8Ziw

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
