### PR TITLE
move create_rule earlier

### DIFF
--- a/cli/tests/unit/test_rule_match.py
+++ b/cli/tests/unit/test_rule_match.py
@@ -233,6 +233,7 @@ def test_rule_match_is_nosemgrep_agnostic(mocker):
 
 @pytest.mark.quick
 def test_rule_match_set_indexes(mocker):
+    rule = create_rule()
     file_content = dedent(
         """
         # first line
@@ -320,7 +321,6 @@ def test_rule_match_set_indexes(mocker):
             ),
         ),
     )
-    rule = create_rule()
     matches = RuleMatchSet(rule)
     matches.update(
         [line3, line4, line5, line6]


### PR DESCRIPTION
`create_rule` calls `Path.open` on the rule schema path, but this test mocks the open method to return some python, which causes the yaml parser called on the result of opening the rule schema to run on this python and fail. No idea why this only just started happening, but I moved the call to before the mock.

PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
