### PR TITLE
fix: [ci] enable multi-arch setting for nightly release-dry-run

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -46,6 +46,7 @@ jobs:
     secrets: inherit
     with:
       dry-run: true
+      multi-arch: true
 
   notify-failure:
     needs: [brew-build, release-dry-run]


### PR DESCRIPTION
Nightly checks failed to run because the multi-arch input wasn't specified when the `nightly.yml` workflow called `release.yml`. Specifying this should suffice.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
