### PR TITLE
osemgrep: support --matching-explanations flag

### DIFF
--- a/src/osemgrep/cli_scan/Core_runner.ml
+++ b/src/osemgrep/cli_scan/Core_runner.ml
@@ -198,11 +198,11 @@ let semgrep_with_prepared_rules_and_targets (config : Runner_config.t)
    Take in rules and targets and return object with findings.
 *)
 let invoke_semgrep_core ?(respect_git_ignore = true)
-    ?(file_match_results_hook = None) (conf : conf) (all_rules : Rule.t list)
-    (rule_errors : Rule.invalid_rule_error list) (all_targets : Fpath.t list) :
-    result =
+    ?(file_match_results_hook = None) ~matching_explanations (conf : conf)
+    (all_rules : Rule.t list) (rule_errors : Rule.invalid_rule_error list)
+    (all_targets : Fpath.t list) : result =
   let config : Runner_config.t = runner_config_of_conf conf in
-  let config = { config with file_match_results_hook } in
+  let config = { config with file_match_results_hook; matching_explanations } in
 
   match rule_errors with
   (* with pysemgrep, semgrep-core is passed all the rules unparsed,

--- a/src/osemgrep/cli_scan/Core_runner.mli
+++ b/src/osemgrep/cli_scan/Core_runner.mli
@@ -28,6 +28,7 @@ val invoke_semgrep_core :
   ?respect_git_ignore:bool ->
   ?file_match_results_hook:
     (Fpath.t -> Report.partial_profiling Report.match_result -> unit) option ->
+  matching_explanations:bool ->
   conf ->
   (* LATER? use Config_resolve.rules_and_origin instead? *)
   Rule.rules ->

--- a/src/osemgrep/cli_scan/Scan_CLI.mli
+++ b/src/osemgrep/cli_scan/Scan_CLI.mli
@@ -32,6 +32,8 @@ type conf = {
   (* Display options *)
   (* mix of --json, --emacs, --vim, etc. *)
   output_format : Output_format.t;
+  (* osemgrep-only: (was passed via --core-opts in pysemgrep) *)
+  matching_explanations : bool;
   (* mix of --debug, --quiet, --verbose *)
   logging_level : Logs.level option;
   force_color : bool;

--- a/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -269,6 +269,7 @@ let run (conf : Scan_CLI.conf) : Exit_code.t =
         in
         let (res : Core_runner.result) =
           Core_runner.invoke_semgrep_core
+            ~matching_explanations:conf.matching_explanations
             ~respect_git_ignore:conf.targeting_conf.respect_git_ignore
             ~file_match_results_hook conf.core_runner_conf filtered_rules errors
             targets

--- a/src/osemgrep/cli_scan/Validate_subcommand.ml
+++ b/src/osemgrep/cli_scan/Validate_subcommand.ml
@@ -103,8 +103,8 @@ let run (conf : conf) : Exit_code.t =
           Error.abort (spf "error in metachecks! please fix %s" metarules_pack);
 
         let res =
-          Core_runner.invoke_semgrep_core conf.core_runner_conf metarules []
-            targets
+          Core_runner.invoke_semgrep_core ~matching_explanations:false
+            conf.core_runner_conf metarules [] targets
         in
 
         (* TODO? sanity check errors below too? *)


### PR DESCRIPTION
Not finished yet.

test plan:
```
$ xx --config test.yaml test.ml --matching-explanations --json
...
explanation in json output
```


PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)