### PR TITLE
osemgrep ci: fetch and decode rules, register scan id to semgrep app (step 3)

### DIFF
--- a/src/osemgrep/cli_ci/Project_metadata.ml
+++ b/src/osemgrep/cli_ci/Project_metadata.ml
@@ -23,6 +23,7 @@ type 'e t = {
   extension : 'e;
 }
 
+(* TODO: use atd to serialize (and the same in the Semgrep App) *)
 let to_dict t =
   let open JSON in
   let or_null = Option.value ~default:Null in

--- a/src/osemgrep/cli_ci/Project_metadata.ml
+++ b/src/osemgrep/cli_ci/Project_metadata.ml
@@ -23,6 +23,62 @@ type 'e t = {
   extension : 'e;
 }
 
+let to_dict t =
+  let open JSON in
+  let or_null = Option.value ~default:Null in
+  Object
+    [
+      ("semgrep_version", String Version.version);
+      (* REQUIRED for semgrep-app backend *)
+      ("repository", String t.repository);
+      (* OPTIONAL for semgrep-app backend *)
+      ( "repo_url",
+        or_null (Option.map (fun url -> String (Uri.to_string url)) t.repo_url)
+      );
+      ("branch", or_null (Option.map (fun branch -> String branch) t.branch));
+      ( "ci_job_url",
+        or_null
+          (Option.map (fun url -> String (Uri.to_string url)) t.ci_job_url) );
+      ( "commit",
+        or_null
+          (Option.map (fun sha -> String (Digestif.SHA1.to_hex sha)) t.commit)
+      );
+      ( "commit_author_email",
+        or_null
+          (Option.map
+             (fun email -> String (Emile.to_string email))
+             t.commit_author_email) );
+      ( "commit_author_name",
+        or_null (Option.map (fun name -> String name) t.commit_author_name) );
+      ( "commit_author_username",
+        or_null (Option.map (fun name -> String name) t.commit_author_username)
+      );
+      ( "commit_author_image_url",
+        or_null
+          (Option.map
+             (fun url -> String (Uri.to_string url))
+             t.commit_author_image_url) );
+      ( "commit_title",
+        or_null (Option.map (fun name -> String name) t.commit_title) );
+      ("on", or_null (Option.map (fun name -> String name) t.on));
+      ( "pull_request_author_username",
+        or_null
+          (Option.map (fun name -> String name) t.pull_request_author_username)
+      );
+      ( "pull_request_author_image_url",
+        or_null
+          (Option.map
+             (fun url -> String (Uri.to_string url))
+             t.pull_request_author_image_url) );
+      ( "pull_request_id",
+        or_null (Option.map (fun pr_id -> String pr_id) t.pull_request_id) );
+      ( "pull_request_title",
+        or_null (Option.map (fun title -> String title) t.pull_request_title) );
+      ( "scan_environment",
+        or_null (Option.map (fun env -> String env) t.scan_environment) );
+      ("is_full_scan", Bool t.is_full_scan);
+    ]
+
 module type S = sig
   type env
   type extension

--- a/src/osemgrep/cli_ci/Project_metadata.mli
+++ b/src/osemgrep/cli_ci/Project_metadata.mli
@@ -36,6 +36,8 @@ type 'e t = {
   extension : 'e;  (** Some environments extend metadata. *)
 }
 
+val to_dict : 'e t -> JSON.t
+
 module type S = sig
   type env
   type extension

--- a/src/osemgrep/cli_ci/dune
+++ b/src/osemgrep/cli_ci/dune
@@ -8,6 +8,7 @@
     commons
     emile
 
+    osemgrep_configuring
     osemgrep_core
     osemgrep_networking
     osemgrep_cli_scan ; reusing the same flags and most of the code

--- a/src/osemgrep/networking/Http_helpers.mli
+++ b/src/osemgrep/networking/Http_helpers.mli
@@ -1,14 +1,14 @@
+val get : ?headers:(string * string) list -> Uri.t -> (string, string) result
 (** [get ~headers uri] retrieves [uri] (via HTTP GET) with the provided
     [headers]. The return value is either [Ok body] - if the request was
     successful, or an error message. *)
-val get : ?headers:(string * string) list -> Uri.t -> (string, string) result
 
-(** [post ~body ~headers uri] sends a POST request to [uri] with the provided
-    [headers] (default: content-type: application/json) and [body]. The returned
-    value is either [Ok body] if the request was successful, or an
-    [Error (code, msg)], including the HTTP status [code] and a message. *)
 val post :
   body:string ->
   ?headers:(string * string) list ->
   Uri.t ->
   (string, int * string) result
+(** [post ~body ~headers uri] sends a POST request to [uri] with the provided
+    [headers] (default: content-type: application/json) and [body]. The returned
+    value is either [Ok body] if the request was successful, or an
+    [Error (code, msg)], including the HTTP status [code] and a message. *)

--- a/src/osemgrep/networking/Http_helpers.mli
+++ b/src/osemgrep/networking/Http_helpers.mli
@@ -1,5 +1,12 @@
+(** [get ~headers uri] retrieves [uri] (via HTTP GET) with the provided
+    [headers]. The return value is either [Ok body] - if the request was
+    successful, or an error message. *)
 val get : ?headers:(string * string) list -> Uri.t -> (string, string) result
 
+(** [post ~body ~headers uri] sends a POST request to [uri] with the provided
+    [headers] (default: content-type: application/json) and [body]. The returned
+    value is either [Ok body] if the request was successful, or an
+    [Error (code, msg)], including the HTTP status [code] and a message. *)
 val post :
   body:string ->
   ?headers:(string * string) list ->

--- a/src/osemgrep/networking/Scan_helper.ml
+++ b/src/osemgrep/networking/Scan_helper.ml
@@ -1,0 +1,71 @@
+let start_scan ~dry_run ~token url meta =
+  if dry_run then (
+    Logs.app (fun m -> m "Would have sent POST request to create scan");
+    Ok None)
+  else (
+    Logs.debug (fun m -> m "Starting scan");
+    let headers =
+      [
+        ("content-type", "application/json");
+        ("authorization", "Bearer " ^ token);
+      ]
+    in
+    let scan_endpoint = Uri.with_path url "api/agent/deployments/scans" in
+    let body = JSON.(string_of_json (Object [ ("meta", meta) ])) in
+    match Http_helpers.post ~body ~headers scan_endpoint with
+    | Ok body -> (
+        let json = JSON.json_of_string body in
+        match json with
+        | Object xs -> (
+            match List.assoc_opt "scan" xs with
+            | Some (Object dd) -> (
+                match List.assoc_opt "id" dd with
+                | Some (Int i) -> Ok (Some (string_of_int i))
+                | _else -> Ok None)
+            | _else -> Ok None)
+        | _else -> Ok None)
+    | Error (status, msg) ->
+        let pre_msg =
+          if status = 404 then
+            {|Failed to create a scan with given token and deployment_id.
+Please make sure they have been set correctly.
+|}
+          else ""
+        in
+        let msg =
+          Fmt.str "%sAPI server at %a returned this error: %s" pre_msg Uri.pp
+            url msg
+        in
+        Error msg)
+
+let fetch_scan_config ~token ~sca ~dry_run ~full_scan repository =
+  (* TODO (see below): once we have the CLI logic in place to ignore findings that are from old rule versions
+     if self.dry_run:
+       app_get_config_url = f"{state.env.semgrep_url}/{DEFAULT_SEMGREP_APP_CONFIG_URL}?{self._scan_params}"
+     else:
+       app_get_config_url = f"{state.env.semgrep_url}/{DEFAULT_SEMGREP_APP_CONFIG_URL}?{self._scan_params}"
+       # TODO: uncomment the line below to replace the old endpoint with the new one once we have the
+       # CLI logic in place to ignore findings that are from old rule versions
+       # app_get_config_url = f"{state.env.semgrep_url}/api/agent/deployments/scans/{self.scan_id}/config"
+  *)
+  let url = Semgrep_App.scan_config ~sca ~dry_run ~full_scan repository in
+  let content =
+    let headers = [ ("authorization", "Bearer " ^ token) ] in
+    match Http_helpers.get ~headers url with
+    | Ok body -> body
+    | Error msg ->
+        (* was raise Semgrep_error, but equivalent to abort now *)
+        Error.abort
+          (Printf.sprintf "Failed to download config from %s: %s"
+             (Uri.to_string url) msg)
+  in
+  Logs.debug (fun m -> m "finished downloading from %s" (Uri.to_string url));
+  try
+    match Yojson.Basic.from_string content with
+    | `Assoc e -> (
+        match List.assoc "rule_config" e with
+        | `String e -> e
+        | _else -> invalid_arg "couldn't retrieve config")
+    | _else -> invalid_arg "couldn't retrieve config"
+  with
+  | _failure -> invalid_arg "couldn't retrieve config"

--- a/src/osemgrep/networking/Scan_helper.mli
+++ b/src/osemgrep/networking/Scan_helper.mli
@@ -1,0 +1,11 @@
+(* from scans.py *)
+
+val start_scan :
+  dry_run:bool ->
+  token:string ->
+  Uri.t ->
+  JSON.t ->
+  (string option, string) result
+
+val fetch_scan_config :
+  token:string -> sca:bool -> dry_run:bool -> full_scan:bool -> string -> string

--- a/src/osemgrep/networking/Scan_helper.mli
+++ b/src/osemgrep/networking/Scan_helper.mli
@@ -1,15 +1,15 @@
 (* from scans.py *)
 
-(** [start_scan ~dry_run ~token url meta] informs the Semgrep App that a scan
-    is about to be started, and returns the scan id from the server. *)
 val start_scan :
   dry_run:bool ->
   token:string ->
   Uri.t ->
   JSON.t ->
   (string option, string) result
+(** [start_scan ~dry_run ~token url meta] informs the Semgrep App that a scan
+    is about to be started, and returns the scan id from the server. *)
 
-(** [fetch_scan_config ~token ~sca ~dry_run ~full_scan repo] returns the rules
-    for the provided configuration. *)
 val fetch_scan_config :
   token:string -> sca:bool -> dry_run:bool -> full_scan:bool -> string -> string
+(** [fetch_scan_config ~token ~sca ~dry_run ~full_scan repo] returns the rules
+    for the provided configuration. *)

--- a/src/osemgrep/networking/Scan_helper.mli
+++ b/src/osemgrep/networking/Scan_helper.mli
@@ -1,5 +1,7 @@
 (* from scans.py *)
 
+(** [start_scan ~dry_run ~token url meta] informs the Semgrep App that a scan
+    is about to be started, and returns the scan id from the server. *)
 val start_scan :
   dry_run:bool ->
   token:string ->
@@ -7,5 +9,7 @@ val start_scan :
   JSON.t ->
   (string option, string) result
 
+(** [fetch_scan_config ~token ~sca ~dry_run ~full_scan repo] returns the rules
+    for the provided configuration. *)
 val fetch_scan_config :
   token:string -> sca:bool -> dry_run:bool -> full_scan:bool -> string -> string

--- a/src/osemgrep/networking/Semgrep_App.ml
+++ b/src/osemgrep/networking/Semgrep_App.ml
@@ -71,6 +71,19 @@ let get_deployment_from_token ~token =
 
 let default_semgrep_app_config_url = "api/agent/deployments/scans/config"
 
+let scan_config ?(sca = false) ?(dry_run = true) ?(full_scan = true) repo_name =
+  let json_bool_to_string b = JSON.(string_of_json (Bool b)) in
+  Uri.(
+    add_query_params'
+      (with_path Semgrep_envvars.v.semgrep_url default_semgrep_app_config_url)
+      [
+        ("sca", json_bool_to_string sca);
+        ("dry_run", json_bool_to_string dry_run);
+        ("full_scan", json_bool_to_string full_scan);
+        ("repo_name", repo_name);
+        ("semgrep_version", Version.version);
+      ])
+
 let url_for_policy ~token_opt =
   match get_deployment_id ~token_opt with
   | None ->
@@ -82,15 +95,4 @@ let url_for_policy ~token_opt =
           Error.abort
             (spf
                "Need to set env var SEMGREP_REPO_NAME to use `--config policy`")
-      | Some repo_name ->
-          Uri.(
-            add_query_params'
-              (with_path Semgrep_envvars.v.semgrep_url
-                 default_semgrep_app_config_url)
-              [
-                ("sca", "False");
-                ("dry_run", "True");
-                ("full_scan", "True");
-                ("repo_name", repo_name);
-                ("semgrep_version", Version.version);
-              ]))
+      | Some repo_name -> scan_config repo_name)

--- a/src/osemgrep/networking/Semgrep_App.mli
+++ b/src/osemgrep/networking/Semgrep_App.mli
@@ -1,8 +1,10 @@
 (* internally rely on api_token in ~/.settings and SEMGREP_REPO_NAME *)
 val url_for_policy : token_opt:Auth.token option -> Uri.t
 
+(* construct the Uri where to retrieve the scan configuration, depending on
+   the parameters and the repository name *)
 val scan_config :
   ?sca:bool -> ?dry_run:bool -> ?full_scan:bool -> string -> Uri.t
 
-(* *)
+(* retrieves the deployment name from the provided token. *)
 val get_deployment_from_token : token:Auth.token -> string option

--- a/src/osemgrep/networking/Semgrep_App.mli
+++ b/src/osemgrep/networking/Semgrep_App.mli
@@ -1,5 +1,8 @@
 (* internally rely on api_token in ~/.settings and SEMGREP_REPO_NAME *)
 val url_for_policy : token_opt:Auth.token option -> Uri.t
 
+val scan_config :
+  ?sca:bool -> ?dry_run:bool -> ?full_scan:bool -> string -> Uri.t
+
 (* *)
 val get_deployment_from_token : token:Auth.token -> string option


### PR DESCRIPTION
Now we serialize the metadata and communicate with Semgrep App about starting a scan, and retrieving the rules.

Again, the test plan is "make core", and there's not yet much to see (there's still no scanning, and no reporintg)

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
