### PR TITLE
feat: [release] remove semgrep before trying to remove tree-sitter

### DIFF
--- a/scripts/osx-setup-for-release.sh
+++ b/scripts/osx-setup-for-release.sh
@@ -22,6 +22,7 @@ opam update
 # Some CI runners have tree-sitter preinstalled which interfere with
 # out static linking plans below so better to remove it.
 # TODO: fix setup-m1-builder.sh instead?
+brew uninstall --force semgrep
 brew uninstall --force tree-sitter
 
 #coupling: this should be the same version than in our Dockerfile


### PR DESCRIPTION
In some cases, self-hosted runners could become polluted by a leftover semgrep installation. I believe this was caused by cases where the nightly CI tests didn't finish, the semgrep installation was not cleaned up properly. This PR updates our setup script (that's run on both x86 and M1) to remove semgrep before removing tree-sitter, which was causing our errors. 

I'll open a follow-on PR to set up background jobs for testing migration back to `macos-12` instead of our self-hosted `x86` runners - this would be a step in the right direction. Unfortunately, we'll have to continue using our self-hosted M1 runners, and deal with issues such as this as they pop up. 

Test Plan:
- CI on this PR
- [Release test run here](https://github.com/returntocorp/semgrep/actions/runs/5347815654/jobs/9696851397)

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
