### PR TITLE
feat: [ci] set cache timeout

### DIFF
--- a/.github/workflows/build-test-osx-x86.yaml
+++ b/.github/workflows/build-test-osx-x86.yaml
@@ -88,6 +88,8 @@ jobs:
         id: cache-opam
         uses: actions/cache@v3
         if: ${{ inputs.use-cache }}
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
         with:
           path: ~/.opam
           #TODO: we should add the md5sum of opam.lock as part of the key


### PR DESCRIPTION
Default Cache retrieval timeout is 10m, but in the average case (at least from the small sample size we have), cache read should take only ~30s. Set the timeout to 2m in case of a read issue, we shave 8m off the total runtime. 

Test Plan: 
- CI on this PR. 

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
