### PR TITLE
fix: Partial revert of #7929

### DIFF
--- a/changelog.d/pa-2822.fixed
+++ b/changelog.d/pa-2822.fixed
@@ -1,0 +1,1 @@
+Fix a recent regression that caused failures to match in certain cases that combined metavariable-regex and typed metavariables which themselves contain metavariables (e.g. in Go `($X: $T)` with a `metavariable-regex` operating on `$T`).

--- a/src/matching/Generic_vs_generic.ml
+++ b/src/matching/Generic_vs_generic.ml
@@ -1403,6 +1403,12 @@ and m_compatible_type lang typed_mvar t e =
       m_type_ t
         (G.TyPointer (t1, G.TyN (G.Id (("char", tok), id_info)) |> G.t) |> G.t)
       >>= fun () -> envf typed_mvar (MV.E e)
+  (* for matching ids *)
+  (* this is covered by the basic type propagation done in Naming_AST.ml *)
+  | _ta, B.N (B.Id (idb, ({ B.id_type = tb; _ } as id_infob))) ->
+      (* NOTE: Name values must be represented with MV.Id! *)
+      m_type_option_with_hook idb (Some t) !tb >>= fun () ->
+      envf typed_mvar (MV.Id (idb, Some id_infob))
   | _ta, _eb -> (
       let with_bound_metavar =
         match e.G.e with

--- a/tests/patterns/java/typed_metavar_class.java
+++ b/tests/patterns/java/typed_metavar_class.java
@@ -15,13 +15,13 @@ public class SemgrepTest
     // `Class<MessageDigest>`, not type `MessageDigest`. Maybe the pattern for
     // this shouldn't even involve a typed metavariable?
 
-    // MATCH:
+    // TODO ?:
     MessageDigest md1 = MessageDigest.getInstance("MD5");
 
-    // MATCH:
+    // TODO ?:
     MessageDigest md2 = MessageDigest.getInstance(MD5_1);
 
-    // MATCH:
+    // TODO ?:
     MessageDigest md3 = MessageDigest.getInstance(MD5_2);
 
     int stam1 = 0;

--- a/tests/rules/typed_metavar_metavar_regex.go
+++ b/tests/rules/typed_metavar_metavar_regex.go
@@ -1,0 +1,4 @@
+func f(c *http.Request) {
+  // ruleid: typed-metavar-metavar-regex
+  c.Foo()
+}

--- a/tests/rules/typed_metavar_metavar_regex.yaml
+++ b/tests/rules/typed_metavar_metavar_regex.yaml
@@ -1,0 +1,11 @@
+rules:
+- id: typed-metavar-metavar-regex
+  message: asdf
+  severity: ERROR
+  languages:
+  - go
+  patterns:
+    - pattern: '($X : $TYPE).Foo()'
+    - metavariable-regex:
+        metavariable: $TYPE
+        regex: ^\*http.Request$


### PR DESCRIPTION
My recent type inference work involves sometimes pulling types out of thin air, and even for those that do, in some form, exist in the written program, their tokens aren't stored in `Type.t`. This causes problems with `metavariable-regex`, since metavariables bound to inferred types won't have correct ranges associated with them, so they won't be able to extract reasonable text to match against.

To address this, I'm adding back in the special case that previously existed. This skips the more sophisticated type inference when the expression being matched is a name which has a resolved type. More complex cases will continue to fail, but they would have failed before my recent type inference work anyway.

This is the same issue that we have with resolved names getting bound to metavariables. When we get resolved names from the Pro Engine, they are entirely synthetic and do not have any associated location information. At some point, we should come up with a thorough solution to both of these problems. Perhaps we need to be able to consistently print ASTs. We could focus first on printing for names and types. Then for synthetic ASTs we could print them, and use the printed text to match against regexes. Anyway, for now this at least gets us back to where we were.

Test plan: Automated tests

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
