### PR TITLE
Remove duplicate extension to language test

### DIFF
--- a/cli/tests/consistency/test_lang_consistency.py
+++ b/cli/tests/consistency/test_lang_consistency.py
@@ -14,18 +14,3 @@ def test_no_duplicate_keys() -> None:
             if k in keys:
                 raise Exception(f"Duplicate language key {k}")
             keys.add(k)
-
-
-@pytest.mark.quick
-def test_no_duplicate_reverse_exts() -> None:
-    """
-    Ensures one-to-one assumption of mapping from reverse file extensions to language in lang.json
-    """
-    exts = set()
-    for d in LANGUAGE.definition_by_id.values():
-        for e in d.reverse_exts:
-            if e in exts:
-                raise Exception(
-                    f"Duplicate reverse extension {e} in lang.json occurring in language {d.id}"
-                )
-            exts.add(e)


### PR DESCRIPTION
Extensions can be part of multiple languages, for example `.h` with `c` and `cpp` or `.pl` for `perl` and `prolog`.

PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
