### PR TITLE
tainting: Improvements to taint_assume_safe_{booleans,numbers}

### DIFF
--- a/changelog.d/pa-2777.changed
+++ b/changelog.d/pa-2777.changed
@@ -1,0 +1,3 @@
+taint-mode: Several improvements to `taint_assume_safe_{booleans,numbers}` options.
+Most notably, we will now use type info provided by explicit type casts, and we will
+also use const-prop info to infer types.

--- a/src/core/Type.ml
+++ b/src/core/Type.ml
@@ -72,6 +72,7 @@ and 'resolved t =
    * See also of_opt() below.
    *)
   | NoType
+  | Wildcard
   | Todo of todo_kind
 
 and builtin_type =
@@ -87,6 +88,7 @@ and 'resolved function_type = 'resolved parameter list * 'resolved t
 
 and 'resolved parameter =
   | Param of 'resolved parameter_classic
+  | WildcardParam
   | OtherParam of todo_kind
 
 and 'resolved parameter_classic = {
@@ -266,6 +268,8 @@ let rec to_ast_generic_type_ ?(tok = None) lang
                  | _else_ ->
                      G.OtherParam
                        (("to_ast_generic_type for param", make_tok ""), []))
+             | WildcardParam ->
+                 G.OtherParam (("Wildcard", Tok.unsafe_fake_tok "_"), [])
              | OtherParam x ->
                  G.OtherParam (todo_kind_to_ast_generic_todo_kind x, []))
       in
@@ -275,6 +279,7 @@ let rec to_ast_generic_type_ ?(tok = None) lang
       let* ty = to_ast_generic_type_ lang f ty in
       Some (G.TyPointer (make_tok "Pointer", ty) |> G.t)
   | NoType
+  | Wildcard
   | Todo _ ->
       None
 

--- a/src/core/Type.ml
+++ b/src/core/Type.ml
@@ -72,7 +72,7 @@ and 'resolved t =
    * See also of_opt() below.
    *)
   | NoType
-  | Wildcard
+  | Wildcard  (** An arbitrary type that is not important. *)
   | Todo of todo_kind
 
 and builtin_type =

--- a/src/core/Type.ml
+++ b/src/core/Type.ml
@@ -156,9 +156,12 @@ let todo_kind_to_ast_generic_todo_kind (x : todo_kind) : G.todo_kind =
 let builtin_type_of_string _langTODO str =
   match str with
   | "int"
-  | "Integer" ->
+  | "long"
+  | "Integer"
+  | "Long" ->
       Some Int
   | "float"
+  | "double"
   | "Float" ->
       Some Float
   | "str"

--- a/src/matching/Generic_vs_generic.ml
+++ b/src/matching/Generic_vs_generic.ml
@@ -2105,6 +2105,9 @@ and m_generic_type_vs_type_t lang tok a b =
   | _, Type.Function _
   | _, Type.Pointer _
   | _, Type.NoType
+  | _, Type.Wildcard
+  (* TDOO: ^^^ We don't curently accept wildcards in type patterns but if we did
+   * we will want to let wildcards match anything rather than failing here! *)
   | _, Type.Todo _ ->
       fail ()
 
@@ -2142,6 +2145,9 @@ and m_generic_param_vs_param lang tok a b =
       | Some t1 -> m_generic_type_vs_type_t lang tok t1 t2
       | None -> (* THINK: Is this right? *) return ())
   | _, Type.Param _
+  | _, Type.WildcardParam
+  (* TDOO: ^^^ We don't curently accept wildcards in type patterns but if we did
+   * we will want to let wildcards match anything rather than failing here! *)
   | _, Type.OtherParam _ ->
       fail ()
 

--- a/src/tainting/Dataflow_tainting.ml
+++ b/src/tainting/Dataflow_tainting.ml
@@ -1666,6 +1666,13 @@ let check_tainted_instr env instr : Taints.t * Lval_env.t =
       in
       let taints = Taints.union taints taints_propagated in
       check_orig_if_sink env instr.iorig taints;
+      let taints =
+        match LV.lval_of_instr_opt instr with
+        | None -> taints
+        | Some lval ->
+            check_type_and_drop_taints_if_bool_or_number env taints type_of_lval
+              lval
+      in
       (taints, lval_env')
 
 (* Test whether a `return' is tainted, and if it is also a sink,

--- a/src/typing/Typing.ml
+++ b/src/typing/Typing.ml
@@ -22,22 +22,19 @@ module G = AST_generic
 let rec type_of_expr lang e : G.name Type.t * G.ident option =
   match e.G.e with
   | G.L lit ->
-      let t =
-        match lit with
-        (* NB: We could infer Type.Number for JS int/float literals, but we can
-         * handle that relationship in matching and we can be more precise for
-         * now. One actual rule uses `float` for a typed metavariable in JS so
-         * let's avoid breaking that for now at least. *)
-        | G.Int _ -> Type.Builtin Type.Int
-        | G.Float _ -> Type.Builtin Type.Float
-        | G.Bool _ -> Type.Builtin Type.Bool
-        | G.String _ -> Type.Builtin Type.String
-        | _else_ -> Type.NoType
-      in
+      let t = type_of_lit lit in
       (t, None)
+  | G.DotAccess
+      (_obj, _, FN (Id (("length", _), { id_type = { contents = None }; _ })))
+    when lang =*= Lang.Java ->
+      (* TODO: Fix guess_type_of_dotaccess to take an "expected type" (as in bidirectional
+       * type checking) so that we can distinguish `length` as a method (e.g. `String`) and
+       * `length` as an attribute (arrays). *)
+      (Type.Builtin Type.Int, None)
   | G.N name
   | G.DotAccess (_, _, FN name) ->
       type_of_name lang name
+  | G.Cast (t, _, _) -> (type_of_ast_generic_type lang t, None)
   (* TODO? or generate a fake "new" id for LSP to query on tk? *)
   (* We conflate the type of a class with the type of its instance. Maybe at
    * some point we should introduce a `Class` type and unwrap it here upon
@@ -50,11 +47,13 @@ let rec type_of_expr lang e : G.name Type.t * G.ident option =
       let t =
         match (t1, op, t2) with
         | Type.(Builtin (Int | Float)), (G.Plus | G.Minus (* TODO more *)), _
-        | _, (G.Plus | G.Minus (* TODO more *)), Type.(Builtin (Int | Float))
+        | ( _,
+            (G.Plus | G.Minus | G.Mult (* TODO more *)),
+            Type.(Builtin (Int | Float)) )
         (* Note that `+` is overloaded in many languages and may also be
          * string concatenation, and unfortunately some languages such
          * as Java and JS/TS have implicit coercions to string. *)
-          when lang =*= Lang.Python (* TODO more *) ->
+          when lang =*= Lang.Python || lang =*= Lang.Php (* TODO more *) ->
             Type.Builtin Type.Number
         | ( Type.Builtin Type.Int,
             (G.Plus | G.Minus (* TODO more *)),
@@ -125,7 +124,27 @@ let rec type_of_expr lang e : G.name Type.t * G.ident option =
       (t, idopt)
   | _else_ -> (Type.NoType, None)
 
+and type_of_lit = function
+  (* NB: We could infer Type.Number for JS int/float literals, but we can
+     * handle that relationship in matching and we can be more precise for
+     * now. One actual rule uses `float` for a typed metavariable in JS so
+     * let's avoid breaking that for now at least. *)
+  | G.Int _ -> Type.Builtin Type.Int
+  | G.Float _ -> Type.Builtin Type.Float
+  | G.Bool _ -> Type.Builtin Type.Bool
+  | G.String _ -> Type.Builtin Type.String
+  | _else_ -> Type.NoType
+
 and type_of_name lang = function
+  | Id (ident, { id_svalue = { contents = Some (Lit lit) }; _ }) ->
+      let t = type_of_lit lit in
+      (t, Some ident)
+  | Id (ident, { id_svalue = { contents = Some (Cst Cbool) }; _ }) ->
+      (Type.Builtin Type.Bool, Some ident)
+  | Id (ident, { id_svalue = { contents = Some (Cst Cint) }; _ }) ->
+      (Type.Builtin Type.Int, Some ident)
+  | Id (ident, { id_svalue = { contents = Some (Cst Cstr) }; _ }) ->
+      (Type.Builtin Type.String, Some ident)
   | Id (ident, id_info) ->
       let t = resolved_type_of_id_info lang id_info in
       let t =

--- a/src/typing/Typing.mli
+++ b/src/typing/Typing.mli
@@ -14,4 +14,8 @@ val check_program : Lang.t -> AST_generic.program -> unit
  *
  * Exposed for use in Pro Engine. *)
 val guess_type_of_dotaccess :
-  Lang.t -> (string * 'a Type.type_argument list) option -> string -> 'a Type.t
+  Lang.t ->
+  expected:AST_generic.name Type.t ->
+  (string * 'a Type.type_argument list) option ->
+  string ->
+  'a Type.t

--- a/tests/rules/taint_assume_safe_numbers1.java
+++ b/tests/rules/taint_assume_safe_numbers1.java
@@ -1,6 +1,38 @@
 class Test {
-    public void test(int x) {
+    public void test1(int x) {
         //OK: test
         sink(x);
+    }
+    public void test2(long x) {
+        //OK: test
+        sink(x);
+    }
+    public void test3(Object x) {
+        long t = x.getSomething();
+        //OK: test
+        sink(t);
+    }
+    public void test4(Object[] x) {
+        //OK: test
+        sink(x.length);
+    }
+    public void test5(Object x) {
+        var t = (int)x.getSomething();
+        //OK: test
+        sink(t);
+    }
+    public void test6(Object[] x) {
+        var u = 1;
+        var v = u + 1;
+        var w = v + x.length;
+        //OK: test
+        sink(w);
+    }
+    public void test7(Object x) {
+        var u = "a";
+        var v = "a" + 1;
+        var w = v + x.getSomething();
+        //ruleid: test
+        sink(w);
     }
 }

--- a/tests/rules/taint_assume_safe_numbers2.php
+++ b/tests/rules/taint_assume_safe_numbers2.php
@@ -1,0 +1,20 @@
+<?php
+
+// ok:taint-assume-safe-numbers
+sink((int) source());
+
+// ok:taint-assume-safe-numbers
+sink(source() * 3);
+// ok:taint-assume-safe-numbers
+sink(source() - 1);
+
+$i = (int) source();
+// ok:taint-assume-safe-numbers
+sink($i);
+
+$i = 3;
+// ok:taint-assume-safe-numbers
+sink(source() * $i);
+
+// ok:taint-assume-safe-numbers
+sink((float) source());

--- a/tests/rules/taint_assume_safe_numbers2.yaml
+++ b/tests/rules/taint_assume_safe_numbers2.yaml
@@ -1,0 +1,15 @@
+rules:
+  - id: taint-assume-safe-numbers
+    message: Match!
+    languages:
+      - php
+    severity: WARNING
+    mode: taint
+    options:
+      taint_assume_safe_numbers: true
+    pattern-sources:
+      - pattern: source()
+    pattern-sinks:
+      - pattern: sink(...)
+    pattern-sanitizers:
+      - pattern: sanitizer(...)


### PR DESCRIPTION
Mainly:

- Use type info provided by explicit casts.
- Use const-prop info to infer types.
- Guess the type of `length` when used as an attribute.
- Add `long` and `Long` as "synonyms" for `int` and `Integer`, and `double` for `float`.
- Sometimes we cannot infer the type of the RHS but the LHS is a variable with e.g. a number type, so we can avoid tracking it.

Follows: 64cb387f7a0 ("tainting: Add options to ignore taint based on types (#7936)")

test plan:
make test # new tests

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
