### PR TITLE
osemgrep: improve logging

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -415,8 +415,6 @@ For more information see https://semsgrep.dev
     bos
     (digestif (>= 1.0.0))
     notty
-    mtime
-    duration
   )
 )
 

--- a/libs/commons/Logs_helpers.ml
+++ b/libs/commons/Logs_helpers.ml
@@ -1,3 +1,25 @@
+open Common
+
+(*****************************************************************************)
+(* Globals *)
+(*****************************************************************************)
+
+(** This global is used by the reporter to print the difference between
+    the time the log call was done and the time the program was started.
+    TODO? Actually, the implementation is a bit dumb and probably show weird
+     metrics when we use [lwt]. For such case, it's better to add a _counter_
+     and use the tag mechanism to really show right metrics.
+
+     This variable is set when we configure loggers.
+*)
+
+(* in seconds *)
+let time_program_start = ref 0.
+
+(*****************************************************************************)
+(* Helpers *)
+(*****************************************************************************)
+
 (* ANSI escape sequences for colored output, depending on log level *)
 let color level =
   match level with
@@ -12,19 +34,8 @@ let pp_sgr ppf style =
   Format.pp_print_as ppf 0 style;
   Format.pp_print_as ppf 0 "m"
 
-(** This global is used by our reporter to do the diff between the last
-    log we outputed and the current one. Actually, the implementation is a
-    bit dumb and probably show weird metrics when we use [lwt]. For such
-    case, it's better to add a _counter_ and use the tag mechanism to really
-    show right metrics.
-
-    This variable is set when we configure loggers. *)
-
-let time_program_start = ref 0.
-
-let now () =
-  Mtime.to_uint64_ns (Mtime_clock.now ())
-  |> Duration.to_sec_64 |> Int64.to_float
+(* alt: use Mtime_clock.now () *)
+let now () : float = Unix.gettimeofday ()
 
 (* log reporter *)
 let reporter ?(with_timestamp = false) ?(dst = Fmt.stderr) () =
@@ -40,19 +51,22 @@ let reporter ?(with_timestamp = false) ?(dst = Fmt.stderr) () =
     in
     let r =
       msgf @@ fun ?header ?tags:_ fmt ->
-      match with_timestamp with
-      | true ->
-          let current = now () in
-          Format.kfprintf k dst
-            ("@[[+%010.2fms]%a: " ^^ fmt ^^ "@]@.")
-            (current -. !time_program_start)
-            Logs_fmt.pp_header (level, header)
-      | _ -> Format.kfprintf k dst ("@[%a" ^^ fmt ^^ "@]@.") pp_style style
+      if with_timestamp then
+        let current = now () in
+        Format.kfprintf k dst
+          ("@[[%05.2f]%a: " ^^ fmt ^^ "@]@.")
+          (current -. !time_program_start)
+          Logs_fmt.pp_header (level, header)
+      else Format.kfprintf k dst ("@[%a" ^^ fmt ^^ "@]@.") pp_style style
     in
     Format.fprintf dst "%a" pp_style style_off;
     r
   in
   { Logs.report }
+
+(*****************************************************************************)
+(* Entry points *)
+(*****************************************************************************)
 
 (* Enable basic logging (level = Logs.Warning) so that you can use Logging
  * calls even before a precise call to setup_logging.
@@ -66,7 +80,7 @@ let setup_logging ~force_color ~level =
   let style_renderer = if force_color then Some `Ansi_tty else None in
   Fmt_tty.setup_std_outputs ?style_renderer ();
   Logs.set_level ~all:true level;
-  let with_timestamp = level = Some Logs.Debug in
+  let with_timestamp = level =*= Some Logs.Debug in
   time_program_start := now ();
   Logs.set_reporter (reporter ~with_timestamp ());
   (* from https://github.com/mirage/ocaml-cohttp#debugging *)
@@ -74,13 +88,9 @@ let setup_logging ~force_color ~level =
   Logs.Src.list ()
   |> List.iter (fun src ->
          match Logs.Src.name src with
-         | "dns"
-         | "dns_cache"
-         | "dns_client"
          | "dns_client_lwt"
          | "ca-certs"
          | "bos"
-         | "happy-eyeballs"
          | "happy-eyeballs.lwt"
          | "mirage-crypto-rng.lwt"
          | "mirage-crypto-rng-lwt"
@@ -90,5 +100,14 @@ let setup_logging ~force_color ~level =
          | "tls.tracing"
          | "x509" ->
              Logs.Src.set_level src None
-         | "application" -> ()
+         (* let's keep the logs for those networking libraries to
+          * help debug networking issues (e.g., timeout).
+          *)
+         | "dns"
+         | "dns_cache"
+         | "dns_client"
+         | "happy-eyeballs"
+         (* those are the one we are really interested in *)
+         | "application" ->
+             ()
          | s -> failwith ("Logs library not handled: " ^ s))

--- a/libs/commons/dune
+++ b/libs/commons/dune
@@ -17,9 +17,6 @@
    re
    pcre
    parmap
-   mtime
-   mtime.clock.os
-   duration
    digestif.c
  )
  ; can't use profiling.ppx because of circular dependencies :(

--- a/semgrep.opam
+++ b/semgrep.opam
@@ -57,8 +57,6 @@ depends: [
   "bos"
   "digestif" {>= "1.0.0"}
   "notty"
-  "mtime"
-  "duration"
   "odoc" {with-doc}
 ]
 build: [

--- a/src/osemgrep/networking/Http_helpers.ml
+++ b/src/osemgrep/networking/Http_helpers.ml
@@ -34,7 +34,10 @@ let get ?headers url =
       Error
         ("HTTP request failed, server response "
         ^ Status.to_string response.status)
-  | Error (`Msg msg) -> Error ("HTTP request failed: " ^ msg)
+  | Error (`Msg msg) ->
+      let err = "HTTP request failed: " ^ msg in
+      Logs.debug (fun m -> m "%s" err);
+      Error err
   [@@profiling]
 
 let post ~body ?(headers = [ ("content-type", "application/json") ]) url =
@@ -52,5 +55,8 @@ let post ~body ?(headers = [ ("content-type", "application/json") ]) url =
         ( Status.to_code response.status,
           "HTTP request failed, server response "
           ^ Status.to_string response.status )
-  | Error (`Msg msg) -> Error (-1, "HTTP request failed: " ^ msg)
+  | Error (`Msg msg) ->
+      let err = "HTTP request failed: " ^ msg in
+      Logs.debug (fun m -> m "%s" err);
+      Error (-1, err)
   [@@profiling]


### PR DESCRIPTION
test plan:
```
$ osemgrep --debug --config semgrep.jsonnet src/metachecking
...
[00.77][DEBUG]: Start an h2 connection as requested by the server.
[00.77][DEBUG]: Sending ((method "GET") (target "/c/p/ocaml") (scheme "https") (headers
                        ((":authority" "semgrep.dev")("content-length" "0"))))
[01.17][DEBUG]: finished downloading from https://semgrep.dev/c/p/ocaml
[01.17][DEBUG]: loading yaml file /tmp/tmp-686976-d05b13.yaml, converting to jsonnet
...
```


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)