### PR TITLE
Elixir: split Parse_elixir_tree_sitter.ml in 3

### DIFF
--- a/languages/elixir/ast/AST_elixir.ml
+++ b/languages/elixir/ast/AST_elixir.ml
@@ -1,0 +1,113 @@
+(* Yoann Padioleau
+ *
+ * Copyright (c) 2023 Semgrep Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * version 2.1 as published by the Free Software Foundation, with the
+ * special exception on linking described in file LICENSE.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
+ * LICENSE for more details.
+ *)
+open Common
+
+(*****************************************************************************)
+(* Prelude *)
+(*****************************************************************************)
+(* AST(s) for Elixir.
+ *
+ * Elixir is quite an unusual language with a very flexible syntax and
+ * macro system. For example, there are no 'definition' or 'declaration'
+ * grammar rules. Instead a definition looks really like a function call.
+ * This is a bit similar to LISP where '(defun ...)' is not part of
+ * the LISP syntax definition; 'defun' is actually a call to a
+ * special construct that defines functions!
+ * This is why we parse Elixir source in 2 phases:
+ *  - phase 1, we parse the "Raw" constructs which roughly correspond to
+ *    LISP sexps
+ *  - TODO: phase 2, we analyze those raw constructs and try to infer higher-level
+ *    constructs like module definitions or function definitions that
+ *    are standard in Elixir
+ * Note that because our aim is ultimately to transform Elixir code
+ * in the generic ASTs, we didn't define an Elixir 'expr' type but
+ * instead reuse the one from the generic AST, which makes it
+ * easier later in Elixir_to_generic.ml to get back a full generic AST.
+ *
+ * references:
+ * - https://hexdocs.pm/elixir/syntax-reference.html
+ *)
+
+(*****************************************************************************)
+(* Raw constructs *)
+(*****************************************************************************)
+(* AST constructs or aliases corresponding to "raw" Elixir constructs.
+ *
+ * We try to follow the naming conventions in
+ * https://hexdocs.pm/elixir/syntax-reference.html
+ *)
+
+type 'a wrap = 'a AST_generic.wrap
+type 'a bracket = 'a AST_generic.bracket
+
+(* lowercase ident *)
+type ident = string wrap
+
+(* uppercase ident *)
+type alias = string wrap
+
+(* there is no 'name' below. They use the term 'remote' for qualified calls
+ * with lowercase ident.
+ * Note that the alias can actually also contain some dots
+ * and be also kinda of a name.
+ *)
+
+type expr = AST_generic.expr
+type argument = AST_generic.argument
+
+(* exprs separated by terminators (newlines or semicolons)
+ * can be empty.
+ *)
+type body = expr list
+
+(* less: restrict with special arg? *)
+type call = expr
+
+(* Ideally we would want just 'type keyword = ident * tok (*:*)',
+ * but Elixir allows also "interpolated{ x }string": keywords.
+ *)
+type keyword = expr
+
+(* note that Elixir supports also pairs using the (:atom => expr) syntax *)
+type pair = keyword * expr
+
+(* inside containers (list, bits, maps, tuples), separated by commas *)
+type item = expr
+
+(* Ideally it should be pattern list * tok * body option, but Elixir
+ * is more general and use '->' also for type declarations in typespecs,
+ * or for parameters (kind of patterns though).
+ *)
+type stab_clause =
+  (argument list * (Tok.t (*'when'*) * expr) option) * Tok.t (* '->' *) * body
+
+type clauses = stab_clause list
+
+(* in after/rescue/catch/else and do blocks *)
+type body_or_clauses = (body, clauses) either
+
+(* the bracket here are do/end *)
+type do_block =
+  (body_or_clauses
+  * (ident (* 'after/rescue/catch/else' *) * body_or_clauses) list)
+  bracket
+
+(* the bracket here are () *)
+type block = body_or_clauses bracket
+
+(*****************************************************************************)
+(* Refined constructs *)
+(*****************************************************************************)
+(* TODO *)

--- a/languages/elixir/ast/dune
+++ b/languages/elixir/ast/dune
@@ -1,0 +1,11 @@
+(library
+ (public_name parser_elixir.ast)
+ (name parser_elixir_ast)
+ (wrapped false)
+ (libraries
+   commons
+   lib_parsing
+   ast_generic
+ )
+ (preprocess (pps ppx_deriving.show))
+)

--- a/languages/elixir/generic/Elixir_to_generic.ml
+++ b/languages/elixir/generic/Elixir_to_generic.ml
@@ -1,0 +1,158 @@
+(* Yoann Padioleau
+ *
+ * Copyright (C) 2023 Semgrep Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * version 2.1 as published by the Free Software Foundation, with the
+ * special exception on linking described in file LICENSE.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
+ * LICENSE for more details.
+ *)
+open Common
+open AST_elixir
+module G = AST_generic
+module H = AST_generic_helpers
+
+(*****************************************************************************)
+(* Prelude *)
+(*****************************************************************************)
+(* AST_elixir to AST_generic.
+ *
+ * See AST_generic.ml for more information.
+ *)
+
+(*****************************************************************************)
+(* Helpers *)
+(*****************************************************************************)
+let fb = Tok.unsafe_fake_bracket
+let keyval_of_kwd (k, v) = G.keyval k (G.fake "=>") v
+let kwd_of_id (id : ident) : keyword = N (H.name_of_id id) |> G.e
+let body_to_stmts es = es |> Common.map G.exprstmt
+
+(* TODO: lots of work here to detect when args is really a single
+ * pattern, or tuples *)
+let pat_of_args_and_when (args, when_opt) : G.pattern =
+  let rest =
+    match when_opt with
+    | None -> []
+    | Some (_tok, e) -> [ G.E e ]
+  in
+  G.OtherPat (("ArgsAndWhenOpt", G.fake ""), G.Args args :: rest) |> G.p
+
+(*****************************************************************************)
+(* Converters *)
+(*****************************************************************************)
+let case_and_body_of_stab_clause (x : stab_clause) : G.case_and_body =
+  (* body can be empty *)
+  let args_and_when, _tarrow, body = x in
+  let pat = pat_of_args_and_when args_and_when in
+  let stmts = body_to_stmts body in
+  let stmt = G.stmt1 stmts in
+  G.case_of_pat_and_stmt (pat, stmt)
+
+(* TODO: if the list contains just one element, can be a simple lambda
+ * as in 'fn (x, y) -> x + y end'. Otherwise it can be a multiple-cases
+ * switch/match.
+ * The first tk parameter corresponds to 'fn' for lambdas and 'do' when
+ * used in a do_block.
+ *)
+let stab_clauses_to_function_definition tk (xs : stab_clause list) :
+    G.function_definition =
+  (* mostly a copy-paste of code to handle Function in ml_to_generic *)
+  let xs = xs |> Common.map case_and_body_of_stab_clause in
+  let id = G.implicit_param_id tk in
+  let params = [ G.Param (G.param_of_id id) ] in
+  let body_stmt =
+    G.Switch (tk, Some (G.Cond (G.N (H.name_of_id id) |> G.e)), xs) |> G.s
+  in
+  {
+    G.fparams = fb params;
+    frettype = None;
+    fkind = (G.Function, tk);
+    fbody = G.FBStmt body_stmt;
+  }
+
+(* following Elixir semantic (unsugaring pairs) *)
+let list_container_of_kwds xs =
+  let es = xs |> Common.map keyval_of_kwd in
+  Container (List, fb es) |> G.e
+
+let args_of_exprs_and_keywords (es : expr list) (kwds : pair list) :
+    argument list =
+  let rest =
+    match kwds with
+    | [] -> []
+    | kwds -> [ list_container_of_kwds kwds ]
+  in
+  Common.map G.arg (es @ rest)
+
+let items_of_exprs_and_keywords (es : expr list) (kwds : pair list) : item list
+    =
+  es @ (kwds |> Common.map keyval_of_kwd)
+
+let expr_of_body_or_clauses tk (x : body_or_clauses) : expr =
+  match x with
+  | Left [ e ] -> e
+  | Left xs ->
+      let stmts = body_to_stmts xs in
+      (* less: use G.stmt1 instead? or get rid of fake_bracket here
+       * passed down from caller? *)
+      let block = Block (fb stmts) |> G.s in
+      G.stmt_to_expr block
+  | Right clauses ->
+      let fdef = stab_clauses_to_function_definition tk clauses in
+      Lambda fdef |> G.e
+
+(* following Elixir semantic (unsugaring do/end block in keywords) *)
+let kwds_of_do_block (bl : do_block) : pair list =
+  let tdo, (body_or_clauses, extras), _tend = bl in
+  let dokwd = kwd_of_id ("do:", tdo) in
+  let e = expr_of_body_or_clauses tdo body_or_clauses in
+  let pair1 = (dokwd, e) in
+  let rest =
+    extras
+    |> Common.map (fun ((s, t), body_or_clauses) ->
+           let kwd = kwd_of_id (s ^ ":", t) in
+           let e = expr_of_body_or_clauses t body_or_clauses in
+           (kwd, e))
+  in
+  pair1 :: rest
+
+let expr_of_block (blk : block) : expr =
+  (* TODO: could pass a 'body_or_clauses bracket' to
+   * expr_of_body_or_clauses to avoid the fake_bracket above
+   *)
+  let l, body_or_clauses, _r = blk in
+  expr_of_body_or_clauses l body_or_clauses
+
+let args_of_do_block_opt (blopt : do_block option) : argument list =
+  match blopt with
+  | None -> []
+  | Some bl ->
+      let kwds = kwds_of_do_block bl in
+      args_of_exprs_and_keywords [] kwds
+
+let mk_call_no_parens (e : expr) (args : argument list)
+    (blopt : do_block option) : call =
+  Call (e, fb (args @ args_of_do_block_opt blopt)) |> G.e
+
+let mk_call_parens (e : expr) (args : argument list bracket)
+    (blopt : do_block option) : call =
+  let l, xs, r = args in
+  Call (e, (l, xs @ args_of_do_block_opt blopt, r)) |> G.e
+
+let binary_call (e1 : expr) op_either (e2 : expr) : expr =
+  match op_either with
+  | Left id ->
+      let n = N (H.name_of_id id) |> G.e in
+      Call (n, fb ([ e1; e2 ] |> Common.map G.arg)) |> G.e
+  | Right op -> G.opcall op [ e1; e2 ]
+
+let expr_of_e_or_kwds (x : (expr, pair list) either) : expr =
+  match x with
+  | Left e -> e
+  | Right kwds -> list_container_of_kwds kwds

--- a/languages/elixir/generic/Elixir_to_generic.mli
+++ b/languages/elixir/generic/Elixir_to_generic.mli
@@ -1,0 +1,33 @@
+val args_of_exprs_and_keywords :
+  AST_elixir.expr list -> AST_elixir.pair list -> AST_elixir.argument list
+
+val items_of_exprs_and_keywords :
+  AST_elixir.expr list -> AST_elixir.pair list -> AST_elixir.item list
+
+val mk_call_parens :
+  AST_elixir.expr ->
+  AST_elixir.argument list AST_elixir.bracket ->
+  AST_elixir.do_block option ->
+  AST_elixir.call
+
+val mk_call_no_parens :
+  AST_elixir.expr ->
+  AST_elixir.argument list ->
+  AST_elixir.do_block option ->
+  AST_elixir.call
+
+val binary_call :
+  AST_elixir.expr ->
+  (AST_elixir.ident, AST_generic.operator AST_generic.wrap) Common.either ->
+  AST_elixir.expr ->
+  AST_elixir.expr
+
+val expr_of_e_or_kwds :
+  (AST_elixir.expr, AST_elixir.pair list) Common.either -> AST_elixir.expr
+
+val expr_of_block : AST_elixir.block -> AST_elixir.expr
+
+val stab_clauses_to_function_definition :
+  Tok.t -> AST_elixir.stab_clause list -> AST_generic.function_definition
+
+val body_to_stmts : AST_elixir.body -> AST_generic.stmt list

--- a/languages/elixir/generic/dune
+++ b/languages/elixir/generic/dune
@@ -6,6 +6,7 @@
    commons
    lib_parsing lib_parsing_tree_sitter
    tree-sitter-lang.elixir
+   parser_elixir.ast
    ast_generic
  )
  (preprocess (pps ppx_deriving.show))


### PR DESCRIPTION
This will be easier to work on and try to parse
the defmodule and co constructs.

This will help https://github.com/returntocorp/semgrep/issues/7855

test plan:
make core-test


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)