### PR TITLE
use variable for last docker validation test as well

### DIFF
--- a/scripts/validate-docker-build.sh
+++ b/scripts/validate-docker-build.sh
@@ -75,5 +75,6 @@ echo " -> OK"
 echo "Semgrep should be able to return findings (file)"
 TEMP_DIR=$(mktemp -d)
 echo "if 1 == 1: pass" > "${TEMP_DIR}/bar.py"
-docker run "${docker_args[@]}" -v "${TEMP_DIR}:/src" -i "$image" semgrep -l python -e '$X == $X' | grep -q "1 == 1"
+result=$(docker run "${docker_args[@]}" -v "${TEMP_DIR}:/src" -i "$image" semgrep -l python -e '$X == $X')
+echo "${result}" | grep -q "1 == 1"
 echo " -> OK"


### PR DESCRIPTION
We're seeing random failures in the arm64 test image step -- I have a feeling that the `docker run` process is exiting too soon and closing the pipe before `grep` can finish.

I thought the stdin test was the culprit, so I saved the output to a variable and then echo-ed it to grep, but it looks like the other test is flaky too. This PR applies this change to the other flakey test.

test plan:
- checks pass
