### PR TITLE
fix(ci):  xfail failing qa test

### DIFF
--- a/cli/tests/qa/public_repos.py
+++ b/cli/tests/qa/public_repos.py
@@ -107,7 +107,6 @@ REPOS = [
     Repo("https://github.com/dropbox/zinger"),
     Repo("https://github.com/seemoo-lab/opendrop"),
     Repo("https://github.com/lightstep/lightstep-tracer-python"),
-    Repo("https://github.com/draios/sysdig-inspect"),
     Repo("https://github.com/getsentry/sentry-python"),
     Repo("https://github.com/signalapp/signal-webrtc-ios"),
     Repo("https://github.com/secdev/scapy"),
@@ -138,6 +137,10 @@ REPOS = [
     Repo("https://github.com/DevSlop/Pixi"),
     Repo("https://github.com/home-assistant/home-assistant"),
     Repo("https://github.com/we45/Vulnerable-Flask-App"),
+    Repo(
+        "https://github.com/draios/sysdig-inspect",
+        xfail_reason="Merge conflicts on `dev`, see https://github.com/draios/sysdig-inspect/blob/ee3b8fa9335bf6fc19fd0976d51d87b961db6ebb/testem.js",
+    ),
     Repo(
         "https://github.com/rails/rails",
         ["ruby"],


### PR DESCRIPTION
## What:
This PR xfails a QA test for a public repo which is currently failing.

## Why:
Said repository has pushed a merge conflict to `dev`, meaning that we are not working properly on them. See this file + commit: https://github.com/draios/sysdig-inspect/blob/ee3b8fa9335bf6fc19fd0976d51d87b961db6ebb/testem.js

We can un-xfail it once the repo is good.

## Test plan:
Automated tests


PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
