### PR TITLE
tainting: Fix perf regression caused by #7936

### DIFF
--- a/changelog.d/pa-2777-1.fixed
+++ b/changelog.d/pa-2777-1.fixed
@@ -1,0 +1,1 @@
+taint-mode: Fixed performance regression in 1.24.0 that affected taint rules.

--- a/src/tainting/Dataflow_tainting.ml
+++ b/src/tainting/Dataflow_tainting.ml
@@ -491,6 +491,13 @@ let drop_taints_if_bool_or_number (options : Rule_options.t) taints ty =
       Taints.empty
   | __else__ -> taints
 
+(* Calls to 'type_of_expr' seem not to be cheap and even though we tried to limit the
+ * number of these calls being made, doing them unconditionally caused a slowdown of
+ * ~25% in a ~dozen repos in our stress-test-monorepo. We should just not call
+ * 'type_of_expr' unless at least one of the taint_assume_safe_{booleans,numbers} has
+ * been set, so rules that do not use these options remain unaffected. Long term we
+ * should make type_of_expr less costly.
+ *)
 let check_type_and_drop_taints_if_bool_or_number env taints type_of_x x =
   if
     env.options.taint_assume_safe_booleans

--- a/src/tainting/Dataflow_tainting.ml
+++ b/src/tainting/Dataflow_tainting.ml
@@ -491,6 +491,17 @@ let drop_taints_if_bool_or_number (options : Rule_options.t) taints ty =
       Taints.empty
   | __else__ -> taints
 
+let check_type_and_drop_taints_if_bool_or_number env taints type_of_x x =
+  if
+    env.options.taint_assume_safe_booleans
+    || env.options.taint_assume_safe_numbers
+  then
+    match type_of_x env x with
+    | Type.Function (_, return_ty) ->
+        drop_taints_if_bool_or_number env.options taints return_ty
+    | ty -> drop_taints_if_bool_or_number env.options taints ty
+  else taints
+
 (*****************************************************************************)
 (* Labels *)
 (*****************************************************************************)
@@ -932,7 +943,7 @@ let rec check_tainted_lval env (lval : IL.lval) : Taints.t * Lval_env.t =
   let taints_from_env = status_to_taints lval_in_env in
   let taints = Taints.union new_taints taints_from_env in
   let taints =
-    drop_taints_if_bool_or_number env.options taints (type_of_lval env lval)
+    check_type_and_drop_taints_if_bool_or_number env taints type_of_lval lval
   in
   let sinks =
     lval_is_sink env.config lval
@@ -1515,7 +1526,7 @@ let check_tainted_instr env instr : Taints.t * Lval_env.t =
     | Assign (_, e) ->
         let taints, lval_env = check_expr env e in
         let taints =
-          drop_taints_if_bool_or_number env.options taints (type_of_expr env e)
+          check_type_and_drop_taints_if_bool_or_number env taints type_of_expr e
         in
         (taints, lval_env)
     | AssignAnon _ -> (Taints.empty, env.lval_env) (* TODO *)
@@ -1559,11 +1570,8 @@ let check_tainted_instr env instr : Taints.t * Lval_env.t =
         (* We add the taint of the function itselt (i.e., 'e_taints') too. *)
         let all_call_taints = Taints.union e_taints call_taints in
         let all_call_taints =
-          match type_of_expr env e with
-          | Type.Function (_, return_ty) ->
-              drop_taints_if_bool_or_number env.options all_call_taints
-                return_ty
-          | __else__ -> all_call_taints
+          check_type_and_drop_taints_if_bool_or_number env all_call_taints
+            type_of_expr e
         in
         (all_call_taints, lval_env)
     | New (_lval, _ty, Some constructor, args) -> (
@@ -1619,7 +1627,7 @@ let check_tainted_return env tok e : Taints.t * Lval_env.t =
   in
   let taints, var_env' = check_tainted_expr env e in
   let taints =
-    drop_taints_if_bool_or_number env.options taints (type_of_expr env e)
+    check_type_and_drop_taints_if_bool_or_number env taints type_of_expr e
   in
   let findings = findings_of_tainted_sinks env taints sinks in
   report_findings env findings;

--- a/src/tainting/Dataflow_tainting.ml
+++ b/src/tainting/Dataflow_tainting.ml
@@ -500,8 +500,9 @@ let drop_taints_if_bool_or_number (options : Rule_options.t) taints ty =
  *)
 let check_type_and_drop_taints_if_bool_or_number env taints type_of_x x =
   if
-    env.options.taint_assume_safe_booleans
-    || env.options.taint_assume_safe_numbers
+    (env.options.taint_assume_safe_booleans
+   || env.options.taint_assume_safe_numbers)
+    && not (Taints.is_empty taints)
   then
     match type_of_x env x with
     | Type.Function (_, return_ty) ->


### PR DESCRIPTION
Calls to `type_of_expr` seem not to be cheap and even though we tried to limit them this cause a slowdown of about 25% in about a dozen repos in our benchmark. We should just not call `type_of_expr` unless at least one of the `taint_assume_safe_{booleans,numbers}` has been set, so rules that do not use these options remain unaffected. Long term we should make `type_of_expr` less costly.

Fixes: 64cb387f7a0 ("tainting: Add options to ignore taint based on types (#7936)")

test plan:
Run semgrep-compare full workflow based on stress-test-monorepo

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
