### PR TITLE
osemgrep: dogfood osemgrep in 'make check_with_docker'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -490,11 +490,12 @@ check_for_emacs:
 
 DOCKER_IMAGE=returntocorp/semgrep:develop
 
-# If you get semgrep-core parsing errors while running this command, maybe you
-# have an old cached version of the docker image.
-# You can invalidate the cache with 'docker rmi returntocorp/semgrep:develop`
+# If you get parsing errors while running this command, maybe you have an old
+# cached version of the docker image. You can invalidate the cache with
+#   'docker rmi returntocorp/semgrep:develop`
+# We're dogfooding osemgrep here too! which is now part of the docker image.
 check_with_docker:
-	docker run --rm -v "${PWD}:/src" $(DOCKER_IMAGE) semgrep $(SEMGREP_ARGS)
+	docker run --rm -v "${PWD}:/src" $(DOCKER_IMAGE) osemgrep $(SEMGREP_ARGS)
 
 ###############################################################################
 # Martin's targets


### PR DESCRIPTION
test plan:
make check_with_docker

this currently wrongly returns error code 3, but Hannes should
fix that soon.


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)