### PR TITLE
const-prop: Fix bug detecting overflow in multiplication

### DIFF
--- a/changelog.d/gh-7893.fixed
+++ b/changelog.d/gh-7893.fixed
@@ -1,0 +1,3 @@
+Fixed bug in constant propagation that made Semgrep fail to compute the value of
+an integer constant when this was obtained via the multiplication of two other
+constants.

--- a/src/analyzing/Dataflow_svalue.ml
+++ b/src/analyzing/Dataflow_svalue.ml
@@ -236,17 +236,17 @@ let eval_unop_int op opt_i =
  * integers have just 63-bits in 64-bit architectures!
  *)
 let eval_binop_int tok op opt_i1 opt_i2 =
-  let sign i = i asr (Sys.int_size - 1) in
+  let sign_bit i = i asr (Sys.int_size - 1) =|= 1 in
   match (op, opt_i1, opt_i2) with
   | G.Plus, Some i1, Some i2 ->
       let r = i1 + i2 in
-      if sign i1 =|= sign i2 && sign r <> sign i1 then
+      if sign_bit i1 =:= sign_bit i2 && sign_bit r <> sign_bit i1 then
         G.Cst G.Cint (* overflow *)
       else G.Lit (literal_of_int (i1 + i2))
   | G.Minus, Some i1, Some i2 ->
       let r = i1 - i2 in
-      if sign i1 <> sign i2 && sign r <> sign i1 then G.Cst G.Cint
-        (* overflow *)
+      if sign_bit i1 <> sign_bit i2 && sign_bit r <> sign_bit i1 then
+        G.Cst G.Cint (* overflow *)
       else G.Lit (literal_of_int (i1 - i2))
   | G.Mult, Some i1, Some i2 ->
       let overflow =
@@ -254,7 +254,7 @@ let eval_binop_int tok op opt_i1 opt_i2 =
         && ((i1 < 0 && i2 =|= min_int) (* >max_int *)
            || (i1 =|= min_int && i2 < 0) (* >max_int *)
            ||
-           if sign i1 * sign i2 =|= 1 then abs i1 > abs (max_int / i2)
+           if sign_bit i1 =:= sign_bit i2 then abs i1 > abs (max_int / i2)
              (* >max_int *)
            else abs i1 > abs (min_int / i2) (* <min_int *))
       in

--- a/tests/rules/cp_mults.py
+++ b/tests/rules/cp_mults.py
@@ -1,0 +1,28 @@
+# https://github.com/returntocorp/semgrep/issues/7893
+
+# This requires Pro
+# from constants import ONE_DAY
+ONE_DAY = 60 * 60 * 60 * 24
+
+MANY_DAYS = 5 * ONE_DAY
+ONE = 1
+TWO = 2 * ONE
+FIVE = 5 * ONE
+
+def bad(var):
+    print(var)
+
+# ok: test
+bad(var=2)
+# ok: test
+bad(var=TWO)
+# ruleid: test
+bad(var=3)
+# ruleid: test
+bad(var=FIVE)
+# ruleid: test
+bad(var=ONE_DAY)
+# ruleid: test
+bad(var=3000)
+# ruleid: test
+bad(var=MANY_DAYS)

--- a/tests/rules/cp_mults.yaml
+++ b/tests/rules/cp_mults.yaml
@@ -1,0 +1,11 @@
+rules:
+  - id: test
+    patterns:
+      - pattern: $F(..., $VAR=$VAL, ...)
+      - metavariable-comparison:
+          comparison: $VAL > 2
+      - focus-metavariable: $VAL
+    languages:
+      - python
+    severity: INFO
+    message: "`$VAR` has value `value($VAL)`"


### PR DESCRIPTION
Wrote the overflow check for multiplication like if `sign` returned `1` for positives, when it is just returning the sign bit. Renamed `sign` to `sign_bit` to make it more clear, and changed its return type to `bool`.

Closes #7893

test plan:
make test # new tests

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
