### PR TITLE
chore: update to latest semgrep-interfaces and remove cai_ids

### DIFF
--- a/cli/src/semgrep/app/scans.py
+++ b/cli/src/semgrep/app/scans.py
@@ -256,8 +256,7 @@ class ScanHandler:
         commit_date here for legacy reasons. epoch time of latest commit
         """
         state = get_state()
-        all_ids = [r.id for r in rules]
-        cai_ids, rule_ids = partition(all_ids, lambda r_id: "r2c-internal-cai" in r_id)
+        rule_ids = [r.id for r in rules]
         all_matches = [
             match
             for matches_of_rule in matches_by_rule.values()
@@ -301,7 +300,6 @@ class ScanHandler:
             findings=findings,
             searched_paths=[str(t) for t in sorted(targets)],
             rule_ids=rule_ids,
-            cai_ids=cai_ids,
             gitlab_token=None,
         )
         # TODO: add those fields in semgrep_output_v1.atd spec

--- a/cli/tests/e2e/snapshots/test_ci/test_dryrun/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_dryrun/results.txt
@@ -433,7 +433,6 @@ Would have sent findings and ignores blob: {
         "supply-chain1",
         "supply-chain2"
     ],
-    "cai_ids": [],
     "renamed_paths": [],
     "ignores": [
         {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines-overwrite-autodetected-variables/findings_and_ignores.json
@@ -329,7 +329,6 @@
     "supply-chain1",
     "supply-chain2"
   ],
-  "cai_ids": [],
   "renamed_paths": [],
   "ignores": [
     {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines/findings_and_ignores.json
@@ -329,7 +329,6 @@
     "supply-chain1",
     "supply-chain2"
   ],
-  "cai_ids": [],
   "renamed_paths": [],
   "ignores": [
     {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket-overwrite-autodetected-variables/findings_and_ignores.json
@@ -329,7 +329,6 @@
     "supply-chain1",
     "supply-chain2"
   ],
-  "cai_ids": [],
   "renamed_paths": [],
   "ignores": [
     {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket/findings_and_ignores.json
@@ -329,7 +329,6 @@
     "supply-chain1",
     "supply-chain2"
   ],
-  "cai_ids": [],
   "renamed_paths": [],
   "ignores": [
     {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite-overwrite-autodetected-variables/findings_and_ignores.json
@@ -329,7 +329,6 @@
     "supply-chain1",
     "supply-chain2"
   ],
-  "cai_ids": [],
   "renamed_paths": [],
   "ignores": [
     {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite/findings_and_ignores.json
@@ -329,7 +329,6 @@
     "supply-chain1",
     "supply-chain2"
   ],
-  "cai_ids": [],
   "renamed_paths": [],
   "ignores": [
     {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci-overwrite-autodetected-variables/findings_and_ignores.json
@@ -329,7 +329,6 @@
     "supply-chain1",
     "supply-chain2"
   ],
-  "cai_ids": [],
   "renamed_paths": [],
   "ignores": [
     {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci/findings_and_ignores.json
@@ -329,7 +329,6 @@
     "supply-chain1",
     "supply-chain2"
   ],
-  "cai_ids": [],
   "renamed_paths": [],
   "ignores": [
     {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/findings_and_ignores.json
@@ -329,7 +329,6 @@
     "supply-chain1",
     "supply-chain2"
   ],
-  "cai_ids": [],
   "renamed_paths": [],
   "ignores": [
     {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr-semgrepconfig/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr-semgrepconfig/findings_and_ignores.json
@@ -279,7 +279,6 @@
     "supply-chain1",
     "supply-chain2"
   ],
-  "cai_ids": [],
   "renamed_paths": [],
   "ignores": [
     {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr/findings_and_ignores.json
@@ -279,7 +279,6 @@
     "supply-chain1",
     "supply-chain2"
   ],
-  "cai_ids": [],
   "renamed_paths": [],
   "ignores": [
     {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push-special-env-vars/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push-special-env-vars/findings_and_ignores.json
@@ -329,7 +329,6 @@
     "supply-chain1",
     "supply-chain2"
   ],
-  "cai_ids": [],
   "renamed_paths": [],
   "ignores": [
     {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/findings_and_ignores.json
@@ -329,7 +329,6 @@
     "supply-chain1",
     "supply-chain2"
   ],
-  "cai_ids": [],
   "renamed_paths": [],
   "ignores": [
     {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-push/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-push/findings_and_ignores.json
@@ -329,7 +329,6 @@
     "supply-chain1",
     "supply-chain2"
   ],
-  "cai_ids": [],
   "renamed_paths": [],
   "ignores": [
     {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-special-env-vars/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-special-env-vars/findings_and_ignores.json
@@ -279,7 +279,6 @@
     "supply-chain1",
     "supply-chain2"
   ],
-  "cai_ids": [],
   "renamed_paths": [],
   "ignores": [
     {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab/findings_and_ignores.json
@@ -279,7 +279,6 @@
     "supply-chain1",
     "supply-chain2"
   ],
-  "cai_ids": [],
   "renamed_paths": [],
   "ignores": [
     {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/findings_and_ignores.json
@@ -329,7 +329,6 @@
     "supply-chain1",
     "supply-chain2"
   ],
-  "cai_ids": [],
   "renamed_paths": [],
   "ignores": [
     {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-overwrite-autodetected-variables/findings_and_ignores.json
@@ -329,7 +329,6 @@
     "supply-chain1",
     "supply-chain2"
   ],
-  "cai_ids": [],
   "renamed_paths": [],
   "ignores": [
     {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins/findings_and_ignores.json
@@ -329,7 +329,6 @@
     "supply-chain1",
     "supply-chain2"
   ],
-  "cai_ids": [],
   "renamed_paths": [],
   "ignores": [
     {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/findings_and_ignores.json
@@ -329,7 +329,6 @@
     "supply-chain1",
     "supply-chain2"
   ],
-  "cai_ids": [],
   "renamed_paths": [],
   "ignores": [
     {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-self-hosted/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-self-hosted/findings_and_ignores.json
@@ -329,7 +329,6 @@
     "supply-chain1",
     "supply-chain2"
   ],
-  "cai_ids": [],
   "renamed_paths": [],
   "ignores": [
     {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis-overwrite-autodetected-variables/findings_and_ignores.json
@@ -329,7 +329,6 @@
     "supply-chain1",
     "supply-chain2"
   ],
-  "cai_ids": [],
   "renamed_paths": [],
   "ignores": [
     {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis/findings_and_ignores.json
@@ -329,7 +329,6 @@
     "supply-chain1",
     "supply-chain2"
   ],
-  "cai_ids": [],
   "renamed_paths": [],
   "ignores": [
     {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-unparsable_url/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-unparsable_url/findings_and_ignores.json
@@ -329,7 +329,6 @@
     "supply-chain1",
     "supply-chain2"
   ],
-  "cai_ids": [],
   "renamed_paths": [],
   "ignores": [
     {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines-overwrite-autodetected-variables/findings_and_ignores.json
@@ -326,7 +326,6 @@
     "supply-chain1",
     "supply-chain2"
   ],
-  "cai_ids": [],
   "renamed_paths": [],
   "ignores": [
     {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines/findings_and_ignores.json
@@ -326,7 +326,6 @@
     "supply-chain1",
     "supply-chain2"
   ],
-  "cai_ids": [],
   "renamed_paths": [],
   "ignores": [
     {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket-overwrite-autodetected-variables/findings_and_ignores.json
@@ -326,7 +326,6 @@
     "supply-chain1",
     "supply-chain2"
   ],
-  "cai_ids": [],
   "renamed_paths": [],
   "ignores": [
     {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket/findings_and_ignores.json
@@ -326,7 +326,6 @@
     "supply-chain1",
     "supply-chain2"
   ],
-  "cai_ids": [],
   "renamed_paths": [],
   "ignores": [
     {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite-overwrite-autodetected-variables/findings_and_ignores.json
@@ -326,7 +326,6 @@
     "supply-chain1",
     "supply-chain2"
   ],
-  "cai_ids": [],
   "renamed_paths": [],
   "ignores": [
     {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite/findings_and_ignores.json
@@ -326,7 +326,6 @@
     "supply-chain1",
     "supply-chain2"
   ],
-  "cai_ids": [],
   "renamed_paths": [],
   "ignores": [
     {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci-overwrite-autodetected-variables/findings_and_ignores.json
@@ -326,7 +326,6 @@
     "supply-chain1",
     "supply-chain2"
   ],
-  "cai_ids": [],
   "renamed_paths": [],
   "ignores": [
     {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci/findings_and_ignores.json
@@ -326,7 +326,6 @@
     "supply-chain1",
     "supply-chain2"
   ],
-  "cai_ids": [],
   "renamed_paths": [],
   "ignores": [
     {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/findings_and_ignores.json
@@ -326,7 +326,6 @@
     "supply-chain1",
     "supply-chain2"
   ],
-  "cai_ids": [],
   "renamed_paths": [],
   "ignores": [
     {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr-semgrepconfig/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr-semgrepconfig/findings_and_ignores.json
@@ -276,7 +276,6 @@
     "supply-chain1",
     "supply-chain2"
   ],
-  "cai_ids": [],
   "renamed_paths": [],
   "ignores": [
     {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr/findings_and_ignores.json
@@ -276,7 +276,6 @@
     "supply-chain1",
     "supply-chain2"
   ],
-  "cai_ids": [],
   "renamed_paths": [],
   "ignores": [
     {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push-special-env-vars/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push-special-env-vars/findings_and_ignores.json
@@ -326,7 +326,6 @@
     "supply-chain1",
     "supply-chain2"
   ],
-  "cai_ids": [],
   "renamed_paths": [],
   "ignores": [
     {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/findings_and_ignores.json
@@ -326,7 +326,6 @@
     "supply-chain1",
     "supply-chain2"
   ],
-  "cai_ids": [],
   "renamed_paths": [],
   "ignores": [
     {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-push/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-push/findings_and_ignores.json
@@ -326,7 +326,6 @@
     "supply-chain1",
     "supply-chain2"
   ],
-  "cai_ids": [],
   "renamed_paths": [],
   "ignores": [
     {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-special-env-vars/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-special-env-vars/findings_and_ignores.json
@@ -276,7 +276,6 @@
     "supply-chain1",
     "supply-chain2"
   ],
-  "cai_ids": [],
   "renamed_paths": [],
   "ignores": [
     {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab/findings_and_ignores.json
@@ -276,7 +276,6 @@
     "supply-chain1",
     "supply-chain2"
   ],
-  "cai_ids": [],
   "renamed_paths": [],
   "ignores": [
     {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/findings_and_ignores.json
@@ -326,7 +326,6 @@
     "supply-chain1",
     "supply-chain2"
   ],
-  "cai_ids": [],
   "renamed_paths": [],
   "ignores": [
     {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-overwrite-autodetected-variables/findings_and_ignores.json
@@ -326,7 +326,6 @@
     "supply-chain1",
     "supply-chain2"
   ],
-  "cai_ids": [],
   "renamed_paths": [],
   "ignores": [
     {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins/findings_and_ignores.json
@@ -326,7 +326,6 @@
     "supply-chain1",
     "supply-chain2"
   ],
-  "cai_ids": [],
   "renamed_paths": [],
   "ignores": [
     {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/findings_and_ignores.json
@@ -326,7 +326,6 @@
     "supply-chain1",
     "supply-chain2"
   ],
-  "cai_ids": [],
   "renamed_paths": [],
   "ignores": [
     {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-self-hosted/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-self-hosted/findings_and_ignores.json
@@ -326,7 +326,6 @@
     "supply-chain1",
     "supply-chain2"
   ],
-  "cai_ids": [],
   "renamed_paths": [],
   "ignores": [
     {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis-overwrite-autodetected-variables/findings_and_ignores.json
@@ -326,7 +326,6 @@
     "supply-chain1",
     "supply-chain2"
   ],
-  "cai_ids": [],
   "renamed_paths": [],
   "ignores": [
     {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis/findings_and_ignores.json
@@ -326,7 +326,6 @@
     "supply-chain1",
     "supply-chain2"
   ],
-  "cai_ids": [],
   "renamed_paths": [],
   "ignores": [
     {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-unparsable_url/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-unparsable_url/findings_and_ignores.json
@@ -326,7 +326,6 @@
     "supply-chain1",
     "supply-chain2"
   ],
-  "cai_ids": [],
   "renamed_paths": [],
   "ignores": [
     {

--- a/cli/tests/e2e/snapshots/test_ci/test_lockfile_parse_failure_reporting/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_lockfile_parse_failure_reporting/findings_and_ignores.json
@@ -327,7 +327,6 @@
     "supply-chain1",
     "supply-chain2"
   ],
-  "cai_ids": [],
   "renamed_paths": [],
   "ignores": [
     {

--- a/cli/tests/e2e/snapshots/test_metrics/test_metrics_payload/pro_flag0/metrics-payload.json
+++ b/cli/tests/e2e/snapshots/test_metrics/test_metrics_payload/pro_flag0/metrics-payload.json
@@ -1,11 +1,11 @@
 {
   "anonymous_user_id": "11111111-1111-1111-1111-111111111111",
   "environment": {
-    "ci": "None",
+    "ci": null,
     "configNamesHash": "d3e03c9938537c0a0668cec7204f37f1e9da87d03e18e8cc444dd7454b36c4d5",
     "integrationName": "funkyintegration",
     "isAuthenticated": false,
-    "projectHash": "None",
+    "projectHash": null,
     "rulesHash": "43af0cc99ad4b3620194d238a7875cc37f8d8eaa1800fd395c15a5ee21967ac3",
     "version": "x.x.x"
   },

--- a/cli/tests/e2e/snapshots/test_metrics/test_metrics_payload/pro_flag0/metrics-payload.json
+++ b/cli/tests/e2e/snapshots/test_metrics/test_metrics_payload/pro_flag0/metrics-payload.json
@@ -1,11 +1,11 @@
 {
   "anonymous_user_id": "11111111-1111-1111-1111-111111111111",
   "environment": {
-    "ci": null,
+    "ci": "None",
     "configNamesHash": "d3e03c9938537c0a0668cec7204f37f1e9da87d03e18e8cc444dd7454b36c4d5",
     "integrationName": "funkyintegration",
     "isAuthenticated": false,
-    "projectHash": null,
+    "projectHash": "None",
     "rulesHash": "43af0cc99ad4b3620194d238a7875cc37f8d8eaa1800fd395c15a5ee21967ac3",
     "version": "x.x.x"
   },
@@ -33,7 +33,6 @@
         "size": 6
       }
     ],
-    "maxMemoryBytes": null,
     "numRules": 4,
     "numTargets": 1,
     "profilingTimes": {


### PR DESCRIPTION
test plan:
pre-commit run -a mypy
make test


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)