### PR TITLE
Allow @ in rule id validation

### DIFF
--- a/changelog.d/gh-8038.fixed
+++ b/changelog.d/gh-8038.fixed
@@ -1,0 +1,1 @@
+Allow @ in rule ids

--- a/src/core/Rule.ml
+++ b/src/core/Rule.ml
@@ -67,7 +67,7 @@ end = struct
   let to_string x = x
 
   let validate =
-    let rex = SPcre.regexp "^[a-zA-Z0-9._-]*$" in
+    let rex = SPcre.regexp "^[a-zA-Z0-9._-@]*$" in
     fun str -> SPcre.pmatch_noerr ~rex str
 
   let of_string x = if not (validate x) then raise (Malformed_rule_ID x) else x

--- a/src/core/Rule.ml
+++ b/src/core/Rule.ml
@@ -67,7 +67,7 @@ end = struct
   let to_string x = x
 
   let validate =
-    let rex = SPcre.regexp "^[a-zA-Z0-9._-@]*$" in
+    let rex = SPcre.regexp "^[a-zA-Z0-9._@-]*$" in
     fun str -> SPcre.pmatch_noerr ~rex str
 
   let of_string x = if not (validate x) then raise (Malformed_rule_ID x) else x


### PR DESCRIPTION
PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)

Related to https://github.com/returntocorp/semgrep/pull/8026

For folks that publish their `semgrep` rules as namespaced `npm` packages the current validation would be a breaking change.

For example for rules at the path:

`node_modules/@myorg/semgrep-rules/dist/rules.yml`

This gets run as:
`"node_modules.@myorg.semgrep-rules.dist.rule-name"`

which fails with:

```
[ERROR] Fatal error at line :1:
 Rule.ID.Malformed_rule_ID("node_modules.@myorg.semgrep-rules.dist.rule-name")
====[ BEGIN error trace ]====
Rule.ID.Malformed_rule_ID("node_modules.@myorg.semgrep-rules.dist.rule-name")
Raised at Rule.ID.of_string in file "src/core/Rule.ml", line 73, characters 45-72
Called from Parse_rule.parse_one_rule in file "src/parsing/Parse_rule.ml", line 1613, characters 5-34
Called from Parse_rule.parse_generic_ast.(fun) in file "src/parsing/Parse_rule.ml", line 1709, characters 22-47
```