### PR TITLE
bump semgrep-interfaces for finding.severity

### DIFF
--- a/src/osemgrep/cli_ci/Ci_subcommand.ml
+++ b/src/osemgrep/cli_ci/Ci_subcommand.ml
@@ -170,10 +170,10 @@ let partition_findings ~keep_ignored (results : Out.cli_match list) =
 
 (* from rule_match.py *)
 let severity_to_int = function
-  | "EXPERIMENT" -> 4
-  | "WARNING" -> 1
-  | "ERROR" -> 2
-  | _ -> 0
+  | "EXPERIMENT" -> `Int 4
+  | "WARNING" -> `Int 1
+  | "ERROR" -> `Int 2
+  | _ -> `Int 0
 
 let finding_of_cli_match _commit_date index (m : Out.cli_match) : Out.finding =
   let (r : Out.finding) =


### PR DESCRIPTION
Test plan: run a scan end to end and verify that serialization of severity stays as an int.

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
