### PR TITLE
chore: Fix `make core-install` command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -221,7 +221,7 @@ core-install: copy-core-for-cli
 	# causing an error when running a straight cp if a file is already
 	# there.
 	# Known alternative: use 'install -m 0644 ...' instead of cp
-	$(MAKE) uninstall
+	$(MAKE) core-uninstall
 	cp bin/semgrep-core "$$(opam var bin)"/
 
 # Try to uninstall what was installed by 'make core-install'.


### PR DESCRIPTION
The `make core-install` command uninstalls semgrep. This makes the flow to update the `semgrep-core` binary really annoying. Should instead be uninstalling `semgrep-core`.

Test plan: `make && make core-install && semgrep --config p/default .`

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
