### PR TITLE
cleanup: move Stmts_match_span.ml out of src/optimizing/

### DIFF
--- a/src/matching/Match_patterns.ml
+++ b/src/matching/Match_patterns.ml
@@ -1,7 +1,7 @@
 (* Yoann Padioleau
  *
  * Copyright (C) 2011 Facebook
- * Copyright (C) 2019, 2020 r2c
+ * Copyright (C) 2019-2023 r2c
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/src/matching/Stmts_match_span.mli
+++ b/src/matching/Stmts_match_span.mli
@@ -1,0 +1,10 @@
+type span = {
+  left_stmts : AST_generic.stmt list;
+  right_stmts : AST_generic.stmt list;
+}
+
+type t = Empty | Span of span
+
+val extend : AST_generic.stmt -> t -> t
+val location : t -> (Tok.location * Tok.location) option
+val list_original_tokens : t -> Tok.t list

--- a/src/optimizing/Analyze_pattern.ml
+++ b/src/optimizing/Analyze_pattern.ml
@@ -1,6 +1,6 @@
 (* Yoann Padioleau
  *
- * Copyright (C) 2021 r2c
+ * Copyright (C) 2021 Semgrep Inc.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
@@ -33,19 +33,10 @@ open AST_generic
  *  - Mini_rules_filter and Semgrep_generic, to skip certain mini-rules
  *    (but not entire files)
  *  - the Semgrep.ml engine to skip entire files!
- *
- * TODO:
- *  - extract identifiers, and basic strings
- *  - TODO extract filenames in import
  *)
 
 (*****************************************************************************)
-(* Helpers *)
-(*****************************************************************************)
-let _error s = failwith s
-
-(*****************************************************************************)
-(* Extractions *)
+(* Entry points *)
 (*****************************************************************************)
 
 let extract_strings_and_mvars ?lang any =


### PR DESCRIPTION
It's not really an optimization. Maybe some code in it
was used for optimization purpose when we had stmts caching,
but this code was removed and what remains is not really an
optimization

test plan:
make core


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)