### PR TITLE
fix: [ci] nightly brew tests failing

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -23,15 +23,16 @@ jobs:
     runs-on: macos-12
     steps:
       - name: Brew update
+        env:
+          HOMEBREW_NO_INSTALL_FROM_API: 1
         run: brew update --debug --verbose
       - name: Brew Install
         env:
           NONINTERACTIVE: 1
+          HOMEBREW_NO_INSTALL_FROM_API: 1
         # See https://github.com/Homebrew/brew/issues/1742 for context on the brew link step.
         run: brew install semgrep --HEAD --debug || brew link --overwrite semgrep
       - name: Check installed correctly
+        env:
+          HOMEBREW_NO_INSTALL_FROM_API: 1
         run: brew test --HEAD semgrep
-      - name: Debug
-        run: |
-          which semgrep
-          semgrep --version

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -29,37 +29,23 @@ jobs:
     # brew discussions.
     steps:
       - name: Brew update
-        env:
-          HOMEBREW_NO_INSTALL_FROM_API: 1
         run: brew update --debug --verbose
+      # - run: |
+      #     rm '/usr/local/bin/2to3'
+      #     rm '/usr/local/bin/2to3-3.11'
+      #     rm '/usr/local/bin/idle3'
+      #     rm '/usr/local/bin/idle3.11'
+      #     rm '/usr/local/bin/pydoc3'
+      #     rm '/usr/local/bin/pydoc3.11'
+      #     rm '/usr/local/bin/python3'
+      #     rm '/usr/local/bin/python3-config'
       - name: Brew Install
         env:
-          HOMEBREW_NO_INSTALL_FROM_API: 1
           NONINTERACTIVE: 1
-        run: brew install semgrep --HEAD --debug
+        run: brew install semgrep --debug || brew link --overwrite semgrep
       - name: Check installed correctly
-        env:
-          HOMEBREW_NO_INSTALL_FROM_API: 1
-        run: brew test semgrep --HEAD
-
-  release-dry-run:
-    uses: ./.github/workflows/release.yml
-    secrets: inherit
-    with:
-      dry-run: true
-
-  notify-failure:
-    needs: [brew-build, release-dry-run]
-    name: Notify of Failure
-    runs-on: ubuntu-20.04
-    if: failure()
-    steps:
-      - name: Notify Failure
+        run: brew test semgrep
+      - name: Debug
         run: |
-          curl --request POST \
-          --url  ${{ secrets.HOMEBREW_NIGHTLY_NOTIFICATIONS_URL }} \
-          --header 'content-type: application/json' \
-          --data '{
-            "commit_sha": "${{needs.release-setup.outputs.version}}",
-            "workflow_url": "https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}"
-          }'
+          which semgrep
+          semgrep --version

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -36,3 +36,25 @@ jobs:
         env:
           HOMEBREW_NO_INSTALL_FROM_API: 1
         run: brew test --HEAD semgrep
+
+  release-dry-run:
+    uses: ./.github/workflows/release.yml
+    secrets: inherit
+    with:
+      dry-run: true
+
+  notify-failure:
+    needs: [brew-build, release-dry-run]
+    name: Notify of Failure
+    runs-on: ubuntu-20.04
+    if: failure()
+    steps:
+      - name: Notify Failure
+        run: |
+          curl --request POST \
+          --url  ${{ secrets.HOMEBREW_NIGHTLY_NOTIFICATIONS_URL }} \
+          --header 'content-type: application/json' \
+          --data '{
+            "commit_sha": "${{needs.release-setup.outputs.version}}",
+            "workflow_url": "https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}"
+          }'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -21,6 +21,12 @@ jobs:
   brew-build:
     name: Build Semgrep via Brew from `returntocorp/semgrep:develop`
     runs-on: macos-12
+    # We've had issues with this workflow in the past, and needed to ensure that
+    # homebrew wouldn't use the API.
+    # See: https://github.com/orgs/Homebrew/discussions/4150, and
+    # https://github.com/orgs/Homebrew/discussions/4136
+    # There's also much other discussion on this topic available on GH and in the
+    # brew discussions.
     steps:
       - name: Brew update
         env:
@@ -28,14 +34,14 @@ jobs:
         run: brew update --debug --verbose
       - name: Brew Install
         env:
-          NONINTERACTIVE: 1
           HOMEBREW_NO_INSTALL_FROM_API: 1
+          NONINTERACTIVE: 1
         # See https://github.com/Homebrew/brew/issues/1742 for context on the brew link step.
         run: brew install semgrep --HEAD --debug || brew link --overwrite semgrep
       - name: Check installed correctly
         env:
           HOMEBREW_NO_INSTALL_FROM_API: 1
-        run: brew test --HEAD semgrep
+        run: brew test semgrep --HEAD
 
   release-dry-run:
     uses: ./.github/workflows/release.yml

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -21,30 +21,16 @@ jobs:
   brew-build:
     name: Build Semgrep via Brew from `returntocorp/semgrep:develop`
     runs-on: macos-12
-    # We've had issues with this workflow in the past, and needed to ensure that
-    # homebrew wouldn't use the API.
-    # See: https://github.com/orgs/Homebrew/discussions/4150, and
-    # https://github.com/orgs/Homebrew/discussions/4136
-    # There's also much other discussion on this topic available on GH and in the
-    # brew discussions.
     steps:
       - name: Brew update
         run: brew update --debug --verbose
-      # - run: |
-      #     rm '/usr/local/bin/2to3'
-      #     rm '/usr/local/bin/2to3-3.11'
-      #     rm '/usr/local/bin/idle3'
-      #     rm '/usr/local/bin/idle3.11'
-      #     rm '/usr/local/bin/pydoc3'
-      #     rm '/usr/local/bin/pydoc3.11'
-      #     rm '/usr/local/bin/python3'
-      #     rm '/usr/local/bin/python3-config'
       - name: Brew Install
         env:
           NONINTERACTIVE: 1
-        run: brew install semgrep --debug || brew link --overwrite semgrep
+        # See https://github.com/Homebrew/brew/issues/1742 for context on the brew link step.
+        run: brew install semgrep --HEAD --debug || brew link --overwrite semgrep
       - name: Check installed correctly
-        run: brew test semgrep
+        run: brew test --HEAD semgrep
       - name: Debug
         run: |
           which semgrep


### PR DESCRIPTION
Brew nightly verification has been failing - this error was originally obscured by a required update to the homebrew formula, which was applied to upstream `homebrew/homebrew-core` on 07JUL. This PR updates the way that `semgrep` is installed via brew on the Github-Hosted x86 MacOS runners. Because python3 already exists on the system, the brew link step fails, so we must also tell brew to link semgrep with the `--overwrite` flag.

See https://github.com/Homebrew/brew/issues/1742 for context on the brew link step.

It's unclear why this wasn't failing during our test runs - I noticed that new `macos-12` runner images were published around the same time, but they make no mention of how python was installed. In any case, this appears to be the way that the brew maintainers recommend proceeding. 

Test Plan:
- waiting for a test run here to pass: https://github.com/returntocorp/semgrep/actions/runs/5521938423/jobs/10070781425

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
