### PR TITLE
osemgrep: replacing the semgrep entry point, part1, setuptools

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@
 # This config defines also 2 "jobs" with the `stages: [manual]` directive
 # which are only exercised in CI (see .github/workflows/lint.yml).
 
-exclude: "^tests|^cli/tests/e2e/(targets|snapshots|rules/syntax)|^cli/src/semgrep/external|^cli/src/semdep/external|\\binvalid\\b|TOPORT"
+exclude: "^tests|^cli/tests/e2e/(targets|snapshots|rules/syntax)|^cli/src/semgrep/external|^cli/src/semdep/external|^cli/bin|\\binvalid\\b|TOPORT"
 default_stages: [commit]
 # See https://pre-commit.com/#pre-commit-configyaml---repos
 # for more information on the format of the content below

--- a/cli/bin/semgrep
+++ b/cli/bin/semgrep
@@ -2,8 +2,5 @@
 # TODO: for now this file is a python script, but the idea is to
 # replace it with a bash script that calls osemgrep at some point
 import sys
-
-from semgrep.__main__ import main
-
-if __name__ == "__main__":
-    sys.exit(main())
+import semgrep.__main__
+sys.exit(semgrep.__main__.main())

--- a/cli/bin/semgrep
+++ b/cli/bin/semgrep
@@ -1,0 +1,9 @@
+#!/usr/bin/env python3
+# TODO: for now this file is a python script, but the idea is to
+# replace it with a bash script that calls osemgrep at some point
+import sys
+
+from semgrep.__main__ import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -157,7 +157,7 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/returntocorp/semgrep",
-    entry_points={"console_scripts": ["semgrep=semgrep.__main__:main"]},
+    scripts=["bin/semgrep"],
     packages=setuptools.find_packages(where="src"),
     package_dir={"": "src"},
     package_data={"semgrep": [os.path.join(BIN_DIR, "*")]},


### PR DESCRIPTION
This just does the minimum change to our python setuptools,
to see if nothing break

test plan:
pipenv install --dev
pipenv shell
semgrep --help still works


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)