### PR TITLE
Sophia/7992 adding date comparison Closes #7992

### DIFF
--- a/changelog.d/pa-2807.changed
+++ b/changelog.d/pa-2807.changed
@@ -1,0 +1,1 @@
+Updated the maximum number of cores autodetected to 16 to prevent overloading on large machines when users do not specify number of jobs themselves

--- a/changelog.d/pa-7992.added
+++ b/changelog.d/pa-7992.added
@@ -1,0 +1,2 @@
+Added support for date comparison and functionality to get current date.
+Currently this requires date strings to be in the format "yyyy-mm-dd" next step is to support other formats.

--- a/cli/src/semgrep/engine.py
+++ b/cli/src/semgrep/engine.py
@@ -63,7 +63,8 @@ class EngineType(Enum):
     def default_jobs(self) -> int:
         if self == EngineType.PRO_INTERFILE:
             return 1
-        return self.get_cpu_count()
+
+        return min(16, self.get_cpu_count())
 
     @property
     def default_max_memory(self) -> int:

--- a/cli/src/semgrep/engine.py
+++ b/cli/src/semgrep/engine.py
@@ -63,7 +63,7 @@ class EngineType(Enum):
     def default_jobs(self) -> int:
         if self == EngineType.PRO_INTERFILE:
             return 1
-        """Maxing out number of cores used to 16 if more not requested to not overload on large machines"""
+        # Maxing out number of cores used to 16 if more not requested to not overload on large machines
         return min(16, self.get_cpu_count())
 
     @property

--- a/cli/src/semgrep/engine.py
+++ b/cli/src/semgrep/engine.py
@@ -63,7 +63,7 @@ class EngineType(Enum):
     def default_jobs(self) -> int:
         if self == EngineType.PRO_INTERFILE:
             return 1
-
+        """Maxing out number of cores used to 16 if more not requested to not overload on large machines"""
         return min(16, self.get_cpu_count())
 
     @property

--- a/src/engine/Eval_generic.ml
+++ b/src/engine/Eval_generic.ml
@@ -217,10 +217,15 @@ let rec eval env code =
               match
                 (int_of_string_opt y, int_of_string_opt m, int_of_string_opt d)
               with
-              | Some a, Some b, Some c -> Date (a, b, c)
+              | Some yv, Some mv, Some dv ->
+                  if CalendarLib.Date.is_valid_date yv mv dv then
+                    Date (yv, mv, dv)
+                  else raise (NotHandled code)
               | _ -> raise (NotHandled code))
           | _ -> raise (NotHandled code))
       | __else__ -> raise (NotHandled code))
+  | G.Call ({ e = G.N (G.Id (("current_date", _), _)); _ }, (_, _, _)) ->
+      Date (2023, 6, 26)
   (* Emulate Python re.match just enough *)
   | G.Call
       ( {
@@ -348,7 +353,7 @@ and eval_str _env ~code v =
     | Float f -> string_of_float f
     | String s -> s
     | Date (y, m, d) ->
-        string_of_int y ^ string_of_int m ^ string_of_int d
+        string_of_int y ^ "-" ^ string_of_int m ^ "-" ^ string_of_int d
         (*TODO: change this A LOT*)
     | AST s -> s
     | List _ -> raise (NotHandled code)

--- a/src/engine/Eval_generic.ml
+++ b/src/engine/Eval_generic.ml
@@ -207,7 +207,7 @@ let rec eval env code =
   (* Convert string to date
      Todo: date validity checker
      https://semgrep.dev/playground/s/ZoLW possible test *)
-  | G.Call ({ e = G.N (G.Id (("date", _), _)); _ }, (_, [ Arg e ], _)) -> (
+  | G.Call ({ e = G.N (G.Id (("strptime", _), _)); _ }, (_, [ Arg e ], _)) -> (
       let v = eval env e in
       match v with
       | String s -> (

--- a/src/engine/Eval_generic.ml
+++ b/src/engine/Eval_generic.ml
@@ -45,6 +45,8 @@ type value =
   | Float of float
   | String of string (* string without the enclosing '"' *)
   | List of value list
+  | Date of int * int * int
+  (*year, month, date for now, can maybe add support for other formats later?*)
   (* default case where we don't really have good builtin operations.
    * This should be a AST_generic.any once parsed.
    * See JSON_report.json_metavar().
@@ -202,6 +204,23 @@ let rec eval env code =
   | G.Call ({ e = G.N (G.Id (("str", _), _)); _ }, (_, [ G.Arg e ], _)) ->
       let v = eval env e in
       eval_str env ~code v
+  (* Convert string to date
+     Todo: date validity checker
+     https://semgrep.dev/playground/s/ZoLW possible test *)
+  | G.Call ({ e = G.N (G.Id (("date", _), _)); _ }, (_, [ Arg e ], _)) -> (
+      let v = eval env e in
+      match v with
+      | String s -> (
+          let yyyy_mm_dd = String.split_on_char '-' s in
+          match yyyy_mm_dd with
+          | [ y; m; d ] -> (
+              match
+                (int_of_string_opt y, int_of_string_opt m, int_of_string_opt d)
+              with
+              | Some a, Some b, Some c -> Date (a, b, c)
+              | _ -> raise (NotHandled code))
+          | _ -> raise (NotHandled code))
+      | __else__ -> raise (NotHandled code))
   (* Emulate Python re.match just enough *)
   | G.Call
       ( {
@@ -246,18 +265,28 @@ and eval_op op values code =
   | G.Gt, [ Float i1; Float i2 ] -> Bool (i1 > i2)
   | G.Gt, [ Int i1; Float i2 ] -> Bool (float_of_int i1 > i2)
   | G.Gt, [ Float i1; Int i2 ] -> Bool (i1 > float_of_int i2)
+  | G.Gt, [ Date (y1, m1, d1); Date (y2, m2, d2) ] ->
+      Bool
+        (if y1 =*= y2 then if m1 =*= m2 then d1 > d2 else m1 > m2 else y1 > y2)
   | G.GtE, [ Int i1; Int i2 ] -> Bool (i1 >= i2)
   | G.GtE, [ Float i1; Float i2 ] -> Bool (i1 >= i2)
   | G.GtE, [ Int i1; Float i2 ] -> Bool (float_of_int i1 >= i2)
   | G.GtE, [ Float i1; Int i2 ] -> Bool (i1 >= float_of_int i2)
+  | G.GtE, [ Date (y1, m1, d1); Date (y2, m2, d2) ] ->
+      Bool (if y1 >= y2 then true else if m1 >= m2 then true else d1 >= d2)
   | G.Lt, [ Int i1; Int i2 ] -> Bool (i1 < i2)
   | G.Lt, [ Float i1; Float i2 ] -> Bool (i1 < i2)
   | G.Lt, [ Int i1; Float i2 ] -> Bool (float_of_int i1 < i2)
   | G.Lt, [ Float i1; Int i2 ] -> Bool (i1 < float_of_int i2)
+  | G.Lt, [ Date (y1, m1, d1); Date (y2, m2, d2) ] ->
+      Bool
+        (if y1 =*= y2 then if m1 =*= m2 then d1 < d2 else m1 < m2 else y1 < y2)
   | G.LtE, [ Int i1; Int i2 ] -> Bool (i1 <= i2)
   | G.LtE, [ Float i1; Float i2 ] -> Bool (i1 <= i2)
   | G.LtE, [ Int i1; Float i2 ] -> Bool (float_of_int i1 <= i2)
   | G.LtE, [ Float i1; Int i2 ] -> Bool (i1 <= float_of_int i2)
+  | G.LtE, [ Date (y1, m1, d1); Date (y2, m2, d2) ] ->
+      Bool (if y1 >= y2 then true else if m1 >= m2 then true else d1 >= d2)
   | G.Div, [ Int i1; Int i2 ] -> Int (i1 / i2)
   | G.Div, [ Float i1; Float i2 ] -> Float (i1 /. i2)
   | G.Div, [ Int i1; Float i2 ] -> Float (float_of_int i1 /. i2)
@@ -318,6 +347,9 @@ and eval_str _env ~code v =
     | Int i -> string_of_int i
     | Float f -> string_of_float f
     | String s -> s
+    | Date (y, m, d) ->
+        string_of_int y ^ string_of_int m ^ string_of_int d
+        (*TODO: change this A LOT*)
     | AST s -> s
     | List _ -> raise (NotHandled code)
   in

--- a/src/engine/Eval_generic.mli
+++ b/src/engine/Eval_generic.mli
@@ -5,6 +5,7 @@ type value =
   (* the string does not contain the enclosing '"' *)
   | String of string
   | List of value list
+  | Date of int * int * int
   (* any AST, e.g., "x+1" *)
   | AST of string
 

--- a/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -103,7 +103,10 @@ let default : conf =
     (* alt: could move in a Core_runner.default *)
     core_runner_conf =
       {
-        Core_runner.num_jobs = Parmap_helpers.get_cpu_count ();
+        (* Maxing out number of cores used to 16 if more not requested to
+         * not overload on large machines
+         *)
+        Core_runner.num_jobs = Int.min 16 (Parmap_helpers.get_cpu_count ());
         timeout = 30.0 (* seconds *);
         timeout_threshold = 3;
         max_memory_mb = 0;


### PR DESCRIPTION
This adds the functionality requested in issue 7992. Currently supports strptime("yyyy-mm-dd") only as a way to create a date. Also has today() to get the current date, again currently supporting only year, month, and date. 

PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
