### PR TITLE
feat(js/ts): decorated async and static properties

### DIFF
--- a/changelog.d/pa-2675.added
+++ b/changelog.d/pa-2675.added
@@ -1,0 +1,17 @@
+JS/TS: Patterns for class properties can now have the `static`
+and `async` modifiers.
+
+For instance:
+```
+@Foo(...)
+async bar(...) {
+  ...
+}
+```
+or
+```
+@Foo(...)
+static bar(...) {
+  ...
+}
+```

--- a/tests/rules/ts_decorated_async_property.ts
+++ b/tests/rules/ts_decorated_async_property.ts
@@ -1,0 +1,46 @@
+
+class Foo {
+  @Query()
+  async foo(){
+  }
+
+  @Query()
+  static async foo(){
+  }
+
+  // ruleid: decorated-async-property
+  @Query()
+  async bar(){
+  }
+
+  // ruleid: decorated-async-property
+  @Query()
+  static async bar(){
+  }
+
+  // ruleid: decorated-async-property
+  @Query()
+  async qux(){
+  }
+
+  // ruleid: decorated-async-property
+  @Query()
+  static async qux(){
+  }
+
+  @Query()
+  not_async(){
+  }
+
+  @NotQuery
+  async foo(){
+  }
+
+  @NotQuery
+  async bar(){
+  }
+
+  @NotQuery
+  async qux(){
+  }
+}

--- a/tests/rules/ts_decorated_async_property.yaml
+++ b/tests/rules/ts_decorated_async_property.yaml
@@ -15,6 +15,4 @@ rules:
           ...
         }
   message: Matching a decorated async property 
-  options:
-    symbolic_propagation: true
   severity: ERROR

--- a/tests/rules/ts_decorated_async_property.yaml
+++ b/tests/rules/ts_decorated_async_property.yaml
@@ -1,0 +1,20 @@
+rules:
+- id: decorated-async-property 
+  languages:
+  - typescript 
+  pattern-either:
+    - pattern: |
+        @Query(...)
+        async foo
+    - pattern: |
+        @Query(...)
+        async bar(...)
+    - pattern: |
+        @Query(...)
+        async qux(...){
+          ...
+        }
+  message: Matching a decorated async property 
+  options:
+    symbolic_propagation: true
+  severity: ERROR

--- a/tests/rules/ts_decorated_static_property.ts
+++ b/tests/rules/ts_decorated_static_property.ts
@@ -1,0 +1,46 @@
+
+class Foo {
+  @Query()
+  static foo(){
+  }
+
+  @Query()
+  static async foo(){
+  }
+
+  // ruleid: decorated-static-property
+  @Query()
+  static bar(){
+  }
+
+  // ruleid: decorated-static-property
+  @Query()
+  static async bar(){
+  }
+
+  // ruleid: decorated-static-property
+  @Query()
+  static qux(){
+  }
+
+  // ruleid: decorated-static-property
+  @Query()
+  static async qux(){
+  }
+
+  @Query()
+  not_static(){
+  }
+
+  @NotQuery
+  static foo(){
+  }
+
+  @NotQuery
+  static bar(){
+  }
+
+  @NotQuery
+  static qux(){
+  }
+}

--- a/tests/rules/ts_decorated_static_property.yaml
+++ b/tests/rules/ts_decorated_static_property.yaml
@@ -15,6 +15,4 @@ rules:
           ...
         }
   message: Matching a decorated static property 
-  options:
-    symbolic_propagation: true
   severity: ERROR

--- a/tests/rules/ts_decorated_static_property.yaml
+++ b/tests/rules/ts_decorated_static_property.yaml
@@ -1,0 +1,20 @@
+rules:
+- id: decorated-static-property 
+  languages:
+  - typescript 
+  pattern-either:
+    - pattern: |
+        @Query(...)
+        static foo
+    - pattern: |
+        @Query(...)
+        static bar(...)
+    - pattern: |
+        @Query(...)
+        static qux(...){
+          ...
+        }
+  message: Matching a decorated static property 
+  options:
+    symbolic_propagation: true
+  severity: ERROR


### PR DESCRIPTION
## What:
This PR allows JS/TS property patterns which have `static` or `async`.

## Why:
SR wants!

## How:
Just added `static` and `async` to the allowed modifiers, per the Javascript grammar.

## Test plan:
`make test`, and no new shift/reduce conflicts

Closes PA-2675

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
