### PR TITLE
build aarch64 python wheels

### DIFF
--- a/.github/workflows/build-test-manylinux-aarch64.yaml
+++ b/.github/workflows/build-test-manylinux-aarch64.yaml
@@ -28,5 +28,5 @@ jobs:
           docker run --platform linux/arm64 --rm ${{ steps.build-semgrep-wheel.outputs.imageid }} zip -r - dist > /tmp/dist.zip
       - uses: actions/upload-artifact@v3
         with:
-          name: wheel-manylinux-aarch64
+          name: manylinux-wheel-aarch64
           path: /tmp/dist.zip

--- a/.github/workflows/build-test-manylinux-aarch64.yaml
+++ b/.github/workflows/build-test-manylinux-aarch64.yaml
@@ -1,0 +1,32 @@
+name: build-test-manylinux-aarch64
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  build-wheel:
+    name: Build and test Semgrep python wheel
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: docker/setup-qemu-action@v2
+      - uses: depot/setup-action@v1
+      - name: Build and test python wheel
+        id: build-semgrep-wheel
+        uses: depot/build-push-action@v1.7.1
+        with:
+          project: fhmxj6w9z8
+          platforms: linux/arm64
+          outputs: type=docker,dest=/tmp/image.tar
+          target: semgrep-wheel
+      - name: Extract wheel from docker image
+        run: |
+          docker load --input /tmp/image.tar
+          docker run --platform linux/arm64 --rm ${{ steps.build-semgrep-wheel.outputs.imageid }} zip -r - dist > /tmp/dist.zip
+      - uses: actions/upload-artifact@v3
+        with:
+          name: wheel-manylinux-aarch64
+          path: /tmp/dist.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,6 +125,7 @@ jobs:
       [
         build-test-docker,
         build-test-manylinux-x86,
+        build-test-manylinux-aarch64,
         build-test-osx-x86,
         build-test-osx-m1,
       ]
@@ -151,6 +152,11 @@ jobs:
         with:
           name: manylinux-wheel
           path: manylinux-wheel
+      - name: Download aarch64 Artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: manylinux-wheel-aarch64
+          path: manylinux-wheel-aarch64
       - name: Download Osx Artifact
         uses: actions/download-artifact@v3
         with:
@@ -161,8 +167,10 @@ jobs:
         with:
           name: m1-wheel
           path: m1-wheel
-      - name: Unzip
+      - name: Unzip x86_64 Wheel
         run: unzip ./manylinux-wheel/dist.zip
+      - name: Unzip aarch64 Wheel
+        run: unzip ./manylinux-wheel-aarch64/dist.zip "*.whl"
       - name: Unzip OSX Wheel
         # Don't unzip tar.gz because it already exists from ./manylinux-wheel/dist.zip.
         run: unzip ./osx-wheel/dist.zip "*.whl"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -345,13 +345,13 @@ jobs:
     uses: ./.github/workflows/build-test-core-x86.yaml
     secrets: inherit
 
-  # build-test-manylinux-x86:
-  #   needs: [build-test-core-x86]
-  #   uses: ./.github/workflows/build-test-manylinux-x86.yaml
-  #   secrets: inherit
+  build-test-manylinux-x86:
+    needs: [build-test-core-x86]
+    uses: ./.github/workflows/build-test-manylinux-x86.yaml
+    secrets: inherit
 
   build-test-manylinux-aarch64:
-    #needs: [build-test-docker]
+    needs: [build-test-docker]
     uses: ./.github/workflows/build-test-manylinux-aarch64.yaml
     secrets: inherit
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -345,9 +345,14 @@ jobs:
     uses: ./.github/workflows/build-test-core-x86.yaml
     secrets: inherit
 
-  build-test-manylinux-x86:
-    needs: [build-test-core-x86]
-    uses: ./.github/workflows/build-test-manylinux-x86.yaml
+  # build-test-manylinux-x86:
+  #   needs: [build-test-core-x86]
+  #   uses: ./.github/workflows/build-test-manylinux-x86.yaml
+  #   secrets: inherit
+
+  build-test-manylinux-aarch64:
+    #needs: [build-test-docker]
+    uses: ./.github/workflows/build-test-manylinux-aarch64.yaml
     secrets: inherit
 
   build-test-osx-x86:

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,8 @@ WORKDIR /src/semgrep
 # copy over the entire semgrep repository
 COPY . .
 
-# remove folders that aren't necessary for the semgrep-core build
-RUN rm -rf cli js .github .circleci
+# remove files and folders that aren't necessary for the semgrep-core build
+RUN rm -rf cli js .github .circleci Dockerfile
 
 # we *do* need the cli's semgrep_interfaces folder, however
 COPY cli/src/semgrep/semgrep_interfaces cli/src/semgrep/semgrep_interfaces
@@ -97,6 +97,22 @@ RUN eval "$(opam env)" &&\
     # Sanity check
     /src/semgrep/_build/default/src/main/Main.exe -version
 
+FROM python:3.7-alpine AS semgrep-wheel
+
+WORKDIR /semgrep
+
+RUN apk add --no-cache build-base zip
+
+COPY cli ./
+
+COPY --from=semgrep-core-container /src/semgrep/_build/default/src/main/Main.exe src/semgrep/bin/semgrep-core
+
+RUN python setup.py sdist bdist_wheel
+
+COPY scripts/validate-wheel.sh ./scripts/validate-wheel.sh
+
+RUN ./scripts/validate-wheel.sh dist/*.whl
+
 ###############################################################################
 # Step2: Build the final docker image with Python wrapper and semgrep-core bin
 ###############################################################################
@@ -159,7 +175,7 @@ RUN apk add --no-cache --virtual=.build-deps build-base make g++ &&\
      pip install jsonnet &&\
      pip install /semgrep &&\
      # running this pre-compiles some python files for faster startup times
-     SEMGREP_SKIP_ARM64_CHECK=1 semgrep --version &&\
+     semgrep --version &&\
      apk del .build-deps
 
 # Let the user know how their container was built
@@ -172,8 +188,7 @@ RUN ln -s semgrep-core /usr/local/bin/osemgrep
 
 # ???
 ENV SEMGREP_IN_DOCKER=1 \
-    SEMGREP_USER_AGENT_APPEND="Docker" \
-    SEMGREP_SKIP_ARM64_CHECK=1
+    SEMGREP_USER_AGENT_APPEND="Docker"
 
 # The command we tell people to run for testing semgrep in Docker is
 #   docker run --rm -v "${PWD}:/src" returntocorp/semgrep semgrep --config=auto

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -33,8 +33,6 @@ if WHEEL_CMD in sys.argv:
             abi = "none"
             if "macosx" in plat:
                 plat = "macosx_11_0_arm64" if "arm" in plat else "macosx_10_14_x86_64"
-            else:
-                plat = "any"
             return python, abi, plat
 
     cmdclass = {WHEEL_CMD: BdistWheel}

--- a/cli/src/semgrep/cli.py
+++ b/cli/src/semgrep/cli.py
@@ -1,7 +1,4 @@
 #!/usr/bin/env python3
-import os
-import platform
-import sys
 from typing import Dict
 
 import click
@@ -15,7 +12,6 @@ from semgrep.commands.publish import publish
 from semgrep.commands.scan import scan
 from semgrep.commands.shouldafound import shouldafound
 from semgrep.default_group import DefaultGroup
-from semgrep.error import FATAL_EXIT_CODE
 from semgrep.state import get_state
 from semgrep.util import git_check_output
 from semgrep.verbose_logging import getLogger
@@ -48,16 +44,6 @@ def maybe_set_git_safe_directories() -> None:
         )
 
 
-def abort_if_linux_arm64() -> None:
-    """
-    Exit with FATAL_EXIT_CODE if the user is running on Linux ARM64.
-    Print helpful error message.
-    """
-    if platform.machine() in {"arm64", "aarch64"} and platform.system() == "Linux":
-        logger.error("Semgrep does not support Linux ARM64")
-        sys.exit(FATAL_EXIT_CODE)
-
-
 @click.group(cls=DefaultGroup, default_command="scan", name="semgrep")
 @click.help_option("--help", "-h")
 @click.pass_context
@@ -71,10 +57,6 @@ def cli(ctx: click.Context) -> None:
     """
     state = get_state()
     state.terminal.init_for_cli()
-
-    # SEMGREP_SKIP_ARM64_CHECK is temporary -- we'll remove the check entirely once we're consistently pushing arm64 docker images and python wheels
-    if not os.getenv("SEMGREP_SKIP_ARM64_CHECK"):
-        abort_if_linux_arm64()
 
     commands: Dict[str, click.Command] = ctx.command.commands  # type: ignore
 

--- a/scripts/build-wheels.sh
+++ b/scripts/build-wheels.sh
@@ -8,8 +8,6 @@
 # for pip to package semgrep correctly.
 
 set -e
-export PATH=/opt/python/cp37-cp37m/bin:$PATH
-
 pip3 install setuptools wheel
 cd cli && python3 setup.py sdist bdist_wheel
 # Zipping for a stable name to upload as an artifact

--- a/scripts/validate-wheel.sh
+++ b/scripts/validate-wheel.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 # This script build "wheels", which is a format used by the Pypi package manager
 # to distribute binaries (for us semgrep-core) with regular Python code.
 # See https://packaging.python.org/en/latest/glossary/#term-Wheel
@@ -8,9 +8,15 @@
 # for pip to package semgrep correctly.
 
 set -e
-export PATH=/opt/python/cp37-cp37m/bin:$PATH
 
-pip3 install setuptools wheel
-cd cli && python3 setup.py sdist bdist_wheel
-# Zipping for a stable name to upload as an artifact
-zip -r dist.zip dist
+if [ -z "$1" ]; then
+    echo "missing 1st argument: wheel file"
+    exit 1
+fi
+
+pip install "$1"
+
+semgrep --version
+
+# shellcheck disable=SC2016
+echo '1 == 1' | semgrep -l python -e '$X == $X' -

--- a/scripts/validate-wheel.sh
+++ b/scripts/validate-wheel.sh
@@ -1,11 +1,5 @@
 #!/usr/bin/env sh
-# This script build "wheels", which is a format used by the Pypi package manager
-# to distribute binaries (for us semgrep-core) with regular Python code.
-# See https://packaging.python.org/en/latest/glossary/#term-Wheel
-# and https://realpython.com/python-wheels/ for more information.
-# This script is called from our GHA build-xxx workflows.
-# It assumes the semgrep-core binary has been copied under cli/src/semgrep/bin
-# for pip to package semgrep correctly.
+# This script installs a semgrep python wheel and then validates that semgrep works.
 
 set -e
 


### PR DESCRIPTION
This PR adds support for building `aarch64` python wheels. This isn't simply a copypasta of the `x86_64` workflow because the cost of ARM emulation in GHA would make this job take forever. Instead, we:
- Add a new intermediate stage to the Dockerfile (`semgrep-wheel`) which:
   1. installs some prereqs (`build-base` because `ruamel.yaml` has native code  that needs to be compiled, `zip` because we gotta zip)
   2. copies the arch-specific `semgrep-core` binary from the `semgrep-core-container` stage
   3. builds the python wheel
   4. runs a script to validate that the wheel installs correctly and semgrep works
  (We don't have to worry about folks needlessly building this image because `docker build` only targets the last image in the Dockerfile by default)
- Add a new workflow that:
   - Kicks off a docker build targeting the `semgrep-wheel` image. This will be very fast because the docker layer cache will be populated already
   - If the image builds successfully, we extract `dist.zip` from the image and upload it as an artifact
- Remove the ARM64 check in the CLI (woo!)

If this ends up working smoothly, I'd like to consolidate on using this workflow for the `x86_64` wheel as well. (future PR)

NOTE: the CLI depends on `ruamel.yaml` which doesn't currently have an aarch64 python wheel published to PyPI, which means that gcc is required in order to install this dependency. Not ideal, but better than what we have currently (which is nothing). Medium-term we can look into switching from ruamel.yaml to pyyaml, and long-term osemgrep will make this go away.

test plan:
- checks pass
- grabbed the `manylinux-wheel-aarch64` artifact and confirmed it installed correctly and semgrep scan worked in an arm64 docker container

related: https://github.com/returntocorp/semgrep/issues/2252