### PR TITLE
feat(SSC): Scan un-edited lockfiles in PR scans

### DIFF
--- a/cli/src/semgrep/run_scan.py
+++ b/cli/src/semgrep/run_scan.py
@@ -254,6 +254,7 @@ def run_rules(
                     dep_rule_matches,
                     dep_rule_errors,
                     already_reachable,
+                    scanned_lockfiles,
                 ) = generate_reachable_sca_findings(
                     rule_matches_by_rule.get(rule, []),
                     rule,
@@ -269,6 +270,17 @@ def run_rules(
                 )
                 rule_matches_by_rule[rule].extend(dep_rule_matches)
                 output_handler.handle_semgrep_errors(dep_rule_errors)
+
+                for lockfile in scanned_lockfiles:
+                    # Add lockfiles as a target that was scanned
+                    output_extra.all_targets.add(lockfile)
+                    # Warning temporal assumption: this is the only place we process
+                    # parse errors. We silently toss them in other places we call parse_lockfile_path
+                    # It doesn't really matter where it gets handled as long as we collect the parse errors somewhere
+                    deps, parse_error = parse_lockfile_path(lockfile)
+                    dependencies[str(lockfile)] = deps
+                    if parse_error:
+                        dependency_parser_errors.append(parse_error)
             else:
                 (
                     dep_rule_matches,

--- a/cli/src/semgrep/target_manager.py
+++ b/cli/src/semgrep/target_manager.py
@@ -97,6 +97,12 @@ ECOSYSTEM_TO_LOCKFILES = {
     Ecosystem(Pub()): ["pubspec.lock"],
 }
 
+ALL_ECOSYSTEMS = list(ECOSYSTEM_TO_LOCKFILES.keys())
+
+ALL_LOCKFILE_NAMES = [
+    name for names in ECOSYSTEM_TO_LOCKFILES.values() for name in names
+]
+
 
 def write_pipes_to_disk(targets: Sequence[str], temp_dir: Path) -> Sequence[str]:
     """
@@ -478,7 +484,7 @@ class Target:
         )
 
     @lru_cache(maxsize=None)
-    def files(self) -> FrozenSet[Path]:
+    def files(self, ignore_baseline_handler: bool = False) -> FrozenSet[Path]:
         """
         Recursively go through a directory and return list of all files with
         default file extension of language
@@ -486,7 +492,7 @@ class Target:
         if not self.path.is_dir() and self.path.is_file():
             return frozenset([self.path])
 
-        if self.baseline_handler is not None:
+        if self.baseline_handler is not None and not ignore_baseline_handler:
             try:
                 return self.files_from_git_diff()
             except (subprocess.CalledProcessError, FileNotFoundError):
@@ -698,12 +704,14 @@ class TargetManager:
         return FilteredFiles(frozenset(kept), frozenset(removed))
 
     @lru_cache(maxsize=None)
-    def get_all_files(self) -> FrozenSet[Path]:
-        return frozenset(f for target in self.targets for f in target.files())
+    def get_all_files(self, ignore_baseline_handler: bool = False) -> FrozenSet[Path]:
+        return frozenset(
+            f for target in self.targets for f in target.files(ignore_baseline_handler)
+        )
 
     @lru_cache(maxsize=None)
     def get_files_for_language(
-        self, lang: Union[Language, Ecosystem], product: out.Product
+        self, lang: Union[Language, Ecosystem], product: out.Product, ignore_baseline_handler: bool = False
     ) -> FilteredFiles:
         """
         Return all files that are decendants of any directory in TARGET that have
@@ -714,7 +722,7 @@ class TargetManager:
 
         Note also filters out any directory and descendants of `.git`
         """
-        all_files = self.get_all_files()
+        all_files = self.get_all_files(ignore_baseline_handler)
 
         files = self.filter_by_language(lang, candidates=all_files)
         self.ignore_log.by_language[lang].update(files.removed)
@@ -790,32 +798,20 @@ class TargetManager:
         """
         Return a dict mapping each ecosystem to the set of lockfiles for that ecosystem
         """
-        ALL_ECOSYSTEMS: Set[Ecosystem] = {
-            Ecosystem(Npm()),
-            Ecosystem(Pypi()),
-            Ecosystem(Gem()),
-            Ecosystem(Gomod()),
-            Ecosystem(Cargo()),
-            Ecosystem(Maven()),
-            Ecosystem(Composer()),
-            Ecosystem(Nuget()),
-            Ecosystem(Pub()),
-        }
-
         return {
             ecosystem: self.get_lockfiles(ecosystem) for ecosystem in ALL_ECOSYSTEMS
         }
 
     @lru_cache(maxsize=None)
     def get_lockfiles(
-        self, ecosystem: Ecosystem, product: out.Product = SCA_PRODUCT
+        self, ecosystem: Ecosystem, product: out.Product = SCA_PRODUCT, ignore_baseline_hander: bool = False
     ) -> FrozenSet[Path]:
         """
         Return set of paths to lockfiles for a given ecosystem
 
         Respects semgrepignore/exclude flag
         """
-        return self.get_files_for_language(ecosystem, product).kept
+        return self.get_files_for_language(ecosystem, product, ignore_baseline_hander).kept
 
     def find_single_lockfile(self, p: Path, ecosystem: Ecosystem) -> Optional[Path]:
         """
@@ -825,7 +821,7 @@ class TargetManager:
         If lockfile not in self.get_lockfiles(ecosystem) then return None
         this would happen if the lockfile is ignored by a .semgrepignore or --exclude
         """
-        candidates = self.get_lockfiles(ecosystem)
+        candidates = self.get_lockfiles(ecosystem, ignore_baseline_hander=True)
 
         for path in p.parents:
             for lockfile_pattern in ECOSYSTEM_TO_LOCKFILES[ecosystem]:

--- a/cli/src/semgrep/target_manager.py
+++ b/cli/src/semgrep/target_manager.py
@@ -711,7 +711,10 @@ class TargetManager:
 
     @lru_cache(maxsize=None)
     def get_files_for_language(
-        self, lang: Union[Language, Ecosystem], product: out.Product, ignore_baseline_handler: bool = False
+        self,
+        lang: Union[Language, Ecosystem],
+        product: out.Product,
+        ignore_baseline_handler: bool = False,
     ) -> FilteredFiles:
         """
         Return all files that are decendants of any directory in TARGET that have
@@ -804,14 +807,19 @@ class TargetManager:
 
     @lru_cache(maxsize=None)
     def get_lockfiles(
-        self, ecosystem: Ecosystem, product: out.Product = SCA_PRODUCT, ignore_baseline_hander: bool = False
+        self,
+        ecosystem: Ecosystem,
+        product: out.Product = SCA_PRODUCT,
+        ignore_baseline_hander: bool = False,
     ) -> FrozenSet[Path]:
         """
         Return set of paths to lockfiles for a given ecosystem
 
         Respects semgrepignore/exclude flag
         """
-        return self.get_files_for_language(ecosystem, product, ignore_baseline_hander).kept
+        return self.get_files_for_language(
+            ecosystem, product, ignore_baseline_hander
+        ).kept
 
     def find_single_lockfile(self, p: Path, ecosystem: Ecosystem) -> Optional[Path]:
         """


### PR DESCRIPTION
If a PR introduces a new vulnerable usage of a dependency that was already in their lockfile, but does not edit their lockfile, we currently will not catch it, because on PR scans we only target files that were edited in the PR. 

This fixes that by adding an `ignore_baseline_handler` option to the file targeting code that just ignores whether or not we're doing a PR scan. Then `find_single_lockfile`, which is used when generating reachable findings to locate the lockfile associated to a given code file, sets this to `True`. So reachable finding generation can bypass the `baseline_handler`, but we won't just scan every lockfile on every PR scan.

I also update `generate_reachable_sca_findings` to return a `FrozenSet[Path]` of the lockfiles scanned during its execution, which are added to `all_targets` and the scan's dependencies.

PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
