### PR TITLE
js: fix libyaml bindings

### DIFF
--- a/js/engine/core.js
+++ b/js/engine/core.js
@@ -23,3 +23,8 @@ function unix_environment() {
 function get_jsoo_mount_point() {
   return jsoo_mount_point;
 }
+
+//Provides: override_yaml_ctypes_field_offset
+function override_yaml_ctypes_field_offset(field, newOffset) {
+  field[2] = newOffset;
+}

--- a/js/examples/yaml.html
+++ b/js/examples/yaml.html
@@ -1,0 +1,39 @@
+<html>
+  <body>
+    <pre id="result">Loading...</pre>
+  </body>
+  <script>
+    window.module = { exports: {} };
+  </script>
+  <script src="../engine/dist/index.cjs"></script>
+  <script>
+    window.EngineFactory = module.exports.EngineFactory;
+  </script>
+  <script>
+    const rules = JSON.stringify({
+      rules: [
+        {
+          id: "test",
+          languages: ["yaml"],
+          message: "test",
+          pattern: "foo: $Y",
+          severity: "ERROR",
+        },
+      ],
+    });
+
+    (async () => {
+      const engine = await EngineFactory();
+
+      engine.writeFile("/static/rules.json", rules);
+      engine.writeFile("/static/test.py", `foo: bar`);
+      document.getElementById("result").innerHTML = JSON.stringify(
+        JSON.parse(
+          engine.execute("yaml", "/static/rules.json", "/static/test.py")
+        ),
+        null,
+        2
+      );
+    })();
+  </script>
+</html>

--- a/js/languages/shared/Makefile.include
+++ b/js/languages/shared/Makefile.include
@@ -19,7 +19,7 @@ COMMON_TS_EXPORTED_FUNCTIONS = _malloc,_free,_ts_parser_new,_ts_parser_set_langu
 
 EMCC_DEFAULTS = \
    -sALLOW_MEMORY_GROWTH=1 \
-   -sEXPORTED_RUNTIME_METHODS=AsciiToString,stringToAscii,stringToUTF8,getValue,setValue \
+   -sEXPORTED_RUNTIME_METHODS=UTF8ToString,AsciiToString,stringToAscii,stringToUTF8,getValue,setValue \
    -sMODULARIZE
 
 SEMGREP_TS_LANG ?= $(SEMGREP_LANG)

--- a/js/libpcre/runtime.js
+++ b/js/libpcre/runtime.js
@@ -80,7 +80,6 @@ function pcre_ocaml_init() {
 function pcre_version_stub() {
   var ptr = libpcre._pcre_version();
   var value = libpcre.UTF8ToString(ptr);
-  libpcre._free(ptr);
   return value;
 }
 

--- a/js/libyaml/ctypes.js
+++ b/js/libyaml/ctypes.js
@@ -389,12 +389,6 @@ function ctypes_use(x) {
   caml_failwith("ctypes: ctypes_use not implemented");
 }
 
-//Provides: ctypes_string_of_cstring
-//Requires: caml_failwith
-function ctypes_string_of_cstring(x) {
-  caml_failwith("ctypes: ctypes_string_of_cstring not implemented");
-}
-
 //Provides: ctypes_cstring_of_string
 //Requires: caml_failwith
 function ctypes_cstring_of_string(x) {

--- a/js/libyaml/runtime.js
+++ b/js/libyaml/runtime.js
@@ -30,8 +30,14 @@ function ctypes_write(primType, v, buffer) {
   }
 }
 
+//Provides: ctypes_string_of_cstring
+//Requires: libyaml, caml_string_of_jsstring
+function ctypes_string_of_cstring(ptr) {
+  return caml_string_of_jsstring(libyaml.UTF8ToString(ptr[2]));
+}
+
 //Provides: ctypes_read
-//Requires: libyaml
+//Requires: libyaml, UInt32
 function ctypes_read(primType, buffer) {
   switch (primType) {
     case 0:
@@ -41,21 +47,24 @@ function ctypes_read(primType, buffer) {
     case 13: // Ctypes_Size_t
       return libyaml.getValue(buffer[2], "i32");
     case 20: // Ctypes_Uint32_t
-      return libyaml.getValue(buffer[2], "i32") >>> 0;
+      return new UInt32(libyaml.getValue(buffer[2], "i32"));
     default:
-      throw new Error(`how to read prim ${primType}`);
+      throw new Error(`Don't know how to read prim ${primType}`);
   }
 }
 
 //Provides: ctypes_read_pointer
+//Requires: libyaml
 function ctypes_read_pointer(ptr) {
-  return ptr[2];
+  return libyaml.getValue(ptr[2], "i32");
 }
 
 //Provides: yaml_stub_1_yaml_get_version_string const
-//Requires: libyaml
+//Requires: libyaml, caml_string_of_jsstring
 function yaml_stub_1_yaml_get_version_string() {
-  return libyaml.UTF8ToString(libyaml._yaml_get_version_string());
+  return caml_string_of_jsstring(
+    libyaml.UTF8ToString(libyaml._yaml_get_version_string())
+  );
 }
 
 //Provides: yaml_stub_2_yaml_get_version
@@ -87,8 +96,8 @@ function yaml_stub_5_yaml_parser_delete(parser_ptr) {
 //Requires: libyaml
 function yaml_stub_6_yaml_parser_set_input_string(parser_ptr, input_ptr, size) {
   libyaml._yaml_parser_set_input_string(
-    parser_ptr[parser_ptr.length - 1][1],
-    input_ptr[3][1],
+    parser_ptr[2],
+    input_ptr[2],
     size.value
   );
 }

--- a/js/libyaml/runtime.test.js
+++ b/js/libyaml/runtime.test.js
@@ -4,8 +4,10 @@ const EXPECTED_LIBYAML_VERSION = [0, 1, 7];
 const EXPECTED_LIBYAML_VERSION_STRING = "0.1.7";
 const SIZEOF_YAML_PARSER_T = 248;
 const SIZEOF_YAML_EVENT_T = 56;
-const TEST_YAML_STRING = '{"foo": "bar"}';
+const TEST_YAML_STRING = "foo: bar";
 const EXPECTED_EVENT_TYPE_STREAM = [1, 3, 9, 6, 6, 10, 4, 2];
+
+globalThis.caml_string_of_jsstring = (x) => x;
 
 describe("libyaml", () => {
   const libyamlPromise = LibYamlFactory();

--- a/src/parsing/yaml_to_generic.ml
+++ b/src/parsing/yaml_to_generic.ml
@@ -132,7 +132,8 @@ let mk_bracket
         _;
       } ) v env =
   (* The end index needs to be adjusted by one because the token is off *)
-  let e_index' = e_index - 1 in
+  (* TODO: figure out why we get an off-by-one with jsoo *)
+  let e_index' = if !Common.jsoo then e_index else e_index - 1 in
   let e_line, e_column =
     match env.charpos_to_pos with
     | None -> (e_line, e_column)


### PR DESCRIPTION
This PR fixes memory alignment issues that was preventing YAML parsing from working properly. TL;DR: `ocaml-yaml` uses `ocaml-ctypes` to generate bindings for the `libyaml` library. Since this is done at compile time, the memory offsets are calculated based off of the build machine (64-bit address space --> 8 byte pointer size). WebAssembly, however, is 32-bit (4 bytes), and this mismatch prevented us from interfacing with the library properly.

To fix, we override the memory offsets in JavaScript (exploiting its inherent mutability) at startup. This is a little weird, is much faster than figuring out how to cross-compile `ocaml-yaml` against a 32-bit architecture.

There is a weird off-by-one issue with the index of the end token in Yaml_to_generic, but I'll fix in a separate PR if it proves to be an issue.

test plan:
- make test
- confirm `js/examples/yaml.html` works properly