### PR TITLE
refactor: Add autogenerated mapper for Type.t

### DIFF
--- a/src/core/Type.ml
+++ b/src/core/Type.ml
@@ -31,12 +31,25 @@ let logger = Logging.get_logger [ __MODULE__ ]
  *)
 
 (*****************************************************************************)
+(* Visitor Helpers *)
+(*****************************************************************************)
+
+class virtual ['self] map_parent =
+  object (_self : 'self)
+    (* Could inherit from the AST_generic visitor but we just need this one
+     * thing, and it's just a string list so there's not really a need to
+     * recurse down. We should put alternate names in the type parameter anyway.
+     * *)
+    method visit_alternate_name _env x = x
+  end
+
+(*****************************************************************************)
 (* Types *)
 (*****************************************************************************)
-type todo_kind = string option [@@deriving show, eq]
+type todo_kind = string option
 
 (* Fully qualified name *)
-type 'resolved name = 'resolved * 'resolved type_argument list
+and 'resolved name = 'resolved * 'resolved type_argument list
 and 'resolved type_argument = TA of 'resolved t | OtherTypeArg of todo_kind
 
 and 'resolved t =
@@ -81,7 +94,10 @@ and 'resolved parameter_classic = {
   pident : string option;
   ptype : 'resolved t;
 }
-[@@deriving show { with_path = false }, eq]
+[@@deriving
+  show { with_path = false },
+    eq,
+    visitors { variety = "map"; ancestors = [ "map_parent" ] }]
 
 (*****************************************************************************)
 (* Helpers *)

--- a/src/core/dune
+++ b/src/core/dune
@@ -29,6 +29,7 @@
      ppx_deriving.show
      ppx_deriving.eq
      ppx_hash
+     visitors.ppx
    )
  )
 )


### PR DESCRIPTION
This is going to be useful in a variety of contexts. For example, applying type parameters or converting from one resolved name type to another.

Test plan: Automated tests

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
