### PR TITLE
osemgrep CI: gather metadata (step 2)

### DIFF
--- a/src/osemgrep/cli_ci/Ci_subcommand.ml
+++ b/src/osemgrep/cli_ci/Ci_subcommand.ml
@@ -16,7 +16,8 @@
 (*****************************************************************************)
 
 (* from meta.py *)
-let generate_meta_from_environment (_baseline_ref : Digestif.SHA1.t option) =
+let generate_meta_from_environment (_baseline_ref : Digestif.SHA1.t option) :
+    unit Project_metadata.t =
   (* https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables *)
   let r =
     let argv = [| "empty" |] and info_ = Cmdliner.Cmd.info "" in

--- a/src/osemgrep/cli_ci/Ci_subcommand.ml
+++ b/src/osemgrep/cli_ci/Ci_subcommand.ml
@@ -15,6 +15,55 @@
 (* Helpers *)
 (*****************************************************************************)
 
+(* from meta.py *)
+let generate_meta_from_environment (_baseline_ref : Digestif.SHA1.t option) =
+  (* https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables *)
+  let r =
+    let argv = [| "empty" |] and info_ = Cmdliner.Cmd.info "" in
+    match Sys.getenv_opt "GITHUB_ACTIONS" with
+    | Some "true" ->
+        (* TODO baseline_ref *)
+        Cmdliner.Cmd.(eval_value ~argv (v info_ Github_metadata.term))
+    | _else ->
+        (* TODO baseline_ref *)
+        Cmdliner.Cmd.(eval_value ~argv (v info_ Git_metadata.term))
+    (* https://docs.gitlab.com/ee/ci/variables/predefined_variables.html *)
+    (* match Sys.getenv_opt "GITLAB_CI" with
+       | Some "true" -> return GitlabMeta(baseline_ref)
+       | _else -> *)
+    (* https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables *)
+    (* match Sys.getenv_opt "CIRCLECI" with
+       | Some "true" -> return CircleCIMeta(baseline_ref)
+       | _else -> *)
+    (* https://e.printstacktrace.blog/jenkins-pipeline-environment-variables-the-definitive-guide/ *)
+    (* match Sys.getenv_opt "JENKINS_URL" with
+        | Some _ -> return JenkinsMeta(baseline_ref)
+        | None -> *)
+    (* https://support.atlassian.com/bitbucket-cloud/docs/variables-and-secrets/ *)
+    (* match Sys.getenv_opt "BITBUCKET_BUILD_NUMBER" with
+       | Some _ -> return BitbucketMeta(baseline_ref)
+       | None -> *)
+    (* https://github.com/DataDog/dd-trace-py/blob/f583fec63c4392a0784b4199b0e20931f9aae9b5/ddtrace/ext/ci.py#L90
+       picked an env var that is only defined by Azure Pipelines *)
+    (* match Sys.getenv_opt "BUILD_BUILDID" with
+       | Some _ -> AzurePipelinesMeta(baseline_ref)
+       | None -> *)
+    (* https://buildkite.com/docs/pipelines/environment-variables#bk-env-vars-buildkite-build-author-email *)
+    (* match Sys.getenv_opt "BUILDKITE" with
+       | Some "true" -> return BuildkiteMeta(baseline_ref)
+       | _else -> *)
+    (* https://docs.travis-ci.com/user/environment-variables/ *)
+    (* match Sys.getenv_opt "TRAVIS" with
+       | Some "true" -> return TravisMeta(baseline_ref)
+       | _else -> return GitMeta(baseline_ref) *)
+  in
+  match r with
+  | Ok (`Ok a) -> a
+  | Ok `Version
+  | Ok `Help ->
+      invalid_arg "unexpected version or help"
+  | Error _e -> invalid_arg "couldn't decode environment"
+
 (*****************************************************************************)
 (* Main logic *)
 (*****************************************************************************)
@@ -51,26 +100,29 @@ let run (conf : Ci_CLI.conf) : Exit_code.t =
             Error Exit_code.invalid_api_key
         | Some t -> Ok (Some t))
   in
+  (* TODO: pass baseline commit! *)
+  let metadata = generate_meta_from_environment None in
   match deployment with
   | Error e -> e
   | Ok depl ->
       Logs.app (fun m -> m "%a" Fmt_helpers.pp_heading "Debugging Info");
       Logs.app (fun m ->
           m "  %a" Fmt.(styled `Underline string) "SCAN ENVIRONMENT");
-      (* TODO: "on python sys.version_info.micro" *)
       Logs.app (fun m ->
-          m "  versions    - semgrep %a"
+          m "  versions    - semgrep %a on OCaml %a"
             Fmt.(styled `Bold string)
-            Version.version);
-      (* TODO: use metadata.environment and metadata.event_name *)
+            Version.version
+            Fmt.(styled `Bold string)
+            Sys.ocaml_version);
       Logs.app (fun m ->
           m
             "  environment - running in environment %a, triggering event is \
              %a@."
             Fmt.(styled `Bold string)
-            "git"
+            (Option.value ~default:"unknown"
+               metadata.Project_metadata.scan_environment)
             Fmt.(styled `Bold string)
-            "unknown");
+            (Option.value ~default:"unknown" metadata.Project_metadata.on));
       (* TODO: fix_head_if_github_action(metadata) *)
       let _rules_source =
         match depl with

--- a/src/osemgrep/cli_ci/Git_metadata.ml
+++ b/src/osemgrep/cli_ci/Git_metadata.ml
@@ -19,37 +19,47 @@ let env =
   let _semgrep_repo_name =
     let doc = "The name of the Git repository." in
     let env = Cmd.Env.info "SEMGREP_REPO_NAME" in
-    Arg.(value & opt (some string) None & info [] ~env ~doc)
+    Arg.(
+      value & opt (some string) None & info [ "semgrep-repo-name" ] ~env ~doc)
   in
   let _semgrep_repo_url =
     let doc = "The URL of the Git repository." in
     let env = Cmd.Env.info "SEMGREP_REPO_URL" in
-    Arg.(value & opt (some Cmdliner_helpers.uri) None & info [] ~env ~doc)
+    Arg.(
+      value
+      & opt (some Cmdliner_helpers.uri) None
+      & info [ "semgrep-repo-url" ] ~env ~doc)
   in
   let _semgrep_commit =
     let doc = "The commit of the Git repository." in
     let env = Cmd.Env.info "SEMGREP_COMMIT" in
-    Arg.(value & opt (some Cmdliner_helpers.sha1) None & info [] ~env ~doc)
+    Arg.(
+      value
+      & opt (some Cmdliner_helpers.sha1) None
+      & info [ "semgrep-commit" ] ~env ~doc)
   in
   let _semgrep_job_url =
     let doc = "The job URL." in
     let env = Cmd.Env.info "SEMGREP_JOB_URL" in
-    Arg.(value & opt (some Cmdliner_helpers.uri) None & info [] ~env ~doc)
+    Arg.(
+      value
+      & opt (some Cmdliner_helpers.uri) None
+      & info [ "semgrep-job-url" ] ~env ~doc)
   in
   let _semgrep_pr_id =
     let doc = "The PR/MR ID." in
     let env = Cmd.Env.info "SEMGREP_PR_ID" in
-    Arg.(value & opt (some string) None & info [] ~env ~doc)
+    Arg.(value & opt (some string) None & info [ "semgrep-pr-id" ] ~env ~doc)
   in
   let _semgrep_pr_title =
     let doc = "The PR/MR title." in
     let env = Cmd.Env.info "SEMGREP_PR_TITLE" in
-    Arg.(value & opt (some string) None & info [] ~env ~doc)
+    Arg.(value & opt (some string) None & info [ "semgrep-pr-title" ] ~env ~doc)
   in
   let _semgrep_branch =
     let doc = "The Git branch." in
     let env = Cmd.Env.info "SEMGREP_BRANCH" in
-    Arg.(value & opt (some string) None & info [] ~env ~doc)
+    Arg.(value & opt (some string) None & info [ "semgrep-branch" ] ~env ~doc)
   in
   let run _SEMGREP_REPO_NAME _SEMGREP_REPO_URL _SEMGREP_COMMIT _SEMGREP_JOB_URL
       _SEMGREP_PR_ID _SEMGREP_PR_TITLE _SEMGREP_BRANCH =

--- a/src/osemgrep/cli_ci/Github_metadata.ml
+++ b/src/osemgrep/cli_ci/Github_metadata.ml
@@ -22,6 +22,8 @@ let _MAX_FETCH_ATTEMPT_COUNT = 10
 (* A limit of how many fetch we should do until we find the common commit
    between two branches. *)
 
+let scan_environment = Some "github-actions"
+
 let get_repo_name env =
   let err = "Could not get repo_name when running in GitHub Action" in
   if Option.is_none env.git.Git_metadata._SEMGREP_REPO_NAME then
@@ -285,22 +287,27 @@ let env =
   let _github_event_path =
     let doc = "The GitHub event path." in
     let env = Cmd.Env.info "GITHUB_EVENT_PATH" in
-    Arg.(value & opt Glom.cli Glom.default & info [] ~env ~doc)
+    Arg.(
+      value & opt Glom.cli Glom.default & info [ "github-event-path" ] ~env ~doc)
   in
   let _github_sha =
     let doc = "The GitHub commit." in
     let env = Cmd.Env.info "GITHUB_SHA" in
-    Arg.(value & opt (some Cmdliner_helpers.sha1) None & info [] ~env ~doc)
+    Arg.(
+      value
+      & opt (some Cmdliner_helpers.sha1) None
+      & info [ "github-sha" ] ~env ~doc)
   in
   let gh_token =
     let doc = "The GitHub token." in
     let env = Cmd.Env.info "GH_TOKEN" in
-    Arg.(value & opt (some string) None & info [] ~env ~doc)
+    Arg.(value & opt (some string) None & info [ "gh-token" ] ~env ~doc)
   in
   let _github_repository =
     let doc = "The GitHub repository." in
     let env = Cmd.Env.info "GITHUB_REPOSITORY" in
-    Arg.(value & opt (some string) None & info [] ~env ~doc)
+    Arg.(
+      value & opt (some string) None & info [ "github-repository" ] ~env ~doc)
   in
   let _github_server_url =
     let doc = "The GitHub server URL." in
@@ -308,32 +315,36 @@ let env =
     Arg.(
       value
       & opt Cmdliner_helpers.uri (Uri.of_string "https://github.com")
-      & info [] ~doc ~env)
+      & info [ "github-server-url" ] ~doc ~env)
   in
   let _github_api_url =
     let doc = "The GitHub API URL." in
     let env = Cmd.Env.info "GITHUB_API_URL" in
-    Arg.(value & opt (some Cmdliner_helpers.uri) None & info [] ~doc ~env)
+    Arg.(
+      value
+      & opt (some Cmdliner_helpers.uri) None
+      & info [ "github-api-url" ] ~doc ~env)
   in
   let _github_run_id =
     let doc = "The GitHub run ID." in
     let env = Cmd.Env.info "GITHUB_RUN_ID" in
-    Arg.(value & opt (some string) None & info [] ~doc ~env)
+    Arg.(value & opt (some string) None & info [ "github-run-id" ] ~doc ~env)
   in
   let _github_event_name =
     let doc = "The GitHub event name." in
     let env = Cmd.Env.info "GITHUB_EVENT_NAME" in
-    Arg.(value & opt (some string) None & info [] ~doc ~env)
+    Arg.(
+      value & opt (some string) None & info [ "github-event-name" ] ~doc ~env)
   in
   let _github_ref =
     let doc = "The GitHub ref." in
     let env = Cmd.Env.info "GITHUB_REF" in
-    Arg.(value & opt (some string) None & info [] ~doc ~env)
+    Arg.(value & opt (some string) None & info [ "github-ref" ] ~doc ~env)
   in
   let _github_head_ref =
     let doc = "The GitHub HEAD ref." in
     let env = Cmd.Env.info "GITHUB_HEAD_REF" in
-    Arg.(value & opt (some string) None & info [] ~doc ~env)
+    Arg.(value & opt (some string) None & info [ "github-head-ref" ] ~doc ~env)
   in
   let run git (_, _GITHUB_EVENT_JSON) _GITHUB_SHA _GITHUB_REPOSITORY
       _GITHUB_SERVER_URL _GITHUB_API_URL _GITHUB_RUN_ID _GITHUB_EVENT_NAME
@@ -391,6 +402,7 @@ let make env =
     commit_author_image_url;
     pull_request_author_username;
     pull_request_author_image_url;
+    scan_environment;
   }
 
 let term = Cmdliner.Term.(const make $ env)


### PR DESCRIPTION
use the Git_metadata and Github_metadata to collect metadata from environment variables, also adapt scan_environment on github (to be in sync with python's meta.py); and provide names to arguments (otherwise cmdliner raises invalid_arg)

test plan: make core

now, the output is not hardcoded strings, but actually from the environment

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
