### PR TITLE
Add aliengrep test that now works

### DIFF
--- a/cli/tests/e2e/snapshots/test_aliengrep/test_aliengrep/rulesaliengrephttpresponse.yaml-aliengrephttpresponse.txt/results.json
+++ b/cli/tests/e2e/snapshots/test_aliengrep/test_aliengrep/rulesaliengrephttpresponse.yaml-aliengrephttpresponse.txt/results.json
@@ -1,0 +1,63 @@
+{
+  "errors": [],
+  "paths": {
+    "_comment": "<add --verbose for a list of skipped paths>",
+    "scanned": [
+      "targets/aliengrep/httpresponse.txt"
+    ]
+  },
+  "results": [
+    {
+      "check_id": "rules.aliengrep.content-type-text-html",
+      "end": {
+        "col": 24,
+        "line": 6,
+        "offset": 169
+      },
+      "extra": {
+        "engine_kind": "OSS",
+        "fingerprint": "0x42",
+        "is_ignored": false,
+        "lines": "Content-Type: text/html",
+        "message": "Detected text/html",
+        "metadata": {},
+        "metavars": {
+          "$READABLE": {
+            "abstract_content": "OK",
+            "end": {
+              "col": 16,
+              "line": 1,
+              "offset": 15
+            },
+            "start": {
+              "col": 14,
+              "line": 1,
+              "offset": 13
+            }
+          },
+          "$STATUS": {
+            "abstract_content": "200",
+            "end": {
+              "col": 13,
+              "line": 1,
+              "offset": 12
+            },
+            "start": {
+              "col": 10,
+              "line": 1,
+              "offset": 9
+            }
+          }
+        },
+        "severity": "INFO"
+      },
+      "path": "targets/aliengrep/httpresponse.txt",
+      "start": {
+        "col": 1,
+        "line": 6,
+        "offset": 146
+      }
+    }
+  ],
+  "version": "0.42"
+}

--- a/cli/tests/e2e/test_aliengrep.py
+++ b/cli/tests/e2e/test_aliengrep.py
@@ -11,8 +11,7 @@ from tests.fixtures import RunSemgrep
         # Various real-world tests adapted from spacegrep tests.
         ("rules/aliengrep/html.yaml", "aliengrep/html.mustache"),
         ("rules/aliengrep/markdown.yaml", "aliengrep/markdown.md"),
-        # TODO: make leading/trailing ellipses anchored
-        # ("rules/aliengrep/httpresponse.yaml", "aliengrep/httpresponse.txt"),
+        ("rules/aliengrep/httpresponse.yaml", "aliengrep/httpresponse.txt"),
         ("rules/aliengrep/dockerfile.yaml", "aliengrep/dockerfile"),
         ("rules/aliengrep/multi-lines.yaml", "aliengrep/multi-lines.java"),
         # Aliengrep-specific tests


### PR DESCRIPTION
It has to do with that trailing ellipsis that now matches the rest of the input. It used to match an empty sequence.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
