### PR TITLE
fix: Crash when logged in and not in a git repo

### DIFF
--- a/changelog.d/pa-2886.fixed
+++ b/changelog.d/pa-2886.fixed
@@ -1,0 +1,1 @@
+Language server no longer crashes when a user is logged in and opens a non git repo folder

--- a/cli/src/semgrep/lsp/config.py
+++ b/cli/src/semgrep/lsp/config.py
@@ -80,9 +80,13 @@ class LSPConfig:
     def ci_rules(self) -> List[Rule]:
         if len(self._workspace_folders) == 0:
             return []
+        metadata_dict = {}
+        try:
+            metadata = generate_meta_from_environment(None)
+            metadata_dict = metadata.to_dict()
+        except SemgrepError:  # This fails if a user is logged in, and is not in a git repo
+            return []
         scan_handler = ScanHandler(True)
-        metadata = generate_meta_from_environment(None)
-        metadata_dict = metadata.to_dict()
         scan_handler.fetch_and_init_scan_config(metadata_dict)
         json_rules = json.loads(scan_handler.rules).get("rules", [])
         rules = [Rule.from_json(r) for r in json_rules]


### PR DESCRIPTION

# Test Plan

Login in through extension -> Open non git repo workspace -> does it crash?

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
