### PR TITLE
debug: Only log warnings and errors by default

### DIFF
--- a/changelog.d/debug-1.changed
+++ b/changelog.d/debug-1.changed
@@ -1,0 +1,2 @@
+The output of `--debug` will be much less verbose by default, it will only show
+internal warning and error messages.

--- a/cli/tests/e2e/snapshots/test_output/test_debug_experimental_rule/results.txt
+++ b/cli/tests/e2e/snapshots/test_output/test_debug_experimental_rule/results.txt
@@ -45,29 +45,7 @@ Passing whole rules directly to semgrep_core
 Running Semgrep engine with command:
 /<MASKED>/semgrep-core -json -rules <MASKED>-json_time -fast --debug
 --- semgrep-core stderr ---
-<MASKED>
-<MASKED>
-<MASKED>
-{
-  "rules": [
-    {
-      "id": "rules.experiment.research-experiment",
-      "languages": [
-        "python"
-      ],
-      "message": "A match was found.",
-      "pattern": "print(\"...\")",
-      "severity": "EXPERIMENT"
-    }
-  ]
-}
-<MASKED>
-<MASKED>
-<MASKED>
-<MASKED>
-<MASKED>
-<MASKED>
-<MASKED>
+<semgrep-core stderr not captured, should be printed above>
 --- end semgrep-core stderr ---
 semgrep ran in <MASKED> on 1 files
 findings summary: 2 experiment

--- a/libs/commons/Logging_helpers.ml
+++ b/libs/commons/Logging_helpers.ml
@@ -29,7 +29,7 @@ let setup ~debug ~log_config_file ~log_to_file =
    Logging.apply_to_all_loggers (fun logger -> logger#add_handler handler));
 
   (* Set default level to Info rather than logging nothing (NoLevel). *)
-  (if want_logging then Logging.(set_global_level Info));
+  (if want_logging then Logging.(set_global_level Warning));
 
   (*
      Fine-tune log levels for each module, as instructed in the file


### PR DESCRIPTION
We log way too much stuff, if a customers uses --debug they easily get GB-sized logs, and most of what is in there isn't useful for diagnosing their issue. If we want to log more, we should provide users with .json files that specify exactly what we want.

test plan:
Run Semgrep with --debug

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
