### PR TITLE
feat: add osemgrep-pro command

### DIFF
--- a/src/osemgrep/cli/dune
+++ b/src/osemgrep/cli/dune
@@ -2,6 +2,7 @@
 ; This builds a library. The executable's entry point is defined in ../main
 ;
 (library
+  (public_name semgrep.osemgrep_cli)
   (name osemgrep_cli)
   (wrapped false)
   (libraries

--- a/src/osemgrep/cli_ci/dune
+++ b/src/osemgrep/cli_ci/dune
@@ -1,6 +1,7 @@
 ; OCaml implementation of the 'semgrep ci' subcommand.
 ;
 (library
+  (public_name semgrep.osemgrep_cli_ci)
   (name osemgrep_cli_ci)
   (wrapped false)
   (libraries

--- a/src/osemgrep/cli_dump/dune
+++ b/src/osemgrep/cli_dump/dune
@@ -1,6 +1,7 @@
 ; OCaml implementation of the 'semgrep dump' subcommand.
 
 (library
+  (public_name semgrep.osemgrep_cli_dump)
   (name osemgrep_cli_dump)
   (wrapped false)
   (libraries

--- a/src/osemgrep/cli_interactive/dune
+++ b/src/osemgrep/cli_interactive/dune
@@ -1,6 +1,7 @@
 ; OCaml implementation of the 'semgrep interactive' subcommand.
 
 (library
+  (public_name semgrep.osemgrep_cli_interactive)
   (name osemgrep_cli_interactive)
   (wrapped false)
   (inline_tests)

--- a/src/osemgrep/cli_login/dune
+++ b/src/osemgrep/cli_login/dune
@@ -1,6 +1,7 @@
 ; OCaml implementation of the 'semgrep login' and 'semgrep logout' subcommands.
 ;
 (library
+  (public_name semgrep.osemgrep_cli_login)
   (name osemgrep_cli_login)
   (wrapped false)
   (libraries

--- a/src/osemgrep/cli_lsp/dune
+++ b/src/osemgrep/cli_lsp/dune
@@ -1,6 +1,7 @@
 ; OCaml implementation of the 'semgrep lsp' subcommand.
 
 (library
+  (public_name semgrep.osemgrep_cli_lsp)
   (name osemgrep_cli_lsp)
   (wrapped false)
   (libraries

--- a/src/osemgrep/cli_scan/dune
+++ b/src/osemgrep/cli_scan/dune
@@ -1,6 +1,7 @@
 ; OCaml implementation of the 'semgrep scan' subcommand.
 ;
 (library
+  (public_name semgrep.osemgrep_cli_scan)
   (name osemgrep_cli_scan)
   (wrapped false)
   (libraries

--- a/src/osemgrep/cli_test/dune
+++ b/src/osemgrep/cli_test/dune
@@ -1,6 +1,7 @@
 ; OCaml implementation of the 'semgrep test' subcommand.
 
 (library
+  (public_name semgrep.osemgrep_cli_test)
   (name osemgrep_cli_test)
   (wrapped false)
   (libraries

--- a/src/osemgrep/configuring/dune
+++ b/src/osemgrep/configuring/dune
@@ -5,6 +5,7 @@
 ; Eventually, this will be merged with the /configuring library from semgrep-core
 
 (library
+  (public_name semgrep.osemgrep_configuring)
   (name osemgrep_configuring)
   (wrapped false)
   (libraries

--- a/src/osemgrep/core/dune
+++ b/src/osemgrep/core/dune
@@ -4,6 +4,7 @@
 ; Eventually, this will be merged with the /core library from semgrep-core
 
 (library
+  (public_name semgrep.osemgrep_core)
   (name osemgrep_core)
   (wrapped false)
   (libraries

--- a/src/osemgrep/jsonnet/dune
+++ b/src/osemgrep/jsonnet/dune
@@ -1,5 +1,6 @@
 ; see also libs/jsonnet/
 (library
+  (public_name semgrep.osemgrep_jsonnet)
   (name osemgrep_jsonnet)
   (wrapped false)
   (libraries

--- a/src/osemgrep/networking/dune
+++ b/src/osemgrep/networking/dune
@@ -1,5 +1,6 @@
 ; This library should contain all the entry points to access the internet.
 (library
+  (public_name semgrep.osemgrep_networking)
   (name osemgrep_networking)
   (wrapped false)
   (libraries

--- a/src/osemgrep/reporting/dune
+++ b/src/osemgrep/reporting/dune
@@ -1,5 +1,6 @@
 ;LATER: to merge with semgrep_reporting at some point
 (library
+ (public_name semgrep.osemgrep_reporting)
  (name osemgrep_reporting)
  (wrapped false)
  (libraries


### PR DESCRIPTION
Running osemgrep in semgrep-proprietary requires these libraries to be public.

Test plan: see corresponding semgrep-pro pr https://github.com/returntocorp/semgrep-proprietary/pull/819

PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
