### PR TITLE
Java: switch back to PfffPat first before TreeSitterPat

### DIFF
--- a/src/parsing_languages/Parse_pattern2.ml
+++ b/src/parsing_languages/Parse_pattern2.ml
@@ -72,8 +72,12 @@ let parse_pattern print_errors lang str =
         str
         |> run_pattern ~print_errors
              [
-               TreeSitterPat Parse_java_tree_sitter.parse_pattern;
+               (* TODO: we should switch to TreeSitterPat first, but
+                * we get regressions on generic_args.sgrep because
+                * typed metavariables are not parsed correctly then
+                *)
                PfffPat Parse_java.any_of_string;
+               TreeSitterPat Parse_java_tree_sitter.parse_pattern;
              ]
       in
       Java_to_generic.any any

--- a/tests/patterns/java/generics_args.java
+++ b/tests/patterns/java/generics_args.java
@@ -1,0 +1,6 @@
+package org.owasp.benchmark.testcode;
+
+public class bad1 extends HttpServlet {
+    //ERROR: match
+    List<String> argList = new ArrayList<String>();
+}

--- a/tests/patterns/java/generics_args.sgrep
+++ b/tests/patterns/java/generics_args.sgrep
@@ -1,0 +1,1 @@
+(List<$TYPE> $ARGLIST)


### PR DESCRIPTION
This fix the regression introduced by
https://github.com/returntocorp/semgrep/pull/7912
that we found when updating to the latest semgrep
in semgrep-pro

test plan:
test file included (this test was actually in
semgrep-pro/tests/OTHER/semgrep-regressions/)


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)