### PR TITLE
fix(docker): Workaround for rootless containers as git operations may fail due to dubious ownership of /src

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -191,8 +191,8 @@ RUN addgroup --system semgrep \
 #USER semgrep
 
 # Workaround for rootless containers as git operations may fail due to dubious ownership of /src
-RUN echo -e "[safe]\n	directory = /src"  > ~root/.gitconfig
-RUN echo -e "[safe]\n	directory = /src"  > ~semgrep/.gitconfig && \
+RUN printf "[safe]\n	directory = /src"  > ~root/.gitconfig
+RUN printf "[safe]\n	directory = /src"  > ~semgrep/.gitconfig && \
 	chown semgrep:semgrep ~semgrep/.gitconfig
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -190,6 +190,12 @@ RUN addgroup --system semgrep \
 # We can set it by default once we fix the circle ci workflows
 #USER semgrep
 
+# Workaround for rootless containers as git operations may fail due to dubious ownership of /src
+RUN echo -e "[safe]\n	directory = /src"  > ~root/.gitconfig
+RUN echo -e "[safe]\n	directory = /src"  > ~semgrep/.gitconfig && \
+	chown semgrep:semgrep ~semgrep/.gitconfig
+
+
 # In case of problems, if you need to debug the docker image, run 'docker build .',
 # identify the SHA of the build image and run 'docker run -it <sha> /bin/bash'
 # to interactively explore the docker image.

--- a/changelog.d/gh-8267.fixed
+++ b/changelog.d/gh-8267.fixed
@@ -1,0 +1,1 @@
+Workaround for rootless containers as git operations may fail due to dubious ownership of /src


### PR DESCRIPTION
PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
