### PR TITLE
tainting: Filter actual arguments taint by type

### DIFF
--- a/src/tainting/Dataflow_tainting.ml
+++ b/src/tainting/Dataflow_tainting.ml
@@ -1512,9 +1512,11 @@ let check_function_call_arguments env args =
     args
     |> List.fold_left_map
          (fun (lval_env, all_taints) arg ->
-           let taints, lval_env =
-             check_tainted_expr { env with lval_env }
-               (IL_helpers.exp_of_arg arg)
+           let e = IL_helpers.exp_of_arg arg in
+           let taints, lval_env = check_tainted_expr { env with lval_env } e in
+           let taints =
+             check_type_and_drop_taints_if_bool_or_number env taints
+               type_of_expr e
            in
            let new_acc = (lval_env, taints :: all_taints) in
            match arg with

--- a/tests/rules/taint_assume_safe_booleans.py
+++ b/tests/rules/taint_assume_safe_booleans.py
@@ -1,8 +1,19 @@
-def ok():
+def ok1():
     x = "tainted"
     y = x == "safe"
     #OK: test
     sink(y)
+
+def ok2():
+    x = "tainted"
+    #OK: test
+    sink(x == "safe")
+
+def ok3():
+    x = "tainted"
+    y = "something " + x
+    #OK: test
+    sink(x != "safe")
 
 def bad():
     x = "tainted"

--- a/tests/rules/taint_assume_safe_booleans1.java
+++ b/tests/rules/taint_assume_safe_booleans1.java
@@ -1,0 +1,10 @@
+class Test {
+    public void ok(String x) {
+        //OK: test
+        sink("something" + (x != "safe"));
+    }
+    public void bad(String x) {
+        //ruleid: test
+        sink("something" + x);
+    }
+}

--- a/tests/rules/taint_assume_safe_booleans1.yaml
+++ b/tests/rules/taint_assume_safe_booleans1.yaml
@@ -1,0 +1,14 @@
+rules:
+  - id: test
+    message: Test
+    languages: [java]
+    options:
+      taint_assume_safe_booleans: true
+    mode: taint
+    pattern-sources:
+    - patterns:
+      - pattern: public void $F(..., $X, ...) { ... }
+      - focus-metavariable: $X
+    pattern-sinks:
+    - pattern: sink(...)
+    severity: ERROR


### PR DESCRIPTION
Follows: 64cb387f7a0 ("tainting: Add options to ignore taint based on types (#7936)")

test plan:
make test # new tests

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
