### PR TITLE
osemgrep: fix semgrep deprecation python warnings from docker image

### DIFF
--- a/cli/bin/semgrep
+++ b/cli/bin/semgrep
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3 -W ignore::DeprecationWarning
+#!/usr/bin/env python3
 
 # This file is the CLI entry point of the Semgrep pip package,
 # the Semgrep HomeBrew package, and the Semgrep Docker container.
@@ -26,11 +26,17 @@ import sys
 import importlib.resources
 import shutil
 
+#alt: you can also add '-W ignore::DeprecationWarning' after the python3 above,
+# but setuptools and pip adjust this line when installing semgrep so we need
+# this instead.
+import warnings
+warnings.filterwarnings("ignore", category=DeprecationWarning)
+
 # similar to cli/src/semgrep/semgrep_core.py compute_executable_path()
 def find_semgrep_core_path():
     # First, try the packaged binary.
     try:
-        # the use of .path causes a DeprecationWarning hence the -W ignore:Xxx above
+        # the use of .path causes a DeprecationWarning hence the filterwarnings above
         with importlib.resources.path("semgrep.bin", "semgrep-core") as path:
             if path.is_file():
                 return str(path)

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -74,7 +74,6 @@ def find_executable(env_name, exec_name):
     )
 
 
-#
 # The default behavior is to copy the semgrep-core binary
 # into some other folder known to the semgrep wrapper. If somebody knows why,
 # please explain why we do this.


### PR DESCRIPTION
test plan:
make build-docker
docker run ... semgrep and no deprecation warning


PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)