### PR TITLE
osemgrep ci: conduct the scan (re-using Scan_subcommand logic)

### DIFF
--- a/src/osemgrep/cli_ci/Ci_subcommand.ml
+++ b/src/osemgrep/cli_ci/Ci_subcommand.ml
@@ -58,7 +58,7 @@ let fetch_scan_config ~token ~dry_run ~sca ~full_scan ~repository scan_id =
             let e = Exception.catch e in
             Exception.reraise e
       in
-      Ok (Some scan_id, [ rules_and_origins ])
+      Ok [ rules_and_origins ]
 
 (* from meta.py *)
 let generate_meta_from_environment (_baseline_ref : Digestif.SHA1.t option) :
@@ -205,15 +205,57 @@ let run (conf : Ci_CLI.conf) : Exit_code.t =
                 Error Exit_code.fatal
             | Ok scan_id ->
                 (* TODO: set sca to metadata.is_sca_scan / supply_chain *)
-                fetch_scan_config ~token ~dry_run:conf.dryrun ~sca:false
-                  ~full_scan:metadata.is_full_scan
-                  ~repository:metadata.repository scan_id)
+                Result.map
+                  (fun r -> ((if scan_id = "" then None else Some scan_id), r))
+                  (fetch_scan_config ~token ~dry_run:conf.dryrun ~sca:false
+                     ~full_scan:metadata.is_full_scan
+                     ~repository:metadata.repository scan_id))
       in
+
       match r with
       | Error ex -> ex
-      | Ok (_scan_id, _rules) ->
-          (* TODO: do the actual scan, and reporting *)
-          Exit_code.ok)
+      | Ok (scan_id, rules_and_origin) -> (
+          (* TODO:
+             if dataflow_traces is None:
+               dataflow_traces = engine_type.has_dataflow_traces
+
+             if max_memory is None:
+               max_memory = engine_type.default_max_memory
+
+             if interfile_timeout is None:
+               interfile_timeout = engine_type.default_interfile_timeout
+
+             if engine_type.is_pro:
+               console.print(Padding(Title("Engine", order=2), (1, 0, 0, 0)))
+               if engine_type.check_if_installed():
+                 console.print(
+                   f"Using Semgrep Pro Version: [bold]{engine_type.get_pro_version()}[/bold]",
+                    markup=True,
+                 )
+                 console.print(
+                   f"Installed at [bold]{engine_type.get_binary_path()}[/bold]",
+                   markup=True,
+                 )
+             else:
+               run_install_semgrep_pro()
+          *)
+          (* TODO
+             excludes_from_app = scan_handler.ignore_patterns if scan_handler else []
+             assert exclude is not None  # exclude is default empty tuple
+             exclude = ( *exclude, *yield_exclude_paths(excludes_from_app))
+          *)
+          match Scan_subcommand.scan_files rules_and_origin conf with
+          | Error e ->
+              (match (depl, scan_id) with
+              | Some (token, _), Some scan_id ->
+                  ignore
+                    (Scan_helper.report_failure ~dry_run:conf.dryrun ~token
+                       ~scan_id (Exit_code.to_int e))
+              | _else -> ());
+              e
+          | Ok (_res, _cli_output) ->
+              (* TODO: reporting *)
+              Exit_code.ok))
 
 (*****************************************************************************)
 (* Entry point *)

--- a/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -153,6 +153,116 @@ let analyze_skipped (skipped : Out.skipped_target list) =
     | Not_found -> [] )
 
 (*****************************************************************************)
+(* Conduct the scan *)
+(*****************************************************************************)
+
+let scan_files rules_and_origins (conf : Scan_CLI.conf) =
+  let rules, errors =
+    Rule_fetching.partition_rules_and_errors rules_and_origins
+  in
+  (* TODO: we should probably warn the user about rules using the same id *)
+  let rules =
+    Common.uniq_by
+      (fun r1 r2 -> Rule.ID.equal (fst r1.Rule.id) (fst r2.Rule.id))
+      rules
+  in
+  if Common.null rules then Error Exit_code.missing_config
+  else
+    let filtered_rules =
+      Rule_filtering.filter_rules conf.rule_filtering_conf rules
+    in
+    Logs.info (fun m ->
+        m "%a" Rules_report.pp_rules (conf.rules_source, filtered_rules));
+
+    (* step2: getting the targets *)
+    let targets, semgrepignored_targets =
+      Find_targets.get_targets conf.targeting_conf conf.target_roots
+    in
+    Logs.debug (fun m ->
+        m "%a" Targets_report.pp_targets_debug
+          (conf.target_roots, semgrepignored_targets, targets));
+    Logs.info (fun m ->
+        semgrepignored_targets
+        |> List.iter (fun (x : Output_from_core_t.skipped_target) ->
+               m "Ignoring %s due to %s (%s)" x.Output_from_core_t.path
+                 (Output_from_core_t.show_skip_reason
+                    x.Output_from_core_t.reason)
+                 x.Output_from_core_t.details));
+
+    (* step3: running the engine *)
+    let output_format, file_match_results_hook =
+      match conf with
+      | { output_format = Output_format.Text; legacy = false; _ } ->
+          ( Output_format.TextIncremental,
+            Some (file_match_results_hook conf filtered_rules) )
+      | { output_format; _ } -> (output_format, None)
+    in
+    let (res : Core_runner.result) =
+      Core_runner.invoke_semgrep_core
+        ~respect_git_ignore:conf.targeting_conf.respect_git_ignore
+        ~file_match_results_hook conf.core_runner_conf filtered_rules errors
+        targets
+    in
+
+    (* step4: report matches *)
+    let errors_skipped = errors_to_skipped res.core.errors in
+    let semgrepignored, included, excluded, size, other_ignored =
+      analyze_skipped semgrepignored_targets
+    in
+    let res =
+      let skipped_targets =
+        Some
+          (semgrepignored_targets @ errors_skipped
+          @ Common.optlist_to_list res.core.skipped_targets)
+      in
+      (* Add the targets that were semgrepignored or errorneous *)
+      let core = { res.core with skipped_targets } in
+      { res with core }
+    in
+
+    (* outputting the result! in JSON/Text/... depending on conf *)
+    let cli_output = Output.output_result { conf with output_format } res in
+
+    Logs.info (fun m ->
+        m "%a" Skipped_report.pp_skipped
+          ( conf.targeting_conf.respect_git_ignore,
+            conf.legacy,
+            conf.targeting_conf.max_target_bytes,
+            semgrepignored,
+            included,
+            excluded,
+            size,
+            other_ignored,
+            errors_skipped ));
+    Logs.app (fun m ->
+        m "%a" Summary_report.pp_summary
+          ( conf.targeting_conf.respect_git_ignore,
+            conf.legacy,
+            conf.targeting_conf.max_target_bytes,
+            semgrepignored,
+            included,
+            excluded,
+            size,
+            other_ignored,
+            errors_skipped ));
+    Logs.app (fun m ->
+        m "Ran %s on %s: %s."
+          (String_utils.unit_str (List.length filtered_rules) "rule")
+          (String_utils.unit_str (List.length cli_output.paths.scanned) "file")
+          (String_utils.unit_str (List.length cli_output.results) "finding"));
+
+    (* TOPORT? was in formater/base.py
+       def keep_ignores(self) -> bool:
+         """
+         Return True if ignored findings should be passed to this formatter;
+         False otherwise.
+         Ignored findings can still be distinguished using their _is_ignore property.
+         """
+         return False
+    *)
+    Ok (res, cli_output)
+
+(*****************************************************************************)
 (* Main logic *)
 (*****************************************************************************)
 
@@ -191,7 +301,7 @@ let run (conf : Scan_CLI.conf) : Exit_code.t =
   | _ when conf.validate <> None ->
       Validate_subcommand.run (Common2.some conf.validate)
   | _ when conf.dump <> None -> Dump_subcommand.run (Common2.some conf.dump)
-  | _else_ ->
+  | _else_ -> (
       (* --------------------------------------------------------- *)
       (* Let's go *)
       (* --------------------------------------------------------- *)
@@ -227,117 +337,15 @@ let run (conf : Scan_CLI.conf) : Exit_code.t =
           ~rewrite_rule_ids:conf.rewrite_rule_ids
           ~registry_caching:conf.registry_caching conf.rules_source
       in
-      let rules, errors =
-        Rule_fetching.partition_rules_and_errors rules_and_origins
-      in
-      (* TODO: we should probably warn the user about rules using the same id *)
-      let rules =
-        Common.uniq_by
-          (fun r1 r2 -> Rule.ID.equal (fst r1.Rule.id) (fst r2.Rule.id))
-          rules
-      in
-      if Common.null rules then Exit_code.missing_config
-      else
-        let filtered_rules =
-          Rule_filtering.filter_rules conf.rule_filtering_conf rules
-        in
-        Logs.info (fun m ->
-            m "%a" Rules_report.pp_rules (conf.rules_source, filtered_rules));
 
-        (* step2: getting the targets *)
-        let targets, semgrepignored_targets =
-          Find_targets.get_targets conf.targeting_conf conf.target_roots
-        in
-        Logs.debug (fun m ->
-            m "%a" Targets_report.pp_targets_debug
-              (conf.target_roots, semgrepignored_targets, targets));
-        Logs.info (fun m ->
-            semgrepignored_targets
-            |> List.iter (fun (x : Output_from_core_t.skipped_target) ->
-                   m "Ignoring %s due to %s (%s)" x.Output_from_core_t.path
-                     (Output_from_core_t.show_skip_reason
-                        x.Output_from_core_t.reason)
-                     x.Output_from_core_t.details));
-
-        (* step3: running the engine *)
-        let output_format, file_match_results_hook =
-          match conf with
-          | { output_format = Output_format.Text; legacy = false; _ } ->
-              ( Output_format.TextIncremental,
-                Some (file_match_results_hook conf filtered_rules) )
-          | { output_format; _ } -> (output_format, None)
-        in
-        let (res : Core_runner.result) =
-          Core_runner.invoke_semgrep_core
-            ~respect_git_ignore:conf.targeting_conf.respect_git_ignore
-            ~file_match_results_hook conf.core_runner_conf filtered_rules errors
-            targets
-        in
-
-        (* step4: report matches *)
-        let errors_skipped = errors_to_skipped res.core.errors in
-        let semgrepignored, included, excluded, size, other_ignored =
-          analyze_skipped semgrepignored_targets
-        in
-        let res =
-          let skipped_targets =
-            Some
-              (semgrepignored_targets @ errors_skipped
-              @ Common.optlist_to_list res.core.skipped_targets)
-          in
-          (* Add the targets that were semgrepignored or errorneous *)
-          let core = { res.core with skipped_targets } in
-          { res with core }
-        in
-
-        (* outputting the result! in JSON/Text/... depending on conf *)
-        let cli_output = Output.output_result { conf with output_format } res in
-
-        Logs.info (fun m ->
-            m "%a" Skipped_report.pp_skipped
-              ( conf.targeting_conf.respect_git_ignore,
-                conf.legacy,
-                conf.targeting_conf.max_target_bytes,
-                semgrepignored,
-                included,
-                excluded,
-                size,
-                other_ignored,
-                errors_skipped ));
-        Logs.app (fun m ->
-            m "%a" Summary_report.pp_summary
-              ( conf.targeting_conf.respect_git_ignore,
-                conf.legacy,
-                conf.targeting_conf.max_target_bytes,
-                semgrepignored,
-                included,
-                excluded,
-                size,
-                other_ignored,
-                errors_skipped ));
-        Logs.app (fun m ->
-            m "Ran %s on %s: %s."
-              (String_utils.unit_str (List.length filtered_rules) "rule")
-              (String_utils.unit_str
-                 (List.length cli_output.paths.scanned)
-                 "file")
-              (String_utils.unit_str (List.length cli_output.results) "finding"));
-
-        (* TOPORT? was in formater/base.py
-           def keep_ignores(self) -> bool:
-             """
-             Return True if ignored findings should be passed to this formatter;
-             False otherwise.
-             Ignored findings can still be distinguished using their _is_ignore property.
-             """
-             return False
-        *)
-
-        (* step5: exit with the right exit code *)
-        (* final result for the shell *)
-        if conf.error_on_findings && not (Common.null cli_output.results) then
-          Exit_code.findings
-        else exit_code_of_errors ~strict:conf.strict res.core.errors
+      match scan_files rules_and_origins conf with
+      | Error ex -> ex
+      | Ok (res, cli_output) ->
+          (* step5: exit with the right exit code *)
+          (* final result for the shell *)
+          if conf.error_on_findings && not (Common.null cli_output.results) then
+            Exit_code.findings
+          else exit_code_of_errors ~strict:conf.strict res.core.errors)
 
 (*****************************************************************************)
 (* Entry point *)

--- a/src/osemgrep/cli_scan/Scan_subcommand.mli
+++ b/src/osemgrep/cli_scan/Scan_subcommand.mli
@@ -9,3 +9,9 @@ val main : string array -> Exit_code.t
 
 (* internal *)
 val run : Scan_CLI.conf -> Exit_code.t
+
+(* internal: scan all the files - also used in CI *)
+val scan_files :
+  Rule_fetching.rules_and_origin list ->
+  Scan_CLI.conf ->
+  (Core_runner.result * Semgrep_output_v1_t.cli_output, Exit_code.t) result


### PR DESCRIPTION
this does the actual scanning in osemgrep CI, what is missing is the reporting.

on error, the failure is reported to semgrep app

test plan: make osempass and make check should be fine

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
