### PR TITLE
Add log message to indicate the existing of `--no-suppress-errors`

### DIFF
--- a/cli/src/semgrep/error_handler.py
+++ b/cli/src/semgrep/error_handler.py
@@ -71,6 +71,10 @@ class ErrorHandler:
 
         import traceback
 
+        logger.error(
+            "There were errors during analysis but Semgrep will succeed because there were no blocking findings, use --no-suppress-errors if you want Semgrep to fail when there are errors."
+        )
+
         logger.debug(
             f"Sending to fail-open endpoint {url} since fail-open is configured to {self.suppress_errors}"
         )


### PR DESCRIPTION
PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)

---

Hi.


This PR is follow up to #7891, where after discussion it was suggested to add a log message to indicate users the existing of the `--no-suppress-errors` flag:

```bash
$ semgrep ci --config nonexisting.yaml                                                                 francis/message % u=
                  
                  
┌────────────────┐
│ Debugging Info │
└────────────────┘
                  
  SCAN ENVIRONMENT
  versions    - semgrep 1.27.0 on python 3.10.6                        
  environment - running in environment git, triggering event is unknown
[ERROR] WARNING: unable to find a config; path `nonexisting.yaml` does not exist
[ERROR] invalid configuration file found (1 configs were invalid)
There were errors during analysis but Semgrep will succeed because there were no blocking findings, use --no-suppress-errors if you want Semgrep to fail when there are errors.
```

If you see any way to improve this contribution, feel free to share.


Best regards.