### PR TITLE
revert back to user:root for circleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
   semgrep:
     docker:
       - image: returntocorp/semgrep:develop
-        user: semgrep
+        user: root
     working_directory: /src
     steps:
       - checkout


### PR DESCRIPTION
We reverted back to user:root in our Dockerfile, so we need
to do that for circleCI too

test plan:
wait for circleCI green check


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)