### PR TITLE
feat(rule syntax): Metavariable Type Extension for Semgrep Rule Syntax

### DIFF
--- a/changelog.d/gh-8119.added
+++ b/changelog.d/gh-8119.added
@@ -39,4 +39,3 @@ rules:
           metavariable: $Y
           type: String
 ```
-

--- a/changelog.d/gh-8119.added
+++ b/changelog.d/gh-8119.added
@@ -1,0 +1,42 @@
+feat(rule syntax): Metavariable Type Extension for Semgrep Rule Syntax
+
+We've added a dedicated field for annotating the type information of
+metavariables. By adopting this approach, instead of relying solely on
+language-specific casting syntax, we provide an additional way to enhance
+the overall usability by eliminating the need to write redundant type cast
+expressions for a single metavariable.
+
+Moreover, the new syntax brings other benefits, including improved support for
+target languages that lack built-in casting syntax. It also promotes a unified
+approach to expressing type, pattern, and regex constraints for metavariables,
+resulting in improved consistency across rule definitions.
+
+Current syntax:
+```
+rules:
+  - id: no-string-eqeq
+    severity: WARNING
+    message: find errors
+    languages:
+      - java
+    patterns:
+      - pattern-not: null == (String $Y)
+      - pattern: $X == (String $Y)
+```
+
+Added syntax:
+```
+rules:
+  - id: no-string-eqeq
+    severity: WARNING
+    message: find errors
+    languages:
+      - java
+    patterns:
+      - pattern-not: null == $Y
+      - pattern: $X == $Y
+      - metavariable-type:
+          metavariable: $Y
+          type: String
+```
+

--- a/src/core/Rule.ml
+++ b/src/core/Rule.ml
@@ -173,6 +173,7 @@ and metavar_cond =
    *)
   | CondRegexp of
       MV.mvar * Xpattern.regexp_string * bool (* constant-propagation *)
+  | CondType of MV.mvar * Xlang.t option * string * AST_generic.type_
   | CondAnalysis of MV.mvar * metavar_analysis_kind
   | CondNestedFormula of MV.mvar * Xlang.t option * formula
 

--- a/src/core/Rule.ml
+++ b/src/core/Rule.ml
@@ -173,7 +173,11 @@ and metavar_cond =
    *)
   | CondRegexp of
       MV.mvar * Xpattern.regexp_string * bool (* constant-propagation *)
-  | CondType of MV.mvar * Xlang.t option * string * AST_generic.type_
+  | CondType of
+      MV.mvar
+      * Xlang.t option (* when the type expression is in different lang *)
+      * string (* raw input string saved for regenerating rule yaml *)
+      * AST_generic.type_ (* LATER: could parse lazily, like the patterns *)
   | CondAnalysis of MV.mvar * metavar_analysis_kind
   | CondNestedFormula of MV.mvar * Xlang.t option * formula
 

--- a/src/engine/Match_search_mode.ml
+++ b/src/engine/Match_search_mode.ml
@@ -575,6 +575,10 @@ let rec filter_ranges (env : env) (xs : (RM.t * MV.bindings list) list)
                  logger#info
                    "range %d-%d filtered from metavar %s type mismatch."
                    r.r.start r.r.end_ mvar;
+                 (* the type can also contain metavariables, but we probably
+                  * don't want to use that in other parts of the rules, so it's
+                  * probably fine to just check whether the match is empty or
+                  * not *)
                  matches <> [] |> map_bool r
              | None ->
                  error env

--- a/src/matching/Generic_vs_generic.mli
+++ b/src/matching/Generic_vs_generic.mli
@@ -22,3 +22,11 @@ val m_any : AST_generic.any Matching_generic.matcher
 
 val hook_find_possible_parents :
   (AST_generic.dotted_ident -> AST_generic.name list) option ref
+
+val m_compatible_type :
+  Language.t ->
+  AST_generic.ident ->
+  AST_generic.type_ ->
+  AST_generic.expr ->
+  Matching_generic.tin ->
+  Matching_generic.tout

--- a/src/matching/Generic_vs_generic.mli
+++ b/src/matching/Generic_vs_generic.mli
@@ -23,6 +23,7 @@ val m_any : AST_generic.any Matching_generic.matcher
 val hook_find_possible_parents :
   (AST_generic.dotted_ident -> AST_generic.name list) option ref
 
+(* used for evaluating `metavariable-type:` in Match_search_mode.ml *)
 val m_compatible_type :
   Language.t ->
   AST_generic.ident ->

--- a/src/matching/Match_patterns.mli
+++ b/src/matching/Match_patterns.mli
@@ -18,7 +18,6 @@ val check :
 val last_matched_rule : Mini_rule.t option ref
 
 (* used by tainting *)
-
 val match_e_e : Mini_rule.t -> AST_generic.expr Matching_generic.matcher
 
 (* for unit testing *)

--- a/src/metachecking/Check_rule.ml
+++ b/src/metachecking/Check_rule.ml
@@ -140,6 +140,8 @@ let unknown_metavar_in_comparison env f =
                | CondEval _ -> ()
                | CondRegexp (mv, _, _) ->
                    if not (mvar_is_ok mv mvs) then mv_error mv t
+               | CondType (mv, _, _, _) ->
+                   if not (mvar_is_ok mv mvs) then mv_error mv t
                | CondNestedFormula (mv, _, _) ->
                    if not (mvar_is_ok mv mvs) then mv_error mv t
                | CondAnalysis (mv, _) ->

--- a/src/metachecking/Translate_rule.ml
+++ b/src/metachecking/Translate_rule.ml
@@ -44,6 +44,13 @@ let rec expr_to_string expr =
 and translate_metavar_cond cond : [> `O of (string * Yaml.value) list ] =
   match cond with
   | CondEval e -> `O [ ("comparison", `String (expr_to_string e)) ]
+  | CondType (mv, lang, str, _) ->
+      `O
+        ([ ("metavariable", `String mv); ("type", `String str) ]
+        @
+        match lang with
+        | None -> []
+        | Some x -> [ ("language", `String (Xlang.to_string x)) ])
   | CondRegexp (mv, re_str, _) ->
       `O [ ("metavariable", `String mv); ("regex", `String re_str) ]
   | CondAnalysis (mv, analysis) ->

--- a/src/optimizing/Analyze_rule.ml
+++ b/src/optimizing/Analyze_rule.ml
@@ -317,6 +317,7 @@ and metavarcond_step1 x =
   | R.CondNestedFormula _ -> None
   | R.CondRegexp (mvar, re, const_prop) ->
       Some (MvarRegexp (mvar, re, const_prop))
+  (* TODO? maybe we should extract the strings from the type constraint *)
   | R.CondType _ -> None
   | R.CondAnalysis _ -> None
 

--- a/src/optimizing/Analyze_rule.ml
+++ b/src/optimizing/Analyze_rule.ml
@@ -317,6 +317,7 @@ and metavarcond_step1 x =
   | R.CondNestedFormula _ -> None
   | R.CondRegexp (mvar, re, const_prop) ->
       Some (MvarRegexp (mvar, re, const_prop))
+  | R.CondType _ -> None
   | R.CondAnalysis _ -> None
 
 (*****************************************************************************)

--- a/src/parsing/Parse_rule.ml
+++ b/src/parsing/Parse_rule.ml
@@ -468,6 +468,7 @@ let rec parse_type env key (str, tok) =
 
 and wrap_type_expr env key lang str =
   match lang with
+  (* `x` is a placeholder and won't be used during unwrapping. *)
   | Lang.Java -> spf "(%s x)" str
   | _ ->
       error_at_key env.id key

--- a/src/parsing/Parse_rule.ml
+++ b/src/parsing/Parse_rule.ml
@@ -453,6 +453,31 @@ let parse_python_expression env key s =
 
 let parse_metavar_cond env key s = parse_python_expression env key s
 
+let rec parse_type env key (str, tok) =
+  match env.languages.target_analyzer with
+  | Xlang.L (lang, _) ->
+      let str = wrap_type_expr env key lang str in
+      try_and_raise_invalid_pattern_if_error env (str, tok) (fun () ->
+          Parse_pattern.parse_pattern lang ~print_errors:false str)
+      |> unwrap_typed_metavar env key
+  | Xlang.LRegex
+  | Xlang.LSpacegrep
+  | Xlang.LAliengrep ->
+      error_at_key env.id key
+        "`type` is not supported with regex, spacegrep or aliengrep."
+
+and wrap_type_expr env key lang str =
+  match lang with
+  | Lang.Java -> spf "(%s x)" str
+  | _ ->
+      error_at_key env.id key
+        ("`metavariable-type` is not supported for " ^ Lang.show lang)
+
+and unwrap_typed_metavar env key expr =
+  match expr with
+  | G.E { e = G.TypedMetavar (_, _, t); _ } -> t
+  | _ -> error_at_key env.id key "Failed to unwrap the type expression."
+
 let parse_regexp env (s, t) =
   (* We try to compile the regexp just to make sure it's valid, but we store
    * the raw string, see notes attached to 'Xpattern.xpattern_kind'. *)
@@ -701,6 +726,7 @@ let parse_xpattern_expr env e =
 (* extra conditions, usually on metavariable content *)
 type extra =
   | MetavarRegexp of MV.mvar * Xpattern.regexp_string * bool
+  | MetavarType of MV.mvar * Xlang.t option * string * G.type_
   | MetavarPattern of MV.mvar * Xlang.t option * Rule.formula
   | MetavarComparison of metavariable_comparison
   | MetavarAnalysis of MV.mvar * Rule.metavar_analysis_kind
@@ -826,6 +852,8 @@ and parse_pair_old env ((key, value) : key * G.expr) : R.formula =
             let process_extra extra =
               match extra with
               | MetavarRegexp (mvar, regex, b) -> R.CondRegexp (mvar, regex, b)
+              | MetavarType (mvar, xlang_opt, s, t) ->
+                  R.CondType (mvar, xlang_opt, s, t)
               | MetavarPattern (mvar, xlang_opt, formula) ->
                   R.CondNestedFormula (mvar, xlang_opt, formula)
               | MetavarComparison { comparison; strip; _ } ->
@@ -840,17 +868,19 @@ and parse_pair_old env ((key, value) : key * G.expr) : R.formula =
               ( find "focus-metavariable",
                 find "metavariable-analysis",
                 find "metavariable-regex",
+                find "metavariable-type",
                 find "metavariable-pattern",
                 find "metavariable-comparison" )
             with
-            | None, None, None, None, None ->
+            | None, None, None, None, None, None ->
                 Left3 (get_nested_formula_in_list env i expr)
-            | Some (((_, t) as key), value), None, None, None, None ->
+            | Some (((_, t) as key), value), None, None, None, None, None ->
                 Middle3 (t, parse_focus_mvs env key value)
-            | None, Some (key, value), None, None, None
-            | None, None, Some (key, value), None, None
-            | None, None, None, Some (key, value), None
-            | None, None, None, None, Some (key, value) ->
+            | None, Some (key, value), None, None, None, None
+            | None, None, Some (key, value), None, None, None
+            | None, None, None, Some (key, value), None, None
+            | None, None, None, None, Some (key, value), None
+            | None, None, None, None, None, Some (key, value) ->
                 Right3 (snd key, parse_extra env key value |> process_extra)
             | _ ->
                 error_at_expr env.id expr
@@ -878,6 +908,7 @@ and parse_pair_old env ((key, value) : key * G.expr) : R.formula =
   | "focus-metavariable"
   | "metavariable-analysis"
   | "metavariable-regex"
+  | "metavariable-type"
   | "metavariable-pattern"
   | "metavariable-comparison" ->
       error_at_key env.id key "Must occur directly under a patterns:"
@@ -925,6 +956,29 @@ and parse_extra (env : env) (key : key) (value : G.expr) : extra =
           match const_prop with
           | Some b -> b
           | None -> false )
+  | "metavariable-type" ->
+      let mv_type_dict = yaml_to_dict env key value in
+      let metavar = take mv_type_dict env parse_string "metavariable" in
+      let type_str = take mv_type_dict env parse_string_wrap "type" in
+      let env', opt_xlang =
+        match take_opt mv_type_dict env parse_string "language" with
+        | Some s ->
+            let xlang = Xlang.of_string ~rule_id:(env.id :> string) s in
+            let env' =
+              {
+                id = env.id;
+                languages = Rule.languages_of_xlang xlang;
+                in_metavariable_pattern = env.in_metavariable_pattern;
+                path = "metavariable-type" :: "metavariable" :: env.path;
+                options_key = None;
+                options = None;
+              }
+            in
+            (env', Some xlang)
+        | ___else___ -> (env, None)
+      in
+      let t = parse_type env' key type_str in
+      MetavarType (metavar, opt_xlang, fst type_str, t)
   | "metavariable-pattern" ->
       let mv_pattern_dict = yaml_to_dict env key value in
       let metavar = take mv_pattern_dict env parse_string "metavariable" in

--- a/tests/rules/metavar_type_not.java
+++ b/tests/rules/metavar_type_not.java
@@ -1,0 +1,14 @@
+public class BenchmarkTest02388 extends HttpServlet {
+    public void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        PrintWriter pWriter = response.getWriter();
+        // ok: no-direct-response-writer
+        pWriter.println(
+                "Hash Test java.security.MessageDigest.getInstance(java.lang.String) executed");
+        // ruleid: no-direct-response-writer
+        pWriter.println(request.input);
+
+        SafeWriter sWriter = response.getSafeWriter();
+        // ok: no-direct-response-writer
+        sWriter.println(request.input);
+    }
+}

--- a/tests/rules/metavar_type_not.yaml
+++ b/tests/rules/metavar_type_not.yaml
@@ -1,0 +1,21 @@
+rules:
+- id: no-direct-response-writer
+  patterns:
+  - pattern: $WRITER.println(...)
+  - pattern-not: $WRITER.println("...")
+  - metavariable-type:
+      metavariable: $WRITER
+      type: PrintWriter
+  message: |
+    Detected a direct write to the HTTP response. This bypasses any
+    view or template environments, including HTML escaping, which may
+    expose this application to cross-site scripting (XSS) vulnerabilities.
+    Consider using a view technology such as JavaServer Faces (JSFs) which
+    automatically escapes HTML views.
+  metadata:
+    owasp: 'A7: Cross-site Scripting (XSS)'
+    cwe: 'CWE-116: Improper Encoding or Escaping of Output'
+    references:
+    - https://www3.ntu.edu.sg/home/ehchua/programming/java/JavaServerFaces.html
+  severity: WARNING
+  languages: [java]

--- a/tests/rules/metavar_type_str_eq.java
+++ b/tests/rules/metavar_type_str_eq.java
@@ -1,0 +1,14 @@
+public class Example {
+    public int foo(String a, int b) {
+        // ruleid: no-string-eqeq
+        if (a == "hello") return 1;
+        // ruleid: no-string-eqeq
+        if ("hello" == a) return 2;
+        // ok: no-string-eqeq
+        if (b == 2) return -1;
+        // ok: no-string-eqeq
+        if (null == "hello") return 12;
+        // ok: no-string-eqeq
+        if ("hello" == null) return 0;
+    }
+}

--- a/tests/rules/metavar_type_str_eq.yaml
+++ b/tests/rules/metavar_type_str_eq.yaml
@@ -1,0 +1,12 @@
+rules:
+  - id: no-string-eqeq
+    severity: WARNING
+    message: find errors
+    languages:
+      - java
+    patterns:
+      - pattern-not: null == $Y
+      - pattern: $X == $Y
+      - metavariable-type:
+          metavariable: $Y
+          type: String


### PR DESCRIPTION
This commit introduces a dedicated field for annotating the type information of metavariables. By adopting this approach, instead of relying solely on language-specific casting syntax, we provide an additional way to enhance the overall usability by eliminating the need to write redundant type cast expressions for a single metavariable.

Moreover, the new syntax brings other benefits, including improved support for target languages that lack built-in casting syntax. It also promotes a unified approach to expressing type, pattern, and regex constraints for metavariables, resulting in improved consistency across rule definitions.

Current syntax:
```
rules:
  - id: no-string-eqeq
    severity: WARNING
    message: find errors
    languages:
      - java
    patterns:
      - pattern-not: null == (String $Y)
      - pattern: $X == (String $Y)
```

Proposed syntax:
```
rules:
  - id: no-string-eqeq
    severity: WARNING
    message: find errors
    languages:
      - java
    patterns:
      - pattern-not: null == $Y
      - pattern: $X == $Y
      - metavariable-type:
          metavariable: $Y
          type: String
```

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
