### PR TITLE
tainting: Add options to ignore taint based on types

### DIFF
--- a/interfaces/Rule_options.atd
+++ b/interfaces/Rule_options.atd
@@ -41,6 +41,8 @@ type t = {
   ~taint_assume_safe_functions <ocaml default="false"> : bool;
   ~taint_assume_safe_indexes <ocaml default="false"> : bool;
   ~taint_assume_safe_comparisons <ocaml default="false"> : bool;
+  ~taint_assume_safe_booleans <ocaml default="false"> : bool;
+  ~taint_assume_safe_numbers <ocaml default="false"> : bool;
   (* when you are paranoid about minimizing FPs, and probably useful for
    * writing secret detection rules *)
   ~taint_only_propagate_through_assignments <ocaml default="false"> : bool;

--- a/src/tainting/Dataflow_tainting.ml
+++ b/src/tainting/Dataflow_tainting.ml
@@ -743,7 +743,7 @@ let fix_poly_taint_with_field env lval st =
                    || not
                         (Stdcompat.String.starts_with ~prefix:"get"
                            (fst n.ident)) ->
-                (* We have an l-value like `o.f` where `f` is has a function type,
+                (* We have an l-value like `o.f` where `f` has a function type,
                  * so it's a method call. We will only fix poly-taint in such case
                  * when it's an unresolved Java `getX` method. In any other case,
                  * we do nothing here. *)

--- a/src/typing/Typing.ml
+++ b/src/typing/Typing.ml
@@ -53,11 +53,13 @@ let rec type_of_expr lang e : G.name Type.t * G.ident option =
       let t2, _id = type_of_expr lang e2 in
       let t =
         match (t1, op, t2) with
-        | Type.Builtin Type.Int, (G.Plus | G.Minus (* TODO more *)), _
-        | _, (G.Plus | G.Minus (* TODO more *)), Type.Builtin Type.Int
-          when not (Lang.is_js lang) ->
-            (* THINK: Is this correct in every other language that we support? *)
-            Type.Builtin Type.Int
+        | Type.(Builtin (Int | Float)), (G.Plus | G.Minus (* TODO more *)), _
+        | _, (G.Plus | G.Minus (* TODO more *)), Type.(Builtin (Int | Float))
+        (* Note that `+` is overloaded in many languages and may also be
+         * string concatenation, and unfortunately some languages such
+         * as Java and JS/TS have implicit coercions to string. *)
+          when lang =*= Lang.Python (* TODO more *) ->
+            Type.Builtin Type.Number
         | ( Type.Builtin Type.Int,
             (G.Plus | G.Minus (* TODO more *)),
             Type.Builtin Type.Int ) ->

--- a/tests/rules/taint_assume_safe_booleans.py
+++ b/tests/rules/taint_assume_safe_booleans.py
@@ -1,0 +1,11 @@
+def ok():
+    x = "tainted"
+    y = x == "safe"
+    #OK: test
+    sink(y)
+
+def bad():
+    x = "tainted"
+    y = x or "safe"
+    #ruleid: test
+    sink(y)

--- a/tests/rules/taint_assume_safe_booleans.yaml
+++ b/tests/rules/taint_assume_safe_booleans.yaml
@@ -1,0 +1,13 @@
+rules:
+  - id: test
+    message: Test
+    languages: [python]
+    options:
+      taint_assume_safe_booleans: true
+    mode: taint
+    pattern-sources:
+    - pattern: |
+        "tainted"
+    pattern-sinks:
+    - pattern: sink(...)
+    severity: ERROR

--- a/tests/rules/taint_assume_safe_numbers.py
+++ b/tests/rules/taint_assume_safe_numbers.py
@@ -1,0 +1,9 @@
+def ok(x):
+    y = x + 1
+    #OK: test
+    sink(y)
+
+def bad(x):
+    y = x + "something"
+    #ruleid: test
+    sink(y)

--- a/tests/rules/taint_assume_safe_numbers.yaml
+++ b/tests/rules/taint_assume_safe_numbers.yaml
@@ -1,0 +1,16 @@
+rules:
+  - id: test
+    message: Test
+    languages: [python]
+    options:
+      taint_assume_safe_numbers: true
+    mode: taint
+    pattern-sources:
+    - patterns:
+        - pattern: |
+            def $FUN(..., $X, ...):
+              ...
+        - focus-metavariable: $X
+    pattern-sinks:
+    - pattern: sink(...)
+    severity: ERROR


### PR DESCRIPTION
In many cases Boolean or integer values do not pose a security risk even if they come from a tainted source. For example, a user input of type integer does not pose a risk of SQLi.

Also checked types to prevent attaching an offset to poly taint when the offset corresponds to a class method.

Also fixed type inference to take some corner cases into consideration.

test plan:
make test # new tests

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
