### PR TITLE
swift #7583: Support if let shorthand for shadowing an existing optional variable

### DIFF
--- a/changelog.d/gh-7583.fixed
+++ b/changelog.d/gh-7583.fixed
@@ -1,0 +1,1 @@
+swift: Support if let shorthand for shadowing an existing optional variable.

--- a/languages/swift/generic/Parse_swift_tree_sitter.ml
+++ b/languages/swift/generic/Parse_swift_tree_sitter.ml
@@ -1595,12 +1595,15 @@ and map_if_condition_sequence_item (env : env)
   | `If_let_bind (v1, v2, v3) ->
       let v1 = map_direct_or_indirect_binding env v1 in
       let v2 =
-        match v2 with
-        | Some (v1, v2) ->
+        match (v1, v2) with
+        | _, Some (v1, v2) ->
             let _v1TODO = (* eq_custom *) token env v1 in
             let v2 = map_expression env v2 in
             v2
-        | None ->
+        | G.OtherPat (_, G.P (G.PatId (ident, info)) :: _), None ->
+            (* if let shorthand for shadowing an existing optional variable since Swift 5.7 *)
+            G.N (G.Id (ident, info)) |> G.e
+        | _, None ->
             (* Does not appear to be valid Swift code *)
             failwith "Missing initializer in condition"
       in

--- a/src/core/Lang.ml
+++ b/src/core/Lang.ml
@@ -146,6 +146,7 @@ let langs_of_filename filename =
   | FT.PL FT.Rust -> [ Rust ]
   | FT.PL FT.R -> [ R ]
   | FT.PL FT.Scala -> [ Scala ]
+  | FT.PL FT.Swift -> [ Swift ]
   | FT.PL (FT.Web FT.Html) -> [ Html ]
   | _ -> []
 

--- a/tests/parsing/swift/statements.swift
+++ b/tests/parsing/swift/statements.swift
@@ -255,6 +255,8 @@ if true {}
 if true {} else {}
 if async let x = true {} else {}
 if case x = true {} else if case x = false {} else {}
+if let x {} else {}
+if var x {} else {}
 if #available(things2) {}
 if #available(things 1 . 2 . 3) {}
 if #available(things 2 . 3) {}
@@ -263,6 +265,8 @@ if #available(*) {}
 // Guard statements
 guard true else {}
 guard async let x = true else {}
+guard let x else {}
+guard var x else {}
 
 // Switch statements
 switch foo {


### PR DESCRIPTION
PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
