### PR TITLE
Fixing php pattern parsing for attributes

### DIFF
--- a/changelog.d/pa-7398.fixed
+++ b/changelog.d/pa-7398.fixed
@@ -1,0 +1,18 @@
+Added support for parsing patterns of the form
+```
+#[Attr1]
+#[Attr2]
+```
+In code such as
+```
+#[Attr1]
+#[Attr2]
+function test ()
+{
+    echo "Test";
+}
+```
+Previously, to match against multiple attributes it was required to write
+```
+#[Attr1, Attr2]
+```

--- a/languages/php/menhir/parser_php.mly
+++ b/languages/php/menhir/parser_php.mly
@@ -904,7 +904,9 @@ return_type: ":" type_php                 { $1, $2 }
 (* Attributes *)
 (*************************************************************************)
 (* PHP 8 extension (was using << >> in HPHP) *)
-attributes: "#[" listc(attribute) "]" { ($1, $2, $3) }
+attributes:
+| "#[" listc(attribute) "]" { ($1, $2, $3) }
+| attributes attributes {match ($1, $2) with ((op,xs1,cl),(_,xs2,_)) -> (op,xs1@xs2,cl)}
 
 attribute:
  | ident                                  { Attribute $1 }

--- a/languages/php/menhir/parser_php.mly
+++ b/languages/php/menhir/parser_php.mly
@@ -906,7 +906,7 @@ return_type: ":" type_php                 { $1, $2 }
 (* PHP 8 extension (was using << >> in HPHP) *)
 attributes:
 | "#[" listc(attribute) "]" { ($1, $2, $3) }
-| attributes attributes {match ($1, $2) with ((op,xs1,cl),(_,xs2,_)) -> (op,xs1@xs2,cl)}
+| attributes attributes {match ($1, $2) with ((lp,xs1,_),(_,xs2,rp)) -> (lp,xs1@xs2,rp)}
 
 attribute:
  | ident                                  { Attribute $1 }

--- a/tests/rules/attributes_match_multiple.php
+++ b/tests/rules/attributes_match_multiple.php
@@ -1,0 +1,16 @@
+<?php
+#ruleid: attributes-match-multiple
+#[Attr1]
+#[Attr2]
+#[Attr3]
+function test ()
+{
+    echo "Test";
+}
+
+#ok: attributes-match-multiple
+#[Attr1]
+function test ()
+{
+    echo "Test";
+}

--- a/tests/rules/attributes_match_multiple.yaml
+++ b/tests/rules/attributes_match_multiple.yaml
@@ -1,0 +1,10 @@
+rules:
+  - id: attributes-match-multiple
+    pattern: |
+      #[Attr1]
+      #[Attr2]
+      function $FUNC (...) { ... }
+    message: Match found
+    languages:
+      - php
+    severity: WARNING


### PR DESCRIPTION
Previously, php pattern parsing could only parse multiple attributes in the format `#[Attr1,Attr2,..]` This fix adds support for parsing patterns such as  
`#[Attr1]
#[Attr2]
...`

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
