### PR TITLE
fix(pysemgrep): add require for jsonnet

### DIFF
--- a/changelog.d/gh-8314.fixed
+++ b/changelog.d/gh-8314.fixed
@@ -1,0 +1,1 @@
+Add missing jsonnet dependency.

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -93,6 +93,7 @@ install_requires = [
     "colorama~=0.4.0",
     "defusedxml~=0.7.1",
     "glom~=22.1",
+    "jsonnet~=0.18",
     "jsonschema~=4.6",
     "packaging>=21.0",
     "peewee~=3.14",
@@ -106,7 +107,7 @@ install_requires = [
     "wcmatch~=8.3",
 ]
 
-extras_require = {"experiments": ["jsonnet~=0.18"]}
+extras_require = {}
 
 setuptools.setup(
     name="semgrep",


### PR DESCRIPTION
## What
Fixing python dependencies for the CLI. The library `jsonnet` wasn't install automatically by  `brew install semgrep` command on my local mac as envidenced by the following bash interaction.

```
$ brew install semgrep
...
$ semgrep --config semgrep.jsonnet .
Support for Jsonnet rules is experimental and currently meant for internal use only. The syntax may change or be removed at any point.
Running jsonnet rules requires the python jsonnet library. Please run `pip install jsonnet` and try again.
cannot access local variable '_jsonnet' where it is not associated with a value
Traceback (most recent call last):
  File "/opt/homebrew/Cellar/semgrep/1.32.0/libexec/lib/python3.11/site-packages/semgrep/commands/wrapper.py", line 35, in wrapper
    func(*args, **kwargs)
  File "/opt/homebrew/Cellar/semgrep/1.32.0/libexec/lib/python3.11/site-packages/semgrep/commands/scan.py", line 907, in scan
    ) = semgrep.semgrep_main.main(
        ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/semgrep/1.32.0/libexec/lib/python3.11/site-packages/semgrep/semgrep_main.py", line 418, in main
    configs_obj, config_errors = get_config(
                                 ^^^^^^^^^^^
  File "/opt/homebrew/Cellar/semgrep/1.32.0/libexec/lib/python3.11/site-packages/semgrep/config_resolver.py", line 806, in get_config
    config, errors = Config.from_config_list(config_strs, project_url)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/semgrep/1.32.0/libexec/lib/python3.11/site-packages/semgrep/config_resolver.py", line 368, in from_config_list
    resolved_config = ConfigPath(config, project_url).resolve_config()
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/semgrep/1.32.0/libexec/lib/python3.11/site-packages/semgrep/config_resolver.py", line 300, in resolve_config
    config = parse_config_files(
             ^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/semgrep/1.32.0/libexec/lib/python3.11/site-packages/semgrep/config_resolver.py", line 279, in parse_config_files
    config.update(parse_config_string(config_id, contents, filename))
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/semgrep/1.32.0/libexec/lib/python3.11/site-packages/semgrep/config_resolver.py", line 644, in parse_config_string
    contents = _jsonnet.evaluate_snippet(
               ^^^^^^^^
UnboundLocalError: cannot access local variable '_jsonnet' where it is not associated with a value

$ pip install jsonnet
Collecting jsonnet
  Downloading jsonnet-0.20.0.tar.gz (594 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 594.2/594.2 kB 9.1 MB/s eta 0:00:00
  Preparing metadata (setup.py) ... done
Building wheels for collected packages: jsonnet
  Building wheel for jsonnet (setup.py) ... done
  Created wheel for jsonnet: filename=jsonnet-0.20.0-cp311-cp311-macosx_13_0_arm64.whl size=425072 sha256=25e970e0cd123941e7f3e7bb91e88d3cd8c4b14f7140c1f32255c9b33928f987
  Stored in directory: /Users/andre/Library/Caches/pip/wheels/9e/42/d6/1754654d2a274cc7dc97b5087e49cded863657d63b7d35f676
Successfully built jsonnet
Installing collected packages: jsonnet
Successfully installed jsonnet-0.20.0

[notice] A new release of pip is available: 23.0.1 -> 23.2
[notice] To update, run: python3.11 -m pip install --upgrade pip
$ semgrep --config semgrep.jsonnet .
Support for Jsonnet rules is experimental and currently meant for internal use only. The syntax may change or be removed at any point.


┌─────────────┐
│ Scan Status │
└─────────────┘
  Scanning 7108 files tracked by git with 58 Code rules:

  Language   Rules   Files          Origin      Rules
 ──────────────────────────        ───────────────────
  ocaml         50     968          Community      31
  python         7     314          Unknown        27

  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:01


┌──────────────┐
│ Scan Summary │
└──────────────┘
Some files were skipped or only partially analyzed.
  Scan was limited to files tracked by git.
  Partially scanned: 8 files only partially analyzed due to parsing or internal Semgrep errors
  Scan skipped: 18 files larger than 1.0 MB, 4919 files matching .semgrepignore patterns
  For a full list of skipped files, run semgrep with the --verbose flag.

(need more rules? `semgrep login` for additional free Semgrep Registry rules)

Ran 58 rules on 1282 files: 0 findings.
If Semgrep missed a finding, please send us feedback to let us know!
  $ semgrep shouldafound --help
```

## How
Moves jsonnet from a extra_require to a regular require.

## Testing
I don't have a great way of testing this in CI. 

1. I manually uninstalled the pip library that I installed to fix this.
2. Ran `make -c cli setup`
3. Ran `pipenv shell`
4. Ran `semgrep --config semgrep.jsonnet` which now works.

I think this shows that this is working, but `make -c cli test` doesn't work for me locally, because of some shenanigans with mypy. Is there a way of testing command #4 in CI?

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
