### PR TITLE
fix(interactive): silly typo

### DIFF
--- a/src/osemgrep/cli_interactive/Zipper.ml
+++ b/src/osemgrep/cli_interactive/Zipper.ml
@@ -60,6 +60,6 @@ let append = Framed_zipper.append
 let position = Framed_zipper.absolute_position
 let length = Framed_zipper.length
 let is_top = Framed_zipper.is_top
-let is_bottom = Framed_zipper.is_top
+let is_bottom = Framed_zipper.is_bottom
 let get_current = Framed_zipper.get_current
 let map_current = Framed_zipper.map_current


### PR DESCRIPTION
## What:
This PR fixes a silly typo. I am a professional software engineer.

At some point, I need to figure out a good way to test Interactive Mode.

## Test plan:
This causes Pattern Builder to no longer break when scrolling the pattern zipper

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
