### PR TITLE
Update changelog regarding rule IDs

### DIFF
--- a/changelog.d/gh-8057.fixed
+++ b/changelog.d/gh-8057.fixed
@@ -1,0 +1,4 @@
+Allow any characters in file paths used to create dotted rule IDs. File path
+characters that aren't allowed in rule IDs are simply removed. For example, a
+rule whose ID is `my-rule` found in the file `hello/@world/rules.yaml`
+becomes `hello.world.my-rule`.


### PR DESCRIPTION
This was missing from https://github.com/returntocorp/semgrep/pull/8038.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
