### PR TITLE
misc: compile semgrep with OCaml 4.12.0

### DIFF
--- a/languages/elixir/generic/Elixir_to_generic.ml
+++ b/languages/elixir/generic/Elixir_to_generic.ml
@@ -127,7 +127,7 @@ let expr_of_body_or_clauses tk (x : body_or_clauses_generic) : G.expr =
       G.stmt_to_expr block
   | Right clauses ->
       let fdef = stab_clauses_to_function_definition tk clauses in
-      Lambda fdef |> G.e
+      G.Lambda fdef |> G.e
 
 (* following Elixir semantic (unsugaring do/end block in keywords) *)
 let kwds_of_do_block (bl : do_block_generic) : keywords_generic =
@@ -337,7 +337,7 @@ and map_expr env v : G.expr =
       let e = map_expr env v1 in
       let items = (map_bracket map_items) env v3 in
       let tuple = G.Container (G.Tuple, items) |> G.e in
-      DotAccess (e, tdot, G.FDynamic tuple) |> G.e
+      G.DotAccess (e, tdot, G.FDynamic tuple) |> G.e
   (* only inside a Call *)
   | DotAnon (v1, tdot) ->
       let e = map_expr env v1 in
@@ -358,8 +358,8 @@ and map_expr env v : G.expr =
       match v1 with
       | Left (op, tk) -> G.opcall (op, tk) [ e ]
       | Right id ->
-          let n = N (H.name_of_id id) |> G.e in
-          Call (n, fb [ G.Arg e ]) |> G.e)
+          let n = G.N (H.name_of_id id) |> G.e in
+          G.Call (n, fb [ G.Arg e ]) |> G.e)
   | BinaryOp (v1, v2, v3) -> (
       let e1 = map_expr env v1 in
       let op = map_wrap_operator env v2 in
@@ -367,8 +367,8 @@ and map_expr env v : G.expr =
       match op with
       | Left (op, tk) -> G.opcall (op, tk) [ e1; e2 ]
       | Right id ->
-          let n = N (H.name_of_id id) |> G.e in
-          Call (n, fb ([ e1; e2 ] |> Common.map G.arg)) |> G.e)
+          let n = G.N (H.name_of_id id) |> G.e in
+          G.Call (n, fb ([ e1; e2 ] |> Common.map G.arg)) |> G.e)
   | OpArity (v1, tslash, v3) ->
       let id = map_wrap_operator_ident env v1 in
       let x = (map_wrap (map_option map_int)) env v3 in
@@ -449,7 +449,7 @@ and map_remote_dot env (v1, tdot, v3) : G.expr =
     | Left id -> G.FN (H.name_of_id id)
     | Right (quoted : quoted_generic) -> G.FDynamic (expr_of_quoted quoted)
   in
-  DotAccess (e, tdot, fld) |> G.e
+  G.DotAccess (e, tdot, fld) |> G.e
 
 and map_stab_clause env (v : stab_clause) : stab_clause_generic =
   let (vargs, vwhenopt), tarrow, vbody = v in

--- a/libs/commons/File.ml
+++ b/libs/commons/File.ml
@@ -49,7 +49,7 @@ let find_first_match_with_whole_line path ?split:(chr = '\n') =
   let len = in_channel_length ic in
   let res = Bytes.create len in
   really_input ic res 0 len;
-  let lines = Bytes.split_on_char chr res in
+  let lines = Stdcompat.Bytes.split_on_char chr res in
   let lines = Common.map Bytes.unsafe_to_string lines in
   List.find_opt
     (fun str -> Option.is_some (String_utils.contains term str))

--- a/libs/commons/dune
+++ b/libs/commons/dune
@@ -2,6 +2,7 @@
  (public_name commons)
  (wrapped false)
  (libraries
+   stdcompat
    str
    unix
    fpath

--- a/src/analyzing/AST_to_IL.ml
+++ b/src/analyzing/AST_to_IL.ml
@@ -1223,7 +1223,7 @@ and stmt_aux env st =
                  obj_lval with
                  rev_offset = [ { o = Dot cons'; oorig = NoOrig } ];
                })
-            (SameAs (N cons |> G.e))
+            (SameAs (G.N cons |> G.e))
           (* THINK: ^^^^^ We need to construct a `SameAs` eorig here because Pro
            * looks at the eorig, but maybe it shouldn't? *)
         in

--- a/src/core/Rule.ml
+++ b/src/core/Rule.ml
@@ -90,7 +90,8 @@ end = struct
   let compare = String.compare
 
   let ends_with r ~suffix:inc_or_exc_rule =
-    r = inc_or_exc_rule || String.ends_with ~suffix:("." ^ inc_or_exc_rule) r
+    r = inc_or_exc_rule
+    || Stdcompat.String.ends_with ~suffix:("." ^ inc_or_exc_rule) r
 end
 
 type rule_id = ID.t [@@deriving show, eq]

--- a/src/core/dune
+++ b/src/core/dune
@@ -6,6 +6,7 @@
  (name semgrep_core)
  (wrapped false)
  (libraries
+   stdcompat
    str
    yaml
    atdgen-runtime

--- a/src/osemgrep/cli_interactive/Interactive_subcommand.ml
+++ b/src/osemgrep/cli_interactive/Interactive_subcommand.ml
@@ -659,7 +659,7 @@ let split_line (t1 : Tok.location) (t2 : Tok.location) (row, line) =
     let lb = if row = t1.pos.line then Some t1.pos.column else None in
     let rb = if row = end_line then Some end_col else None in
     let l_rev, m_rev, r_rev, _ =
-      String.fold_left
+      Stdcompat.String.fold_left
         (fun (l, m, r, i) c ->
           match placement_wrt_bound (lb, rb) i with
           | Common.Left3 _ -> (c :: l, m, r, i + 1)
@@ -718,7 +718,7 @@ let preview_of_match { Pattern_match.range_loc = t1, t2; _ } file state =
     let max_line_num_len =
       line_num_imgs
       |> Common.map (fun line_num_img -> I.width line_num_img)
-      |> List.fold_left Int.max 0
+      |> List.fold_left max 0
     in
     line_num_imgs
     |> Common.map (fun line_num_img ->
@@ -971,7 +971,7 @@ let parse_command ({ xlang; _ } as state : state) =
   | "exit" -> Exit
   | "any" -> Any
   | "all" -> All
-  | _ when String.starts_with ~prefix:"not " s ->
+  | _ when Stdcompat.String.starts_with ~prefix:"not " s ->
       let s = Str.string_after s 4 in
       (* TODO: error handle *)
       let lang = Xlang.to_lang_exn xlang in

--- a/src/osemgrep/cli_scan/Cli_json_output.ml
+++ b/src/osemgrep/cli_scan/Cli_json_output.ml
@@ -407,7 +407,7 @@ let cli_skipped_target_of_skipped_target (x : Out.skipped_target) :
 (* skipping the python intermediate FileTargetingLog for now *)
 let cli_skipped_targets ~(skipped_targets : Out.skipped_target list option) :
     Out.cli_skipped_target list option =
-  let* skipped_targets = skipped_targets in
+  let* skipped_targets_list = skipped_targets in
 
   (* TODO: skipped targets are coming from the FileIgnoreLog which is
    * populated from many places in the code.
@@ -417,7 +417,7 @@ let cli_skipped_targets ~(skipped_targets : Out.skipped_target list option) :
    * core_failure_lines_by_file in target_manager.py
    *)
   let core_skipped =
-    skipped_targets |> Common.map cli_skipped_target_of_skipped_target
+    skipped_targets_list |> Common.map cli_skipped_target_of_skipped_target
   in
   (* TODO: need to sort *)
   Some core_skipped

--- a/src/osemgrep/cli_scan/Cli_json_output.ml
+++ b/src/osemgrep/cli_scan/Cli_json_output.ml
@@ -407,7 +407,7 @@ let cli_skipped_target_of_skipped_target (x : Out.skipped_target) :
 (* skipping the python intermediate FileTargetingLog for now *)
 let cli_skipped_targets ~(skipped_targets : Out.skipped_target list option) :
     Out.cli_skipped_target list option =
-  let* skipped_targets in
+  let* skipped_targets = skipped_targets in
 
   (* TODO: skipped targets are coming from the FileIgnoreLog which is
    * populated from many places in the code.

--- a/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -114,7 +114,7 @@ let default : conf =
         (* Maxing out number of cores used to 16 if more not requested to
          * not overload on large machines
          *)
-        Core_runner.num_jobs = Int.min 16 (Parmap_helpers.get_cpu_count ());
+        Core_runner.num_jobs = min 16 (Parmap_helpers.get_cpu_count ());
         timeout = 30.0 (* seconds *);
         timeout_threshold = 3;
         max_memory_mb = 0;

--- a/src/tainting/Dataflow_tainting.ml
+++ b/src/tainting/Dataflow_tainting.ml
@@ -1432,7 +1432,10 @@ let check_function_signature env fun_exp args args_taints =
                          T.Call (eorig, t.tokens, src.call_trace)
                        in
                        let* taint =
-                         { orig = Src { src with call_trace }; tokens = [] }
+                         {
+                           Taint.orig = Src { src with call_trace };
+                           tokens = [];
+                         }
                          |> subst_in_precondition
                        in
                        Some (`Return (Taints.singleton taint))


### PR DESCRIPTION
One of my tool (codegraph) needs to parse the
.cmt files generated by OCaml 4.12.0 to do some
global analysis and find for example dead OCaml code.
It does not currently work with the .cmt generated by OCaml 4.14.0
so I need to change a bit the semgrep code to be 4.12.0 compliant

test plan:
make core
make core-test


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)