### PR TITLE
refactor: Expose Typing.guess_type_of_dotaccess

### DIFF
--- a/src/typing/Typing.ml
+++ b/src/typing/Typing.ml
@@ -250,13 +250,13 @@ let name_and_targs_of_named_type lang = function
  *
  * For example, in Java we guess that `x.equals(y)` returns a `boolean`, even if
  * we don't know the type of `x`. *)
-let guess_type_of_dotaccess lang obj_ty str =
+let guess_type_of_dotaccess lang ty_name_and_targs str =
   (* TODO: The types of the parameters should just be computed from the actuals. *)
   let todo_param =
     (* Param type could be Top if we add that as a type *)
     Type.Param { pident = None; ptype = Type.NoType }
   in
-  match (lang, name_and_targs_of_named_type lang obj_ty, str) with
+  match (lang, ty_name_and_targs, str) with
   | Lang.Java, _, "isEmpty" -> Type.Function ([], Type.Builtin Type.Bool)
   | Lang.Java, _, ("equals" | "contains" | "containsKey" | "containsValue") ->
       (* Really the return type is all that matters. We could add the parameters
@@ -312,7 +312,8 @@ let typing_visitor =
             _ ) -> (
           let obj_ty, _ = type_of_expr lang obj in
           let guessed_type =
-            guess_type_of_dotaccess lang obj_ty id_str
+            let ty_name_and_targs = name_and_targs_of_named_type lang obj_ty in
+            guess_type_of_dotaccess lang ty_name_and_targs id_str
             |> Type.to_ast_generic_type_ lang (fun name _alts -> name)
           in
           match guessed_type with

--- a/src/typing/Typing.mli
+++ b/src/typing/Typing.mli
@@ -9,3 +9,9 @@ val resolved_type_of_id_info :
   Lang.t -> AST_generic.id_info -> AST_generic.name Type.t
 
 val check_program : Lang.t -> AST_generic.program -> unit
+
+(* Guesses the type of a dotaccess using language-specific heuristics.
+ *
+ * Exposed for use in Pro Engine. *)
+val guess_type_of_dotaccess :
+  Lang.t -> (string * 'a Type.type_argument list) option -> string -> 'a Type.t


### PR DESCRIPTION
We'd like to use it in Pro Engine

Test plan: Automated tests

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
