### PR TITLE
appease circleci by checking out semgrep repo to a different folder

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
     docker:
       - image: returntocorp/semgrep:develop
         user: root
-    working_directory: /src
+    working_directory: /circleci
     steps:
       - checkout
       # Dogfooding on the bleeding edge by using jsonnet, the new syntax, osemgrep!


### PR DESCRIPTION
We're getting `fatal: detected dubious ownership in repository at '/src'` errors in our CircleCI run because of conflicting file permissions when it attempts to mount `/src`. I'm not sure if we want to mark `/src` as safe, so the easy fix for now is to tell CircleCI to check out the repository somewhere else.

test plan:
- checks pass
