### PR TITLE
fix: Remove special-case for typed-metavar matching

### DIFF
--- a/src/core/Type.ml
+++ b/src/core/Type.ml
@@ -107,8 +107,13 @@ let rec to_name_opt lang ty =
   | Pointer ty when lang =*= Lang.Go -> to_name_opt lang ty
   | _else_ -> None
 
-let mkt str =
-  G.TyN (G.Id ((str, Tok.unsafe_fake_tok str), G.empty_id_info ())) |> G.t
+let mkt ?tok str =
+  let tok =
+    match tok with
+    | Some tok -> tok
+    | None -> Tok.unsafe_fake_tok str
+  in
+  G.TyN (G.Id ((str, tok), G.empty_id_info ())) |> G.t
 
 let is_real_type = function
   | NoType
@@ -147,17 +152,17 @@ let builtin_type_of_string _langTODO str =
 (* coupling: Inverse of builtin_type_of_string
  *
  * TODO: Check lang to get proper builtin type for more languages *)
-let ast_generic_type_of_builtin_type lang t =
+let ast_generic_type_of_builtin_type ?tok lang t =
   match (lang, t) with
-  | _, Int -> mkt "int"
-  | _, Float -> mkt "float"
-  (* TODO check lang for string type *)
-  | _, String -> mkt "string"
-  | Lang.Java, Bool -> mkt "boolean"
-  | _, Bool -> mkt "bool"
+  | _, Int -> mkt ?tok "int"
+  | _, Float -> mkt ?tok "float"
+  | Lang.Java, String -> mkt ?tok "String"
+  | _, String -> mkt ?tok "string"
+  | Lang.Java, Bool -> mkt ?tok "boolean"
+  | _, Bool -> mkt ?tok "bool"
   (* TS *)
-  | _, Number -> mkt "number"
-  | _, OtherBuiltins str -> mkt str
+  | _, Number -> mkt ?tok "number"
+  | _, OtherBuiltins str -> mkt ?tok str
 
 let builtin_type_of_type lang t =
   match t.G.t with
@@ -169,9 +174,19 @@ let builtin_type_of_type lang t =
   | __else__ -> None
 
 (* There is no function of_ast_generic_type_. The closest is
- * Naming_AST.type_of_expr  which converts an G.type_ to Type.t *)
-let rec to_ast_generic_type_ lang (f : 'a -> G.alternate_name list -> G.name)
-    (x : 'a t) : G.type_ option =
+ * Naming_AST.type_of_expr  which converts an G.type_ to Type.t.
+ *
+ * If provided, `tok` is used in place of a fake tokens in most contexts where a
+ * token is needed. This allows the resulting synthetic AST to be used in places
+ * that require location information.
+ * *)
+let rec to_ast_generic_type_ ?(tok = None) lang
+    (f : 'a -> G.alternate_name list -> G.name) (x : 'a t) : G.type_ option =
+  let make_tok str =
+    match tok with
+    | Some tok -> tok
+    | None -> Tok.unsafe_fake_tok str
+  in
   match x with
   | N ((name, args), alts) -> (
       let n = f name alts in
@@ -182,19 +197,19 @@ let rec to_ast_generic_type_ lang (f : 'a -> G.alternate_name list -> G.name)
           let* targs = type_arguments lang f xs in
           Some (G.TyApply (t, Tok.unsafe_fake_bracket targs) |> G.t))
   | UnresolvedName (s, args) -> (
-      let t = mkt s in
+      let t = mkt ~tok:(make_tok s) s in
       match args with
       | [] -> Some t
       | xs ->
           let* targs = type_arguments lang f xs in
           Some (G.TyApply (t, Tok.unsafe_fake_bracket targs) |> G.t))
-  | Null -> Some (mkt "null")
-  | Builtin x -> Some (ast_generic_type_of_builtin_type lang x)
+  | Null -> Some (mkt ~tok:(make_tok "null") "null")
+  | Builtin x ->
+      Some (ast_generic_type_of_builtin_type ~tok:(make_tok "") lang x)
   | Array (size, ty) ->
       let size =
         Option.map
-          (fun n ->
-            G.L (G.Int (Some n, Tok.unsafe_fake_tok (string_of_int n))) |> G.e)
+          (fun n -> G.L (G.Int (Some n, make_tok (string_of_int n))) |> G.e)
           size
       in
       let* ty = to_ast_generic_type_ lang f ty in
@@ -210,8 +225,7 @@ let rec to_ast_generic_type_ lang (f : 'a -> G.alternate_name list -> G.name)
                      let classic =
                        {
                          G.pname =
-                           pident
-                           |> Option.map (fun s -> (s, Tok.unsafe_fake_tok s));
+                           pident |> Option.map (fun s -> (s, make_tok s));
                          ptype = Some t;
                          pattrs = [];
                          pinfo = G.empty_id_info ();
@@ -221,9 +235,7 @@ let rec to_ast_generic_type_ lang (f : 'a -> G.alternate_name list -> G.name)
                      G.Param classic
                  | _else_ ->
                      G.OtherParam
-                       ( ( "to_ast_generic_type for param",
-                           Tok.unsafe_fake_tok "" ),
-                         [] ))
+                       (("to_ast_generic_type for param", make_tok ""), []))
              | OtherParam x ->
                  G.OtherParam (todo_kind_to_ast_generic_todo_kind x, []))
       in
@@ -231,7 +243,7 @@ let rec to_ast_generic_type_ lang (f : 'a -> G.alternate_name list -> G.name)
       Some (G.TyFun (params, tret) |> G.t)
   | Pointer ty ->
       let* ty = to_ast_generic_type_ lang f ty in
-      Some (G.TyPointer (Tok.unsafe_fake_tok "Pointer", ty) |> G.t)
+      Some (G.TyPointer (make_tok "Pointer", ty) |> G.t)
   | NoType
   | Todo _ ->
       None

--- a/src/matching/Generic_vs_generic.ml
+++ b/src/matching/Generic_vs_generic.ml
@@ -1403,24 +1403,34 @@ and m_compatible_type lang typed_mvar t e =
       m_type_ t
         (G.TyPointer (t1, G.TyN (G.Id (("char", tok), id_info)) |> G.t) |> G.t)
       >>= fun () -> envf typed_mvar (MV.E e)
-  (* for matching ids *)
-  (* this is covered by the basic type propagation done in Naming_AST.ml *)
-  | _ta, B.N (B.Id (idb, ({ B.id_type = tb; _ } as id_infob))) ->
-      (* NOTE: Name values must be represented with MV.Id! *)
-      m_type_option_with_hook idb (Some t) !tb >>= fun () ->
-      envf typed_mvar (MV.Id (idb, Some id_infob))
   | _ta, _eb -> (
+      let with_bound_metavar =
+        match e.G.e with
+        | B.N (B.Id (id, info)) ->
+            (* NOTE: Name values must be represented with MV.Id! *)
+            envf typed_mvar (MV.Id (id, Some info))
+        | _else_ -> envf typed_mvar (MV.E e)
+      in
       let tb, idopt = Typing.type_of_expr lang e in
       (* If we can infer the type, then match against it. Otherwise, fall back
        * on LSP type matching *)
       if Type.is_real_type tb then
-        let* () = m_generic_type_vs_type_t lang t tb in
-        envf typed_mvar (MV.E e)
+        (* In case the pattern of the type itself contains a metavariable (e.g.
+         * `(List<$T> $X)), take a token from the expression so that we have a
+         * real location to associate with the metavariable. *)
+        let tok =
+          lazy
+            (match H.ii_of_any (G.E e) |> List.filter Tok.is_origintok with
+            | hd :: _ -> Some hd
+            | [] -> None)
+        in
+        let* () = m_generic_type_vs_type_t lang tok t tb in
+        with_bound_metavar
       else
         match idopt with
         | Some idb ->
             m_type_option_with_hook idb (Some t) None >>= fun () ->
-            envf typed_mvar (MV.E e)
+            with_bound_metavar
         | None -> fail ())
 
 (*---------------------------------------------------------------------------*)
@@ -1999,9 +2009,27 @@ and m_wildcard (a1, a2) (b1, b2) =
  * subtype analysis is fairly limited (I believe it only happens with
  * inheritance for nominal types when used with the Pro Engine) but it may be
  * extended at some point.
+ *
+ * Uses the provided `tok` (if any) when constructing synthetic AST to which a
+ * metavariable is bound.
  * *)
-and m_generic_type_vs_type_t lang a b =
+and m_generic_type_vs_type_t lang tok a b =
   match (a.G.t, b) with
+  | G.TyN (Id ((str, idtok), _)), _ when MV.is_metavar_name str -> (
+      match
+        Type.to_ast_generic_type_ ~tok:(Lazy.force tok) lang
+          (fun name _alts -> name)
+          b
+      with
+      | None ->
+          (* Log error? Bind to OtherType? *)
+          fail ()
+      (* Ensure MV bindings are to Id or N as appropriate. THINK: Should this be
+       * part of envf? *)
+      | Some { G.t = G.TyN (Id (id, info)); _ } ->
+          envf (str, idtok) (MV.Id (id, Some info))
+      | Some { G.t = G.TyN name; _ } -> envf (str, idtok) (MV.N name)
+      | Some ty -> envf (str, idtok) (MV.T ty))
   | G.TyN name1, Type.N ((name2, (* targs *) []), _alts) ->
       (* TODO: Alternate names should actually be part of the 'resolved type
        * param in Type.t. They are actually stored in the name, so we ignore
@@ -2010,18 +2038,14 @@ and m_generic_type_vs_type_t lang a b =
   | G.TyApply ({ t = G.TyN name1; _ }, targs1), Type.N ((name2, targs2), _alts)
     ->
       let* () = m_name name1 name2 in
-      m_generic_targs_vs_type_targs lang targs1 targs2
+      m_generic_targs_vs_type_targs lang tok targs1 targs2
   (* TODO: Handle IdQualified matching unresolved name? *)
   | G.TyN (Id ((str1, _), _)), Type.UnresolvedName (str2, (* targs *) []) ->
       m_string str1 str2
   | ( G.TyApply ({ t = G.TyN (Id ((str1, _), _)); _ }, targs1),
       Type.UnresolvedName (str2, targs2) ) ->
       let* () = m_string str1 str2 in
-      m_generic_targs_vs_type_targs lang targs1 targs2
-  | G.TyN (Id ((str, _), _)), Type.Builtin _ when MV.is_metavar_name str ->
-      (* TODO Convert the builtin to AST generic and bind it to the
-       * metavariable. *)
-      return ()
+      m_generic_targs_vs_type_targs lang tok targs1 targs2
   | G.TyN (Id ((str, _), _)), Type.Builtin builtin2 -> (
       (* Convert the string in the pattern to a Type.builtin_type. Currently,
        * this lets users write, for example `str` in Java and have it
@@ -2049,24 +2073,24 @@ and m_generic_type_vs_type_t lang a b =
           fail ())
   (* coupling: we also match on "null" etc. in Typing.type_of_ast_generic_type.
    * Pull out into util? *)
-  | G.TyN (Id ((("null" | "nil"), _), _)), Type.Null -> return ()
+  | G.TyN (Id ((("null" | "nil" | "NULL"), _), _)), Type.Null -> return ()
   (* An array type pattern with no size specified should still match an array
    * type where we know the size. *)
   | G.TyArray ((_l, None, _r), t1), Type.Array (_size, t2) ->
       (* THINK: Should be an invariant match rather than covariant? *)
-      m_generic_type_vs_type_t lang t1 t2
+      m_generic_type_vs_type_t lang tok t1 t2
   | ( G.TyArray ((_l, Some { e = G.L (G.Int (Some size1, _)); _ }, _r), t1),
       Type.Array (Some size2, t2) ) ->
       let* () = m_int size1 size2 in
       (* THINK: Should be an invariant match rather than covariant? *)
-      m_generic_type_vs_type_t lang t1 t2
+      m_generic_type_vs_type_t lang tok t1 t2
   | G.TyFun (params1, tret1), Type.Function (params2, tret2) ->
-      let* () = m_generic_params_vs_params lang params1 params2 in
-      m_generic_type_vs_type_t lang tret1 tret2
+      let* () = m_generic_params_vs_params lang tok params1 params2 in
+      m_generic_type_vs_type_t lang tok tret1 tret2
   | G.TyPointer (_tok, t1), Type.Pointer t2 ->
-      m_generic_type_vs_type_t lang t1 t2
+      m_generic_type_vs_type_t lang tok t1 t2
   | G.TyExpr { e = G.N name1; _ }, _ ->
-      m_generic_type_vs_type_t lang (G.TyN name1 |> G.t) b
+      m_generic_type_vs_type_t lang tok (G.TyN name1 |> G.t) b
   | _, Type.N _
   | _, Type.UnresolvedName _
   | _, Type.Builtin _
@@ -2078,18 +2102,18 @@ and m_generic_type_vs_type_t lang a b =
   | _, Type.Todo _ ->
       fail ()
 
-and m_generic_targs_vs_type_targs lang (_l, a, _r) b =
+and m_generic_targs_vs_type_targs lang tok (_l, a, _r) b =
   (* TODO Handle ellipses? *)
-  m_list (m_generic_targ_vs_type_targ lang) a b
+  m_list (m_generic_targ_vs_type_targ lang tok) a b
 
-and m_generic_targ_vs_type_targ lang a b =
+and m_generic_targ_vs_type_targ lang tok a b =
   match (a, b) with
   | G.TA t1, Type.TA t2 ->
       (* Technically this isn't quite right. m_generic_type_vs_type_t checks if
        * t1 is a supertype of t2. Typically, type parameters must be invariant,
        * and this will assume covariance. But it's probably not a big deal, and
        * they don't have to be invariant in all cases anyway. *)
-      m_generic_type_vs_type_t lang t1 t2
+      m_generic_type_vs_type_t lang tok t1 t2
   | G.TA _, Type.OtherTypeArg _
   (* TODO Represent more typearg kinds in Type.t? *)
   | G.TAWildcard _, _
@@ -2098,18 +2122,18 @@ and m_generic_targ_vs_type_targ lang a b =
   | G.OtherTypeArg _, _ ->
       fail ()
 
-and m_generic_params_vs_params lang a b =
+and m_generic_params_vs_params lang tok a b =
   (* TODO Handle ellipses? *)
-  m_list (m_generic_param_vs_param lang) a b
+  m_list (m_generic_param_vs_param lang tok) a b
 
-and m_generic_param_vs_param lang a b =
+and m_generic_param_vs_param lang tok a b =
   match (a, b) with
   | ( G.Param { G.pname = name1; ptype = t1; _ },
       Type.Param { Type.pident = name2; ptype = t2 } ) -> (
       let name1 = Option.map fst name1 in
       let* () = m_option m_string name1 name2 in
       match t1 with
-      | Some t1 -> m_generic_type_vs_type_t lang t1 t2
+      | Some t1 -> m_generic_type_vs_type_t lang tok t1 t2
       | None -> (* THINK: Is this right? *) return ())
   | _, Type.Param _
   | _, Type.OtherParam _ ->

--- a/src/typing/Typing.ml
+++ b/src/typing/Typing.ml
@@ -148,11 +148,13 @@ and type_of_ast_generic_type lang t : G.name Type.t =
   match t.G.t with
   (* TODO Check language? Someone could make a user type named `nil` in Java,
    * for example. *)
-  | G.TyN (Id ((("null" | "nil"), _), _)) -> Type.Null
+  | G.TyN (Id ((("null" | "nil" | "NULL"), _), _)) -> Type.Null
   | G.TyN (Id ((str, _), _) as name) -> (
       match Type.builtin_type_of_string lang str with
       | Some t -> Type.Builtin t
       | None -> Type.N ((name, []), []))
+  (* Pick up IdQualified as well *)
+  | G.TyN name -> Type.N ((name, []), [])
   | G.TyApply ({ G.t = G.TyN name; _ }, (_l, args, _r)) ->
       let args =
         args

--- a/tests/patterns/java/typed_metavar_class.java
+++ b/tests/patterns/java/typed_metavar_class.java
@@ -1,31 +1,31 @@
 public class SemgrepTest
 {
-	public static final String MD5_1 = "MD5";
-	public final String MD5_2 = "MD5";
+  public static final String MD5_1 = "MD5";
+  public final String MD5_2 = "MD5";
 
-public static void main(String[] args) throws NoSuchAlgorithmException, IOException
-	{
+  public static void main(String[] args) throws NoSuchAlgorithmException, IOException
+  {
 
-		if (args.length != 1)
-		{
-			throw new IOException("Wrong number of arguments");
-		}
+    if (args.length != 1)
+    {
+      throw new IOException("Wrong number of arguments");
+    }
 
-        //unfornutately this will not be matched by
-        // (MessageDigest $MD).getInstance("MD5");
-        //TODO: match
-		MessageDigest md1 = MessageDigest.getInstance("MD5");
+    // TODO: Should these actually match? `MessageDigest` has type
+    // `Class<MessageDigest>`, not type `MessageDigest`. Maybe the pattern for
+    // this shouldn't even involve a typed metavariable?
 
-        //TODO: match
-		MessageDigest md2 = MessageDigest.getInstance(MD5_1);
+    // MATCH:
+    MessageDigest md1 = MessageDigest.getInstance("MD5");
 
-        //TODO: match
-		MessageDigest md3 = MessageDigest.getInstance(MD5_2);	
+    // MATCH:
+    MessageDigest md2 = MessageDigest.getInstance(MD5_1);
 
-		int stam1 = 0;
-		if (stam1 == stam1)
-			throw new IOException("Bad place");
+    // MATCH:
+    MessageDigest md3 = MessageDigest.getInstance(MD5_2);
 
-	}
-
+    int stam1 = 0;
+    if (stam1 == stam1)
+      throw new IOException("Bad place");
+  }
 }


### PR DESCRIPTION
Previously, if a typed metavariable was matched against an identifier, it would go through the old `m_type` matching codepath rather than the new type inference codepath. For consistency and simplicity, I have removed that special case and consolidated on the new type inference and matching.

This required me to make some improvements to the new type inference and new matching in order to pass tests. Notably, metavariables inside of the types in typed metavariables are now bound. Since the AST to which they are bound is the result of type inference, it is synthetic. I adopted the pattern pioneered in https://github.com/returntocorp/semgrep/pull/6900 of using a local token from the AST to associate a synthetic AST with a real program location.

The change in test behavior is because we can now match on unresolved types. The type we infer for `MessageDigest` is just `UnresolvedName "MessageDigest"` (in a simplified representation). As noted in `Typing.type_of_name`, this should most likely be `Typeof "MessageDigest"`, but we conflate class instances with the type of the class itself throughout our type inference infrastructure, with this result. I also reformatted that test since I found the mix of tabs and spaces confusing.

Test plan: Automated tests

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
