### PR TITLE
Fix other source of slowness in git URL parser + limit URL length to 1024

### DIFF
--- a/changelog.d/gh-7943.fixed
+++ b/changelog.d/gh-7943.fixed
@@ -1,2 +1,4 @@
-Fix regexp potentially vulnerable to ReDoS attacks in Python code for parsing
-git URLs. Reported by Sebastian Chnelik, PyUp.io.
+Fix regexps potentially vulnerable to ReDoS attacks in Python code for parsing
+git URLs. Sets maximum length of git URLs to 1024 characters since parsing is
+still perceptibly slow on 5000-byte input. Reported by Sebastian Chnelik,
+PyUp.io.

--- a/cli/src/semgrep/external/git_url_parser.py
+++ b/cli/src/semgrep/external/git_url_parser.py
@@ -107,6 +107,11 @@ class Parser(str):
             'name': None,
             'owner': None,
         }
+        # Parsing is super slow even after fixing obvious problems in regexps.
+        # This mitigates the damage of quadratic behavior.
+        if len(self._url) > 1024:
+            msg = f"URL exceeds maximum supported length of 1024: {self._url}"
+            raise ParserError(msg)
         for regex in POSSIBLE_REGEXES:
             match = regex.search(self._url)
             if match:

--- a/cli/src/semgrep/external/git_url_parser.py
+++ b/cli/src/semgrep/external/git_url_parser.py
@@ -46,7 +46,7 @@ POSSIBLE_REGEXES = (
                r'(?:(?P<user>[^\n@]+)@)*'
                r'(?P<resource>[a-z0-9_.-]*)'
                r'[:/]*'
-               r'(?P<port>[\d]+){0,1}'
+               r'(?P<port>(?<=:)[\d]+){0,1}'
                r'(?P<pathname>\/((?P<owner>[\w\-\/]+)\/)?'
                r'((?P<name>[\w\-\.]+?)(\.git|\/)?)?)$'),
     re.compile(r'(git\+)?'
@@ -58,13 +58,13 @@ POSSIBLE_REGEXES = (
                r'(\/?(?P<name>[\w\-]+)(\.git|\/)?)?)$'),
     re.compile(r'^(?:(?P<user>[^\n@]+)@)*'
                r'(?P<resource>[a-z0-9_.-]*)[:]*'
-               r'(?P<port>[\d]+){0,1}'
+               r'(?P<port>(?<=:)[\d]+){0,1}'
                r'(?P<pathname>\/?(?P<owner>.+)/(?P<name>.+).git)$'),
     re.compile(r'((?P<user>\w+)@)?'
-                r'((?P<resource>[\w\.\-]+))'
-                r'[\:\/]{1,2}'
-                r'(?P<pathname>((?P<owner>([\w\-]+\/)?\w+)/)?'
-                r'((?P<name>[\w\-]+)(\.git|\/)?)?)$'),
+               r'((?P<resource>[\w\.\-]+))'
+               r'[\:\/]{1,2}'
+               r'(?P<pathname>((?P<owner>([\w\-]+\/)?\w+)/)?'
+               r'((?P<name>[\w\-]+)(\.git|\/)?)?)$'),
     re.compile(r'((?P<user>\w+)@)?'
                r'((?P<resource>[\w\.\-]+))'
                r'[\:\/]{1,2}'

--- a/cli/src/semgrep/external/git_url_parser.py
+++ b/cli/src/semgrep/external/git_url_parser.py
@@ -23,6 +23,7 @@
 
 #
 # 2023-06-02 patched by Martin Jambon to avoid potential ReDoS attacks
+# 2023-06-05 patched further by Martin Jambon to avoid potential ReDoS attacks
 #
 
 import collections

--- a/src/osemgrep/TOPORT/external/git_url_parser.py
+++ b/src/osemgrep/TOPORT/external/git_url_parser.py
@@ -1,5 +1,6 @@
 # This file is forked from https://github.com/coala/git-url-parse/blob/master/giturlparse/parser.py
 # MIT license here: https://github.com/coala/git-url-parse/blob/master/LICENSE
+
 # Copyright (c) 2017 John Dewey
 #
 #  Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -22,71 +23,60 @@
 
 #
 # 2023-06-02 patched by Martin Jambon to avoid potential ReDoS attacks
+# 2023-06-05 patched further by Martin Jambon to avoid potential ReDoS attacks
 #
 
 import collections
 import re
 from typing import List
 
-Parsed = collections.namedtuple(
-    "Parsed",
-    [
-        "pathname",
-        "protocols",
-        "protocol",
-        "href",
-        "resource",
-        "user",
-        "port",
-        "name",
-        "owner",
-    ],
-)
+Parsed = collections.namedtuple('Parsed', [
+    'pathname',
+    'protocols',
+    'protocol',
+    'href',
+    'resource',
+    'user',
+    'port',
+    'name',
+    'owner',
+])
 
 POSSIBLE_REGEXES = (
-    re.compile(
-        r"^(?P<protocol>https?|git|ssh|rsync)\://"
-        r"(?:(?P<user>[^\n@]+)@)*"
-        r"(?P<resource>[a-z0-9_.-]*)"
-        r"[:/]*"
-        r"(?P<port>[\d]+){0,1}"
-        r"(?P<pathname>\/((?P<owner>[\w\-]+)\/)?"
-        r"((?P<name>[\w\-\.]+?)(\.git|\/)?)?)$"
-    ),
-    re.compile(
-        r"(git\+)?"
-        r"((?P<protocol>\w+)://)"
-        r"((?P<user>\w+)@)?"
-        r"((?P<resource>[\w\.\-]+))"
-        r"(:(?P<port>\d+))?"
-        r"(?P<pathname>(\/(?P<owner>\w+)/)?"
-        r"(\/?(?P<name>[\w\-]+)(\.git|\/)?)?)$"
-    ),
-    re.compile(
-        r"^(?:(?P<user>[^\n@]+)@)*"
-        r"(?P<resource>[a-z0-9_.-]*)[:]*"
-        r"(?P<port>[\d]+){0,1}"
-        r"(?P<pathname>\/?(?P<owner>.+)/(?P<name>.+).git)$"
-    ),
-    re.compile(
-        r"((?P<user>\w+)@)?"
-        r"((?P<resource>[\w\.\-]+))"
-        r"[\:\/]{1,2}"
-        r"(?P<pathname>((?P<owner>([\w\-]+\/)?\w+)/)?"
-        r"((?P<name>[\w\-]+)(\.git|\/)?)?)$"
-    ),
-    re.compile(
-        r"((?P<user>\w+)@)?"
-        r"((?P<resource>[\w\.\-]+))"
-        r"[\:\/]{1,2}"
-        r"(?P<pathname>((?P<owner>\w+)/)?"
-        r"((?P<name>[\w\-]+)(\.git|\/)?)?)$"
-    ),
+    re.compile(r'^(?P<protocol>https?|git|ssh|rsync)\://'
+               r'(?:(?P<user>[^\n@]+)@)*'
+               r'(?P<resource>[a-z0-9_.-]*)'
+               r'[:/]*'
+               r'(?P<port>(?<=:)[\d]+){0,1}'
+               r'(?P<pathname>\/((?P<owner>[\w\-\/]+)\/)?'
+               r'((?P<name>[\w\-\.]+?)(\.git|\/)?)?)$'),
+    re.compile(r'(git\+)?'
+               r'((?P<protocol>\w+)://)'
+               r'((?P<user>\w+)@)?'
+               r'((?P<resource>[\w\.\-]+))'
+               r'(:(?P<port>\d+))?'
+               r'(?P<pathname>(\/(?P<owner>\w+)/)?'
+               r'(\/?(?P<name>[\w\-]+)(\.git|\/)?)?)$'),
+    re.compile(r'^(?:(?P<user>[^\n@]+)@)*'
+               r'(?P<resource>[a-z0-9_.-]*)[:]*'
+               r'(?P<port>(?<=:)[\d]+){0,1}'
+               r'(?P<pathname>\/?(?P<owner>.+)/(?P<name>.+).git)$'),
+    re.compile(r'((?P<user>\w+)@)?'
+               r'((?P<resource>[\w\.\-]+))'
+               r'[\:\/]{1,2}'
+               r'(?P<pathname>((?P<owner>([\w\-]+\/)?\w+)/)?'
+               r'((?P<name>[\w\-]+)(\.git|\/)?)?)$'),
+    re.compile(r'((?P<user>\w+)@)?'
+               r'((?P<resource>[\w\.\-]+))'
+               r'[\:\/]{1,2}'
+               r'(?P<pathname>((?P<owner>\w+)/)?'
+               r'((?P<name>[\w\-\.]+)(\.git|\/)?)?)$'),
 )
 
 
 class ParserError(Exception):
-    """Error raised when a URL can't be parsed."""
+    """ Error raised when a URL can't be parsed. """
+    pass
 
 
 class Parser(str):
@@ -98,7 +88,7 @@ class Parser(str):
         # to fix an open bug with trailing slashes: https://github.com/coala/git-url-parse/issues/46
         self._url: str = url
         if url[-1] == "/":
-            self._url = url[:-1]
+          self._url = url[:-1]
 
     def parse(self) -> Parsed:
         """
@@ -108,31 +98,36 @@ class Parser(str):
         :raise: :class:`.ParserError`
         """
         d = {
-            "pathname": None,
-            "protocols": self._get_protocols(),
-            "protocol": "ssh",
-            "href": self._url,
-            "resource": None,
-            "user": None,
-            "port": None,
-            "name": None,
-            "owner": None,
+            'pathname': None,
+            'protocols': self._get_protocols(),
+            'protocol': 'ssh',
+            'href': self._url,
+            'resource': None,
+            'user': None,
+            'port': None,
+            'name': None,
+            'owner': None,
         }
+        # Parsing is super slow even after fixing obvious problems in regexps.
+        # This mitigates the damage of quadratic behavior.
+        if len(self._url) > 1024:
+            msg = f"URL exceeds maximum supported length of 1024: {self._url}"
+            raise ParserError(msg)
         for regex in POSSIBLE_REGEXES:
             match = regex.search(self._url)
             if match:
                 d.update(match.groupdict())
                 break
         else:
-            msg = f"Invalid URL '{self._url}'"
+            msg = "Invalid URL '{}'".format(self._url)
             raise ParserError(msg)
 
         return Parsed(**d)
 
     def _get_protocols(self) -> List[str]:
         try:
-            index = self._url.index("://")
+            index = self._url.index('://')
         except ValueError:
             return []
 
-        return self._url[:index].split("+")
+        return self._url[:index].split('+')


### PR DESCRIPTION
This fixes more of the same problems as https://github.com/returntocorp/semgrep/pull/7943

test plan:
* CI for correctness
* For performance, follow these steps:

```
~/semgrep/cli/src $ python3
Python 3.8.10 (default, Mar 13 2023, 10:26:41) 
[GCC 9.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from semgrep.meta import get_repo_name_from_repo_url
>>> get_repo_name_from_repo_url('0' * 1024)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/martin/semgrep/cli/src/semgrep/meta.py", line 60, in get_repo_name_from_repo_url
    result = p.parse()
  File "/home/martin/semgrep/cli/src/semgrep/external/git_url_parser.py", line 123, in parse
    raise ParserError(msg)
semgrep.external.git_url_parser.ParserError: Invalid URL '0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
```
should fail instantly by Python standards.

The following should fail even faster with a different error message:
```
>>> get_repo_name_from_repo_url('0' * 1025)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/martin/semgrep/cli/src/semgrep/meta.py", line 60, in get_repo_name_from_repo_url
    result = p.parse()
  File "/home/martin/semgrep/cli/src/semgrep/external/git_url_parser.py", line 115, in parse
    raise ParserError(msg)
semgrep.external.git_url_parser.ParserError: URL exceeds maximum supported length of 1024: 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
```

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
