### PR TITLE
cleanup GHA OSX part 3

### DIFF
--- a/.github/workflows/build-test-osx-m1.yaml
+++ b/.github/workflows/build-test-osx-m1.yaml
@@ -44,7 +44,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          submodules: "recursive"
+          submodules: true
       - uses: actions/download-artifact@v3
         with:
           name: semgrep-m1-${{ github.sha }}

--- a/.github/workflows/build-test-osx-x86.yaml
+++ b/.github/workflows/build-test-osx-x86.yaml
@@ -35,7 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          submodules: "recursive"
+          submodules: true
       - uses: actions/download-artifact@v3
         with:
           name: semgrep-osx-${{ github.sha }}

--- a/Makefile
+++ b/Makefile
@@ -352,6 +352,17 @@ install-deps-and-build-ALPINE-semgrep-core:
 # macOS (brew)
 # -------------------------------------------------
 
+# Here is why we need those external packages below:
+# - pcre: for ocaml-pcre now used in semgrep-core
+# - TODO gmp: for osemgrep and its use of cohttp
+# - pkg-config?
+# - coreutils?
+# - gettext?
+BREW_DEPS=pkg-config coreutils pcre gettext
+
+install-deps-MACOS-for-semgrep-core:
+	brew install $(BREW_DEPS)
+
 # Install dependencies needed for the Homebrew build.
 #
 # We don't use just 'make setup' because Homebrew installs its own version

--- a/scripts/osx-release.sh
+++ b/scripts/osx-release.sh
@@ -11,12 +11,12 @@ set -eux
 # does not reset the environment between each run, so you may
 # need to do more cleanup than usually necessary.
 
-brew install opam pkg-config coreutils pcre gettext
-
+brew install opam
 #still needed?
 #brew update
+#still needed?
 #opam init --no-setup --bare
-
+#
 #coupling: this should be the same version than in our Dockerfile
 if opam switch 4.14.0 ; then
     # This happens because the self-hosted CI runners do not
@@ -27,24 +27,20 @@ else
     opam switch create 4.14.0
     opam switch 4.14.0
 fi
-
-git submodule update --init --recursive --depth 1
-
 eval "$(opam env)"
 
 #pad:??? What was for? This was set only for the M1 build before
 # Needed so we don't make config w/ sudo
 export HOMEBREW_SYSTEM=1
 
-# Remove pcre dynamically linked to force MacOS to use static.
-# This needs to be done before make setup since it is used there.
+make install-deps-MACOS-for-semgrep-core
+make install-deps-for-semgrep-core
+
+# Remove dynamically linked libraries to force MacOS to use static ones.
 ls -l "$(brew --prefix)"/opt/pcre/lib || true
 rm -f "$(brew --prefix)"/opt/pcre/lib/libpcre.1.dylib
 
-make setup
-
-# Remove dynamically linked libraries to force MacOS to use static ones.
-# This needs to be done after make setup but before make build-*
+# This needs to be done after make install-deps-xxx but before make core
 TREESITTER_LIBDIR=libs/ocaml-tree-sitter-core/tree-sitter/lib
 echo "TREESITTER_LIBDIR is $TREESITTER_LIBDIR and contains:"
 ls -l "$TREESITTER_LIBDIR" || true


### PR DESCRIPTION
test plan:
./scripts/osx-release.sh under my mac


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)