### PR TITLE
fix(js): Include location of `async` keyword in arrow func range

### DIFF
--- a/changelog.d/gh-7353.fixed
+++ b/changelog.d/gh-7353.fixed
@@ -1,0 +1,1 @@
+Fixed an issue leading to incorrect autofix results involving JS/TS async arrow functions (e.g. `async () => {}`, etc.).

--- a/languages/javascript/generic/js_to_generic.ml
+++ b/languages/javascript/generic/js_to_generic.ml
@@ -298,9 +298,15 @@ and expr (x : expr) =
       | Right e -> G.DotAccess (v1, t, G.FDynamic e))
       |> G.e
   | Fun (v1, _v2TODO) ->
-      let def, _more_attrs = fun_ v1 in
-      (* todo? assert more_attrs = []? *)
-      G.Lambda def |> G.e
+      let def, more_attrs = fun_ v1 in
+      (* TODO: Include attrs in generic AST? Where? *)
+      let e = G.Lambda def |> G.e in
+      (* Since the attrs aren't included in the AST, at least update the range
+       * to include them. See
+       * https://github.com/returntocorp/semgrep/issues/7353 *)
+      let attrs_any = Common.map (fun attr -> G.At attr) more_attrs in
+      H.set_e_range_with_anys (G.Dk (G.FuncDef def) :: attrs_any) e;
+      e
   | Apply (IdSpecial v1, v2) ->
       let x = special v1 in
       let v2 = bracket (list expr) v2 in

--- a/libs/ast_generic/AST_generic_helpers.ml
+++ b/libs/ast_generic/AST_generic_helpers.ml
@@ -497,14 +497,24 @@ class ['self] range_visitor =
     method! visit_Alias ranges id _e = self#visit_ident ranges id
   end
 
-let extract_ranges : AST_generic.any -> (Tok.location * Tok.location) option =
+let extract_ranges_with_anys :
+    AST_generic.any list -> (Tok.location * Tok.location) option =
   let v = new range_visitor in
   let ranges = ref None in
-  fun any ->
-    v#visit_any ranges any;
+  fun anys ->
+    List.iter (v#visit_any ranges) anys;
     let res = !ranges in
     ranges := None;
     res
+
+let extract_ranges any = extract_ranges_with_anys [ any ]
+
+let set_e_range_with_anys anys e =
+  match extract_ranges_with_anys anys with
+  | Some (l, r) -> e.e_range <- Some (l, r)
+  | None ->
+      logger#debug "set_e_range_with_anys failed: no locations found";
+      ()
 
 let range_of_tokens tokens =
   List.filter Tok.is_origintok tokens |> Tok_range.min_max_toks_by_pos

--- a/libs/ast_generic/AST_generic_helpers.mli
+++ b/libs/ast_generic/AST_generic_helpers.mli
@@ -110,6 +110,11 @@ val undo_ac_matching_nf :
 (* Sets the e_range on the expression based on the left and right tokens
  * provided. No-op if either has a fake location. *)
 val set_e_range : Tok.t -> Tok.t -> AST_generic.expr -> unit
+
+(* Sets the e_range on the expression to the range defined by the given anys.
+ * Noop if no location information for the anys is available (including if the
+ * any list is empty). *)
+val set_e_range_with_anys : AST_generic.any list -> AST_generic.expr -> unit
 val ii_of_any : AST_generic.any -> Tok.t list
 val info_of_any : AST_generic.any -> Tok.t
 

--- a/tests/patterns/js/autofix_arrow_func.fixed
+++ b/tests/patterns/js/autofix_arrow_func.fixed
@@ -2,13 +2,19 @@
 bar(() => {});
 // MATCH:
 bar(() => 5);
+// MATCH:
+bar(async () => 5);
 
 // MATCH:
 bar((x) => {});
 // MATCH:
 bar((x) => 5);
+// MATCH:
+bar(async (x) => 5);
 
 // MATCH:
 bar(x => {});
 // MATCH:
 bar(x => 5);
+// MATCH:
+bar(async x => 5);

--- a/tests/patterns/js/autofix_arrow_func.js
+++ b/tests/patterns/js/autofix_arrow_func.js
@@ -2,13 +2,19 @@
 foo(() => {});
 // MATCH:
 foo(() => 5);
+// MATCH:
+foo(async () => 5);
 
 // MATCH:
 foo((x) => {});
 // MATCH:
 foo((x) => 5);
+// MATCH:
+foo(async (x) => 5);
 
 // MATCH:
 foo(x => {});
 // MATCH:
 foo(x => 5);
+// MATCH:
+foo(async x => 5);


### PR DESCRIPTION
We don't include the `async` attribute (or any others, if there are others possible) as part of the generic AST. We might want to change that, but we might not want to complicate the generic AST for this one case.

However, since that token does not get included, we get the range wrong. This is especially a problem for metavariable bindings when they are used in autofix. See the test case.

We now set `e_range` when constructing the AST. I've used this technique in a few places in the past to address location issues. To simplify the logic here, I've also refactored a bit to add a utility which will set the `e_range` of an expression based on a list of `AST_generic.any` nodes. Note that this makes it so that calls to `extract_ranges` now entail one additional allocation for the singleton list. While this is a hot code path I very much doubt that one more allocation will make a difference considering all the other work that goes into computing the ranges.

Fixes #7353

Test plan: Automated tests

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
