### PR TITLE
tainting: Fix Taint.pick_taint

### DIFF
--- a/semgrep.yml
+++ b/semgrep.yml
@@ -408,3 +408,11 @@ rules:
     fix: ""
     languages: [ocaml]
     severity: WARNING
+
+  - id: no-match-x-x-with
+    pattern: match $X, $X with ... -> ...
+    message: >-
+      Pattern matching on ($X, $X) is pointless, you are comparing $X with itself.
+      You probably meant ($X, something-else) and this is due to a typo.
+    languages: [ocaml]
+    severity: WARNING

--- a/src/tainting/Taint.ml
+++ b/src/tainting/Taint.ml
@@ -338,7 +338,7 @@ type signature = Findings.t
 let pick_taint taint1 taint2 =
   (* Here we assume that 'compare taint1 taint2 = 0' so we could keep any
      * of them, but we want the one with the shortest trace. *)
-  match (taint1.orig, taint1.orig) with
+  match (taint1.orig, taint2.orig) with
   | Arg _, Arg _ -> taint2
   | Src src1, Src src2 ->
       let call_trace_cmp =
@@ -601,7 +601,7 @@ let rec map_preconditions f taint =
   | Src ({ precondition = Some (incoming, expr); _ } as src) -> (
       let new_incoming =
         incoming
-        |> List.filter_map (map_preconditions f)
+        |> Common.map_filter (map_preconditions f)
         |> f |> Taint_set.of_list
       in
       let new_incoming = filter_relevant_taints expr new_incoming in


### PR DESCRIPTION
Given two taints with the same source, Semgrep is supposed to pick the taint with the shortest call trace, but due to a typo this was not guaranteed.

Found this by chance while working on a new version of `pick_taint`, I don't have a test case for it.

Also fixed non-tail-rec use of `List.filter_map` (not sure why we had not found this before).

test plan:
make test

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
