### PR TITLE
osemgrep: disable registry caching by default

### DIFF
--- a/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -129,8 +129,8 @@ let default : conf =
     max_lines_per_finding = 10;
     rewrite_rule_ids = true;
     metrics = Metrics_.Auto;
-    (* like legacy, should maybe be set to false when we release osemgrep*)
-    registry_caching = true;
+    (* like legacy, should maybe be set to false when we release osemgrep *)
+    registry_caching = false;
     version_check = true;
     (* ugly: should be separate subcommands *)
     version = false;


### PR DESCRIPTION
This causes some errors otherwise if we want to use
osemgrep in pre-commit because we get some sys error
about the failure to create a directory /.semgrep/cache/registry

test plan:
nope


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)