### PR TITLE
engine/Match_rules: guard the Lazy.force of lazy_ast_and_errors

### DIFF
--- a/src/engine/Match_rules.ml
+++ b/src/engine/Match_rules.ml
@@ -159,7 +159,8 @@ let check ~match_hook ~timeout ~timeout_threshold (xconf : Match_env.xconfig)
   logger#trace "checking %s with %d rules" file (List.length rules);
   if !Profiling.profile =*= Profiling.ProfAll then (
     logger#info "forcing eval of ast outside of rules, for better profile";
-    Lazy.force lazy_ast_and_errors |> ignore);
+    try Lazy.force lazy_ast_and_errors |> ignore with
+    | _exn -> ());
 
   let per_rule_boilerplate_fn =
     per_rule_boilerplate_fn ~timeout ~timeout_threshold file


### PR DESCRIPTION
Otherwise, there's a divergence if run with and without --profile:

for osemgrep with semgrep.jsonnet on the src subdirectory: without --profile "Ran 56 rules on 476 files: 0 findings" with --profile "Ran 56 rules on 422 files: 0 findings"

Without catching the exception, osemgrep with --profile immediately exits (the current lang_job) on the first exception, namely

```
[0.385  ESC[94mInfoESC[39m       ESC[4mMain.Run_semgrepESC[24m     ] Uncaught exception: Failure: requesting generic AST for an unspecified target language
Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
Called from Run_semgrep.xtarget_of_file in file "src/runner/Run_semgrep.ml", line 568, characters 13-96
Called from CamlinternalLazy.force_lazy_block in file "camlinternalLazy.ml", line 31, characters 17-27
Re-raised at CamlinternalLazy.force_lazy_block in file "camlinternalLazy.ml", line 36, characters 4-11
Called from Match_rules.check in file "src/engine/Match_rules.ml", line 164, characters 4-34
Called from Match_extract_mode.extract_nested_lang in file "src/engine/Match_extract_mode.ml", line 528, characters 4-110
Called from Run_semgrep.extracted_targets_of_config.(fun) in file "src/runner/Run_semgrep.ml", line 696, characters 13-248
Called from Stdlib__List.concat_map.aux in file "list.ml", line 268, characters 16-19
Called from Run_semgrep.extracted_targets_of_config in file "src/runner/Run_semgrep.ml", line 687, characters 4-942
Called from Run_semgrep.semgrep_with_rules in file "src/runner/Run_semgrep.ml", line 738, characters 4-44
Called from Run_semgrep.semgrep_with_raw_results_and_exn_handler in file "src/runner/Run_semgrep.ml", line 889, characters 21-58
```

(exits with the lang_job, afterwards the next lang job is executed).

With this PR, the behaviour of --profile and no --profile is identical again. I'm curious whether the failure semantics should be revised (at the moment, it's mostly exceptions that are not always caught, as seen here -- maybe it's worth to move to use `result`)?

All other lazy_force of that value seem to be well guarded in terms of exceptions (though I've lost track in the code to find the exception handlers -- the other force use `Common.with_time` (which AFAICT `reraise`)).

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
