### PR TITLE
Elixir: fix -filter_irrelevant_rules for elixir

### DIFF
--- a/changelog.d/gh-7855.fixed
+++ b/changelog.d/gh-7855.fixed
@@ -1,0 +1,1 @@
+Elixir: fix the string extraction used for -filter_irrelevant_rules

--- a/tests/patterns/elixir/dots_nested_stmts.xxx
+++ b/tests/patterns/elixir/dots_nested_stmts.xxx
@@ -1,6 +1,6 @@
 function foo()
 
-    --ERROR: match
+    #ERROR: match
     if (x == 1) then
         return 2
     end

--- a/tests/patterns/elixir/dots_params.ex
+++ b/tests/patterns/elixir/dots_params.ex
@@ -1,0 +1,9 @@
+defmodule MyAppWeb.UserController do
+  use MyAppWeb, :controller
+
+  #ERROR: match
+  def show(conn, %{"id" => id}) do
+    user = Repo.get(User, id)
+    render(conn, :show, user: user)
+  end
+end

--- a/tests/patterns/elixir/dots_params.sgrep
+++ b/tests/patterns/elixir/dots_params.sgrep
@@ -1,0 +1,3 @@
+def $VAL(...) do
+   ...
+end

--- a/tests/rules/elixir_kwd_relevant_rule.ex
+++ b/tests/rules/elixir_kwd_relevant_rule.ex
@@ -1,0 +1,9 @@
+defmodule MyAppWeb.UserController do
+  use MyAppWeb, :controller
+
+  #ruleid: match
+  def show(conn, %{"id" => id}) do
+    user = Repo.get(User, id)
+    render(conn, :show, user: user)
+  end
+end

--- a/tests/rules/elixir_kwd_relevant_rule.yaml
+++ b/tests/rules/elixir_kwd_relevant_rule.yaml
@@ -1,0 +1,11 @@
+rules:
+  - id: untitled_rule
+    message: Semgrep found a match
+    languages:
+      - elixir
+    severity: WARNING
+    patterns:
+      - pattern: |
+          def $VAL(...) do
+            ...
+          end


### PR DESCRIPTION
This closes #7855

test plan:
```
$ semgrep-core -l elixir -rules tests/rules/elixir_kwd_relevant_rule.yaml tests/rules/elixir_kwd_relevant_rule.ex
...
[0.046  Trace      Main.Match_rules     ] looking for ["Pred",["Idents",["do","def"]]] in tests/rules/elixir_kwd_relevant_rule.ex
...
tests/rules/elixir_kwd_relevant_rule.ex:5 with rule untitled_rule
   def show(conn, %{"id" => id}) do
     user = Repo.get(User, id)
     render(conn, :show, user: user)
```

Before this PR we were wrongly looking for:
```
[0.047  Trace      Main.Match_rules     ] looking for ["Pred",["Idents",["do:","def"]]] in tests/rules/elixir_kwd_relevant_rule.ex
```

with the "do:" string which is not contained in the file and so the
file was not even analyzed (because of -filter_irrelevant_rules set to
true by default)


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)