### PR TITLE
Adding testing infrastructure for jsonnet interpreter

### DIFF
--- a/libs/ojsonnet/Unit_jsonnet.ml
+++ b/libs/ojsonnet/Unit_jsonnet.ml
@@ -1,0 +1,47 @@
+open Common
+open File.Operators
+
+(*open Testutil*)
+module Y = Yojson.Basic
+
+let dir = Fpath.v "tests/jsonnet/eval"
+
+let related_file_of_target ~ext ~file =
+  let dirname, basename, _e = Common2.dbe_of_filename !!file in
+  let path = Common2.filename_of_dbe (dirname, basename, ext) in
+  if Sys.file_exists path then Ok (Fpath.v path)
+  else
+    let msg =
+      spf "could not find %s file for test '%s' in %s" ext basename dirname
+    in
+    Error msg
+
+(* CURRENTLY VERY BAD TESTING, need to be able to print out output
+   *  rather than expected true/false, leaving this as is for now to just set up
+   * tests to run, then will change*)
+let test_maker () =
+  Common2.glob (spf "%s/*%s" !!dir "jsonnet")
+  |> File.Path.of_strings
+  |> Common.map (fun file ->
+         ( Fpath.basename file,
+           fun () ->
+             let comparison_file_path =
+               match related_file_of_target ~ext:"json" ~file with
+               | Ok json_file -> json_file
+               | Error msg -> failwith msg
+             in
+             let correct =
+               Y.from_string (File.read_file comparison_file_path)
+             in
+
+             let ast = Parse_jsonnet.parse_program file in
+             let core = Desugar_jsonnet.desugar_program file ast in
+             let value_ =
+               Eval_jsonnet.eval_program core Core_jsonnet.empty_env
+             in
+             let json = JSON.to_yojson (Eval_jsonnet.manifest_value value_) in
+             let fmt = format_of_string "expected %s but got %s" in
+             let result = Printf.sprintf fmt (Y.show correct) (Y.show json) in
+             Alcotest.(check bool) result (Y.equal json correct) true ))
+
+let tests () = test_maker ()

--- a/libs/ojsonnet/Unit_jsonnet.ml
+++ b/libs/ojsonnet/Unit_jsonnet.ml
@@ -1,7 +1,5 @@
 open Common
 open File.Operators
-
-(*open Testutil*)
 module Y = Yojson.Basic
 
 let dir = Fpath.v "tests/jsonnet/eval"
@@ -16,9 +14,6 @@ let related_file_of_target ~ext ~file =
     in
     Error msg
 
-(* CURRENTLY VERY BAD TESTING, need to be able to print out output
-   *  rather than expected true/false, leaving this as is for now to just set up
-   * tests to run, then will change*)
 let test_maker () =
   Common2.glob (spf "%s/*%s" !!dir "jsonnet")
   |> File.Path.of_strings
@@ -36,12 +31,14 @@ let test_maker () =
 
              let ast = Parse_jsonnet.parse_program file in
              let core = Desugar_jsonnet.desugar_program file ast in
-             let value_ =
-               Eval_jsonnet.eval_program core Core_jsonnet.empty_env
+             let value_ = Eval_jsonnet.eval_program core in
+             let json =
+               JSON.to_yojson (Manifest_jsonnet.manifest_value value_)
              in
-             let json = JSON.to_yojson (Eval_jsonnet.manifest_value value_) in
-             let fmt = format_of_string "expected %s but got %s" in
-             let result = Printf.sprintf fmt (Y.show correct) (Y.show json) in
-             Alcotest.(check bool) result (Y.equal json correct) true ))
+             let fmt = format_of_string "expected %s \n but got %s" in
+             let result =
+               Printf.sprintf fmt (Y.to_string correct) (Y.to_string json)
+             in
+             Alcotest.(check bool) result true (Y.equal json correct) ))
 
 let tests () = test_maker ()

--- a/libs/ojsonnet/Unit_jsonnet.mli
+++ b/libs/ojsonnet/Unit_jsonnet.mli
@@ -1,0 +1,1 @@
+val tests : unit -> Testutil.test list

--- a/src/tests/Test.ml
+++ b/src/tests/Test.ml
@@ -69,6 +69,7 @@ let tests () =
       (* TODO Unit_matcher.spatch_unittest ~xxx *)
       (* TODO Unit_matcher_php.unittest; (* sgrep, spatch, refactoring, unparsing *) *)
       Unit_engine.tests ();
+      Unit_jsonnet.tests ();
       Unit_metachecking.tests ();
       Unit_LS.tests;
       Aliengrep.Unit_tests.tests;

--- a/tests/jsonnet/eval/simple_test.json
+++ b/tests/jsonnet/eval/simple_test.json
@@ -1,0 +1,49 @@
+{
+  "cocktails": {
+    "Manhattan": {
+      "description": "A clear \\ red drink.",
+      "garnish": "Maraschino Cherry",
+      "ingredients": [
+        {
+          "kind": "Rye",
+          "qty": 2.5
+        },
+        {
+          "kind": "Sweet Red Vermouth",
+          "qty": 1
+        },
+        {
+          "kind": "Angostura",
+          "qty": "dash"
+        }
+      ],
+      "served": "Straight Up"
+    },
+    "Tom Collins": {
+      "garnish": "Maraschino Cherry",
+      "ingredients": [
+        {
+          "kind": "Farmer's Gin",
+          "qty": 1.5
+        },
+        {
+          "kind": "Lemon",
+          "qty": 1
+        },
+        {
+          "kind": "Simple Syrup",
+          "qty": 0.5
+        },
+        {
+          "kind": "Soda",
+          "qty": 2
+        },
+        {
+          "kind": "Angostura",
+          "qty": "dash"
+        }
+      ],
+      "served": "Tall"
+    }
+  }
+}

--- a/tests/jsonnet/eval/simple_test.jsonnet
+++ b/tests/jsonnet/eval/simple_test.jsonnet
@@ -1,0 +1,25 @@
+{
+  cocktails: {
+    'Tom Collins': {
+      ingredients: [
+        { kind: "Farmer's Gin", qty: 1.5 },
+        { kind: 'Lemon', qty: 1 },
+        { kind: 'Simple Syrup', qty: 0.5 },
+        { kind: 'Soda', qty: 2 },
+        { kind: 'Angostura', qty: 'dash' },
+      ],
+      garnish: 'Maraschino Cherry',
+      served: 'Tall',
+    },
+    Manhattan: {
+      ingredients: [
+        { kind: 'Rye', qty: 2.5 },
+        { kind: 'Sweet Red Vermouth', qty: 1 },
+        { kind: 'Angostura', qty: 'dash' },
+      ],
+      garnish: 'Maraschino Cherry',
+      served: 'Straight Up',
+      description: @'A clear \ red drink.',
+    },
+  },
+}


### PR DESCRIPTION
This pull request sets up testing infrastructure for the interpreter for jsonnet. This pull request just contains 1 simple test that demonstrates that the infrastructure works. 
PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
