### PR TITLE
osemgrep: create a random temporary file for the settings

### DIFF
--- a/src/osemgrep/configuring/Semgrep_settings.ml
+++ b/src/osemgrep/configuring/Semgrep_settings.ml
@@ -115,13 +115,12 @@ let save setting =
   try
     let dir = Fpath.(to_string (parent settings)) in
     if not (Sys.file_exists dir) then Sys.mkdir dir 0o755;
-    let tmp = Fpath.(settings + "tmp") in
-    if Sys.file_exists (Fpath.to_string tmp) then
-      Sys.remove (Fpath.to_string tmp);
-    File.write_file tmp str;
+    let tmp = Filename.temp_file ~temp_dir:dir "settings" "yml" in
+    if Sys.file_exists tmp then Sys.remove tmp;
+    File.write_file (Fpath.v tmp) str;
     (* Create a termporary file and rename to have a consisting settings file,
        even if the power fails (or a Ctrl-C happens) during the write_file. *)
-    Unix.rename (Fpath.to_string tmp) (Fpath.to_string settings);
+    Unix.rename tmp (Fpath.to_string settings);
     true
   with
   | Sys_error e ->


### PR DESCRIPTION
this avoids a race if multiple osemgrep are being executed which race for the settings.yml.tmp.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
