### PR TITLE
fix(supply-chain): baseline scans reporting on existing findings

### DIFF
--- a/changelog.d/baseline-supply-chain.fixed
+++ b/changelog.d/baseline-supply-chain.fixed
@@ -1,0 +1,1 @@
+baseline scans reporting on existing findings

--- a/cli/tests/e2e/snapshots/test_ci/test_existing_supply_chain_finding/base_output.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_existing_supply_chain_finding/base_output.txt
@@ -1,0 +1,69 @@
+=== command
+SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERSION_CACHE_PATH="<MASKED>" SEMGREP_ENABLE_VERSION_CHECK="0" SEMGREP_SEND_METRICS="off" semgrep ci --no-suppress-errors
+=== end of command
+
+=== exit code
+1
+=== end of exit code
+
+=== stdout - plain
+
+
+┌──────────────────────────────────┐
+│ 1 Reachable Supply Chain Finding │
+└──────────────────────────────────┘
+
+    poetry.lock
+       supply-chain1
+          found a dependency
+
+           17┆ [[package]]
+           18┆ name = "python-dateutil"
+
+
+=== end of stdout - plain
+
+=== stderr - plain
+
+
+┌────────────────┐
+│ Debugging Info │
+└────────────────┘
+
+  SCAN ENVIRONMENT
+  versions    - semgrep <MASKED> on python <MASKED>
+  environment - running in environment git, triggering event is unknown
+
+  CONNECTION
+  Reporting start of scan for deployment_name
+  Fetching configuration from Semgrep Cloud Platform
+
+┌─────────────┐
+│ Scan Status │
+└─────────────┘
+  Scanning 4 files tracked by git with 0 Code rules, 1 Supply Chain rule:
+
+
+  CODE RULES
+  Nothing to scan.
+
+  SUPPLY CHAIN RULES
+  Scanning 1 file.
+
+
+┌──────────────┐
+│ Scan Summary │
+└──────────────┘
+Some files were skipped or only partially analyzed.
+  Scan was limited to files tracked by git.
+
+CI scan completed successfully.
+  Found 1 finding (1 blocking) from 1 rule.
+  Uploading scan results
+  Finalizing scan           View results in Semgrep Cloud Platform:
+    https://semgrep.dev/orgs/org_name/findings
+    https://semgrep.dev/orgs/org_name/supply-chain
+  Has findings for blocking rules so exiting with code 1
+  semgrep.dev is suggesting a non-zero exit code <MASKED>
+
+=== end of stderr - plain

--- a/cli/tests/e2e/snapshots/test_ci/test_existing_supply_chain_finding/new_output.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_existing_supply_chain_finding/new_output.txt
@@ -8,19 +8,6 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
 
 === stdout - plain
 
-
-┌──────────────────────────────────┐
-│ 1 Reachable Supply Chain Finding │
-└──────────────────────────────────┘
-
-    poetry.lock
-       supply-chain1
-          found a dependency
-
-           17┆ [[package]]
-           18┆ name = "mypy"
-
-
 === end of stdout - plain
 
 === stderr - plain
@@ -77,12 +64,12 @@ Some files were skipped or only partially analyzed.
   Scan was limited to files changed since baseline commit.
 
 CI scan completed successfully.
-  Found 1 finding (1 blocking) from 1 rule.
+  Found 0 findings (0 blocking) from 1 rule.
   Uploading scan results
   Finalizing scan           View results in Semgrep Cloud Platform:
     https://semgrep.dev/orgs/org_name/findings
     https://semgrep.dev/orgs/org_name/supply-chain
-  Has findings for blocking rules so exiting with code 1
+  No blocking findings so exiting with code 0
   semgrep.dev is suggesting a non-zero exit code <MASKED>
 
 === end of stderr - plain

--- a/cli/tests/e2e/snapshots/test_ci/test_existing_supply_chain_finding/new_output.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_existing_supply_chain_finding/new_output.txt
@@ -1,0 +1,88 @@
+=== command
+SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERSION_CACHE_PATH="<MASKED>" SEMGREP_ENABLE_VERSION_CHECK="0" SEMGREP_SEND_METRICS="off" semgrep ci --no-suppress-errors --baseline-commit <MASKED>
+=== end of command
+
+=== exit code
+1
+=== end of exit code
+
+=== stdout - plain
+
+
+┌──────────────────────────────────┐
+│ 1 Reachable Supply Chain Finding │
+└──────────────────────────────────┘
+
+    poetry.lock
+       supply-chain1
+          found a dependency
+
+           17┆ [[package]]
+           18┆ name = "mypy"
+
+
+=== end of stdout - plain
+
+=== stderr - plain
+
+
+┌────────────────┐
+│ Debugging Info │
+└────────────────┘
+
+  SCAN ENVIRONMENT
+  versions    - semgrep <MASKED> on python <MASKED>
+  environment - running in environment git, triggering event is unknown
+
+  CONNECTION
+  Reporting start of scan for deployment_name
+  Fetching configuration from Semgrep Cloud Platform
+
+┌─────────────┐
+│ Scan Status │
+└─────────────┘
+  Scanning 1 file tracked by git with 0 Code rules, 1 Supply Chain rule:
+
+
+  CODE RULES
+  Nothing to scan.
+
+  SUPPLY CHAIN RULES
+  Nothing to scan.
+  Current version has 1 finding.
+
+Creating git worktree from '<MASKED>' to scan baseline.
+  Will report findings introduced by these commits (may be incomplete for shallow checkouts):
+    * <MASKED> add lockfile
+
+
+
+┌─────────────┐
+│ Scan Status │
+└─────────────┘
+  Scanning 1 file tracked by git with 0 Code rules, 1 Supply Chain rule:
+
+
+  CODE RULES
+  Nothing to scan.
+
+  SUPPLY CHAIN RULES
+  Nothing to scan.
+
+
+┌──────────────┐
+│ Scan Summary │
+└──────────────┘
+Some files were skipped or only partially analyzed.
+  Scan was limited to files changed since baseline commit.
+
+CI scan completed successfully.
+  Found 1 finding (1 blocking) from 1 rule.
+  Uploading scan results
+  Finalizing scan           View results in Semgrep Cloud Platform:
+    https://semgrep.dev/orgs/org_name/findings
+    https://semgrep.dev/orgs/org_name/supply-chain
+  Has findings for blocking rules so exiting with code 1
+  semgrep.dev is suggesting a non-zero exit code <MASKED>
+
+=== end of stderr - plain

--- a/cli/tests/e2e/test_ci.py
+++ b/cli/tests/e2e/test_ci.py
@@ -176,6 +176,16 @@ def git_tmp_path_with_commit(monkeypatch, tmp_path, mocker):
     subprocess.run(["git", "pull", "origin"])
     subprocess.run(["git", "checkout", f"{MAIN_BRANCH_NAME}"])
     subprocess.run(["git", "checkout", f"{BRANCH_NAME}"])
+    subprocess.run(
+        ["git", "config", "user.email", AUTHOR_EMAIL],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", AUTHOR_NAME],
+        check=True,
+        capture_output=True,
+    )
 
     yield (repo_copy_base, base_commit, head_commit)
 


### PR DESCRIPTION
lockfile parsing was caching based only on file name which was resulting in the lockfile being cached even between baseline and head scans. When changes were added above an existing vulnerability this would cause match_based_id to access the wrong lines (everything will be off by new additions or deletions) which caused deduplication logic to be incorrect

This PR adds a test to catch this case and also caches the parsing on both filename and last update time of the file.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
