### PR TITLE
Add rule ID validation to semgrep-core.

### DIFF
--- a/changelog.d/gh-8026.fixed
+++ b/changelog.d/gh-8026.fixed
@@ -1,0 +1,2 @@
+semgrep-core now validates rule IDs. This should not affect users since rule
+ID validation is done by the Python wrapper.

--- a/src/core/Rule.ml
+++ b/src/core/Rule.ml
@@ -36,11 +36,18 @@ open Ppx_hash_lib.Std.Hash.Builtin
 module ID : sig
   type t = private string [@@deriving show, eq]
 
+  exception Malformed_rule_ID of string
+
   val to_string : t -> string
   val of_string : string -> t
+  val of_string_opt : string -> t option
   val to_string_list : t list -> string list
   val of_string_list : string list -> t list
   val compare : t -> t -> int
+
+  (* Validation function called by of_string.
+     Checks for the format [a-zA-Z0-9._-]* *)
+  val validate : string -> bool
 
   (*
      Rule ids are prepended with the `path.to.the.rules.file.`, so
@@ -55,11 +62,16 @@ module ID : sig
 end = struct
   type t = string [@@deriving show, eq]
 
+  exception Malformed_rule_ID of string
+
   let to_string x = x
 
-  (* TODO: check the validity of the rule ID (spec?) and produce a polite
-     and informative error message describing the expected format. *)
-  let of_string x = x
+  let validate =
+    let rex = SPcre.regexp "^[a-zA-Z0-9._-]*$" in
+    fun str -> SPcre.pmatch_noerr ~rex str
+
+  let of_string x = if not (validate x) then raise (Malformed_rule_ID x) else x
+  let of_string_opt x = if validate x then Some x else None
   let to_string_list x = x
   let of_string_list x = x
   let compare = String.compare

--- a/src/engine/Unit_engine.ml
+++ b/src/engine/Unit_engine.ml
@@ -283,7 +283,7 @@ let match_pattern ~lang ~hook ~file ~pattern ~fix_pattern =
   in
   let rule =
     {
-      MR.id = Rule.ID.of_string "unit testing";
+      MR.id = Rule.ID.of_string "unit-testing";
       pattern;
       inside = false;
       message = "";
@@ -350,7 +350,7 @@ let regression_tests_for_lang ~polyglot_pattern_path ~with_caching files lang =
                      ~hook:(fun { Pattern_match.range_loc; _ } ->
                        let start_loc, _end_loc = range_loc in
                        E.error
-                         (Rule.ID.of_string "test pattern")
+                         (Rule.ID.of_string "test-pattern")
                          start_loc "" Out.SemgrepMatchFound)
                      ~file ~pattern ~fix_pattern
                  in

--- a/src/experiments/synthesizing/Unit_synthesizer_targets.ml
+++ b/src/experiments/synthesizing/Unit_synthesizer_targets.ml
@@ -59,7 +59,7 @@ let ranges_matched lang file pattern : Range.t list =
   let ast = parse_file lang file in
   let rule =
     {
-      Mini_rule.id = Rule.ID.of_string "unit testing";
+      Mini_rule.id = Rule.ID.of_string "unit-testing";
       pattern;
       inside = false;
       message = "";
@@ -78,7 +78,7 @@ let ranges_matched lang file pattern : Range.t list =
         let minii, _maxii = Tok_range.min_max_toks_by_pos toks in
         let minii_loc = Tok.unsafe_loc_of_tok minii in
         E.error
-          (Rule.ID.of_string "Synthesizer tests")
+          (Rule.ID.of_string "Synthesizer-tests")
           minii_loc "" Out.SemgrepMatchFound)
       (Rule_options.default_config, equiv)
       [ rule ] (file, lang, ast)

--- a/src/parsing/Parse_rule.ml
+++ b/src/parsing/Parse_rule.ml
@@ -1795,7 +1795,7 @@ let parse_and_filter_invalid_rules file = parse_file ~error_recovery:true file
 let parse_xpattern xlang (str, tok) =
   let env =
     {
-      id = Rule.ID.of_string "-e/-f";
+      id = Rule.ID.of_string "anon-pattern";
       languages = Rule.languages_of_xlang xlang;
       in_metavariable_pattern = false;
       path = [];

--- a/src/runner/Run_semgrep.ml
+++ b/src/runner/Run_semgrep.ml
@@ -943,7 +943,7 @@ let semgrep_with_rules_and_formatted_output config =
 
 let minirule_of_pattern lang pattern_string pattern =
   {
-    MR.id = Rule.ID.of_string "-e/-f";
+    MR.id = Rule.ID.of_string "anon-pattern";
     pattern_string;
     pattern;
     inside = false;


### PR DESCRIPTION
Note that rule ID validation is already performed by the Python CLI. This fixes IDs assigned to auto-created rules. This should not break existing semgrep user setups.

I don't think this should affect users by I added a changelog entry just in case.

test plan: `make test` (or CI)

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
