### PR TITLE
formatting improvements for `semgrep ci` output

### DIFF
--- a/cli/src/semgrep/commands/ci.py
+++ b/cli/src/semgrep/commands/ci.py
@@ -491,21 +491,27 @@ def ci(
     app_block_override = False
     reason = ""
     if scan_handler:
-        logger.info("  Uploading findings.")
-        app_block_override, reason = scan_handler.report_findings(
-            filtered_matches_by_rule,
-            semgrep_errors,
-            filtered_rules,
-            output_extra.all_targets,
-            renamed_targets,
-            ignore_log.unsupported_lang_paths,
-            output_extra.parsing_data,
-            total_time,
-            metadata.commit_datetime,
-            dependencies,
-            dependency_parser_errors,
-            engine_type,
-        )
+        with Progress(
+            TextColumn("  {task.description}"),
+            SpinnerColumn(spinner_name="simpleDotsScrolling"),
+            console=console,
+        ) as progress_bar:
+            app_block_override, reason = scan_handler.report_findings(
+                filtered_matches_by_rule,
+                semgrep_errors,
+                filtered_rules,
+                output_extra.all_targets,
+                renamed_targets,
+                ignore_log.unsupported_lang_paths,
+                output_extra.parsing_data,
+                total_time,
+                metadata.commit_datetime,
+                dependencies,
+                dependency_parser_errors,
+                engine_type,
+                progress_bar,
+            )
+
         logger.info("  View results in Semgrep Cloud Platform:")
         logger.info(
             f"    https://semgrep.dev/orgs/{scan_handler.deployment_name}/findings"

--- a/cli/tests/e2e/snapshots/test_ci/test_dryrun/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_dryrun/results.txt
@@ -104,7 +104,6 @@ Some files were skipped or only partially analyzed.
 
 CI scan completed successfully.
   Found 8 findings (6 blocking) from 6 rules.
-  Uploading findings.
 Would have sent findings and ignores blob: {
     "findings": [
         {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines-overwrite-autodetected-variables/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines-overwrite-autodetected-variables/results.txt
@@ -104,8 +104,8 @@ Some files were skipped or only partially analyzed.
 
 CI scan completed successfully.
   Found 8 findings (6 blocking) from 6 rules.
-  Uploading findings.
-  View results in Semgrep Cloud Platform:
+  Uploading scan results
+  Finalizing scan           View results in Semgrep Cloud Platform:
     https://semgrep.dev/orgs/org_name/findings
     https://semgrep.dev/orgs/org_name/supply-chain
   Has findings for blocking rules so exiting with code 1

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines/results.txt
@@ -104,8 +104,8 @@ Some files were skipped or only partially analyzed.
 
 CI scan completed successfully.
   Found 8 findings (6 blocking) from 6 rules.
-  Uploading findings.
-  View results in Semgrep Cloud Platform:
+  Uploading scan results
+  Finalizing scan           View results in Semgrep Cloud Platform:
     https://semgrep.dev/orgs/org_name/findings
     https://semgrep.dev/orgs/org_name/supply-chain
   Has findings for blocking rules so exiting with code 1

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket-overwrite-autodetected-variables/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket-overwrite-autodetected-variables/results.txt
@@ -104,8 +104,8 @@ Some files were skipped or only partially analyzed.
 
 CI scan completed successfully.
   Found 8 findings (6 blocking) from 6 rules.
-  Uploading findings.
-  View results in Semgrep Cloud Platform:
+  Uploading scan results
+  Finalizing scan           View results in Semgrep Cloud Platform:
     https://semgrep.dev/orgs/org_name/findings
     https://semgrep.dev/orgs/org_name/supply-chain
   Has findings for blocking rules so exiting with code 1

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket/results.txt
@@ -104,8 +104,8 @@ Some files were skipped or only partially analyzed.
 
 CI scan completed successfully.
   Found 8 findings (6 blocking) from 6 rules.
-  Uploading findings.
-  View results in Semgrep Cloud Platform:
+  Uploading scan results
+  Finalizing scan           View results in Semgrep Cloud Platform:
     https://semgrep.dev/orgs/org_name/findings
     https://semgrep.dev/orgs/org_name/supply-chain
   Has findings for blocking rules so exiting with code 1

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite-overwrite-autodetected-variables/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite-overwrite-autodetected-variables/results.txt
@@ -104,8 +104,8 @@ Some files were skipped or only partially analyzed.
 
 CI scan completed successfully.
   Found 8 findings (6 blocking) from 6 rules.
-  Uploading findings.
-  View results in Semgrep Cloud Platform:
+  Uploading scan results
+  Finalizing scan           View results in Semgrep Cloud Platform:
     https://semgrep.dev/orgs/org_name/findings
     https://semgrep.dev/orgs/org_name/supply-chain
   Has findings for blocking rules so exiting with code 1

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite/results.txt
@@ -104,8 +104,8 @@ Some files were skipped or only partially analyzed.
 
 CI scan completed successfully.
   Found 8 findings (6 blocking) from 6 rules.
-  Uploading findings.
-  View results in Semgrep Cloud Platform:
+  Uploading scan results
+  Finalizing scan           View results in Semgrep Cloud Platform:
     https://semgrep.dev/orgs/org_name/findings
     https://semgrep.dev/orgs/org_name/supply-chain
   Has findings for blocking rules so exiting with code 1

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci-overwrite-autodetected-variables/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci-overwrite-autodetected-variables/results.txt
@@ -104,8 +104,8 @@ Some files were skipped or only partially analyzed.
 
 CI scan completed successfully.
   Found 8 findings (6 blocking) from 6 rules.
-  Uploading findings.
-  View results in Semgrep Cloud Platform:
+  Uploading scan results
+  Finalizing scan           View results in Semgrep Cloud Platform:
     https://semgrep.dev/orgs/org_name/findings
     https://semgrep.dev/orgs/org_name/supply-chain
   Has findings for blocking rules so exiting with code 1

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci/results.txt
@@ -104,8 +104,8 @@ Some files were skipped or only partially analyzed.
 
 CI scan completed successfully.
   Found 8 findings (6 blocking) from 6 rules.
-  Uploading findings.
-  View results in Semgrep Cloud Platform:
+  Uploading scan results
+  Finalizing scan           View results in Semgrep Cloud Platform:
     https://semgrep.dev/orgs/org_name/findings
     https://semgrep.dev/orgs/org_name/supply-chain
   Has findings for blocking rules so exiting with code 1

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/results.txt
@@ -99,8 +99,8 @@ Some files were skipped or only partially analyzed.
 
 CI scan completed successfully.
   Found 8 findings (6 blocking) from 6 rules.
-  Uploading findings.
-  View results in Semgrep Cloud Platform:
+  Uploading scan results
+  Finalizing scan           View results in Semgrep Cloud Platform:
     https://semgrep.dev/orgs/org_name/findings
     https://semgrep.dev/orgs/org_name/supply-chain
   Has findings for blocking rules so exiting with code 1

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr-semgrepconfig/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr-semgrepconfig/results.txt
@@ -101,8 +101,8 @@ Some files were skipped or only partially analyzed.
 
 CI scan completed successfully.
   Found 7 findings (6 blocking) from 6 rules.
-  Uploading findings.
-  View results in Semgrep Cloud Platform:
+  Uploading scan results
+  Finalizing scan           View results in Semgrep Cloud Platform:
     https://semgrep.dev/orgs/org_name/findings
     https://semgrep.dev/orgs/org_name/supply-chain
   Has findings for blocking rules so exiting with code 1

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr/results.txt
@@ -98,8 +98,8 @@ Some files were skipped or only partially analyzed.
 
 CI scan completed successfully.
   Found 7 findings (6 blocking) from 6 rules.
-  Uploading findings.
-  View results in Semgrep Cloud Platform:
+  Uploading scan results
+  Finalizing scan           View results in Semgrep Cloud Platform:
     https://semgrep.dev/orgs/org_name/findings
     https://semgrep.dev/orgs/org_name/supply-chain
   Has findings for blocking rules so exiting with code 1

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push-special-env-vars/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push-special-env-vars/results.txt
@@ -99,8 +99,8 @@ Some files were skipped or only partially analyzed.
 
 CI scan completed successfully.
   Found 8 findings (6 blocking) from 6 rules.
-  Uploading findings.
-  View results in Semgrep Cloud Platform:
+  Uploading scan results
+  Finalizing scan           View results in Semgrep Cloud Platform:
     https://semgrep.dev/orgs/org_name/findings
     https://semgrep.dev/orgs/org_name/supply-chain
   Has findings for blocking rules so exiting with code 1

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/results.txt
@@ -99,8 +99,8 @@ Some files were skipped or only partially analyzed.
 
 CI scan completed successfully.
   Found 8 findings (6 blocking) from 6 rules.
-  Uploading findings.
-  View results in Semgrep Cloud Platform:
+  Uploading scan results
+  Finalizing scan           View results in Semgrep Cloud Platform:
     https://semgrep.dev/orgs/org_name/findings
     https://semgrep.dev/orgs/org_name/supply-chain
   Has findings for blocking rules so exiting with code 1

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-push/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-push/results.txt
@@ -103,8 +103,8 @@ Some files were skipped or only partially analyzed.
 
 CI scan completed successfully.
   Found 8 findings (6 blocking) from 6 rules.
-  Uploading findings.
-  View results in Semgrep Cloud Platform:
+  Uploading scan results
+  Finalizing scan           View results in Semgrep Cloud Platform:
     https://semgrep.dev/orgs/org_name/findings
     https://semgrep.dev/orgs/org_name/supply-chain
   Has findings for blocking rules so exiting with code 1

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-special-env-vars/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-special-env-vars/results.txt
@@ -99,8 +99,8 @@ Some files were skipped or only partially analyzed.
 
 CI scan completed successfully.
   Found 7 findings (6 blocking) from 6 rules.
-  Uploading findings.
-  View results in Semgrep Cloud Platform:
+  Uploading scan results
+  Finalizing scan           View results in Semgrep Cloud Platform:
     https://semgrep.dev/orgs/org_name/findings
     https://semgrep.dev/orgs/org_name/supply-chain
   Has findings for blocking rules so exiting with code 1

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab/results.txt
@@ -99,8 +99,8 @@ Some files were skipped or only partially analyzed.
 
 CI scan completed successfully.
   Found 7 findings (6 blocking) from 6 rules.
-  Uploading findings.
-  View results in Semgrep Cloud Platform:
+  Uploading scan results
+  Finalizing scan           View results in Semgrep Cloud Platform:
     https://semgrep.dev/orgs/org_name/findings
     https://semgrep.dev/orgs/org_name/supply-chain
   Has findings for blocking rules so exiting with code 1

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/results.txt
@@ -103,8 +103,8 @@ Some files were skipped or only partially analyzed.
 
 CI scan completed successfully.
   Found 8 findings (6 blocking) from 6 rules.
-  Uploading findings.
-  View results in Semgrep Cloud Platform:
+  Uploading scan results
+  Finalizing scan           View results in Semgrep Cloud Platform:
     https://semgrep.dev/orgs/org_name/findings
     https://semgrep.dev/orgs/org_name/supply-chain
   Has findings for blocking rules so exiting with code 1

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-overwrite-autodetected-variables/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-overwrite-autodetected-variables/results.txt
@@ -103,8 +103,8 @@ Some files were skipped or only partially analyzed.
 
 CI scan completed successfully.
   Found 8 findings (6 blocking) from 6 rules.
-  Uploading findings.
-  View results in Semgrep Cloud Platform:
+  Uploading scan results
+  Finalizing scan           View results in Semgrep Cloud Platform:
     https://semgrep.dev/orgs/org_name/findings
     https://semgrep.dev/orgs/org_name/supply-chain
   Has findings for blocking rules so exiting with code 1

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins/results.txt
@@ -103,8 +103,8 @@ Some files were skipped or only partially analyzed.
 
 CI scan completed successfully.
   Found 8 findings (6 blocking) from 6 rules.
-  Uploading findings.
-  View results in Semgrep Cloud Platform:
+  Uploading scan results
+  Finalizing scan           View results in Semgrep Cloud Platform:
     https://semgrep.dev/orgs/org_name/findings
     https://semgrep.dev/orgs/org_name/supply-chain
   Has findings for blocking rules so exiting with code 1

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/results.txt
@@ -103,8 +103,8 @@ Some files were skipped or only partially analyzed.
 
 CI scan completed successfully.
   Found 8 findings (6 blocking) from 6 rules.
-  Uploading findings.
-  View results in Semgrep Cloud Platform:
+  Uploading scan results
+  Finalizing scan           View results in Semgrep Cloud Platform:
     https://semgrep.dev/orgs/org_name/findings
     https://semgrep.dev/orgs/org_name/supply-chain
   Has findings for blocking rules so exiting with code 1

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-self-hosted/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-self-hosted/results.txt
@@ -103,8 +103,8 @@ Some files were skipped or only partially analyzed.
 
 CI scan completed successfully.
   Found 8 findings (6 blocking) from 6 rules.
-  Uploading findings.
-  View results in Semgrep Cloud Platform:
+  Uploading scan results
+  Finalizing scan           View results in Semgrep Cloud Platform:
     https://semgrep.dev/orgs/org_name/findings
     https://semgrep.dev/orgs/org_name/supply-chain
   Has findings for blocking rules so exiting with code 1

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis-overwrite-autodetected-variables/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis-overwrite-autodetected-variables/results.txt
@@ -104,8 +104,8 @@ Some files were skipped or only partially analyzed.
 
 CI scan completed successfully.
   Found 8 findings (6 blocking) from 6 rules.
-  Uploading findings.
-  View results in Semgrep Cloud Platform:
+  Uploading scan results
+  Finalizing scan           View results in Semgrep Cloud Platform:
     https://semgrep.dev/orgs/org_name/findings
     https://semgrep.dev/orgs/org_name/supply-chain
   Has findings for blocking rules so exiting with code 1

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis/results.txt
@@ -104,8 +104,8 @@ Some files were skipped or only partially analyzed.
 
 CI scan completed successfully.
   Found 8 findings (6 blocking) from 6 rules.
-  Uploading findings.
-  View results in Semgrep Cloud Platform:
+  Uploading scan results
+  Finalizing scan           View results in Semgrep Cloud Platform:
     https://semgrep.dev/orgs/org_name/findings
     https://semgrep.dev/orgs/org_name/supply-chain
   Has findings for blocking rules so exiting with code 1

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-unparsable_url/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-unparsable_url/results.txt
@@ -103,8 +103,8 @@ Some files were skipped or only partially analyzed.
 
 CI scan completed successfully.
   Found 8 findings (6 blocking) from 6 rules.
-  Uploading findings.
-  View results in Semgrep Cloud Platform:
+  Uploading scan results
+  Finalizing scan           View results in Semgrep Cloud Platform:
     https://semgrep.dev/orgs/org_name/findings
     https://semgrep.dev/orgs/org_name/supply-chain
   Has findings for blocking rules so exiting with code 1

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines-overwrite-autodetected-variables/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines-overwrite-autodetected-variables/results.txt
@@ -104,8 +104,8 @@ Some files were skipped or only partially analyzed.
 
 CI scan completed successfully.
   Found 8 findings (6 blocking) from 6 rules.
-  Uploading findings.
-  View results in Semgrep Cloud Platform:
+  Uploading scan results
+  Finalizing scan           View results in Semgrep Cloud Platform:
     https://semgrep.dev/orgs/org_name/findings
     https://semgrep.dev/orgs/org_name/supply-chain
   Has findings for blocking rules so exiting with code 1

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines/results.txt
@@ -104,8 +104,8 @@ Some files were skipped or only partially analyzed.
 
 CI scan completed successfully.
   Found 8 findings (6 blocking) from 6 rules.
-  Uploading findings.
-  View results in Semgrep Cloud Platform:
+  Uploading scan results
+  Finalizing scan           View results in Semgrep Cloud Platform:
     https://semgrep.dev/orgs/org_name/findings
     https://semgrep.dev/orgs/org_name/supply-chain
   Has findings for blocking rules so exiting with code 1

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket-overwrite-autodetected-variables/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket-overwrite-autodetected-variables/results.txt
@@ -104,8 +104,8 @@ Some files were skipped or only partially analyzed.
 
 CI scan completed successfully.
   Found 8 findings (6 blocking) from 6 rules.
-  Uploading findings.
-  View results in Semgrep Cloud Platform:
+  Uploading scan results
+  Finalizing scan           View results in Semgrep Cloud Platform:
     https://semgrep.dev/orgs/org_name/findings
     https://semgrep.dev/orgs/org_name/supply-chain
   Has findings for blocking rules so exiting with code 1

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket/results.txt
@@ -104,8 +104,8 @@ Some files were skipped or only partially analyzed.
 
 CI scan completed successfully.
   Found 8 findings (6 blocking) from 6 rules.
-  Uploading findings.
-  View results in Semgrep Cloud Platform:
+  Uploading scan results
+  Finalizing scan           View results in Semgrep Cloud Platform:
     https://semgrep.dev/orgs/org_name/findings
     https://semgrep.dev/orgs/org_name/supply-chain
   Has findings for blocking rules so exiting with code 1

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite-overwrite-autodetected-variables/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite-overwrite-autodetected-variables/results.txt
@@ -104,8 +104,8 @@ Some files were skipped or only partially analyzed.
 
 CI scan completed successfully.
   Found 8 findings (6 blocking) from 6 rules.
-  Uploading findings.
-  View results in Semgrep Cloud Platform:
+  Uploading scan results
+  Finalizing scan           View results in Semgrep Cloud Platform:
     https://semgrep.dev/orgs/org_name/findings
     https://semgrep.dev/orgs/org_name/supply-chain
   Has findings for blocking rules so exiting with code 1

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite/results.txt
@@ -104,8 +104,8 @@ Some files were skipped or only partially analyzed.
 
 CI scan completed successfully.
   Found 8 findings (6 blocking) from 6 rules.
-  Uploading findings.
-  View results in Semgrep Cloud Platform:
+  Uploading scan results
+  Finalizing scan           View results in Semgrep Cloud Platform:
     https://semgrep.dev/orgs/org_name/findings
     https://semgrep.dev/orgs/org_name/supply-chain
   Has findings for blocking rules so exiting with code 1

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci-overwrite-autodetected-variables/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci-overwrite-autodetected-variables/results.txt
@@ -104,8 +104,8 @@ Some files were skipped or only partially analyzed.
 
 CI scan completed successfully.
   Found 8 findings (6 blocking) from 6 rules.
-  Uploading findings.
-  View results in Semgrep Cloud Platform:
+  Uploading scan results
+  Finalizing scan           View results in Semgrep Cloud Platform:
     https://semgrep.dev/orgs/org_name/findings
     https://semgrep.dev/orgs/org_name/supply-chain
   Has findings for blocking rules so exiting with code 1

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci/results.txt
@@ -104,8 +104,8 @@ Some files were skipped or only partially analyzed.
 
 CI scan completed successfully.
   Found 8 findings (6 blocking) from 6 rules.
-  Uploading findings.
-  View results in Semgrep Cloud Platform:
+  Uploading scan results
+  Finalizing scan           View results in Semgrep Cloud Platform:
     https://semgrep.dev/orgs/org_name/findings
     https://semgrep.dev/orgs/org_name/supply-chain
   Has findings for blocking rules so exiting with code 1

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/results.txt
@@ -99,8 +99,8 @@ Some files were skipped or only partially analyzed.
 
 CI scan completed successfully.
   Found 8 findings (6 blocking) from 6 rules.
-  Uploading findings.
-  View results in Semgrep Cloud Platform:
+  Uploading scan results
+  Finalizing scan           View results in Semgrep Cloud Platform:
     https://semgrep.dev/orgs/org_name/findings
     https://semgrep.dev/orgs/org_name/supply-chain
   Has findings for blocking rules so exiting with code 1

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr-semgrepconfig/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr-semgrepconfig/results.txt
@@ -101,8 +101,8 @@ Some files were skipped or only partially analyzed.
 
 CI scan completed successfully.
   Found 7 findings (6 blocking) from 6 rules.
-  Uploading findings.
-  View results in Semgrep Cloud Platform:
+  Uploading scan results
+  Finalizing scan           View results in Semgrep Cloud Platform:
     https://semgrep.dev/orgs/org_name/findings
     https://semgrep.dev/orgs/org_name/supply-chain
   Has findings for blocking rules so exiting with code 1

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr/results.txt
@@ -98,8 +98,8 @@ Some files were skipped or only partially analyzed.
 
 CI scan completed successfully.
   Found 7 findings (6 blocking) from 6 rules.
-  Uploading findings.
-  View results in Semgrep Cloud Platform:
+  Uploading scan results
+  Finalizing scan           View results in Semgrep Cloud Platform:
     https://semgrep.dev/orgs/org_name/findings
     https://semgrep.dev/orgs/org_name/supply-chain
   Has findings for blocking rules so exiting with code 1

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push-special-env-vars/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push-special-env-vars/results.txt
@@ -99,8 +99,8 @@ Some files were skipped or only partially analyzed.
 
 CI scan completed successfully.
   Found 8 findings (6 blocking) from 6 rules.
-  Uploading findings.
-  View results in Semgrep Cloud Platform:
+  Uploading scan results
+  Finalizing scan           View results in Semgrep Cloud Platform:
     https://semgrep.dev/orgs/org_name/findings
     https://semgrep.dev/orgs/org_name/supply-chain
   Has findings for blocking rules so exiting with code 1

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/results.txt
@@ -99,8 +99,8 @@ Some files were skipped or only partially analyzed.
 
 CI scan completed successfully.
   Found 8 findings (6 blocking) from 6 rules.
-  Uploading findings.
-  View results in Semgrep Cloud Platform:
+  Uploading scan results
+  Finalizing scan           View results in Semgrep Cloud Platform:
     https://semgrep.dev/orgs/org_name/findings
     https://semgrep.dev/orgs/org_name/supply-chain
   Has findings for blocking rules so exiting with code 1

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-push/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-push/results.txt
@@ -103,8 +103,8 @@ Some files were skipped or only partially analyzed.
 
 CI scan completed successfully.
   Found 8 findings (6 blocking) from 6 rules.
-  Uploading findings.
-  View results in Semgrep Cloud Platform:
+  Uploading scan results
+  Finalizing scan           View results in Semgrep Cloud Platform:
     https://semgrep.dev/orgs/org_name/findings
     https://semgrep.dev/orgs/org_name/supply-chain
   Has findings for blocking rules so exiting with code 1

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-special-env-vars/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-special-env-vars/results.txt
@@ -99,8 +99,8 @@ Some files were skipped or only partially analyzed.
 
 CI scan completed successfully.
   Found 7 findings (6 blocking) from 6 rules.
-  Uploading findings.
-  View results in Semgrep Cloud Platform:
+  Uploading scan results
+  Finalizing scan           View results in Semgrep Cloud Platform:
     https://semgrep.dev/orgs/org_name/findings
     https://semgrep.dev/orgs/org_name/supply-chain
   Has findings for blocking rules so exiting with code 1

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab/results.txt
@@ -99,8 +99,8 @@ Some files were skipped or only partially analyzed.
 
 CI scan completed successfully.
   Found 7 findings (6 blocking) from 6 rules.
-  Uploading findings.
-  View results in Semgrep Cloud Platform:
+  Uploading scan results
+  Finalizing scan           View results in Semgrep Cloud Platform:
     https://semgrep.dev/orgs/org_name/findings
     https://semgrep.dev/orgs/org_name/supply-chain
   Has findings for blocking rules so exiting with code 1

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/results.txt
@@ -103,8 +103,8 @@ Some files were skipped or only partially analyzed.
 
 CI scan completed successfully.
   Found 8 findings (6 blocking) from 6 rules.
-  Uploading findings.
-  View results in Semgrep Cloud Platform:
+  Uploading scan results
+  Finalizing scan           View results in Semgrep Cloud Platform:
     https://semgrep.dev/orgs/org_name/findings
     https://semgrep.dev/orgs/org_name/supply-chain
   Has findings for blocking rules so exiting with code 1

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-overwrite-autodetected-variables/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-overwrite-autodetected-variables/results.txt
@@ -103,8 +103,8 @@ Some files were skipped or only partially analyzed.
 
 CI scan completed successfully.
   Found 8 findings (6 blocking) from 6 rules.
-  Uploading findings.
-  View results in Semgrep Cloud Platform:
+  Uploading scan results
+  Finalizing scan           View results in Semgrep Cloud Platform:
     https://semgrep.dev/orgs/org_name/findings
     https://semgrep.dev/orgs/org_name/supply-chain
   Has findings for blocking rules so exiting with code 1

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins/results.txt
@@ -103,8 +103,8 @@ Some files were skipped or only partially analyzed.
 
 CI scan completed successfully.
   Found 8 findings (6 blocking) from 6 rules.
-  Uploading findings.
-  View results in Semgrep Cloud Platform:
+  Uploading scan results
+  Finalizing scan           View results in Semgrep Cloud Platform:
     https://semgrep.dev/orgs/org_name/findings
     https://semgrep.dev/orgs/org_name/supply-chain
   Has findings for blocking rules so exiting with code 1

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/results.txt
@@ -103,8 +103,8 @@ Some files were skipped or only partially analyzed.
 
 CI scan completed successfully.
   Found 8 findings (6 blocking) from 6 rules.
-  Uploading findings.
-  View results in Semgrep Cloud Platform:
+  Uploading scan results
+  Finalizing scan           View results in Semgrep Cloud Platform:
     https://semgrep.dev/orgs/org_name/findings
     https://semgrep.dev/orgs/org_name/supply-chain
   Has findings for blocking rules so exiting with code 1

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-self-hosted/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-self-hosted/results.txt
@@ -103,8 +103,8 @@ Some files were skipped or only partially analyzed.
 
 CI scan completed successfully.
   Found 8 findings (6 blocking) from 6 rules.
-  Uploading findings.
-  View results in Semgrep Cloud Platform:
+  Uploading scan results
+  Finalizing scan           View results in Semgrep Cloud Platform:
     https://semgrep.dev/orgs/org_name/findings
     https://semgrep.dev/orgs/org_name/supply-chain
   Has findings for blocking rules so exiting with code 1

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis-overwrite-autodetected-variables/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis-overwrite-autodetected-variables/results.txt
@@ -104,8 +104,8 @@ Some files were skipped or only partially analyzed.
 
 CI scan completed successfully.
   Found 8 findings (6 blocking) from 6 rules.
-  Uploading findings.
-  View results in Semgrep Cloud Platform:
+  Uploading scan results
+  Finalizing scan           View results in Semgrep Cloud Platform:
     https://semgrep.dev/orgs/org_name/findings
     https://semgrep.dev/orgs/org_name/supply-chain
   Has findings for blocking rules so exiting with code 1

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis/results.txt
@@ -104,8 +104,8 @@ Some files were skipped or only partially analyzed.
 
 CI scan completed successfully.
   Found 8 findings (6 blocking) from 6 rules.
-  Uploading findings.
-  View results in Semgrep Cloud Platform:
+  Uploading scan results
+  Finalizing scan           View results in Semgrep Cloud Platform:
     https://semgrep.dev/orgs/org_name/findings
     https://semgrep.dev/orgs/org_name/supply-chain
   Has findings for blocking rules so exiting with code 1

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-unparsable_url/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-unparsable_url/results.txt
@@ -103,8 +103,8 @@ Some files were skipped or only partially analyzed.
 
 CI scan completed successfully.
   Found 8 findings (6 blocking) from 6 rules.
-  Uploading findings.
-  View results in Semgrep Cloud Platform:
+  Uploading scan results
+  Finalizing scan           View results in Semgrep Cloud Platform:
     https://semgrep.dev/orgs/org_name/findings
     https://semgrep.dev/orgs/org_name/supply-chain
   Has findings for blocking rules so exiting with code 1

--- a/cli/tests/e2e/snapshots/test_ci/test_lockfile_parse_failure_reporting/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_lockfile_parse_failure_reporting/results.txt
@@ -108,8 +108,8 @@ Some files were skipped or only partially analyzed.
 
 CI scan completed successfully.
   Found 8 findings (6 blocking) from 6 rules.
-  Uploading findings.
-  View results in Semgrep Cloud Platform:
+  Uploading scan results
+  Finalizing scan           View results in Semgrep Cloud Platform:
     https://semgrep.dev/orgs/org_name/findings
     https://semgrep.dev/orgs/org_name/supply-chain
   Has findings for blocking rules so exiting with code 1

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---emacs/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---emacs/results.txt
@@ -54,8 +54,8 @@ Some files were skipped or only partially analyzed.
 
 CI scan completed successfully.
   Found 8 findings (6 blocking) from 6 rules.
-  Uploading findings.
-  View results in Semgrep Cloud Platform:
+  Uploading scan results
+  Finalizing scan           View results in Semgrep Cloud Platform:
     https://semgrep.dev/orgs/org_name/findings
     https://semgrep.dev/orgs/org_name/supply-chain
   Has findings for blocking rules so exiting with code 1

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---gitlab-sast/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---gitlab-sast/results.txt
@@ -314,8 +314,8 @@ Some files were skipped or only partially analyzed.
 
 CI scan completed successfully.
   Found 8 findings (6 blocking) from 6 rules.
-  Uploading findings.
-  View results in Semgrep Cloud Platform:
+  Uploading scan results
+  Finalizing scan           View results in Semgrep Cloud Platform:
     https://semgrep.dev/orgs/org_name/findings
     https://semgrep.dev/orgs/org_name/supply-chain
   Has findings for blocking rules so exiting with code 1

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---gitlab-secrets/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---gitlab-secrets/results.txt
@@ -371,8 +371,8 @@ Some files were skipped or only partially analyzed.
 
 CI scan completed successfully.
   Found 8 findings (6 blocking) from 6 rules.
-  Uploading findings.
-  View results in Semgrep Cloud Platform:
+  Uploading scan results
+  Finalizing scan           View results in Semgrep Cloud Platform:
     https://semgrep.dev/orgs/org_name/findings
     https://semgrep.dev/orgs/org_name/supply-chain
   Has findings for blocking rules so exiting with code 1

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---json/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---json/results.txt
@@ -487,8 +487,8 @@ Some files were skipped or only partially analyzed.
 
 CI scan completed successfully.
   Found 8 findings (6 blocking) from 6 rules.
-  Uploading findings.
-  View results in Semgrep Cloud Platform:
+  Uploading scan results
+  Finalizing scan           View results in Semgrep Cloud Platform:
     https://semgrep.dev/orgs/org_name/findings
     https://semgrep.dev/orgs/org_name/supply-chain
   Has findings for blocking rules so exiting with code 1

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---sarif/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---sarif/results.txt
@@ -612,8 +612,8 @@ Some files were skipped or only partially analyzed.
 
 CI scan completed successfully.
   Found 13 findings (10 blocking) from 6 rules.
-  Uploading findings.
-  View results in Semgrep Cloud Platform:
+  Uploading scan results
+  Finalizing scan           View results in Semgrep Cloud Platform:
     https://semgrep.dev/orgs/org_name/findings
     https://semgrep.dev/orgs/org_name/supply-chain
   Has findings for blocking rules so exiting with code 1

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---vim/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---vim/results.txt
@@ -54,8 +54,8 @@ Some files were skipped or only partially analyzed.
 
 CI scan completed successfully.
   Found 8 findings (6 blocking) from 6 rules.
-  Uploading findings.
-  View results in Semgrep Cloud Platform:
+  Uploading scan results
+  Finalizing scan           View results in Semgrep Cloud Platform:
     https://semgrep.dev/orgs/org_name/findings
     https://semgrep.dev/orgs/org_name/supply-chain
   Has findings for blocking rules so exiting with code 1

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---emacs/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---emacs/results.txt
@@ -54,8 +54,8 @@ Some files were skipped or only partially analyzed.
 
 CI scan completed successfully.
   Found 8 findings (6 blocking) from 6 rules.
-  Uploading findings.
-  View results in Semgrep Cloud Platform:
+  Uploading scan results
+  Finalizing scan           View results in Semgrep Cloud Platform:
     https://semgrep.dev/orgs/org_name/findings
     https://semgrep.dev/orgs/org_name/supply-chain
   Has findings for blocking rules so exiting with code 1

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---gitlab-sast/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---gitlab-sast/results.txt
@@ -314,8 +314,8 @@ Some files were skipped or only partially analyzed.
 
 CI scan completed successfully.
   Found 8 findings (6 blocking) from 6 rules.
-  Uploading findings.
-  View results in Semgrep Cloud Platform:
+  Uploading scan results
+  Finalizing scan           View results in Semgrep Cloud Platform:
     https://semgrep.dev/orgs/org_name/findings
     https://semgrep.dev/orgs/org_name/supply-chain
   Has findings for blocking rules so exiting with code 1

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---gitlab-secrets/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---gitlab-secrets/results.txt
@@ -371,8 +371,8 @@ Some files were skipped or only partially analyzed.
 
 CI scan completed successfully.
   Found 8 findings (6 blocking) from 6 rules.
-  Uploading findings.
-  View results in Semgrep Cloud Platform:
+  Uploading scan results
+  Finalizing scan           View results in Semgrep Cloud Platform:
     https://semgrep.dev/orgs/org_name/findings
     https://semgrep.dev/orgs/org_name/supply-chain
   Has findings for blocking rules so exiting with code 1

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---json/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---json/results.txt
@@ -484,8 +484,8 @@ Some files were skipped or only partially analyzed.
 
 CI scan completed successfully.
   Found 8 findings (6 blocking) from 6 rules.
-  Uploading findings.
-  View results in Semgrep Cloud Platform:
+  Uploading scan results
+  Finalizing scan           View results in Semgrep Cloud Platform:
     https://semgrep.dev/orgs/org_name/findings
     https://semgrep.dev/orgs/org_name/supply-chain
   Has findings for blocking rules so exiting with code 1

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---sarif/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---sarif/results.txt
@@ -558,8 +558,8 @@ Some files were skipped or only partially analyzed.
 
 CI scan completed successfully.
   Found 13 findings (10 blocking) from 6 rules.
-  Uploading findings.
-  View results in Semgrep Cloud Platform:
+  Uploading scan results
+  Finalizing scan           View results in Semgrep Cloud Platform:
     https://semgrep.dev/orgs/org_name/findings
     https://semgrep.dev/orgs/org_name/supply-chain
   Has findings for blocking rules so exiting with code 1

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---vim/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---vim/results.txt
@@ -54,8 +54,8 @@ Some files were skipped or only partially analyzed.
 
 CI scan completed successfully.
   Found 8 findings (6 blocking) from 6 rules.
-  Uploading findings.
-  View results in Semgrep Cloud Platform:
+  Uploading scan results
+  Finalizing scan           View results in Semgrep Cloud Platform:
     https://semgrep.dev/orgs/org_name/findings
     https://semgrep.dev/orgs/org_name/supply-chain
   Has findings for blocking rules so exiting with code 1

--- a/cli/tests/e2e/snapshots/test_ci/test_query_dependency/output.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_query_dependency/output.txt
@@ -79,8 +79,8 @@ Some files were skipped or only partially analyzed.
 
 CI scan completed successfully.
   Found 5 findings (4 blocking) from 2 rules.
-  Uploading findings.
-  View results in Semgrep Cloud Platform:
+  Uploading scan results
+  Finalizing scan           View results in Semgrep Cloud Platform:
     https://semgrep.dev/orgs/org_name/findings
     https://semgrep.dev/orgs/org_name/supply-chain
   Has findings for blocking rules so exiting with code 1

--- a/cli/tests/e2e/snapshots/test_ci/test_shallow_wrong_merge_base/bad_results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_shallow_wrong_merge_base/bad_results.txt
@@ -74,8 +74,8 @@ Some files were skipped or only partially analyzed.
 
 CI scan completed successfully.
   Found 2 findings (0 blocking) from 6 rules.
-  Uploading findings.
-  View results in Semgrep Cloud Platform:
+  Uploading scan results
+  Finalizing scan           View results in Semgrep Cloud Platform:
     https://semgrep.dev/orgs/org_name/findings
     https://semgrep.dev/orgs/org_name/supply-chain
   No blocking findings so exiting with code 0

--- a/cli/tests/e2e/snapshots/test_ci/test_shallow_wrong_merge_base/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_shallow_wrong_merge_base/results.txt
@@ -56,8 +56,8 @@ Some files were skipped or only partially analyzed.
 
 CI scan completed successfully.
   Found 1 finding (0 blocking) from 6 rules.
-  Uploading findings.
-  View results in Semgrep Cloud Platform:
+  Uploading scan results
+  Finalizing scan           View results in Semgrep Cloud Platform:
     https://semgrep.dev/orgs/org_name/findings
     https://semgrep.dev/orgs/org_name/supply-chain
   No blocking findings so exiting with code 0


### PR DESCRIPTION
Before
```
┌──────────────┐
│ Scan Summary │
└──────────────┘
...

CI scan completed successfully.
  Found 5 findings (0 blocking) from 10854 rules.
  Uploading findings.
Waiting for semgrep.dev to process scan results...
Waiting for semgrep.dev to process scan results...
Waiting for semgrep.dev to process scan results...
  View results in Semgrep Cloud Platform:
    https://semgrep.dev/orgs/jbergler/findings
    https://semgrep.dev/orgs/jbergler/supply-chain
  No blocking findings so exiting with code 0
```

After
```
┌──────────────┐
│ Scan Summary │
└──────────────┘
...

CI scan completed successfully.
  Found 5 findings (0 blocking) from 10854 rules.
  Uploading scan results
  Finalizing scan
  View results in Semgrep Cloud Platform:
    https://semgrep.dev/orgs/jbergler/findings
    https://semgrep.dev/orgs/jbergler/supply-chain
  No blocking findings so exiting with code 0
```


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
