### PR TITLE
chore: allow tests to set a regex to override ERROR/ruleid

### DIFF
--- a/src/reporting/Semgrep_error_code.ml
+++ b/src/reporting/Semgrep_error_code.ml
@@ -239,9 +239,10 @@ let default_error_regexp = ".*\\(ERROR\\|MATCH\\):"
 
 let (expected_error_lines_of_files :
       ?regexp:string ->
+      ?ok_regexp:string option ->
       Common.filename list ->
       (Common.filename * int) (* line *) list) =
- fun ?(regexp = default_error_regexp) test_files ->
+ fun ?(regexp = default_error_regexp) ?(ok_regexp = None) test_files ->
   test_files
   |> List.concat_map (fun file ->
          Common.cat file |> Common.index_list_1
@@ -250,7 +251,13 @@ let (expected_error_lines_of_files :
                  * don't check if they match. We are just happy to check for
                  * correct lines error reporting.
                  *)
-                if s =~ regexp (* + 1 because the comment is one line before *)
+                if
+                  s =~ regexp (* + 1 because the comment is one line before *)
+                  (* This is so that we can mark a line differently for OSS and Pro,
+                     e.g. `ruleid: deepok: example_rule_id` *)
+                  && Option.fold ~none:true
+                       ~some:(fun ok_regexp -> not (s =~ ok_regexp))
+                       ok_regexp
                 then Some (file, idx + 1)
                 else None))
 

--- a/src/reporting/Semgrep_error_code.mli
+++ b/src/reporting/Semgrep_error_code.mli
@@ -63,6 +63,7 @@ val severity_of_error :
 (* extract all the lines with ERROR: comment in test files *)
 val expected_error_lines_of_files :
   ?regexp:string ->
+  ?ok_regexp:string option ->
   Common.filename list ->
   (Common.filename * int) (* line with ERROR *) list
 


### PR DESCRIPTION
We have deepruleid to mark lines as matching only with the pro engine, but we didn't have anything to mark lines as ok only with the pro engine. deepok is intended for that.

This PR makes it possible to check for an overriding annotation.

Test plan: see [corresponding semgrep-pro PR](https://github.com/returntocorp/semgrep-proprietary/pull/810)

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
