### PR TITLE
feat(ls): Add better error handling

### DIFF
--- a/changelog.d/pa-2791.added
+++ b/changelog.d/pa-2791.added
@@ -1,0 +1,1 @@
+Language Server will now notify users of errors, and reason for crash

--- a/cli/src/semgrep/lsp/server.py
+++ b/cli/src/semgrep/lsp/server.py
@@ -6,6 +6,7 @@ import sys
 import tempfile
 import threading
 import time
+import traceback
 import urllib
 from pathlib import PosixPath
 from tempfile import _TemporaryFileWrapper
@@ -19,6 +20,7 @@ from pylsp_jsonrpc.streams import JsonRpcStreamWriter
 from semgrep.app import auth
 from semgrep.commands.login import make_login_url
 from semgrep.core_runner import CoreRunner
+from semgrep.error import SemgrepError
 from semgrep.lsp.config import LSPConfig
 from semgrep.state import get_state
 from semgrep.types import JsonObject
@@ -37,6 +39,8 @@ class SemgrepCoreLSServer:
         self.config = LSPConfig({}, [])
         self.rule_file = rule_file
         self.target_file = target_file
+        self.core_process: Optional[subprocess.Popen] = None
+        self.exit_code: int = 0
 
     def update_targets_file(self) -> None:
         self.config.refresh_target_manager()
@@ -101,9 +105,30 @@ class SemgrepCoreLSServer:
         def core_handler() -> None:
             self.core_reader.listen(self.on_core_message)
 
+        def core_poller() -> None:
+            while True:
+                self.poll_ls()
+                time.sleep(1)
+
         self.thread = threading.Thread(target=core_handler)
         self.thread.daemon = True
         self.thread.start()
+
+        self.poll_thread = threading.Thread(target=core_poller)
+        self.poll_thread.daemon = True
+        self.poll_thread.start()
+
+    def poll_ls(self) -> None:
+        if not self.core_process:
+            return
+        status = self.core_process.poll()
+        if status is not None and status != 0:
+            self.notify_show_message(
+                1,
+                "Semgrep core process died, exiting...",
+            )
+            self.exit_code = status
+            self.stop()
 
     def notify(self, method: str, params: JsonObject) -> None:
         """Send a notification to the client"""
@@ -256,8 +281,25 @@ class SemgrepCoreLSServer:
 
     def stop(self) -> None:
         """Stop the language server"""
-        self.core_writer.write({"jsonrpc": "2.0", "method": "shutdown", "id": 1})
-        self.core_process.wait()
+        exception = sys.exc_info()[1]
+        error = None
+        if exception is not None:
+            self.notify_show_message(
+                1, f"Error running Semgrep Language Server:\t{traceback.format_exc()}"
+            )
+            traceback.print_exc(file=sys.stderr)
+            self.exit_code = 1
+            error = SemgrepError(exception)
+        if self.core_process and self.core_process.poll() is None:
+            self.core_writer.write({"jsonrpc": "2.0", "method": "shutdown", "id": 1})
+            self.core_process.wait()
+        try:
+            self.core_reader.close()
+            self.core_writer.close()
+        except Exception:
+            pass
+
+        self.config.send_metrics(self.exit_code, error)
 
 
 def run_server() -> None:
@@ -267,7 +309,9 @@ def run_server() -> None:
         tempfile.NamedTemporaryFile("w+", suffix=".json")
     )
     target_file = exit_stack.enter_context(tempfile.NamedTemporaryFile("w+"))
+    server = SemgrepCoreLSServer(rule_file, target_file)
+    exit_stack.callback(server.stop)
     with exit_stack:
-        server = SemgrepCoreLSServer(rule_file, target_file)
         server.start()
     log.info("Server stopped!")
+    sys.exit(server.exit_code)


### PR DESCRIPTION
Errors while running the language server will now be shown to the user through an error notification

Test plan:
- manually introduced error and visually checked output

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
