### PR TITLE
feat(interactive): print single pattern nicer

### DIFF
--- a/src/osemgrep/cli_interactive/Interactive_subcommand.ml
+++ b/src/osemgrep/cli_interactive/Interactive_subcommand.ml
@@ -500,28 +500,33 @@ let render_preview_no_matches ~has_changed state =
 (* This just pretty-prints out the patterns we currently have in
    our tree.
 *)
-let rec render_patterns = function
-  | IPat ({ Xpattern.pstr = s, _; _ }, b) ->
-      if b then I.(string A.empty (Common.spf "%s" s))
-      else I.(string A.(fg lightblue) "not: " <|> string A.empty s)
-  | IAll pats ->
-      I.(
-        let patterns =
-          pats |> Common.map render_patterns
-          |> Common.map (fun img -> I.(string A.empty "- " <|> img))
-          |> vcat |> hpad 2 0
-        in
-        hsnap (I.width patterns) ~align:`Left (string A.(fg lightblue) "all:")
-        <-> patterns)
-  | IAny pats ->
-      I.(
-        let patterns =
-          pats |> Common.map render_patterns
-          |> Common.map (fun img -> I.(string A.empty "- " <|> img))
-          |> vcat |> hpad 2 0
-        in
-        hsnap (I.width patterns) ~align:`Left (string A.(fg lightblue) "any:")
-        <-> patterns)
+let render_patterns iformula =
+  let rec loop = function
+    | IPat ({ Xpattern.pstr = s, _; _ }, b) ->
+        if b then I.(string A.empty (Common.spf "%s" s))
+        else I.(string A.(fg lightblue) "not: " <|> string A.empty s)
+    | IAll pats ->
+        I.(
+          let patterns =
+            pats |> Common.map loop
+            |> Common.map (fun img -> I.(string A.empty "- " <|> img))
+            |> vcat |> hpad 2 0
+          in
+          hsnap (I.width patterns) ~align:`Left (string A.(fg lightblue) "all:")
+          <-> patterns)
+    | IAny pats ->
+        I.(
+          let patterns =
+            pats |> Common.map loop
+            |> Common.map (fun img -> I.(string A.empty "- " <|> img))
+            |> vcat |> hpad 2 0
+          in
+          hsnap (I.width patterns) ~align:`Left (string A.(fg lightblue) "any:")
+          <-> patterns)
+  in
+  match iformula with
+  | IPat (_, true) -> I.(string A.(fg lightblue) "pattern: " <|> loop iformula)
+  | _ -> loop iformula
 
 (* This differs based on our mode. In Turbo Mode, this is just the
    list of files.


### PR DESCRIPTION
## What:
This PR makes it so when printing out the visualized pattern in the pattern builder menu, a singleton pattern is not just printed out wholesale, but prefaced with `pattern: `.

This is not printed when it becomes part of a composite pattern, though.

## Why:
This looks nicer, because it looks more like a pattern.

## How:
Gave it a non-recursive base case.

## Test plan:
![image](https://github.com/returntocorp/semgrep/assets/49291449/6de00d81-3705-4036-bf45-2c7d00b25e86)
![image](https://github.com/returntocorp/semgrep/assets/49291449/c9596edc-b5bc-42f3-a367-f24a0ce35a63)


PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
