### PR TITLE
Remove tree-sitter lib in OSX runner

### DIFF
--- a/scripts/osx-release.sh
+++ b/scripts/osx-release.sh
@@ -16,7 +16,10 @@ brew install opam
 #brew update
 #still needed?
 #opam init --no-setup --bare
-#
+
+# Some CI runners have tree-sitter preinstalled which interfere with
+# out static linking plans below so better to remove it.
+brew uninstall --force tree-sitter
 
 #coupling: this should be the same version than in our Dockerfile
 if opam switch 4.14.0 ; then


### PR DESCRIPTION
Some recent PRs show some failure such as
https://github.com/returntocorp/semgrep/actions/runs/5190051263/jobs/9357504701?pr=7964
because tree-sitter was actually already installed in
/usr/local/opt/tree-sitter
which then interfere with the static linking

test plan:
hope to not get this error in futur PRs


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)