### PR TITLE
fix(osemgrep): fix error caused by unfiltered logging stream

### DIFF
--- a/changelog.d/gh-8310.fixed
+++ b/changelog.d/gh-8310.fixed
@@ -1,0 +1,1 @@
+Fixed error where we were not filtering the logging of a new third party library.

--- a/libs/commons/Logs_helpers.ml
+++ b/libs/commons/Logs_helpers.ml
@@ -92,6 +92,8 @@ let setup_logging ~force_color ~level =
          | "ca-certs"
          | "bos"
          | "happy-eyeballs.lwt"
+         | "http_lwt_client"
+         | "http_lwt_unix"
          | "mirage-crypto-rng.lwt"
          | "mirage-crypto-rng-lwt"
          | "mirage-crypto-rng.unix"


### PR DESCRIPTION
## What
Fixes the following two errors that occur when invoking `osemgrep`:
```bash
$ bin/osemgrep --config semgrep.jsonnet .
Error: Logs library not handled: http_lwt_client
exiting with error status 2: bin/osemgrep --config semgrep.jsonnet .
```
After "fixing" that this one shows up.
```bash
$ bin/osemgrep --config semgrep.jsonnet .
Error: Logs library not handled: http_lwt_unix
exiting with error status 2: bin/osemgrep --config semgrep.jsonnet .
```
## How
Add these libraries to the log file filter.

## Testing
Manually invoke `osemgrep` a final time showing that it works.

```bash
bin/osemgrep --config semgrep.jsonnet .
Support for Jsonnet rules is experimental and currently meant for internal use only. The syntax may change or be removed at any point.


┌─────────────┐
│ Scan Status │
└─────────────┘
  Scanning 2121 files tracked by git with 58 Code rules:

  Language      Rules   Files          Origin      Rules
 ─────────────────────────────        ───────────────────
  ocaml            50     968          Unknown        27
  <multilang>       1    2121          Community      31
  python            7     313



┌──────────────┐
│ Scan Summary │
└──────────────┘
Some files were skipped or only partially analyzed.
  Scan was limited to files tracked by git.  Partially scanned: 8 files only partially analyzed due to a parsing or internal Semgrep error
  Scan skipped: 197 files matching .semgrepignore patterns
  For a full list of skipped files, run semgrep with the --verbose flag.


Ran 58 rules on 2121 files: 0 findings.
```

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
