### PR TITLE
fix: swap defaults for release dry-run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ on:
         description: "Run the release in dry-run mode, e.g., without changing external state (like pushing to PyPI/Docker)"
         required: true
         type: boolean
-        default: true
+        default: false
 
   workflow_call:
     inputs:

--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -25,7 +25,7 @@ on:
         required: true
         type: boolean
         description: Check the box for a dry-run - A dry-run will not push any external state (branches, tags, images, or PyPI packages).
-        default: true
+        default: false
 
 jobs:
   get-version:


### PR DESCRIPTION
We've had a few false starts where a dry-run went out instead of a real release. By default, we do a real release, so the default should be `dry-run: false`. The `nightly.yml` is explicitly setting `dry-run: false`.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
