### PR TITLE
Implement anchored ellipsis where it makes sense

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -249,12 +249,20 @@ test:
 core-test: core build-spacegrep
 	# The test executable has a few options that can be useful
 	# in some contexts.
+	$(MAKE) build-core-test
 	dune build ./_build/default/src/tests/test.exe
 	# The following command ensures that we can call 'test.exe --help'
-	# from the directory of the checkou
+	# from the directory of the checkout
 	./_build/default/src/tests/test.exe --show-errors --help 2>&1 >/dev/null
 	$(MAKE) -C libs/spacegrep test
 	dune runtest -f --no-buffer
+
+# This is useful when working on one or a few specific test cases.
+# It rebuilds the test executable which can then be called with
+# './test <filter>' where <filter> selects the tests to run.
+.PHONY: build-core-test
+build-core-test:
+	dune build ./_build/default/src/tests/test.exe
 
 #coupling: this is run by .github/workflow/tests.yml
 .PHONY: core-e2etest

--- a/changelog.d/gh-7881.fixed
+++ b/changelog.d/gh-7881.fixed
@@ -1,0 +1,4 @@
+Aliengrep: ellipsis patterns that would be useless because of being placed
+at the extremity of a pattern (always) or a line (in single-mode) are now
+anchored to the beginning/end of input/line. For example, `...` in multiline
+mode matches the whole input rather than matching nothing many times.

--- a/libs/aliengrep/Conf.ml
+++ b/libs/aliengrep/Conf.ml
@@ -81,7 +81,7 @@ let default_multiline_conf =
     brackets = [ ('(', ')'); ('[', ']'); ('{', '}') ];
   }
 
-let default_uniline_conf =
+let default_singleline_conf =
   {
     multiline = false;
     word_chars = default_multiline_conf.word_chars;

--- a/libs/aliengrep/Conf.mli
+++ b/libs/aliengrep/Conf.mli
@@ -12,7 +12,7 @@ type t = {
 
 (* TODO: document the difference in the defaults *)
 val default_multiline_conf : t
-val default_uniline_conf : t
+val default_singleline_conf : t
 
 (* Check the validity of the configuration.
    Raises an exception if the configuration is invalid. *)

--- a/libs/aliengrep/Pat_AST.ml
+++ b/libs/aliengrep/Pat_AST.ml
@@ -16,6 +16,7 @@ and node =
   | Long_metavar_ellipsis of string (* same *)
   | Bracket of char * t * char
   | Word of string
+  | Newline
   | Other of string
 [@@deriving show]
 
@@ -41,6 +42,7 @@ let check ast =
         add name kind
     | Bracket (_open, seq, _close) -> check_seq seq
     | Word _str -> ()
+    | Newline -> ()
     | Other _str -> ()
   and check_seq seq = List.iter check_node seq in
   check_seq ast

--- a/libs/aliengrep/Pat_AST.mli
+++ b/libs/aliengrep/Pat_AST.mli
@@ -18,6 +18,7 @@ and node =
   | Long_metavar_ellipsis of string (* same *)
   | Bracket of char * t * char
   | Word of string (* a word may not be adjacent to another word *)
+  | Newline
   | Other of string
 [@@deriving show]
 

--- a/libs/aliengrep/Pat_compile.ml
+++ b/libs/aliengrep/Pat_compile.ml
@@ -81,20 +81,20 @@ type param = {
   long_ellipsis : spacing_param;
 }
 
-(* uniline mode and regular ellipsis "..." *)
-let uniline_spacing_param =
+(* single-line mode and regular ellipsis "..." *)
+let singleline_spacing_param =
   {
     whitespace_pat = {|[[:blank:]]*+|};
-    bracket_name = "u_bracket";
-    node_name = "u_node";
+    bracket_name = "sl_bracket";
+    node_name = "sl_node";
   }
 
 (* multiline mode and long ellipsis "...." *)
 let multiline_spacing_param =
   {
     whitespace_pat = {|[[:space:]]*+|};
-    bracket_name = "m_bracket";
-    node_name = "m_node";
+    bracket_name = "ml_bracket";
+    node_name = "ml_node";
   }
 
 let param_of_conf (conf : Conf.t) =
@@ -109,10 +109,21 @@ let param_of_conf (conf : Conf.t) =
   else
     {
       multiline_mode = false;
-      spacing = uniline_spacing_param;
-      ellipsis = uniline_spacing_param;
+      spacing = singleline_spacing_param;
+      ellipsis = singleline_spacing_param;
       long_ellipsis = multiline_spacing_param;
     }
+
+let beginning_of_input_pat = {|\A|}
+let end_of_input_pat = {|\z|}
+
+(*
+   For peace of mind, the following definitions are independent of whether
+   PCRE_MULTILINE is set.
+   Alternatively: set PCRE_MULTILINE and use '^' and '$'
+*)
+let beginning_of_line_pat = {|(?:\A|(?<=\n))|}
+let end_of_line_pat = {|(?:\z|(?=\r?\n))|}
 
 (* sequence of any nodes to be captured by a regular ellipsis or by a long
    ellipsis. It uses lazy quantifiers so as to favor shorter matches over
@@ -138,7 +149,7 @@ let ellipsis_pat ~excluded_brace param =
 
 (* In addition to allowing newlines in-between the sequence elements,
    a long ellipsis pattern must allow leading and trailing whitespace
-   containing newlines in uniline mode.
+   containing newlines in single-line mode.
    We try to include as little leading/trailing whitespace as possible,
    though.
 *)
@@ -149,10 +160,87 @@ let long_ellipsis_pat ~excluded_brace param =
        by the ellipsis. *)
     ellipsis_pat_of_spacing_param ~excluded_brace param.ellipsis
   else
-    (* uniline mode *)
+    (* single-line mode *)
     sprintf {|(?:\n %s)?? %s (?:%s \n)??|} param.long_ellipsis.whitespace_pat
       (ellipsis_pat_of_spacing_param ~excluded_brace param.long_ellipsis)
       param.long_ellipsis.whitespace_pat
+
+(* A version of List.iter that passes the previous and next elements
+   if they exist. *)
+let iter3 f ~prev:first_prev ~next:last_next xs =
+  let rec iter prev xs =
+    match xs with
+    | [] -> ()
+    | [ x ] -> f ~prev ~next:last_next x
+    | x :: (next :: _ as xs) ->
+        f ~prev ~next:(Some next) x;
+        iter (Some x) xs
+  in
+  iter first_prev xs
+
+let is_singleline_ellipsis (conf : Conf.t) (x : Pat_AST.node) =
+  match x with
+  | Ellipsis
+  | Metavar_ellipsis _ ->
+      not conf.multiline
+  | Long_ellipsis
+  | Long_metavar_ellipsis _ ->
+      false
+  | Metavar _
+  | Bracket _
+  | Word _
+  | Newline
+  | Other _ ->
+      false
+
+let is_multiline_ellipsis (conf : Conf.t) (x : Pat_AST.node) =
+  match x with
+  | Ellipsis
+  | Metavar_ellipsis _ ->
+      conf.multiline
+  | Long_ellipsis
+  | Long_metavar_ellipsis _ ->
+      true
+  | Metavar _
+  | Bracket _
+  | Word _
+  | Newline
+  | Other _ ->
+      false
+
+let must_match_beginning_of_line conf ~(prev : Pat_AST.node option) node =
+  let starts_line =
+    match prev with
+    | None -> true
+    | Some Newline -> true
+    | Some _ -> false
+  in
+  starts_line && is_singleline_ellipsis conf node
+
+let must_match_beginning_of_input conf ~(prev : Pat_AST.node option) node =
+  let starts_input =
+    match prev with
+    | None -> true
+    | Some _ -> false
+  in
+  starts_input && is_multiline_ellipsis conf node
+
+let must_match_end_of_line conf ~(next : Pat_AST.node option) node =
+  let ends_line =
+    match next with
+    | None -> true
+    | Some Newline -> true
+    | Some _ -> false
+  in
+  ends_line && is_singleline_ellipsis conf node
+
+let must_match_end_of_input conf ~(next : Pat_AST.node option) node =
+  let ends_input =
+    match next with
+    | None -> true
+    | Some _ -> false
+  in
+  ends_input && is_multiline_ellipsis conf node
 
 (* We generate a rather complex PCRE pattern. The syntax assumes the
    so-called extended mode which ignores whitespace and #-comments.
@@ -212,7 +300,7 @@ let to_regexp (conf : Conf.t) (ast : Pat_AST.t) =
      - must exclude the closing brace character if one is expected.
      - may not match ignorable whitespace (so that $...X doesn't capture
        leading or trailing whitespace).
-     - may not match newline characters in uniline mode (except in
+     - may not match newline characters in single-line mode (except in
        long ellipses)
   *)
   let def_other =
@@ -223,7 +311,7 @@ let to_regexp (conf : Conf.t) (ast : Pat_AST.t) =
     define "other" pat
   in
   let def_bracket sparam =
-    define sparam.bracket_name (* = u_bracket or m_bracket *)
+    define sparam.bracket_name (* = sl_bracket or ml_bracket *)
       (conf.brackets
       |> Common.map (fun (open_, close) ->
              sprintf {|%s%s%s|}
@@ -242,7 +330,7 @@ let to_regexp (conf : Conf.t) (ast : Pat_AST.t) =
   in
   let definitions =
     [ def_lwb; def_rwb; def_not_in_word; def_ws; def_word; def_other ]
-    @ parametrized_definitions uniline_spacing_param
+    @ parametrized_definitions singleline_spacing_param
     @ parametrized_definitions multiline_spacing_param
   in
   let word str =
@@ -289,8 +377,12 @@ let to_regexp (conf : Conf.t) (ast : Pat_AST.t) =
        and treated as ordinary punctuation characters ("other") forming
        a node.
     *)
-    let rec of_node ~excluded_brace (node : Pat_AST.node) =
-      match node with
+    let rec of_node ~excluded_brace ~prev ~next (node : Pat_AST.node) =
+      if must_match_beginning_of_input conf ~prev node then
+        add beginning_of_input_pat;
+      if must_match_beginning_of_line conf ~prev node then
+        add beginning_of_line_pat;
+      (match node with
       | Ellipsis -> add (ellipsis_pat ~excluded_brace param)
       | Long_ellipsis -> add (long_ellipsis_pat ~excluded_brace param)
       | Metavar name -> add (capture (Metavariable, name) {|(?&word)|})
@@ -306,12 +398,22 @@ let to_regexp (conf : Conf.t) (ast : Pat_AST.t) =
                (long_ellipsis_pat ~excluded_brace param))
       | Bracket (open_, seq, close) ->
           add (Pcre_util.quote (String.make 1 open_));
-          of_seq ~excluded_brace:(Some close) seq;
+          let some_node =
+            (* what matters is that it's not None and not (Some Newline) *)
+            Some node
+          in
+          of_seq ~excluded_brace:(Some close) ~prev:some_node ~next:some_node
+            seq;
           add (Pcre_util.quote (String.make 1 close))
       | Word str -> add (word str)
-      | Other str -> add (Pcre_util.quote str)
-    and of_seq ~excluded_brace xs = List.iter (of_node ~excluded_brace) xs in
-    of_seq ~excluded_brace:None ast;
+      | Newline -> add {|\r?\n|}
+      | Other str -> add (Pcre_util.quote str));
+      if must_match_end_of_line conf ~next node then add end_of_line_pat;
+      if must_match_end_of_input conf ~next node then add end_of_input_pat
+    and of_seq ~excluded_brace ~prev ~next xs =
+      iter3 (of_node ~excluded_brace) ~prev ~next xs
+    in
+    of_seq ~excluded_brace:None ~prev:None ~next:None ast;
     let elements = List.rev !acc in
     String.concat ("\n" ^ {|(?&ws)|} ^ "\n") elements
   in

--- a/libs/aliengrep/Pat_lexer.ml
+++ b/libs/aliengrep/Pat_lexer.ml
@@ -22,6 +22,7 @@ type token =
   | WORD of string
   | OPEN of char * char
   | CLOSE of char
+  | NEWLINE (* only exists in single-line mode *)
   | OTHER of string
 
 let pattern_error source_name msg =
@@ -49,7 +50,8 @@ let compile conf =
   in
   let open_7 = sprintf {|(%s)|} (Pcre_util.char_class_of_list open_chars) in
   let close_8 = sprintf {|(%s)|} (Pcre_util.char_class_of_list close_chars) in
-  let other_9 = sprintf {|(.|\n)|} in
+  let newline_9 = sprintf {|(\r?\n)|} in
+  let other_10 = sprintf {|(.)|} in
   let pat =
     String.concat "|"
       [
@@ -62,7 +64,8 @@ let compile conf =
         word_6;
         open_7;
         close_8;
-        other_9;
+        newline_9;
+        other_10;
       ]
   in
   let pcre_regexp =
@@ -120,5 +123,6 @@ let read_string ?(source_name = "<pattern>") conf str =
                      in
                      OPEN (opening_brace, expected_closing_brace)
                  | 8 -> CLOSE (char_of_string capture)
-                 | 9 -> OTHER capture
+                 | 9 -> NEWLINE
+                 | 10 -> OTHER capture
                  | _ -> assert false))

--- a/libs/aliengrep/Pat_lexer.mli
+++ b/libs/aliengrep/Pat_lexer.mli
@@ -19,6 +19,7 @@ type token =
     (* any of the opening-brace characters
        and the expected closing brace *)
   | CLOSE of char (* any of the closing-brace characters *)
+  | NEWLINE (* only exists in single-line mode *)
   (* a single character according to PCRE (UTF-8-encoded code point) *)
   | OTHER of string
 

--- a/libs/aliengrep/Pat_parser.ml
+++ b/libs/aliengrep/Pat_parser.ml
@@ -54,6 +54,7 @@ let parse (tokens : Pat_lexer.token list) : Pat_AST.node list =
                normal text *)
             let acc = A.Other (String.make 1 close) :: acc in
             parse_seq_until acc expected_close xs)
+    | NEWLINE :: xs -> parse_seq_until (Newline :: acc) expected_close xs
     | OTHER str :: xs -> parse_seq_until (Other str :: acc) expected_close xs
   in
   let ast =

--- a/libs/aliengrep/Unit_Match.ml
+++ b/libs/aliengrep/Unit_Match.ml
@@ -280,6 +280,30 @@ var e = "xx";
       Capture_value ((Metavariable, "COPY"), "d");
     ]
 
+let test_left_anchored_ellipses () =
+  check uconf "... $A" "!!!\n!!!hello world"
+    [ Num_matches 1; Match_value "!!!hello" ];
+  check uconf ".... $A" "!!!\n!!!hello world"
+    [ Num_matches 1; Match_value "!!!\n!!!hello" ];
+  check mconf "... $A" "!!!\n!!!hello world"
+    [ Num_matches 1; Match_value "!!!\n!!!hello" ]
+
+let test_right_anchored_ellipses () =
+  check uconf "$A ..." "hello!!!\n!!!" [ Num_matches 1; Match_value "hello!!!" ];
+  check uconf "$A ...." "hello!!!\n!!!"
+    [ Num_matches 1; Match_value "hello!!!\n!!!" ];
+  check mconf "... $A" "hello!!!\n!!!"
+    [ Num_matches 1; Match_value "hello!!!\n!!!" ];
+  check mconf "... $A" "hello!!!\n!!!"
+    [ Num_matches 1; Match_value "hello!!!\n!!!" ]
+
+let test_pure_ellipsis () =
+  check uconf "..." "hello\nworld"
+    [ Num_matches 2; Match_value "hello"; Match_value "world" ];
+  check uconf "...." "hello\nworld"
+    [ Num_matches 1; Match_value "hello\nworld" ];
+  check mconf "..." "hello\nworld" [ Num_matches 1; Match_value "hello\nworld" ]
+
 let tests =
   [
     ("word", test_word);
@@ -292,4 +316,7 @@ let tests =
     ("backreferences", test_backreferences);
     ("ellipsis metavariable", test_ellipsis_metavariable);
     ("skip lines", test_skip_lines);
+    ("left-anchored ellipses", test_left_anchored_ellipses);
+    ("right-anchored ellipses", test_right_anchored_ellipses);
+    ("pure ellipsis", test_pure_ellipsis);
   ]

--- a/libs/aliengrep/Unit_Match.ml
+++ b/libs/aliengrep/Unit_Match.ml
@@ -65,64 +65,65 @@ let check conf pat_string target_string expectations =
         failwith ("failed expectation: " ^ show_expectation expectation))
     expectations
 
-let uconf = Conf.default_uniline_conf
-let mconf = Conf.default_multiline_conf
+let slconf = Conf.default_singleline_conf
+let mlconf = Conf.default_multiline_conf
 
 let test_word () =
-  check uconf {|a|} {|a b c|} [ Num_matches 1; Match_value "a" ];
-  check uconf {|ab|} {|ab abc|} [ Num_matches 1; Match_value "ab" ];
-  check uconf {|ab|} {|ab c ab|} [ Num_matches 2; Match_value "ab" ];
-  check uconf {|ab|} {|xabx|} [ Num_matches 0 ]
+  check slconf {|a|} {|a b c|} [ Num_matches 1; Match_value "a" ];
+  check slconf {|ab|} {|ab abc|} [ Num_matches 1; Match_value "ab" ];
+  check slconf {|ab|} {|ab c ab|} [ Num_matches 2; Match_value "ab" ];
+  check slconf {|ab|} {|xabx|} [ Num_matches 0 ]
 
 let test_whitespace () =
-  check uconf {|a b|} {|a  b|} [ Num_matches 1; Match_value "a  b" ];
-  check uconf {|a  b|} {|a b|} [ Num_matches 1; Match_value "a b" ];
-  check uconf "a\nb" "a b" [ Num_matches 0 ];
-  check uconf "a b" "a\nb" [ Num_matches 0 ];
-  check mconf "a\nb" "a b" [ Num_matches 1; Match_value "a b" ];
-  check mconf "a b" "a\nb" [ Num_matches 1; Match_value "a\nb" ]
+  check slconf {|a b|} {|a  b|} [ Num_matches 1; Match_value "a  b" ];
+  check slconf {|a  b|} {|a b|} [ Num_matches 1; Match_value "a b" ];
+  check slconf "a\nb" "a b" [ Num_matches 0 ];
+  check slconf "a b" "a\nb" [ Num_matches 0 ];
+  check mlconf "a\nb" "a b" [ Num_matches 1; Match_value "a b" ];
+  check mlconf "a b" "a\nb" [ Num_matches 1; Match_value "a\nb" ]
 
 let test_ellipsis () =
   (* test behavior shared with long ellipsis *)
-  check uconf {|a...b|} {|a b|} [ Num_matches 1; Match_value "a b" ];
-  check uconf {|a...b|} {|a/b|} [ Num_matches 1; Match_value "a/b" ];
-  check uconf {|a...b|} {|a x y b|} [ Num_matches 1; Match_value "a x y b" ];
-  check uconf {|a...b|} {|a b b|} [ Num_matches 1; Match_value "a b" ];
-  check uconf {|a...b b c|} {|a b b b c|}
+  check slconf {|a...b|} {|a b|} [ Num_matches 1; Match_value "a b" ];
+  check slconf {|a...b|} {|a/b|} [ Num_matches 1; Match_value "a/b" ];
+  check slconf {|a...b|} {|a x y b|} [ Num_matches 1; Match_value "a x y b" ];
+  check slconf {|a...b|} {|a b b|} [ Num_matches 1; Match_value "a b" ];
+  check slconf {|a...b b c|} {|a b b b c|}
     [ Num_matches 1; Match_value "a b b b c" ];
   (* test behavior specific to regular ellipsis *)
-  check uconf {|a...b|} "a\nb" [ Num_matches 0 ];
+  check slconf {|a...b|} "a\nb" [ Num_matches 0 ];
   (* in multiline mode, a regular ellipsis matches newlines *)
-  check mconf {|a...b|} "a\nx\nx\nb" [ Num_matches 1; Match_value "a\nx\nx\nb" ]
+  check mlconf {|a...b|} "a\nx\nx\nb"
+    [ Num_matches 1; Match_value "a\nx\nx\nb" ]
 
 let test_long_ellipsis () =
   (* test behavior shared with regular ellipsis *)
-  check uconf {|a....b|} {|a b|} [ Num_matches 1; Match_value "a b" ];
-  check uconf {|a....b|} {|a/b|} [ Num_matches 1; Match_value "a/b" ];
-  check uconf {|a....b|} {|a x y b|} [ Num_matches 1; Match_value "a x y b" ];
-  check uconf {|a....b|} {|a b b|} [ Num_matches 1; Match_value "a b" ];
-  check uconf {|a....b b c|} {|a b b b c|}
+  check slconf {|a....b|} {|a b|} [ Num_matches 1; Match_value "a b" ];
+  check slconf {|a....b|} {|a/b|} [ Num_matches 1; Match_value "a/b" ];
+  check slconf {|a....b|} {|a x y b|} [ Num_matches 1; Match_value "a x y b" ];
+  check slconf {|a....b|} {|a b b|} [ Num_matches 1; Match_value "a b" ];
+  check slconf {|a....b b c|} {|a b b b c|}
     [ Num_matches 1; Match_value "a b b b c" ];
   (* test behavior specific to long ellipsis *)
-  check uconf {|a....b|} "a\nb" [ Num_matches 1; Match_value "a\nb" ];
-  check mconf {|a....b|} "a\nx\nx\nb"
+  check slconf {|a....b|} "a\nb" [ Num_matches 1; Match_value "a\nb" ];
+  check mlconf {|a....b|} "a\nx\nx\nb"
     [ Num_matches 1; Match_value "a\nx\nx\nb" ]
 
 let test_metavariables () =
-  check uconf {|a $X b|} {|a xy b|}
+  check slconf {|a $X b|} {|a xy b|}
     [
       Num_matches 1;
       Match_value "a xy b";
       Capture (Metavariable, "X");
       Capture_value ((Metavariable, "X"), "xy");
     ];
-  check uconf {|a $AB_4! b|} {|a xy! b|}
+  check slconf {|a $AB_4! b|} {|a xy! b|}
     [
       Num_matches 1;
       Match_value "a xy! b";
       Capture_value ((Metavariable, "AB_4"), "xy");
     ];
-  check uconf {|$ X|} {|$ X|}
+  check slconf {|$ X|} {|$ X|}
     [
       Num_matches 1;
       Match_value "$ X";
@@ -130,7 +131,7 @@ let test_metavariables () =
       Not (Capture (Metavariable, ""));
       Not (Capture (Metavariable, "$"));
     ];
-  check uconf {|$A $B|} {|1 2 3 4|}
+  check slconf {|$A $B|} {|1 2 3 4|}
     [
       (* at the moment, matches don't overlap -> no match on "2 3" *)
       Num_matches 2;
@@ -145,43 +146,43 @@ let test_metavariables () =
     ]
 
 let test_ellipsis_brackets () =
-  check uconf {|x...x|} {|x [x] x|} [ Num_matches 1; Match_value {|x [x] x|} ];
+  check slconf {|x...x|} {|x [x] x|} [ Num_matches 1; Match_value {|x [x] x|} ];
   (* unexpected closing parenthesis is treated as an ordinary character *)
-  check uconf {|x...x|} {|x ([)x])x|}
+  check slconf {|x...x|} {|x ([)x])x|}
     [ Num_matches 1; Match_value {|x ([)x])x|} ];
   (* nested parentheses *)
-  check uconf {|f(...)|} {|f(((x)))|}
+  check slconf {|f(...)|} {|f(((x)))|}
     [ Num_matches 1; Match_value {|f(((x)))|} ];
   (* quotes *)
-  check uconf {|"..."|} {|"("")"|} [ Num_matches 1; Match_value {|"("")"|} ];
-  check uconf {|(...)|} {|(")")|} [ Num_matches 1; Match_value {|(")")|} ];
-  check uconf {|x...x|} {|x "'x' x" x x|}
+  check slconf {|"..."|} {|"("")"|} [ Num_matches 1; Match_value {|"("")"|} ];
+  check slconf {|(...)|} {|(")")|} [ Num_matches 1; Match_value {|(")")|} ];
+  check slconf {|x...x|} {|x "'x' x" x x|}
     [ Num_matches 1; Match_value {|x "'x' x" x|} ];
   (* default multiline config doesn't treat quotes as brackets *)
-  check mconf {|(...)|} {|(")")|} [ Num_matches 1; Match_value {|(")|} ]
+  check mlconf {|(...)|} {|(")")|} [ Num_matches 1; Match_value {|(")|} ]
 
 let test_explicit_brackets () =
-  check uconf {|(...)|} {|())|} [ Num_matches 1; Match_value {|()|} ];
+  check slconf {|(...)|} {|())|} [ Num_matches 1; Match_value {|()|} ];
   (* Since parentheses are defined as brackets, we're not allowed to reject
      a closing parenthesis that matches the opening parenthesis. *)
-  check uconf {|(... x)|} {|()x)|} [ Num_matches 0 ];
-  check uconf {|(...)|} {|([])|} [ Num_matches 1; Match_value {|([])|} ];
+  check slconf {|(... x)|} {|()x)|} [ Num_matches 0 ];
+  check slconf {|(...)|} {|([])|} [ Num_matches 1; Match_value {|([])|} ];
   (* The behavior of the following test cases is subject to change.
      There's only so much we can do when braces are mismatched. *)
-  check uconf {|(...)|} {|([)|} [ Num_matches 1; Match_value {|([)|} ];
-  check uconf {|(...)|} {|(])|} [ Num_matches 1; Match_value {|(])|} ];
-  check uconf {|(...)|} {|([)]|} [ Num_matches 0 ];
-  check uconf {|(...)|} {|[([)]|} [ Num_matches 0 ]
+  check slconf {|(...)|} {|([)|} [ Num_matches 1; Match_value {|([)|} ];
+  check slconf {|(...)|} {|(])|} [ Num_matches 1; Match_value {|(])|} ];
+  check slconf {|(...)|} {|([)]|} [ Num_matches 0 ];
+  check slconf {|(...)|} {|[([)]|} [ Num_matches 0 ]
 
 let test_backreferences () =
-  check uconf {|$A ... $A|} {|a, b, c, a, d|}
+  check slconf {|$A ... $A|} {|a, b, c, a, d|}
     [
       Num_matches 1;
       Match_value {|a, b, c, a|};
       Capture_value ((Metavariable, "A"), "a");
     ];
   (* no overlaps -> only 2 matches *)
-  check uconf {|$A ... $A ... $A|} {|a x x x a x x x a x x x x a|}
+  check slconf {|$A ... $A ... $A|} {|a x x x a x x x a x x x x a|}
     [
       Num_matches 2;
       Match_value {|a x x x a x x x a|};
@@ -190,74 +191,61 @@ let test_backreferences () =
       Capture_value ((Metavariable, "A"), "x");
     ];
   (* back-references should not end in the middle of a word *)
-  check uconf {|$A ... $A|} {|ab abc|} [ Num_matches 0 ];
+  check slconf {|$A ... $A|} {|ab abc|} [ Num_matches 0 ];
   (* word matches should not start in the middle of a word *)
-  check uconf {|$A ... $A|} {|abc bc|} [ Num_matches 0 ];
+  check slconf {|$A ... $A|} {|abc bc|} [ Num_matches 0 ];
   (* ellipsis extremities that are not words may touch words *)
-  check uconf {|$...A : $...A|} {|x+ : +x|}
-    [ Num_matches 1; Match_value {|+ : +|} ];
+  check slconf {|... $...A : $...A ...|} {|x+ : +x|}
+    [ Num_matches 1; Capture_value ((Metavariable_ellipsis, "A"), "+") ];
   (* ellipsis extremities that are not words may touch [specific] words *)
-  check uconf {|x $...A : $...A x|} {|x+ : +x|}
+  check slconf {|x $...A : $...A x|} {|x+ : +x|}
     [ Num_matches 1; Match_value {|x+ : +x|} ];
   (* ellipsis extremities that are words may not touch words *)
-  check uconf {|$...A : $...A|} {|xy : yx|}
-    [
-      Num_matches 1;
-      (* not {|y : y|} *)
-      Match_value {| : |};
-      Capture_value ((Metavariable_ellipsis, "A"), "");
-    ];
+  check slconf {|... $...A : $...A ...|} {|xy : yx|}
+    [ Num_matches 1; Capture_value ((Metavariable_ellipsis, "A"), "") ];
   (* ellipsis extremities that are words may not touch [specific] words *)
-  check uconf {|x $...A : $...A x|} {|x+ : +x|}
+  check slconf {|x $...A : $...A x|} {|x+ : +x|}
     [
       Num_matches 1;
       Match_value {|x+ : +x|};
       Capture_value ((Metavariable_ellipsis, "A"), "+");
     ];
   (* word extremities of ellipsis back-references may not touch words *)
-  check uconf {|$...A : $...A|} {|x : xx|}
-    [
-      Num_matches 1;
-      Match_value {| : |};
-      Capture_value ((Metavariable_ellipsis, "A"), "");
-    ];
+  check slconf {|... $...A : $...A ...|} {|x : xx|}
+    [ Num_matches 1; Capture_value ((Metavariable_ellipsis, "A"), "") ];
   (* nonword extremities of ellipsis back-references may touch words *)
-  check uconf {|$...A : $...A|} {|+ : ++|}
-    [
-      Num_matches 1;
-      Match_value {|+ : +|};
-      Capture_value ((Metavariable_ellipsis, "A"), "+");
-    ]
+  check slconf {|... $...A : $...A ...|} {|+ : ++|}
+    [ Num_matches 1; Capture_value ((Metavariable_ellipsis, "A"), "+") ]
 
 let test_ellipsis_metavariable () =
-  check uconf {|[$...ITEMS]|} {|a, [ b, c ], d|}
+  check slconf {|[$...ITEMS]|} {|a, [ b, c ], d|}
     [
       Num_matches 1;
       Match_value {|[ b, c ]|};
       Capture_value ((Metavariable_ellipsis, "ITEMS"), {|b, c|});
     ];
-  (* regular vs. long ellipsis in uniline mode *)
-  check uconf {|[$...ITEMS]|} "a, [ b,\nc ], d" [ Num_matches 0 ];
-  check uconf {|[$....ITEMS]|} "a, [ b,\nc ], d"
+  (* regular vs. long ellipsis in single-line mode *)
+  check slconf {|[$...ITEMS]|} "a, [ b,\nc ], d" [ Num_matches 0 ];
+  check slconf {|[$....ITEMS]|} "a, [ b,\nc ], d"
     [
       Num_matches 1;
       Match_value "[ b,\nc ]";
       Capture_value ((Metavariable_ellipsis, "ITEMS"), "b,\nc");
     ];
   (* backtracking and back-references *)
-  check uconf {|[$...A $...A]|} "[a b a b]"
+  check slconf {|[$...A $...A]|} "[a b a b]"
     [
       Num_matches 1;
       Match_value "[a b a b]";
       Capture_value ((Metavariable_ellipsis, "A"), "a b");
     ];
   (* back-references require exact whitespace match, unfortunately *)
-  check uconf {|[$...A $...A]|} "[a b a  b]" [ Num_matches 0 ]
+  check slconf {|[$...A $...A]|} "[a b a  b]" [ Num_matches 0 ]
 
 (* Demonstrate the use of long ellipsis to match multiple lines
-   in uniline mode. *)
+   in single-line mode. *)
 let test_skip_lines () =
-  check uconf "\na\nb\n" "\na\nb\n" [ Num_matches 1; Match_value "\na\nb\n" ];
+  check slconf "\na\nb\n" "\na\nb\n" [ Num_matches 1; Match_value "\na\nb\n" ];
   let pat = {|
 var $ORIG = ...;
 ....
@@ -273,7 +261,7 @@ var d = b;
 var e = "xx";
 |}
   in
-  check uconf pat target
+  check slconf pat target
     [
       Num_matches 1;
       Capture_value ((Metavariable, "ORIG"), "b");
@@ -281,28 +269,33 @@ var e = "xx";
     ]
 
 let test_left_anchored_ellipses () =
-  check uconf "... $A" "!!!\n!!!hello world"
+  check slconf "... $A" "!!!\n!!!hello world"
     [ Num_matches 1; Match_value "!!!hello" ];
-  check uconf ".... $A" "!!!\n!!!hello world"
+  check slconf ".... $A" "!!!\n!!!hello world"
     [ Num_matches 1; Match_value "!!!\n!!!hello" ];
-  check mconf "... $A" "!!!\n!!!hello world"
+  check mlconf "... $A" "!!!\n!!!hello world"
     [ Num_matches 1; Match_value "!!!\n!!!hello" ]
 
 let test_right_anchored_ellipses () =
-  check uconf "$A ..." "hello!!!\n!!!" [ Num_matches 1; Match_value "hello!!!" ];
-  check uconf "$A ...." "hello!!!\n!!!"
+  check slconf "$A ..." "hello!!!\n!!!"
+    [ Num_matches 1; Match_value "hello!!!" ];
+  check slconf "$A ...." "hello!!!\n!!!"
     [ Num_matches 1; Match_value "hello!!!\n!!!" ];
-  check mconf "... $A" "hello!!!\n!!!"
+  check mlconf "$A ..." "hello!!!\n!!!"
     [ Num_matches 1; Match_value "hello!!!\n!!!" ];
-  check mconf "... $A" "hello!!!\n!!!"
+  check mlconf "$A ..." "hello!!!\n!!!"
     [ Num_matches 1; Match_value "hello!!!\n!!!" ]
 
 let test_pure_ellipsis () =
-  check uconf "..." "hello\nworld"
+  check slconf "..." "hello\nworld"
     [ Num_matches 2; Match_value "hello"; Match_value "world" ];
-  check uconf "...." "hello\nworld"
+  check slconf "...." "hello\nworld"
     [ Num_matches 1; Match_value "hello\nworld" ];
-  check mconf "..." "hello\nworld" [ Num_matches 1; Match_value "hello\nworld" ]
+  check mlconf "..." "hello\nworld"
+    [ Num_matches 1; Match_value "hello\nworld" ];
+  check slconf "...\n..." "a\nb" [ Num_matches 1; Match_value "a\nb" ];
+  check slconf "...\n..." "a\nb\nc\n"
+    [ Num_matches 2; Match_value "a\nb"; Match_value "c\n" ]
 
 let tests =
   [

--- a/libs/aliengrep/Unit_Pat_parser.ml
+++ b/libs/aliengrep/Unit_Pat_parser.ml
@@ -2,8 +2,8 @@
 
 open Pat_AST
 
-let uconf = Conf.default_uniline_conf
-let mconf = Conf.default_multiline_conf
+let slconf = Conf.default_singleline_conf
+let mlconf = Conf.default_multiline_conf
 let ast = Alcotest.testable (Fmt.of_to_string Pat_AST.show) ( = )
 
 let check conf pat expected_ast =
@@ -11,32 +11,32 @@ let check conf pat expected_ast =
   Alcotest.(check ast) "equal" expected_ast res
 
 let test_literal_match () =
-  check uconf "a bc!" [ Word "a"; Word "bc"; Other "!" ]
+  check slconf "a bc!" [ Word "a"; Word "bc"; Other "!" ]
 
 let test_parentheses () =
-  check uconf "([x])"
+  check slconf "([x])"
     [ Bracket ('(', [ Bracket ('[', [ Word "x" ], ']') ], ')') ];
-  check uconf "(})" [ Bracket ('(', [ Other "}" ], ')') ];
-  check uconf "(" [ Other "(" ];
-  check uconf "}" [ Other "}" ];
-  check uconf "(}" [ Other "("; Other "}" ];
-  check uconf "[(}]" [ Bracket ('[', [ Other "("; Other "}" ], ']') ];
+  check slconf "(})" [ Bracket ('(', [ Other "}" ], ')') ];
+  check slconf "(" [ Other "(" ];
+  check slconf "}" [ Other "}" ];
+  check slconf "(}" [ Other "("; Other "}" ];
+  check slconf "[(}]" [ Bracket ('[', [ Other "("; Other "}" ], ']') ];
   (* Uniline mode treats quotes as brackets *)
-  check uconf "''" [ Bracket ('\'', [], '\'') ];
-  check uconf "'ab'" [ Bracket ('\'', [ Word "ab" ], '\'') ];
-  check uconf {|'a"b"'|}
+  check slconf "''" [ Bracket ('\'', [], '\'') ];
+  check slconf "'ab'" [ Bracket ('\'', [ Word "ab" ], '\'') ];
+  check slconf {|'a"b"'|}
     [ Bracket ('\'', [ Word "a"; Bracket ('"', [ Word "b" ], '"') ], '\'') ];
   (* Multiline mode doesn't treat quotes as brackets *)
-  check mconf {|'a"b"'|}
+  check mlconf {|'a"b"'|}
     [ Other "'"; Word "a"; Other {|"|}; Word "b"; Other {|"|}; Other "'" ]
 
 let test_metavariables () =
-  check uconf "$A $A $BB" [ Metavar "A"; Metavar "A"; Metavar "BB" ]
+  check slconf "$A $A $BB" [ Metavar "A"; Metavar "A"; Metavar "BB" ]
 
-let test_ellipsis () = check uconf "a ... b" [ Word "a"; Ellipsis; Word "b" ]
+let test_ellipsis () = check slconf "a ... b" [ Word "a"; Ellipsis; Word "b" ]
 
 let test_long_ellipsis () =
-  check uconf "a .... b" [ Word "a"; Long_ellipsis; Word "b" ]
+  check slconf "a .... b" [ Word "a"; Long_ellipsis; Word "b" ]
 
 let test_multiline () = ()
 

--- a/test
+++ b/test
@@ -22,6 +22,6 @@ case "$(basename "$0")" in
     subcommand=list
 esac
 
-cd _build/default/tests
+cd _build/default/src/tests
 ./test.exe "$subcommand" $options "$@"
 echo


### PR DESCRIPTION
This matches the spacegrep behavior.

For example, in multiline mode, `...` alone matches the whole input rather than matching the empty sequence many times. In single-line mode, `...` alone matches a whole line for each line in the input. In other contexts where `...` or `....` is sandwiched between other elements, the behavior is still to prefer the shortest match possible.

Fixes https://github.com/returntocorp/semgrep/issues/7881

test plan: `make test`

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
