### PR TITLE
C#: support ellipsis inside enum declarations

### DIFF
--- a/changelog.d/gh-7914.fixed
+++ b/changelog.d/gh-7914.fixed
@@ -1,0 +1,1 @@
+C#: support ellipsis in enum declarations

--- a/languages/csharp/generic/Parse_csharp_tree_sitter.ml
+++ b/languages/csharp/generic/Parse_csharp_tree_sitter.ml
@@ -2481,12 +2481,14 @@ let constructor_initializer (env : env)
   let v3 = argument_list env v3 in
   ExprStmt (Call (v2, v3) |> G.e, sc) |> G.s
 
-let enum_member_declaration (env : env)
-    ((v1, v2, v3) : CST.enum_member_declaration) =
-  let _v1TODO = List.concat_map (attribute_list env) v1 in
-  let v2 = identifier env v2 (* identifier *) in
-  let v3 = Option.map (equals_value_clause env) v3 in
-  OrEnum (v2, v3)
+let enum_member_declaration (env : env) (x : CST.enum_member_declaration) =
+  match x with
+  | `Rep_attr_list_id_opt_EQ_exp (v1, v2, v3) ->
+      let _v1TODO = List.concat_map (attribute_list env) v1 in
+      let v2 = identifier env v2 (* identifier *) in
+      let v3 = Option.map (equals_value_clause env) v3 in
+      OrEnum (v2, v3)
+  | `Ellips tok -> OrEllipsis (token env tok)
 
 let base_list (env : env) ((v1, v2, v3) : CST.base_list) : G.class_parent list =
   let _v1 = token env v1 (* ":" *) in

--- a/src/parsing/tests/Test_parsing.ml
+++ b/src/parsing/tests/Test_parsing.ml
@@ -148,7 +148,7 @@ let dump_tree_sitter_cst lang file =
       |> dump_and_print_errors Tree_sitter_go.CST.dump_tree
   | Lang.Csharp ->
       Tree_sitter_c_sharp.Parse.file file
-      |> dump_and_print_errors Tree_sitter_c_sharp.CST.dump_tree
+      |> dump_and_print_errors Tree_sitter_c_sharp.Boilerplate.dump_tree
   | Lang.Kotlin ->
       Tree_sitter_kotlin.Parse.file file
       |> dump_and_print_errors Tree_sitter_kotlin.Boilerplate.dump_tree

--- a/src/parsing_languages/Parse_pattern2.ml
+++ b/src/parsing_languages/Parse_pattern2.ml
@@ -165,7 +165,7 @@ let dump_tree_sitter_pattern_cst lang file =
   match lang with
   | Lang.Csharp ->
       Tree_sitter_c_sharp.Parse.file file
-      |> dump_and_print_errors Tree_sitter_c_sharp.CST.dump_tree
+      |> dump_and_print_errors Tree_sitter_c_sharp.Boilerplate.dump_tree
   | Lang.Lua ->
       Tree_sitter_lua.Parse.file file
       |> dump_and_print_errors Tree_sitter_lua.Boilerplate.dump_tree

--- a/tests/patterns/csharp/misc_enum_pattern.cs
+++ b/tests/patterns/csharp/misc_enum_pattern.cs
@@ -1,0 +1,11 @@
+namespace Foo.Bar.Baz
+{
+    //ERROR: match
+    public enum MyEnum
+    {
+        VAL1,
+        VAL2,
+        VAL3,
+        VAL4
+    }
+}

--- a/tests/patterns/csharp/misc_enum_pattern.sgrep
+++ b/tests/patterns/csharp/misc_enum_pattern.sgrep
@@ -1,0 +1,1 @@
+public enum $ENUM { ... }


### PR DESCRIPTION
This closes #7914

test plan:
test file included


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)