### PR TITLE
feat(osemgrep): Add support for pro engine in osemgrep via hook

### DIFF
--- a/src/osemgrep/cli_scan/Core_runner.ml
+++ b/src/osemgrep/cli_scan/Core_runner.ml
@@ -53,7 +53,8 @@ type result = {
   *)
 }
 
-(* function *)
+(* Type for the core runner function, which can either be invoked by
+   invoke_semgrep_core or invoke_semgrep_core_proprietary *)
 
 type semgrep_core_runner =
   ?respect_git_ignore:bool ->

--- a/src/osemgrep/cli_scan/Core_runner.ml
+++ b/src/osemgrep/cli_scan/Core_runner.ml
@@ -53,6 +53,19 @@ type result = {
   *)
 }
 
+(* function *)
+
+type semgrep_core_runner =
+  ?respect_git_ignore:bool ->
+  ?file_match_results_hook:
+    (Fpath.t -> Report.partial_profiling Report.match_result -> unit) option ->
+  conf ->
+  (* LATER? use Config_resolve.rules_and_origin instead? *)
+  Rule.rules ->
+  Rule.invalid_rule_error list ->
+  Fpath.t list ->
+  result
+
 (*************************************************************************)
 (* Helpers *)
 (*************************************************************************)
@@ -180,10 +193,11 @@ let prepare_config_for_semgrep_core (config : Runner_config.t)
 (*
    Take in rules and targets and return object with findings.
 *)
-let invoke_semgrep_core ?(respect_git_ignore = true)
-    ?(file_match_results_hook = None) (conf : conf) (all_rules : Rule.t list)
-    (rule_errors : Rule.invalid_rule_error list) (all_targets : Fpath.t list) :
-    result =
+let invoke_semgrep_core
+    ?(engine = Run_semgrep.semgrep_with_raw_results_and_exn_handler)
+    ?(respect_git_ignore = true) ?(file_match_results_hook = None) (conf : conf)
+    (all_rules : Rule.t list) (rule_errors : Rule.invalid_rule_error list)
+    (all_targets : Fpath.t list) : result =
   let config : Runner_config.t = runner_config_of_conf conf in
   let config = { config with file_match_results_hook } in
 
@@ -247,9 +261,7 @@ let invoke_semgrep_core ?(respect_git_ignore = true)
       let config = prepare_config_for_semgrep_core config lang_jobs in
 
       (* !!!!Finally! this is where we branch to semgrep-core!!! *)
-      let _exn_opt_TODO, res, files =
-        Run_semgrep.semgrep_with_raw_results_and_exn_handler config
-      in
+      let _exn_opt_TODO, res, files = engine config in
 
       let scanned = Set_.of_list files in
 

--- a/src/osemgrep/cli_scan/Core_runner.mli
+++ b/src/osemgrep/cli_scan/Core_runner.mli
@@ -17,14 +17,7 @@ type result = {
   scanned : Fpath.t Set_.t;
 }
 
-(*
-   This calls the semgrep-core command like the Python implementation used
-   to, but without creating a subprocess.
-
-   LATER: This function should go away, eventually, with some parts being
-   integrated into what's currently semgrep-core.
-*)
-val invoke_semgrep_core :
+type semgrep_core_runner =
   ?respect_git_ignore:bool ->
   ?file_match_results_hook:
     (Fpath.t -> Report.partial_profiling Report.match_result -> unit) option ->
@@ -34,6 +27,16 @@ val invoke_semgrep_core :
   Rule.invalid_rule_error list ->
   Fpath.t list ->
   result
+
+(*
+   This calls the semgrep-core command like the Python implementation used
+   to, but without creating a subprocess.
+
+   LATER: This function should go away, eventually, with some parts being
+   integrated into what's currently semgrep-core.
+*)
+val invoke_semgrep_core :
+  ?engine:Runner_config.semgrep_engine -> semgrep_core_runner
 
 (* Helper used in Semgrep_scan.ml to setup logging *)
 val runner_config_of_conf : conf -> Runner_config.t

--- a/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -47,6 +47,8 @@ type conf = {
   rewrite_rule_ids : bool;
   time_flag : bool;
   profile : bool;
+  (* Engine selection *)
+  engine_type : Engine_type.t;
   (* osemgrep-only: whether to keep pysemgrep behavior/limitations/errors *)
   legacy : bool;
   (* osemgrep-only: currently to explicitely choose osemgrep over pysemgrep.
@@ -129,6 +131,7 @@ let default : conf =
     strict = false;
     profile = false;
     time_flag = false;
+    engine_type = (`OSS, None);
     (* ultimately should be set to true when we release osemgrep *)
     legacy = false;
     experimental = false;
@@ -433,6 +436,36 @@ let o_vim : bool Term.t =
   Arg.value (Arg.flag info)
 
 (* ------------------------------------------------------------------ *)
+(* TOPORT "Engine type" (mutually exclusive) *)
+(* ------------------------------------------------------------------ *)
+
+let o_oss : bool Term.t =
+  let info = Arg.info [ "oss" ] ~doc:{|Run with the OSS engine.|} in
+  Arg.value (Arg.flag info)
+
+let o_pro_languages : bool Term.t =
+  let info =
+    Arg.info [ "pro-languages" ]
+      ~doc:
+        {|Run a language only supported by the pro engine without extra analysis features.|}
+  in
+  Arg.value (Arg.flag info)
+
+let o_pro_intrafile : bool Term.t =
+  let info =
+    Arg.info [ "pro-intrafile" ]
+      ~doc:{|Run with intrafile cross-function analysis.|}
+  in
+  Arg.value (Arg.flag info)
+
+let o_pro : bool Term.t =
+  let info =
+    Arg.info [ "pro" ]
+      ~doc:{|Run with all pro engine features including cross-file analysis.|}
+  in
+  Arg.value (Arg.flag info)
+
+(* ------------------------------------------------------------------ *)
 (* TOPORT "Configuration options" *)
 (* ------------------------------------------------------------------ *)
 let o_config : string list Term.t =
@@ -661,11 +694,11 @@ let cmdline_term ~allow_empty_config : conf Term.t =
       dump_config emacs error exclude exclude_rule_ids experimental force_color
       include_ json lang legacy logging_level max_chars_per_line
       max_lines_per_finding max_memory_mb max_target_bytes metrics num_jobs
-      nosem optimizations pattern profile project_root registry_caching
-      replacement respect_git_ignore rewrite_rule_ids scan_unknown_extensions
-      severity show_supported_languages strict target_roots test
-      test_ignore_todo time_flag timeout timeout_threshold validate version
-      version_check vim =
+      nosem optimizations oss pattern pro profile project_root pro_intrafile
+      pro_lang registry_caching replacement respect_git_ignore rewrite_rule_ids
+      scan_unknown_extensions severity show_supported_languages strict
+      target_roots test test_ignore_todo time_flag timeout timeout_threshold
+      validate version version_check vim =
     (* ugly: call setup_logging ASAP so the Logs.xxx below are displayed
      * correctly *)
     Logs_helpers.setup_logging ~force_color ~level:logging_level;
@@ -693,6 +726,19 @@ let cmdline_term ~allow_empty_config : conf Term.t =
       | _else_ ->
           (* TOPORT: list the possibilities *)
           Error.abort "Mutually exclusive options --json/--emacs/--vim"
+    in
+    let engine_type =
+      match (oss, pro_lang, pro_intrafile, pro) with
+      | false, false, false, false -> default.engine_type
+      | true, false, false, false -> (`OSS, None)
+      | false, true, false, false -> (`PRO, Some Engine_type.Language_only)
+      | false, false, true, false -> (`PRO, Some Engine_type.Intrafile)
+      | false, false, false, true -> (`PRO, Some Engine_type.Interfile)
+      | _else_ ->
+          (* TOPORT: list the possibilities *)
+          Error.abort
+            "Mutually exclusive options \
+             --oss/--pro-languages/--pro-intrafile/--pro"
     in
     let rules_source =
       match (config, (pattern, lang, replacement)) with
@@ -901,6 +947,7 @@ let cmdline_term ~allow_empty_config : conf Term.t =
       registry_caching;
       version_check;
       output_format;
+      engine_type;
       profile;
       rewrite_rule_ids;
       strict;
@@ -925,8 +972,9 @@ let cmdline_term ~allow_empty_config : conf Term.t =
     $ o_exclude_rule_ids $ CLI_common.o_experimental $ o_force_color $ o_include
     $ o_json $ o_lang $ o_legacy $ CLI_common.o_logging $ o_max_chars_per_line
     $ o_max_lines_per_finding $ o_max_memory_mb $ o_max_target_bytes $ o_metrics
-    $ o_num_jobs $ o_nosem $ o_optimizations $ o_pattern $ CLI_common.o_profile
-    $ o_project_root $ o_registry_caching $ o_replacement $ o_respect_git_ignore
+    $ o_num_jobs $ o_nosem $ o_optimizations $ o_oss $ o_pattern $ o_pro
+    $ CLI_common.o_profile $ o_project_root $ o_pro_intrafile $ o_pro_languages
+    $ o_registry_caching $ o_replacement $ o_respect_git_ignore
     $ o_rewrite_rule_ids $ o_scan_unknown_extensions $ o_severity
     $ o_show_supported_languages $ o_strict $ o_target_roots $ o_test
     $ o_test_ignore_todo $ o_time $ o_timeout $ o_timeout_threshold $ o_validate

--- a/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -131,7 +131,7 @@ let default : conf =
     strict = false;
     profile = false;
     time_flag = false;
-    engine_type = (`OSS, None);
+    engine_type = OSS;
     (* ultimately should be set to true when we release osemgrep *)
     legacy = false;
     experimental = false;
@@ -730,10 +730,10 @@ let cmdline_term ~allow_empty_config : conf Term.t =
     let engine_type =
       match (oss, pro_lang, pro_intrafile, pro) with
       | false, false, false, false -> default.engine_type
-      | true, false, false, false -> (`OSS, None)
-      | false, true, false, false -> (`PRO, Some Engine_type.Language_only)
-      | false, false, true, false -> (`PRO, Some Engine_type.Intrafile)
-      | false, false, false, true -> (`PRO, Some Engine_type.Interfile)
+      | true, false, false, false -> OSS
+      | false, true, false, false -> PRO Engine_type.Language_only
+      | false, false, true, false -> PRO Engine_type.Intrafile
+      | false, false, false, true -> PRO Engine_type.Interfile
       | _else_ ->
           (* TOPORT: list the possibilities *)
           Error.abort

--- a/src/osemgrep/cli_scan/Scan_CLI.mli
+++ b/src/osemgrep/cli_scan/Scan_CLI.mli
@@ -23,6 +23,7 @@ type conf = {
   rewrite_rule_ids : bool;
   time_flag : bool;
   profile : bool;
+  engine_type : Engine_type.t;
   (* osemgrep-only: whether to keep pysemgrep behavior/limitations/errors *)
   legacy : bool;
   (* osemgrep-only: currently to explicitely choose osemgrep over pysemgrep *)

--- a/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -184,8 +184,6 @@ let rules_and_counted_matches (res : Core_runner.result) : (Rule.t * int) list =
 (* Conduct the scan *)
 (*****************************************************************************)
 
-type errors = Out.core_error list [@@deriving show]
-
 let scan_files rules_and_origins profiler (conf : Scan_CLI.conf) =
   let rules, errors =
     Rule_fetching.partition_rules_and_errors rules_and_origins
@@ -264,7 +262,6 @@ let scan_files rules_and_origins profiler (conf : Scan_CLI.conf) =
     Metrics_.add_errors res.core.errors;
 
     (* step4: report matches *)
-    Common.pr2 (show_errors res.core.errors);
     let errors_skipped = errors_to_skipped res.core.errors in
     let semgrepignored, included, excluded, size, other_ignored =
       analyze_skipped semgrepignored_targets

--- a/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -228,10 +228,10 @@ let scan_files rules_and_origins profiler (conf : Scan_CLI.conf) =
     let core () =
       let invoke_semgrep_core =
         match conf.engine_type with
-        | `OSS, _ ->
+        | OSS ->
             Core_runner.invoke_semgrep_core
               ~engine:Run_semgrep.semgrep_with_raw_results_and_exn_handler
-        | `PRO, _ -> (
+        | PRO _ -> (
             match !invoke_semgrep_core_proprietary with
             | None ->
                 (* TODO: improve this error message depending on what the instructions should be *)

--- a/src/osemgrep/cli_scan/Scan_subcommand.mli
+++ b/src/osemgrep/cli_scan/Scan_subcommand.mli
@@ -1,3 +1,9 @@
+(* Semgrep Pro hook *)
+(* TODO it might be better to pass this through and avoid the hook,
+   but it was fairly annoying to *)
+val invoke_semgrep_core_proprietary :
+  (Fpath.t list -> Engine_type.t -> Core_runner.semgrep_core_runner) option ref
+
 (*
    Parse a semgrep-scan command, execute it and exit.
 

--- a/src/osemgrep/configuring/Engine_type.ml
+++ b/src/osemgrep/configuring/Engine_type.ml
@@ -2,4 +2,4 @@ module Out = Semgrep_output_v1_t
 
 (* TODO it would be better for this also to be in the atd *)
 type pro_flavor = Language_only | Intrafile | Interfile [@@deriving show]
-type t = Out.engine_kind * pro_flavor option [@@deriving show]
+type t = OSS | PRO of pro_flavor [@@deriving show]

--- a/src/osemgrep/configuring/Engine_type.ml
+++ b/src/osemgrep/configuring/Engine_type.ml
@@ -1,0 +1,5 @@
+module Out = Semgrep_output_v1_t
+
+(* TODO it would be better for this also to be in the atd *)
+type pro_flavor = Language_only | Intrafile | Interfile [@@deriving show]
+type t = Out.engine_kind * pro_flavor option [@@deriving show]

--- a/src/runner/Runner_config.ml
+++ b/src/runner/Runner_config.ml
@@ -74,8 +74,16 @@ type t = {
 }
 [@@deriving show]
 
+(* The type of the semgrep core runner. We define it here so that
+   semgrep and semgrep-proprietary use the same definition *)
 type semgrep_engine =
-  t -> Exception.t option * Report.final_result * Fpath.t list
+  t ->
+  (* Exceptions raised *)
+  Exception.t option
+  * (* Result *)
+    Report.final_result
+  * (* The processed targets *)
+  Fpath.t list
 
 (*
    Default values for all the semgrep-core command-line arguments and options.

--- a/src/runner/Runner_config.ml
+++ b/src/runner/Runner_config.ml
@@ -74,6 +74,9 @@ type t = {
 }
 [@@deriving show]
 
+type semgrep_engine =
+  t -> Exception.t option * Report.final_result * Fpath.t list
+
 (*
    Default values for all the semgrep-core command-line arguments and options.
 


### PR DESCRIPTION
Osemgrep currently only allows users to run with the OSS engine. This PR adds in the `pro`, `pro-intrafile`, `pro-languages`, and `oss` flags and adjusts behavior depending on the flag. The first three flags only work when run with the binary built with semgrep-proprietary.

Test plan: see PR in semgrep-proprietary

PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
