### PR TITLE
Added test annotation

### DIFF
--- a/cli/tests/unit/test_rule_match.py
+++ b/cli/tests/unit/test_rule_match.py
@@ -441,6 +441,7 @@ def create_sca_rule_match(sca_kind, reachable_in_code, transitivity):
     )
 
 
+@pytest.mark.quick
 def test_supply_chain_blocking():
     assert create_sca_rule_match("reachable", True, out.Direct()).is_blocking
     assert create_sca_rule_match("reachable", True, out.Transitive()).is_blocking


### PR DESCRIPTION
Updated an existing test from the addition of PR Blocking Functionality that was missing a test annotation. Determined the annotation via local testing

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
