### PR TITLE
fix: [ci] revert back to root user in docker image

### DIFF
--- a/.github/workflows/test-semgrep-pro-latest.yaml
+++ b/.github/workflows/test-semgrep-pro-latest.yaml
@@ -5,18 +5,19 @@
 # If this workflow succeeds, then it should be safe to release Semgrep and
 # not immediately be incompatible with Semgrep Pro.
 
+# TODO(brandonspark): Verify if this workflow can be fully removed.
+
 name: test-semgrep-pro-latest
 
 on:
   workflow_dispatch:
-  pull_request:
   push:
     branches:
       - "develop"
 jobs:
   test-semgrep-pro-latest:
     name: Test Semgrep Pro Engine (latest release)
-    if: github.ref == 'refs/heads/develop' || github.event.pull_request.head.repo.full_name == github.repository # only returntocorp has the necessary credentials to access semgrep pro
+    if: github.ref == 'refs/heads/develop'
     runs-on: ubuntu-22.04
     permissions:
       id-token: write

--- a/.github/workflows/test-semgrep-pro-latest.yaml
+++ b/.github/workflows/test-semgrep-pro-latest.yaml
@@ -44,5 +44,4 @@ jobs:
           aws s3 cp s3://web-assets.r2c.dev/assets/semgrep-core-proprietary-manylinux-develop ./semgrep-core-proprietary
       - name: Run Semgrep Pro Engine!
         run: |
-          chmod +x ./semgrep-core-proprietary
-          docker run --rm -v "$(pwd):/root" -v "$(pwd)/semgrep-core-proprietary:/usr/local/bin/semgrep-core-proprietary" -e SEMGREP_APP_TOKEN=${{ secrets.SEMGREP_APP_TOKEN }} --entrypoint=bash "returntocorp/semgrep:develop" /root/scripts/test-pro.sh
+          docker run --rm -v "$(pwd):/root" -e SEMGREP_APP_TOKEN=${{ secrets.SEMGREP_APP_TOKEN }} --entrypoint=bash "returntocorp/semgrep:develop" /root/scripts/test-pro.sh

--- a/.github/workflows/test-semgrep-pro.yaml
+++ b/.github/workflows/test-semgrep-pro.yaml
@@ -80,5 +80,4 @@ jobs:
           aws s3 cp s3://web-assets.r2c.dev/assets/semgrep-core-proprietary-manylinux-develop ./semgrep-core-proprietary
       - name: Run Semgrep Pro Engine!
         run: |
-          chmod +x ./semgrep-core-proprietary
-          docker run --rm -v "$(pwd):/root" -v "$(pwd)/semgrep-core-proprietary:/usr/local/bin/semgrep-core-proprietary" -e SEMGREP_APP_TOKEN=${{ secrets.SEMGREP_APP_TOKEN }} --entrypoint=bash "${{ inputs.repository-name }}:${{ needs.setup-docker-tag.outputs.docker-tag }}" /root/scripts/test-pro.sh
+          docker run --rm -v "$(pwd):/root" -e SEMGREP_APP_TOKEN=${{ secrets.SEMGREP_APP_TOKEN }} --entrypoint=bash "${{ inputs.repository-name }}:${{ needs.setup-docker-tag.outputs.docker-tag }}" /root/scripts/test-pro.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -130,19 +130,33 @@ COPY cli ./
 #    TODO: at some point we should not need the 'pip install jsonnet' because
 #    jsonnet would be mentioned in the setup.py for semgrep as a dependency.
 #    LATER: at some point we would not need at all because of osemgrep/ojsonnet
+# TODO? why the mkdir -p /tmp/.cache?
 # hadolint ignore=DL3013
 RUN apk add --no-cache --virtual=.build-deps build-base make g++ &&\
      pip install jsonnet &&\
      SEMGREP_SKIP_BIN=true pip install /semgrep &&\
      # running this pre-compiles some python files for faster startup times
      semgrep --version &&\
-     apk del .build-deps
+     apk del .build-deps &&\
+     mkdir -p /tmp/.cache
 
 # Let the user know how their container was built
 COPY Dockerfile /Dockerfile
 
 # Get semgrep-core from step1
 COPY --from=semgrep-core-container /src/semgrep/_build/default/src/main/Main.exe /usr/local/bin/semgrep-core
+
+RUN ln -s semgrep-core /usr/local/bin/osemgrep
+
+# ???
+ENV SEMGREP_IN_DOCKER=1 \
+    SEMGREP_VERSION_CACHE_PATH=/tmp/.cache/semgrep_version \
+    SEMGREP_USER_AGENT_APPEND="Docker"
+
+# The command we tell people to run for testing semgrep in Docker is
+#   docker run --rm -v "${PWD}:/src" returntocorp/semgrep semgrep --config=auto
+# (see https://semgrep.dev/docs/getting-started/ ), hence the WORKDIR directive below
+WORKDIR /src
 
 # 'semgrep' is now available in /usr/local/bin thanks to the 'pip install' command
 # above, so let's remove /semgrep which is not needed anymore.
@@ -154,26 +168,7 @@ COPY --from=semgrep-core-container /src/semgrep/_build/default/src/main/Main.exe
 # git history).
 # TODO? to save space, we could have another docker build stage like we already
 # do between the ocaml build and the Python build.
-# The addition of osemgrep is temporary, just so that we can dogfood osemgrep
-# in CI explicitely. Once osemgrep becomes semgrep, we will not need symlink.
-RUN rm -rf /semgrep &&\
-    ln -s semgrep-core /usr/local/bin/osemgrep
-
-# ???
-ENV SEMGREP_IN_DOCKER=1 \
-    SEMGREP_USER_AGENT_APPEND="Docker"
-
-# The command we tell people to run for testing semgrep in Docker is
-#   docker run --rm -v "${PWD}:/src" returntocorp/semgrep semgrep --config=auto
-# (see https://semgrep.dev/docs/getting-started/ ), hence the WORKDIR directive below
-WORKDIR /src
-
-# Better to avoid running semgrep as root
-# See https://stackoverflow.com/questions/49193283/why-it-is-unsafe-to-run-applications-as-root-in-docker-container
-RUN addgroup --system semgrep \
-    && adduser --system --shell /bin/false --ingroup semgrep semgrep \
-    && chown semgrep /src
-USER semgrep
+RUN rm -rf /semgrep
 
 # In case of problems, if you need to debug the docker image, run 'docker build .',
 # identify the SHA of the build image and run 'docker run -it <sha> /bin/bash'

--- a/changelog.d/gh-7293.changed
+++ b/changelog.d/gh-7293.changed
@@ -1,1 +1,0 @@
-Dockerfile: Add a `semgrep` user and use that user when executing semgrep inside the container

--- a/scripts/test-pro.sh
+++ b/scripts/test-pro.sh
@@ -2,6 +2,11 @@
 
 set -e
 
+cp /root/semgrep-core-proprietary /usr/local/bin/semgrep-core-proprietary
+
+# We need to give it executable permissions or it won't run
+chmod +x /usr/local/bin/semgrep-core-proprietary
+
 # Relocate to the directory, because otherwise some weirdness happens and
 # we run with all the rules, taking ~30 minutes.
 cd /root || exit

--- a/scripts/validate-docker-build.sh
+++ b/scripts/validate-docker-build.sh
@@ -60,6 +60,5 @@ echo "if 1 == 1: pass" \
     | grep -q "1 == 1"
 
 TEMP_DIR=$(mktemp -d)
-chmod +rwx "$TEMP_DIR"
 echo "if 1 == 1: pass" > "${TEMP_DIR}/bar.py"
 docker run -v "${TEMP_DIR}:/src" -i "$image" semgrep -l python -e '$X == $X' | grep -q "1 == 1"


### PR DESCRIPTION
This reverts commit ea884475618c8b63c4794e44dc09447a902cb140.

Dogfooding has encountered some issues with this change, I'll propose a revert and we can sort this out without needed to fix forward.

PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
