### PR TITLE
fix(extract): Improve syntax

### DIFF
--- a/cli/tests/e2e/rules/extract_rules/python_jupyter_paths_exclude.yaml
+++ b/cli/tests/e2e/rules/extract_rules/python_jupyter_paths_exclude.yaml
@@ -3,7 +3,7 @@ rules:
     mode: extract
     languages:
     - json
-    rules:
+    dest-rules:
       exclude:
         - check-for-data
     pattern: |

--- a/cli/tests/e2e/rules/extract_rules/python_jupyter_paths_include.yaml
+++ b/cli/tests/e2e/rules/extract_rules/python_jupyter_paths_include.yaml
@@ -3,7 +3,7 @@ rules:
     mode: extract
     languages:
     - json
-    rules:
+    dest-rules:
       include:
         - check-for-data
         - test123

--- a/src/parsing/Parse_rule.ml
+++ b/src/parsing/Parse_rule.ml
@@ -1565,7 +1565,7 @@ let parse_mode env mode_opt (rule_dict : dict) : R.mode =
       (* TODO: determine fmt---string with interpolated metavars? *)
       let extract = take rule_dict env parse_string "extract" in
       let extract_rule_ids =
-        take_opt rule_dict env parse_rules_to_run_with_extract "rules"
+        take_opt rule_dict env parse_rules_to_run_with_extract "dest-rules"
       in
       let transform =
         take_opt rule_dict env parse_string_wrap "transform"


### PR DESCRIPTION
Rename `rules` (indicating the rules to run on the extracted target) to `dest-rules` to prevent ambiguity.

Test plan: automated tests

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date (docs will be added after SR tests, or after next reelase)
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
