### PR TITLE
pysemgrep: use ATD classes in app/scans.py

### DIFF
--- a/cli/src/semgrep/app/scans.py
+++ b/cli/src/semgrep/app/scans.py
@@ -282,9 +282,7 @@ class ScanHandler:
         new_ignored, new_matches = partition(
             all_matches, lambda match: bool(match.is_ignored)
         )
-        findings = [
-            match.to_app_finding_format(commit_date).to_json() for match in new_matches
-        ]
+        findings = [match.to_app_finding_format(commit_date) for match in new_matches]
         ignores = [
             match.to_app_finding_format(commit_date).to_json() for match in new_ignored
         ]

--- a/cli/src/semgrep/app/scans.py
+++ b/cli/src/semgrep/app/scans.py
@@ -305,7 +305,8 @@ class ScanHandler:
             gitlab_token=None,
         )
         # TODO: add those fields in semgrep_output_v1.atd spec
-        findings_and_ignores = api_scans_findings.to_json() + {
+        findings_and_ignores = {
+            **api_scans_findings.to_json(),
             "renamed_paths": [str(rt) for rt in sorted(renamed_targets)],
             "ignores": ignores,
         }

--- a/cli/src/semgrep/app/scans.py
+++ b/cli/src/semgrep/app/scans.py
@@ -18,6 +18,7 @@ import click
 import requests
 from boltons.iterutils import partition
 
+import semgrep.semgrep_interfaces.semgrep_output_v1 as out
 from semdep.parsers.util import DependencyParserError
 from semgrep.constants import DEFAULT_SEMGREP_APP_CONFIG_URL
 from semgrep.constants import RuleSeverity
@@ -25,7 +26,6 @@ from semgrep.error import SemgrepError
 from semgrep.parsing_data import ParsingData
 from semgrep.rule import Rule
 from semgrep.rule_match import RuleMatchMap
-from semgrep.semgrep_interfaces.semgrep_output_v1 import FoundDependency
 from semgrep.state import get_state
 from semgrep.verbose_logging import getLogger
 
@@ -248,7 +248,7 @@ class ScanHandler:
         parse_rate: ParsingData,
         total_time: float,
         commit_date: str,
-        lockfile_dependencies: Dict[str, List[FoundDependency]],
+        lockfile_dependencies: Dict[str, List[out.FoundDependency]],
         dependency_parser_errors: List[DependencyParserError],
         engine_requested: "EngineType",
     ) -> Tuple[bool, str]:
@@ -297,14 +297,18 @@ class ScanHandler:
             or os.getenv("BITBUCKET_TOKEN")
         )
 
-        findings_and_ignores = {
+        api_scans_findings = out.ApiScansFindings(
             # send a backup token in case the app is not available
-            "token": token,
-            "findings": findings,
-            "searched_paths": [str(t) for t in sorted(targets)],
+            token=token,
+            findings=findings,
+            searched_paths=[str(t) for t in sorted(targets)],
+            rule_ids=rule_ids,
+            cai_ids=cai_ids,
+            gitlab_token=None,
+        )
+        # TODO: add those fields in semgrep_output_v1.atd spec
+        findings_and_ignores = api_scans_findings.to_json() + {
             "renamed_paths": [str(rt) for rt in sorted(renamed_targets)],
-            "rule_ids": rule_ids,
-            "cai_ids": cai_ids,
             "ignores": ignores,
         }
 

--- a/cli/tests/e2e/snapshots/test_ci/test_dryrun/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_dryrun/results.txt
@@ -106,7 +106,6 @@ CI scan completed successfully.
   Found 8 findings (6 blocking) from 6 rules.
   Uploading findings.
 Would have sent findings and ignores blob: {
-    "token": null,
     "findings": [
         {
             "check_id": "taint-test",
@@ -419,12 +418,13 @@ Would have sent findings and ignores blob: {
             }
         }
     ],
+    "token": null,
+    "gitlab_token": null,
     "searched_paths": [
         "foo.py",
         "poetry.lock",
         "yarn.lock"
     ],
-    "renamed_paths": [],
     "rule_ids": [
         "eqeq-bad",
         "eqeq-five",
@@ -434,6 +434,7 @@ Would have sent findings and ignores blob: {
         "supply-chain2"
     ],
     "cai_ids": [],
+    "renamed_paths": [],
     "ignores": [
         {
             "check_id": "eqeq-four",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines-overwrite-autodetected-variables/findings_and_ignores.json
@@ -1,5 +1,4 @@
 {
-  "token": null,
   "findings": [
     {
       "check_id": "taint-test",
@@ -315,12 +314,13 @@
       }
     }
   ],
+  "token": null,
+  "gitlab_token": null,
   "searched_paths": [
     "foo.py",
     "poetry.lock",
     "yarn.lock"
   ],
-  "renamed_paths": [],
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
@@ -330,6 +330,7 @@
     "supply-chain2"
   ],
   "cai_ids": [],
+  "renamed_paths": [],
   "ignores": [
     {
       "check_id": "eqeq-four",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines/findings_and_ignores.json
@@ -1,5 +1,4 @@
 {
-  "token": null,
   "findings": [
     {
       "check_id": "taint-test",
@@ -315,12 +314,13 @@
       }
     }
   ],
+  "token": null,
+  "gitlab_token": null,
   "searched_paths": [
     "foo.py",
     "poetry.lock",
     "yarn.lock"
   ],
-  "renamed_paths": [],
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
@@ -330,6 +330,7 @@
     "supply-chain2"
   ],
   "cai_ids": [],
+  "renamed_paths": [],
   "ignores": [
     {
       "check_id": "eqeq-four",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket-overwrite-autodetected-variables/findings_and_ignores.json
@@ -1,5 +1,4 @@
 {
-  "token": null,
   "findings": [
     {
       "check_id": "taint-test",
@@ -315,12 +314,13 @@
       }
     }
   ],
+  "token": null,
+  "gitlab_token": null,
   "searched_paths": [
     "foo.py",
     "poetry.lock",
     "yarn.lock"
   ],
-  "renamed_paths": [],
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
@@ -330,6 +330,7 @@
     "supply-chain2"
   ],
   "cai_ids": [],
+  "renamed_paths": [],
   "ignores": [
     {
       "check_id": "eqeq-four",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket/findings_and_ignores.json
@@ -1,5 +1,4 @@
 {
-  "token": null,
   "findings": [
     {
       "check_id": "taint-test",
@@ -315,12 +314,13 @@
       }
     }
   ],
+  "token": null,
+  "gitlab_token": null,
   "searched_paths": [
     "foo.py",
     "poetry.lock",
     "yarn.lock"
   ],
-  "renamed_paths": [],
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
@@ -330,6 +330,7 @@
     "supply-chain2"
   ],
   "cai_ids": [],
+  "renamed_paths": [],
   "ignores": [
     {
       "check_id": "eqeq-four",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite-overwrite-autodetected-variables/findings_and_ignores.json
@@ -1,5 +1,4 @@
 {
-  "token": null,
   "findings": [
     {
       "check_id": "taint-test",
@@ -315,12 +314,13 @@
       }
     }
   ],
+  "token": null,
+  "gitlab_token": null,
   "searched_paths": [
     "foo.py",
     "poetry.lock",
     "yarn.lock"
   ],
-  "renamed_paths": [],
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
@@ -330,6 +330,7 @@
     "supply-chain2"
   ],
   "cai_ids": [],
+  "renamed_paths": [],
   "ignores": [
     {
       "check_id": "eqeq-four",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite/findings_and_ignores.json
@@ -1,5 +1,4 @@
 {
-  "token": null,
   "findings": [
     {
       "check_id": "taint-test",
@@ -315,12 +314,13 @@
       }
     }
   ],
+  "token": null,
+  "gitlab_token": null,
   "searched_paths": [
     "foo.py",
     "poetry.lock",
     "yarn.lock"
   ],
-  "renamed_paths": [],
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
@@ -330,6 +330,7 @@
     "supply-chain2"
   ],
   "cai_ids": [],
+  "renamed_paths": [],
   "ignores": [
     {
       "check_id": "eqeq-four",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci-overwrite-autodetected-variables/findings_and_ignores.json
@@ -1,5 +1,4 @@
 {
-  "token": null,
   "findings": [
     {
       "check_id": "taint-test",
@@ -315,12 +314,13 @@
       }
     }
   ],
+  "token": null,
+  "gitlab_token": null,
   "searched_paths": [
     "foo.py",
     "poetry.lock",
     "yarn.lock"
   ],
-  "renamed_paths": [],
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
@@ -330,6 +330,7 @@
     "supply-chain2"
   ],
   "cai_ids": [],
+  "renamed_paths": [],
   "ignores": [
     {
       "check_id": "eqeq-four",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci/findings_and_ignores.json
@@ -1,5 +1,4 @@
 {
-  "token": null,
   "findings": [
     {
       "check_id": "taint-test",
@@ -315,12 +314,13 @@
       }
     }
   ],
+  "token": null,
+  "gitlab_token": null,
   "searched_paths": [
     "foo.py",
     "poetry.lock",
     "yarn.lock"
   ],
-  "renamed_paths": [],
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
@@ -330,6 +330,7 @@
     "supply-chain2"
   ],
   "cai_ids": [],
+  "renamed_paths": [],
   "ignores": [
     {
       "check_id": "eqeq-four",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/findings_and_ignores.json
@@ -1,5 +1,4 @@
 {
-  "token": null,
   "findings": [
     {
       "check_id": "taint-test",
@@ -315,12 +314,13 @@
       }
     }
   ],
+  "token": null,
+  "gitlab_token": null,
   "searched_paths": [
     "foo.py",
     "poetry.lock",
     "yarn.lock"
   ],
-  "renamed_paths": [],
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
@@ -330,6 +330,7 @@
     "supply-chain2"
   ],
   "cai_ids": [],
+  "renamed_paths": [],
   "ignores": [
     {
       "check_id": "eqeq-four",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr-semgrepconfig/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr-semgrepconfig/findings_and_ignores.json
@@ -1,5 +1,4 @@
 {
-  "token": null,
   "findings": [
     {
       "check_id": "taint-test",
@@ -267,10 +266,11 @@
       }
     }
   ],
+  "token": null,
+  "gitlab_token": null,
   "searched_paths": [
     "foo.py"
   ],
-  "renamed_paths": [],
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
@@ -280,6 +280,7 @@
     "supply-chain2"
   ],
   "cai_ids": [],
+  "renamed_paths": [],
   "ignores": [
     {
       "check_id": "eqeq-four",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr/findings_and_ignores.json
@@ -1,5 +1,4 @@
 {
-  "token": null,
   "findings": [
     {
       "check_id": "taint-test",
@@ -267,10 +266,11 @@
       }
     }
   ],
+  "token": null,
+  "gitlab_token": null,
   "searched_paths": [
     "foo.py"
   ],
-  "renamed_paths": [],
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
@@ -280,6 +280,7 @@
     "supply-chain2"
   ],
   "cai_ids": [],
+  "renamed_paths": [],
   "ignores": [
     {
       "check_id": "eqeq-four",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push-special-env-vars/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push-special-env-vars/findings_and_ignores.json
@@ -1,5 +1,4 @@
 {
-  "token": null,
   "findings": [
     {
       "check_id": "taint-test",
@@ -315,12 +314,13 @@
       }
     }
   ],
+  "token": null,
+  "gitlab_token": null,
   "searched_paths": [
     "foo.py",
     "poetry.lock",
     "yarn.lock"
   ],
-  "renamed_paths": [],
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
@@ -330,6 +330,7 @@
     "supply-chain2"
   ],
   "cai_ids": [],
+  "renamed_paths": [],
   "ignores": [
     {
       "check_id": "eqeq-four",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/findings_and_ignores.json
@@ -1,5 +1,4 @@
 {
-  "token": null,
   "findings": [
     {
       "check_id": "taint-test",
@@ -315,12 +314,13 @@
       }
     }
   ],
+  "token": null,
+  "gitlab_token": null,
   "searched_paths": [
     "foo.py",
     "poetry.lock",
     "yarn.lock"
   ],
-  "renamed_paths": [],
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
@@ -330,6 +330,7 @@
     "supply-chain2"
   ],
   "cai_ids": [],
+  "renamed_paths": [],
   "ignores": [
     {
       "check_id": "eqeq-four",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-push/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-push/findings_and_ignores.json
@@ -1,5 +1,4 @@
 {
-  "token": null,
   "findings": [
     {
       "check_id": "taint-test",
@@ -315,12 +314,13 @@
       }
     }
   ],
+  "token": null,
+  "gitlab_token": null,
   "searched_paths": [
     "foo.py",
     "poetry.lock",
     "yarn.lock"
   ],
-  "renamed_paths": [],
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
@@ -330,6 +330,7 @@
     "supply-chain2"
   ],
   "cai_ids": [],
+  "renamed_paths": [],
   "ignores": [
     {
       "check_id": "eqeq-four",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-special-env-vars/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-special-env-vars/findings_and_ignores.json
@@ -1,5 +1,4 @@
 {
-  "token": null,
   "findings": [
     {
       "check_id": "taint-test",
@@ -267,10 +266,11 @@
       }
     }
   ],
+  "token": null,
+  "gitlab_token": null,
   "searched_paths": [
     "foo.py"
   ],
-  "renamed_paths": [],
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
@@ -280,6 +280,7 @@
     "supply-chain2"
   ],
   "cai_ids": [],
+  "renamed_paths": [],
   "ignores": [
     {
       "check_id": "eqeq-four",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab/findings_and_ignores.json
@@ -1,5 +1,4 @@
 {
-  "token": null,
   "findings": [
     {
       "check_id": "taint-test",
@@ -267,10 +266,11 @@
       }
     }
   ],
+  "token": null,
+  "gitlab_token": null,
   "searched_paths": [
     "foo.py"
   ],
-  "renamed_paths": [],
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
@@ -280,6 +280,7 @@
     "supply-chain2"
   ],
   "cai_ids": [],
+  "renamed_paths": [],
   "ignores": [
     {
       "check_id": "eqeq-four",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/findings_and_ignores.json
@@ -1,5 +1,4 @@
 {
-  "token": null,
   "findings": [
     {
       "check_id": "taint-test",
@@ -315,12 +314,13 @@
       }
     }
   ],
+  "token": null,
+  "gitlab_token": null,
   "searched_paths": [
     "foo.py",
     "poetry.lock",
     "yarn.lock"
   ],
-  "renamed_paths": [],
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
@@ -330,6 +330,7 @@
     "supply-chain2"
   ],
   "cai_ids": [],
+  "renamed_paths": [],
   "ignores": [
     {
       "check_id": "eqeq-four",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-overwrite-autodetected-variables/findings_and_ignores.json
@@ -1,5 +1,4 @@
 {
-  "token": null,
   "findings": [
     {
       "check_id": "taint-test",
@@ -315,12 +314,13 @@
       }
     }
   ],
+  "token": null,
+  "gitlab_token": null,
   "searched_paths": [
     "foo.py",
     "poetry.lock",
     "yarn.lock"
   ],
-  "renamed_paths": [],
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
@@ -330,6 +330,7 @@
     "supply-chain2"
   ],
   "cai_ids": [],
+  "renamed_paths": [],
   "ignores": [
     {
       "check_id": "eqeq-four",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins/findings_and_ignores.json
@@ -1,5 +1,4 @@
 {
-  "token": null,
   "findings": [
     {
       "check_id": "taint-test",
@@ -315,12 +314,13 @@
       }
     }
   ],
+  "token": null,
+  "gitlab_token": null,
   "searched_paths": [
     "foo.py",
     "poetry.lock",
     "yarn.lock"
   ],
-  "renamed_paths": [],
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
@@ -330,6 +330,7 @@
     "supply-chain2"
   ],
   "cai_ids": [],
+  "renamed_paths": [],
   "ignores": [
     {
       "check_id": "eqeq-four",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/findings_and_ignores.json
@@ -1,5 +1,4 @@
 {
-  "token": null,
   "findings": [
     {
       "check_id": "taint-test",
@@ -315,12 +314,13 @@
       }
     }
   ],
+  "token": null,
+  "gitlab_token": null,
   "searched_paths": [
     "foo.py",
     "poetry.lock",
     "yarn.lock"
   ],
-  "renamed_paths": [],
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
@@ -330,6 +330,7 @@
     "supply-chain2"
   ],
   "cai_ids": [],
+  "renamed_paths": [],
   "ignores": [
     {
       "check_id": "eqeq-four",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-self-hosted/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-self-hosted/findings_and_ignores.json
@@ -1,5 +1,4 @@
 {
-  "token": null,
   "findings": [
     {
       "check_id": "taint-test",
@@ -315,12 +314,13 @@
       }
     }
   ],
+  "token": null,
+  "gitlab_token": null,
   "searched_paths": [
     "foo.py",
     "poetry.lock",
     "yarn.lock"
   ],
-  "renamed_paths": [],
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
@@ -330,6 +330,7 @@
     "supply-chain2"
   ],
   "cai_ids": [],
+  "renamed_paths": [],
   "ignores": [
     {
       "check_id": "eqeq-four",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis-overwrite-autodetected-variables/findings_and_ignores.json
@@ -1,5 +1,4 @@
 {
-  "token": null,
   "findings": [
     {
       "check_id": "taint-test",
@@ -315,12 +314,13 @@
       }
     }
   ],
+  "token": null,
+  "gitlab_token": null,
   "searched_paths": [
     "foo.py",
     "poetry.lock",
     "yarn.lock"
   ],
-  "renamed_paths": [],
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
@@ -330,6 +330,7 @@
     "supply-chain2"
   ],
   "cai_ids": [],
+  "renamed_paths": [],
   "ignores": [
     {
       "check_id": "eqeq-four",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis/findings_and_ignores.json
@@ -1,5 +1,4 @@
 {
-  "token": null,
   "findings": [
     {
       "check_id": "taint-test",
@@ -315,12 +314,13 @@
       }
     }
   ],
+  "token": null,
+  "gitlab_token": null,
   "searched_paths": [
     "foo.py",
     "poetry.lock",
     "yarn.lock"
   ],
-  "renamed_paths": [],
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
@@ -330,6 +330,7 @@
     "supply-chain2"
   ],
   "cai_ids": [],
+  "renamed_paths": [],
   "ignores": [
     {
       "check_id": "eqeq-four",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-unparsable_url/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-unparsable_url/findings_and_ignores.json
@@ -1,5 +1,4 @@
 {
-  "token": null,
   "findings": [
     {
       "check_id": "taint-test",
@@ -315,12 +314,13 @@
       }
     }
   ],
+  "token": null,
+  "gitlab_token": null,
   "searched_paths": [
     "foo.py",
     "poetry.lock",
     "yarn.lock"
   ],
-  "renamed_paths": [],
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
@@ -330,6 +330,7 @@
     "supply-chain2"
   ],
   "cai_ids": [],
+  "renamed_paths": [],
   "ignores": [
     {
       "check_id": "eqeq-four",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines-overwrite-autodetected-variables/findings_and_ignores.json
@@ -1,5 +1,4 @@
 {
-  "token": null,
   "findings": [
     {
       "check_id": "taint-test",
@@ -312,12 +311,13 @@
       }
     }
   ],
+  "token": null,
+  "gitlab_token": null,
   "searched_paths": [
     "foo.py",
     "poetry.lock",
     "yarn.lock"
   ],
-  "renamed_paths": [],
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
@@ -327,6 +327,7 @@
     "supply-chain2"
   ],
   "cai_ids": [],
+  "renamed_paths": [],
   "ignores": [
     {
       "check_id": "eqeq-four",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines/findings_and_ignores.json
@@ -1,5 +1,4 @@
 {
-  "token": null,
   "findings": [
     {
       "check_id": "taint-test",
@@ -312,12 +311,13 @@
       }
     }
   ],
+  "token": null,
+  "gitlab_token": null,
   "searched_paths": [
     "foo.py",
     "poetry.lock",
     "yarn.lock"
   ],
-  "renamed_paths": [],
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
@@ -327,6 +327,7 @@
     "supply-chain2"
   ],
   "cai_ids": [],
+  "renamed_paths": [],
   "ignores": [
     {
       "check_id": "eqeq-four",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket-overwrite-autodetected-variables/findings_and_ignores.json
@@ -1,5 +1,4 @@
 {
-  "token": null,
   "findings": [
     {
       "check_id": "taint-test",
@@ -312,12 +311,13 @@
       }
     }
   ],
+  "token": null,
+  "gitlab_token": null,
   "searched_paths": [
     "foo.py",
     "poetry.lock",
     "yarn.lock"
   ],
-  "renamed_paths": [],
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
@@ -327,6 +327,7 @@
     "supply-chain2"
   ],
   "cai_ids": [],
+  "renamed_paths": [],
   "ignores": [
     {
       "check_id": "eqeq-four",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket/findings_and_ignores.json
@@ -1,5 +1,4 @@
 {
-  "token": null,
   "findings": [
     {
       "check_id": "taint-test",
@@ -312,12 +311,13 @@
       }
     }
   ],
+  "token": null,
+  "gitlab_token": null,
   "searched_paths": [
     "foo.py",
     "poetry.lock",
     "yarn.lock"
   ],
-  "renamed_paths": [],
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
@@ -327,6 +327,7 @@
     "supply-chain2"
   ],
   "cai_ids": [],
+  "renamed_paths": [],
   "ignores": [
     {
       "check_id": "eqeq-four",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite-overwrite-autodetected-variables/findings_and_ignores.json
@@ -1,5 +1,4 @@
 {
-  "token": null,
   "findings": [
     {
       "check_id": "taint-test",
@@ -312,12 +311,13 @@
       }
     }
   ],
+  "token": null,
+  "gitlab_token": null,
   "searched_paths": [
     "foo.py",
     "poetry.lock",
     "yarn.lock"
   ],
-  "renamed_paths": [],
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
@@ -327,6 +327,7 @@
     "supply-chain2"
   ],
   "cai_ids": [],
+  "renamed_paths": [],
   "ignores": [
     {
       "check_id": "eqeq-four",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite/findings_and_ignores.json
@@ -1,5 +1,4 @@
 {
-  "token": null,
   "findings": [
     {
       "check_id": "taint-test",
@@ -312,12 +311,13 @@
       }
     }
   ],
+  "token": null,
+  "gitlab_token": null,
   "searched_paths": [
     "foo.py",
     "poetry.lock",
     "yarn.lock"
   ],
-  "renamed_paths": [],
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
@@ -327,6 +327,7 @@
     "supply-chain2"
   ],
   "cai_ids": [],
+  "renamed_paths": [],
   "ignores": [
     {
       "check_id": "eqeq-four",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci-overwrite-autodetected-variables/findings_and_ignores.json
@@ -1,5 +1,4 @@
 {
-  "token": null,
   "findings": [
     {
       "check_id": "taint-test",
@@ -312,12 +311,13 @@
       }
     }
   ],
+  "token": null,
+  "gitlab_token": null,
   "searched_paths": [
     "foo.py",
     "poetry.lock",
     "yarn.lock"
   ],
-  "renamed_paths": [],
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
@@ -327,6 +327,7 @@
     "supply-chain2"
   ],
   "cai_ids": [],
+  "renamed_paths": [],
   "ignores": [
     {
       "check_id": "eqeq-four",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci/findings_and_ignores.json
@@ -1,5 +1,4 @@
 {
-  "token": null,
   "findings": [
     {
       "check_id": "taint-test",
@@ -312,12 +311,13 @@
       }
     }
   ],
+  "token": null,
+  "gitlab_token": null,
   "searched_paths": [
     "foo.py",
     "poetry.lock",
     "yarn.lock"
   ],
-  "renamed_paths": [],
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
@@ -327,6 +327,7 @@
     "supply-chain2"
   ],
   "cai_ids": [],
+  "renamed_paths": [],
   "ignores": [
     {
       "check_id": "eqeq-four",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/findings_and_ignores.json
@@ -1,5 +1,4 @@
 {
-  "token": null,
   "findings": [
     {
       "check_id": "taint-test",
@@ -312,12 +311,13 @@
       }
     }
   ],
+  "token": null,
+  "gitlab_token": null,
   "searched_paths": [
     "foo.py",
     "poetry.lock",
     "yarn.lock"
   ],
-  "renamed_paths": [],
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
@@ -327,6 +327,7 @@
     "supply-chain2"
   ],
   "cai_ids": [],
+  "renamed_paths": [],
   "ignores": [
     {
       "check_id": "eqeq-four",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr-semgrepconfig/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr-semgrepconfig/findings_and_ignores.json
@@ -1,5 +1,4 @@
 {
-  "token": null,
   "findings": [
     {
       "check_id": "taint-test",
@@ -264,10 +263,11 @@
       }
     }
   ],
+  "token": null,
+  "gitlab_token": null,
   "searched_paths": [
     "foo.py"
   ],
-  "renamed_paths": [],
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
@@ -277,6 +277,7 @@
     "supply-chain2"
   ],
   "cai_ids": [],
+  "renamed_paths": [],
   "ignores": [
     {
       "check_id": "eqeq-four",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr/findings_and_ignores.json
@@ -1,5 +1,4 @@
 {
-  "token": null,
   "findings": [
     {
       "check_id": "taint-test",
@@ -264,10 +263,11 @@
       }
     }
   ],
+  "token": null,
+  "gitlab_token": null,
   "searched_paths": [
     "foo.py"
   ],
-  "renamed_paths": [],
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
@@ -277,6 +277,7 @@
     "supply-chain2"
   ],
   "cai_ids": [],
+  "renamed_paths": [],
   "ignores": [
     {
       "check_id": "eqeq-four",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push-special-env-vars/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push-special-env-vars/findings_and_ignores.json
@@ -1,5 +1,4 @@
 {
-  "token": null,
   "findings": [
     {
       "check_id": "taint-test",
@@ -312,12 +311,13 @@
       }
     }
   ],
+  "token": null,
+  "gitlab_token": null,
   "searched_paths": [
     "foo.py",
     "poetry.lock",
     "yarn.lock"
   ],
-  "renamed_paths": [],
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
@@ -327,6 +327,7 @@
     "supply-chain2"
   ],
   "cai_ids": [],
+  "renamed_paths": [],
   "ignores": [
     {
       "check_id": "eqeq-four",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/findings_and_ignores.json
@@ -1,5 +1,4 @@
 {
-  "token": null,
   "findings": [
     {
       "check_id": "taint-test",
@@ -312,12 +311,13 @@
       }
     }
   ],
+  "token": null,
+  "gitlab_token": null,
   "searched_paths": [
     "foo.py",
     "poetry.lock",
     "yarn.lock"
   ],
-  "renamed_paths": [],
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
@@ -327,6 +327,7 @@
     "supply-chain2"
   ],
   "cai_ids": [],
+  "renamed_paths": [],
   "ignores": [
     {
       "check_id": "eqeq-four",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-push/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-push/findings_and_ignores.json
@@ -1,5 +1,4 @@
 {
-  "token": null,
   "findings": [
     {
       "check_id": "taint-test",
@@ -312,12 +311,13 @@
       }
     }
   ],
+  "token": null,
+  "gitlab_token": null,
   "searched_paths": [
     "foo.py",
     "poetry.lock",
     "yarn.lock"
   ],
-  "renamed_paths": [],
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
@@ -327,6 +327,7 @@
     "supply-chain2"
   ],
   "cai_ids": [],
+  "renamed_paths": [],
   "ignores": [
     {
       "check_id": "eqeq-four",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-special-env-vars/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-special-env-vars/findings_and_ignores.json
@@ -1,5 +1,4 @@
 {
-  "token": null,
   "findings": [
     {
       "check_id": "taint-test",
@@ -264,10 +263,11 @@
       }
     }
   ],
+  "token": null,
+  "gitlab_token": null,
   "searched_paths": [
     "foo.py"
   ],
-  "renamed_paths": [],
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
@@ -277,6 +277,7 @@
     "supply-chain2"
   ],
   "cai_ids": [],
+  "renamed_paths": [],
   "ignores": [
     {
       "check_id": "eqeq-four",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab/findings_and_ignores.json
@@ -1,5 +1,4 @@
 {
-  "token": null,
   "findings": [
     {
       "check_id": "taint-test",
@@ -264,10 +263,11 @@
       }
     }
   ],
+  "token": null,
+  "gitlab_token": null,
   "searched_paths": [
     "foo.py"
   ],
-  "renamed_paths": [],
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
@@ -277,6 +277,7 @@
     "supply-chain2"
   ],
   "cai_ids": [],
+  "renamed_paths": [],
   "ignores": [
     {
       "check_id": "eqeq-four",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/findings_and_ignores.json
@@ -1,5 +1,4 @@
 {
-  "token": null,
   "findings": [
     {
       "check_id": "taint-test",
@@ -312,12 +311,13 @@
       }
     }
   ],
+  "token": null,
+  "gitlab_token": null,
   "searched_paths": [
     "foo.py",
     "poetry.lock",
     "yarn.lock"
   ],
-  "renamed_paths": [],
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
@@ -327,6 +327,7 @@
     "supply-chain2"
   ],
   "cai_ids": [],
+  "renamed_paths": [],
   "ignores": [
     {
       "check_id": "eqeq-four",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-overwrite-autodetected-variables/findings_and_ignores.json
@@ -1,5 +1,4 @@
 {
-  "token": null,
   "findings": [
     {
       "check_id": "taint-test",
@@ -312,12 +311,13 @@
       }
     }
   ],
+  "token": null,
+  "gitlab_token": null,
   "searched_paths": [
     "foo.py",
     "poetry.lock",
     "yarn.lock"
   ],
-  "renamed_paths": [],
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
@@ -327,6 +327,7 @@
     "supply-chain2"
   ],
   "cai_ids": [],
+  "renamed_paths": [],
   "ignores": [
     {
       "check_id": "eqeq-four",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins/findings_and_ignores.json
@@ -1,5 +1,4 @@
 {
-  "token": null,
   "findings": [
     {
       "check_id": "taint-test",
@@ -312,12 +311,13 @@
       }
     }
   ],
+  "token": null,
+  "gitlab_token": null,
   "searched_paths": [
     "foo.py",
     "poetry.lock",
     "yarn.lock"
   ],
-  "renamed_paths": [],
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
@@ -327,6 +327,7 @@
     "supply-chain2"
   ],
   "cai_ids": [],
+  "renamed_paths": [],
   "ignores": [
     {
       "check_id": "eqeq-four",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/findings_and_ignores.json
@@ -1,5 +1,4 @@
 {
-  "token": null,
   "findings": [
     {
       "check_id": "taint-test",
@@ -312,12 +311,13 @@
       }
     }
   ],
+  "token": null,
+  "gitlab_token": null,
   "searched_paths": [
     "foo.py",
     "poetry.lock",
     "yarn.lock"
   ],
-  "renamed_paths": [],
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
@@ -327,6 +327,7 @@
     "supply-chain2"
   ],
   "cai_ids": [],
+  "renamed_paths": [],
   "ignores": [
     {
       "check_id": "eqeq-four",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-self-hosted/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-self-hosted/findings_and_ignores.json
@@ -1,5 +1,4 @@
 {
-  "token": null,
   "findings": [
     {
       "check_id": "taint-test",
@@ -312,12 +311,13 @@
       }
     }
   ],
+  "token": null,
+  "gitlab_token": null,
   "searched_paths": [
     "foo.py",
     "poetry.lock",
     "yarn.lock"
   ],
-  "renamed_paths": [],
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
@@ -327,6 +327,7 @@
     "supply-chain2"
   ],
   "cai_ids": [],
+  "renamed_paths": [],
   "ignores": [
     {
       "check_id": "eqeq-four",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis-overwrite-autodetected-variables/findings_and_ignores.json
@@ -1,5 +1,4 @@
 {
-  "token": null,
   "findings": [
     {
       "check_id": "taint-test",
@@ -312,12 +311,13 @@
       }
     }
   ],
+  "token": null,
+  "gitlab_token": null,
   "searched_paths": [
     "foo.py",
     "poetry.lock",
     "yarn.lock"
   ],
-  "renamed_paths": [],
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
@@ -327,6 +327,7 @@
     "supply-chain2"
   ],
   "cai_ids": [],
+  "renamed_paths": [],
   "ignores": [
     {
       "check_id": "eqeq-four",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis/findings_and_ignores.json
@@ -1,5 +1,4 @@
 {
-  "token": null,
   "findings": [
     {
       "check_id": "taint-test",
@@ -312,12 +311,13 @@
       }
     }
   ],
+  "token": null,
+  "gitlab_token": null,
   "searched_paths": [
     "foo.py",
     "poetry.lock",
     "yarn.lock"
   ],
-  "renamed_paths": [],
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
@@ -327,6 +327,7 @@
     "supply-chain2"
   ],
   "cai_ids": [],
+  "renamed_paths": [],
   "ignores": [
     {
       "check_id": "eqeq-four",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-unparsable_url/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-unparsable_url/findings_and_ignores.json
@@ -1,5 +1,4 @@
 {
-  "token": null,
   "findings": [
     {
       "check_id": "taint-test",
@@ -312,12 +311,13 @@
       }
     }
   ],
+  "token": null,
+  "gitlab_token": null,
   "searched_paths": [
     "foo.py",
     "poetry.lock",
     "yarn.lock"
   ],
-  "renamed_paths": [],
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
@@ -327,6 +327,7 @@
     "supply-chain2"
   ],
   "cai_ids": [],
+  "renamed_paths": [],
   "ignores": [
     {
       "check_id": "eqeq-four",

--- a/cli/tests/e2e/snapshots/test_ci/test_lockfile_parse_failure_reporting/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_lockfile_parse_failure_reporting/findings_and_ignores.json
@@ -1,5 +1,4 @@
 {
-  "token": null,
   "findings": [
     {
       "check_id": "taint-test",
@@ -312,13 +311,14 @@
       }
     }
   ],
+  "token": null,
+  "gitlab_token": null,
   "searched_paths": [
     "Pipfile.lock",
     "foo.py",
     "poetry.lock",
     "yarn.lock"
   ],
-  "renamed_paths": [],
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
@@ -328,6 +328,7 @@
     "supply-chain2"
   ],
   "cai_ids": [],
+  "renamed_paths": [],
   "ignores": [
     {
       "check_id": "eqeq-four",


### PR DESCRIPTION
test plan:
precommit run -a mypy


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)