### PR TITLE
tainting: Fix perf issue due to allocating tons of `id_info's

### DIFF
--- a/cli/tests/e2e/snapshots/test_dump_ast/test_dump_ast/results.json
+++ b/cli/tests/e2e/snapshots/test_dump_ast/test_dump_ast/results.json
@@ -13,7 +13,7 @@
                 ],
                 {
                   "id_hidden": "false",
-                  "id_info_id": 7,
+                  "id_info_id": 8,
                   "id_resolved": {
                     "ref@": null
                   },
@@ -71,7 +71,7 @@
                                               ],
                                               {
                                                 "id_hidden": "false",
-                                                "id_info_id": 3,
+                                                "id_info_id": 4,
                                                 "id_resolved": {
                                                   "ref@": null
                                                 },
@@ -96,7 +96,7 @@
                                               ],
                                               {
                                                 "id_hidden": "false",
-                                                "id_info_id": 4,
+                                                "id_info_id": 5,
                                                 "id_resolved": {
                                                   "ref@": null
                                                 },
@@ -137,7 +137,7 @@
                                               ],
                                               {
                                                 "id_hidden": "false",
-                                                "id_info_id": 5,
+                                                "id_info_id": 6,
                                                 "id_resolved": {
                                                   "ref@": null
                                                 },
@@ -162,7 +162,7 @@
                                               ],
                                               {
                                                 "id_hidden": "false",
-                                                "id_info_id": 6,
+                                                "id_info_id": 7,
                                                 "id_resolved": {
                                                   "ref@": null
                                                 },
@@ -202,7 +202,7 @@
                   "pdefault": null,
                   "pinfo": {
                     "id_hidden": "false",
-                    "id_info_id": 1,
+                    "id_info_id": 2,
                     "id_resolved": {
                       "ref@": {
                         "some": [
@@ -233,7 +233,7 @@
                   "pdefault": null,
                   "pinfo": {
                     "id_hidden": "false",
-                    "id_info_id": 2,
+                    "id_info_id": 3,
                     "id_resolved": {
                       "ref@": {
                         "some": [
@@ -277,7 +277,7 @@
                 ],
                 {
                   "id_hidden": "false",
-                  "id_info_id": 12,
+                  "id_info_id": 13,
                   "id_resolved": {
                     "ref@": null
                   },
@@ -321,7 +321,7 @@
                                     ],
                                     {
                                       "id_hidden": "false",
-                                      "id_info_id": 10,
+                                      "id_info_id": 11,
                                       "id_resolved": {
                                         "ref@": null
                                       },
@@ -346,7 +346,7 @@
                                     ],
                                     {
                                       "id_hidden": "false",
-                                      "id_info_id": 11,
+                                      "id_info_id": 12,
                                       "id_resolved": {
                                         "ref@": null
                                       },
@@ -381,7 +381,7 @@
                   "pdefault": null,
                   "pinfo": {
                     "id_hidden": "false",
-                    "id_info_id": 8,
+                    "id_info_id": 9,
                     "id_resolved": {
                       "ref@": {
                         "some": [
@@ -412,7 +412,7 @@
                   "pdefault": null,
                   "pinfo": {
                     "id_hidden": "false",
-                    "id_info_id": 9,
+                    "id_info_id": 10,
                     "id_resolved": {
                       "ref@": {
                         "some": [
@@ -456,7 +456,7 @@
                   ],
                   {
                     "id_hidden": "false",
-                    "id_info_id": 13,
+                    "id_info_id": 14,
                     "id_resolved": {
                       "ref@": null
                     },
@@ -493,7 +493,7 @@
                               ],
                               {
                                 "id_hidden": "false",
-                                "id_info_id": 14,
+                                "id_info_id": 15,
                                 "id_resolved": {
                                   "ref@": null
                                 },
@@ -518,7 +518,7 @@
                               ],
                               {
                                 "id_hidden": "false",
-                                "id_info_id": 15,
+                                "id_info_id": 16,
                                 "id_resolved": {
                                   "ref@": null
                                 },

--- a/src/tainting/Dataflow_tainting.ml
+++ b/src/tainting/Dataflow_tainting.ml
@@ -927,6 +927,10 @@ let find_lval_taint_sources env incoming_taints lval =
   let lval_env = Lval_env.add env.lval_env lval taints_sources_mut in
   (Taints.union taints_sources_reg taints_sources_mut, lval_env)
 
+let fixme_fake_id_info_for_propagate_taint_via_unresolved_java_getters_and_setters
+    =
+  G.empty_id_info ()
+
 let rec check_tainted_lval env (lval : IL.lval) : Taints.t * Lval_env.t =
   let new_taints, lval_in_env, lval_env = check_tainted_lval_aux env lval in
   let taints_from_env = status_to_taints lval_in_env in
@@ -968,7 +972,13 @@ and propagate_taint_via_unresolved_java_getters_and_setters env e args
         {
           ident = (prop_str, method_tok);
           sid = G.SId.unsafe_default;
-          id_info = G.empty_id_info ();
+          id_info =
+            (* Allocating one of this every time turns out to be very expensive,
+             * but if we reuse the one from the getter/setter the id_type could
+             * be set to a function type. In Pro we could look up the actual
+             * property and use it here.
+             * TODO: Should cache them using (obj_ty, prop_str) as a cache key ? *)
+            fixme_fake_id_info_for_propagate_taint_via_unresolved_java_getters_and_setters;
         }
       in
       let prop_lval =


### PR DESCRIPTION
Fixes: 7e7641fb1b3 ("feat(taint): Relate Java getters and setters to properties (take 2) (#7983)")

test plan:
See returntocorp/semgrep-proprietary#767 (passes benchmarks)

PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
