### PR TITLE
fix: [ci] speed up OSX builds by allowing cache saves

### DIFF
--- a/.github/workflows/build-test-osx-arm64.yaml
+++ b/.github/workflows/build-test-osx-arm64.yaml
@@ -45,16 +45,15 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      # Note that this action handles both cache read and cache write.
-      # See https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows for more information on GHA caching.
-      - name: Cache Opam
-        id: cache-opam
-        uses: actions/cache@v3
-        if: ${{ inputs.use-cache || github.event_name == 'pull_request' }}
+      - name: Restore Opam Cache
+        id: restore-opam-cache
+        uses: actions/cache/restore@v3
+        if: ${{ inputs.use-cache }}
         env:
           SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
         with:
           path: ~/.opam
+          #TODO: we should add the md5sum of opam.lock as part of the key
           key: "${{ runner.os }}-${{ runner.arch }}-${{ env.OPAM_SWITCH_NAME }}-opam-deps"
       - name: Install dependencies
         run: |
@@ -69,6 +68,18 @@ jobs:
         with:
           path: artifacts.zip
           name: semgrep-osx-arm64-${{ github.sha }}
+      # By default, the actions/cache workflow will not save the directory to the cache if a cache hit occurs in
+      # restore-opam-cache. This allows us to manually save off the ~/.opam dir, keeping things up to date and speedy.
+      - name: Save Opam Cache
+        id: save-opam-cache
+        uses: actions/cache/restore@v3
+        if: ${{ inputs.use-cache }}
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
+        with:
+          path: ~/.opam
+          #TODO: we should add the md5sum of opam.lock as part of the key
+          key: "${{ runner.os }}-${{ runner.arch }}-${{ env.OPAM_SWITCH_NAME }}-opam-deps"
 
   build-wheels-osx-arm64:
     runs-on:

--- a/.github/workflows/build-test-osx-arm64.yaml
+++ b/.github/workflows/build-test-osx-arm64.yaml
@@ -54,7 +54,7 @@ jobs:
         with:
           path: ~/.opam
           #TODO: we should add the md5sum of opam.lock as part of the key
-          key: "${{ runner.os }}-${{ runner.arch }}-${{ env.OPAM_SWITCH_NAME }}-opam-deps-jpLFDCCCAsC3RGTj"
+          key: "${{ runner.os }}-${{ runner.arch }}-${{ env.OPAM_SWITCH_NAME }}-opam-deps"
       - name: Install dependencies
         run: |
           ./scripts/osx-setup-for-release.sh "${{ env.OPAM_SWITCH_NAME }}"
@@ -79,7 +79,7 @@ jobs:
         with:
           path: ~/.opam
           #TODO: we should add the md5sum of opam.lock as part of the key
-          key: "${{ runner.os }}-${{ runner.arch }}-${{ env.OPAM_SWITCH_NAME }}-opam-deps-jpLFDCCCAsC3RGTj"
+          key: "${{ runner.os }}-${{ runner.arch }}-${{ env.OPAM_SWITCH_NAME }}-opam-deps"
 
   build-wheels-osx-arm64:
     runs-on:

--- a/.github/workflows/build-test-osx-arm64.yaml
+++ b/.github/workflows/build-test-osx-arm64.yaml
@@ -72,7 +72,7 @@ jobs:
       # restore-opam-cache. This allows us to manually save off the ~/.opam dir, keeping things up to date and speedy.
       - name: Save Opam Cache
         id: save-opam-cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/save@v3
         if: ${{ inputs.use-cache }}
         env:
           SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2

--- a/.github/workflows/build-test-osx-arm64.yaml
+++ b/.github/workflows/build-test-osx-arm64.yaml
@@ -54,7 +54,7 @@ jobs:
         with:
           path: ~/.opam
           #TODO: we should add the md5sum of opam.lock as part of the key
-          key: "${{ runner.os }}-${{ runner.arch }}-${{ env.OPAM_SWITCH_NAME }}-opam-deps"
+          key: "${{ runner.os }}-${{ runner.arch }}-${{ env.OPAM_SWITCH_NAME }}-opam-deps-jpLFDCCCAsC3RGTj"
       - name: Install dependencies
         run: |
           ./scripts/osx-setup-for-release.sh "${{ env.OPAM_SWITCH_NAME }}"
@@ -79,7 +79,7 @@ jobs:
         with:
           path: ~/.opam
           #TODO: we should add the md5sum of opam.lock as part of the key
-          key: "${{ runner.os }}-${{ runner.arch }}-${{ env.OPAM_SWITCH_NAME }}-opam-deps"
+          key: "${{ runner.os }}-${{ runner.arch }}-${{ env.OPAM_SWITCH_NAME }}-opam-deps-jpLFDCCCAsC3RGTj"
 
   build-wheels-osx-arm64:
     runs-on:

--- a/.github/workflows/build-test-osx-x86.yaml
+++ b/.github/workflows/build-test-osx-x86.yaml
@@ -91,7 +91,7 @@ jobs:
         with:
           path: ~/.opam
           #TODO: we should add the md5sum of opam.lock as part of the key
-          key: "${{ runner.os }}-${{ runner.arch }}-${{ env.OPAM_SWITCH_NAME }}-opam-deps-jpLFDCCCAsC3RGTj"
+          key: "${{ runner.os }}-${{ runner.arch }}-${{ env.OPAM_SWITCH_NAME }}-opam-deps"
       - name: Install dependencies
         run: |
           ./scripts/osx-setup-for-release.sh "${{ env.OPAM_SWITCH_NAME }}"
@@ -116,7 +116,7 @@ jobs:
         with:
           path: ~/.opam
           #TODO: we should add the md5sum of opam.lock as part of the key
-          key: "${{ runner.os }}-${{ runner.arch }}-${{ env.OPAM_SWITCH_NAME }}-opam-deps-jpLFDCCCAsC3RGTj"
+          key: "${{ runner.os }}-${{ runner.arch }}-${{ env.OPAM_SWITCH_NAME }}-opam-deps"
 
   build-wheels-osx:
     runs-on: macos-12

--- a/.github/workflows/build-test-osx-x86.yaml
+++ b/.github/workflows/build-test-osx-x86.yaml
@@ -91,7 +91,7 @@ jobs:
         with:
           path: ~/.opam
           #TODO: we should add the md5sum of opam.lock as part of the key
-          key: "${{ runner.os }}-${{ runner.arch }}-${{ env.OPAM_SWITCH_NAME }}-opam-deps"
+          key: "${{ runner.os }}-${{ runner.arch }}-${{ env.OPAM_SWITCH_NAME }}-opam-deps-jpLFDCCCAsC3RGTj"
       - name: Install dependencies
         run: |
           ./scripts/osx-setup-for-release.sh "${{ env.OPAM_SWITCH_NAME }}"
@@ -116,7 +116,7 @@ jobs:
         with:
           path: ~/.opam
           #TODO: we should add the md5sum of opam.lock as part of the key
-          key: "${{ runner.os }}-${{ runner.arch }}-${{ env.OPAM_SWITCH_NAME }}-opam-deps"
+          key: "${{ runner.os }}-${{ runner.arch }}-${{ env.OPAM_SWITCH_NAME }}-opam-deps-jpLFDCCCAsC3RGTj"
 
   build-wheels-osx:
     runs-on: macos-12

--- a/.github/workflows/build-test-osx-x86.yaml
+++ b/.github/workflows/build-test-osx-x86.yaml
@@ -109,7 +109,7 @@ jobs:
       # restore-opam-cache. This allows us to manually save off the ~/.opam dir, keeping things up to date and speedy.
       - name: Save Opam Cache
         id: save-opam-cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/save@v3
         if: ${{ inputs.use-cache }}
         env:
           SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2

--- a/.github/workflows/build-test-osx-x86.yaml
+++ b/.github/workflows/build-test-osx-x86.yaml
@@ -69,11 +69,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      # Note that this action handles both cache read and cache write.
       # See https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows for more information on GHA caching.
-      # Things are saved automatically by GHA in a "Post Cache Opam" phase runs
-      # when the full job has been completed (click on 'Details' in the PR for the
-      # check to see this phase).
       # Note that this works and speedup things because of the way OPAM works
       # and osx-setup-for-release.sh is written. Indeed, this script checks
       # if the opam switch is already created, and if a package is already
@@ -82,11 +78,9 @@ jobs:
       # hit the cache unfortunately, but we would spend time only for installing
       # those new packages (ideally we would want to regenerate the cache by
       # using an opam.pock in the cache key).
-      # TODO? Should we use instead the actions/cache/save@v3 and
-      # actions/cache/restore@v3 instead like in build-test-javascript.yaml?
-      - name: Cache Opam
-        id: cache-opam
-        uses: actions/cache@v3
+      - name: Restore Opam Cache
+        id: restore-opam-cache
+        uses: actions/cache/restore@v3
         if: ${{ inputs.use-cache }}
         # The size of the tgz of ~/.opam is around 500MB, which usually takes less than
         # 2min to download from GHA. If it takes more than that, that means something
@@ -111,6 +105,18 @@ jobs:
         with:
           path: artifacts.zip
           name: semgrep-osx-${{ github.sha }}
+      # By default, the actions/cache workflow will not save the directory to the cache if a cache hit occurs in
+      # restore-opam-cache. This allows us to manually save off the ~/.opam dir, keeping things up to date and speedy.
+      - name: Save Opam Cache
+        id: save-opam-cache
+        uses: actions/cache/restore@v3
+        if: ${{ inputs.use-cache }}
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
+        with:
+          path: ~/.opam
+          #TODO: we should add the md5sum of opam.lock as part of the key
+          key: "${{ runner.os }}-${{ runner.arch }}-${{ env.OPAM_SWITCH_NAME }}-opam-deps"
 
   build-wheels-osx:
     runs-on: macos-12


### PR DESCRIPTION
the `actions/cache` workflow was not saving the cache back after workflow completion whenever there was a cache hit. This caused the builds to slow down over time, as the `opam update` step needed to do more work to bring packages up to do. 

The fix is to manually restore and then manually save the cache on each run. This can still be overridden using existing flags. 

Test Plan:

- CI on this PR.

PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
