### PR TITLE
osemgrep: increase the HTTP timeout: DNS resolution is 2 seconds now,

### DIFF
--- a/src/osemgrep/networking/Http_helpers.ml
+++ b/src/osemgrep/networking/Http_helpers.ml
@@ -1,5 +1,20 @@
 open Http_lwt_client
 
+(* happy eyeballs is an Internet standard
+   (https://datatracker.ietf.org/doc/html/rfc8305) and an OCaml package which
+   purpose is to establish a TCP connection, independent of the internet
+   protocol version:
+   - the input is a hostname (and a port), the output is either a file
+     descriptor or an error
+   - it does DNS resolution (for both A (IPv4) and AAAA (IPv6)) - 3 attempts
+     with a timeout of "resolve_timeout" (here: 2 seconds)
+   - it then attempts to establish to the IPv6 address(es) and IPv4 address(es)
+     (with a preference to IPv6), using a 10 seconds timeout ("connect_timeout",
+     defaults to 10 seconds)
+
+   The HTTP lwt client library uses happy_eyeballs as the underlying
+   layer for establishing connections.
+*)
 let happy_eyeballs =
   let happy_eyeballs =
     Happy_eyeballs.create ~resolve_timeout:(Duration.of_sec 2)


### PR DESCRIPTION
TCP connection establishment 10 seconds

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
