### PR TITLE
[DRAFT] event once

### DIFF
--- a/src/osemgrep/cli_interactive/Interactive_subcommand.ml
+++ b/src/osemgrep/cli_interactive/Interactive_subcommand.ml
@@ -879,17 +879,15 @@ let interactive_loop ~turbo xlang xtargets =
          TODO(pad): we should not need any Unix.select, and no 0.0005 timeout.
          Thread should work fine with Term.event
       *)
-      match Unix.select [ Unix.stdin ] [] [] 0.0005 with
-      | [], _, _ ->
-          (* stdin not available for reading, no data so let's cycle again
-        *)
-          loop t state
-      | _ :: _, _, _ -> do_event (Term.event t) t state
+      (* stdin not available for reading, no data so let's cycle again
+    *)
+      loop t state
   in
   let t = Term.create () in
   Common.finalize
     (fun () ->
       let state = init_state turbo xlang xtargets t in
+      do_event (Term.event t) t state |> ignore;
       (* fake if to shutdown warning 21 of ocamlc "nonreturn-statement" *)
       if true then render_and_loop state.term state)
     (fun () -> Term.release t)


### PR DESCRIPTION
This PR makes a tiny change to `brandon/kill-select`, which refactors and inserts a `failwith` just as the match thread terminates.

This PR changes it so instead of looping in `do_event`, we do `do_event` a single time at the head of the loop. This causes entering `1` to, instead of failwith-ing immediately, to take a really freaking long time, and then eventually failwith. I don't know why.

PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
