### PR TITLE
refactor: Add type arg wildcards to Type.ml

### DIFF
--- a/src/matching/Generic_vs_generic.ml
+++ b/src/matching/Generic_vs_generic.ml
@@ -2120,6 +2120,17 @@ and m_generic_targ_vs_type_targ lang tok a b =
        * and this will assume covariance. But it's probably not a big deal, and
        * they don't have to be invariant in all cases anyway. *)
       m_generic_type_vs_type_t lang tok t1 t2
+  (* TODO equivalence between Java `List<?>` and `List<? extends Object>`? *)
+  | G.TAWildcard (_, None), Type.TAWildcard None -> return ()
+  | G.TAWildcard (_, Some kinda), Type.TAWildcard (Some kindb) -> (
+      match (kinda, kindb) with
+      | ((false, _), t1), Type.TAUpper t2
+      | ((true, _), t1), Type.TALower t2 ->
+          m_generic_type_vs_type_t lang tok t1 t2
+      | _, Type.TAUpper _
+      | _, Type.TALower _ ->
+          fail ())
+  | G.TA _, Type.TAWildcard _
   | G.TA _, Type.OtherTypeArg _
   (* TODO Represent more typearg kinds in Type.t? *)
   | G.TAWildcard _, _

--- a/src/typing/Typing.ml
+++ b/src/typing/Typing.ml
@@ -170,6 +170,15 @@ and type_of_ast_generic_type lang t : G.name Type.t =
         args
         |> Common.map (function
              | G.TA t -> Type.TA (type_of_ast_generic_type lang t)
+             | G.TAWildcard (_, None) -> Type.TAWildcard None
+             | G.TAWildcard (_, Some ((kind, _), t)) ->
+                 let t = type_of_ast_generic_type lang t in
+                 let kind =
+                   match kind with
+                   | false -> Type.TAUpper t
+                   | true -> Type.TALower t
+                 in
+                 Type.TAWildcard (Some kind)
              | _else_ -> Type.OtherTypeArg None)
       in
       Type.N ((name, args), [])


### PR DESCRIPTION
This allows us to represent types such as `List<? extends Foo>` in Java. I need this for improved typing in Pro Engine. This might improve some edge case matching behavior in OSS too but I struggled to construct an example.

Test plan: Automated tests

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
