### PR TITLE
upload semgrep JS assets directly to the static bucket

### DIFF
--- a/.github/workflows/build-test-javascript.yaml
+++ b/.github/workflows/build-test-javascript.yaml
@@ -116,7 +116,8 @@ jobs:
           path: /tmp/semgrep
       - name: Upload to S3
         run: |
+          cd /tmp/semgrep
+          tar xvzf semgrep-js-artifacts.tar.gz
           branch_name=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
           urlencoded_branch_name=$(printf %s $branch_name | jq -sRr @uri)
-          current_datetime=$(date +"%Y-%m-%dT%H:%M:%S")
-          aws s3 cp /tmp/semgrep/semgrep-js-artifacts.tar.gz "s3://semgrep-oss-js-artifacts/branch/${urlencoded_branch_name}/sha/${{ github.sha }}/semgrep-js-artifacts_${current_datetime}.tar.gz"
+          aws s3 sync /tmp/semgrep/js/ "s3://semgrep-app-static-assets/static/turbo/${urlencoded_branch_name}/"


### PR DESCRIPTION
Uploading semgrep JS artifacts directly to the static bucket makes it easier to roll out to the playground

/cc @ajbt200128 

test plan:
- checks pass
