### PR TITLE
Add rule option to enable interfile analysis

### DIFF
--- a/changelog.d/pro-94.added
+++ b/changelog.d/pro-94.added
@@ -1,0 +1,3 @@
+Added rule option `interfile: true`, so this can be set under `options:` as it
+is the norm for rule options. This rule option shall replace setting `interfile`
+under `metadata`. Metadata is not mean to have any effect on how a rule is run.

--- a/interfaces/Rule_options.atd
+++ b/interfaces/Rule_options.atd
@@ -150,6 +150,9 @@ type t = {
   (* Preprocess comments away to facilitate matching with spacegrep. *)
   ?generic_comment_style: generic_comment_style option;
 
+  (* Whether a rule should be considered for interfile analysis. *)
+  ~interfile <ocaml default="false"> : bool;
+
   (* TODO: equivalences:
    *   - require_to_import (but need pass config to Js_to_generic)
    *)


### PR DESCRIPTION
This shall replace

    metadata:
      interfile: true

test plan:
See returntocorp/semgrep-proprietary#838

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
