### PR TITLE
Optimize `apk upgrade` in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -93,8 +93,7 @@ ENV PIP_DISABLE_PIP_VERSION_CHECK=true \
 # See docker-library/python#761 for an example of such an issue in the past
 # where the time between the CVE was discovered and the package update was X days, but
 # the new base image was updated only after Y days.
-RUN apk update &&\
-    apk upgrade
+RUN apk upgrade --no-cache
 
 
 # Here is why we need the apk packages below:


### PR DESCRIPTION
Run `apk upgrade` with `--no-cache`, instead of an additional `apk update` to leave the cache in the Docker image.

PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
