### PR TITLE
tainting: Improvements to taint_assume_safe_{booleans,numbers}

### DIFF
--- a/changelog.d/pa-2777.changed
+++ b/changelog.d/pa-2777.changed
@@ -1,0 +1,3 @@
+taint-mode: Several improvements to `taint_assume_safe_{booleans,numbers}` options.
+Most notably, we will now use type info provided by explicit type casts, and we will
+also use const-prop info to infer types.

--- a/src/core/Type.ml
+++ b/src/core/Type.ml
@@ -156,9 +156,12 @@ let todo_kind_to_ast_generic_todo_kind (x : todo_kind) : G.todo_kind =
 let builtin_type_of_string _langTODO str =
   match str with
   | "int"
-  | "Integer" ->
+  | "long"
+  | "Integer"
+  | "Long" ->
       Some Int
   | "float"
+  | "double"
   | "Float" ->
       Some Float
   | "str"

--- a/src/tainting/Dataflow_tainting.ml
+++ b/src/tainting/Dataflow_tainting.ml
@@ -1666,6 +1666,13 @@ let check_tainted_instr env instr : Taints.t * Lval_env.t =
       in
       let taints = Taints.union taints taints_propagated in
       check_orig_if_sink env instr.iorig taints;
+      let taints =
+        match LV.lval_of_instr_opt instr with
+        | None -> taints
+        | Some lval ->
+            check_type_and_drop_taints_if_bool_or_number env taints type_of_lval
+              lval
+      in
       (taints, lval_env')
 
 (* Test whether a `return' is tainted, and if it is also a sink,

--- a/tests/rules/taint_assume_safe_booleans1.java
+++ b/tests/rules/taint_assume_safe_booleans1.java
@@ -1,7 +1,17 @@
+import java.lang.Boolean;
+
 class Test {
-    public void ok(String x) {
+    public void ok1(String x) {
         //OK: test
         sink("something" + (x != "safe"));
+    }
+    public void ok2(String x) {
+        //OK: test
+        sink(Boolean.valueOf(x));
+    }
+    public void ok3(String x) {
+        //OK: test
+        sink(Boolean.parseBoolean(x));
     }
     public void bad(String x) {
         //ruleid: test

--- a/tests/rules/taint_assume_safe_numbers1.java
+++ b/tests/rules/taint_assume_safe_numbers1.java
@@ -1,6 +1,52 @@
+import java.lang.Integer;
+
 class Test {
-    public void test(int x) {
+    public void test1(int x) {
         //OK: test
         sink(x);
+    }
+    public void test2(long x) {
+        //OK: test
+        sink(x);
+    }
+    public void test3(Object x) {
+        long t = x.getSomething();
+        //OK: test
+        sink(t);
+    }
+    public void test4(Object[] x) {
+        //OK: test
+        sink(x.length);
+    }
+    public void test5(Object x) {
+        var t = (int)x.getSomething();
+        //OK: test
+        sink(t);
+    }
+    public void test6(Object[] x) {
+        var u = 1;
+        var v = u + 1;
+        var w = v + x.length;
+        //OK: test
+        sink(w);
+    }
+    public void test7(Object x) {
+        var u = "a";
+        var v = "a" + 1;
+        var w = v + x.getSomething();
+        //ruleid: test
+        sink(w);
+    }
+    public void test8(String x) {
+        //OK: test
+        sink(Integer.valueOf(x));
+    }
+    public void test9(String x) {
+        //OK: test
+        sink(Integer.parseInt(x));
+    }
+    public void test10(String x) {
+        //OK: test
+        sink(x.compareTo("safe"));
     }
 }

--- a/tests/rules/taint_assume_safe_numbers2.php
+++ b/tests/rules/taint_assume_safe_numbers2.php
@@ -1,0 +1,20 @@
+<?php
+
+// ok:taint-assume-safe-numbers
+sink((int) source());
+
+// ok:taint-assume-safe-numbers
+sink(source() * 3);
+// ok:taint-assume-safe-numbers
+sink(source() - 1);
+
+$i = (int) source();
+// ok:taint-assume-safe-numbers
+sink($i);
+
+$i = 3;
+// ok:taint-assume-safe-numbers
+sink(source() * $i);
+
+// ok:taint-assume-safe-numbers
+sink((float) source());

--- a/tests/rules/taint_assume_safe_numbers2.yaml
+++ b/tests/rules/taint_assume_safe_numbers2.yaml
@@ -1,0 +1,15 @@
+rules:
+  - id: taint-assume-safe-numbers
+    message: Match!
+    languages:
+      - php
+    severity: WARNING
+    mode: taint
+    options:
+      taint_assume_safe_numbers: true
+    pattern-sources:
+      - pattern: source()
+    pattern-sinks:
+      - pattern: sink(...)
+    pattern-sanitizers:
+      - pattern: sanitizer(...)


### PR DESCRIPTION
Mainly:

- Use type info provided by explicit casts.
- Use const-prop info to infer types.
- Guess the type of `length` when used as an attribute.
- Add `long` and `Long` as "synonyms" for `int` and `Integer`, and `double` for `float`.
- Guess types for `decode`, `valueOf` and `parseXyz` methods in classes `Boolean`, `Integer`, `Long`, and `Float`.
- Sometimes we cannot infer the type of the RHS but the LHS is a variable with e.g. a number type, so we can avoid tracking it.

Follows: 64cb387f7a0 ("tainting: Add options to ignore taint based on types (#7936)")

test plan:
make test # new tests

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
