### PR TITLE
chore: [ci] add labels to run on AWS-hosted runner

### DIFF
--- a/.github/workflows/build-test-osx-m1.yaml
+++ b/.github/workflows/build-test-osx-m1.yaml
@@ -16,7 +16,7 @@ jobs:
     # we might as well move out of a self-hosted runner for M1 too.
     # This would remove the need for those ugly hard cleanup below because
     # our self-hosted runner builds are not "hermetic".
-    runs-on: [self-hosted, macOS, ARM64]
+    runs-on: [self-hosted, macOS, ARM64, aws]
     env:
       OPAM_SWITCH_NAME: "4.14.0"
     steps:
@@ -52,7 +52,7 @@ jobs:
           name: semgrep-m1-${{ github.sha }}
 
   build-wheels-m1:
-    runs-on: [self-hosted, macOS, ARM64]
+    runs-on: [self-hosted, macOS, ARM64, aws]
     needs: [build-core-m1]
     steps:
       - uses: actions/checkout@v3
@@ -71,7 +71,7 @@ jobs:
           name: m1-wheel
 
   test-wheels-m1:
-    runs-on: [self-hosted, macOS, ARM64]
+    runs-on: [self-hosted, macOS, ARM64, aws]
     needs: [build-wheels-m1]
     steps:
       - name: cleanup semgrep


### PR DESCRIPTION
We want to experiment with some additional runners without interfering with the current status of semgrep CI. To do so, we've tagged our self-hosted runners with an additional `aws` tag that'll allow us to spin up other runners that don't have this tag, without interfering.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
