### PR TITLE
refactor(tainting): Add a proper constructor for `this'

### DIFF
--- a/src/tainting/Dataflow_tainting.ml
+++ b/src/tainting/Dataflow_tainting.ml
@@ -1322,7 +1322,7 @@ let lval_of_sig_arg fun_exp fparams args_exps (sig_arg : T.arg) =
   in
   let* lval, obj =
     match sig_arg.base with
-    | Bthis -> (
+    | BThis -> (
         match fun_exp with
         | {
          e = Fetch { base = Var obj; rev_offset = [ { o = Dot _method; _ } ] };
@@ -1330,7 +1330,7 @@ let lval_of_sig_arg fun_exp fparams args_exps (sig_arg : T.arg) =
         } ->
             Some ({ base = Var obj; rev_offset = List.rev os }, obj)
         | __else__ -> None)
-    | Barg pos -> (
+    | BArg pos -> (
         let* arg_exp = find_pos_in_actual_args args_exps fparams pos in
         match (arg_exp.e, sig_arg.offset) with
         | Fetch ({ base = Var obj; _ } as arg_lval), _ ->
@@ -1370,7 +1370,7 @@ let lval_of_sig_arg fun_exp fparams args_exps (sig_arg : T.arg) =
 let taints_of_sig_arg env fparams fun_exp args_exps args_taints
     (sig_arg : T.arg) =
   match sig_arg with
-  | { base = Barg pos; offset = [] } ->
+  | { base = BArg pos; offset = [] } ->
       find_pos_in_actual_args args_taints fparams pos
   | __else__ ->
       (* We want to know what's the taint carried by 'arg_exp.x1. ... .xN'. *)

--- a/src/tainting/Dataflow_tainting.ml
+++ b/src/tainting/Dataflow_tainting.ml
@@ -722,7 +722,7 @@ let find_pos_in_actual_args args_taints fparams =
                (i + 1, rest))
          (0, remaining_params)
   in
-  fun (s, i) ->
+  fun ({ name = s; index = i } : Taint.arg_pos) ->
     let taint_opt =
       match
         (Hashtbl.find_opt name_to_taints s, Hashtbl.find_opt idx_to_taints i)
@@ -1321,8 +1321,8 @@ let lval_of_sig_arg fun_exp fparams args_exps (sig_arg : T.arg) =
     sig_arg.offset |> Common.map (fun x -> { o = Dot x; oorig = NoOrig })
   in
   let* lval, obj =
-    match sig_arg.pos with
-    | "<this>", -1 -> (
+    match sig_arg.base with
+    | Bthis -> (
         match fun_exp with
         | {
          e = Fetch { base = Var obj; rev_offset = [ { o = Dot _method; _ } ] };
@@ -1330,7 +1330,7 @@ let lval_of_sig_arg fun_exp fparams args_exps (sig_arg : T.arg) =
         } ->
             Some ({ base = Var obj; rev_offset = List.rev os }, obj)
         | __else__ -> None)
-    | pos -> (
+    | Barg pos -> (
         let* arg_exp = find_pos_in_actual_args args_exps fparams pos in
         match (arg_exp.e, sig_arg.offset) with
         | Fetch ({ base = Var obj; _ } as arg_lval), _ ->
@@ -1369,9 +1369,9 @@ let lval_of_sig_arg fun_exp fparams args_exps (sig_arg : T.arg) =
 (* What is the taint denoted by 'sig_arg' ? *)
 let taints_of_sig_arg env fparams fun_exp args_exps args_taints
     (sig_arg : T.arg) =
-  match sig_arg.offset with
-  | [] when snd sig_arg.pos >= 0 (* not `this`/`self` *) ->
-      find_pos_in_actual_args args_taints fparams sig_arg.pos
+  match sig_arg with
+  | { base = Barg pos; offset = [] } ->
+      find_pos_in_actual_args args_taints fparams pos
   | __else__ ->
       (* We want to know what's the taint carried by 'arg_exp.x1. ... .xN'. *)
       let* lval, _obj = lval_of_sig_arg fun_exp fparams args_exps sig_arg in

--- a/src/tainting/Taint.ml
+++ b/src/tainting/Taint.ml
@@ -109,15 +109,15 @@ let rec _show_call_trace show_thing = function
 (*****************************************************************************)
 
 type arg_pos = { name : string; index : int } [@@deriving show, compare]
-type arg_base = Bthis | Barg of arg_pos [@@deriving show, compare]
+type arg_base = BThis | BArg of arg_pos [@@deriving show, compare]
 type arg = { base : arg_base; offset : IL.name list } [@@deriving show]
 
 let _show_pos { name = s; index = i } = Printf.sprintf "arg(%s@%d)" s i
 
 let _show_base base =
   match base with
-  | Bthis -> "this"
-  | Barg pos -> _show_pos pos
+  | BThis -> "this"
+  | BArg pos -> _show_pos pos
 
 let _show_arg { base; offset = os } =
   _show_base base

--- a/src/tainting/Taint.mli
+++ b/src/tainting/Taint.mli
@@ -16,8 +16,9 @@ type 'a call_trace =
 type sink = { pm : Pattern_match.t; rule_sink : Rule.taint_sink }
 [@@deriving show]
 
-type arg_pos = string * int [@@deriving show]
-type arg = { pos : arg_pos; offset : IL.name list } [@@deriving show]
+type arg_pos = { name : string; index : int } [@@deriving show]
+type arg_base = Bthis | Barg of arg_pos [@@deriving show]
+type arg = { base : arg_base; offset : IL.name list } [@@deriving show]
 
 type source = {
   call_trace : Rule.taint_source call_trace;

--- a/src/tainting/Taint.mli
+++ b/src/tainting/Taint.mli
@@ -1,106 +1,121 @@
+(** Taint, taint traces, taint sets, and taint findings. *)
+
 module LabelSet : Set.S with type elt = string
+(** A set of taint labels. *)
+
+(*****************************************************************************)
+(* Taint *)
+(*****************************************************************************)
 
 type tainted_tokens = AST_generic.tok list [@@deriving show]
 (** A list of tokens showing where the taint passed through,
-  * at present these represent only code variables. *)
+  * at present these represent only code variables. For example,
+  * when passing through a statement like `x = tainted`, the token
+  * corresponding to `x` will be added to this list. *)
 
 (** A call trace to a source or sink match.
-  * E.g. Call('foo(a)', PM('sink(x)')) is an indirect match for 'sink(x)'
-  * through the function call 'foo(a)'. *)
-type 'a call_trace =
-  | PM of Pattern_match.t * 'a  (** A direct match.  *)
-  | Call of AST_generic.expr * tainted_tokens * 'a call_trace
+  * E.g. Call('foo()', PM('sink(x)')) tells us that by calling `foo(a)` we reach
+  * 'sink(x)' (here `a` is the actual argument passed to `foo`, and `x` could be
+  *  the formal argument of `foo`). *)
+type 'spec call_trace =
+  | PM of Pattern_match.t * 'spec
+      (** A direct match. The `'spec` would typically contain the pattern that
+        * was used to produce the match, e.g. one of the `pattern-sources`.  *)
+  | Call of AST_generic.expr * tainted_tokens * 'spec call_trace
       (** An indirect match through a function call. *)
 [@@deriving show]
 
-type sink = { pm : Pattern_match.t; rule_sink : Rule.taint_sink }
+type arg_pos = { name : string; index : int } [@@deriving show]
+(** A formal argument of a function given by its name and it's index/position. *)
+
+type arg_base =
+  | BThis
+      (** The 'this' or 'self' object, treated here like an special argument. *)
+  | BArg of arg_pos
 [@@deriving show]
 
-type arg_pos = { name : string; index : int } [@@deriving show]
-type arg_base = Bthis | Barg of arg_pos [@@deriving show]
 type arg = { base : arg_base; offset : IL.name list } [@@deriving show]
+(** An 'arg' taint acts like a taint variable that refers to a specific formal
+ * argument of a function/method, or to a specific offset of it. See 'signature'
+ * for more details. *)
 
 type source = {
   call_trace : Rule.taint_source call_trace;
   label : string;
       (** The label of this particular taint.
-        This may not agree with the source of the `call_trace`, because
-        this label may have changed, for instance by being propagated to
-        a different label.
-      *)
+       * This may not agree with the source of the `call_trace`, because
+       * this label may have changed by a propagator.
+       *)
   precondition : (taint list * Rule.precondition) option;
-      (** A precondition is a Boolean formula that must hold of a list of
-          taints, which may include taint variables.
-          A taint with an attached precondition is a "hypothetical taint",
-          because it may or may not actually exist. This is spawned by
-          (as of now) sources with an attached `requires`, because in the
-          interprocedural case, this taint's existence may depend on the
-          particular taint that the taint variables are instantiated with.
-      *)
+      (** A precondition is a Boolean formula over taint labels that must
+       * hold of a list of "input" taints, which should include at least one
+       * taint variable (if there were no taint variables then the precondition
+       * can be trivially solved). The precondition expression should be neither
+       * 'PBool true' nor 'PBool false'. Trivially true preconditions are
+       * represented by 'None', and trivially false preconditions should be
+       * droppped from taint sets.
+       *
+       * A taint with an attached precondition is "conditional", because
+       * its existence depends on the taints that arrive through the inputs of
+       * a function.  This is spawned by (as of now) sources with an attached
+       * `requires`. In the interprocedural case, the presence of a conditional
+       * taint label may depend on the particular taint that the taint variables
+       * are instantiated with.
+       *
+       * For example, given:
+       *
+       *     - label: B
+       *       requires: A
+       *       pattern: a2b(...)
+       *
+       * and a function definition:
+       *
+       *     def foo(x):
+       *         return a2b(x)
+       *
+       * we will determine that the taint of `a2b(x)` is `B` *conditional to*
+       * `x` having taint 'A':
+       *
+       *    (['arg(x#0)'], PLabel A)
+       *)
 }
 [@@deriving show]
 
 (** The origin of taint, where does taint comes from? *)
 and orig =
-  | Src of source  (** An actual taint source (`pattern-sources:` match). *)
+  | Src of source  (** An actual taint source (a `pattern-sources` match). *)
   | Arg of arg
-      (** A taint variable (potential taint coming through an argument). *)
+      (** Polymorphic taint variable: arbitrary taint coming through one of the
+       * arguments in a function definition. *)
 [@@deriving show]
 
 and taint = { orig : orig; tokens : tainted_tokens } [@@deriving show]
+(** At a given program location, taint is given by its origin (i.e. 'orig') and
+ * the path it took from that origin to the current location (i.e. 'tokens'). *)
 
-type taint_to_sink_item = {
-  taint : taint;
-  sink_trace : unit call_trace;
-      (** This trace is from the current calling context of the taint finding,
-        to the sink.
-        It's a `unit` call_trace because we don't actually need the item at the
-        end, and we need to be able to dispatch on the particular variant of taint
-        (source or arg).
-        *)
-}
-[@@deriving show]
+val trace_of_pm : Pattern_match.t * 'a -> 'a call_trace
+val pm_of_trace : 'a call_trace -> Pattern_match.t * 'a
 
-type taints_to_sink = {
-  taints_with_precondition : taint_to_sink_item list * Rule.precondition;
-  sink : sink;
-  merged_env : Metavariable.bindings;
-}
-[@@deriving show]
+(* TODO: Move 'Dataflow_tainting.subst_in_precondition' here, parameterized
+     by 'arg_to_taints'. *)
+(* This function just maps, bottom-up, the preconditions in a taint.
+   Since this only acts on the children of a taint, the type remains
+   the same.
+*)
+val map_preconditions : (taint list -> taint list) -> taint -> taint option
 
-(** Function-level finding (not necessarily a Semgrep finding). These may
-  * depend on taint variables so they must be interpreted on a specific
-  * context.
-  *)
-type finding =
-  | ToSink of taints_to_sink
-      (** Taint sources or potentially-tainted arguments inside the function
-          reach a sink. *)
-  | ToReturn of taint list * AST_generic.tok
-      (** Taint sources or potentially-tainted arguments
-          would reach a `return` statement. *)
-  | ToArg of taint list * arg
-[@@deriving show]
+val _show_arg : arg -> string
+(** Debugging functions. (TODO: Rename to 'debug_xyz' ? Replace 'show_xyz' ?) *)
 
-val compare_finding : finding -> finding -> int
+val _show_taint : taint -> string
 
-module Findings : Set.S with type elt = finding
-module Findings_tbl : Hashtbl.S with type key = finding
+(*****************************************************************************)
+(* Taint sets *)
+(*****************************************************************************)
 
-type signature = Findings.t
-(** A taint signature, it is simply a list of findings for a function.
- *
- * Note that `ArgToSink` and `ArgToReturn` introduce a form of
- * "taint polymorphism", making the taint analysis context-sensitive.
- *
- * Also note that, within each function, if there are multiple paths through
- * which a taint source may reach a sink, we do not keep all of them but only
- * the shortest one.
- *
- * THINK: We could write this in a way that resembles a function type,
- *   but right now it would probably just add complexity. *)
-
-(** A set of taint sources. *)
+(** A set of taints, where given two pieces of taint that are the same except
+ * for "details" such as their call trace, the set picks the "best" one (e.g.
+ * the one with the shortest trace). *)
 module Taint_set : sig
   type t
 
@@ -123,9 +138,6 @@ end
 
 type taints = Taint_set.t
 
-val trace_of_pm : Pattern_match.t * 'a -> 'a call_trace
-val pm_of_trace : 'a call_trace -> Pattern_match.t * 'a
-
 val solve_precondition :
   ignore_poly_taint:bool -> taints:taints -> Rule.precondition -> bool option
 
@@ -134,12 +146,88 @@ val taints_satisfy_requires : taint list -> Rule.precondition -> bool
 val taints_of_pms :
   incoming:taints -> (Pattern_match.t * Rule.taint_source) list -> taints
 
-(* This function just maps, bottom-up, the preconditions in a taint.
-   Since this only acts on the children of a taint, the type remains
-   the same.
-*)
-val map_preconditions : (taint list -> taint list) -> taint -> taint option
 val show_taints : taints -> string
-val _show_arg : arg -> string
+
+(*****************************************************************************)
+(* Taint findings / signatures *)
+(*****************************************************************************)
+
+type sink = { pm : Pattern_match.t; rule_sink : Rule.taint_sink }
+[@@deriving show]
+(** A sink match with its corresponding sink specification (one of the `pattern-sinks`). *)
+
+type taint_to_sink_item = {
+  taint : taint;
+  sink_trace : unit call_trace;
+      (** This trace is from the current calling context of the taint finding,
+        to the sink.
+        It's a `unit` call_trace because we don't actually need the item at the
+        end, and we need to be able to dispatch on the particular variant of taint
+        (source or arg).
+        *)
+}
+[@@deriving show]
+
+type taints_to_sink = {
+  taints_with_precondition : taint_to_sink_item list * Rule.precondition;
+      (** Taints reaching the sink and the precondition for the sink to apply. *)
+  sink : sink;
+  merged_env : Metavariable.bindings;
+      (** The metavariable environment that results of merging the environment from
+   * matching the source and the one from matching the sink. *)
+}
+[@@deriving show]
+
+(** Function-level finding.
+  *
+  * 'ToSink' findings where a taint source reaches a sink are candidates for
+  * actual Semgrep findings, although some may be dropped by deduplication.
+  *
+  * Findings are computed for each function/method definition, and formulated
+  * using 'arg' taints to act as placeholders of the taint that may be passed
+  * by an arbitrary caller via the function arguments. Thus the findings are
+  * polymorphic/context-sensitive, as the 'arg' taints can be instantiated
+  * accordingly at each call site.
+  *)
+type finding =
+  | ToSink of taints_to_sink  (** Taints reach a sink. *)
+  | ToReturn of taint list * AST_generic.tok
+      (** Taints reach a `return` statement. *)
+  | ToArg of taint list * arg  (** Taints reach an argument of the function *)
+[@@deriving show]
+
+val compare_finding : finding -> finding -> int
+
+module Findings : Set.S with type elt = finding
+module Findings_tbl : Hashtbl.S with type key = finding
+
+type signature = Findings.t
+(** A (polymorphic) taint signature: simply a set of findings for a function.
+ *
+ * Note that this signature is polymorphic/context-sensitive given that the
+ * potential taints coming into the function via its arguments are represented
+ * by 'arg' taints, that can be instantiated as needed.
+ *
+ * Also note that, within each function, if there are multiple paths through
+ * which a taint source may reach a sink, we do not keep all of them but only
+ * the shortest one.
+ *
+ * For example given:
+ *
+ *     def foo(x):
+ *         sink(x.a)
+ *
+ * We infer a signature that states (via a `ToSink` finding) that whatever
+ * taints come via the `.a` field of the argument `x` of `foo`, denoted by an
+ * 'arg' taint "variable", will reach the `sink`. So, when `foo(x)` is called in
+ * a context where the actual argument for `x` has it's `.a` field tainted,
+ * Semgrep will instantiate this signature and report a finding.
+ *
+ * THINK: We could use a type-and-effect language to represent taint sigantures,
+ * e.g.
+ *
+ *     forall 'a. {x: 'a} -{ sink('a) }-> unit
+ *
+ *)
+
 val _show_finding : finding -> string
-val _show_taint : taint -> string


### PR DESCRIPTION
We were representing `this` as a special argument with name "this" at position -1...

test plan:
make test

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
