### PR TITLE
fix CI, semgrep error

### DIFF
--- a/src/osemgrep/cli_ci/Ci_subcommand.ml
+++ b/src/osemgrep/cli_ci/Ci_subcommand.ml
@@ -292,7 +292,7 @@ let prepare_for_report ~blocking_findings findings errors rules ~targets
      POST to /api/agent/scans/<scan_id>/complete *)
   let complete =
     let errors =
-      List.map
+      Common.map
         (fun e ->
           JSON.json_of_string (Semgrep_output_v1_j.string_of_cli_error e))
         errors


### PR DESCRIPTION
This fixes the error introduced in
https://github.com/returntocorp/semgrep/pull/8213
but that was hard to diagnose because we weirdly can't see
precommit errors generated by osemgrep

test plan:
make check_for_emacs


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)