### PR TITLE
Java: do not parse record patterns as functions returning a "record"

### DIFF
--- a/languages/java/menhir/lexer_java.mll
+++ b/languages/java/menhir/lexer_java.mll
@@ -123,6 +123,8 @@ let keyword_table = Common.hash_of_list [
   "enum", (fun ii -> ENUM ii);
   (* javaext: 1.? *)
   (*  "var", (fun ii -> VAR ii); REGRESSIONS *)
+  (* javaext: 15 *)
+  "record", (fun ii -> RECORD ii);
 ]
 
 }

--- a/languages/java/menhir/parser_java.mly
+++ b/languages/java/menhir/parser_java.mly
@@ -246,6 +246,11 @@ let mk_stmt_or_stmts = function
  ENUM
  TRUE FALSE NULL
  VAR
+ (* This terminal is currently not used but lexed so that we generate parse
+  * errors on code using records so that we switch to the tree-sitter
+  * parser for files using this construct.
+  *)
+ RECORD
 
 (*-----------------------------------------*)
 (* Extra tokens: *)

--- a/languages/java/menhir/token_helpers_java.ml
+++ b/languages/java/menhir/token_helpers_java.ml
@@ -162,6 +162,7 @@ let visitor_info_of_tok f = function
   | WHILE ii -> WHILE (f ii)
   | ASSERT ii -> ASSERT (f ii)
   | ENUM ii -> ENUM (f ii)
+  | RECORD ii -> RECORD (f ii)
   | EOF ii -> EOF (f ii)
 
 let info_of_tok tok =

--- a/src/parsing/Pfff_or_tree_sitter.ml
+++ b/src/parsing/Pfff_or_tree_sitter.ml
@@ -102,7 +102,8 @@ let extract_pattern_from_tree_sitter_result
         res.errors
         |> List.iter (fun err ->
                pr2 (Tree_sitter_run.Tree_sitter_error.to_string ~color:true err));
-      failwith "error parsing the pattern"
+      (* to be backward compatible with what we do in PfffPat *)
+      raise Parsing.Parse_error
 
 (*****************************************************************************)
 (* Run target parsers *)

--- a/src/parsing_languages/Parse_pattern2.ml
+++ b/src/parsing_languages/Parse_pattern2.ml
@@ -72,8 +72,8 @@ let parse_pattern print_errors lang str =
         str
         |> run_pattern ~print_errors
              [
-               PfffPat Parse_java.any_of_string;
                TreeSitterPat Parse_java_tree_sitter.parse_pattern;
+               PfffPat Parse_java.any_of_string;
              ]
       in
       Java_to_generic.any any

--- a/src/parsing_languages/Parse_target2.ml
+++ b/src/parsing_languages/Parse_target2.ml
@@ -84,7 +84,7 @@ let just_parse_with_lang lang file =
       run file
         [
           (* we used to start with the pfff one; it was quite good and faster
-           * than tree-sitter (because we need to wrap tree-sitter inside
+           * than tree-sitter (because we used to wrap tree-sitter inside
            * an invoke because of a segfault/memory-leak), but when both parsers
            * fail, it's better to give the tree-sitter parsing error now.
            *)


### PR DESCRIPTION
This will help https://github.com/returntocorp/semgrep/issues/7911
The next PR will add support for those patterns in ocaml-tree-sitter-semgrep

test plan:
```
$ cat foo.sgrep
public record $R(...) { ...}
$ semgrep-core -l java -dump_pattern foo.sgrep
<source>, line 1, characters 24-27:
public record $R(...) { ...}

parent: class_body, left sibling: "{", first child: "..."
node type: ERROR
children: [
  "..."
]
Unrecognized construct
misc_record_pattern.sgrep:1:0: "Fatal error": Failure: error parsing the pattern
Failure: error parsing the pattern
Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
Called from Pfff_or_tree_sitter.run_parser_pat.parse in file "src/parsing/Pfff_or_tree_sitter.ml", line 244, characters 8-64
Re-raised at Exception.reraise in file "libs/commons/Exception.ml", line 19, characters 33-72
Called from Parse_pattern2.parse_pattern in file "src/parsing_languages/Parse_pattern2.ml", line 72, characters 8-194
Called from Parse_pattern.parse_pattern in file "src/parsing/Parse_pattern.ml", line 73, characters 12-52
Called from Core_CLI.dump_pattern.(fun) in file "src/core_cli/Core_CLI.ml", line 201, characters 16-69
Called from Semgrep_error_code.try_with_print_exn_and_reraise in file "src/reporting/Semgrep_error_code.ml", line 226, characters 6-10

Exception: Failure: error parsing the pattern
Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
Called from Pfff_or_tree_sitter.run_parser_pat.parse in file "src/parsing/Pfff_or_tree_sitter.ml", line 244, characters 8-64
Re-raised at Exception.reraise in file "libs/commons/Exception.ml", line 19, characters 33-72
Called from Parse_pattern2.parse_pattern in file "src/parsing_languages/Parse_pattern2.ml", line 72, characters 8-194
Called from Parse_pattern.parse_pattern in file "src/parsing/Parse_pattern.ml", line 73, characters 12-52
Called from Core_CLI.dump_pattern.(fun) in file "src/core_cli/Core_CLI.ml", line 201, characters 16-69
Called from Semgrep_error_code.try_with_print_exn_and_reraise in file "src/reporting/Semgrep_error_code.ml", line 226, characters 6-10
Re-raised at Exception.reraise in file "libs/commons/Exception.ml", line 19, characters 33-72
Called from Core_CLI.with_exception_trace in file "src/core_cli/Core_CLI.ml", line 836, characters 6-10

java_update/home/pad/yy/tests/patterns/java $
```


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)