### PR TITLE
osemgrep: add comments and remove unneeded code

### DIFF
--- a/.github/workflows/build-test-core-x86.yaml
+++ b/.github/workflows/build-test-core-x86.yaml
@@ -13,7 +13,7 @@ jobs:
   build-test-core-x86:
     name: Build Test Semgrep Core
     runs-on: ubuntu-latest
-    container: returntocorp/ocaml:alpine-2023-04-17
+    container: returntocorp/ocaml:alpine-2023-06-16
     # We need this hack because GHA tampers with the HOME in container
     # and this does not play well with 'opam' installed in /root
     env:

--- a/.github/workflows/build-test-javascript.yaml
+++ b/.github/workflows/build-test-javascript.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   build-semgrep-js-ocaml:
     runs-on: ubuntu-latest-16-core
-    container: returntocorp/ocaml:alpine-2023-04-17
+    container: returntocorp/ocaml:alpine-2023-06-16
     # We need this hack because GHA tampers with the HOME in container
     # and this does not play well with 'opam' installed in /root
     env:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -71,7 +71,7 @@ jobs:
     # This custom image provides 'ocamlformat' with a specific version needed to check
     # OCaml code (must be the same than the one in dev/dev.opam)
     # See https://github.com/returntocorp/ocaml-layer/blob/master/configs/ubuntu.sh
-    container: returntocorp/ocaml:ubuntu-2023-04-17
+    container: returntocorp/ocaml:ubuntu-2023-06-16
     # HOME in the container is tampered by GHA and modified from /root to /home/github
     # which then confuses opam below which can not find its ~/.opam (which is at /root/.opam)
     # hence the ugly use of 'env: HOME ...' below.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
   test-core:
     name: test semgrep-core
     runs-on: ubuntu-22.04
-    container: returntocorp/ocaml:alpine-2023-04-03
+    container: returntocorp/ocaml:alpine-2023-06-16
     env:
       HOME: /root
     steps:
@@ -69,7 +69,7 @@ jobs:
   test-osemgrep:
     name: test osemgrep
     runs-on: ubuntu-22.04
-    container: returntocorp/ocaml:alpine-2023-04-03
+    container: returntocorp/ocaml:alpine-2023-06-16
     env:
       HOME: /root
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@
 #
 # coupling: if you modify the FROM below, you probably need to modify also
 # a few .github/workflows/ files. grep for returntocorp/ocaml there.
-FROM returntocorp/ocaml:alpine-2023-04-17 as semgrep-core-container
+FROM returntocorp/ocaml:alpine-2023-06-16 as semgrep-core-container
 
 WORKDIR /src/semgrep
 COPY . .

--- a/dune-project
+++ b/dune-project
@@ -402,6 +402,7 @@ For more information see https://semsgrep.dev
     uri
     uuidm
     http-lwt-client ; this brings lots of dependencies. This is for osemgrep.
+    (happy-eyeballs-lwt (>= 0.6.0)) ; there's a bug with GitHub action & pre-commit before 0.6.0
     terminal_size
     lwt
     lwt_ppx

--- a/semgrep.opam
+++ b/semgrep.opam
@@ -44,6 +44,7 @@ depends: [
   "uri"
   "uuidm"
   "http-lwt-client"
+  "happy-eyeballs-lwt" {>= "0.6.0"}
   "terminal_size"
   "lwt"
   "lwt_ppx"

--- a/src/osemgrep/networking/Http_helpers.ml
+++ b/src/osemgrep/networking/Http_helpers.ml
@@ -1,26 +1,16 @@
 open Http_lwt_client
 
-(* happy eyeballs is an Internet standard
-   (https://datatracker.ietf.org/doc/html/rfc8305) and an OCaml package which
-   purpose is to establish a TCP connection, independent of the internet
-   protocol version:
-   - the input is a hostname (and a port), the output is either a file
-     descriptor or an error
-   - it does DNS resolution (for both A (IPv4) and AAAA (IPv6)) - 3 attempts
-     with a timeout of "resolve_timeout" (here: 2 seconds)
-   - it then attempts to establish to the IPv6 address(es) and IPv4 address(es)
-     (with a preference to IPv6), using a 10 seconds timeout ("connect_timeout",
-     defaults to 10 seconds)
-
-   The HTTP lwt client library uses happy_eyeballs as the underlying
-   layer for establishing connections.
+(* The http-lwt-client package offers:
+   - HTTP/1 and HTTP/2 support (using http/af and h2)
+   - TLS support (using OCaml-TLS)
+   - IPv4 and IPv6 connection establishment (via happy-eyeballs)
 *)
-let happy_eyeballs =
-  let happy_eyeballs =
-    Happy_eyeballs.create ~resolve_timeout:(Duration.of_sec 2)
-      (Mtime_clock.elapsed_ns ())
-  in
-  Happy_eyeballs_lwt.create ~happy_eyeballs ()
+
+(* The HTTP lwt client library uses happy_eyeballs as the underlying
+   layer for establishing connections. It uses DNS, and comes with a small DNS
+   cache. We use a single happy_eyeballs instance to reuse the cache present.
+*)
+let happy_eyeballs = Happy_eyeballs_lwt.create ()
 
 (* TODO: extend to allow to curl with JSON as answer *)
 let get ?headers url =


### PR DESCRIPTION
require a happy-eyeballs package which doesn't end up in the Azure (GitHub action) pre-commit issue

If that compiles fine, the right happy-eyeballs version is being used. And this paves the way for #7982

This reverts the timeout changes from #7984 (since they're not needed), and falls back to the defaults provided.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
