### PR TITLE
osemgrep ci: improve error handling, add Scan_helper.report_failure and use that

### DIFF
--- a/src/osemgrep/cli_ci/Ci_subcommand.ml
+++ b/src/osemgrep/cli_ci/Ci_subcommand.ml
@@ -105,7 +105,7 @@ let run (conf : Ci_CLI.conf) : Exit_code.t =
   let metadata = generate_meta_from_environment None in
   match deployment with
   | Error e -> e
-  | Ok depl ->
+  | Ok depl -> (
       Logs.app (fun m -> m "%a" Fmt_helpers.pp_heading "Debugging Info");
       Logs.app (fun m ->
           m "  %a" Fmt.(styled `Underline string) "SCAN ENVIRONMENT");
@@ -125,15 +125,16 @@ let run (conf : Ci_CLI.conf) : Exit_code.t =
             Fmt.(styled `Bold string)
             (Option.value ~default:"unknown" metadata.Project_metadata.on));
       (* TODO: fix_head_if_github_action(metadata) *)
-      let _scan_id, _rules_and_origins =
+      let r =
         match depl with
         | None ->
-            ( None,
-              Rule_fetching.rules_from_rules_source
-                ~token_opt:settings.api_token
-                ~rewrite_rule_ids:conf.rewrite_rule_ids
-                ~registry_caching:conf.registry_caching conf.rules_source )
-        | Some (token, deployment) ->
+            Ok
+              ( None,
+                Rule_fetching.rules_from_rules_source
+                  ~token_opt:settings.api_token
+                  ~rewrite_rule_ids:conf.rewrite_rule_ids
+                  ~registry_caching:conf.registry_caching conf.rules_source )
+        | Some (token, deployment) -> (
             Logs.app (fun m ->
                 m "  %a" Fmt.(styled `Underline string) "CONNECTION");
             Logs.app (fun m ->
@@ -144,42 +145,70 @@ let run (conf : Ci_CLI.conf) : Exit_code.t =
             (* TODO: metadata_dict["is_sca_scan"] = supply_chain *)
             (* TODO: proj_config = ProjectConfig.load_all()
                metadata_dict = {**metadata_dict, **proj_config.to_dict()} *)
-            let scan_id =
+            match
               Scan_helper.start_scan ~dry_run:conf.dryrun ~token
                 Semgrep_envvars.v.semgrep_url metadata_dict
-            in
-            let at_url_maybe ppf () =
-              if
-                Uri.equal Semgrep_envvars.v.semgrep_url
-                  (Uri.of_string "https://semgrep.dev")
-              then Fmt.string ppf ""
-              else
-                Fmt.pf ppf " at %a"
-                  Fmt.(styled `Bold string)
-                  (Uri.to_string Semgrep_envvars.v.semgrep_url)
-            in
-            Logs.app (fun m ->
-                m "  Fetching configuration from Semgrep Cloud Platform%a"
-                  at_url_maybe ());
-            let rules =
-              (* TODO: set sca to metadata.is_sca_scan / supply_chain *)
-              Scan_helper.fetch_scan_config ~token ~sca:false
-                ~dry_run:conf.dryrun ~full_scan:metadata.is_full_scan
-                metadata.repository
-            in
-            ( Some scan_id,
-              [
-                Common2.with_tmp_file ~str:rules ~ext:"json" (fun file ->
-                    let file = Fpath.v file in
-                    let res =
-                      Rule_fetching.load_rules_from_file ~registry_caching:false
-                        file
+            with
+            | Error msg ->
+                Logs.err (fun m -> m "%s" msg);
+                Error Exit_code.fatal
+            | Ok scan_id -> (
+                let at_url_maybe ppf () =
+                  if
+                    Uri.equal Semgrep_envvars.v.semgrep_url
+                      (Uri.of_string "https://semgrep.dev")
+                  then Fmt.string ppf ""
+                  else
+                    Fmt.pf ppf " at %a"
+                      Fmt.(styled `Bold string)
+                      (Uri.to_string Semgrep_envvars.v.semgrep_url)
+                in
+                Logs.app (fun m ->
+                    m "  Fetching configuration from Semgrep Cloud Platform%a"
+                      at_url_maybe ());
+                match
+                  (* TODO: set sca to metadata.is_sca_scan / supply_chain *)
+                  Scan_helper.fetch_scan_config ~token ~sca:false
+                    ~dry_run:conf.dryrun ~full_scan:metadata.is_full_scan
+                    metadata.repository
+                with
+                | Error msg ->
+                    Logs.err (fun m ->
+                        m "Failed to download configuration: %s" msg);
+                    let r = Exit_code.fatal in
+                    ignore
+                      (Scan_helper.report_failure ~dry_run:conf.dryrun ~token
+                         ~scan_id (Exit_code.to_int r));
+                    Error r
+                | Ok rules ->
+                    let rules_and_origins =
+                      try
+                        Common2.with_tmp_file ~str:rules ~ext:"json"
+                          (fun file ->
+                            let file = Fpath.v file in
+                            let res =
+                              Rule_fetching.load_rules_from_file
+                                ~registry_caching:false file
+                            in
+                            { res with origin = None })
+                      with
+                      | Error.Semgrep_error (_, opt_ex) as e ->
+                          let ex =
+                            Option.value ~default:Exit_code.fatal opt_ex
+                          in
+                          ignore
+                            (Scan_helper.report_failure ~dry_run:conf.dryrun
+                               ~token ~scan_id (Exit_code.to_int ex));
+                          let e = Exception.catch e in
+                          Exception.reraise e
                     in
-                    { res with origin = None });
-              ] )
+                    Ok (Some scan_id, [ rules_and_origins ])))
       in
-      (* TODO: do the actual scan, and reporting *)
-      Exit_code.ok
+      match r with
+      | Error ex -> ex
+      | Ok (_scan_id, _rules) ->
+          (* TODO: do the actual scan, and reporting *)
+          Exit_code.ok)
 
 (*****************************************************************************)
 (* Entry point *)

--- a/src/osemgrep/networking/Scan_helper.ml
+++ b/src/osemgrep/networking/Scan_helper.ml
@@ -1,3 +1,26 @@
+(* TODO: specify as ATD the reply of api/agent/deployments/scans *)
+let extract_scan_id data =
+  try
+    let json = JSON.json_of_string data in
+    match json with
+    | Object xs -> (
+        match List.assoc_opt "scan" xs with
+        | Some (Object dd) -> (
+            match List.assoc_opt "id" dd with
+            | Some (Int i) -> Ok (string_of_int i)
+            | Some (String s) -> Ok s
+            | _else ->
+                Error
+                  ("Bad json in body when looking for scan id: no id: " ^ data))
+        | _else ->
+            Error
+              ("Bad json in body when trying to find scan id: no scan: " ^ data)
+        )
+    | _else -> Error ("Bad json in body when asking for scan id: " ^ data)
+  with
+  | e ->
+      Error ("Couldn't parse json, error: " ^ Printexc.to_string e ^ ": " ^ data)
+
 let start_scan ~dry_run ~token url meta =
   if dry_run then (
     Logs.app (fun m -> m "Would have sent POST request to create scan");
@@ -13,30 +36,7 @@ let start_scan ~dry_run ~token url meta =
     let scan_endpoint = Uri.with_path url "api/agent/deployments/scans" in
     let body = JSON.(string_of_json (Object [ ("meta", meta) ])) in
     match Http_helpers.post ~body ~headers scan_endpoint with
-    | Ok body -> (
-        try
-          let json = JSON.json_of_string body in
-          match json with
-          | Object xs -> (
-              match List.assoc_opt "scan" xs with
-              | Some (Object dd) -> (
-                  match List.assoc_opt "id" dd with
-                  | Some (Int i) -> Ok (string_of_int i)
-                  | Some (String s) -> Ok s
-                  | _else ->
-                      Error
-                        ("Bad json in body when looking for scan id: no id: "
-                       ^ body))
-              | _else ->
-                  Error
-                    ("Bad json in body when trying to find scan id: no scan: "
-                   ^ body))
-          | _else -> Error ("Bad json in body when asking for scan id: " ^ body)
-        with
-        | e ->
-            Error
-              ("Couldn't parse json, error: " ^ Printexc.to_string e ^ ": "
-             ^ body))
+    | Ok body -> extract_scan_id body
     | Error (status, msg) ->
         let pre_msg =
           if status = 404 then
@@ -50,6 +50,19 @@ Please make sure they have been set correctly.
             url msg
         in
         Error msg)
+
+(* TODO: specify as ATD the reply to api/agent/deployments/scans/config *)
+let extract_rule_config data =
+  try
+    match Yojson.Basic.from_string data with
+    | `Assoc e -> (
+        match List.assoc "rule_config" e with
+        | `String e -> Ok e
+        | _else -> Error ("Couldn't retrieve config: no rule_config in " ^ data)
+        )
+    | _else -> Error ("Couldn't retrieve config: not an json object: " ^ data)
+  with
+  | e -> Error ("Failed to decode config: " ^ Printexc.to_string e ^ ": " ^ data)
 
 let fetch_scan_config ~token ~sca ~dry_run ~full_scan repository =
   (* TODO (see below): once we have the CLI logic in place to ignore findings that are from old rule versions
@@ -74,22 +87,7 @@ let fetch_scan_config ~token ~sca ~dry_run ~full_scan repository =
   Logs.debug (fun m -> m "finished downloading from %s" (Uri.to_string url));
   match content with
   | Error _ as e -> e
-  | Ok content -> (
-      try
-        match Yojson.Basic.from_string content with
-        | `Assoc e -> (
-            match List.assoc "rule_config" e with
-            | `String e -> Ok e
-            | _else ->
-                Error ("Couldn't retrieve config: no rule_config in " ^ content)
-            )
-        | _else ->
-            Error ("Couldn't retrieve config: not an json object: " ^ content)
-      with
-      | e ->
-          Error
-            ("Failed to decode config: " ^ Printexc.to_string e ^ ": " ^ content)
-      )
+  | Ok content -> extract_rule_config content
 
 let report_failure ~dry_run ~token ~scan_id exit_code =
   if dry_run then (

--- a/src/osemgrep/networking/Scan_helper.ml
+++ b/src/osemgrep/networking/Scan_helper.ml
@@ -1,7 +1,7 @@
 let start_scan ~dry_run ~token url meta =
   if dry_run then (
     Logs.app (fun m -> m "Would have sent POST request to create scan");
-    Ok None)
+    Ok "")
   else (
     Logs.debug (fun m -> m "Starting scan");
     let headers =
@@ -14,16 +14,29 @@ let start_scan ~dry_run ~token url meta =
     let body = JSON.(string_of_json (Object [ ("meta", meta) ])) in
     match Http_helpers.post ~body ~headers scan_endpoint with
     | Ok body -> (
-        let json = JSON.json_of_string body in
-        match json with
-        | Object xs -> (
-            match List.assoc_opt "scan" xs with
-            | Some (Object dd) -> (
-                match List.assoc_opt "id" dd with
-                | Some (Int i) -> Ok (Some (string_of_int i))
-                | _else -> Ok None)
-            | _else -> Ok None)
-        | _else -> Ok None)
+        try
+          let json = JSON.json_of_string body in
+          match json with
+          | Object xs -> (
+              match List.assoc_opt "scan" xs with
+              | Some (Object dd) -> (
+                  match List.assoc_opt "id" dd with
+                  | Some (Int i) -> Ok (string_of_int i)
+                  | Some (String s) -> Ok s
+                  | _else ->
+                      Error
+                        ("Bad json in body when looking for scan id: no id: "
+                       ^ body))
+              | _else ->
+                  Error
+                    ("Bad json in body when trying to find scan id: no scan: "
+                   ^ body))
+          | _else -> Error ("Bad json in body when asking for scan id: " ^ body)
+        with
+        | e ->
+            Error
+              ("Couldn't parse json, error: " ^ Printexc.to_string e ^ ": "
+             ^ body))
     | Error (status, msg) ->
         let pre_msg =
           if status = 404 then
@@ -52,20 +65,55 @@ let fetch_scan_config ~token ~sca ~dry_run ~full_scan repository =
   let content =
     let headers = [ ("authorization", "Bearer " ^ token) ] in
     match Http_helpers.get ~headers url with
-    | Ok body -> body
+    | Ok _ as r -> r
     | Error msg ->
-        (* was raise Semgrep_error, but equivalent to abort now *)
-        Error.abort
+        Error
           (Printf.sprintf "Failed to download config from %s: %s"
              (Uri.to_string url) msg)
   in
   Logs.debug (fun m -> m "finished downloading from %s" (Uri.to_string url));
-  try
-    match Yojson.Basic.from_string content with
-    | `Assoc e -> (
-        match List.assoc "rule_config" e with
-        | `String e -> e
-        | _else -> invalid_arg "couldn't retrieve config")
-    | _else -> invalid_arg "couldn't retrieve config"
-  with
-  | _failure -> invalid_arg "couldn't retrieve config"
+  match content with
+  | Error _ as e -> e
+  | Ok content -> (
+      try
+        match Yojson.Basic.from_string content with
+        | `Assoc e -> (
+            match List.assoc "rule_config" e with
+            | `String e -> Ok e
+            | _else ->
+                Error ("Couldn't retrieve config: no rule_config in " ^ content)
+            )
+        | _else ->
+            Error ("Couldn't retrieve config: not an json object: " ^ content)
+      with
+      | e ->
+          Error
+            ("Failed to decode config: " ^ Printexc.to_string e ^ ": " ^ content)
+      )
+
+let report_failure ~dry_run ~token ~scan_id exit_code =
+  if dry_run then (
+    Logs.app (fun m ->
+        m "Would have reported failure to semgrep.dev: %u" exit_code);
+    Ok ())
+  else
+    let uri =
+      Uri.with_path Semgrep_envvars.v.semgrep_url
+        ("/api/agent/scans/" ^ scan_id ^ "/error")
+    in
+    let headers =
+      [
+        ("content-type", "application/json");
+        ("authorization", "Bearer " ^ token);
+      ]
+    in
+    let body =
+      JSON.(
+        string_of_json
+          (Object [ ("exit_code", Int exit_code); ("stderr", String "") ]))
+    in
+    match Http_helpers.post ~body ~headers uri with
+    | Ok _ -> Ok ()
+    | Error (code, msg) ->
+        Error
+          ("API server returned " ^ string_of_int code ^ ", this error: " ^ msg)

--- a/src/osemgrep/networking/Scan_helper.mli
+++ b/src/osemgrep/networking/Scan_helper.mli
@@ -1,15 +1,22 @@
 (* from scans.py *)
 
 val start_scan :
-  dry_run:bool ->
-  token:string ->
-  Uri.t ->
-  JSON.t ->
-  (string option, string) result
+  dry_run:bool -> token:string -> Uri.t -> JSON.t -> (string, string) result
 (** [start_scan ~dry_run ~token url meta] informs the Semgrep App that a scan
-    is about to be started, and returns the scan id from the server. *)
+    is about to be started, and returns the scan id from the server. If
+    [dry_run] is [true], the empty string will be returned ([Ok ""]). *)
 
 val fetch_scan_config :
-  token:string -> sca:bool -> dry_run:bool -> full_scan:bool -> string -> string
+  token:string ->
+  sca:bool ->
+  dry_run:bool ->
+  full_scan:bool ->
+  string ->
+  (string, string) result
 (** [fetch_scan_config ~token ~sca ~dry_run ~full_scan repo] returns the rules
     for the provided configuration. *)
+
+val report_failure :
+  dry_run:bool -> token:string -> scan_id:string -> int -> (unit, string) result
+(** [report_failure ~dry+run ~token ~scan_id exit_code] reports the failure
+    for [scan_id] to Semgrep App. *)


### PR DESCRIPTION
still, there's some work to do:
- scan the repository
- report findings

test plan: make core

This removed the spurious invalid_arg mentioned in https://github.com/returntocorp/semgrep/pull/8136#issuecomment-1607554087

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
