### PR TITLE
implement pcre_names_stub

### DIFF
--- a/js/engine/tests/__snapshots__/index.test.js.snap
+++ b/js/engine/tests/__snapshots__/index.test.js.snap
@@ -1,0 +1,201 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`yaml parser parses a pattern with pattern-regex 1`] = `
+{
+  "engine_requested": "OSS",
+  "errors": [],
+  "explanations": [
+    {
+      "children": [],
+      "loc": {
+        "end": {
+          "col": 30,
+          "line": 6,
+          "offset": 99,
+        },
+        "path": "test-rule-yaml.json",
+        "start": {
+          "col": 24,
+          "line": 6,
+          "offset": 93,
+        },
+      },
+      "matches": [
+        {
+          "extra": {
+            "engine_kind": "OSS",
+            "message": "test",
+            "metavars": {},
+          },
+          "location": {
+            "end": {
+              "col": 4,
+              "line": 1,
+              "offset": 3,
+            },
+            "path": "test.yaml",
+            "start": {
+              "col": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "rule_id": "test",
+        },
+      ],
+      "op": [
+        "XPat",
+        "^fo+",
+      ],
+    },
+  ],
+  "matches": [
+    {
+      "extra": {
+        "engine_kind": "OSS",
+        "message": "test",
+        "metavars": {},
+      },
+      "location": {
+        "end": {
+          "col": 4,
+          "line": 1,
+          "offset": 3,
+        },
+        "path": "test.yaml",
+        "start": {
+          "col": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "rule_id": "test",
+    },
+  ],
+  "rules_by_engine": [
+    [
+      "test",
+      "OSS",
+    ],
+  ],
+  "skipped_rules": [],
+  "stats": {
+    "errorfiles": 0,
+    "okfiles": 1,
+  },
+}
+`;
+
+exports[`yaml parser parses a simple pattern 1`] = `
+{
+  "engine_requested": "OSS",
+  "errors": [],
+  "explanations": [
+    {
+      "children": [],
+      "loc": {
+        "end": {
+          "col": 27,
+          "line": 6,
+          "offset": 96,
+        },
+        "path": "test-rule-yaml.json",
+        "start": {
+          "col": 18,
+          "line": 6,
+          "offset": 87,
+        },
+      },
+      "matches": [
+        {
+          "extra": {
+            "engine_kind": "OSS",
+            "message": "test",
+            "metavars": {
+              "$X": {
+                "abstract_content": "bar",
+                "end": {
+                  "col": 9,
+                  "line": 1,
+                  "offset": 8,
+                },
+                "start": {
+                  "col": 6,
+                  "line": 1,
+                  "offset": 5,
+                },
+              },
+            },
+          },
+          "location": {
+            "end": {
+              "col": 9,
+              "line": 1,
+              "offset": 8,
+            },
+            "path": "test.yaml",
+            "start": {
+              "col": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "rule_id": "test",
+        },
+      ],
+      "op": [
+        "XPat",
+        "foo: $X",
+      ],
+    },
+  ],
+  "matches": [
+    {
+      "extra": {
+        "engine_kind": "OSS",
+        "message": "test",
+        "metavars": {
+          "$X": {
+            "abstract_content": "bar",
+            "end": {
+              "col": 9,
+              "line": 1,
+              "offset": 8,
+            },
+            "start": {
+              "col": 6,
+              "line": 1,
+              "offset": 5,
+            },
+          },
+        },
+      },
+      "location": {
+        "end": {
+          "col": 9,
+          "line": 1,
+          "offset": 8,
+        },
+        "path": "test.yaml",
+        "start": {
+          "col": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "rule_id": "test",
+    },
+  ],
+  "rules_by_engine": [
+    [
+      "test",
+      "OSS",
+    ],
+  ],
+  "skipped_rules": [],
+  "stats": {
+    "errorfiles": 0,
+    "okfiles": 1,
+  },
+}
+`;

--- a/js/engine/tests/index.test.js
+++ b/js/engine/tests/index.test.js
@@ -1,3 +1,5 @@
+const path = require("path");
+
 const { EngineFactory } = require("../dist/index.cjs");
 
 const enginePromise = EngineFactory("./dist/semgrep-engine.wasm");
@@ -24,39 +26,39 @@ describe("engine", () => {
     );
     expect(engine.isMissingLanguages()).toBe(true);
     expect(engine.getMissingLanguages()).toEqual(["python"]);
+
     engine.clearMissingLanguages();
     expect(engine.isMissingLanguages()).toBe(false);
   });
 });
 
 describe("yaml parser", () => {
-  test("parses a pattern", async () => {
+  test("parses a simple pattern", async () => {
     const engine = await enginePromise;
+    const rulePath = path.resolve(`${__dirname}/test-rule-yaml.json`);
+    const targetPath = path.resolve(`${__dirname}/test.yaml`);
+
     const result = JSON.parse(
-      engine.execute(
-        "yaml",
-        `${__dirname}/test-rule-yaml.json`,
-        `${__dirname}/test.yaml`
-      )
+      engine
+        .execute("yaml", rulePath, targetPath)
+        .replaceAll(rulePath, "test-rule-yaml.json")
+        .replaceAll(targetPath, "test.yaml")
     );
 
-    // it took a lot of work to get libyaml working, so let's confirm start/end locations are correct
-    expect(result.stats.okfiles).toBe(1);
-    expect(result.matches.length).toBe(1);
-    expect(result.explanations.length).toBe(1);
-    const match = result.matches[0];
-    expect(match.location.start).toEqual(
-      expect.objectContaining({ offset: 0, line: 1, col: 1 })
+    expect(result).toMatchSnapshot();
+  });
+  test("parses a pattern with pattern-regex", async () => {
+    const engine = await enginePromise;
+    const rulePath = path.resolve(`${__dirname}/test-rule-yaml-regex.json`);
+    const targetPath = path.resolve(`${__dirname}/test.yaml`);
+
+    const result = JSON.parse(
+      engine
+        .execute("yaml", rulePath, targetPath)
+        .replaceAll(rulePath, "test-rule-yaml.json")
+        .replaceAll(targetPath, "test.yaml")
     );
-    expect(match.location.end).toEqual(
-      expect.objectContaining({ offset: 8, line: 1, col: 9 })
-    );
-    expect(match.extra.metavars["$X"].start).toEqual(
-      expect.objectContaining({ offset: 5, line: 1, col: 6 })
-    );
-    expect(match.extra.metavars["$X"].end).toEqual(
-      expect.objectContaining({ offset: 8, line: 1, col: 9 })
-    );
-    expect(match.extra.metavars["$X"].abstract_content).toEqual("bar");
+
+    expect(result).toMatchSnapshot();
   });
 });

--- a/js/engine/tests/test-rule-yaml-regex.json
+++ b/js/engine/tests/test-rule-yaml-regex.json
@@ -1,0 +1,11 @@
+{
+  "rules": [
+    {
+      "id": "test",
+      "languages": ["yaml"],
+      "pattern-regex": "^fo+",
+      "message": "test",
+      "severity": "ERROR"
+    }
+  ]
+}

--- a/js/engine/tests/test.yaml
+++ b/js/engine/tests/test.yaml
@@ -1,1 +1,2 @@
 foo: bar
+boo: baz


### PR DESCRIPTION
semgrep.js was failing to evaluate rules that contained regexes because we started doing stuff with capture group names at some point. This PR wires up that missing piece

test plan:
- add test for regex
- checks and tests pass

/cc @LewisArdern 