### PR TITLE
feat(ssc): Add severity and fixed at versions to Supply Chain issues

### DIFF
--- a/changelog.d/sc-772.added
+++ b/changelog.d/sc-772.added
@@ -1,0 +1,1 @@
+Add severity and suggested upgrade versions to Supply Chain findings

--- a/cli/src/semgrep/formatter/text.py
+++ b/cli/src/semgrep/formatter/text.py
@@ -615,20 +615,22 @@ def print_text_output(
             # this is a list of objects like [{'minimist': '0.2.4'}, {'minimist': '1.2.6'}]
             fixes = rule_match.metadata["sca-fix-versions"]
             # will be structure { 'package_name': set('1.2.3', '2.3.4') }
-            fixed_versions = set()
             dep_name = rule_match.extra[
                 "sca_info"
             ].dependency_match.found_dependency.package
-            for fix_obj in fixes:
-                for name, version in fix_obj.items():
-                    if name == dep_name:
-                        fixed_versions.add(version)
-            sorted_fixed_versions = list(fixed_versions)
-            sorted_fixed_versions.sort()
+            fixed_versions = sorted(
+                {
+                    version
+                    for fix_obj in fixes
+                    for name, version in fix_obj.items()
+                    if name == dep_name
+                }
+            )
+            version_txt = "versions" if len(fixed_versions) > 1 else "version"
             console.print(
                 with_color(
                     Colors.green,
-                    f"         ▶▶┆ Fixed for {dep_name} at versions: {', '.join(sorted_fixed_versions)}",
+                    f"         ▶▶┆ Fixed for {dep_name} at {version_txt}: {', '.join(fixed_versions)}",
                 )
             )
 

--- a/cli/src/semgrep/formatter/text.py
+++ b/cli/src/semgrep/formatter/text.py
@@ -612,24 +612,23 @@ def print_text_output(
             and "sca-fix-versions" in rule_match.metadata
             and (last_message is None or last_message != message)
         ):
-            fix_tag = with_color(Colors.green, "         ▶▶┆ Fixed at versions:")
             # this is a list of objects like [{'minimist': '0.2.4'}, {'minimist': '1.2.6'}]
             fixes = rule_match.metadata["sca-fix-versions"]
             # will be structure { 'package_name': set('1.2.3', '2.3.4') }
-            reduced_fixes: Dict[str, set[str]] = {}
+            fixed_versions = set()
+            dep_name = rule_match.extra[
+                "sca_info"
+            ].dependency_match.found_dependency.package
             for fix_obj in fixes:
                 for name, version in fix_obj.items():
-                    if name not in reduced_fixes:
-                        reduced_fixes[name] = set()
-                    reduced_fixes[name].add(version)
-            console.print(fix_tag)
-            for name, versions in reduced_fixes.items():
-                console.print(
-                    with_color(
-                        Colors.green, f"           ┆   {name}: {', '.join(versions)}"
-                    )
+                    if name == dep_name:
+                        fixed_versions.add(version)
+            console.print(
+                with_color(
+                    Colors.green,
+                    f"         ▶▶┆ Fixed for {dep_name} at versions: {', '.join(fixed_versions)}",
                 )
-            console.print("          ⋮┆")
+            )
 
         last_file = current_file
         last_message = message

--- a/cli/src/semgrep/formatter/text.py
+++ b/cli/src/semgrep/formatter/text.py
@@ -586,16 +586,17 @@ def print_text_output(
                 5 * " ",
                 False,
             )
+            severity = (
+                (
+                    f"{8 * ' '}Severity: {with_color(Colors.foreground, rule_match.metadata['sca-severity'], bold=True)}\n"
+                )
+                if "sca_info" in rule_match.extra
+                and "sca-severity" in rule_match.metadata
+                else ""
+            )
             message_text = click.wrap_text(f"{message}", width, 8 * " ", 8 * " ", True)
-            console.print(f"{title_text}\n{message_text}\n{shortlink_text}")
+            console.print(f"{title_text}\n{severity}{message_text}\n{shortlink_text}")
 
-        last_file = current_file
-        last_message = message
-        next_rule_match = (
-            sorted_rule_matches[rule_index + 1]
-            if rule_index != len(sorted_rule_matches) - 1
-            else None
-        )
         autofix_tag = with_color(Colors.green, "         ▶▶┆ Autofix ▶")
         if fix is not None:
             console.print(
@@ -606,7 +607,37 @@ def print_text_output(
             console.print(
                 f"{autofix_tag} s/{fix_regex.regex}/{fix_regex.replacement}/{fix_regex.count or 'g'}"
             )
+        elif (
+            "sca_info" in rule_match.extra
+            and "sca-fix-versions" in rule_match.metadata
+            and (last_message is None or last_message != message)
+        ):
+            fix_tag = with_color(Colors.green, "         ▶▶┆ Fixed at versions:")
+            # this is a list of objects like [{'minimist': '0.2.4'}, {'minimist': '1.2.6'}]
+            fixes = rule_match.metadata["sca-fix-versions"]
+            # will be structure { 'package_name': set('1.2.3', '2.3.4') }
+            reduced_fixes: Dict[str, set[str]] = {}
+            for fix_obj in fixes:
+                for name, version in fix_obj.items():
+                    if name not in reduced_fixes:
+                        reduced_fixes[name] = set()
+                    reduced_fixes[name].add(version)
+            console.print(fix_tag)
+            for name, versions in reduced_fixes.items():
+                console.print(
+                    with_color(
+                        Colors.green, f"           ┆   {name}: {', '.join(versions)}"
+                    )
+                )
+            console.print("          ⋮┆")
 
+        last_file = current_file
+        last_message = message
+        next_rule_match = (
+            sorted_rule_matches[rule_index + 1]
+            if rule_index != len(sorted_rule_matches) - 1
+            else None
+        )
         is_same_file = (
             next_rule_match.path == rule_match.path if next_rule_match else False
         )

--- a/cli/src/semgrep/formatter/text.py
+++ b/cli/src/semgrep/formatter/text.py
@@ -623,10 +623,12 @@ def print_text_output(
                 for name, version in fix_obj.items():
                     if name == dep_name:
                         fixed_versions.add(version)
+            sorted_fixed_versions = list(fixed_versions)
+            sorted_fixed_versions.sort()
             console.print(
                 with_color(
                     Colors.green,
-                    f"         ▶▶┆ Fixed for {dep_name} at versions: {', '.join(fixed_versions)}",
+                    f"         ▶▶┆ Fixed for {dep_name} at versions: {', '.join(sorted_fixed_versions)}",
                 )
             )
 

--- a/cli/tests/e2e/rules/dependency_aware/monorepo_with_first_party.yaml
+++ b/cli/tests/e2e/rules/dependency_aware/monorepo_with_first_party.yaml
@@ -8,6 +8,20 @@ rules:
     message: oh no
     languages: [js]
     severity: WARNING
+    metadata:
+      sca-kind: reachable
+      category: security
+      confidence: HIGH
+      sca-schema: 20230302
+      sca-severity: HIGH
+      sca-fix-versions:
+      - bad-lib: 0.0.9
+      - bad-lib: 1.0.1
+      - bad-lib-2: 2.0.1
+      publish-date: '2023-06-13T18:30:39Z'
+      owasp:
+      - A06:2021 - Vulnerable and Outdated Components
+      sca-vuln-database-identifier: CVE-FOO-BAR
   - id: js-other
     pattern: bad()
     message: this is always bad

--- a/cli/tests/e2e/snapshots/test_output/test_sca_output/results.txt
+++ b/cli/tests/e2e/snapshots/test_output/test_sca_output/results.txt
@@ -6,9 +6,11 @@
 
     targets/dependency_aware/monorepo/webapp1/app.js with lockfile
   targets/dependency_aware/monorepo/webapp1/yarn.lock
-       rules.dependency_aware.js-sca
+       bad-lib - CVE-FOO-BAR
+          Severity: HIGH
           oh no
 
+           ▶▶┆ Fixed for bad-lib at versions: 0.0.9, 1.0.1
             1┆ bad()
 
 
@@ -17,9 +19,11 @@
 └────────────────────────────────────┘
 
     targets/dependency_aware/monorepo/webapp2/yarn.lock
-       rules.dependency_aware.js-sca
+       bad-lib - CVE-FOO-BAR
+          Severity: HIGH
           oh no
 
+           ▶▶┆ Fixed for bad-lib at versions: 0.0.9, 1.0.1
             5┆ bad-lib@0.0.7:
             6┆   version "0.0.7"
 


### PR DESCRIPTION
Some folks have asked to add the severity and fixed at versions to the output for Supply Chain issues. Severity is useful so that folks can prioritize important issues, fixed at versions makes it easier for people to go fix those important issues. For folks who are running semgrep manually or who read the output of their CI jobs, this will make the results easier to action.

Note that supply chain issues can have multiple packages (e.g. lodash, lodash.merge) AND multiple fixed versions per package (e.g. minimist 0.2.4 and 1.2.6). As such, we display fixes in the following format:

  package a: 1.2.3, 2.3.4
  package b: 4.5.6

Here's an example with both reachable and unreachable findings:
<img width="546" alt="Screenshot 2023-06-27 at 1 42 38 PM" src="https://github.com/returntocorp/semgrep/assets/8356503/4256a67a-7c9a-49f3-beac-f6d68f10b1b2">

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
