### PR TITLE
sophia/pa-2807 limit core autodetect to 16 

### DIFF
--- a/changelog.d/pa-2807.changed
+++ b/changelog.d/pa-2807.changed
@@ -1,0 +1,1 @@
+Updated the maximum number of cores autodetected to 16 to prevent overloading on large machines when users do not specify number of jobs themselves

--- a/cli/src/semgrep/engine.py
+++ b/cli/src/semgrep/engine.py
@@ -63,7 +63,8 @@ class EngineType(Enum):
     def default_jobs(self) -> int:
         if self == EngineType.PRO_INTERFILE:
             return 1
-        return self.get_cpu_count()
+
+        return min(16, self.get_cpu_count())
 
     @property
     def default_max_memory(self) -> int:

--- a/cli/src/semgrep/engine.py
+++ b/cli/src/semgrep/engine.py
@@ -63,7 +63,7 @@ class EngineType(Enum):
     def default_jobs(self) -> int:
         if self == EngineType.PRO_INTERFILE:
             return 1
-        """Maxing out number of cores used to 16 if more not requested to not overload on large machines"""
+        # Maxing out number of cores used to 16 if more not requested to not overload on large machines
         return min(16, self.get_cpu_count())
 
     @property

--- a/cli/src/semgrep/engine.py
+++ b/cli/src/semgrep/engine.py
@@ -63,7 +63,7 @@ class EngineType(Enum):
     def default_jobs(self) -> int:
         if self == EngineType.PRO_INTERFILE:
             return 1
-
+        """Maxing out number of cores used to 16 if more not requested to not overload on large machines"""
         return min(16, self.get_cpu_count())
 
     @property

--- a/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -103,7 +103,10 @@ let default : conf =
     (* alt: could move in a Core_runner.default *)
     core_runner_conf =
       {
-        Core_runner.num_jobs = Parmap_helpers.get_cpu_count ();
+        (* Maxing out number of cores used to 16 if more not requested to
+         * not overload on large machines
+         *)
+        Core_runner.num_jobs = Int.min 16 (Parmap_helpers.get_cpu_count ());
         timeout = 30.0 (* seconds *);
         timeout_threshold = 3;
         max_memory_mb = 0;


### PR DESCRIPTION
Semgrep's memory usage grows linearly with the number of jobs. For now, limiting --jobs to 16 when autodetected. Otherwise, we can get into a situation where we detect a large number of underlying CPU cores, but the customer hasn't allocated a corresponding amount of memory.

Test Plan: For now tested by setting the max cores to 4, on a 10 core machine. Checked to see that this would run with 4 when no value given for jobs, but would run as 10 when set explicitly to 10 by user. 

PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
