### PR TITLE
circleCI: switch to semgrep user

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
   semgrep:
     docker:
       - image: returntocorp/semgrep:develop
-        user: root
+        user: semgrep
     working_directory: /src
     steps:
       - checkout


### PR DESCRIPTION
This follows https://github.com/returntocorp/semgrep/pull/7972

test plan:
wait for green check in CI for circleCI


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)