### PR TITLE
devops: cleanup osx-release.sh

### DIFF
--- a/.github/workflows/build-test-osx-m1.yaml
+++ b/.github/workflows/build-test-osx-m1.yaml
@@ -40,8 +40,8 @@ jobs:
           zip -r artifacts.zip artifacts
       - uses: actions/upload-artifact@v3
         with:
-          name: semgrep-m1-${{ github.sha }}
           path: artifacts.zip
+          name: semgrep-m1-${{ github.sha }}
 
   build-wheels-m1:
     runs-on: [self-hosted, macOS, ARM64]
@@ -60,8 +60,8 @@ jobs:
         run: ./scripts/build-wheels.sh
       - uses: actions/upload-artifact@v3
         with:
-          name: m1-wheel
           path: cli/dist.zip
+          name: m1-wheel
 
   test-wheels-m1:
     runs-on: [self-hosted, macOS, ARM64]

--- a/.github/workflows/build-test-osx-m1.yaml
+++ b/.github/workflows/build-test-osx-m1.yaml
@@ -32,7 +32,12 @@ jobs:
           # M1 builds failing due to a permissions issue. this cleanup is an optimization,
           # and we can revisit re-enabling cleanup when we have more time/resources to debug.
           HOMEBREW_NO_INSTALL_CLEANUP: "true"
-        run: ./scripts/osx-release.sh
+        run: |
+          ./scripts/osx-setup-for-release.sh
+          make core
+          mkdir -p artifacts
+          cp ./bin/semgrep-core artifacts
+          zip -r artifacts.zip artifacts
       - uses: actions/upload-artifact@v3
         with:
           name: semgrep-m1-${{ github.sha }}

--- a/.github/workflows/build-test-osx-m1.yaml
+++ b/.github/workflows/build-test-osx-m1.yaml
@@ -34,7 +34,7 @@ jobs:
           HOMEBREW_NO_INSTALL_CLEANUP: "true"
         run: |
           ./scripts/osx-setup-for-release.sh
-          make core
+          opam exec -- make core
           mkdir -p artifacts
           cp ./bin/semgrep-core artifacts
           zip -r artifacts.zip artifacts

--- a/.github/workflows/build-test-osx-x86.yaml
+++ b/.github/workflows/build-test-osx-x86.yaml
@@ -23,7 +23,7 @@ jobs:
           submodules: true
       - run: |
           ./scripts/osx-setup-for-release.sh
-          make core
+          opam exec -- make core
           mkdir -p artifacts
           cp ./bin/semgrep-core artifacts
           zip -r artifacts.zip artifacts

--- a/.github/workflows/build-test-osx-x86.yaml
+++ b/.github/workflows/build-test-osx-x86.yaml
@@ -21,11 +21,16 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - run: ./scripts/osx-release.sh
+      - run: |
+          ./scripts/osx-setup-for-release.sh
+          make core
+          mkdir -p artifacts
+          cp ./bin/semgrep-core artifacts
+          zip -r artifacts.zip artifacts
       - uses: actions/upload-artifact@v3
         with:
-          name: semgrep-osx-${{ github.sha }}
           path: artifacts.zip
+          name: semgrep-osx-${{ github.sha }}
 
   build-wheels-osx:
     runs-on: macos-12
@@ -44,8 +49,8 @@ jobs:
         run: ./scripts/build-wheels.sh
       - uses: actions/upload-artifact@v3
         with:
-          name: osx-wheel
           path: cli/dist.zip
+          name: osx-wheel
 
   test-wheels-osx:
     runs-on: macos-12

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ build:
 	cd cli && pipenv install --dev
 	$(MAKE) -C cli build
 
-# was the 'all' target in in semgrep-core/Makefile before
+#history: was the 'all' target in in semgrep-core/Makefile before
 .PHONY: core
 core:
 	$(MAKE) minimal-build
@@ -114,23 +114,17 @@ build-docker:
 # Build just this executable
 .PHONY: build-otarzan
 build-otarzan:
-	rm -f bin
 	dune build _build/install/default/bin/otarzan
-	test -e bin || ln -s _build/install/default/bin .
 
 # Build just this executable
 .PHONY: build-pfff
 build-pfff:
-	rm -f bin
 	dune build _build/install/default/bin/pfff
-	test -e bin || ln -s _build/install/default/bin .
 
 # This is an example of how to build one of those parse-xxx ocaml-tree-sitter binaries
 .PHONY: build-parse-cairo
 build-parse-cairo:
-	rm -f bin
 	dune build _build/install/default/bin/parse-cairo
-	test -e bin || ln -s _build/install/default/bin .
 
 # Build the js_of_ocaml portion of the semgrep javascript packages
 # TODO: you actually can't 'cd js; make'; You first need this step

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,6 @@ build:
 # was the 'all' target in in semgrep-core/Makefile before
 .PHONY: core
 core:
-	rm -f bin
 	$(MAKE) minimal-build
 	# make executables easily accessible for manual testing:
 	test -e bin || ln -s _build/install/default/bin .

--- a/scripts/osx-setup-for-release.sh
+++ b/scripts/osx-setup-for-release.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 set -eux
 
-# Build semgrep-core for MacOS
+# Setup the environment under MacOS to build and release semgrep-core.
 
 # history: there used to be a separate osx-m1-release.sh script
-# that was mostly a copy of osx-release.sh, but now the
+# that was mostly a copy of this file, but now the
 # build steps are identical so we just have one script.
 
 # Note that this script runs from a self-hosted CI runner which
@@ -19,6 +19,7 @@ brew install opam
 
 # Some CI runners have tree-sitter preinstalled which interfere with
 # out static linking plans below so better to remove it.
+# TODO: fix setup-m1-builder.sh instead?
 brew uninstall --force tree-sitter
 
 #coupling: this should be the same version than in our Dockerfile
@@ -55,10 +56,3 @@ echo "Deleting all the tree-sitter dynamic libraries to force static linking."
 rm -f "$TREESITTER_LIBDIR"/libtree-sitter.0.0.dylib
 rm -f "$TREESITTER_LIBDIR"/libtree-sitter.0.dylib
 rm -f "$TREESITTER_LIBDIR"/libtree-sitter.dylib
-
-make core
-make core-install
-
-mkdir -p artifacts
-cp ./_build/install/default/bin/semgrep-core artifacts
-zip -r artifacts.zip artifacts


### PR DESCRIPTION
This will also help factorize code between semgrep and semgrep-pro
where we will not need anymore to have our own osx-release.sh;
we can just reuse and call the scripts under semgrep

test plan:
make
wait for CI green checks


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)