### PR TITLE
feat: [nightly] install semgrep via brew non-interactively

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -35,6 +35,7 @@ jobs:
       - name: Brew Install
         env:
           HOMEBREW_NO_INSTALL_FROM_API: 1
+          NONINTERACTIVE: 1
         run: brew install semgrep --HEAD --debug
       - name: Check installed correctly
         env:


### PR DESCRIPTION
In our nightly tests, we install semgrep via brew to check for compatibility. In some cases when this fails, brew will stop and wait for user input, which will not be given, and GHA times out the job after 6 hours. 

Run the brew install in non-interactive mode. 

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
