### PR TITLE
feat: Additional heuristics for Java type inference

### DIFF
--- a/src/core/Type.ml
+++ b/src/core/Type.ml
@@ -157,20 +157,23 @@ let builtin_type_of_string _langTODO str =
   | "number" -> Some Number
   | __else__ -> None
 
-(* coupling: Inverse of builtin_type_of_string
- *
- * TODO: Check lang to get proper builtin type for more languages *)
-let ast_generic_type_of_builtin_type ?tok lang t =
+(* TODO: Check lang to get proper builtin type for more languages *)
+let name_of_builtin_type lang t =
   match (lang, t) with
-  | _, Int -> mkt ?tok "int"
-  | _, Float -> mkt ?tok "float"
-  | Lang.Java, String -> mkt ?tok "String"
-  | _, String -> mkt ?tok "string"
-  | Lang.Java, Bool -> mkt ?tok "boolean"
-  | _, Bool -> mkt ?tok "bool"
+  | _, Int -> "int"
+  | _, Float -> "float"
+  | Lang.Java, String -> "String"
+  | _, String -> "string"
+  | Lang.Java, Bool -> "boolean"
+  | _, Bool -> "bool"
   (* TS *)
-  | _, Number -> mkt ?tok "number"
-  | _, OtherBuiltins str -> mkt ?tok str
+  | _, Number -> "number"
+  | _, OtherBuiltins str -> str
+
+(* coupling: Inverse of builtin_type_of_string *)
+let ast_generic_type_of_builtin_type ?tok lang t =
+  let str = name_of_builtin_type lang t in
+  mkt ?tok str
 
 let builtin_type_of_type lang t =
   match t.G.t with

--- a/tests/patterns/java/metavar_typed_bool.java
+++ b/tests/patterns/java/metavar_typed_bool.java
@@ -103,8 +103,18 @@ public class metavar_typed_bool {
     System.out.println(m1.get("x"));
 
     Map<String, Boolean> m2 = new HashMap<>();
-    m1.put("x", false);
+    m2.put("x", false);
     // MATCH:
     System.out.println(m2.get("x"));
+
+    // MATCH:
+    System.out.println("asdf".matches("asdf"));
+
+    // MATCH:
+    System.out.println(m1.isEmpty());
+
+    java.lang.String y = "test";
+    // MATCH:
+    System.out.println(y.matches("test"));
   }
 }

--- a/tests/patterns/java/metavar_typed_int.java
+++ b/tests/patterns/java/metavar_typed_int.java
@@ -1,4 +1,7 @@
-public class Main {
+import java.util.*;
+
+public class metavar_typed_int {
+  // Run with `javac metavar_typed_int.java && java metavar_typed_int`
   public static void main(String[] args) {
     // MATCH:
     System.out.println(1);
@@ -22,5 +25,12 @@ public class Main {
     System.out.println(x);
     // MATCH:
     System.out.println(x + 1);
+
+    List<String> l = new ArrayList<>();
+    l.add("foo");
+    // OK:
+    System.out.println(l.get(0));
+    // MATCH:
+    System.out.println(l.size());
   }
 }


### PR DESCRIPTION
We still don't intend to embed the entire Java standard library, but I've added a few more common methods that will be useful heuristics for type inference. I've also added a few more tests to spot check them.

Test plan: Automated tests

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
