### PR TITLE
tainting: Set size limits to prevent memory blowups

### DIFF
--- a/changelog.d/pa-2570.changed
+++ b/changelog.d/pa-2570.changed
@@ -1,0 +1,2 @@
+Set limits to the amount of taint that is tracked by Semgrep to prevent perf
+issues on very large fiels and some other rare cases.

--- a/changelog.d/pa-2570.changed
+++ b/changelog.d/pa-2570.changed
@@ -1,2 +1,2 @@
 Set limits to the amount of taint that is tracked by Semgrep to prevent perf
-issues on very large fiels and some other rare cases.
+issues.

--- a/src/configuring/Limits_semgrep.ml
+++ b/src/configuring/Limits_semgrep.ml
@@ -1,0 +1,25 @@
+(*****************************************************************************)
+(* Taint analysis *)
+(*****************************************************************************)
+
+(* We need to set some limits to prevent taint sets from exploding in some cases.
+ * As we root cause these problems and fix them properly, we may be able to raise
+ * these limits.
+ *
+ * These problems became more serious with field-sensitivity: where previously we
+ * would just track taint for `x`, now we track taint for `x.a`, `x.b` and `x.c`.
+ *
+ * In the case of 'WebGoat/src/main/resources/webgoat/static/js/libs/ace.js',
+ * for example, it seems that this problem would be greatly reduced if we did
+ * not propagate taint for data with Boolean and integer type. Improving some
+ * of the data structures involved may help too.
+ *)
+
+(** Bounds the number of l-values we can track. *)
+let taint_MAX_TAINTED_LVALS = 100
+
+(** Bounds the number of taints we can track per l-value. *)
+let taint_MAX_TAINT_SET_SIZE = 50
+
+(** Bounds the length of the offsets we can track per l-value. *)
+let taint_MAX_LVAL_OFFSET = 2

--- a/src/tainting/Dataflow_tainting.ml
+++ b/src/tainting/Dataflow_tainting.ml
@@ -733,7 +733,8 @@ let fix_poly_taint_with_field env lval st =
                                 * TODO: This is way less likely to happen if we had better
                                 *   type info and we used to remove taint, e.g. if Boolean
                                 *   and integer expressions didn't propagate taint. *)
-                            List.length offset <= 1 ->
+                            List.length offset
+                            < Limits_semgrep.taint_MAX_LVAL_OFFSET ->
                          let arg' = { arg with offset = arg.offset @ [ n ] } in
                          { taint with orig = Arg arg' }
                      | Arg _

--- a/src/tainting/Taint.ml
+++ b/src/tainting/Taint.ml
@@ -277,6 +277,7 @@ module Taint_set = struct
 
   let empty = Taint_map.empty
   let is_empty set = Taint_map.is_empty set
+  let cardinal set = Taint_map.cardinal set
 
   let equal set1 set2 =
     let eq t1 t2 = compare_taint t1 t2 = 0 in

--- a/src/tainting/Taint.mli
+++ b/src/tainting/Taint.mli
@@ -100,6 +100,7 @@ module Taint_set : sig
 
   val empty : t
   val is_empty : t -> bool
+  val cardinal : t -> int
   val equal : t -> t -> bool
   val singleton : taint -> t
   val add : taint -> t -> t

--- a/src/tainting/Taint_lval_env.ml
+++ b/src/tainting/Taint_lval_env.ml
@@ -27,22 +27,6 @@ module LvalSet = Set.Make (LV.LvalOrdered)
 
 let logger = Logging.get_logger [ __MODULE__ ]
 
-(* We need to set some limits to prevent taint from exploding in some cases. As
- * we root cause these problems and fix them properly, we may be able to raise
- * these limits.
- *
- * These problems used to be pretty rare but with field-sensitivity they seem
- * to have become more common. (Where previously we would just track taint for
- * `x`, now we track taint for `x.a`, `x.b` and `x.c`.)
- *
- * In the case of 'WebGoat/src/main/resources/webgoat/static/js/libs/ace.js',
- * for example, it seems that this problem would be greatly reduced if we did
- * not propagate taint for data with Boolean and integer type. Improving some
- * of the data structures involved may help too.
- *)
-let max_TAINTED_LVALS = 100
-let max_TAINT_SET_SIZE = 50
-
 type t = {
   tainted : T.taints LvalMap.t;
       (** Lvalues that are tainted, it is only meant to track l-values of the form x.a_1. ... . a_N. *)
@@ -141,7 +125,7 @@ let add ({ tainted; propagated; cleaned } as lval_env) lval taints =
       lval_env
   | Some _
     when (not (LvalMap.mem lval tainted))
-         && LvalMap.cardinal tainted > max_TAINTED_LVALS ->
+         && LvalMap.cardinal tainted > Limits_semgrep.taint_MAX_TAINTED_LVALS ->
       logger#warning
         "Already tracking too many tainted l-values, will not track %s"
         (Display_IL.string_of_lval lval);
@@ -168,8 +152,10 @@ let add ({ tainted; propagated; cleaned } as lval_env) lval taints =
                 | None -> Some taints
                 (* THINK: couldn't we just replace the existing taints? *)
                 | Some taints' ->
-                    if Taints.cardinal taints' < max_TAINT_SET_SIZE then
-                      Some (Taints.union taints taints')
+                    if
+                      Taints.cardinal taints'
+                      < Limits_semgrep.taint_MAX_TAINT_SET_SIZE
+                    then Some (Taints.union taints taints')
                     else (
                       logger#warning
                         "Already tracking too many taint sources for %s, will \


### PR DESCRIPTION
Follows: c5640661b82 ("tainting: pro: JS/TS: Interprocedural field-sensitivity (#7867)")

test plan:
See returntocorp/semgrep-proprietary#750

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
