### PR TITLE
devops: use opam update in macos setup

### DIFF
--- a/scripts/osx-setup-for-release.sh
+++ b/scripts/osx-setup-for-release.sh
@@ -16,6 +16,9 @@ opam init --no-setup --bare
 #still needed?
 #brew update
 
+# we might need recent packages and the self-hosted runner opam might be behind
+opam update
+
 # Some CI runners have tree-sitter preinstalled which interfere with
 # out static linking plans below so better to remove it.
 # TODO: fix setup-m1-builder.sh instead?


### PR DESCRIPTION
test plan:
wait for green checks in CI


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)