### PR TITLE
Ppath: cleanup Ppath.mli, reduce the number of way to build a ppath

### DIFF
--- a/languages/elixir/generic/Parse_elixir_tree_sitter.ml
+++ b/languages/elixir/generic/Parse_elixir_tree_sitter.ml
@@ -1,6 +1,6 @@
 (* Yoann Padioleau
  *
- * Copyright (c) 2022 R2C
+ * Copyright (c) 2022-2023 Semgrep Inc.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/libs/gitignore/Gitignore_filter.ml
+++ b/libs/gitignore/Gitignore_filter.ml
@@ -97,11 +97,8 @@ let select_path opt_gitignore_file_cache sel_events levels relative_segments =
    that folder which add filters to the existing filters found earlier.
 *)
 let select t sel_events (full_git_path : Ppath.t) =
-  if Ppath.is_relative full_git_path then
-    invalid_arg
-      ("Gitignore_filter.select: not an absolute path: " ^ full_git_path.string);
   let rel_segments =
-    match full_git_path.segments with
+    match Ppath.segments full_git_path with
     | "" :: xs -> xs
     | __else__ -> assert false
   in

--- a/libs/gitignore/Parse_gitignore.ml
+++ b/libs/gitignore/Parse_gitignore.ml
@@ -78,8 +78,8 @@ let parse_line ~anchor source_name source_kind line_number line_contents =
       | Some s -> (true, s)
     in
     let pattern = parse_pattern ~source:loc ~anchor pattern_str in
-    let matcher (path : Ppath.t) =
-      match M.run pattern path.string with
+    let matcher (ppath : Ppath.t) =
+      match M.run pattern (Ppath.to_string ppath) with
       | true ->
           if is_negated then Some (Deselected loc) else Some (Selected loc)
       | false -> None

--- a/libs/gitignore/Unit_gitignore.ml
+++ b/libs/gitignore/Unit_gitignore.ml
@@ -35,7 +35,7 @@ let test_filter (files : F.t list) selection () =
       let error = ref false in
       selection
       |> List.iter (fun (path, should_be_selected) ->
-             let path = Ppath.of_string path in
+             let path = Ppath.of_string_for_tests path in
              let status, selection_events =
                Common.save_excursion Glob.Match.debug true (fun () ->
                    let selection_events = [] in

--- a/libs/paths/Git_project.ml
+++ b/libs/paths/Git_project.ml
@@ -37,7 +37,7 @@ let find_git_project_root_abs (start_dir, start_git_segments) =
   let rec loop acc dir =
     if is_git_root dir then
       let ppath = Ppath.create ("" :: acc) in
-      match Ppath.normalize ppath with
+      match Ppath.normalize_ppath ppath with
       | Ok ppath -> Some (dir, ppath)
       | Error _s -> None
     else

--- a/libs/paths/Git_project.ml
+++ b/libs/paths/Git_project.ml
@@ -36,8 +36,7 @@ let is_git_submodule_root (path : Fpath.t) : bool =
 let find_git_project_root_abs (start_dir, start_git_segments) =
   let rec loop acc dir =
     if is_git_root dir then
-      let ppath = Ppath.create ("" :: acc) in
-      match Ppath.normalize_ppath ppath with
+      match Ppath.from_segments ("" :: acc) with
       | Ok ppath -> Some (dir, ppath)
       | Error _s -> None
     else

--- a/libs/paths/Ppath.ml
+++ b/libs/paths/Ppath.ml
@@ -20,7 +20,7 @@ open File.Operators
 
      in_project ~root:(Fpath.v "/a") (Fpath.v "/a/b/c")
 
-   will return { string = "/b/c"; segments = ["b"; "c"] }
+    will return { segments = [""; "b"; "c"]; string = "/b/c"; }
  *)
 type t = {
   (* path segments within the project root *)
@@ -44,6 +44,8 @@ let of_string_for_tests string =
 
 (* old: was of_string_for_tests "/" *)
 let root = { string = "/"; segments = [ ""; "" ] }
+
+(* for debugging *)
 let to_string x = x.string
 
 let check_segment str =
@@ -79,6 +81,7 @@ end
 
 let segments x = x.segments
 
+(* A ppath should always be absolute! *)
 let is_absolute x =
   match x.segments with
   | "" :: _ -> true

--- a/libs/paths/Ppath.ml
+++ b/libs/paths/Ppath.ml
@@ -43,6 +43,8 @@ let root = { string = "/"; segments = [ ""; "" ] }
 
 (* Useful to debug, to use in error messages, or when passing the ppath
  * to a regexp matcher (e.g., Glob.Match.run()).
+ * However, you should prefer to_fpath() most of the time, and then
+ * Fpath.to_string() if needed.
  *)
 let to_string x = x.string
 

--- a/libs/paths/Ppath.ml
+++ b/libs/paths/Ppath.ml
@@ -217,7 +217,12 @@ let in_project ~root path =
            !!root)
   | Some path -> path |> of_fpath |> make_absolute |> normalize_ppath
 
-let from_segments _segs = failwith "TODO"
+(* TODO: make more verification, ensure it's an absolute path, as
+ * opposed to normalize_ppath which accepts relative paths
+ *)
+let from_segments segs =
+  let ppath = create segs in
+  normalize_ppath ppath
 
 (*****************************************************************************)
 (* Tests helpers *)

--- a/libs/paths/Ppath.ml
+++ b/libs/paths/Ppath.ml
@@ -1,4 +1,3 @@
-open Printf
 open File.Operators
 
 (*****************************************************************************)
@@ -34,7 +33,7 @@ type t = {
 (* Helpers *)
 (*****************************************************************************)
 
-let of_string string =
+let of_string_for_tests string =
   let segments =
     match String.split_on_char '/' string with
     | [ "" ] -> (* should be an error? *) [ "." ]
@@ -43,7 +42,8 @@ let of_string string =
   in
   { string; segments }
 
-let root = of_string "/"
+(* old: was of_string_for_tests "/" *)
+let root = { string = "/"; segments = [ ""; "" ] }
 let to_string x = x.string
 
 let check_segment str =
@@ -187,7 +187,8 @@ let in_project ~root path =
   match remove_prefix root path with
   | None ->
       Error
-        (sprintf "cannot make path %S relative to project root %S" !!path !!root)
+        (Common.spf "cannot make path %S relative to project root %S" !!path
+           !!root)
   | Some path -> path |> of_fpath |> make_absolute |> normalize
 
 (*****************************************************************************)
@@ -199,19 +200,19 @@ let () =
       let test_str f input expected_output =
         Alcotest.(check string) "equal" expected_output (f input)
       in
-      let rewrite str = to_string (of_string str) in
+      let rewrite str = to_string (of_string_for_tests str) in
       test_str rewrite "/" "/";
       test_str rewrite "//" "//";
       test_str rewrite "" "";
       test_str rewrite "a/" "a/";
 
       let norm str =
-        match of_string str |> normalize with
+        match of_string_for_tests str |> normalize with
         | Ok x -> to_string x
         | Error s -> failwith s
       in
       let norm_err str =
-        match of_string str |> normalize with
+        match of_string_for_tests str |> normalize with
         | Ok _ -> false
         | Error _ -> true
       in
@@ -237,7 +238,9 @@ let () =
       test_str norm "/a/b/" "/a/b/";
 
       let test_add_seg a b ab =
-        Alcotest.(check string) "equal" ab (add_seg (of_string a) b |> to_string)
+        Alcotest.(check string)
+          "equal" ab
+          (add_seg (of_string_for_tests a) b |> to_string)
       in
       test_add_seg "/" "a" "/a";
       test_add_seg "/a" "b" "/a/b";

--- a/libs/paths/Ppath.mli
+++ b/libs/paths/Ppath.mli
@@ -35,7 +35,7 @@ val to_fpath : root:Fpath.t -> t -> Fpath.t
 (* /, useful as a folding starting point *)
 val root : t
 
-(* to debug *)
+(* To debug or error messages. You should use to_fpath() most of the time *)
 val to_string : t -> string
 
 (* Append a segment to a path. *)
@@ -49,11 +49,12 @@ end
 
 (* ------------- TO DELETE *)
 
+val of_fpath : Fpath.t -> t
+
 (* Create a path from the list of segments. Segments may not contain
    slashes. *)
 val create : string list -> t
 val segments : t -> string list
-val is_absolute : t -> bool
 val is_relative : t -> bool
 
 (* Turn foo/bar into /foo/bar *)

--- a/libs/paths/Ppath.mli
+++ b/libs/paths/Ppath.mli
@@ -8,23 +8,39 @@
    Project path (instead of File path).
 *)
 
+(* All file paths are *absolute* and *normalized* *)
 type t
 
 (*
-   Returns an *absolute*, *normalized* path relative to the project root.
+   Returns an absolute, normalized path relative to the project root.
    This is purely syntactic.
-   It is recommended to work on physical paths as returned by 'realpath'
+   It is recommended to work on physical paths as returned by 'realpath()'
    to ensure that both paths below share the longest common prefix.
-   For example,
+
+   Example of use:
 
      let* ppath = in_project ~root:(Fpath.v "/a") (Fpath.v "/a/b/c") in
-     (segments ppath, to_string ppath)
+     Ok (segments ppath, to_string ppath)
 
    equals to
 
      Ok ([""; "b"; "c"], "/b/c" )
 *)
 val in_project : root:Fpath.t -> Fpath.t -> (t, string) result
+
+(* Creates a ppath from a list of segments. Segments may not contain
+   slashes. The first segment must be "" because ppath must be
+   absolute paths.
+
+   Fail if the resulting path is absolute but refers to a file above the
+   root e.g. '/..' or '/../..'.
+   Example of syntactic path normalization:
+   foo/../bar -> bar  (even if 'foo/' doesn't exist)
+
+   Example of use: from_segments ["";"a";"b";"..";"c"] should
+   return a ppath whose final segments are ["";"a";"c"].
+*)
+val from_segments : string list -> (t, string) result
 
 (* Convert back to a system path. *)
 val to_fpath : root:Fpath.t -> t -> Fpath.t
@@ -59,18 +75,7 @@ val create : string list -> t
 
 (* Turn foo/bar into /foo/bar *)
 val make_absolute : t -> t
-
-(*
-   Syntactic path normalization.
-   e.g. foo/../bar -> bar  (even if 'foo/' doesn't exist)
-
-   Fail if the resulting path is absolute and refers to a file above the
-   root e.g. '/..' or '/../..'.
-
-   TODO: use filesystem path to the project root to perform a correct
-   normalization.
-*)
-val normalize : t -> (t, string) result
+val normalize_ppath : t -> (t, string) result
 
 (* internals *)
 

--- a/libs/paths/Ppath.mli
+++ b/libs/paths/Ppath.mli
@@ -65,12 +65,6 @@ module Operators : sig
   val ( / ) : t -> string -> t
 end
 
-(* ------------- TO DELETE *)
-
-(* Create a path from the list of segments. Segments may not contain
-   slashes. *)
-val create : string list -> t
-
 (* internals *)
 
 (* A slash-separated path. *)

--- a/libs/paths/Ppath.mli
+++ b/libs/paths/Ppath.mli
@@ -8,7 +8,7 @@
    Project path (instead of File path).
 *)
 
-(* All file paths are *absolute* and *normalized* *)
+(* All project paths are *absolute* and *normalized* *)
 type t
 
 (*
@@ -67,14 +67,9 @@ end
 
 (* ------------- TO DELETE *)
 
-val of_fpath : Fpath.t -> t
-
 (* Create a path from the list of segments. Segments may not contain
    slashes. *)
 val create : string list -> t
-
-(* Turn foo/bar into /foo/bar *)
-val make_absolute : t -> t
 
 (* internals *)
 

--- a/libs/paths/Ppath.mli
+++ b/libs/paths/Ppath.mli
@@ -1,7 +1,7 @@
 (*
    Abstract type for a file path within a project.
 
-   This avoids issues of Unix-style vs. Windows-style paths; all
+   This avoids issues of Unix-style vs. Windows-style paths; All
    paths use '/' as a separator.
 
    The name of the module imitates Fpath.ml, but use Ppath.ml for

--- a/libs/paths/Ppath.mli
+++ b/libs/paths/Ppath.mli
@@ -75,7 +75,6 @@ val create : string list -> t
 
 (* Turn foo/bar into /foo/bar *)
 val make_absolute : t -> t
-val normalize_ppath : t -> (t, string) result
 
 (* internals *)
 

--- a/libs/paths/Ppath.mli
+++ b/libs/paths/Ppath.mli
@@ -1,7 +1,7 @@
 (*
    Abstract type for a file path within a project.
 
-   This avoids issues of Unix-style vs. Windows-style paths. All
+   This avoids issues of Unix-style vs. Windows-style paths; all
    paths use '/' as a separator.
 
    The name of the module imitates Fpath.ml, but use Ppath.ml for
@@ -16,27 +16,27 @@ type t = private {
 }
 
 (*
-   Return an absolute, normalized path relative to the project root.
-   This is purely syntactic. It is recommended to work on physical paths
-   as returned by 'realpath' to ensure that both paths share the longest
-   common prefix.
+   Returns an *absolute*, *normalized* path relative to the project root.
+   This is purely syntactic.
+   It is recommended to work on physical paths as returned by 'realpath'
+   to ensure that both paths below share the longest common prefix.
 
      in_project ~root:(Fpath.v "/a") (Fpath.v "/a/b/c")
 
    equals
 
-     Ok (of_string "/b/c")
+     Ok { segments = [""; "b"; "c"]; string = "/b/c" }
 *)
 val in_project : root:Fpath.t -> Fpath.t -> (t, string) result
 
-(* A slash-separated path. *)
-val of_string : string -> t
-val to_string : t -> string
+(* Convert back to a system path. *)
+val to_fpath : root:Fpath.t -> t -> Fpath.t
 
-(* Create a path from the list of segments. Segments may not contain
-   slashes. *)
-val create : string list -> t
-val segments : t -> string list
+(* /, useful as a folding starting point *)
+val root : t
+
+(* to debug *)
+val to_string : t -> string
 
 (* Append a segment to a path. *)
 val add_seg : t -> string -> t
@@ -47,6 +47,12 @@ module Operators : sig
   val ( / ) : t -> string -> t
 end
 
+(* ------------- TO DELETE *)
+
+(* Create a path from the list of segments. Segments may not contain
+   slashes. *)
+val create : string list -> t
+val segments : t -> string list
 val is_absolute : t -> bool
 val is_relative : t -> bool
 
@@ -64,10 +70,8 @@ val make_absolute : t -> t
    normalization.
 *)
 val normalize : t -> (t, string) result
-val of_fpath : Fpath.t -> t
 
-(* Convert back to a system path. *)
-val to_fpath : root:Fpath.t -> t -> Fpath.t
+(* internals *)
 
-(* / *)
-val root : t
+(* A slash-separated path. *)
+val of_string_for_tests : string -> t

--- a/libs/paths/Ppath.mli
+++ b/libs/paths/Ppath.mli
@@ -15,12 +15,14 @@ type t
    This is purely syntactic.
    It is recommended to work on physical paths as returned by 'realpath'
    to ensure that both paths below share the longest common prefix.
+   For example,
 
-     in_project ~root:(Fpath.v "/a") (Fpath.v "/a/b/c")
+     let* ppath = in_project ~root:(Fpath.v "/a") (Fpath.v "/a/b/c") in
+     (segments ppath, to_string ppath)
 
-   equals
+   equals to
 
-     Ok { segments = [""; "b"; "c"]; string = "/b/c" }
+     Ok ([""; "b"; "c"], "/b/c" )
 *)
 val in_project : root:Fpath.t -> Fpath.t -> (t, string) result
 
@@ -54,7 +56,6 @@ val of_fpath : Fpath.t -> t
 (* Create a path from the list of segments. Segments may not contain
    slashes. *)
 val create : string list -> t
-val is_relative : t -> bool
 
 (* Turn foo/bar into /foo/bar *)
 val make_absolute : t -> t

--- a/libs/paths/Ppath.mli
+++ b/libs/paths/Ppath.mli
@@ -8,12 +8,7 @@
    Project path (instead of File path).
 *)
 
-type t = private {
-  (* path segments within the project root *)
-  segments : string list;
-  (* internal *)
-  string : string;
-}
+type t
 
 (*
    Returns an *absolute*, *normalized* path relative to the project root.
@@ -35,8 +30,11 @@ val to_fpath : root:Fpath.t -> t -> Fpath.t
 (* /, useful as a folding starting point *)
 val root : t
 
-(* To debug or error messages. You should use to_fpath() most of the time *)
+(* Useful to debug, to use in error messages, or when passing the ppath
+ * to a regexp matcher (e.g., Glob.Match.run()).
+ * However, you should prefer to_fpath() most of the time *)
 val to_string : t -> string
+val segments : t -> string list
 
 (* Append a segment to a path. *)
 val add_seg : t -> string -> t
@@ -54,7 +52,6 @@ val of_fpath : Fpath.t -> t
 (* Create a path from the list of segments. Segments may not contain
    slashes. *)
 val create : string list -> t
-val segments : t -> string list
 val is_relative : t -> bool
 
 (* Turn foo/bar into /foo/bar *)

--- a/libs/paths/Ppath.mli
+++ b/libs/paths/Ppath.mli
@@ -30,10 +30,12 @@ val to_fpath : root:Fpath.t -> t -> Fpath.t
 (* /, useful as a folding starting point *)
 val root : t
 
-(* Useful to debug, to use in error messages, or when passing the ppath
- * to a regexp matcher (e.g., Glob.Match.run()).
- * However, you should prefer to_fpath() most of the time *)
+(* Deprecated: you should use to_fpath (and then Fpath.to_string if needed) *)
 val to_string : t -> string
+
+(* The first element returned will always be "", because ppaths are always
+ * absolute paths
+ *)
 val segments : t -> string list
 
 (* Append a segment to a path. *)

--- a/src/osemgrep/targeting/Include_filter.ml
+++ b/src/osemgrep/targeting/Include_filter.ml
@@ -76,7 +76,7 @@ let select t (full_git_path : Ppath.t) =
               else scan_segments matcher file_path segments)
   in
   let rel_segments =
-    match full_git_path.segments with
+    match Ppath.segments full_git_path with
     | "" :: xs -> xs
     | __else__ -> assert false
   in

--- a/src/osemgrep/targeting/Semgrepignore.ml
+++ b/src/osemgrep/targeting/Semgrepignore.ml
@@ -81,17 +81,7 @@ let create ?include_patterns ?(cli_patterns = []) ~exclusion_mechanism
   in
   { include_filter; gitignore_filter }
 
-let select t path =
-  (*
-     Syntactic path normalization: 'foo/../bar' becomes 'bar' even if 'foo'
-     doesn't exist. This isn't what we want: ideally, 'foo/..' should result
-     in an error if 'foo' doesn't exist or isn't a readable directory.
-  *)
-  let git_path =
-    match Ppath.make_absolute path |> Ppath.normalize with
-    | Ok x -> x
-    | Error msg -> failwith msg
-  in
+let select t (git_path : Ppath.t) =
   let status, sel_events =
     match t.include_filter with
     | None -> (Gitignore.Not_ignored, [])

--- a/src/osemgrep/targeting/Unit_semgrepignore.ml
+++ b/src/osemgrep/targeting/Unit_semgrepignore.ml
@@ -34,7 +34,7 @@ let test_filter ?includes:include_patterns ?excludes:cli_patterns
       let error = ref false in
       selection
       |> List.iter (fun (path, should_be_selected) ->
-             let path = Ppath.of_string path in
+             let path = Ppath.of_string_for_tests path in
              let status, selection_events =
                Common.save_excursion Glob.Match.debug true (fun () ->
                    Semgrepignore.select filter path)

--- a/src/targeting/Find_targets_old.ml
+++ b/src/targeting/Find_targets_old.ml
@@ -259,7 +259,13 @@ let get_targets conf scanning_roots =
                         (* we're supposed to be working with clean paths by now *)
                         assert false
                   in
-                  let git_path = Ppath.(of_fpath rel_path |> make_absolute) in
+                  let git_path =
+                    let segments = Fpath.segs rel_path in
+                    match Ppath.from_segments ("" :: segments) with
+                    | Ok x -> x
+                    (* or raise Impossible? *)
+                    | Error s -> failwith s
+                  in
                   let status, selection_events =
                     Semgrepignore.select ign git_path
                   in


### PR DESCRIPTION
Ideally we should just provide one way to build a ppath,
with Ppath.in_project

Test plan:
make core


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)