### PR TITLE
refactor(interactive): kill `Unix.select`

### DIFF
--- a/src/osemgrep/cli_interactive/Interactive_subcommand.ml
+++ b/src/osemgrep/cli_interactive/Interactive_subcommand.ml
@@ -22,7 +22,7 @@ open Notty
 open Notty_unix
 
 (*****************************************************************************)
-(* Types and constants *)
+(* Types *)
 (*****************************************************************************)
 
 type command =
@@ -94,6 +94,10 @@ type state = {
   should_continue_iterating_targets : bool ref;
 }
 
+(*****************************************************************************)
+(* Constants *)
+(*****************************************************************************)
+
 (* Arbitrarily, let's just set the width of files to 40 chars. *)
 let files_width = 40
 
@@ -113,6 +117,15 @@ let fg_line_num = A.(fg neutral_yellow)
    redraw the screen, so we only redraw when this condition is true.
 *)
 let should_refresh = ref false
+
+let event_queue :
+    [ `End
+    | `Key of Unescape.key
+    | `Mouse of Unescape.mouse
+    | `Paste of Unescape.paste
+    | `Resize of int * int ]
+    Queue.t =
+  Queue.create ()
 
 (*****************************************************************************)
 (* ASCII art *)
@@ -804,10 +817,78 @@ let stop_thread_if_turbo state =
 (* Interactive loop *)
 (*****************************************************************************)
 
+(* This thread's job is to constantly check for events (and consistently block
+   if they do not occur).
+
+   When an event is read, it will be added to a global queue, which will then
+   signal to the interactive loop that an event has occurred, and cause a
+   rerender.
+*)
+let spawn_event_thread term =
+  Thread.create
+    (fun _ ->
+      let rec loop () =
+        let e = Term.event term in
+        Queue.add e event_queue;
+        (* THINK: yield here? *)
+        loop ()
+      in
+      loop ())
+    ()
+  |> ignore
+
 let interactive_loop ~turbo xlang xtargets =
   let rec render_and_loop ?(has_changed = false) (t : Term.t) state =
     Term.image t (render_screen ~has_changed state);
     loop t state
+  and on_event e state =
+    let t = state.term in
+    match e with
+    | `Key (`Enter, _) ->
+        let state = execute_command state in
+        render_and_loop t state
+    | `Key (`Backspace, _) -> (
+        match state.cur_line_rev with
+        (* nothing to delete, just stay the same *)
+        | [] -> loop t state
+        | _ :: cs ->
+            stop_thread_if_turbo state;
+            let state = fresh_state { state with cur_line_rev = cs } in
+            spawn_thread_if_turbo state;
+            render_and_loop ~has_changed:true t state)
+    | `Key (`ASCII c, _) ->
+        stop_thread_if_turbo state;
+        let state =
+          fresh_state { state with cur_line_rev = c :: state.cur_line_rev }
+        in
+        spawn_thread_if_turbo state;
+        render_and_loop ~has_changed:true t state
+    | `Key (`Arrow `Left, _) ->
+        let file_zipper = !(state.file_zipper) in
+        state.file_zipper :=
+          Pointed_zipper.map_current
+            (fun { file; matches = mz } ->
+              { file; matches = Pointed_zipper.move_left mz })
+            file_zipper;
+        render_and_loop t state
+    | `Key (`Arrow `Right, _) ->
+        let file_zipper = !(state.file_zipper) in
+        state.file_zipper :=
+          Pointed_zipper.map_current
+            (fun { file; matches = mz } ->
+              { file; matches = Pointed_zipper.move_right mz })
+            file_zipper;
+        render_and_loop t state
+    | `Key (`Arrow `Up, _) ->
+        let file_zipper = !(state.file_zipper) in
+        state.file_zipper := Pointed_zipper.move_left file_zipper;
+        render_and_loop t state
+    | `Key (`Arrow `Down, _) ->
+        let file_zipper = !(state.file_zipper) in
+        state.file_zipper := Pointed_zipper.move_right file_zipper;
+        render_and_loop t state
+    | `Resize _ -> render_and_loop t state
+    | __else__ -> render_and_loop t state
   and loop t state =
     if !should_refresh then (
       (* If this is true, this indicates that we should refresh, because a
@@ -816,76 +897,17 @@ let interactive_loop ~turbo xlang xtargets =
       should_refresh := false;
       render_and_loop t state)
     else
-      (* I (Brandon) have absolutely no idea why, but for some reason
-         using `Term.pending` here just loops forever and
-         seems to think that it's always not pending.
-
-         if not (Term.pending t) then
-
-         ^ loops forever to this case
-
-         So instead we just poll stdin to see whether there is
-         data, which should be a good proxy for whether or not it
-         is safe to proceed to the blocking `event` call.
-
-         TODO(pad): we should not need any Unix.select, and no 0.0005 timeout.
-         Thread should work fine with Term.event
-      *)
-      match Unix.select [ Unix.stdin ] [] [] 0.0005 with
-      | [], _, _ ->
-          (* stdin not available for reading, no data so let's cycle again
-         *)
+      match Queue.take_opt event_queue with
+      | None ->
+          (* We have to yield here, or else the turbo thread will take a long time
+             to compute, because we're hogging all the process' time!
+          *)
+          Thread.yield ();
           loop t state
-      | _ :: _, _, _ -> (
-          match Term.event t with
-          | `Key (`Enter, _) ->
-              let state = execute_command state in
-              render_and_loop t state
-          | `Key (`Backspace, _) -> (
-              match state.cur_line_rev with
-              (* nothing to delete, just stay the same *)
-              | [] -> loop t state
-              | _ :: cs ->
-                  stop_thread_if_turbo state;
-                  let state = fresh_state { state with cur_line_rev = cs } in
-                  spawn_thread_if_turbo state;
-                  render_and_loop ~has_changed:true t state)
-          | `Key (`ASCII c, _) ->
-              stop_thread_if_turbo state;
-              let state =
-                fresh_state
-                  { state with cur_line_rev = c :: state.cur_line_rev }
-              in
-              spawn_thread_if_turbo state;
-              render_and_loop ~has_changed:true t state
-          | `Key (`Arrow `Left, _) ->
-              let file_zipper = !(state.file_zipper) in
-              state.file_zipper :=
-                Pointed_zipper.map_current
-                  (fun { file; matches = mz } ->
-                    { file; matches = Pointed_zipper.move_left mz })
-                  file_zipper;
-              render_and_loop t state
-          | `Key (`Arrow `Right, _) ->
-              let file_zipper = !(state.file_zipper) in
-              state.file_zipper :=
-                Pointed_zipper.map_current
-                  (fun { file; matches = mz } ->
-                    { file; matches = Pointed_zipper.move_right mz })
-                  file_zipper;
-              render_and_loop t state
-          | `Key (`Arrow `Up, _) ->
-              let file_zipper = !(state.file_zipper) in
-              state.file_zipper := Pointed_zipper.move_left file_zipper;
-              render_and_loop t state
-          | `Key (`Arrow `Down, _) ->
-              let file_zipper = !(state.file_zipper) in
-              state.file_zipper := Pointed_zipper.move_right file_zipper;
-              render_and_loop t state
-          | `Resize _ -> render_and_loop t state
-          | __else__ -> render_and_loop t state)
+      | Some e -> on_event e state
   in
   let t = Term.create () in
+  spawn_event_thread t;
   Common.finalize
     (fun () ->
       let state = init_state turbo xlang xtargets t in


### PR DESCRIPTION
## What:
This PR kills our previous workflow of polling `stdin` every `0.0005` seconds with `Unix.select`, and instead opts for using threads to determine when events should happen.

## Why:
Ideally, looping but taking actions on events should be able to be done with the `Term.pending` call, which supposedly tells us when there is a pending event to the terminal, to be acted upon. Past experimentation shows that this does not work, so we must find another way.

This way is cleaner, because we don't need to rely on `Unix.select`.

## How:
Instead of `Unix.select`, we spin up another thread (call it the _event thread_) which simply tightly loops and blocks via `Term.event`. This is fine, because this just means that the event thread blocks -- the main thread is free to take input and refresh on an asynchronous flag (such as the turbo thread completing matches).

## Test plan:
https://asciinema.org/a/VMyjaMUZsTCehnV9783qQHqPS

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
