### PR TITLE
perf: remove constraint on lvals in the taints set

### DIFF
--- a/src/configuring/Limits_semgrep.ml
+++ b/src/configuring/Limits_semgrep.ml
@@ -15,9 +15,6 @@
  * of the data structures involved may help too.
  *)
 
-(** Bounds the number of l-values we can track. *)
-let taint_MAX_TAINTED_LVALS = 100
-
 (** Bounds the number of taints we can track per l-value. *)
 let taint_MAX_TAINT_SET_SIZE = 50
 

--- a/src/tainting/Taint_lval_env.ml
+++ b/src/tainting/Taint_lval_env.ml
@@ -123,13 +123,6 @@ let add ({ tainted; propagated; cleaned } as lval_env) lval taints =
       (* Cannot track taint for this l-value; e.g. because the base is not a simple
          variable. We just return the same environment untouched. *)
       lval_env
-  | Some _
-    when (not (LvalMap.mem lval tainted))
-         && LvalMap.cardinal tainted > Limits_semgrep.taint_MAX_TAINTED_LVALS ->
-      logger#warning
-        "Already tracking too many tainted l-values, will not track %s"
-        (Display_IL.string_of_lval lval);
-      lval_env
   | Some lval ->
       let taints =
         (* If the lvalue is a simple variable, we record it as part of


### PR DESCRIPTION
This constraint doesn't seem to make a big difference, so let's remove it until we see a reason for it.

Test plan: run pro on dotCMS, make sure it completes

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
