### PR TITLE
feat: [nightly, test, release] set up background macos-12 jobs

### DIFF
--- a/.github/workflows/build-test-osx-x86-macos-12.yaml
+++ b/.github/workflows/build-test-osx-x86-macos-12.yaml
@@ -1,0 +1,82 @@
+# This workflow builds and tests the semgrep-core binary for macOS x86
+# but does so on the github-hosted macos-12 runner. This'll run as a background job for the time being
+# once we build confidence, we'll swap over the regular build-test-osx-x86.yaml to use this runner,
+# and remove this file.
+
+# coupling: if you modify this file, modify also build-test-osx-m1.yaml
+name: build-test-osx-x86
+
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: "37 16 * * *"
+    - cron: "37 12 * * *"
+    - cron: "37 08 * * *"
+
+jobs:
+  build-core-osx:
+    name: Build the OSX binaries
+    runs-on: macos-12
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - run: |
+          ./scripts/osx-setup-for-release.sh
+          opam exec -- make core
+          mkdir -p artifacts
+          cp ./bin/semgrep-core artifacts
+          zip -r artifacts.zip artifacts
+      - uses: actions/upload-artifact@v3
+        with:
+          path: artifacts.zip
+          name: semgrep-osx-${{ github.sha }}
+
+  build-wheels-osx:
+    runs-on: macos-12
+    needs: [build-core-osx]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - uses: actions/download-artifact@v3
+        with:
+          name: semgrep-osx-${{ github.sha }}
+      - run: unzip artifacts.zip
+      - env:
+          # Relative because build-wheels does a 'cd cli'
+          SEMGREP_CORE_BIN: ../artifacts/semgrep-core
+        run: ./scripts/build-wheels.sh
+      - uses: actions/upload-artifact@v3
+        with:
+          path: cli/dist.zip
+          name: osx-wheel
+
+  test-wheels-osx:
+    runs-on: macos-12
+    needs: [build-wheels-osx]
+    steps:
+      - uses: actions/download-artifact@v1
+        with:
+          name: osx-wheel
+      - run: unzip ./osx-wheel/dist.zip
+      - name: install package
+        run: pip3 install dist/*.whl
+      - run: semgrep --version
+      - name: e2e semgrep-core test
+        run: echo '1 == 1' | semgrep --debug -l python -e '$X == $X' -
+      - name: test dynamically linked libraries are in /usr/lib/
+        shell: bash {0}
+        run: |
+          otool -L $(semgrep --dump-engine-path) > otool.txt
+          if [ $? -ne 0 ]; then
+            echo "Failed to list dynamically linked libraries.";
+            cat otool.txt;
+            exit 1;
+          fi
+          NON_USR_LIB_DYNAMIC_LIBRARIES=$(cat otool.txt | tail -n +2 | grep -v "^\s*/usr/lib/")
+          if [ $? -eq 0 ]; then
+            echo "Error: semgrep-core has been dynamically linked against libraries outside /usr/lib:"
+            echo $NON_USR_LIB_DYNAMIC_LIBRARIES
+            exit 1;
+          fi;

--- a/.github/workflows/build-test-osx-x86-macos-12.yaml
+++ b/.github/workflows/build-test-osx-x86-macos-12.yaml
@@ -4,7 +4,7 @@
 # and remove this file.
 
 # coupling: if you modify this file, modify also build-test-osx-m1.yaml
-name: build-test-osx-x86
+name: Test - build-test-osx-x86 MacOS 12
 
 on:
   workflow_dispatch: {}

--- a/.github/workflows/nightly-macos-12.yml
+++ b/.github/workflows/nightly-macos-12.yml
@@ -1,0 +1,34 @@
+# This workflow is a subset of as the nightly.yml,
+# but runs on the github-hosted macos-12 runner. This'll run as a background job for the time being
+# once we build confidence, we'll swap over the regular build-test-osx-x86.yaml to use this runner,
+# and remove this file.
+
+name: Nightly Verification
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "37 15 * * *"
+    - cron: "37 11 * * *"
+    - cron: "37 07 * * *"
+
+jobs:
+  brew-build:
+    name: Build Semgrep via Brew from `returntocorp/semgrep:develop`
+    runs-on: macos-12
+    # We've had issues with this workflow in the past, and needed to ensure that homebrew wouldn't use the API.
+    # See: https://github.com/orgs/Homebrew/discussions/4150, https://github.com/orgs/Homebrew/discussions/4136
+    # There's also much other discussion on this topic available on GH and in the brew discussions.
+    steps:
+      - name: Brew update
+        env:
+          HOMEBREW_NO_INSTALL_FROM_API: 1
+        run: brew update --debug --verbose
+      - name: Brew Install
+        env:
+          HOMEBREW_NO_INSTALL_FROM_API: 1
+        run: brew install semgrep --HEAD --debug
+      - name: Check installed correctly
+        env:
+          HOMEBREW_NO_INSTALL_FROM_API: 1
+        run: brew test semgrep --HEAD

--- a/.github/workflows/nightly-macos-12.yml
+++ b/.github/workflows/nightly-macos-12.yml
@@ -3,7 +3,7 @@
 # once we build confidence, we'll swap over the regular build-test-osx-x86.yaml to use this runner,
 # and remove this file.
 
-name: Nightly Verification
+name: Test - Nightly Verification MacOS 12
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
In the past, we've had some issues with using the `macos-12` runners to build semgrep. We saw intermittent, seemingly random failures on these runners. Some recent testings shows this may no longer be the case. This PR:
- sets up a `nightly-macos-12` job to run the pertinent parts of the nightly tests on the `macos-12` runner 3x daily
- sets up a `build-test-osx-x86-macos-12` job to run the macos x86 build on the `macos-12` runner 3x daily

This'll allow us to build some confidence in the background while we ensure we're not seeing those intermittent issues anymore. 

Test Plan:
Unfortunately because these are new workflows, I can't run them based on my branch. I'll need to merge, test, and then apply any fixes. Shouldn't be an issue, since they're completely separate from the original. 

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
