### PR TITLE
fallback default to workaround inputs.multi-arch being null

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,7 +149,7 @@ jobs:
       artifact-name: image-release
       repository-name: ${{ github.repository }}
       dry-run: ${{ needs.dry-run.outputs.dry-run == 'true' }}
-      multi-arch: ${{ inputs.multi-arch }}
+      multi-arch: ${{ inputs.multi-arch || 'false' }}
 
   upload-wheels:
     name: Upload Wheels to PyPI


### PR DESCRIPTION
Fixes this release workflow issue:
```
release: .github#L1
The template is not valid. .github/workflows/release.yml (Line: 152, Col: 19): Unexpected value ''
```
