### PR TITLE
cleanup: remove AST_generic.s_backrefs

### DIFF
--- a/libs/ast_generic/AST_generic.ml
+++ b/libs/ast_generic/AST_generic.ml
@@ -418,7 +418,6 @@ class virtual ['self] iter_parent =
     method visit_resolved_name _env _ = ()
     method visit_tok _env _ = ()
     method visit_node_id_t _env _ = ()
-    method visit_string_set_t _env _ = ()
   end
 
 (* Basically a copy paste of iter_parent above, but with different return types
@@ -484,7 +483,6 @@ class virtual ['self] map_parent =
     method visit_resolved_name _env x = x
     method visit_tok _env x = x
     method visit_node_id_t _env x = x
-    method visit_string_set_t _env x = x
   end
 
 (* Start of big mutually recursive types because of the use of 'any'
@@ -1133,17 +1131,6 @@ and stmt = {
   (* used to quickly get the range of a statement *)
   mutable s_range : (Tok.location * Tok.location) option;
       [@equal fun _a _b -> true] [@hash.ignore]
-  mutable s_backrefs : (AST_utils.String_set.t[@name "string_set_t"]) option;
-      [@equal fun _a _b -> true] [@hash.ignore]
-      (* set of metavariables referenced in the "rest of the pattern", as
-         determined by matching order.
-         This field is relevant for patterns only.
-
-         This is used to determine which of the bound
-         metavariables should be added to the cache key for this node.
-         This field is set on pattern ASTs only, in a pass right after parsing
-         and before matching.
-      *)
 }
 
 and stmt_kind =
@@ -2120,13 +2107,7 @@ let sc = Tok.unsafe_fake_tok ""
 (* ------------------------------------------------------------------------- *)
 
 (* statements *)
-let s skind =
-  {
-    s = skind;
-    s_id = AST_utils.Node_ID.mk ();
-    s_backrefs = None;
-    s_range = None;
-  }
+let s skind = { s = skind; s_id = AST_utils.Node_ID.mk (); s_range = None }
 
 (* expressions *)
 let e ekind = { e = ekind; e_id = 0; e_range = None }

--- a/src/optimizing/Metavariable_capture.ml
+++ b/src/optimizing/Metavariable_capture.ml
@@ -43,33 +43,3 @@ let add_capture k v env =
   let full_env = kv :: env.full_env in
   let min_env = kv :: env.min_env in
   { env with full_env; min_env }
-
-(*
-     To be called as early as possible after passing a backreference
-     which may no longer be needed when descending down the pattern.
-     For now, we call this only when reaching a new stmt pattern node.
-
-     For simplicity, we assume any member of 'min_env' may no longer be
-     needed. It may be more efficient to accumulate the backreferences
-     that were encountered since the last stmt and only consider removing
-     their bindings, rather than considering all the bindings in min_env.
-
-     If we don't call this, the cache keys will be overspecified, reducing
-     or preventing reuse.
-  *)
-let update_min_env env (stmt_pat : AST_generic.stmt) =
-  if debug then printf "update_min_env\n";
-  let backrefs =
-    match stmt_pat.s_backrefs with
-    | None -> assert false (* missing initialization *)
-    | Some x -> x
-  in
-  let min_env =
-    List.filter
-      (fun (k, _v) ->
-        let keep = Set_.mem k backrefs in
-        if debug then printf "keep %s in min env: %B\n" k keep;
-        keep)
-      env.min_env
-  in
-  { env with min_env; last_stmt_backrefs = backrefs }


### PR DESCRIPTION
Followup to #8300 to remove cruft related to
the stmts caching

test plan:
make core


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)