### PR TITLE
tainting: Further lower limit on taint set size

### DIFF
--- a/src/configuring/Limits_semgrep.ml
+++ b/src/configuring/Limits_semgrep.ml
@@ -34,8 +34,16 @@ let taint_FIXPOINT_TIMEOUT = 0.1
 (** Bounds the number of l-values we can track. *)
 let taint_MAX_TAINTED_LVALS = 100
 
-(** Bounds the number of taints we can track per l-value. *)
-let taint_MAX_TAINT_SET_SIZE = 50
+(** Bounds the number of taints we can track per l-value.
+ *
+ * The size of the taint sets has a significant impact on performance and most
+ * "reasonable" taint rules only require small taint sets to work. When the sets
+ * grow large is often due to some bug or "inefficiency". The limit could be
+ * insufficient for some pathological cases (e.g. rules that have very liberal
+ * source specs that match essentially everything), but those we will not be
+ * able to run inter-file, and they should be discouraged anyways.
+ *)
+let taint_MAX_TAINT_SET_SIZE = 25
 
-(** Bounds the length of the offsets we can track per l-value. *)
-let taint_MAX_LVAL_OFFSET = 2
+(** Bounds the length of the offsets we can track per arg/poly-taint. *)
+let taint_MAX_POLY_OFFSET = 1

--- a/src/tainting/Dataflow_tainting.ml
+++ b/src/tainting/Dataflow_tainting.ml
@@ -782,7 +782,7 @@ let fix_poly_taint_with_field env lval st =
                                     *   type info and we used to remove taint, e.g. if Boolean
                                     *   and integer expressions didn't propagate taint. *)
                                 List.length offset
-                                < Limits_semgrep.taint_MAX_LVAL_OFFSET ->
+                                < Limits_semgrep.taint_MAX_POLY_OFFSET ->
                              let arg' =
                                { arg with offset = arg.offset @ [ n ] }
                              in


### PR DESCRIPTION
While we have such serious perf issues, we better run in a restricted mode than not run at all.

Also, when the limit of max number of tracked l-values is reached, we now try to remove some auxiliary `_tmp` l-value to make space.

test plan:
make test

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
