### PR TITLE
fix: [ci] release workflow non-functional

### DIFF
--- a/.github/workflows/build-test-manylinux-aarch64.yaml
+++ b/.github/workflows/build-test-manylinux-aarch64.yaml
@@ -3,6 +3,13 @@ name: build-test-manylinux-aarch64
 on:
   workflow_dispatch:
   workflow_call:
+    outputs:
+      wheel-artifact-name:
+        description: "The name under which the wheel artifact was stored"
+        value: ${{ jobs.build-wheel.outputs.wheel-artifact-name }}
+
+env:
+  WHEEL_ARTIFACT_NAME: manylinux-aarch64-wheel
 
 jobs:
   build-wheel:
@@ -11,6 +18,8 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    outputs:
+      wheel-artifact-name: ${{ steps.wheel-artifact-name.outputs.wheel-artifact-name }}
     steps:
       - uses: docker/setup-qemu-action@v2
       - uses: docker/setup-buildx-action@v2
@@ -30,5 +39,9 @@ jobs:
           docker run --platform linux/arm64 --rm ${{ steps.build-semgrep-wheel.outputs.imageid }} zip -r - dist > /tmp/dist.zip
       - uses: actions/upload-artifact@v3
         with:
-          name: manylinux-wheel-aarch64
+          name: "${{ env.WHEEL_ARTIFACT_NAME }}"
           path: /tmp/dist.zip
+      - name: Set Wheel Name Output
+        id: wheel-artifact-name
+        run: |
+          echo "wheel-artifact-name=${WHEEL_ARTIFACT_NAME}" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-test-manylinux-aarch64.yaml
+++ b/.github/workflows/build-test-manylinux-aarch64.yaml
@@ -3,13 +3,6 @@ name: build-test-manylinux-aarch64
 on:
   workflow_dispatch:
   workflow_call:
-    outputs:
-      wheel-artifact-name:
-        description: "The name under which the wheel artifact was stored"
-        value: ${{ jobs.build-wheel.outputs.wheel-artifact-name }}
-
-env:
-  WHEEL_ARTIFACT_NAME: manylinux-aarch64-wheel
 
 jobs:
   build-wheel:
@@ -18,8 +11,6 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    outputs:
-      wheel-artifact-name: ${{ steps.wheel-artifact-name.outputs.wheel-artifact-name }}
     steps:
       - uses: docker/setup-qemu-action@v2
       - uses: docker/setup-buildx-action@v2
@@ -39,9 +30,5 @@ jobs:
           docker run --platform linux/arm64 --rm ${{ steps.build-semgrep-wheel.outputs.imageid }} zip -r - dist > /tmp/dist.zip
       - uses: actions/upload-artifact@v3
         with:
-          name: "${{ env.WHEEL_ARTIFACT_NAME }}"
+          name: manylinux-aarch64-wheel
           path: /tmp/dist.zip
-      - name: Set Wheel Name Output
-        id: wheel-artifact-name
-        run: |
-          echo "wheel-artifact-name=${WHEEL_ARTIFACT_NAME}" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-test-manylinux-x86.yaml
+++ b/.github/workflows/build-test-manylinux-x86.yaml
@@ -5,12 +5,21 @@ name: build-test-manylinux-x86
 on:
   workflow_dispatch:
   workflow_call:
+    outputs:
+      wheel-artifact-name:
+        description: "The name under which the wheel artifact was stored"
+        value: ${{ jobs.build-wheels-manylinux.outputs.wheel-artifact-name }}
+
+env:
+  WHEEL_ARTIFACT_NAME: manylinux-x86-wheel
 
 jobs:
   build-wheels-manylinux:
     runs-on: ubuntu-latest
     #pad: What is this sgrep-xxx image?
     container: returntocorp/sgrep-build:ubuntu-16.04
+    outputs:
+      wheel-artifact-name: ${{ steps.wheel-artifact-name.outputs.wheel-artifact-name }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -30,8 +39,12 @@ jobs:
           ./scripts/build-wheels.sh
       - uses: actions/upload-artifact@v3
         with:
-          name: manylinux-wheel
+          name: "${{ env.WHEEL_ARTIFACT_NAME }}"
           path: cli/dist.zip
+      - name: Set Wheel Name Output
+        id: wheel-artifact-name
+        run: |
+          echo "wheel-artifact-name=${WHEEL_ARTIFACT_NAME}" >> $GITHUB_OUTPUT
 
   test-wheels-manylinux:
     runs-on: ubuntu-latest
@@ -40,8 +53,8 @@ jobs:
     steps:
       - uses: actions/download-artifact@v1
         with:
-          name: manylinux-wheel
-      - run: unzip ./manylinux-wheel/dist.zip
+          name: "${{ env.WHEEL_ARTIFACT_NAME }}"
+      - run: unzip "./${{ env.WHEEL_ARTIFACT_NAME }}/dist.zip"
       - name: install package
         run: /opt/python/cp37-cp37m/bin/pip install dist/*.whl
       - name: test package

--- a/.github/workflows/build-test-manylinux-x86.yaml
+++ b/.github/workflows/build-test-manylinux-x86.yaml
@@ -5,21 +5,12 @@ name: build-test-manylinux-x86
 on:
   workflow_dispatch:
   workflow_call:
-    outputs:
-      wheel-artifact-name:
-        description: "The name under which the wheel artifact was stored"
-        value: ${{ jobs.build-wheels-manylinux.outputs.wheel-artifact-name }}
-
-env:
-  WHEEL_ARTIFACT_NAME: manylinux-x86-wheel
 
 jobs:
   build-wheels-manylinux:
     runs-on: ubuntu-latest
     #pad: What is this sgrep-xxx image?
     container: returntocorp/sgrep-build:ubuntu-16.04
-    outputs:
-      wheel-artifact-name: ${{ steps.wheel-artifact-name.outputs.wheel-artifact-name }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -39,12 +30,8 @@ jobs:
           ./scripts/build-wheels.sh
       - uses: actions/upload-artifact@v3
         with:
-          name: "${{ env.WHEEL_ARTIFACT_NAME }}"
+          name: manylinux-x86-wheel
           path: cli/dist.zip
-      - name: Set Wheel Name Output
-        id: wheel-artifact-name
-        run: |
-          echo "wheel-artifact-name=${WHEEL_ARTIFACT_NAME}" >> $GITHUB_OUTPUT
 
   test-wheels-manylinux:
     runs-on: ubuntu-latest
@@ -53,8 +40,8 @@ jobs:
     steps:
       - uses: actions/download-artifact@v1
         with:
-          name: "${{ env.WHEEL_ARTIFACT_NAME }}"
-      - run: unzip "./${{ env.WHEEL_ARTIFACT_NAME }}/dist.zip"
+          name: manylinux-x86-wheel
+      - run: unzip ./manylinux-x86-wheel/dist.zip
       - name: install package
         run: /opt/python/cp37-cp37m/bin/pip install dist/*.whl
       - name: test package

--- a/.github/workflows/build-test-osx-arm64.yaml
+++ b/.github/workflows/build-test-osx-arm64.yaml
@@ -20,13 +20,6 @@ on:
         required: false
         type: boolean
         default: true
-    outputs:
-      wheel-artifact-name:
-        description: "The name under which the wheel artifact was stored"
-        value: ${{ jobs.build-wheels-osx-arm64.outputs.wheel-artifact-name }}
-
-env:
-  WHEEL_ARTIFACT_NAME: osx-arm64-wheel
 
 jobs:
   build-core-osx-arm64:
@@ -86,8 +79,6 @@ jobs:
         "ghcr.io/cirruslabs/macos-monterey-base:latest",
       ]
     needs: [build-core-osx-arm64]
-    outputs:
-      wheel-artifact-name: ${{ steps.wheel-artifact-name.outputs.wheel-artifact-name }}
     steps:
       - name: Setup runner directory
         run: |
@@ -111,11 +102,7 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           path: cli/dist.zip
-          name: ${{ env.WHEEL_ARTIFACT_NAME }}
-      - name: Set Wheel Name Output
-        id: wheel-artifact-name
-        run: |
-          echo "wheel-artifact-name=${WHEEL_ARTIFACT_NAME}" >> $GITHUB_OUTPUT
+          name: osx-arm64-wheel
 
   test-wheels-osx-arm64:
     runs-on:
@@ -134,11 +121,11 @@ jobs:
           sudo chown -R admin:staff /Users/runner
       - uses: actions/download-artifact@v1
         with:
-          name: ${{ env.WHEEL_ARTIFACT_NAME }}
+          name: osx-arm64-wheel
       - uses: actions/setup-python@v4
         with:
           python-version: "3.11"
-      - run: unzip "./${{ env.WHEEL_ARTIFACT_NAME }}/dist.zip"
+      - run: unzip ./osx-arm64-wheel/dist.zip
       - name: install package
         run: pip3 install dist/*.whl
       - run: semgrep --version

--- a/.github/workflows/build-test-osx-arm64.yaml
+++ b/.github/workflows/build-test-osx-arm64.yaml
@@ -13,10 +13,6 @@ on:
         required: true
         type: boolean
         default: true
-      wheel-artifact-name:
-        description: "The name under which to store the wheel artifact"
-        type: string
-        default: osx-arm64-wheel
   workflow_call:
     inputs:
       use-cache:
@@ -24,13 +20,13 @@ on:
         required: false
         type: boolean
         default: true
+    outputs:
       wheel-artifact-name:
-        description: "The name under which to store the wheel artifact"
-        type: string
-        default: osx-arm64-wheel
+        description: "The name under which the wheel artifact was stored"
+        value: ${{ jobs.build-wheels-osx-arm64.outputs.wheel-artifact-name }}
 
 env:
-  WHEEL_ARTIFACT_NAME: ${{ inputs.wheel-artifact-name }}
+  WHEEL_ARTIFACT_NAME: osx-arm64-wheel
 
 jobs:
   build-core-osx-arm64:
@@ -90,6 +86,8 @@ jobs:
         "ghcr.io/cirruslabs/macos-monterey-base:latest",
       ]
     needs: [build-core-osx-arm64]
+    outputs:
+      wheel-artifact-name: ${{ steps.wheel-artifact-name.outputs.wheel-artifact-name }}
     steps:
       - name: Setup runner directory
         run: |
@@ -114,6 +112,10 @@ jobs:
         with:
           path: cli/dist.zip
           name: ${{ env.WHEEL_ARTIFACT_NAME }}
+      - name: Set Wheel Name Output
+        id: wheel-artifact-name
+        run: |
+          echo "wheel-artifact-name=${WHEEL_ARTIFACT_NAME}" >> $GITHUB_OUTPUT
 
   test-wheels-osx-arm64:
     runs-on:

--- a/.github/workflows/build-test-osx-arm64.yaml
+++ b/.github/workflows/build-test-osx-arm64.yaml
@@ -136,7 +136,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.11"
-      - run: unzip ./osx-arm64-wheel/dist.zip
+      - run: unzip "./${{ env.WHEEL_ARTIFACT_NAME }}/dist.zip"
       - name: install package
         run: pip3 install dist/*.whl
       - run: semgrep --version

--- a/.github/workflows/build-test-osx-arm64.yaml
+++ b/.github/workflows/build-test-osx-arm64.yaml
@@ -13,6 +13,10 @@ on:
         required: true
         type: boolean
         default: true
+      wheel-artifact-name:
+        description: "The name under which to store the wheel artifact"
+        type: string
+        default: osx-arm64-wheel
   workflow_call:
     inputs:
       use-cache:
@@ -20,6 +24,13 @@ on:
         required: false
         type: boolean
         default: true
+      wheel-artifact-name:
+        description: "The name under which to store the wheel artifact"
+        type: string
+        default: osx-arm64-wheel
+
+env:
+  WHEEL_ARTIFACT_NAME: ${{ inputs.wheel-artifact-name }}
 
 jobs:
   build-core-osx-arm64:
@@ -102,7 +113,7 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           path: cli/dist.zip
-          name: osx-arm64-wheel
+          name: ${{ env.WHEEL_ARTIFACT_NAME }}
 
   test-wheels-osx-arm64:
     runs-on:
@@ -121,7 +132,7 @@ jobs:
           sudo chown -R admin:staff /Users/runner
       - uses: actions/download-artifact@v1
         with:
-          name: osx-arm64-wheel
+          name: ${{ env.WHEEL_ARTIFACT_NAME }}
       - uses: actions/setup-python@v4
         with:
           python-version: "3.11"

--- a/.github/workflows/build-test-osx-x86.yaml
+++ b/.github/workflows/build-test-osx-x86.yaml
@@ -48,6 +48,10 @@ on:
         required: true
         type: boolean
         default: true
+      wheel-artifact-name:
+        description: "The name under which to store the wheel artifact"
+        type: string
+        default: osx-x86-wheel
   workflow_call:
     inputs:
       use-cache:
@@ -55,6 +59,13 @@ on:
         required: false
         type: boolean
         default: true
+      wheel-artifact-name:
+        description: "The name under which to store the wheel artifact"
+        type: string
+        default: osx-x86-wheel
+
+env:
+  WHEEL_ARTIFACT_NAME: ${{ inputs.wheel-artifact-name }}
 
 jobs:
   build-core-osx:
@@ -129,7 +140,7 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           path: cli/dist.zip
-          name: osx-wheel
+          name: ${{ env.WHEEL_ARTIFACT_NAME }}
 
   test-wheels-osx-x86:
     runs-on: macos-12
@@ -137,7 +148,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v1
         with:
-          name: osx-wheel
+          name: ${{ env.WHEEL_ARTIFACT_NAME }}
       - run: unzip ./osx-wheel/dist.zip
       - name: install package
         run: pip3 install dist/*.whl

--- a/.github/workflows/build-test-osx-x86.yaml
+++ b/.github/workflows/build-test-osx-x86.yaml
@@ -48,10 +48,6 @@ on:
         required: true
         type: boolean
         default: true
-      wheel-artifact-name:
-        description: "The name under which to store the wheel artifact"
-        type: string
-        default: osx-x86-wheel
   workflow_call:
     inputs:
       use-cache:
@@ -59,13 +55,13 @@ on:
         required: false
         type: boolean
         default: true
+    outputs:
       wheel-artifact-name:
-        description: "The name under which to store the wheel artifact"
-        type: string
-        default: osx-x86-wheel
+        description: "The name under which the wheel artifact was stored"
+        value: ${{ jobs.build-wheels-osx.outputs.wheel-artifact-name }}
 
 env:
-  WHEEL_ARTIFACT_NAME: ${{ inputs.wheel-artifact-name }}
+  WHEEL_ARTIFACT_NAME: osx-x86-wheel
 
 jobs:
   build-core-osx:
@@ -126,6 +122,8 @@ jobs:
   build-wheels-osx:
     runs-on: macos-12
     needs: [build-core-osx]
+    outputs:
+      wheel-artifact-name: ${{ steps.wheel-artifact-name.outputs.wheel-artifact-name }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -141,6 +139,10 @@ jobs:
         with:
           path: cli/dist.zip
           name: ${{ env.WHEEL_ARTIFACT_NAME }}
+      - name: Set Wheel Name Output
+        id: wheel-artifact-name
+        run: |
+          echo "wheel-artifact-name=${WHEEL_ARTIFACT_NAME}" >> $GITHUB_OUTPUT
 
   test-wheels-osx-x86:
     runs-on: macos-12

--- a/.github/workflows/build-test-osx-x86.yaml
+++ b/.github/workflows/build-test-osx-x86.yaml
@@ -55,13 +55,6 @@ on:
         required: false
         type: boolean
         default: true
-    outputs:
-      wheel-artifact-name:
-        description: "The name under which the wheel artifact was stored"
-        value: ${{ jobs.build-wheels-osx.outputs.wheel-artifact-name }}
-
-env:
-  WHEEL_ARTIFACT_NAME: osx-x86-wheel
 
 jobs:
   build-core-osx:
@@ -122,8 +115,6 @@ jobs:
   build-wheels-osx:
     runs-on: macos-12
     needs: [build-core-osx]
-    outputs:
-      wheel-artifact-name: ${{ steps.wheel-artifact-name.outputs.wheel-artifact-name }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -138,11 +129,7 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           path: cli/dist.zip
-          name: ${{ env.WHEEL_ARTIFACT_NAME }}
-      - name: Set Wheel Name Output
-        id: wheel-artifact-name
-        run: |
-          echo "wheel-artifact-name=${WHEEL_ARTIFACT_NAME}" >> $GITHUB_OUTPUT
+          name: osx-x86-wheel
 
   test-wheels-osx-x86:
     runs-on: macos-12
@@ -150,8 +137,8 @@ jobs:
     steps:
       - uses: actions/download-artifact@v1
         with:
-          name: ${{ env.WHEEL_ARTIFACT_NAME }}
-      - run: unzip "./${{ env.WHEEL_ARTIFACT_NAME }}/dist.zip"
+          name: osx-x86-wheel
+      - run: unzip ./osx-x86-wheel/dist.zip
       - name: install package
         run: pip3 install dist/*.whl
       - run: semgrep --version

--- a/.github/workflows/build-test-osx-x86.yaml
+++ b/.github/workflows/build-test-osx-x86.yaml
@@ -149,7 +149,7 @@ jobs:
       - uses: actions/download-artifact@v1
         with:
           name: ${{ env.WHEEL_ARTIFACT_NAME }}
-      - run: unzip ./osx-wheel/dist.zip
+      - run: unzip "./${{ env.WHEEL_ARTIFACT_NAME }}/dist.zip"
       - name: install package
         run: pip3 install dist/*.whl
       - run: semgrep --version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,10 +178,10 @@ jobs:
         run: unzip ./manylinux-aarch64-wheel/dist.zip "*.whl"
       - name: Unzip OSX x86 Wheel
         # Don't unzip tar.gz because it already exists from ./manylinux-wheel/dist.zip.
-        run: unzip ./osx-x86-wheel/dist.zip "*.whl
+        run: unzip ./osx-x86-wheel/dist.zip "*.whl"
       - name: Unzip OSX ARM64 Wheel
         # Don't unzip tar.gz because it already exists from ./manylinux-wheel/dist.zip.
-        run: unzip ./osx-arm64-wheel/dist.zip "*.whl
+        run: unzip ./osx-arm64-wheel/dist.zip "*.whl"
       - name: Publish to Pypi
         uses: pypa/gh-action-pypi-publish@master
         if: ${{ !contains(github.ref, '-test-release') && needs.inputs.outputs.dry-run != 'true' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,6 +104,8 @@ jobs:
   build-test-osx-x86:
     uses: ./.github/workflows/build-test-osx-x86.yaml
     secrets: inherit
+    with:
+      wheel-artifact-name: osx-x86-wheel
 
   build-test-osx-arm64:
     uses: ./.github/workflows/build-test-osx-arm64.yaml
@@ -114,8 +116,6 @@ jobs:
   build-test-core-x86:
     uses: ./.github/workflows/build-test-core-x86.yaml
     secrets: inherit
-    with:
-      wheel-artifact-name: osx-x86-wheel
 
   build-test-manylinux-x86:
     needs: [build-test-core-x86]
@@ -169,8 +169,8 @@ jobs:
       - name: Download Osx Artifact
         uses: actions/download-artifact@v3
         with:
-          name: osx-wheel
-          path: osx-wheel
+          name: osx-x86-wheel
+          path: osx-x86-wheel
       - name: Download OSX ARM64 Artifact
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,14 +104,10 @@ jobs:
   build-test-osx-x86:
     uses: ./.github/workflows/build-test-osx-x86.yaml
     secrets: inherit
-    with:
-      wheel-artifact-name: osx-x86-wheel
 
   build-test-osx-arm64:
     uses: ./.github/workflows/build-test-osx-arm64.yaml
     secrets: inherit
-    with:
-      wheel-artifact-name: osx-arm64-wheel
 
   build-test-core-x86:
     uses: ./.github/workflows/build-test-core-x86.yaml
@@ -138,9 +134,21 @@ jobs:
         build-test-osx-x86,
         build-test-osx-arm64,
       ]
+    outputs:
+      manylinux-x86-wheel-artifact-name: ${{ steps.wait-for-build-test.outputs.manylinux-x86-wheel-artifact-name }}
+      manylinux-aarch64-wheel-artifact-name: ${{ steps.wait-for-build-test.outputs.manylinux-aarch64-wheel-artifact-name }}
+      osx-x86-wheel-artifact-name: ${{ steps.wait-for-build-test.outputs.osx-x86-wheel-artifact-name }}
+      osx-arm64-wheel-artifact-name: ${{ steps.wait-for-build-test.outputs.osx-arm64-wheel-artifact-name }}
     steps:
-      - name: Continue
-        run: echo "All Platforms have been built and tested - proceeding!"
+      - name: Wait for Build Test
+        id: wait-for-build-test
+        # Set up outputs on the this "gate" for ease of reference later in the workflow.
+        run: |
+          echo "manylinux-x86-wheel-artifact-name=${{ needs.build-test-manylinux-x86.outputs.wheel-artifact-name }}" >> $GITHUB_OUTPUT
+          echo "manylinux-aarch64-wheel-artifact-name=${{ needs.build-test-manylinux-aarch64.outputs.wheel-artifact-name }}" >> $GITHUB_OUTPUT
+          echo "osx-x86-wheel-artifact-name=${{ needs.build-test-osx-x86.outputs.wheel-artifact-name }}" >> $GITHUB_OUTPUT
+          echo "osx-arm64-wheel-artifact-name=${{ needs.build-test-osx-arm64.outputs.wheel-artifact-name }}" >> $GITHUB_OUTPUT
+          echo "All Platforms have been built and tested - proceeding!"
 
   push-docker:
     needs: [wait-for-build-test, inputs]
@@ -159,33 +167,33 @@ jobs:
       - name: Download Artifact
         uses: actions/download-artifact@v3
         with:
-          name: manylinux-wheel
-          path: manylinux-wheel
+          name: ${{ needs.wait-for-build-test.outputs.manylinux-x86-wheel-artifact-name }}
+          path: ${{ needs.wait-for-build-test.outputs.manylinux-x86-wheel-artifact-name }}
       - name: Download aarch64 Artifact
         uses: actions/download-artifact@v3
         with:
-          name: manylinux-wheel-aarch64
-          path: manylinux-wheel-aarch64
-      - name: Download Osx Artifact
+          name: ${{ needs.wait-for-build-test.outputs.manylinux-aarch64-wheel-artifact-name }}
+          path: ${{ needs.wait-for-build-test.outputs.manylinux-aarch64-wheel-artifact-name }}
+      - name: Download OSX x86 Artifact
         uses: actions/download-artifact@v3
         with:
-          name: osx-x86-wheel
-          path: osx-x86-wheel
+          name: ${{ needs.wait-for-build-test.outputs.osx-x86-wheel-artifact-name }}
+          path: ${{ needs.wait-for-build-test.outputs.osx-x86-wheel-artifact-name }}
       - name: Download OSX ARM64 Artifact
         uses: actions/download-artifact@v3
         with:
-          name: osx-arm64-wheel
-          path: osx-arm64-wheel
+          name: ${{ needs.wait-for-build-test.outputs.osx-arm64-wheel-artifact-name }}
+          path: ${{ needs.wait-for-build-test.outputs.osx-arm64-wheel-artifact-name }}
       - name: Unzip x86_64 Wheel
-        run: unzip ./manylinux-wheel/dist.zip
+        run: unzip "./${{ needs.wait-for-build-test.outputs.manylinux-x86-wheel-artifact-name }}/dist.zip"
       - name: Unzip aarch64 Wheel
-        run: unzip ./manylinux-wheel-aarch64/dist.zip "*.whl"
+        run: unzip "./${{ needs.wait-for-build-test.outputs.manylinux-aarch64-wheel-artifact-name }}/dist.zip" "*.whl"
       - name: Unzip OSX x86 Wheel
         # Don't unzip tar.gz because it already exists from ./manylinux-wheel/dist.zip.
-        run: unzip ./osx-x86-wheel/dist.zip "*.whl"
+        run: unzip "./${{ needs.wait-for-build-test.outputs.osx-x86-wheel-artifact-name }}/dist.zip" "*.whl"
       - name: Unzip OSX ARM64 Wheel
         # Don't unzip tar.gz because it already exists from ./manylinux-wheel/dist.zip.
-        run: unzip ./osx-arm64-wheel/dist.zip "*.whl"
+        run: unzip "./${{ needs.wait-for-build-test.outputs.osx-arm64-wheel-artifact-name }}/dist.zip" "*.whl"
       - name: Publish to Pypi
         uses: pypa/gh-action-pypi-publish@master
         if: ${{ !contains(github.ref, '-test-release') && needs.inputs.outputs.dry-run != 'true' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,14 +108,23 @@ jobs:
   build-test-osx-arm64:
     uses: ./.github/workflows/build-test-osx-arm64.yaml
     secrets: inherit
+    with:
+      wheel-artifact-name: osx-arm64-wheel
 
   build-test-core-x86:
     uses: ./.github/workflows/build-test-core-x86.yaml
     secrets: inherit
+    with:
+      wheel-artifact-name: osx-x86-wheel
 
   build-test-manylinux-x86:
     needs: [build-test-core-x86]
     uses: ./.github/workflows/build-test-manylinux-x86.yaml
+    secrets: inherit
+
+  build-test-manylinux-aarch64:
+    needs: [build-test-docker]
+    uses: ./.github/workflows/build-test-manylinux-aarch64.yaml
     secrets: inherit
 
   wait-for-build-test:
@@ -127,7 +136,7 @@ jobs:
         build-test-manylinux-x86,
         build-test-manylinux-aarch64,
         build-test-osx-x86,
-        build-test-osx-m1,
+        build-test-osx-arm64,
       ]
     steps:
       - name: Continue
@@ -162,11 +171,11 @@ jobs:
         with:
           name: osx-wheel
           path: osx-wheel
-      - name: Download Artifact
+      - name: Download OSX ARM64 Artifact
         uses: actions/download-artifact@v3
         with:
-          name: m1-wheel
-          path: m1-wheel
+          name: osx-arm64-wheel
+          path: osx-arm64-wheel
       - name: Unzip x86_64 Wheel
         run: unzip ./manylinux-wheel/dist.zip
       - name: Unzip aarch64 Wheel
@@ -176,7 +185,7 @@ jobs:
         run: unzip ./osx-wheel/dist.zip "*.whl"
       - name: Unzip M1 Wheel
         # Don't unzip tar.gz because it already exists from ./manylinux-wheel/dist.zip.
-        run: unzip ./m1-wheel/dist.zip "*.whl"
+        run: unzip ./osx-arm64-wheel/dist.zip "*.whl"
       - name: Publish to Pypi
         uses: pypa/gh-action-pypi-publish@master
         if: ${{ !contains(github.ref, '-test-release') && needs.inputs.outputs.dry-run != 'true' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,10 +178,10 @@ jobs:
         run: unzip ./manylinux-aarch64-wheel/dist.zip "*.whl"
       - name: Unzip OSX x86 Wheel
         # Don't unzip tar.gz because it already exists from ./manylinux-wheel/dist.zip.
-        run: unzip ./osx-x86-wheel/dist.zip" "*.whl
+        run: unzip ./osx-x86-wheel/dist.zip "*.whl
       - name: Unzip OSX ARM64 Wheel
         # Don't unzip tar.gz because it already exists from ./manylinux-wheel/dist.zip.
-        run: unzip ./osx-arm64-wheel/dist.zip" "*.whl
+        run: unzip ./osx-arm64-wheel/dist.zip "*.whl
       - name: Publish to Pypi
         uses: pypa/gh-action-pypi-publish@master
         if: ${{ !contains(github.ref, '-test-release') && needs.inputs.outputs.dry-run != 'true' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,10 +180,10 @@ jobs:
         run: unzip ./manylinux-wheel/dist.zip
       - name: Unzip aarch64 Wheel
         run: unzip ./manylinux-wheel-aarch64/dist.zip "*.whl"
-      - name: Unzip OSX Wheel
+      - name: Unzip OSX x86 Wheel
         # Don't unzip tar.gz because it already exists from ./manylinux-wheel/dist.zip.
-        run: unzip ./osx-wheel/dist.zip "*.whl"
-      - name: Unzip M1 Wheel
+        run: unzip ./osx-x86-wheel/dist.zip "*.whl"
+      - name: Unzip OSX ARM64 Wheel
         # Don't unzip tar.gz because it already exists from ./manylinux-wheel/dist.zip.
         run: unzip ./osx-arm64-wheel/dist.zip "*.whl"
       - name: Publish to Pypi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,21 +134,9 @@ jobs:
         build-test-osx-x86,
         build-test-osx-arm64,
       ]
-    outputs:
-      manylinux-x86-wheel-artifact-name: ${{ steps.wait-for-build-test.outputs.manylinux-x86-wheel-artifact-name }}
-      manylinux-aarch64-wheel-artifact-name: ${{ steps.wait-for-build-test.outputs.manylinux-aarch64-wheel-artifact-name }}
-      osx-x86-wheel-artifact-name: ${{ steps.wait-for-build-test.outputs.osx-x86-wheel-artifact-name }}
-      osx-arm64-wheel-artifact-name: ${{ steps.wait-for-build-test.outputs.osx-arm64-wheel-artifact-name }}
     steps:
-      - name: Wait for Build Test
-        id: wait-for-build-test
-        # Set up outputs on the this "gate" for ease of reference later in the workflow.
-        run: |
-          echo "manylinux-x86-wheel-artifact-name=${{ needs.build-test-manylinux-x86.outputs.wheel-artifact-name }}" >> $GITHUB_OUTPUT
-          echo "manylinux-aarch64-wheel-artifact-name=${{ needs.build-test-manylinux-aarch64.outputs.wheel-artifact-name }}" >> $GITHUB_OUTPUT
-          echo "osx-x86-wheel-artifact-name=${{ needs.build-test-osx-x86.outputs.wheel-artifact-name }}" >> $GITHUB_OUTPUT
-          echo "osx-arm64-wheel-artifact-name=${{ needs.build-test-osx-arm64.outputs.wheel-artifact-name }}" >> $GITHUB_OUTPUT
-          echo "All Platforms have been built and tested - proceeding!"
+      - name: Continue
+        run: echo "All Platforms have been built and tested - proceeding!"
 
   push-docker:
     needs: [wait-for-build-test, inputs]
@@ -167,33 +155,33 @@ jobs:
       - name: Download Artifact
         uses: actions/download-artifact@v3
         with:
-          name: ${{ needs.wait-for-build-test.outputs.manylinux-x86-wheel-artifact-name }}
-          path: ${{ needs.wait-for-build-test.outputs.manylinux-x86-wheel-artifact-name }}
+          name: manylinux-x86-wheel
+          path: manylinux-x86-wheel
       - name: Download aarch64 Artifact
         uses: actions/download-artifact@v3
         with:
-          name: ${{ needs.wait-for-build-test.outputs.manylinux-aarch64-wheel-artifact-name }}
-          path: ${{ needs.wait-for-build-test.outputs.manylinux-aarch64-wheel-artifact-name }}
+          name: manylinux-aarch64-wheel
+          path: manylinux-aarch64-wheel
       - name: Download OSX x86 Artifact
         uses: actions/download-artifact@v3
         with:
-          name: ${{ needs.wait-for-build-test.outputs.osx-x86-wheel-artifact-name }}
-          path: ${{ needs.wait-for-build-test.outputs.osx-x86-wheel-artifact-name }}
+          name: osx-x86-wheel
+          path: osx-x86-wheel
       - name: Download OSX ARM64 Artifact
         uses: actions/download-artifact@v3
         with:
-          name: ${{ needs.wait-for-build-test.outputs.osx-arm64-wheel-artifact-name }}
-          path: ${{ needs.wait-for-build-test.outputs.osx-arm64-wheel-artifact-name }}
+          name: osx-arm64-wheel
+          path: osx-arm64-wheel
       - name: Unzip x86_64 Wheel
-        run: unzip "./${{ needs.wait-for-build-test.outputs.manylinux-x86-wheel-artifact-name }}/dist.zip"
+        run: unzip ./manylinux-x86-wheel/dist.zip "*.whl"
       - name: Unzip aarch64 Wheel
-        run: unzip "./${{ needs.wait-for-build-test.outputs.manylinux-aarch64-wheel-artifact-name }}/dist.zip" "*.whl"
+        run: unzip ./manylinux-aarch64-wheel/dist.zip "*.whl"
       - name: Unzip OSX x86 Wheel
         # Don't unzip tar.gz because it already exists from ./manylinux-wheel/dist.zip.
-        run: unzip "./${{ needs.wait-for-build-test.outputs.osx-x86-wheel-artifact-name }}/dist.zip" "*.whl"
+        run: unzip ./osx-x86-wheel/dist.zip" "*.whl
       - name: Unzip OSX ARM64 Wheel
         # Don't unzip tar.gz because it already exists from ./manylinux-wheel/dist.zip.
-        run: unzip "./${{ needs.wait-for-build-test.outputs.osx-arm64-wheel-artifact-name }}/dist.zip" "*.whl"
+        run: unzip ./osx-arm64-wheel/dist.zip" "*.whl
       - name: Publish to Pypi
         uses: pypa/gh-action-pypi-publish@master
         if: ${{ !contains(github.ref, '-test-release') && needs.inputs.outputs.dry-run != 'true' }}

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -31,7 +31,6 @@ if WHEEL_CMD in sys.argv:
             _, _, plat = bdist_wheel.get_tag(self)
             python = "cp37.cp38.cp39.cp310.cp311.py37.py38.py39.py310.py311"
             abi = "none"
-            plat = plat if "macosx" in plat else "any"
             return python, abi, plat
 
     cmdclass = {WHEEL_CMD: BdistWheel}


### PR DESCRIPTION
Release workflow was misconfigured and had been failing since Friday - we did not get any notifications about this because the workflow file was invalid and could not run (therefore, it couldn't send us the slack message about it's failure). In addition, we've changed the name of the OSX artifacts which would've broken, had this workflow been able to run successfully.

This PR gets release back on the rails by:
- allowing jobs that build wheels to pass an artifact name as output, to standardize usage
- Adding the required missing job for aarch64 linux wheels. 

Test Plan:
- release dry-run here: https://github.com/returntocorp/semgrep/actions/runs/5582933738

I'll re-enable release workflow once this goes in.

@cgdolan it looks like a while back, you set up linting on PRs for GHA that I would've expected to catch this - I'm going to dig into that separately.

PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
