### PR TITLE
feat(Java): Guess types when we can't resolve them definitively

### DIFF
--- a/changelog.d/heuristics.added
+++ b/changelog.d/heuristics.added
@@ -1,0 +1,1 @@
+Semgrep now includes heuristics based on the Java standard library and common naming patterns. These allow Semgrep to determine the types of more expressions in Java, for use with typed metavariables (https://semgrep.dev/docs/writing-rules/pattern-syntax/#typed-metavariables).

--- a/src/core/Type.ml
+++ b/src/core/Type.ml
@@ -133,17 +133,25 @@ let todo_kind_to_ast_generic_todo_kind (x : todo_kind) : G.todo_kind =
 (* less: should sanity check things by looking at [lang]. but maybe users like
  * to write `bool` in a language that uses `boolean`, and we should allow that?
  *
+ * NB: Conflates Java boxed types with primitives. This is probably fine for our
+ * analysis.
+ *
  * coupling: Inverse of ast_generic_type_of_builtin_type *)
 let builtin_type_of_string _langTODO str =
   match str with
-  | "int" -> Some Int
-  | "float" -> Some Float
+  | "int"
+  | "Integer" ->
+      Some Int
+  | "float"
+  | "Float" ->
+      Some Float
   | "str"
   | "string"
   | "String" ->
       Some String
   | "bool"
-  | "boolean" ->
+  | "boolean"
+  | "Boolean" ->
       Some Bool
   (* TS *)
   | "number" -> Some Number

--- a/src/typing/Typing.ml
+++ b/src/typing/Typing.ml
@@ -18,116 +18,126 @@ module G = AST_generic
 
 (* returns possibly the inferred type of the expression,
  * as well as an ident option that can then be used to query LSP to get the
- * type of the ident.
- *
- * New Type inference over `Type.t`. Prefer this to the old type inference over
- * `AST_generic.type_`. Eventually we'll do all the type inference here and
- * delete the old. *)
+ * type of the ident. *)
 let rec type_of_expr lang e : G.name Type.t * G.ident option =
-  match e.G.e with
-  | G.L lit ->
-      let t =
-        match lit with
-        (* NB: We could infer Type.Number for JS int/float literals, but we can
-         * handle that relationship in matching and we can be more precise for
-         * now. One actual rule uses `float` for a typed metavariable in JS so
-         * let's avoid breaking that for now at least. *)
-        | G.Int _ -> Type.Builtin Type.Int
-        | G.Float _ -> Type.Builtin Type.Float
-        | G.Bool _ -> Type.Builtin Type.Bool
-        | G.String _ -> Type.Builtin Type.String
-        | _else_ -> Type.NoType
-      in
-      (t, None)
-  | G.N name
-  | G.DotAccess (_, _, FN name) ->
-      type_of_name lang name
-  (* TODO? or generate a fake "new" id for LSP to query on tk? *)
-  (* We conflate the type of a class with the type of its instance. Maybe at
-   * some point we should introduce a `Class` type and unwrap it here upon
-   * instantiation. *)
-  | G.New (_tk, t, _ii, _) -> (type_of_ast_generic_type lang t, None)
-  (* Binary operator *)
-  | G.Call ({ e = IdSpecial (Op op, _); _ }, (_l, [ Arg e1; Arg e2 ], _r)) ->
-      let t1, _id = type_of_expr lang e1 in
-      let t2, _id = type_of_expr lang e2 in
-      let t =
-        match (t1, op, t2) with
-        | Type.(Builtin (Int | Float)), (G.Plus | G.Minus (* TODO more *)), _
-        | _, (G.Plus | G.Minus (* TODO more *)), Type.(Builtin (Int | Float))
-        (* Note that `+` is overloaded in many languages and may also be
-         * string concatenation, and unfortunately some languages such
-         * as Java and JS/TS have implicit coercions to string. *)
-          when lang =*= Lang.Python (* TODO more *) ->
-            Type.Builtin Type.Number
-        | ( Type.Builtin Type.Int,
-            (G.Plus | G.Minus (* TODO more *)),
-            Type.Builtin Type.Int ) ->
-            Type.Builtin Type.Int
-        | ( _,
-            ( G.Eq | G.PhysEq | G.NotEq | G.NotPhysEq | G.Lt | G.LtE | G.Gt
-            | G.GtE | G.In | G.NotIn | G.Is | G.NotIs | G.And ),
-            _ ) ->
-            Type.Builtin Type.Bool
-        | Type.Builtin Type.Bool, G.Or, _
-        | _, G.Or, Type.Builtin Type.Bool ->
-            Type.Builtin Type.Bool
-        | _, G.Or, _ when lang =*= Lang.Java ->
-            (* E.g. in Python you can write `x or ""` to mean `""` in case `x` is `None`.
-             * THINK: Is there a similar idiom involving `and`/`&&` ? *)
-            Type.Builtin Type.Bool
-        | Type.Builtin Type.Bool, (G.BitOr | G.BitAnd | G.BitXor), _
-        | _, (G.BitOr | G.BitAnd | G.BitXor), Type.Builtin Type.Bool
-          when lang =*= Lang.Java ->
-            (* If the operands to |, &, or ^ are boolean, in Java these are
-             * boolean operators. If we can resolve one operand to a boolean, we
-             * know that in a well-formed program, the other is also a boolean.
-             * *)
-            Type.Builtin Type.Bool
-        | _else_ -> Type.NoType
-      in
-      (t, None)
-  (* Unary operator *)
-  | G.Call ({ e = IdSpecial (Op op, _); _ }, (_l, [ Arg e ], _r)) ->
-      let t, _id = type_of_expr lang e in
-      let t =
-        match (op, t) with
-        | G.Not, _ -> Type.Builtin Type.Bool
-        | _else_ -> Type.NoType
-      in
-      (t, None)
-  | G.Call (e, _args) ->
-      let t, id = type_of_expr lang e in
-      let t =
-        match t with
-        (* less: in OCaml functions can be curried, so we need to match _params
-         * and _args to calculate the resulting type. *)
-        | Function (_params, ret) -> ret
-        | _else_ -> Type.NoType
-      in
-      (t, id)
-  | G.Conditional (_, e1, e2) ->
-      let t1, id1opt = type_of_expr lang e1 in
-      let t2, id2opt = type_of_expr lang e2 in
-      (* LATER: we could also not enforce to have a type for both branches,
-       * but let's go simple for now and enforce both branches have
-       * a type and that the types are equal.
-       *)
-      let t =
-        (* LATER: in theory we should look if the types are compatible,
-         * and take the lowest upper bound of the two types *)
-        let eq = Type.equal (AST_utils.with_structural_equal G.equal_name) in
-        if eq t1 t2 then t1 else Type.NoType
-      in
-      let idopt =
-        (* TODO? is there an Option.xxx or Common.xxx function for that? *)
-        match (id1opt, id2opt) with
-        | Some id1, _ -> Some id1
-        | _, Some id2 -> Some id2
-        | None, None -> None
-      in
-      (t, idopt)
-  | _else_ -> (Type.NoType, None)
+  let ty, ident =
+    match e.G.e with
+    | G.L lit ->
+        let t =
+          match lit with
+          (* NB: We could infer Type.Number for JS int/float literals, but we can
+           * handle that relationship in matching and we can be more precise for
+           * now. One actual rule uses `float` for a typed metavariable in JS so
+           * let's avoid breaking that for now at least. *)
+          | G.Int _ -> Type.Builtin Type.Int
+          | G.Float _ -> Type.Builtin Type.Float
+          | G.Bool _ -> Type.Builtin Type.Bool
+          | G.String _ -> Type.Builtin Type.String
+          | _else_ -> Type.NoType
+        in
+        (t, None)
+    | G.N name
+    | G.DotAccess (_, _, FN name) ->
+        type_of_name lang name
+    (* TODO? or generate a fake "new" id for LSP to query on tk? *)
+    (* We conflate the type of a class with the type of its instance. Maybe at
+     * some point we should introduce a `Class` type and unwrap it here upon
+     * instantiation. *)
+    | G.New (_tk, t, _ii, _) -> (type_of_ast_generic_type lang t, None)
+    (* Binary operator *)
+    | G.Call ({ e = IdSpecial (Op op, _); _ }, (_l, [ Arg e1; Arg e2 ], _r)) ->
+        let t1, _id = type_of_expr lang e1 in
+        let t2, _id = type_of_expr lang e2 in
+        let t =
+          match (t1, op, t2) with
+          | Type.(Builtin (Int | Float)), (G.Plus | G.Minus (* TODO more *)), _
+          | _, (G.Plus | G.Minus (* TODO more *)), Type.(Builtin (Int | Float))
+          (* Note that `+` is overloaded in many languages and may also be
+           * string concatenation, and unfortunately some languages such
+           * as Java and JS/TS have implicit coercions to string. *)
+            when lang =*= Lang.Python (* TODO more *) ->
+              Type.Builtin Type.Number
+          | ( Type.Builtin Type.Int,
+              (G.Plus | G.Minus (* TODO more *)),
+              Type.Builtin Type.Int ) ->
+              Type.Builtin Type.Int
+          | ( _,
+              ( G.Eq | G.PhysEq | G.NotEq | G.NotPhysEq | G.Lt | G.LtE | G.Gt
+              | G.GtE | G.In | G.NotIn | G.Is | G.NotIs | G.And ),
+              _ ) ->
+              Type.Builtin Type.Bool
+          | Type.Builtin Type.Bool, G.Or, _
+          | _, G.Or, Type.Builtin Type.Bool ->
+              Type.Builtin Type.Bool
+          | _, G.Or, _ when lang =*= Lang.Java ->
+              (* E.g. in Python you can write `x or ""` to mean `""` in case `x` is `None`.
+               * THINK: Is there a similar idiom involving `and`/`&&` ? *)
+              Type.Builtin Type.Bool
+          | Type.Builtin Type.Bool, (G.BitOr | G.BitAnd | G.BitXor), _
+          | _, (G.BitOr | G.BitAnd | G.BitXor), Type.Builtin Type.Bool
+            when lang =*= Lang.Java ->
+              (* If the operands to |, &, or ^ are boolean, in Java these are
+               * boolean operators. If we can resolve one operand to a boolean, we
+               * know that in a well-formed program, the other is also a boolean.
+               * *)
+              Type.Builtin Type.Bool
+          | _else_ -> Type.NoType
+        in
+        (t, None)
+    (* Unary operator *)
+    | G.Call ({ e = IdSpecial (Op op, _); _ }, (_l, [ Arg e ], _r)) ->
+        let t, _id = type_of_expr lang e in
+        let t =
+          match (op, t) with
+          | G.Not, _ -> Type.Builtin Type.Bool
+          | _else_ -> Type.NoType
+        in
+        (t, None)
+    | G.Call (e, _args) ->
+        let t, id = type_of_expr lang e in
+        let t =
+          match t with
+          (* less: in OCaml functions can be curried, so we need to match _params
+           * and _args to calculate the resulting type. *)
+          | Function (_params, ret) -> ret
+          | _else_ -> Type.NoType
+        in
+        (t, id)
+    | G.Conditional (_, e1, e2) ->
+        let t1, id1opt = type_of_expr lang e1 in
+        let t2, id2opt = type_of_expr lang e2 in
+        (* LATER: we could also not enforce to have a type for both branches,
+         * but let's go simple for now and enforce both branches have
+         * a type and that the types are equal.
+         *)
+        let t =
+          (* LATER: in theory we should look if the types are compatible,
+           * and take the lowest upper bound of the two types *)
+          let eq = Type.equal (AST_utils.with_structural_equal G.equal_name) in
+          if eq t1 t2 then t1 else Type.NoType
+        in
+        let idopt =
+          (* TODO? is there an Option.xxx or Common.xxx function for that? *)
+          match (id1opt, id2opt) with
+          | Some id1, _ -> Some id1
+          | _, Some id2 -> Some id2
+          | None, None -> None
+        in
+        (t, idopt)
+    | _else_ -> (Type.NoType, None)
+  in
+  match ty with
+  | Type.NoType
+  | Type.Todo _
+  | Type.UnresolvedName _ ->
+      (* Dependency injection to avoid a circular dependency between this module
+       * and Typing_heuristics. To resolve a DotAccess, for example, we need to
+       * get the type of the LHS in order to apply heuristics for the RHS. *)
+      let f e = type_of_expr lang e |> fst in
+      let guessed_type = Typing_heuristics.guess_type lang f e in
+      if Type.is_real_type guessed_type then (guessed_type, ident)
+      else (ty, ident)
+  | _else_ -> (ty, ident)
 
 and type_of_name lang = function
   | Id (ident, id_info) ->

--- a/src/typing/Typing_heuristics.ml
+++ b/src/typing/Typing_heuristics.ml
@@ -1,0 +1,87 @@
+(* Nat Mote
+ *
+ * Copyright (C) 2019-2023 Semgrep, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * version 2.1 as published by the Free Software Foundation, with the
+ * special exception on linking described in file LICENSE.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
+ * LICENSE for more details.
+ *)
+
+module G = AST_generic
+
+(* This module is for guessing the type of an expression, when we can't figure
+ * it out using ordinary type inference. This typically happens when some name
+ * cannot be resolved because it either came from an external file (in OSS
+ * Semgrep) or from the standard library or a third party library (in Pro
+ * Engine).
+ *
+ * For example, in Java we guess that `x.equals(y)` returns a `boolean`, even if
+ * we don't know the type of `x`. *)
+
+(******************************************************************************)
+(* Helpers *)
+(******************************************************************************)
+
+(* Currently, for types created during naming in Semgrep (OSS and Pro Engine),
+ * we can't tell the difference between a resolved name and an unresolved name,
+ * so we turn them all into `Type.N`s. Some of the names will be fully-qualified
+ * resolved names, and some will just be names as written by the user.
+ *
+ * We should use Type.t for `id_type` to address this ambiguity. In the
+ * meantime, we will use this helper function to abstract it away for type
+ * guessing purposes. *)
+let name_and_targs_of_named_type = function
+  | Type.N ((G.Id ((str, _), _), targs), _)
+  | Type.UnresolvedName (str, targs) ->
+      Some (str, targs)
+  | Type.N
+      ( ( G.IdQualified { G.name_last; name_middle = Some (QDots middle); _ },
+          targs ),
+        _ ) ->
+      let (str_last, _), _ = name_last in
+      let middle_strs =
+        middle |> Common.map (fun ((str, _info), _targs) -> str)
+      in
+      let str = String.concat "." (middle_strs @ [ str_last ]) in
+      Some (str, targs)
+  | _else_ -> None
+
+let guess_type_of_dotaccess lang lhs_ty str =
+  match (lang, name_and_targs_of_named_type lhs_ty, str) with
+  | Lang.Java, _, "equals" -> Type.Function ([], Type.Builtin Type.Bool)
+  (* For unresolved types with one type parameter, assume that the `get`
+   * method's return type is the type parameter (e.g. List<T>). For unresolved
+   * types with two type parameters, assume that the `get` method's return type
+   * is the second (e.g. Map<K, V>) *)
+  | ( Lang.Java,
+      Some (_str, ([ _; Type.TA elt_type ] | [ Type.TA elt_type ])),
+      "get" ) ->
+      (* Param type could be Top if we add that as a type *)
+      let param = Type.Param { pident = None; ptype = Type.NoType } in
+      Type.Function ([ param ], elt_type)
+  | _else_ -> Type.NoType
+
+(******************************************************************************)
+(* Entry Point *)
+(******************************************************************************)
+
+(* Guess the type of an expression based on heuristics. This is a fallback used
+ * only if we cannot resolve the type of an expression using traditional type
+ * inference.
+ *
+ * We take `type_of_expr` as a parameter so that we can determine the type of
+ * subexpressions as part of guessing the type of `e`. *)
+let guess_type lang type_of_expr e =
+  match e.G.e with
+  | G.DotAccess (lhs, _, FN name) -> (
+      let lhs_ty = type_of_expr lhs in
+      match name with
+      | G.Id ((str, _), _) -> guess_type_of_dotaccess lang lhs_ty str
+      | G.IdQualified _ -> Type.NoType)
+  | _else_ -> Type.NoType

--- a/src/typing/Typing_heuristics.mli
+++ b/src/typing/Typing_heuristics.mli
@@ -1,0 +1,6 @@
+val guess_type :
+  Lang.t ->
+  (* type_of_expr *)
+  (AST_generic.expr -> AST_generic.name Type.t) ->
+  AST_generic.expr ->
+  AST_generic.name Type.t

--- a/tests/patterns/java/metavar_typed_bool.java
+++ b/tests/patterns/java/metavar_typed_bool.java
@@ -1,3 +1,5 @@
+import java.util.*;
+
 public class metavar_typed_bool {
   public static void main(String[] args) {
     boolean x = true;
@@ -34,6 +36,7 @@ public class metavar_typed_bool {
     System.out.println(!(1 == 2));
 
     metavar_typed_bool.overloaded();
+    metavar_typed_bool.stdlib();
   }
 
   public static void overloaded() {
@@ -67,5 +70,41 @@ public class metavar_typed_bool {
     System.out.println(3 | 4);
     // OK:
     System.out.println(3 & 4);
+  }
+
+  public static void stdlib() {
+    String x = "test";
+    // OK:
+    System.out.println(x);
+    // MATCH:
+    System.out.println(x.equals("y"));
+
+    List<String> y1 = new ArrayList<>();
+    y1.add("test");
+    // OK:
+    System.out.println(y1.get(0));
+    List<Boolean> z1 = new ArrayList<>();
+    z1.add(true);
+    // MATCH:
+    System.out.println(z1.get(0));
+
+    java.util.List<String> y2 = new ArrayList<>();
+    y2.add("test");
+    // OK:
+    System.out.println(y2.get(0));
+    java.util.List<Boolean> z2 = new ArrayList<>();
+    z2.add(true);
+    // MATCH:
+    System.out.println(z2.get(0));
+
+    Map<String, String> m1 = new HashMap<>();
+    m1.put("x", "y");
+    // OK:
+    System.out.println(m1.get("x"));
+
+    Map<String, Boolean> m2 = new HashMap<>();
+    m1.put("x", false);
+    // MATCH:
+    System.out.println(m2.get("x"));
   }
 }


### PR DESCRIPTION
We currently use type inference to handle typed metavariables. For example, a Java pattern might include `(boolean $X)` which will match any expression that is inferred to have the type `boolean`.

This PR extends type inference to include heuristics which we use to make a best guess for types of expressions whose types we cannot infer using traditional means. This typically happens when there is an unresolved name involved in the type.

While the heuristics are based on naming patterns in the Java standard library, they are not limited to the standard library. Nor do we intend to replicate the entire Java standard library as heuristics. Instead, we should include heuristics when we believe that they correctly describe the type of an expression with high confidence, whether they are based on a convention in the standard library or other common conventions.

Test plan: Automated tests

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
