### PR TITLE
fix(CI): add `ppx-expect` to opam

### DIFF
--- a/semgrep.opam
+++ b/semgrep.opam
@@ -35,6 +35,7 @@ depends: [
   "ppx_deriving"
   "ppx_hash"
   "ppx_inline_test"
+  "ppx_expect"
   "ppx_sexp_conv" {!= "v0.15.0" & != "v0.15.1"}
   "re"
   "pcre"


### PR DESCRIPTION
## What:
This PR adds `ppx-expect` to our `semgrep.opam` file, so CI runs fine again.

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
