### PR TITLE
osemgrep: fix --profile

### DIFF
--- a/src/runner/Run_semgrep.ml
+++ b/src/runner/Run_semgrep.ml
@@ -565,6 +565,7 @@ let xtarget_of_file (config : Runner_config.t) (xlang : Xlang.t)
              (* xlang from the language field in -target should be unique *)
              assert false
          | _ ->
+             (* alt: could return an empty program, but better to be defensive*)
              failwith
                "requesting generic AST for an unspecified target language"
        in


### PR DESCRIPTION
This supersedes https://github.com/returntocorp/semgrep/pull/7949/
We should lazy force the AST only when there's an actual AST ...

test plan:
osemgrep --config semgrep.jsonnet src/ --profile
now gives the same output in #files scanned than without --profile


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)