### PR TITLE
feat(rule syntax): Support metavariable-type field for csharp, typescript, php, rust

### DIFF
--- a/changelog.d/gh-8164.added
+++ b/changelog.d/gh-8164.added
@@ -1,0 +1,3 @@
+feat(rule syntax): Support metavariable-type field for csharp, typescript, php, rust
+
+`metavariable-type` field is now supported for csharp, typescript, php, rust.

--- a/src/parsing/Parse_metavariable_type.ml
+++ b/src/parsing/Parse_metavariable_type.ml
@@ -21,6 +21,10 @@ let wrap_type_expr lang str =
   | Lang.Go -> Some (spf "var x %s" str)
   | Lang.Kotlin -> Some (spf "x as %s" str)
   | Lang.Scala -> Some (spf "x.asInstanceOf[%s]" str)
+  | Lang.Php -> Some (spf "(%s) $x" str)
+  | Lang.Ts -> Some (spf "x as %s" str)
+  | Lang.Csharp -> Some (spf "x as %s" str)
+  | Lang.Rust -> Some (spf "x as %s" str)
   | _ -> None
 
 let unwrap_type_expr lang expr =
@@ -32,4 +36,8 @@ let unwrap_type_expr lang expr =
       Some t
   | Lang.Kotlin, G.E { e = G.Cast (t, _, _); _ } -> Some t
   | Lang.Scala, G.E { e = OtherExpr (_, _ :: T t :: _); _ } -> Some t
+  | Lang.Php, G.E { e = G.Cast (t, _, _); _ } -> Some t
+  | Lang.Ts, G.E { e = G.Cast (t, _, _); _ } -> Some t
+  | Lang.Csharp, G.E { e = G.Cast (t, _, _); _ } -> Some t
+  | Lang.Rust, G.E { e = G.Cast (t, _, _); _ } -> Some t
   | _ -> None

--- a/tests/rules/metavar_type_not_csharp.cs
+++ b/tests/rules/metavar_type_not_csharp.cs
@@ -1,0 +1,20 @@
+public class BenchmarkTest02388 : IHttpHandler
+{
+    public void ProcessRequest(HttpContext context)
+    {
+        HttpResponse response = context.Response;
+        HttpRequest request = context.Request;
+
+        // ok: no-direct-response-writer
+        response.Write("Hash Test java.security.MessageDigest.getInstance(java.lang.String) executed");
+        // ruleid: no-direct-response-writer
+        response.Write(request.Form["input"]);
+
+        // Assuming response has a getSafeWriter() method
+        SafeWriter sWriter = response.getSafeWriter();
+        // ok: no-direct-response-writer
+        sWriter.Write(request.Form["input"]);
+    }
+
+    public bool IsReusable => false;
+}

--- a/tests/rules/metavar_type_not_csharp.yaml
+++ b/tests/rules/metavar_type_not_csharp.yaml
@@ -1,0 +1,21 @@
+rules:
+- id: no-direct-response-write
+  patterns:
+  - pattern: $RES.Write(...)
+  - pattern-not: $RES.Write("...")
+  - metavariable-type:
+      metavariable: $RES
+      type: HttpResponse
+  message: |
+    Detected a direct write to the HTTP response. This bypasses any
+    view or template environments, including HTML escaping, which may
+    expose this application to cross-site scripting (XSS) vulnerabilities.
+    Consider using a view technology such as JavaServer Faces (JSFs) which
+    automatically escapes HTML views.
+  metadata:
+    owasp: 'A7: Cross-site Scripting (XSS)'
+    cwe: 'CWE-116: Improper Encoding or Escaping of Output'
+    references:
+    - https://www3.ntu.edu.sg/home/ehchua/programming/java/JavaServerFaces.html
+  severity: WARNING
+  languages: [csharp]

--- a/tests/rules/metavar_type_not_rust.rs
+++ b/tests/rules/metavar_type_not_rust.rs
@@ -1,0 +1,12 @@
+async fn index(form: web::Form<MyForm>, response: HttpResponseBuilder) -> impl Responder {
+    let input = form.input.clone();
+    if input.is_empty() {
+      // ok: no-direct-response-write
+      response.body("default string".to_string())
+    } else {
+      // Construct an HTTP response with the tainted input
+      let msg = format!("Hello, {}!", input);
+      // ruleid: no-direct-response-write
+      response.body(msg)
+    }
+}

--- a/tests/rules/metavar_type_not_rust.yaml
+++ b/tests/rules/metavar_type_not_rust.yaml
@@ -1,0 +1,21 @@
+rules:
+- id: no-direct-response-write
+  patterns:
+  - pattern: $BUILDER.body(...)
+  - pattern-not: $BUILDER.body("...".to_string())
+  - metavariable-type:
+      metavariable: $BUILDER
+      type: HttpResponseBuilder
+  message: |
+    Detected a direct write to the HTTP response. This bypasses any
+    view or template environments, including HTML escaping, which may
+    expose this application to cross-site scripting (XSS) vulnerabilities.
+    Consider using a view technology such as JavaServer Faces (JSFs) which
+    automatically escapes HTML views.
+  metadata:
+    owasp: 'A7: Cross-site Scripting (XSS)'
+    cwe: 'CWE-116: Improper Encoding or Escaping of Output'
+    references:
+    - https://www3.ntu.edu.sg/home/ehchua/programming/java/JavaServerFaces.html
+  severity: WARNING
+  languages: [rust]

--- a/tests/rules/metavar_type_not_typescript.ts
+++ b/tests/rules/metavar_type_not_typescript.ts
@@ -1,0 +1,9 @@
+function displayMessage(req: Request, res: Response) {
+  const message = req.query.message;
+
+  // ruleid: no-direct-response-write
+  res.send(`<h1>${message}</h1>`);
+
+  // ok: no-direct-response-write
+  res.send(`<h1>constant string</h1>`);
+}

--- a/tests/rules/metavar_type_not_typescript.yaml
+++ b/tests/rules/metavar_type_not_typescript.yaml
@@ -1,0 +1,21 @@
+rules:
+- id: no-direct-response-write
+  patterns:
+  - pattern: $RES.send(...)
+  - pattern-not: $RES.send("...")
+  - metavariable-type:
+      metavariable: $RES
+      type: Response
+  message: |
+    Detected a direct write to the HTTP response. This bypasses any
+    view or template environments, including HTML escaping, which may
+    expose this application to cross-site scripting (XSS) vulnerabilities.
+    Consider using a view technology such as JavaServer Faces (JSFs) which
+    automatically escapes HTML views.
+  metadata:
+    owasp: 'A7: Cross-site Scripting (XSS)'
+    cwe: 'CWE-116: Improper Encoding or Escaping of Output'
+    references:
+    - https://www3.ntu.edu.sg/home/ehchua/programming/java/JavaServerFaces.html
+  severity: WARNING
+  languages: [typescript]

--- a/tests/rules/metavar_type_str_eq_php.php
+++ b/tests/rules/metavar_type_str_eq_php.php
@@ -1,0 +1,13 @@
+<?php
+function foo(string $a, int $b) {
+    # ruleid: no-string-eqeq
+    echo $a == "hello";
+    # ruleid: no-string-eqeq
+    echo "hello" == $a;
+    # ok: no-string-eqeq
+    echo $b == 2;
+    # ok: no-string-eqeq
+    echo null == "hello";
+    # ok: no-string-eqeq
+    echo "hello" == null;
+}

--- a/tests/rules/metavar_type_str_eq_php.yaml
+++ b/tests/rules/metavar_type_str_eq_php.yaml
@@ -1,0 +1,12 @@
+rules:
+  - id: no-string-eqeq
+    severity: WARNING
+    message: find errors
+    languages:
+      - php
+    patterns:
+      - pattern-not: null == $Y
+      - pattern: $X == $Y
+      - metavariable-type:
+          metavariable: $Y
+          type: string


### PR DESCRIPTION
Support metavariable-type field for C#, typescript, php, rust.

fix #8164 

PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
