### PR TITLE
feat(taint): Relate Java getters and setters to properties (take 2)

### DIFF
--- a/changelog.d/getters.added
+++ b/changelog.d/getters.added
@@ -1,0 +1,1 @@
+In Java, Semgrep can now track taint through more getters and setters. It could already relate setters to getters (e.g. `o.setX(taint); o.getX()` but now it can relate setters and getters to properties (e.g. `o.setX(taint); o.x`).

--- a/tests/rules/taint_get_set_sensitivity1.java
+++ b/tests/rules/taint_get_set_sensitivity1.java
@@ -1,0 +1,22 @@
+public class H {
+    public void h1() {
+        RE e = null;
+        e = new RE();
+        e.setX(tainted);
+        // OK: test
+        sink(e.y);
+        // ruleid: test
+        sink(e.x);
+
+    }
+    public void h2() {
+        d = new RE();
+        d.x = tainted;
+        // OK:
+        sink(d.getY());
+        // ruleid: test
+        sink(d.getX());
+        // ruleid: test
+        sink(d.x);
+    }
+}

--- a/tests/rules/taint_get_set_sensitivity1.yaml
+++ b/tests/rules/taint_get_set_sensitivity1.yaml
@@ -1,0 +1,11 @@
+rules:
+  - id: test
+    languages:
+      - java
+    severity: WARNING
+    mode: taint
+    message: Test
+    pattern-sources:
+      - pattern: tainted
+    pattern-sinks:
+      - pattern: sink(...)


### PR DESCRIPTION
Fixes: 22b421dc597 ("feat(taint): Relate Java getters and setters to properties (#7977)")
Reverts: 62f60ffb068 ("Revert "feat(taint): Relate Java getters and setters to properties (#7977)" (#7980)")

Previously in Java, Semgrep would consider `o.getX()` tainted if a tainted argument was passed to `o.setX(...)`. However, it would not relate that taint back to the underlying property itself. This means that taint would only be tracked if getters and setters were used in concert. If a regular assignment to the property was made, followed by a getter, or if a setter was used, followed by a direct access to the property, Semgrep would fail to track taint.

Here, I've changed the handling of `o.setX(...)` to make Semgrep consider the property `o.x` tainted, and added functionality to consider `o.getX()` tainted if `o.x` is tainted. The modified tests illustrate the change in behavior.

Test plan: Automated tests
(Also, see returntocorp/semgrep-proprietary#767)

Co-authored-by: Nat Mote <nat@semgrep.com>
Co-authored-by: Iago Abal <iago@semgrep.com>

---------

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
