### PR TITLE
Add a timestamp when we use osemgrep with --debug

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -415,6 +415,8 @@ For more information see https://semsgrep.dev
     bos
     (digestif (>= 1.0.0))
     notty
+    mtime
+    duration
   )
 )
 

--- a/libs/commons/Logs_helpers.ml
+++ b/libs/commons/Logs_helpers.ml
@@ -12,8 +12,22 @@ let pp_sgr ppf style =
   Format.pp_print_as ppf 0 style;
   Format.pp_print_as ppf 0 "m"
 
+(** This global is used by our reporter to do the diff between the last
+    log we outputed and the current one. Actually, the implementation is a
+    bit dumb and probably show weird metrics when we use [lwt]. For such
+    case, it's better to add a _counter_ and use the tag mechanism to really
+    show right metrics.
+
+    This variable is set when we configure loggers. *)
+
+let time_program_start = ref 0.
+
+let now () =
+  Mtime.to_uint64_ns (Mtime_clock.now ())
+  |> Duration.to_sec_64 |> Int64.to_float
+
 (* log reporter *)
-let reporter ?(dst = Format.err_formatter) () =
+let reporter ?(with_timestamp = false) ?(dst = Fmt.stderr) () =
   let report _src level ~over k msgf =
     let pp_style, style, style_off =
       match color level with
@@ -25,8 +39,15 @@ let reporter ?(dst = Format.err_formatter) () =
       k ()
     in
     let r =
-      msgf @@ fun ?header:_ ?tags:_ fmt ->
-      Format.kfprintf k dst ("@[%a" ^^ fmt ^^ "@]@.") pp_style style
+      msgf @@ fun ?header ?tags:_ fmt ->
+      match with_timestamp with
+      | true ->
+          let current = now () in
+          Format.kfprintf k dst
+            ("@[[+%010.2fms]%a: " ^^ fmt ^^ "@]@.")
+            (current -. !time_program_start)
+            Logs_fmt.pp_header (level, header)
+      | _ -> Format.kfprintf k dst ("@[%a" ^^ fmt ^^ "@]@.") pp_style style
     in
     Format.fprintf dst "%a" pp_style style_off;
     r
@@ -45,7 +66,9 @@ let setup_logging ~force_color ~level =
   let style_renderer = if force_color then Some `Ansi_tty else None in
   Fmt_tty.setup_std_outputs ?style_renderer ();
   Logs.set_level ~all:true level;
-  Logs.set_reporter (reporter ());
+  let with_timestamp = level = Some Logs.Debug in
+  time_program_start := now ();
+  Logs.set_reporter (reporter ~with_timestamp ());
   (* from https://github.com/mirage/ocaml-cohttp#debugging *)
   (* Disable all third-party libs logs *)
   Logs.Src.list ()

--- a/libs/commons/dune
+++ b/libs/commons/dune
@@ -17,6 +17,9 @@
    re
    pcre
    parmap
+   mtime
+   mtime.clock.os
+   duration
    digestif.c
  )
  ; can't use profiling.ppx because of circular dependencies :(

--- a/semgrep.opam
+++ b/semgrep.opam
@@ -57,6 +57,8 @@ depends: [
   "bos"
   "digestif" {>= "1.0.0"}
   "notty"
+  "mtime"
+  "duration"
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)

This small PR add a timestamp on the `DEBUG` output (it concerns only the `DEBUG` level). The metrics can be interesting to see and debug few things. Actually, we do the computation when we print but we probably should use the tags mechanism. /cc @aryx 