### PR TITLE
chore: update benchmark to latest

### DIFF
--- a/scripts/run-benchmarks.sh
+++ b/scripts/run-benchmarks.sh
@@ -8,7 +8,7 @@ set -e
 cd cli || return
 
 # Run timing benchmark
-pipenv install semgrep==1.14.0
+pipenv install semgrep==1.29.0
 pipenv run python -m semgrep --version
 export PATH=/github/home/.local/bin:$PATH
 


### PR DESCRIPTION
The benchmarks have been warning of a 7% slowdown intermittently. I haven't seen a significant upwards creep in scan times across our 30 worst performing customers, so I'm just updating the benchmark.

Test plan: automated tests

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
