### PR TITLE
feat(taint): make the taint limits configurable

### DIFF
--- a/src/configuring/Flag_semgrep.ml
+++ b/src/configuring/Flag_semgrep.ml
@@ -33,6 +33,12 @@ let max_cache = ref false
 (* Maximum size of a single target file, in bytes (exceptions apply). *)
 let max_target_bytes = ref 5_000_000
 
+(* Maximum number of tainted lvals to save. *)
+let max_tainted_lvals = ref Limits_semgrep.taint_MAX_TAINTED_LVALS
+
+(* Maximum size of the taints set for each lval *)
+let max_taint_set_size = ref Limits_semgrep.taint_MAX_TAINT_SET_SIZE
+
 (* Whether or not to skip files believed to be minified. *)
 let skip_minified_files = ref true
 

--- a/src/core_cli/Core_CLI.ml
+++ b/src/core_cli/Core_CLI.ml
@@ -642,6 +642,21 @@ let options actions =
        when running out of memory. This value should be less than the actual \
        memory available because the limit will be exceeded before it gets \
        detected. Try 5% less or 15000 if you have 16 GB." );
+    ( "-max_tainted_lvals",
+      Arg.Set_int Flag_semgrep.max_tainted_lvals,
+      "<int> maximum number of lvals to store. This is mostly for internal use \
+       to make performance testing easier" );
+    ( "-max_taint_set_size",
+      Arg.Set_int Flag_semgrep.max_taint_set_size,
+      "<int> maximum size of a taint set. This is mostly for internal use to \
+       make performance testing easier" );
+    ( "-max_match_per_file",
+      Arg.Set_int max_match_per_file,
+      " <int> maximum numbers of match per file" );
+    ("-debug", Arg.Set debug, " output debugging information");
+    ("-test", Arg.Set test, " (internal) set test context");
+    ("-ls", Arg.Set ls, " run Semgrep Language Server");
+    ("-raja", Arg.Set Flag_semgrep.raja, " undocumented");
     ( "-max_match_per_file",
       Arg.Set_int max_match_per_file,
       " <int> maximum numbers of match per file" );

--- a/src/tainting/Taint_lval_env.ml
+++ b/src/tainting/Taint_lval_env.ml
@@ -125,7 +125,8 @@ let add ({ tainted; propagated; cleaned } as lval_env) lval taints =
       lval_env
   | Some _
     when (not (LvalMap.mem lval tainted))
-         && LvalMap.cardinal tainted > Limits_semgrep.taint_MAX_TAINTED_LVALS ->
+         && !Flag_semgrep.max_tainted_lvals > 0
+         && LvalMap.cardinal tainted > !Flag_semgrep.max_tainted_lvals ->
       logger#warning
         "Already tracking too many tainted l-values, will not track %s"
         (Display_IL.string_of_lval lval);
@@ -153,8 +154,9 @@ let add ({ tainted; propagated; cleaned } as lval_env) lval taints =
                 (* THINK: couldn't we just replace the existing taints? *)
                 | Some taints' ->
                     if
-                      Taints.cardinal taints'
-                      < Limits_semgrep.taint_MAX_TAINT_SET_SIZE
+                      !Flag_semgrep.max_taint_set_size > 0
+                      && Taints.cardinal taints'
+                         < !Flag_semgrep.max_taint_set_size
                     then Some (Taints.union taints taints')
                     else (
                       logger#warning

--- a/src/tainting/Taint_lval_env.ml
+++ b/src/tainting/Taint_lval_env.ml
@@ -154,8 +154,8 @@ let add ({ tainted; propagated; cleaned } as lval_env) lval taints =
                 (* THINK: couldn't we just replace the existing taints? *)
                 | Some taints' ->
                     if
-                      !Flag_semgrep.max_taint_set_size > 0
-                      && Taints.cardinal taints'
+                      !Flag_semgrep.max_taint_set_size = 0
+                      || Taints.cardinal taints'
                          < !Flag_semgrep.max_taint_set_size
                     then Some (Taints.union taints taints')
                     else (


### PR DESCRIPTION
Allow semgrep-core/-proprietary users to configure the taint limits via command-line argument.

As noted in the help descriptions, this is meant for internal testing.

Test plan: ran locally, printed out when the limits were hit. Confirmed that the limits were hit without `-max_tainted_lvals 0 -max_taint_set_size 0` 

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
