### PR TITLE
devops: cleanup build-test-javascript.yaml

### DIFF
--- a/.github/workflows/build-test-javascript.yaml
+++ b/.github/workflows/build-test-javascript.yaml
@@ -30,16 +30,8 @@ jobs:
       - name: Build semgrep
         run: |
           eval $(opam env)
-
           make install-deps-ALPINE-for-semgrep-core
           make install-deps-for-semgrep-core
-
-          # This symlink seems to be necessary because our tree-sitter langs don't
-          # explicitly include the $TREESITTER_INCDIR folder when building c++ files.
-          # I'm puzzled why we haven't hit this issue elsewhere.
-          . libs/ocaml-tree-sitter-core/tree-sitter-config.sh
-          ln -s $TREESITTER_INCDIR/tree_sitter /usr/include/tree_sitter
-
           make build-semgrep-jsoo
       - uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
I think Hannes fixed recently this C++ issue.
We should not need it anymore

test plan:
wait for green CI check


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)