### PR TITLE
precommit: switch to 1.30.0 for semgrep jsonnet

### DIFF
--- a/.github/workflows/build-test-osx-x86.yaml
+++ b/.github/workflows/build-test-osx-x86.yaml
@@ -88,6 +88,10 @@ jobs:
         id: cache-opam
         uses: actions/cache@v3
         if: ${{ inputs.use-cache }}
+        # The size of the tgz of ~/.opam is around 500MB, which usually takes less than
+        # 2min to download from GHA. If it takes more than that, that means something
+        # wrong is going on in which case it's better to timeout early than spend
+        # 10min (the default timeout) and then still timeout.
         env:
           SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -178,7 +178,7 @@ repos:
   # Dogfood! running semgrep in pre-commit!
   # ----------------------------------------------------------
   - repo: https://github.com/returntocorp/semgrep
-    rev: v1.29.0
+    rev: v1.30.0
     hooks:
       - id: semgrep
         name: Semgrep Jsonnet


### PR DESCRIPTION
Switch to a more recent version which includes the fix
https://github.com/returntocorp/semgrep/pull/8153 that
fixes some errors about concurrent access to settings.yml

test plan:
wait for green CI check and hope we don't get those
errors about settings.yml anymore in the next few days


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)