### PR TITLE
fix(taint): Improve the Taint comparison for offsets

### DIFF
--- a/changelog.d/misc-1.fixed
+++ b/changelog.d/misc-1.fixed
@@ -1,0 +1,2 @@
+Fixed comparison of taint information that was causing duplicate taints to be tracked.
+Interfile analysis on large repos will see a small speedup.

--- a/src/tainting/Taint.ml
+++ b/src/tainting/Taint.ml
@@ -134,10 +134,7 @@ and compare_args a1 a2 =
   let pos1 = a1.pos in
   let pos2 = a2.pos in
   match Stdlib.compare pos1 pos2 with
-  | 0 ->
-      List.compare
-        (fun n1 n2 -> IL_helpers.compare_name n1 n2)
-        a1.offset a2.offset
+  | 0 -> List.compare IL_helpers.compare_name a1.offset a2.offset
   | other -> other
 
 and compare_orig orig1 orig2 =

--- a/src/tainting/Taint.ml
+++ b/src/tainting/Taint.ml
@@ -130,6 +130,21 @@ and compare_sources s1 s2 =
       Option.compare compare_precondition s1.precondition s2.precondition
   | other -> other
 
+and compare_name n1 n2 =
+  match
+    AST_utils.with_structural_equal G.equal_ident n1.IL.ident n2.IL.ident
+  with
+  | true -> Stdlib.compare n1.sid n2.sid
+  | false -> Stdlib.compare n1.ident n2.ident
+
+(* type arg = { pos : arg_pos; offset : IL.name list } *)
+and compare_args a1 a2 =
+  let pos1 = a1.pos in
+  let pos2 = a2.pos in
+  match Stdlib.compare pos1 pos2 with
+  | 0 -> List.compare (fun n1 n2 -> compare_name n1 n2) a1.offset a2.offset
+  | other -> other
+
 and compare_orig orig1 orig2 =
   match (orig1, orig2) with
   | Arg { pos = s, i; _ }, Arg { pos = s', j; _ } -> (
@@ -269,7 +284,7 @@ module Taint_set = struct
       match (k1, k2) with
       | Arg _, Src _ -> -1
       | Src _, Arg _ -> 1
-      | Arg a1, Arg a2 -> Stdlib.compare a1 a2
+      | Arg a1, Arg a2 -> compare_args a1 a2
       | Src s1, Src s2 -> compare_sources s1 s2
   end)
 

--- a/src/tainting/Taint.ml
+++ b/src/tainting/Taint.ml
@@ -130,19 +130,14 @@ and compare_sources s1 s2 =
       Option.compare compare_precondition s1.precondition s2.precondition
   | other -> other
 
-and compare_name n1 n2 =
-  match
-    AST_utils.with_structural_equal G.equal_ident n1.IL.ident n2.IL.ident
-  with
-  | true -> Stdlib.compare n1.sid n2.sid
-  | false -> Stdlib.compare n1.ident n2.ident
-
-(* type arg = { pos : arg_pos; offset : IL.name list } *)
 and compare_args a1 a2 =
   let pos1 = a1.pos in
   let pos2 = a2.pos in
   match Stdlib.compare pos1 pos2 with
-  | 0 -> List.compare (fun n1 n2 -> compare_name n1 n2) a1.offset a2.offset
+  | 0 ->
+      List.compare
+        (fun n1 n2 -> IL_helpers.compare_name n1 n2)
+        a1.offset a2.offset
   | other -> other
 
 and compare_orig orig1 orig2 =


### PR DESCRIPTION
We use Stdlib.compare for offsets for taints in the Taint set, but offsets include variables of type `IL.ident`. These include tokens, id_info, etc. Make compare more precise.

Test plan: make test, especially see benchmark tests

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
