### PR TITLE
Pause rule ID validation in semgrep-core

### DIFF
--- a/src/core/Rule.ml
+++ b/src/core/Rule.ml
@@ -66,10 +66,17 @@ end = struct
 
   let to_string x = x
 
-  let validate =
-    let rex = SPcre.regexp "^[a-zA-Z0-9._-]*$" in
-    fun str -> SPcre.pmatch_noerr ~rex str
+  (* TODO: re-enable validation after checking that we're not
+        introducing major breakage.
+        We may need to support other characters such as '@'
+        as used in Node.js file paths.
+        See https://github.com/returntocorp/semgrep/pull/8038
 
+     let validate =
+       let rex = SPcre.regexp "^[a-zA-Z0-9._-]*$" in
+       fun str -> SPcre.pmatch_noerr ~rex str
+  *)
+  let validate _str = true
   let of_string x = if not (validate x) then raise (Malformed_rule_ID x) else x
   let of_string_opt x = if validate x then Some x else None
   let to_string_list x = x

--- a/src/core/Rule.ml
+++ b/src/core/Rule.ml
@@ -76,7 +76,7 @@ end = struct
        let rex = SPcre.regexp "^[a-zA-Z0-9._-]*$" in
        fun str -> SPcre.pmatch_noerr ~rex str
   *)
-  let validate _str = true
+  let validate str = not (str = "!!TEST!!")
   let of_string x = if not (validate x) then raise (Malformed_rule_ID x) else x
   let of_string_opt x = if validate x then Some x else None
   let to_string_list x = x

--- a/tests/rule_formats/debatable-rule-ids.yaml
+++ b/tests/rule_formats/debatable-rule-ids.yaml
@@ -1,0 +1,8 @@
+rules:
+  # Should we allow '@' in rule IDs?
+  # See https://github.com/returntocorp/semgrep/pull/8038
+  - id: "node_modules.@myorg.semgrep-rules.dist.rule-name"
+    pattern: zzzzz
+    languages: [js]
+    severity: ERROR
+    message: uh oh

--- a/tests/rule_formats/ok-rule-ids.yaml
+++ b/tests/rule_formats/ok-rule-ids.yaml
@@ -1,0 +1,11 @@
+rules:
+  - id: "src.hello-world"
+    pattern: zzzzz
+    languages: [python]
+    severity: ERROR
+    message: uh oh
+  - id: "2..aB._zZA-876--"
+    pattern: zzzzz
+    languages: [python]
+    severity: ERROR
+    message: uh oh


### PR DESCRIPTION
Pausing rule ID validation in OCaml due to breakage in file paths containining `@` and getting translated into rule IDs. See https://github.com/returntocorp/semgrep/pull/8038

test plan: `make test`

(I added test rules to test rule IDs)

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
