### PR TITLE
cleanup: use Fpath in xtarget_of_file

### DIFF
--- a/src/osemgrep/cli_interactive/Interactive_subcommand.ml
+++ b/src/osemgrep/cli_interactive/Interactive_subcommand.ml
@@ -942,7 +942,7 @@ let run (conf : Interactive_CLI.conf) : Exit_code.t =
   let config = Core_runner.runner_config_of_conf conf.core_runner_conf in
   let config = { config with roots = conf.target_roots; lang = Some xlang } in
   let xtargets =
-    targets |> Common.map Fpath.to_string
+    targets
     |> Common.map (fun file ->
            let xtarget = Run_semgrep.xtarget_of_file config xlang file in
            Lock_protected.protect xtarget)

--- a/src/runner/Run_semgrep.mli
+++ b/src/runner/Run_semgrep.mli
@@ -219,7 +219,7 @@ val filter_files_with_too_many_matches_and_transform_as_timeout :
 (* TODO: This is used by semgrep-pro and not by semgrep. What is it?
    TODO: Explain what it does if xlang contains multiple langs. *)
 val rules_for_xlang : Xlang.t -> Rule.t list -> Rule.t list
-val xtarget_of_file : Runner_config.t -> Xlang.t -> Common.filename -> Xtarget.t
+val xtarget_of_file : Runner_config.t -> Xlang.t -> Fpath.t -> Xtarget.t
 
 (*
    Sort targets by decreasing size. This is meant for optimizing


### PR DESCRIPTION
I'll update semgrep-pro after this is merged.

test plan:
make core-test


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)