### PR TITLE
enable multi-arch builds for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Evaluate Multi-Arch
         id: multi-arch
         run: |
-          if [[ "${{ inputs.multi-arch }}" == "true" ]]; then
+          if [[ "${{ inputs.multi-arch }}" == "true" || "${{ inputs.multi-arch }}" == "" ]]; then
             echo "multi-arch=true" >> $GITHUB_OUTPUT
             echo "Setting multi-arch to TRUE"
           else
@@ -120,6 +120,7 @@ jobs:
       artifact-name: image-release
       file: Dockerfile
       enable-tests: true
+      multi-arch: true
 
   build-test-osx-x86:
     uses: ./.github/workflows/build-test-osx-x86.yaml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,7 +120,7 @@ jobs:
       artifact-name: image-release
       file: Dockerfile
       enable-tests: true
-      multi-arch: true
+      multi-arch: ${{ needs.inputs.outputs.multi-arch == 'true' }}
 
   build-test-osx-x86:
     uses: ./.github/workflows/build-test-osx-x86.yaml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,6 +112,7 @@ jobs:
   build-test-docker:
     uses: ./.github/workflows/build-test-docker.yaml
     secrets: inherit
+    needs: [inputs]
     with:
       docker-tags: |
         type=semver,pattern={{version}}

--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -26,6 +26,11 @@ on:
         type: boolean
         description: Check the box for a dry-run - A dry-run will not push any external state (branches, tags, images, or PyPI packages).
         default: false
+      multi-arch:
+        required: true
+        type: boolean
+        description: Check the box to publish multi-arch Docker images
+        default: true
 
 jobs:
   get-version:


### PR DESCRIPTION
We've had enough multi-arch branch builds where I feel comfortable with this.