### PR TITLE
fix: [ci] update handling of multi-arch input for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,11 +41,12 @@ on:
       - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
 
 jobs:
-  dry-run:
-    name: Evaluate Dry Run
+  inputs:
+    name: Evaluate Inputs
     runs-on: ubuntu-22.04
     outputs:
       dry-run: ${{steps.dry-run.outputs.dry-run}}
+      multi-arch: ${{steps.multi-arch.outputs.multi-arch}}
     steps:
       - name: Evaluate Dry Run
         id: dry-run
@@ -57,12 +58,22 @@ jobs:
             echo "dry-run=false" >> $GITHUB_OUTPUT
             echo "Setting dry-run to FALSE"
           fi
+      - name: Evaluate Multi-Arch
+        id: multi-arch
+        run: |
+          if [ "${{ inputs.multi-arch }}" = "true" ]; then
+            echo "multi-arch=true" >> $GITHUB_OUTPUT
+            echo "Setting multi-arch to TRUE"
+          else
+            echo "multi-arch=false" >> $GITHUB_OUTPUT
+            echo "Setting multi-arch to FALSE"
+          fi
 
   park-pypi-packages:
     name: Park PyPI package names
     runs-on: ubuntu-latest
-    needs: [dry-run]
-    if: ${{ !contains(github.ref, '-test-release') && needs.dry-run.outputs.dry-run != 'true' }}
+    needs: [inputs]
+    if: ${{ !contains(github.ref, '-test-release') && needs.inputs.outputs.dry-run != 'true' }}
     defaults:
       run:
         working-directory: cli/
@@ -142,19 +153,19 @@ jobs:
         run: echo "All Platforms have been built and tested - proceeding!"
 
   push-docker:
-    needs: [wait-for-build-test, dry-run]
+    needs: [wait-for-build-test, inputs]
     uses: ./.github/workflows/push-docker.yaml
     secrets: inherit
     with:
       artifact-name: image-release
       repository-name: ${{ github.repository }}
-      dry-run: ${{ needs.dry-run.outputs.dry-run == 'true' }}
-      multi-arch: ${{ inputs.multi-arch || 'false' }}
+      dry-run: ${{ needs.inputs.outputs.dry-run == 'true' }}
+      multi-arch: ${{ needs.inputs.outputs.multi-arch == 'true' }}
 
   upload-wheels:
     name: Upload Wheels to PyPI
     runs-on: ubuntu-latest
-    needs: [wait-for-build-test, dry-run]
+    needs: [wait-for-build-test, inputs]
     steps:
       - name: Download Artifact
         uses: actions/download-artifact@v3
@@ -181,7 +192,7 @@ jobs:
         run: unzip ./m1-wheel/dist.zip "*.whl"
       - name: Publish to Pypi
         uses: pypa/gh-action-pypi-publish@master
-        if: ${{ !contains(github.ref, '-test-release') && needs.dry-run.outputs.dry-run != 'true' }}
+        if: ${{ !contains(github.ref, '-test-release') && needs.inputs.outputs.dry-run != 'true' }}
         with:
           user: __token__
           password: ${{ secrets.pypi_upload_token }}
@@ -190,8 +201,8 @@ jobs:
   create-release:
     name: Create the Github Release
     runs-on: ubuntu-latest
-    needs: [wait-for-build-test, dry-run]
-    if: ${{ !contains(github.ref, '-test-release') && needs.dry-run.outputs.dry-run != 'true' }}
+    needs: [wait-for-build-test, inputs]
+    if: ${{ !contains(github.ref, '-test-release') && needs.inputs.outputs.dry-run != 'true' }}
     steps:
       - name: Get the version
         id: get-version
@@ -216,8 +227,8 @@ jobs:
   create-release-interfaces:
     name: Create the Github Release on Semgrep Interfaces
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.ref, '-test-release') && needs.dry-run.outputs.dry-run != 'true' }}
-    needs: [wait-for-build-test, dry-run]
+    if: ${{ !contains(github.ref, '-test-release') && needs.inputs.outputs.dry-run != 'true' }}
+    needs: [wait-for-build-test, inputs]
     steps:
       - name: Get the version
         id: get-version
@@ -260,23 +271,23 @@ jobs:
   sleep-before-homebrew:
     name: Sleep 10 min before releasing to homebrew
     # Need to wait for pypi to propagate ssince pipgrip relies on it being published on pypi
-    needs: [dry-run, upload-wheels]
+    needs: [inputs, upload-wheels]
     runs-on: ubuntu-latest
     steps:
       - name: Sleep 10 min
-        if: ${{ !contains(github.ref, '-test-release') && needs.dry-run.outputs.dry-run != 'true' }}
+        if: ${{ !contains(github.ref, '-test-release') && needs.inputs.outputs.dry-run != 'true' }}
         run: sleep 10m
 
   homebrew-core-pr:
     name: Update on Homebrew-Core
-    needs: [dry-run, sleep-before-homebrew] # Needs to run after pypi released so brew can update pypi dependency hashes
+    needs: [inputs, sleep-before-homebrew] # Needs to run after pypi released so brew can update pypi dependency hashes
     runs-on: macos-12
     steps:
       - name: Get the version
         id: get-version
         run: |
           TAG=${GITHUB_REF/refs\/tags\//}
-          if [ "${{ needs.dry-run.outputs.dry-run }}" = "true" ]; then
+          if [ "${{ needs.inputs.outputs.dry-run }}" = "true" ]; then
             TAG=v99.99.99
           fi
           echo "Using TAG=${TAG}"
@@ -301,13 +312,13 @@ jobs:
         # The `brew bump-formula-pr` does checks to ensure your PR is legit, but we want to do a phony PR (or at least prep it) for Dry Run only
         env:
           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.SEMGREP_HOMEBREW_RELEASE_PAT }}
-        if: ${{ contains(github.ref, '-test-release') || needs.dry-run.outputs.dry-run == 'true' }}
+        if: ${{ contains(github.ref, '-test-release') || needs.inputs.outputs.dry-run == 'true' }}
         run: |
           brew bump-formula-pr --force --no-audit --no-browse --write-only \
             --message="semgrep 99.99.99" \
             --tag="v99.99.99" --revision="${GITHUB_SHA}" semgrep --python-exclude-packages semgrep
       - name: Open Brew PR
-        if: ${{ !contains(github.ref, '-test-release') && needs.dry-run.outputs.dry-run != 'true' }}
+        if: ${{ !contains(github.ref, '-test-release') && needs.inputs.outputs.dry-run != 'true' }}
         env:
           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.SEMGREP_HOMEBREW_RELEASE_PAT }}
         run: |
@@ -332,7 +343,7 @@ jobs:
       - name: Push Branch to Fork
         env:
           GITHUB_TOKEN: ${{ secrets.SEMGREP_HOMEBREW_RELEASE_PAT }}
-        if: ${{ !contains(github.ref, '-test-release') && needs.dry-run.outputs.dry-run != 'true' }}
+        if: ${{ !contains(github.ref, '-test-release') && needs.inputs.outputs.dry-run != 'true' }}
         run: |
           cd "$(brew --repository)/Library/Taps/homebrew/homebrew-core"
           git push --set-upstream r2c --force "bump-semgrep-${{ steps.get-version.outputs.VERSION }}"
@@ -340,7 +351,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.SEMGREP_HOMEBREW_RELEASE_PAT }}
           R2C_HOMEBREW_CORE_OWNER: semgrep-release
-        if: ${{ !contains(github.ref, '-test-release') && needs.dry-run.outputs.dry-run != 'true' }}
+        if: ${{ !contains(github.ref, '-test-release') && needs.inputs.outputs.dry-run != 'true' }}
         run: |
           gh pr create --repo homebrew/homebrew-core \
             --base master --head "${R2C_HOMEBREW_CORE_OWNER}:bump-semgrep-${{ steps.get-version.outputs.VERSION }}" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Evaluate Dry Run
         id: dry-run
         run: |
-          if [ "${{ inputs.dry-run }}" = "true" ]; then
+          if [[ "${{ inputs.dry-run }}" == "true" ]]; then
             echo "dry-run=true" >> $GITHUB_OUTPUT
             echo "Setting dry-run to TRUE"
           else
@@ -61,7 +61,7 @@ jobs:
       - name: Evaluate Multi-Arch
         id: multi-arch
         run: |
-          if [ "${{ inputs.multi-arch }}" = "true" ]; then
+          if [[ "${{ inputs.multi-arch }}" == "true" ]]; then
             echo "multi-arch=true" >> $GITHUB_OUTPUT
             echo "Setting multi-arch to TRUE"
           else


### PR DESCRIPTION
Our last release failed due to the `multi-arch` input being null, which was not acceptable as a boolean input. [A fix was applied here](https://github.com/returntocorp/semgrep/commit/8157c0cfaaa039f444f10dca5e042acdad1f7d2b), but that also passes false as a string, so I'm not sure that it'll be acceptable either, and small test shows that this might not work as expected. 

To remedy this, we can handle the multi-arch input the same way handle dry-run input, and explicitly check for the values we're looking for. 

I'm also open to updating how we handle/trigger the `release.yml` job to standardize things, but would prefer to do that large refactor in a separate step. This PR just uses a pattern that we're already relying on to get us back, but we can update once release is complete.

Test Plan:
- [Dry run here](https://github.com/returntocorp/semgrep/actions/runs/5487629034) - note that this dry-run still isn't a 100% valid test, since we aren't running it based on a tag push. We won't know for sure until we attempt to actually push the image if this has been updated successfully. 

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
