### PR TITLE
Add option for case-insensitive matching with aliengrep

### DIFF
--- a/changelog.d/gh-7883.added
+++ b/changelog.d/gh-7883.added
@@ -1,0 +1,1 @@
+aliengrep: new option 'generic_caseless' to achieve case-insensitive matching

--- a/cli/tests/e2e/rules/aliengrep/httpresponse.yaml
+++ b/cli/tests/e2e/rules/aliengrep/httpresponse.yaml
@@ -5,11 +5,9 @@ rules:
     languages: [generic]
     options:
       generic_engine: aliengrep
+      generic_caseless: true
     patterns:
       - pattern-inside: |
           HTTP/1.1 $STATUS $READABLE
           ...
-      - pattern-either:
-          - pattern: "Content-Type: text/html"
-          - pattern: "Content-type: text/html"
-          - pattern: "content-type: text/html"
+      - pattern: "content-type: text/html"

--- a/interfaces/Rule_options.atd
+++ b/interfaces/Rule_options.atd
@@ -134,6 +134,13 @@ type t = {
      a dash to the word characters, allowing '$FOO' to match 'e-mail'. *)
   ~generic_extra_word_characters: string list;
 
+  (* Perform case-insensitive matching according to Unicode rules.
+     The default is false.
+     This is supported only by the aliengrep engine.
+     Back-references, however, must still respect the case of the first
+     match e.g. "$A $A" matches "Hello Hello" but not "Hello hello". *)
+  ~generic_caseless: bool;
+
   (* Maximum number of newlines that an ellipsis can match with the spacegrep
      engine. Use 0 to contain the match within a single line. *)
   ~generic_ellipsis_max_span <ocaml default="10">: int;

--- a/libs/aliengrep/Conf.ml
+++ b/libs/aliengrep/Conf.ml
@@ -5,6 +5,7 @@
 open Printf
 
 type t = {
+  caseless : bool;
   (* multiline = newlines are treated as ordinary whitespace *)
   multiline : bool;
   (* TODO: support UTF-8 word characters *)
@@ -76,6 +77,7 @@ let digit = [ '0'; '1'; '2'; '3'; '4'; '5'; '6'; '7'; '8'; '9' ]
 
 let default_multiline_conf =
   {
+    caseless = false;
     multiline = true;
     word_chars = ('_' :: upper) @ lower @ digit;
     brackets = [ ('(', ')'); ('[', ']'); ('{', '}') ];
@@ -83,6 +85,7 @@ let default_multiline_conf =
 
 let default_singleline_conf =
   {
+    caseless = false;
     multiline = false;
     word_chars = default_multiline_conf.word_chars;
     brackets = [ ('"', '"'); ('\'', '\'') ] @ default_multiline_conf.brackets;

--- a/libs/aliengrep/Conf.mli
+++ b/libs/aliengrep/Conf.mli
@@ -3,6 +3,8 @@
 *)
 
 type t = {
+  (* Use case-insensitive matching. Rely on PCRE to do this well. *)
+  caseless : bool;
   (* multiline = newlines are treated as ordinary whitespace *)
   multiline : bool;
   (* TODO: support UTF-8 word characters *)

--- a/libs/aliengrep/Pat_compile.ml
+++ b/libs/aliengrep/Pat_compile.ml
@@ -257,6 +257,7 @@ let must_match_end_of_input conf ~(next : Pat_AST.node option) node =
    of this file).
 *)
 let to_regexp (conf : Conf.t) (ast : Pat_AST.t) =
+  let options = if conf.caseless then [ "(?i)" ] else [] in
   let param = param_of_conf conf in
   let new_capturing_group =
     let n = ref 0 in
@@ -424,7 +425,7 @@ let to_regexp (conf : Conf.t) (ast : Pat_AST.t) =
 # entry point
 %s
 |}
-      (String.concat "\n" definitions)
+      (String.concat "\n" (options @ definitions))
       entrypoint
   in
   (root, get_capturing_group_array ())

--- a/libs/aliengrep/Unit_Match.ml
+++ b/libs/aliengrep/Unit_Match.ml
@@ -297,6 +297,13 @@ let test_pure_ellipsis () =
   check slconf "...\n..." "a\nb\nc\n"
     [ Num_matches 2; Match_value "a\nb"; Match_value "c\n" ]
 
+let test_caseless () =
+  check mlconf "hello" "HeLLo, world" [ Num_matches 0 ];
+  check
+    { mlconf with caseless = true }
+    "hello" "HeLLo, world"
+    [ Num_matches 1; Match_value "HeLLo" ]
+
 let tests =
   [
     ("word", test_word);
@@ -312,4 +319,5 @@ let tests =
     ("left-anchored ellipses", test_left_anchored_ellipses);
     ("right-anchored ellipses", test_right_anchored_ellipses);
     ("pure ellipsis", test_pure_ellipsis);
+    ("caseless", test_caseless);
   ]

--- a/src/parsing/Parse_rule.ml
+++ b/src/parsing/Parse_rule.ml
@@ -575,6 +575,7 @@ let brace_pairs_of_string_pairs env xs =
 let aliengrep_conf_of_options (env : env) : Aliengrep.Conf.t =
   let options = Option.value env.options ~default:Rule_options.default_config in
   let default = Aliengrep.Conf.default_multiline_conf in
+  let caseless = options.generic_caseless in
   let multiline = options.generic_multiline in
   let word_chars =
     default.word_chars
@@ -591,7 +592,7 @@ let aliengrep_conf_of_options (env : env) : Aliengrep.Conf.t =
     in
     base_set @ extra_braces
   in
-  { multiline; word_chars; brackets }
+  { caseless; multiline; word_chars; brackets }
 
 let parse_options rule_id (key : key) value =
   let s = J.string_of_json (generic_to_json rule_id key value) in


### PR DESCRIPTION
Closes https://github.com/returntocorp/semgrep/issues/7883

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
