### PR TITLE
synchronize ts parser with contents of Parse_target2 and Parse_pattern2

### DIFF
--- a/js/languages/typescript/Parser.ml
+++ b/js/languages/typescript/Parser.ml
@@ -11,7 +11,7 @@ let parse_target lang file =
           Pfff (Pfff_or_tree_sitter.throw_tokens Parse_js.parse);
         ]
         Js_to_generic.program
-  | _ -> failwith "no"
+  | _ -> failwith ("This parser cannot parse lang: " ^ Lang.to_string lang)
 
 let parse_pattern print_errors _ str =
   let js_ast =


### PR DESCRIPTION
Turns out JS/TS parsing was failing because the parser had fallen out of sync in the implementation in Parse_target2.ml / ParsePattern2.ml

test plan:
- confirmed working in local playground
- dune build && make test