### PR TITLE
taint analysis #7787: Check function calls without parameters or parenthesis in Ruby

### DIFF
--- a/changelog.d/gh-7787.fixed
+++ b/changelog.d/gh-7787.fixed
@@ -1,1 +1,1 @@
-taint analysis: Check function calls without parameters or parenthesis in Ruby
+Pro (taint analysis): Check function calls without parameters or parenthesis in Ruby

--- a/changelog.d/gh-7787.fixed
+++ b/changelog.d/gh-7787.fixed
@@ -1,0 +1,1 @@
+taint analysis: Check function calls without parameters or parenthesis in Ruby

--- a/src/analyzing/AST_to_IL.ml
+++ b/src/analyzing/AST_to_IL.ml
@@ -33,6 +33,10 @@ let logger = Logging.get_logger [ __MODULE__ ]
 (*****************************************************************************)
 (* Types *)
 (*****************************************************************************)
+module IdentSet = Set.Make (String)
+
+type ctx = { entity_names : IdentSet.t }
+
 type env = {
   lang : Lang.t;
   (* stmts hidden inside expressions that we want to move out of 'exp',
@@ -45,10 +49,19 @@ type env = {
   *)
   break_labels : label list;
   cont_label : label option;
+  ctx : ctx;
 }
 
+let empty_ctx = { entity_names = IdentSet.empty }
+
 let empty_env (lang : Lang.t) : env =
-  { stmts = ref []; break_labels = []; cont_label = None; lang }
+  {
+    stmts = ref [];
+    break_labels = [];
+    cont_label = None;
+    ctx = empty_ctx;
+    lang;
+  }
 
 (*****************************************************************************)
 (* Error management *)
@@ -241,6 +254,9 @@ let mk_class_constructor_name (ty : G.type_) cons_id_info =
     when Option.is_some !(cons_id_info.G.id_resolved) ->
       Some (G.Id (id, cons_id_info))
   | __else__ -> None
+
+let add_entity_name ctx ident =
+  { entity_names = IdentSet.add (H.str_of_ident ident) ctx.entity_names }
 
 (*****************************************************************************)
 (* lvalue *)
@@ -615,7 +631,21 @@ and expr_aux env ?(void = false) e_gen =
   | G.ArrayAccess (_, _)
   | G.DeRef (_, _) ->
       let lval = lval env e_gen in
-      mk_e (Fetch lval) eorig
+      let exp = mk_e (Fetch lval) eorig in
+      let ident_function_call_hack exp =
+        (* Taking into account Ruby's ability to allow function calls without
+         * parameters or parentheses, we are conducting a check to determine
+         * if a function with the same name as the identifier exists, specifically
+         * for Ruby. *)
+        match lval with
+        | { base = Var { ident; _ }; _ }
+          when env.lang =*= Lang.Ruby
+               && IdentSet.mem (H.str_of_ident ident) env.ctx.entity_names ->
+            let tok = G.fake "call" in
+            add_call env tok eorig ~void (fun res -> Call (res, exp, []))
+        | _ -> exp
+      in
+      ident_function_call_hack exp
   | G.Assign (e1, tok, e2) ->
       let exp = expr env e2 in
       assign env e1 tok exp e_gen
@@ -1668,8 +1698,8 @@ and function_definition env fdef =
 (* Entry points *)
 (*****************************************************************************)
 
-let function_definition lang def =
-  let env = empty_env lang in
+let function_definition lang ?ctx def =
+  let env = { (empty_env lang) with ctx = ctx ||| empty_ctx } in
   let params = parameters env def.G.fparams in
   let body = function_body env def.G.fbody in
   (params, body)

--- a/src/analyzing/AST_to_IL.mli
+++ b/src/analyzing/AST_to_IL.mli
@@ -1,5 +1,13 @@
+type ctx
+
+val empty_ctx : ctx
+val add_entity_name : ctx -> AST_generic.ident -> ctx
+
 val function_definition :
-  Lang.t -> AST_generic.function_definition -> IL.name list * IL.stmt list
+  Lang.t ->
+  ?ctx:ctx ->
+  AST_generic.function_definition ->
+  IL.name list * IL.stmt list
 
 val stmt : Lang.t -> AST_generic.stmt -> IL.stmt list
 val name_of_entity : AST_generic.entity -> IL.name option

--- a/src/engine/Match_tainting_mode.mli
+++ b/src/engine/Match_tainting_mode.mli
@@ -63,6 +63,7 @@ val check_fundef :
   Rule_options.t ->
   Dataflow_tainting.config ->
   AST_generic.entity option (** entity being analyzed *) ->
+  AST_to_IL.ctx ->
   AST_generic.function_definition ->
   IL.cfg * Dataflow_tainting.mapping
 (** Check a function definition using a [Dataflow_tainting.config] (which can

--- a/src/engine/Test_dataflow_tainting.ml
+++ b/src/engine/Test_dataflow_tainting.ml
@@ -26,7 +26,8 @@ let test_tainting lang file options config def =
   Common.pr2 "\nDataflow";
   Common.pr2 "--------";
   let flow, mapping =
-    Match_tainting_mode.check_fundef lang options config None def
+    Match_tainting_mode.check_fundef lang options config None
+      AST_to_IL.empty_ctx def
   in
   let taint_to_str taint =
     let show_taint t =

--- a/src/tainting/Dataflow_tainting.ml
+++ b/src/tainting/Dataflow_tainting.ml
@@ -1442,17 +1442,8 @@ let check_function_call_arguments env args =
  * report the finding too (by side effect). *)
 let check_tainted_instr env instr : Taints.t * Lval_env.t =
   let check_expr env = check_tainted_expr env in
-  let rec check_instr = function
-    | Assign (_, e) -> (
-        match e.e with
-        (* Considering that Ruby permits function calls without parameters or
-         * parentheses, we are checking whether the identifier has a function
-         * signature specifically for Ruby. *)
-        | Fetch _
-          when env.lang =*= Lang.Ruby
-               && Option.is_some (check_function_signature env e [] []) ->
-            check_instr (Call (None, e, []))
-        | _ -> check_expr env e)
+  let check_instr = function
+    | Assign (_, e) -> check_expr env e
     | AssignAnon _ -> (Taints.empty, env.lval_env) (* TODO *)
     | Call (_, e, args) ->
         let args_taints, all_args_taints, lval_env =


### PR DESCRIPTION
This pull request aims to address the issue raised in #7787 by incorporating a specific handling for Ruby function calls that lack parentheses or parameters during the IL transformation.

test plan:
See returntocorp/semgrep-proprietary#748

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
