### PR TITLE
Followup from #8100: delete dead grammar rules in python parser

### DIFF
--- a/languages/python/menhir/Parser_python.mly
+++ b/languages/python/menhir/Parser_python.mly
@@ -455,16 +455,6 @@ arglist_paren_opt:
 decorator: "@" namedexpr_test NEWLINE
     { $1, $2 }
 
-decorator_name:
-  | NAME                    { [$1] }
-  | decorator_name "." NAME { $1 @ [$3] }
-
-arglist_paren2_opt:
- | (* empty *) { None }
- | "(" ")"     { Some ($1, [], $2) }
- (* python3-ext: was expr_list before *)
- | "(" list_comma(argument) ")" { Some ($1, $2, $3) }
-
 (*************************************************************************)
 (* Statement *)
 (*************************************************************************)


### PR DESCRIPTION
Purpose is evident from the title!

Test plan: `make test`

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
