### PR TITLE
Build multi-arch docker images

### DIFF
--- a/.github/workflows/build-test-docker.yaml
+++ b/.github/workflows/build-test-docker.yaml
@@ -165,3 +165,8 @@ jobs:
         with:
           name: ${{ inputs.artifact-name }}-arch-${{ matrix.architecture }}
           path: /tmp/image.tar
+      - uses: actions/upload-artifact@v3
+        if: ${{ matrix.architecture == 'amd64' }} # appease the test-semgrep-pro workflow
+        with:
+          name: ${{ inputs.artifact-name }}
+          path: /tmp/image.tar

--- a/.github/workflows/build-test-docker.yaml
+++ b/.github/workflows/build-test-docker.yaml
@@ -27,10 +27,15 @@ on:
         required: true
         type: boolean
         description: Whether or not to run validation on the built image
+      use-depot:
+        required: true
+        type: boolean
+        description: Whether or not to use depot.dev for docker builds
+        default: false
       push-immediately:
         required: true
         type: boolean
-        description: Whether or not to push immediately
+        description: Whether or not to immediately push the docker image after building
         default: false
 
   workflow_call:
@@ -55,6 +60,11 @@ on:
         required: true
         type: boolean
         description: Whether or not to run validation on the built image
+      use-depot:
+        required: true
+        type: boolean
+        description: Whether or not to use depot.dev for docker builds
+        default: false
 
 jobs:
   build-test-docker:
@@ -81,11 +91,24 @@ jobs:
           # :latest is also added automatically
           tags: ${{ inputs.docker-tags }}
       - uses: depot/setup-action@v1
-      - name: Build image
-        id: build-image
+        if: ${{ inputs.use-depot == true }}
+      - name: Build image (depot)
+        id: build-image-depot
+        if: ${{ inputs.use-depot == true }}
         uses: depot/build-push-action@v1.7.1
         with:
           project: fhmxj6w9z8
+          platforms: linux/${{ matrix.architecture }}
+          outputs: type=docker,dest=/tmp/image.tar
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          file: ${{ inputs.file }}
+          buildx-fallback: true
+      - name: Build image (docker)
+        id: build-image-docker
+        if: ${{ inputs.use-depot == false }}
+        uses: docker/build-push-action@v1.7.1
+        with:
           platforms: linux/${{ matrix.architecture }}
           outputs: type=docker,dest=/tmp/image.tar
           cache-from: type=gha,src=/tmp/.buildx-cache
@@ -93,7 +116,6 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           file: ${{ inputs.file }}
-          buildx-fallback: true
       - name: Load image
         run: |
           docker load --input /tmp/image.tar

--- a/.github/workflows/build-test-docker.yaml
+++ b/.github/workflows/build-test-docker.yaml
@@ -31,6 +31,10 @@ on:
         type: boolean
         description: Whether or not to use depot.dev instead of docker buildx to build the docker image
         default: false
+      multi-arch:
+        type: boolean
+        description: Whether or not to build a multi-arch docker image
+        default: false
 
   workflow_call:
     inputs:
@@ -58,10 +62,49 @@ on:
         type: boolean
         description: Whether or not to use depot.dev instead of docker buildx to build the docker image
         default: false
+      multi-arch:
+        type: boolean
+        description: Whether or not to build a multi-arch docker image
+        default: false
 
 jobs:
   build-test-docker:
     name: Build and test Semgrep Docker image
+    if: ${{ ! inputs.multi-arch }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker/setup-buildx-action@v2
+      - id: meta
+        name: Set tags and labels
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ inputs.repository-name }}
+          # :latest is also added automatically
+          tags: ${{ inputs.docker-tags }}
+      - name: Build image
+        id: build-image
+        uses: docker/build-push-action@v4
+        with:
+          outputs: type=docker,dest=/tmp/image.tar
+          cache-from: type=gha,src=/tmp/.buildx-cache
+          cache-to: type=gha,dest=/tmp/.buildx-cache,mode=max
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          file: ${{ inputs.file }}
+      - name: Load image
+        run: |
+          docker load --input /tmp/image.tar
+      - uses: actions/checkout@v3
+      - name: Test Image
+        if: ${{ inputs.enable-tests }}
+        run: ./scripts/validate-docker-build.sh ${{ steps.build-image.outputs.imageid }}
+      - uses: actions/upload-artifact@v3
+        with:
+          name: ${{ inputs.artifact-name }}
+          path: /tmp/image.tar
+  build-test-docker-multi-arch:
+    name: Build and test multi-arch Semgrep Docker image
+    if: ${{ inputs.multi-arch }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/build-test-docker.yaml
+++ b/.github/workflows/build-test-docker.yaml
@@ -107,7 +107,7 @@ jobs:
       - name: Build image (docker)
         id: build-image-docker
         if: ${{ inputs.use-depot == false }}
-        uses: docker/build-push-action@v1.7.1
+        uses: docker/build-push-action@v4.1.1
         with:
           platforms: linux/${{ matrix.architecture }}
           outputs: type=docker,dest=/tmp/image.tar
@@ -116,6 +116,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           file: ${{ inputs.file }}
+          provenance: false
       - name: Load image
         run: |
           docker load --input /tmp/image.tar

--- a/.github/workflows/build-test-docker.yaml
+++ b/.github/workflows/build-test-docker.yaml
@@ -79,7 +79,6 @@ jobs:
           - amd64
           - arm64
     steps:
-      - uses: docker/setup-buildx-action@v2
       - if: ${{ matrix.architecture != 'amd64' }}
         uses: docker/setup-qemu-action@v2
       - uses: docker/setup-buildx-action@v2

--- a/.github/workflows/build-test-docker.yaml
+++ b/.github/workflows/build-test-docker.yaml
@@ -72,6 +72,7 @@ jobs:
       - uses: docker/setup-buildx-action@v2
       - if: ${{ matrix.architecture != 'amd64' }}
         uses: docker/setup-qemu-action@v2
+      - uses: docker/setup-buildx-action@v2
       - id: meta
         name: Set tags and labels
         uses: docker/metadata-action@v4
@@ -92,6 +93,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           file: ${{ inputs.file }}
+          buildx-fallback: true
       - name: Load image
         run: |
           docker load --input /tmp/image.tar

--- a/.github/workflows/build-test-docker.yaml
+++ b/.github/workflows/build-test-docker.yaml
@@ -27,15 +27,9 @@ on:
         required: true
         type: boolean
         description: Whether or not to run validation on the built image
-      use-depot:
-        required: true
+      use-depot-for-docker-build:
         type: boolean
-        description: Whether or not to use depot.dev for docker builds
-        default: false
-      push-immediately:
-        required: true
-        type: boolean
-        description: Whether or not to immediately push the docker image after building
+        description: Whether or not to use depot.dev instead of docker buildx to build the docker image
         default: false
 
   workflow_call:
@@ -60,10 +54,9 @@ on:
         required: true
         type: boolean
         description: Whether or not to run validation on the built image
-      use-depot:
-        required: true
+      use-depot-for-docker-build:
         type: boolean
-        description: Whether or not to use depot.dev for docker builds
+        description: Whether or not to use depot.dev instead of docker buildx to build the docker image
         default: false
 
 jobs:
@@ -90,10 +83,10 @@ jobs:
           # :latest is also added automatically
           tags: ${{ inputs.docker-tags }}
       - uses: depot/setup-action@v1
-        if: ${{ inputs.use-depot == true }}
-      - name: Build image (depot)
+        if: ${{ inputs.use-depot-for-docker-build }}
+      - name: Build image (via depot.dev)
         id: build-image-depot
-        if: ${{ inputs.use-depot == true }}
+        if: ${{ inputs.use-depot-for-docker-build }}
         uses: depot/build-push-action@v1.7.1
         with:
           project: fhmxj6w9z8
@@ -103,9 +96,9 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           file: ${{ inputs.file }}
           buildx-fallback: true
-      - name: Build image (docker)
+      - name: Build image (via docker buildx)
         id: build-image-docker
-        if: ${{ inputs.use-depot == false }}
+        if: ${{ ! inputs.use-depot-for-docker-build }}
         uses: docker/build-push-action@v4.1.1
         with:
           platforms: linux/${{ matrix.architecture }}
@@ -117,9 +110,11 @@ jobs:
           file: ${{ inputs.file }}
           provenance: false
       - name: Load image
+        if: ${{ inputs.enable-tests }}
         run: |
           docker load --input /tmp/image.tar
       - uses: actions/checkout@v3
+        if: ${{ inputs.enable-tests }}
       - name: Test Image
         if: ${{ inputs.enable-tests }}
         run: ./scripts/validate-docker-build.sh ${{ steps.build-image.outputs.imageid }} linux/${{ matrix.architecture }}
@@ -127,13 +122,3 @@ jobs:
         with:
           name: ${{ inputs.artifact-name }}-arch-${{ matrix.architecture }}
           path: /tmp/image.tar
-  push-image:
-    needs: [build-test-docker]
-    uses: ./.github/workflows/push-docker.yaml
-    if: ${{ inputs.push-immediately }}
-    secrets: inherit
-    with:
-      artifact-name: ${{ inputs.artifact-name }}
-      repository-name: ${{ inputs.repository-name }}
-      dry-run: false
-      multi-arch: true

--- a/.github/workflows/build-test-docker.yaml
+++ b/.github/workflows/build-test-docker.yaml
@@ -30,7 +30,7 @@ on:
       use-depot-for-docker-build:
         type: boolean
         description: Whether or not to use depot.dev instead of docker buildx to build the docker image
-        default: false
+        default: true
       multi-arch:
         type: boolean
         description: Whether or not to build a multi-arch docker image
@@ -61,7 +61,7 @@ on:
       use-depot-for-docker-build:
         type: boolean
         description: Whether or not to use depot.dev instead of docker buildx to build the docker image
-        default: false
+        default: true
       multi-arch:
         type: boolean
         description: Whether or not to build a multi-arch docker image

--- a/.github/workflows/build-test-docker.yaml
+++ b/.github/workflows/build-test-docker.yaml
@@ -17,14 +17,21 @@ on:
         required: true
         type: string
         description: The repository/name of the docker image to push, e.g., returntocorp/semgrep
+        default: returntocorp/semgrep
       file:
         required: true
         type: string
         description: Dockerfile to build
+        default: Dockerfile
       enable-tests:
         required: true
         type: boolean
         description: Whether or not to run validation on the built image
+      push-immediately:
+        required: true
+        type: boolean
+        description: Whether or not to push immediately
+        default: false
 
   workflow_call:
     inputs:
@@ -53,8 +60,18 @@ jobs:
   build-test-docker:
     name: Build and test Semgrep Docker image
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    strategy:
+      matrix:
+        architecture:
+          - amd64
+          - arm64
     steps:
       - uses: docker/setup-buildx-action@v2
+      - if: ${{ matrix.architecture != 'amd64' }}
+        uses: docker/setup-qemu-action@v2
       - id: meta
         name: Set tags and labels
         uses: docker/metadata-action@v4
@@ -62,10 +79,13 @@ jobs:
           images: ${{ inputs.repository-name }}
           # :latest is also added automatically
           tags: ${{ inputs.docker-tags }}
+      - uses: depot/setup-action@v1
       - name: Build image
         id: build-image
-        uses: docker/build-push-action@v4
+        uses: depot/build-push-action@v1.7.1
         with:
+          project: fhmxj6w9z8
+          platforms: linux/${{ matrix.architecture }}
           outputs: type=docker,dest=/tmp/image.tar
           cache-from: type=gha,src=/tmp/.buildx-cache
           cache-to: type=gha,dest=/tmp/.buildx-cache,mode=max
@@ -78,8 +98,18 @@ jobs:
       - uses: actions/checkout@v3
       - name: Test Image
         if: ${{ inputs.enable-tests }}
-        run: ./scripts/validate-docker-build.sh ${{ steps.build-image.outputs.imageid }}
+        run: ./scripts/validate-docker-build.sh ${{ steps.build-image.outputs.imageid }} linux/${{ matrix.architecture }}
       - uses: actions/upload-artifact@v3
         with:
-          name: ${{ inputs.artifact-name }}
+          name: ${{ inputs.artifact-name }}-arch-${{ matrix.architecture }}
           path: /tmp/image.tar
+  push-image:
+    needs: [build-test-docker]
+    uses: ./.github/workflows/push-docker.yaml
+    if: ${{ inputs.push-immediately }}
+    secrets: inherit
+    with:
+      artifact-name: ${{ inputs.artifact-name }}
+      repository-name: ${{ inputs.repository-name }}
+      dry-run: false
+      multi-arch: true

--- a/.github/workflows/build-test-docker.yaml
+++ b/.github/workflows/build-test-docker.yaml
@@ -160,7 +160,7 @@ jobs:
         if: ${{ inputs.enable-tests }}
       - name: Test Image
         if: ${{ inputs.enable-tests }}
-        run: ./scripts/validate-docker-build.sh ${{ steps.build-image.outputs.imageid }} linux/${{ matrix.architecture }}
+        run: ./scripts/validate-docker-build.sh ${{ inputs.use-depot-for-docker-build && steps.build-image-depot.outputs.imageid || steps.build-image-docker.outputs.imageid }} linux/${{ matrix.architecture }}
       - uses: actions/upload-artifact@v3
         with:
           name: ${{ inputs.artifact-name }}-arch-${{ matrix.architecture }}

--- a/.github/workflows/push-docker.yaml
+++ b/.github/workflows/push-docker.yaml
@@ -44,7 +44,7 @@ jobs:
   push-docker:
     name: Push Semgrep Docker Image
     runs-on: ubuntu-22.04
-    if: ${{ !inputs.multi-arch }}
+    if: ${{ ! inputs.multi-arch }}
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -78,32 +78,52 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           path: /tmp/artifacts
-      - run: |
-          artifact_filenames=(/tmp/artifacts/${{ inputs.artifact-name }}-arch-*/image.tar)
-          if [[ ${#artifact_filenames[@]} == 0 ]]; then
+      - name: Merge images
+        env:
+          MERGED_IMAGE_PATH: /tmp/merged-image
+        run: |
+          mkdir -p ${MERGED_IMAGE_PATH}/blobs
+
+          # Find docker image artifacts
+          image_filenames=(/tmp/artifacts/${{ inputs.artifact-name }}-arch-*/image.tar)
+          if [[ ${#image_filenames[@]} == 0 ]]; then
             echo "No artifacts found matching ${{ inputs.artifact-name }}-arch-*"
             exit 1
           fi
-          mkdir -p /tmp/merged/blobs/sha256
-          echo '{"schemaVersion": 2, "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json", "manifests": []}' > /tmp/merged/index.json
-          echo '{"imageLayoutVersion":"1.0.0"}' > /tmp/merged/oci-layout
-          for filename in ${artifact_filenames[@]}; do
-            cd $(dirname $filename)
+
+          # Create an empty manifest list. This will ultimately be the union of all the arch-specific image manifests we intend to publish.
+          cat << "EOF" > ${MERGED_IMAGE_PATH}/index.json
+          {
+            "schemaVersion": 2,
+            "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
+            "manifests": []
+          }
+          EOF
+
+          # Merge the contents (blobs and manifest) of each docker image into one big multi-arch image
+          for image_filename in ${image_filenames[@]}; do
+            cd $(dirname $image_filename)
             tar xf image.tar
-            cp -r blobs/sha256/* /tmp/merged/blobs/sha256/
-            jq -s '.[0].manifests+=.[1].manifests|.[0]' /tmp/merged/index.json index.json > /tmp/merged/index.tmp
-            mv /tmp/merged/index.tmp /tmp/merged/index.json
+
+            # Copy image's blobs into merged blobs folder (overwrite is fine since this is content-addressable storage)
+            cp -rf blobs/ ${MERGED_IMAGE_PATH}/blobs/
+
+            # Merge image's manifest list into our merged manifest list
+            jq -s '.[0].manifests+=.[1].manifests|.[0]' ${MERGED_IMAGE_PATH}/index.json index.json > ${MERGED_IMAGE_PATH}/index.tmp
+            mv ${MERGED_IMAGE_PATH}/index.tmp ${MERGED_IMAGE_PATH}/index.json
           done
       - uses: docker/login-action@v2
         if: ${{ ! inputs.dry-run }}
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-      - name: Push Image
+      - name: Push merged image
         if: ${{ ! inputs.dry-run }}
+        env:
+          MERGED_IMAGE_PATH: /tmp/merged-image
         run: |
-          echo "Uploading blobs..."
-          for blob_filename in /tmp/merged/blobs/sha256/*; do
+          echo "Uploading image blobs..."
+          for blob_filename in ${MERGED_IMAGE_PATH}/blobs/sha256/*; do
             blob_digest="sha256:$(basename $blob_filename)"
             echo "-> ${blob_digest}"
             if ! regctl blob head ${{ inputs.repository-name }} ${blob_digest}; then
@@ -111,15 +131,16 @@ jobs:
             fi
           done
 
-          echo "Uploading manifests..."
-          for manifest_digest in $(cat /tmp/merged/index.json | jq -r '.manifests | unique_by(.digest) | .[].digest' | cut -d: -f2); do
-            echo "-> ${manifest_digest}..."
-            cat /tmp/merged/blobs/sha256/${manifest_digest} | regctl manifest put ${{ inputs.repository-name }} --by-digest
+          echo "Uploading image manifests..."
+          for manifest_digest in $(cat ${MERGED_IMAGE_PATH}/index.json | jq -r '.manifests | unique_by(.digest) | .[].digest' | cut -d: -f2); do
+            echo "-> ${manifest_digest}"
+            cat ${MERGED_IMAGE_PATH}/blobs/sha256/${manifest_digest} | regctl manifest put ${{ inputs.repository-name }} --by-digest
           done
 
-          tags=$(cat /tmp/merged/index.json | jq -r '.manifests | unique_by(.annotations."org.opencontainers.image.ref.name") | .[].annotations."org.opencontainers.image.ref.name"')
-          echo "Tags to push: ${tags}"
-          for tag in $tags; do
-            index_digest=$(cat /tmp/merged/index.json | regctl manifest put ${{ inputs.repository-name }}:${tag} -t application/vnd.docker.distribution.manifest.list.v2+json)
-            echo "${tag} -> ${index_digest}"
+          echo "Pushing image tags..."
+          for tag in $(cat ${MERGED_IMAGE_PATH}/index.json | jq -r '.manifests | unique_by(.annotations."org.opencontainers.image.ref.name") | .[].annotations."org.opencontainers.image.ref.name"'); do
+            echo "-> ${{ inputs.repository-name }}:${tag}"
+            index_digest=$(cat ${MERGED_IMAGE_PATH}/index.json | regctl manifest put ${{ inputs.repository-name }}:${tag} -t application/vnd.docker.distribution.manifest.list.v2+json)
           done
+
+          echo "Done!"

--- a/.github/workflows/push-docker.yaml
+++ b/.github/workflows/push-docker.yaml
@@ -82,13 +82,15 @@ jobs:
         env:
           MERGED_IMAGE_PATH: /tmp/merged-image
         run: |
-          mkdir -p ${MERGED_IMAGE_PATH}/blobs
+          mkdir -p ${MERGED_IMAGE_PATH}/blobs/sha256
 
           # Find docker image artifacts
           image_filenames=(/tmp/artifacts/${{ inputs.artifact-name }}-arch-*/image.tar)
           if [[ ${#image_filenames[@]} == 0 ]]; then
             echo "No artifacts found matching ${{ inputs.artifact-name }}-arch-*"
             exit 1
+          else
+            echo "Found images: ${image_filenames[@]}"
           fi
 
           # Create an empty manifest list. This will ultimately be the union of all the arch-specific image manifests we intend to publish.
@@ -99,16 +101,20 @@ jobs:
             "manifests": []
           }
           EOF
+          echo "Wrote empty manifest list to ${MERGED_IMAGE_PATH}/index.json"
 
           # Merge the contents (blobs and manifest) of each docker image into one big multi-arch image
           for image_filename in ${image_filenames[@]}; do
+            echo "Merging contents of ${image_filename}"
             cd $(dirname $image_filename)
-            tar xf image.tar
+            tar xvf image.tar
 
             # Copy image's blobs into merged blobs folder (overwrite is fine since this is content-addressable storage)
-            cp -rf blobs/ ${MERGED_IMAGE_PATH}/blobs/
+            cp -rvf blobs/sha256/* ${MERGED_IMAGE_PATH}/blobs/sha256/
 
             # Merge image's manifest list into our merged manifest list
+            echo "Adding image manifest(s) to manifest list:"
+            jq ".manifests" index.json
             jq -s '.[0].manifests+=.[1].manifests|.[0]' ${MERGED_IMAGE_PATH}/index.json index.json > ${MERGED_IMAGE_PATH}/index.tmp
             mv ${MERGED_IMAGE_PATH}/index.tmp ${MERGED_IMAGE_PATH}/index.json
           done

--- a/.github/workflows/push-docker.yaml
+++ b/.github/workflows/push-docker.yaml
@@ -16,6 +16,10 @@ on:
         type: boolean
         description: Whether a dry-run (e.g., print tags to push) should be peformed. Actually push images if false.
         default: true
+      multi-arch:
+        required: true
+        type: boolean
+        description: Whether or not the image artifact is multi-arch
 
   workflow_call:
     inputs:
@@ -32,11 +36,15 @@ on:
         type: boolean
         description: Whether a dry-run (e.g., print tags to push) should be peformed. Actually push images if false.
         default: true
+      multi-arch:
+        required: true
+        type: boolean
 
 jobs:
   push-docker:
     name: Push Semgrep Docker Image
     runs-on: ubuntu-22.04
+    if: ${{ !inputs.multi-arch }}
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -61,3 +69,57 @@ jobs:
         if: ${{ ! inputs.dry-run }}
         run: |
           docker push --all-tags "${{ inputs.repository-name }}"
+  push-docker-multi-arch:
+    name: Push Semgrep Docker Image (multi-arch)
+    runs-on: ubuntu-22.04
+    if: ${{ inputs.multi-arch }}
+    steps:
+      - uses: iarekylew00t/regctl-installer@v1
+      - uses: actions/download-artifact@v3
+        with:
+          path: /tmp/artifacts
+      - run: |
+          artifact_filenames=(/tmp/artifacts/${{ inputs.artifact-name }}-arch-*/image.tar)
+          if [[ ${#artifact_filenames[@]} == 0 ]]; then
+            echo "No artifacts found matching ${{ inputs.artifact-name }}-arch-*"
+            exit 1
+          fi
+          mkdir -p /tmp/merged/blobs/sha256
+          echo '{"schemaVersion": 2, "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json", "manifests": []}' > /tmp/merged/index.json
+          echo '{"imageLayoutVersion":"1.0.0"}' > /tmp/merged/oci-layout
+          for filename in ${artifact_filenames[@]}; do
+            cd $(dirname $filename)
+            tar xf image.tar
+            cp -r blobs/sha256/* /tmp/merged/blobs/sha256/
+            jq -s '.[0].manifests+=.[1].manifests|.[0]' /tmp/merged/index.json index.json > /tmp/merged/index.tmp
+            mv /tmp/merged/index.tmp /tmp/merged/index.json
+          done
+      - uses: docker/login-action@v2
+        if: ${{ ! inputs.dry-run }}
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Push Image
+        if: ${{ ! inputs.dry-run }}
+        run: |
+          echo "Uploading blobs..."
+          for blob_filename in /tmp/merged/blobs/sha256/*; do
+            blob_digest="sha256:$(basename $blob_filename)"
+            echo "-> ${blob_digest}"
+            if ! regctl blob head ${{ inputs.repository-name }} ${blob_digest}; then
+              cat $blob_filename | regctl blob put ${{ inputs.repository-name }} --digest ${blob_digest}
+            fi
+          done
+
+          echo "Uploading manifests..."
+          for manifest_digest in $(cat /tmp/merged/index.json | jq -r '.manifests | unique_by(.digest) | .[].digest' | cut -d: -f2); do
+            echo "-> ${manifest_digest}..."
+            cat /tmp/merged/blobs/sha256/${manifest_digest} | regctl manifest put ${{ inputs.repository-name }} --by-digest
+          done
+
+          tags=$(cat /tmp/merged/index.json | jq -r '.manifests | unique_by(.annotations."org.opencontainers.image.ref.name") | .[].annotations."org.opencontainers.image.ref.name"')
+          echo "Tags to push: ${tags}"
+          for tag in $tags; do
+            index_digest=$(cat /tmp/merged/index.json | regctl manifest put ${{ inputs.repository-name }}:${tag} -t application/vnd.docker.distribution.manifest.list.v2+json)
+            echo "${tag} -> ${index_digest}"
+          done

--- a/.github/workflows/push-docker.yaml
+++ b/.github/workflows/push-docker.yaml
@@ -19,7 +19,7 @@ on:
       multi-arch:
         required: true
         type: boolean
-        description: Whether or not the image artifact is multi-arch
+        description: Whether or not we intend to push a multi-arch docker image
 
   workflow_call:
     inputs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,11 @@ on:
         required: true
         type: boolean
         default: false
+      multi-arch:
+        description: Publish a multi-arch docker image
+        required: true
+        type: boolean
+        default: false
 
   workflow_call:
     inputs:
@@ -22,6 +27,11 @@ on:
         required: true
         type: boolean
         default: true
+      multi-arch:
+        description: Publish a multi-arch docker image
+        required: true
+        type: boolean
+        default: false
 
   push:
     branches:
@@ -139,6 +149,7 @@ jobs:
       artifact-name: image-release
       repository-name: ${{ github.repository }}
       dry-run: ${{ needs.dry-run.outputs.dry-run == 'true' }}
+      multi-arch: ${{ inputs.multi-arch }}
 
   upload-wheels:
     name: Upload Wheels to PyPI

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -331,6 +331,7 @@ jobs:
       artifact-name: image-test
       repository-name: ${{ github.repository }}
       dry-run: false
+      multi-arch: true
 
   test-semgrep-pro:
     needs: [build-test-docker, push-docker]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -321,6 +321,7 @@ jobs:
       repository-name: ${{ github.repository }}
       file: Dockerfile
       enable-tests: true
+      multi-arch: true
 
   push-docker:
     needs: [build-test-docker]

--- a/Dockerfile
+++ b/Dockerfile
@@ -151,7 +151,8 @@ RUN ln -s semgrep-core /usr/local/bin/osemgrep
 # ???
 ENV SEMGREP_IN_DOCKER=1 \
     SEMGREP_VERSION_CACHE_PATH=/tmp/.cache/semgrep_version \
-    SEMGREP_USER_AGENT_APPEND="Docker"
+    SEMGREP_USER_AGENT_APPEND="Docker" \
+    SEMGREP_SKIP_ARM64_CHECK=1
 
 # The command we tell people to run for testing semgrep in Docker is
 #   docker run --rm -v "${PWD}:/src" returntocorp/semgrep semgrep --config=auto

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,7 +71,7 @@ WORKDIR /src/semgrep
 RUN eval "$(opam env)" &&\
     make minimal-build &&\
     # Sanity check
-    /src/semgrep/_build/default/src/main/Main.exe -version
+    SEMGREP_SKIP_ARM64_CHECK=1 /src/semgrep/_build/default/src/main/Main.exe -version
 
 ###############################################################################
 # Step2: Build the final docker image with Python wrapper and semgrep-core bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,7 +71,7 @@ WORKDIR /src/semgrep
 RUN eval "$(opam env)" &&\
     make minimal-build &&\
     # Sanity check
-    SEMGREP_SKIP_ARM64_CHECK=1 /src/semgrep/_build/default/src/main/Main.exe -version
+    /src/semgrep/_build/default/src/main/Main.exe -version
 
 ###############################################################################
 # Step2: Build the final docker image with Python wrapper and semgrep-core bin
@@ -136,7 +136,7 @@ RUN apk add --no-cache --virtual=.build-deps build-base make g++ &&\
      pip install jsonnet &&\
      pip install /semgrep &&\
      # running this pre-compiles some python files for faster startup times
-     semgrep --version &&\
+     SEMGREP_SKIP_ARM64_CHECK=1 semgrep --version &&\
      apk del .build-deps &&\
      mkdir -p /tmp/.cache
 

--- a/cli/src/semgrep/cli.py
+++ b/cli/src/semgrep/cli.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python3
-import platform
-import sys
 from typing import Dict
 
 import click
@@ -14,7 +12,6 @@ from semgrep.commands.publish import publish
 from semgrep.commands.scan import scan
 from semgrep.commands.shouldafound import shouldafound
 from semgrep.default_group import DefaultGroup
-from semgrep.error import FATAL_EXIT_CODE
 from semgrep.state import get_state
 from semgrep.util import git_check_output
 from semgrep.verbose_logging import getLogger
@@ -47,16 +44,6 @@ def maybe_set_git_safe_directories() -> None:
         )
 
 
-def abort_if_linux_arm64() -> None:
-    """
-    Exit with FATAL_EXIT_CODE if the user is running on Linux ARM64.
-    Print helpful error message.
-    """
-    if platform.machine() in {"arm64", "aarch64"} and platform.system() == "Linux":
-        logger.error("Semgrep does not support Linux ARM64")
-        sys.exit(FATAL_EXIT_CODE)
-
-
 @click.group(cls=DefaultGroup, default_command="scan", name="semgrep")
 @click.help_option("--help", "-h")
 @click.pass_context
@@ -70,8 +57,6 @@ def cli(ctx: click.Context) -> None:
     """
     state = get_state()
     state.terminal.init_for_cli()
-
-    # abort_if_linux_arm64()
 
     commands: Dict[str, click.Command] = ctx.command.commands  # type: ignore
 

--- a/cli/src/semgrep/cli.py
+++ b/cli/src/semgrep/cli.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+import os
+import platform
+import sys
 from typing import Dict
 
 import click
@@ -12,6 +15,7 @@ from semgrep.commands.publish import publish
 from semgrep.commands.scan import scan
 from semgrep.commands.shouldafound import shouldafound
 from semgrep.default_group import DefaultGroup
+from semgrep.error import FATAL_EXIT_CODE
 from semgrep.state import get_state
 from semgrep.util import git_check_output
 from semgrep.verbose_logging import getLogger
@@ -44,6 +48,16 @@ def maybe_set_git_safe_directories() -> None:
         )
 
 
+def abort_if_linux_arm64() -> None:
+    """
+    Exit with FATAL_EXIT_CODE if the user is running on Linux ARM64.
+    Print helpful error message.
+    """
+    if platform.machine() in {"arm64", "aarch64"} and platform.system() == "Linux":
+        logger.error("Semgrep does not support Linux ARM64")
+        sys.exit(FATAL_EXIT_CODE)
+
+
 @click.group(cls=DefaultGroup, default_command="scan", name="semgrep")
 @click.help_option("--help", "-h")
 @click.pass_context
@@ -57,6 +71,10 @@ def cli(ctx: click.Context) -> None:
     """
     state = get_state()
     state.terminal.init_for_cli()
+
+    # SKIP_ARM64_CHECK is temporary -- we'll remove the check entirely once we're consistently pushing arm64 docker images and python wheels
+    if not os.getenv("SKIP_ARM64_CHECK"):
+        abort_if_linux_arm64()
 
     commands: Dict[str, click.Command] = ctx.command.commands  # type: ignore
 

--- a/cli/src/semgrep/cli.py
+++ b/cli/src/semgrep/cli.py
@@ -71,7 +71,7 @@ def cli(ctx: click.Context) -> None:
     state = get_state()
     state.terminal.init_for_cli()
 
-    abort_if_linux_arm64()
+    # abort_if_linux_arm64()
 
     commands: Dict[str, click.Command] = ctx.command.commands  # type: ignore
 

--- a/cli/src/semgrep/cli.py
+++ b/cli/src/semgrep/cli.py
@@ -72,8 +72,8 @@ def cli(ctx: click.Context) -> None:
     state = get_state()
     state.terminal.init_for_cli()
 
-    # SKIP_ARM64_CHECK is temporary -- we'll remove the check entirely once we're consistently pushing arm64 docker images and python wheels
-    if not os.getenv("SKIP_ARM64_CHECK"):
+    # SEMGREP_SKIP_ARM64_CHECK is temporary -- we'll remove the check entirely once we're consistently pushing arm64 docker images and python wheels
+    if not os.getenv("SEMGREP_SKIP_ARM64_CHECK"):
         abort_if_linux_arm64()
 
     commands: Dict[str, click.Command] = ctx.command.commands  # type: ignore

--- a/scripts/validate-docker-build.sh
+++ b/scripts/validate-docker-build.sh
@@ -46,23 +46,28 @@ if [[ -n $platform ]]; then
   docker_args+=(--platform "$platform")
 fi
 
-# Running just the image should print help without error.
+echo "Running just the image should print help without error"
 docker run "${docker_args[@]}" "$image"
+echo " -> OK"
 
-# Random valid shell commands should run ok
+echo "Random valid shell commands should run ok"
 docker run "${docker_args[@]}" "$image" echo -l -a -t -r -v -e -f
+echo " -> OK"
 
-# Semgrep should run when a config is passed
+echo "Semgrep should run when a config is passed"
 docker run "${docker_args[@]}" "$image" semgrep --config=p/ci --help
+echo " -> OK"
 
-# Semgrep should run when just help is requested
+echo "Semgrep should run when just help is requested"
 docker run "${docker_args[@]}" "$image" semgrep --help
+echo " -> OK"
 
-# Semgrep should run when a subcommand is passed
+echo "Semgrep should run when a subcommand is passed"
 docker run "${docker_args[@]}" "$image" semgrep ci --help
 docker run "${docker_args[@]}" "$image" semgrep publish --help
+echo " -> OK"
 
-# Semgrep should be able to return findings
+echo "Semgrep should be able to return findings"
 echo "if 1 == 1: pass" \
     | docker run "${docker_args[@]}" -i "$image" semgrep -l python -e '$X == $X' - \
     | grep -q "1 == 1"
@@ -70,3 +75,4 @@ echo "if 1 == 1: pass" \
 TEMP_DIR=$(mktemp -d)
 echo "if 1 == 1: pass" > "${TEMP_DIR}/bar.py"
 docker run "${docker_args[@]}" -v "${TEMP_DIR}:/src" -i "$image" semgrep -l python -e '$X == $X' | grep -q "1 == 1"
+echo " -> OK"

--- a/scripts/validate-docker-build.sh
+++ b/scripts/validate-docker-build.sh
@@ -47,26 +47,26 @@ if [[ -n $platform ]]; then
 fi
 
 # Running just the image should print help without error.
-docker run ${docker_args[@]} "$image"
+docker run "${docker_args[@]}" "$image"
 
 # Random valid shell commands should run ok
-docker run ${docker_args[@]} "$image" echo -l -a -t -r -v -e -f
+docker run "${docker_args[@]}" "$image" echo -l -a -t -r -v -e -f
 
 # Semgrep should run when a config is passed
-docker run ${docker_args[@]} "$image" semgrep --config=p/ci --help
+docker run "${docker_args[@]}" "$image" semgrep --config=p/ci --help
 
 # Semgrep should run when just help is requested
-docker run ${docker_args[@]} "$image" semgrep --help
+docker run "${docker_args[@]}" "$image" semgrep --help
 
 # Semgrep should run when a subcommand is passed
-docker run ${docker_args[@]} "$image" semgrep ci --help
-docker run ${docker_args[@]} "$image" semgrep publish --help
+docker run "${docker_args[@]}" "$image" semgrep ci --help
+docker run "${docker_args[@]}" "$image" semgrep publish --help
 
 # Semgrep should be able to return findings
 echo "if 1 == 1: pass" \
-    | docker run ${docker_args[@]} -i "$image" semgrep -l python -e '$X == $X' - \
+    | docker run "${docker_args[@]}" -i "$image" semgrep -l python -e '$X == $X' - \
     | grep -q "1 == 1"
 
 TEMP_DIR=$(mktemp -d)
 echo "if 1 == 1: pass" > "${TEMP_DIR}/bar.py"
-docker run ${docker_args[@]} -v "${TEMP_DIR}:/src" -i "$image" semgrep -l python -e '$X == $X' | grep -q "1 == 1"
+docker run "${docker_args[@]}" -v "${TEMP_DIR}:/src" -i "$image" semgrep -l python -e '$X == $X' | grep -q "1 == 1"

--- a/scripts/validate-docker-build.sh
+++ b/scripts/validate-docker-build.sh
@@ -67,11 +67,12 @@ docker run "${docker_args[@]}" "$image" semgrep ci --help
 docker run "${docker_args[@]}" "$image" semgrep publish --help
 echo " -> OK"
 
-echo "Semgrep should be able to return findings"
-echo "if 1 == 1: pass" \
-    | docker run "${docker_args[@]}" -i "$image" semgrep -l python -e '$X == $X' - \
-    | grep -q "1 == 1"
+echo "Semgrep should be able to return findings (stdin)"
+result=$(echo "if 1 == 1: pass" | docker run "${docker_args[@]}" -i "$image" semgrep -l python -e '$X == $X' -)
+echo "${result}" | grep -q "1 == 1"
+echo " -> OK"
 
+echo "Semgrep should be able to return findings (file)"
 TEMP_DIR=$(mktemp -d)
 echo "if 1 == 1: pass" > "${TEMP_DIR}/bar.py"
 docker run "${docker_args[@]}" -v "${TEMP_DIR}:/src" -i "$image" semgrep -l python -e '$X == $X' | grep -q "1 == 1"

--- a/src/osemgrep/cli/CLI.ml
+++ b/src/osemgrep/cli/CLI.ml
@@ -78,6 +78,15 @@ let default_subcommand = "scan"
               logger.info(
                   f"Semgrep failed to set the safe.directory Git config option. Git commands might fail: {e}"
               )
+
+   def abort_if_linux_arm64() -> None:
+       """
+       Exit with FATAL_EXIT_CODE if the user is running on Linux ARM64.
+       Print helpful error message.
+       """
+       if platform.machine() in {"arm64", "aarch64"} and platform.system() == "Linux":
+           logger.error("Semgrep does not support Linux ARM64")
+           sys.exit(FATAL_EXIT_CODE)
 *)
 
 (*****************************************************************************)
@@ -259,6 +268,7 @@ let main argv : Exit_code.t =
 
   (* TOPORT:
       state.terminal.init_for_cli()
+      abort_if_linux_arm64()
       state.app_session.authenticate()
       state.app_session.user_agent.tags.add(f"command/{subcommand}")
       state.metrics.add_feature("subcommand", subcommand)

--- a/src/osemgrep/cli/CLI.ml
+++ b/src/osemgrep/cli/CLI.ml
@@ -78,15 +78,6 @@ let default_subcommand = "scan"
               logger.info(
                   f"Semgrep failed to set the safe.directory Git config option. Git commands might fail: {e}"
               )
-
-   def abort_if_linux_arm64() -> None:
-       """
-       Exit with FATAL_EXIT_CODE if the user is running on Linux ARM64.
-       Print helpful error message.
-       """
-       if platform.machine() in {"arm64", "aarch64"} and platform.system() == "Linux":
-           logger.error("Semgrep does not support Linux ARM64")
-           sys.exit(FATAL_EXIT_CODE)
 *)
 
 (*****************************************************************************)
@@ -268,7 +259,6 @@ let main argv : Exit_code.t =
 
   (* TOPORT:
       state.terminal.init_for_cli()
-      abort_if_linux_arm64()
       state.app_session.authenticate()
       state.app_session.user_agent.tags.add(f"command/{subcommand}")
       state.metrics.add_feature("subcommand", subcommand)


### PR DESCRIPTION
This PR introduces support for multi-arch semgrep docker builds (amd64 + arm64). A few things to note:
- GHA only provides amd64 runners, so ARM builds are abhorrently slow ([45 mins](https://github.com/returntocorp/semgrep/actions/runs/5456229166/jobs/9928763358)). I cut us over to depot.dev, which provides dedicated ARM hardware and a faster docker cache. `depot/build-push-action` will fall back to the standard docker if depot.dev is offline.
- We run some pre-flight checks prior to pushing the image, which warranted some tricky maneuvers because neither docker nor depot can export (and docker can't import) a multi-arch image archive, so instead:
  - We build each arch individually, run the checks, and then upload the archive (name suffixed with the arch)
  - In `push-docker-multi-arch`, we:
    1. Extract the contents of the two images
    2. Generate a manifest list so that the docker image will show up as multi-arch in Docker Hub
    3. Push both images' blobs and manifests to Docker Hub
    4. Push the manifest list for the desired tags to Docker Hub

(this is a bit of a brain-melter so I'm happy to explain further. I can also add comments to the workflow)

All that being said, we should re-assess if `validate-docker-build.sh` is still useful (or if we can push to a staging repository), so that we can rely on docker's/depot's baked-in multi-arch builds

test plan:
- [x] manually triggered `build-test-docker` to push this branch as `returntocorp/test`. Confirmed that the [tom-arm64](https://hub.docker.com/r/returntocorp/test/tags) image works on both amd64 and arm64.

cc: https://github.com/returntocorp/semgrep/issues/2252