### PR TITLE
add parsing of deepok and deepruleid

### DIFF
--- a/cli/src/semgrep/test.py
+++ b/cli/src/semgrep/test.py
@@ -51,6 +51,8 @@ TODORULEID = "todoruleid"
 RULEID = "ruleid"
 TODOOK = "todook"
 OK = "ok"
+DEEPOK = "deepok"
+DEEPRULEID = "deepruleid"
 
 EXIT_FAILURE = 2
 
@@ -65,11 +67,15 @@ def normalize_rule_ids(line: str) -> Set[str]:
     """
     given a line like `     # ruleid:foobar`
     or `      // ruleid:foobar`
+    or `      // ruleid:deepok:foobar`
     return `foobar`
     """
-    _, rules_text = line.strip().split(":")
+    _, rules_text = line.strip().split(":", 1)
     rules_text = rules_text.strip()
-    rules = rules_text.split(",")
+    # strip out "deepok" and "deepruleid" annotations if they are there to get rule name
+    if rules_text.startswith(DEEPOK) or rules_text.startswith(DEEPRULEID):
+        _, rules_text = rules_text.split(":")
+    rules = rules_text.strip().split(",")
     # remove comment ends for non-newline comment syntaxes
     rules_clean = map(lambda rule: _remove_ending_comments(rule), rules)
     return set(filter(None, [rule.strip() for rule in rules_clean]))


### PR DESCRIPTION
This will help solve: https://github.com/returntocorp/semgrep-rules/pull/2985.

Adds parsing of notations like `ruleid: deepok: foobar` and `ruleid: deepruleid: foobar`.

_To Test:_
Run `python -m semgrep --test semgrep-rules/java/spring/security/injection`

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
