### PR TITLE
dataflow: Set a strict timeout on fixpoint computations

### DIFF
--- a/src/analyzing/Dataflow_core.ml
+++ b/src/analyzing/Dataflow_core.ml
@@ -15,6 +15,8 @@
  *)
 open Common
 
+let logger = Logging.get_logger [ __MODULE__ ]
+
 (*****************************************************************************)
 (* Prelude *)
 (*****************************************************************************)
@@ -134,20 +136,29 @@ module Make (F : Flow) = struct
     pr (* nosemgrep: no-print-in-semgrep *)
       (mapping_to_str flow env_to_str mapping)
 
-  let rec fixpoint_worker eq_env mapping trans flow succs workset =
-    if NodeiSet.is_empty workset then mapping
-    else
-      let ni = NodeiSet.choose workset in
-      let work' = NodeiSet.remove ni workset in
-      let old = mapping.(ni) in
-      let new_ = trans mapping ni in
-      let work'' =
-        if eq_inout eq_env old new_ then work'
-        else (
-          mapping.(ni) <- new_;
-          NodeiSet.union work' (succs flow ni))
-      in
-      fixpoint_worker eq_env mapping trans flow succs work''
+  let fixpoint_worker ~timeout eq_env mapping trans flow succs workset =
+    let t0 = Sys.time () in
+    let rec loop work =
+      if NodeiSet.is_empty work then mapping
+      else
+        let t1 = Sys.time () in
+        if t1 -. t0 >= timeout then (
+          logger#error "fixpoint_worker timed out";
+          mapping)
+        else
+          let ni = NodeiSet.choose work in
+          let work' = NodeiSet.remove ni work in
+          let old = mapping.(ni) in
+          let new_ = trans mapping ni in
+          let work'' =
+            if eq_inout eq_env old new_ then work'
+            else (
+              mapping.(ni) <- new_;
+              NodeiSet.union work' (succs flow ni))
+          in
+          loop work''
+    in
+    loop workset
 
   let forward_succs (f : F.flow) n =
     (f.graph#successors n)#fold
@@ -160,19 +171,20 @@ module Make (F : Flow) = struct
       NodeiSet.empty
 
   let (fixpoint :
+        timeout:float ->
         eq_env:('env -> 'env -> bool) ->
         init:'env mapping ->
         trans:'env transfn ->
         flow:F.flow ->
         forward:bool ->
         'env mapping) =
-   fun ~eq_env ~init ~trans ~flow ~forward ->
+   fun ~timeout ~eq_env ~init ~trans ~flow ~forward ->
     let succs = if forward then forward_succs else backward_succs in
     let work =
       (* This prevents dead code from getting analyzed. *)
       flow.reachable
     in
-    fixpoint_worker eq_env init trans flow succs work
+    fixpoint_worker ~timeout eq_env init trans flow succs work
 
   (*****************************************************************************)
   (* Helpers *)

--- a/src/analyzing/Dataflow_core.ml
+++ b/src/analyzing/Dataflow_core.ml
@@ -141,6 +141,8 @@ module Make (F : Flow) = struct
     let rec loop work =
       if NodeiSet.is_empty work then mapping
       else
+        (* 'Time_limit.set_timeout' cannot be nested and we want to make sure that
+         * fixpoint computations run for a limited amount of time. *)
         let t1 = Sys.time () in
         if t1 -. t0 >= timeout then (
           logger#error "fixpoint_worker timed out";

--- a/src/analyzing/Dataflow_core.mli
+++ b/src/analyzing/Dataflow_core.mli
@@ -42,6 +42,7 @@ end
 module Make (F : Flow) : sig
   (* main entry point *)
   val fixpoint :
+    timeout:float ->
     eq_env:('env -> 'env -> bool) ->
     init:'env mapping ->
     trans:'env transfn ->

--- a/src/analyzing/Dataflow_svalue.ml
+++ b/src/analyzing/Dataflow_svalue.ml
@@ -616,7 +616,8 @@ let transfer :
 let (fixpoint : Lang.t -> IL.name list -> F.cfg -> mapping) =
  fun lang _inputs flow ->
   let enter_env = VarMap.empty in
-  DataflowX.fixpoint ~eq_env:(Var_env.eq_env eq)
+  DataflowX.fixpoint ~timeout:Limits_semgrep.svalue_prop_FIXPOINT_TIMEOUT
+    ~eq_env:(Var_env.eq_env eq)
     ~init:(DataflowX.new_node_array flow (Var_env.empty_inout ()))
     ~trans:(transfer ~lang ~enter_env ~flow) (* svalue is a forward analysis! *)
     ~forward:true ~flow

--- a/src/configuring/Limits_semgrep.ml
+++ b/src/configuring/Limits_semgrep.ml
@@ -1,4 +1,11 @@
 (*****************************************************************************)
+(* Const/sym ("svalue") propagation *)
+(*****************************************************************************)
+
+(* Timeout in seconds. *)
+let svalue_prop_FIXPOINT_TIMEOUT = 0.1
+
+(*****************************************************************************)
 (* Taint analysis *)
 (*****************************************************************************)
 
@@ -14,6 +21,9 @@
  * not propagate taint for data with Boolean and integer type. Improving some
  * of the data structures involved may help too.
  *)
+
+(* Timeout in seconds. *)
+let taint_FIXPOINT_TIMEOUT = 0.1
 
 (** Bounds the number of l-values we can track. *)
 let taint_MAX_TAINTED_LVALS = 100

--- a/src/configuring/Limits_semgrep.ml
+++ b/src/configuring/Limits_semgrep.ml
@@ -2,7 +2,9 @@
 (* Const/sym ("svalue") propagation *)
 (*****************************************************************************)
 
-(* Timeout in seconds. *)
+(* TODO: Report these timeouts as errors in 'Report.match_result' *)
+(* Timeout in seconds.
+ * So e.g. the perf of svalue-prop does not prevent rules from running on a file. *)
 let svalue_prop_FIXPOINT_TIMEOUT = 0.1
 
 (*****************************************************************************)
@@ -22,7 +24,9 @@ let svalue_prop_FIXPOINT_TIMEOUT = 0.1
  * of the data structures involved may help too.
  *)
 
-(* Timeout in seconds. *)
+(* TODO: Report these timeouts as errors in 'Report.match_result' *)
+(* Timeout in seconds.
+ * So e.g. we limit the amount of time that Pro will spend inferring taint signatures. *)
 let taint_FIXPOINT_TIMEOUT = 0.1
 
 (** Bounds the number of l-values we can track. *)

--- a/src/configuring/Limits_semgrep.ml
+++ b/src/configuring/Limits_semgrep.ml
@@ -4,7 +4,8 @@
 
 (* TODO: Report these timeouts as errors in 'Report.match_result' *)
 (* Timeout in seconds.
- * So e.g. the perf of svalue-prop does not prevent rules from running on a file. *)
+ * So e.g. the perf of svalue-prop does not prevent rules from running on a file.
+ * Note that 'Time_limit.set_timeout' cannot be nested. *)
 let svalue_prop_FIXPOINT_TIMEOUT = 0.1
 
 (*****************************************************************************)
@@ -26,7 +27,8 @@ let svalue_prop_FIXPOINT_TIMEOUT = 0.1
 
 (* TODO: Report these timeouts as errors in 'Report.match_result' *)
 (* Timeout in seconds.
- * So e.g. we limit the amount of time that Pro will spend inferring taint signatures. *)
+ * So e.g. we limit the amount of time that Pro will spend inferring taint signatures.
+ * Note that 'Time_limit.set_timeout' cannot be nested. *)
 let taint_FIXPOINT_TIMEOUT = 0.1
 
 (** Bounds the number of l-values we can track. *)

--- a/src/tainting/Dataflow_tainting.ml
+++ b/src/tainting/Dataflow_tainting.ml
@@ -1861,7 +1861,8 @@ let (fixpoint :
   (* THINK: Why I cannot just update mapping here ? if I do, the mapping gets overwritten later on! *)
   (* DataflowX.display_mapping flow init_mapping show_tainted; *)
   let end_mapping =
-    DataflowX.fixpoint ~eq_env:Lval_env.equal ~init:init_mapping
+    DataflowX.fixpoint ~timeout:Limits_semgrep.taint_FIXPOINT_TIMEOUT
+      ~eq_env:Lval_env.equal ~init:init_mapping
       ~trans:
         (transfer lang options config enter_env opt_name ~flow ~top_sinks
            ~java_props)


### PR DESCRIPTION
We shouldn't allow a bug, a bad rule, or a "bad" file ruining a Semgrep run, better to abort the analysis and move on.

Note that `Time_limit.set_timeout` cannot be nested.

test plan:
Run `p/default-v2` on a subset of 31 repos from stress-test-monorepo, the average speedup was 1.2x.
(No difference in number of findings.)

PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
