### PR TITLE
cleanup: split AST_bash.ml in 3 modules

### DIFF
--- a/languages/bash/ast/AST_bash_builder.ml
+++ b/languages/bash/ast/AST_bash_builder.ml
@@ -1,0 +1,113 @@
+(* Martin Jambon
+ *
+ * Copyright (C) 2021 Semgrep Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * version 2.1 as published by the Free Software Foundation, with the
+ * special exception on linking described in file license.txt.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
+ * license.txt for more details.
+ *)
+open AST_bash
+
+(*****************************************************************************)
+(* Prelude *)
+(*****************************************************************************)
+(* Helpers to build or convert AST_bash constructs *)
+
+(*****************************************************************************)
+(* Helpers *)
+(*****************************************************************************)
+
+let concat_blists (x : blist list) : blist =
+  match List.rev x with
+  | [] ->
+      (* TODO: use actual location in the program rather than completely
+         fake location *)
+      Empty Tok_range.unsafe_fake_loc
+  | last_blist :: blists ->
+      let end_ = AST_bash_loc.blist_loc last_blist in
+      List.fold_left
+        (fun acc blist ->
+          let start = AST_bash_loc.blist_loc blist in
+          let loc = Tok_range.range start end_ in
+          Seq (loc, blist, acc))
+        last_blist blists
+
+let add_redirects_to_command (cmd_r : cmd_redir) (redirects : redirect list) :
+    cmd_redir =
+  let all_locs = cmd_r.loc :: Common.map AST_bash_loc.redirect_loc redirects in
+  let loc = Tok_range.of_list (fun loc -> loc) all_locs in
+  { cmd_r with loc; redirects = cmd_r.redirects @ redirects }
+
+let rec add_redirects_to_last_command_of_pipeline pip redirects : pipeline =
+  match pip with
+  | Command cmd_r -> Command (add_redirects_to_command cmd_r redirects)
+  | Pipeline (loc, pip, bar, cmd_r) ->
+      let cmd_r = add_redirects_to_command cmd_r redirects in
+      let loc = Tok_range.range loc cmd_r.loc in
+      Pipeline (loc, pip, bar, cmd_r)
+  | Control_operator (loc, pip, op) ->
+      let pip = add_redirects_to_last_command_of_pipeline pip redirects in
+      let loc = Tok_range.range loc (AST_bash_loc.pipeline_loc pip) in
+      Control_operator (loc, pip, op)
+
+(*
+   We use this only to analyze and simplify a pattern. This loses the location
+   information if the list is empty.
+*)
+let flatten_blist blist : pipeline list =
+  let rec flatten acc blist =
+    match blist with
+    | Seq (_loc, a, b) ->
+        let acc = flatten acc a in
+        flatten acc b
+    | Pipelines (_loc, pips) -> List.rev_append pips acc
+    | Empty _loc -> acc
+  in
+  flatten [] blist |> List.rev
+
+(*
+   Simple expressions returned by this function:
+
+     foo
+     $foo
+     ""
+
+   Not simple expressions:
+
+     foo bar
+     foo;
+     foo > bar
+     foo &
+     foo | bar
+*)
+let rec pipeline_as_expression pip : expression option =
+  match pip with
+  | Command cmd_r -> (
+      match (cmd_r.redirects, cmd_r.command) with
+      | [], Simple_command cmd -> (
+          match (cmd.assignments, cmd.arguments) with
+          | [], [ arg0 ] -> Some arg0
+          | _ -> None)
+      | _ -> None)
+  | Pipeline _ -> None
+  | Control_operator (_loc, pip, (op, _tok)) -> (
+      match op with
+      | Foreground Fg_newline -> pipeline_as_expression pip
+      | Foreground (Fg_semi | Fg_semisemi)
+      | Background ->
+          None)
+
+(*
+   This is necessary to that a pattern 'foo' is not translated into to a
+   function/command call.
+*)
+let blist_as_expression blist : expression option =
+  match flatten_blist blist with
+  | [ pip ] -> pipeline_as_expression pip
+  | _ -> None

--- a/languages/bash/ast/AST_bash_builder.mli
+++ b/languages/bash/ast/AST_bash_builder.mli
@@ -1,0 +1,6 @@
+val blist_as_expression : AST_bash.blist -> AST_bash.expression option
+
+val add_redirects_to_last_command_of_pipeline :
+  AST_bash.pipeline -> AST_bash.redirect list -> AST_bash.pipeline
+
+val concat_blists : AST_bash.blist list -> AST_bash.blist

--- a/languages/bash/ast/AST_bash_loc.ml
+++ b/languages/bash/ast/AST_bash_loc.ml
@@ -1,0 +1,169 @@
+(* Martin Jambon
+ *
+ * Copyright (C) 2021 Semgrep Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * version 2.1 as published by the Free Software Foundation, with the
+ * special exception on linking described in file license.txt.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
+ * license.txt for more details.
+ *)
+open AST_bash
+
+(*****************************************************************************)
+(* Extraction of the first token, used for its location info *)
+(*****************************************************************************)
+
+let wrap_loc (_, tok) : loc = (tok, tok)
+let bracket_loc (start_tok, _, end_tok) : loc = (start_tok, end_tok)
+let todo_loc (TODO loc) = loc
+
+let command_loc = function
+  | Simple_command x -> x.loc
+  | And (loc, _, _, _) -> loc
+  | Or (loc, _, _, _) -> loc
+  | Subshell (loc, _) -> loc
+  | Command_group (loc, _) -> loc
+  | Sh_test (loc, _) -> loc
+  | Bash_test (loc, _) -> loc
+  | Arithmetic_expression (loc, _) -> loc
+  | For_loop (loc, _, _, _, _, _, _) -> loc
+  | For_loop_c_style (loc, _) -> loc
+  | Select (loc, _, _, _, _, _, _) -> loc
+  | Case (loc, _, _, _, _, _) -> loc
+  | If (loc, _, _, _, _, _, _, _) -> loc
+  | While_loop (loc, _, _, _, _, _) -> loc
+  | Until_loop (loc, _, _, _, _, _) -> loc
+  | Coprocess (loc, _, _) -> loc
+  | Assignment x -> x.loc
+  | Declaration x -> x.loc
+  | Negated_command (loc, _, _) -> loc
+  | Function_definition (loc, _) -> loc
+
+let pipeline_loc = function
+  | Command x -> x.loc
+  | Pipeline (loc, _, _, _) -> loc
+  | Control_operator (loc, _, _) -> loc
+
+let blist_loc = function
+  | Seq (loc, _, _) -> loc
+  | Pipelines (loc, _) -> loc
+  | Empty loc -> loc
+
+let _sh_test_loc (x : sh_test) =
+  let open_, _, close = x in
+  (open_, close)
+
+let _bash_test_loc (x : bash_test) =
+  let open_, _, close = x in
+  (open_, close)
+
+let _arithmetic_expression_loc (x : arithmetic_expression) =
+  let open_, _, close = x in
+  (open_, close)
+
+let _case_clause_loc ((loc, _, _, _, _) : case_clause) = loc
+
+let case_clause_terminator_tok = function
+  | Break tok
+  | Fallthrough tok
+  | Try_next tok ->
+      tok
+
+let _case_clause_terminator_loc x =
+  let tok = case_clause_terminator_tok x in
+  (tok, tok)
+
+let _elif_loc (x : elif) =
+  let loc, _elif, _cond, _then, _body = x in
+  loc
+
+let _else_loc (x : else_) =
+  let loc, _else, _body = x in
+  loc
+
+let assignment_loc (x : assignment) = x.loc
+
+let _assignment_list_loc (x : assignment list) =
+  Tok_range.of_list assignment_loc x
+
+let _declaration_loc (x : declaration) = x.loc
+
+let expression_loc = function
+  | Word x -> wrap_loc x
+  | String x -> bracket_loc x
+  | String_fragment (loc, _) -> loc
+  | Raw_string x -> wrap_loc x
+  | Ansii_c_string x -> wrap_loc x
+  | Special_character x -> wrap_loc x
+  | Concatenation (loc, _) -> loc
+  | Expr_semgrep_ellipsis tok -> (tok, tok)
+  | Expr_semgrep_deep_ellipsis (loc, _) -> loc
+  | Expr_semgrep_metavar x -> wrap_loc x
+  | Equality_test (loc, _, _) -> loc
+  | Empty_expression loc -> loc
+  | Array (loc, _) -> loc
+  | Process_substitution (loc, _) -> loc
+
+let string_fragment_loc = function
+  | String_content x -> wrap_loc x
+  | Expansion (loc, _) -> loc
+  | Command_substitution x -> bracket_loc x
+  | Frag_semgrep_metavar x -> wrap_loc x
+  | Frag_semgrep_named_ellipsis x -> wrap_loc x
+
+let _expansion_loc = function
+  | Simple_expansion (loc, _) -> loc
+  | Complex_expansion x -> bracket_loc x
+
+let variable_name_loc x = variable_name_wrap x |> wrap_loc
+
+let _complex_expansion_loc = function
+  | Variable (loc, _) -> loc
+  | Complex_expansion_TODO loc -> loc
+
+let _command_substitution_loc x = bracket_loc x
+
+let eq_op_loc = function
+  | EQTILDE (* "=~" *) tok -> (tok, tok)
+  | EQEQ (* "==" *) tok -> (tok, tok)
+
+let right_eq_operand_loc = function
+  | Literal (loc, _) -> loc
+  | Regexp x -> wrap_loc x
+
+let test_expression_loc = function
+  | T_expr (loc, _)
+  | T_unop (loc, _, _)
+  | T_binop (loc, _, _, _)
+  | T_not (loc, _, _)
+  | T_and (loc, _, _, _)
+  | T_or (loc, _, _, _)
+  | T_todo loc ->
+      loc
+
+let _write_redir_src_loc (x : write_redir_src) =
+  match x with
+  | Stdout tok
+  | Stdout_and_stderr tok
+  | File_descriptor (_, tok) ->
+      (tok, tok)
+
+let _file_redir_target_loc (x : file_redir_target) =
+  match x with
+  | File e -> expression_loc e
+  | File_descriptor w -> wrap_loc w
+  | Stdout_and_stderr tok -> (tok, tok)
+  | Close_fd tok -> (tok, tok)
+
+let redirect_loc (x : redirect) =
+  match x with
+  | File_redirect (loc, _) -> loc
+  | Read_heredoc x -> todo_loc x
+  | Read_herestring x -> todo_loc x
+
+let cmd_redir_loc { loc; command = _; redirects = _ } = loc

--- a/languages/bash/ast/AST_bash_loc.mli
+++ b/languages/bash/ast/AST_bash_loc.mli
@@ -1,0 +1,18 @@
+(* Extraction of the first token of an AST construct, used for its
+   location info.
+*)
+
+val expression_loc : AST_bash.expression -> Tok_range.t
+val test_expression_loc : AST_bash.test_expression -> Tok_range.t
+val assignment_loc : AST_bash.assignment -> Tok_range.t
+val pipeline_loc : AST_bash.pipeline -> Tok_range.t
+val blist_loc : AST_bash.blist -> Tok_range.t
+val redirect_loc : AST_bash.redirect -> Tok_range.t
+val command_loc : AST_bash.command -> Tok_range.t
+val cmd_redir_loc : AST_bash.cmd_redir -> Tok_range.t
+val variable_name_loc : AST_bash.variable_name -> Tok_range.t
+val eq_op_loc : AST_bash.eq_op -> Tok_range.t
+val right_eq_operand_loc : AST_bash.right_eq_operand -> Tok_range.t
+val string_fragment_loc : AST_bash.string_fragment -> Tok_range.t
+val wrap_loc : 'a * Tok.t -> Tok_range.t
+val bracket_loc : Tok.t * 'a * Tok.t -> Tok_range.t

--- a/languages/bash/tree-sitter/Parse_bash_tree_sitter.ml
+++ b/languages/bash/tree-sitter/Parse_bash_tree_sitter.ml
@@ -54,8 +54,9 @@ type tmp_stmt =
   | Tmp_pipeline of pipeline
   | Tmp_command of (cmd_redir * unary_control_operator wrap option)
 
+(* TODO? move in AST_bash_builder.ml? *)
 let blist_of_pipeline (pip : pipeline) =
-  let loc = pipeline_loc pip in
+  let loc = AST_bash_loc.pipeline_loc pip in
   Pipelines (loc, [ pip ])
 
 let rec is_empty_blist (blist : blist) =
@@ -77,14 +78,16 @@ let replace_last l replace =
 (* Add a terminator e.g. '&' to the last pipeline of the blist. *)
 let add_terminator_to_blist (blist : blist) (term : unary_control_operator wrap)
     =
-  let term_loc = wrap_loc term in
+  let term_loc = AST_bash_loc.wrap_loc term in
   let rec add_to blist : blist =
     match blist with
     | Seq (loc, a, b) -> if is_empty_blist b then add_to a else blist
     | Pipelines (loc, pipelines) ->
         let pipelines =
           replace_last pipelines (fun pip ->
-              let loc = Tok_range.range (pipeline_loc pip) term_loc in
+              let loc =
+                Tok_range.range (AST_bash_loc.pipeline_loc pip) term_loc
+              in
               [ Control_operator (loc, pip, term) ])
         in
         let loc = Tok_range.range loc term_loc in
@@ -341,7 +344,9 @@ and binary_expression (env : env) (x : CST.binary_expression) : test_expression
       in
       let right = expression env v3 in
       T_todo
-        (Tok_range.range (test_expression_loc left) (test_expression_loc right))
+        (Tok_range.range
+           (AST_bash_loc.test_expression_loc left)
+           (AST_bash_loc.test_expression_loc right))
   | `Exp_choice_EQEQ_regex (v1, v2, v3) ->
       let left = expression env v1 in
       let _op =
@@ -351,7 +356,7 @@ and binary_expression (env : env) (x : CST.binary_expression) : test_expression
       in
 
       let right = token env v3 (* regex *) in
-      T_todo (fst (test_expression_loc left), right)
+      T_todo (fst (AST_bash_loc.test_expression_loc left), right)
 
 and case_item (env : env) ((v1, v2, v3, v4, v5) : CST.case_item) : case_clause =
   let first_pattern = literal env v1 in
@@ -380,7 +385,7 @@ and case_item (env : env) ((v1, v2, v3, v4, v5) : CST.case_item) : case_clause =
             let tok = token env tok (* ";;&" *) in
             (Try_next tok, tok))
   in
-  let loc = (fst (expression_loc first_pattern), end_tok) in
+  let loc = (fst (AST_bash_loc.expression_loc first_pattern), end_tok) in
   (loc, patterns, paren, case_body, Some terminator)
 
 and command (env : env) ((v1, v2, v3) : CST.command) : cmd_redir =
@@ -410,19 +415,21 @@ and command (env : env) ((v1, v2, v3) : CST.command) : cmd_redir =
               match v2 with
               | `Choice_conc x ->
                   let e = literal env x in
-                  Literal (expression_loc e, e)
+                  Literal (AST_bash_loc.expression_loc e, e)
               | `Regex tok -> (* regex *) Regexp (str env tok)
             in
             let loc =
-              Tok_range.range (eq_op_loc eq) (right_eq_operand_loc right)
+              Tok_range.range
+                (AST_bash_loc.eq_op_loc eq)
+                (AST_bash_loc.right_eq_operand_loc right)
             in
             Equality_test (loc, eq, right))
       v3
   in
   let arguments = name :: args in
   let loc =
-    let loc1 = Tok_range.of_list assignment_loc assignments in
-    let loc2 = Tok_range.of_list expression_loc arguments in
+    let loc1 = Tok_range.of_list AST_bash_loc.assignment_loc assignments in
+    let loc2 = Tok_range.of_list AST_bash_loc.expression_loc arguments in
     Tok_range.of_locs [ loc1; loc2 ]
   in
   let command = Simple_command { loc; assignments; arguments } in
@@ -432,12 +439,12 @@ and command_name (env : env) (x : CST.command_name) : expression =
   match x with
   | `Conc x ->
       let el = concatenation env x in
-      let loc = Tok_range.of_list expression_loc el in
+      let loc = Tok_range.of_list AST_bash_loc.expression_loc el in
       Concatenation (loc, el)
   | `Choice_semg_deep_exp x -> primary_expression env x
   | `Rep1_spec_char xs ->
       let el = Common.map (fun tok -> Special_character (str env tok)) xs in
-      let loc = Tok_range.of_list expression_loc el in
+      let loc = Tok_range.of_list AST_bash_loc.expression_loc el in
       Concatenation (loc, el)
 
 and command_substitution (env : env) (x : CST.command_substitution) :
@@ -510,7 +517,7 @@ and elif_clause (env : env) ((v1, v2, v3, v4) : CST.elif_clause) : elif =
     | Some x -> statements2 env x
     | None -> Empty (then_, then_)
   in
-  let loc = (elif, snd (blist_loc body)) in
+  let loc = (elif, snd (AST_bash_loc.blist_loc body)) in
   (loc, elif, cond, then_, body)
 
 and else_clause (env : env) ((v1, v2) : CST.else_clause) : else_ =
@@ -520,7 +527,7 @@ and else_clause (env : env) ((v1, v2) : CST.else_clause) : else_ =
     | Some x -> statements2 env x
     | None -> Empty (else_, else_)
   in
-  let loc = (else_, snd (blist_loc body)) in
+  let loc = (else_, snd (AST_bash_loc.blist_loc body)) in
   (loc, else_, body)
 
 and expansion (env : env) ((v1, v2, v3, v4) : CST.expansion) :
@@ -591,7 +598,7 @@ and expansion (env : env) ((v1, v2, v3, v4) : CST.expansion) :
   let complex_expansion =
     match opt_variable with
     | Some var ->
-        let loc = variable_name_loc var in
+        let loc = AST_bash_loc.variable_name_loc var in
         Variable (loc, var)
     | None ->
         let loc = (open_, close) in
@@ -610,10 +617,10 @@ and expression (env : env) (x : CST.expression) : test_expression =
   match x with
   | `Choice_conc x ->
       let e = literal env x in
-      T_expr (expression_loc e, e)
+      T_expr (AST_bash_loc.expression_loc e, e)
   | `Un_exp (v1, v2) -> (
       let e = expression env v2 in
-      let e_loc = test_expression_loc e in
+      let e_loc = AST_bash_loc.test_expression_loc e in
       match v1 with
       | `BANG tok ->
           let bang = token env tok in
@@ -636,8 +643,8 @@ and expression (env : env) (x : CST.expression) : test_expression =
       let branch1 = expression env v3 in
       let _v4 = token env v4 (* ":" *) in
       let branch2 = expression env v5 in
-      let start, _ = test_expression_loc cond in
-      let _, end_ = test_expression_loc branch2 in
+      let start, _ = AST_bash_loc.test_expression_loc cond in
+      let _, end_ = AST_bash_loc.test_expression_loc branch2 in
       let loc = (start, end_) in
       T_todo loc
   | `Bin_exp x -> binary_expression env x
@@ -649,7 +656,7 @@ and expression (env : env) (x : CST.expression) : test_expression =
         | `PLUSPLUS tok -> (* "++" *) token env tok
         | `DASHDASH tok -> (* "--" *) token env tok
       in
-      let start, _ = test_expression_loc e in
+      let start, _ = AST_bash_loc.test_expression_loc e in
       let loc = (start, op_tok) in
       T_todo loc
   | `Paren_exp (v1, v2, v3) ->
@@ -671,7 +678,7 @@ and file_redir_target (x : expression) : file_redir_target =
 and file_redirect (env : env) ((v1, v2, v3) : CST.file_redirect) : redirect =
   let target_e = literal env v3 in
   let target = target_e |> file_redir_target in
-  let loc = ref (expression_loc target_e) in
+  let loc = ref (AST_bash_loc.expression_loc target_e) in
   let update_loc tok = loc := Tok_range.extend !loc tok in
   let opt_src_fd : write_redir_src option =
     match v1 with
@@ -734,7 +741,7 @@ and file_redirect (env : env) ((v1, v2, v3) : CST.file_redirect) : redirect =
         let tok = token2 env tok (* ">|" *) in
         Write (src_fd1 tok, (Write_force_truncate, tok), target)
   in
-  let loc = Tok_range.union !loc (expression_loc target_e) in
+  let loc = Tok_range.union !loc (AST_bash_loc.expression_loc target_e) in
   File_redirect (loc, file_redir)
 
 and heredoc_body (env : env) (x : CST.heredoc_body) : todo =
@@ -762,7 +769,7 @@ and heredoc_body (env : env) (x : CST.heredoc_body) : todo =
 and herestring_redirect (env : env) ((v1, v2) : CST.herestring_redirect) =
   let op = token env v1 (* "<<<" *) in
   let e = literal env v2 in
-  let loc = (op, snd (expression_loc e)) in
+  let loc = (op, snd (AST_bash_loc.expression_loc e)) in
   TODO loc
 
 (* This is the same as case_item except for the optional terminator. *)
@@ -784,23 +791,23 @@ and last_case_item (env : env) ((v1, v2, v3, v4, v5) : CST.last_case_item) =
     | Some tok ->
         let tok = token env tok (* ";;" *) in
         (Some (Break tok), tok)
-    | None -> (None, snd (blist_loc case_body))
+    | None -> (None, snd (AST_bash_loc.blist_loc case_body))
   in
-  let loc = (fst (expression_loc first_pattern), end_tok) in
+  let loc = (fst (AST_bash_loc.expression_loc first_pattern), end_tok) in
   (loc, patterns, paren, case_body, opt_terminator)
 
 and literal (env : env) (x : CST.literal) : expression =
   match x with
   | `Conc x -> (
       let el = concatenation env x in
-      let loc = Tok_range.of_list expression_loc el in
+      let loc = Tok_range.of_list AST_bash_loc.expression_loc el in
       match el with
       | [ e ] -> e
       | _ -> Concatenation (loc, el))
   | `Choice_semg_deep_exp x -> primary_expression env x
   | `Rep1_spec_char xs -> (
       let el = Common.map (fun tok -> Special_character (str env tok)) xs in
-      let loc = Tok_range.of_list expression_loc el in
+      let loc = Tok_range.of_list AST_bash_loc.expression_loc el in
       match el with
       | [ e ] -> e
       | _ -> Concatenation (loc, el))
@@ -822,11 +829,11 @@ and primary_expression (env : env) (x : CST.primary_expression) : expression =
           Ansii_c_string (str env tok (* pattern "\\$'([^']|\\\\')*'" *))
       | `Expa x ->
           let e = expansion env x in
-          let loc = bracket_loc e in
+          let loc = AST_bash_loc.bracket_loc e in
           String_fragment (loc, Expansion (loc, Complex_expansion e))
       | `Simple_expa x ->
           let frag = simple_expansion env x in
-          let loc = string_fragment_loc frag in
+          let loc = AST_bash_loc.string_fragment_loc frag in
           String_fragment (loc, frag)
       | `Str_expa (v1, v2) ->
           let dollar = token env v1 (* "$" *) in
@@ -844,7 +851,7 @@ and primary_expression (env : env) (x : CST.primary_expression) : expression =
           e
       | `Cmd_subs x ->
           let frag = Command_substitution (command_substitution env x) in
-          let loc = string_fragment_loc frag in
+          let loc = AST_bash_loc.string_fragment_loc frag in
           String_fragment (loc, frag)
       | `Proc_subs (v1, v2, v3) ->
           let open_ =
@@ -869,14 +876,14 @@ and program (env : env) ~tok (opt : CST.program) : blist =
 *)
 and blist_statement (env : env) (x : CST.statement) : blist =
   match statement env x with
-  | Tmp_pipeline x -> Pipelines (pipeline_loc x, [ x ])
+  | Tmp_pipeline x -> Pipelines (AST_bash_loc.pipeline_loc x, [ x ])
   | Tmp_command (cmd_r, control_op) -> (
-      let loc = cmd_redir_loc cmd_r in
+      let loc = AST_bash_loc.cmd_redir_loc cmd_r in
       let cmd = Command cmd_r in
       match control_op with
       | None -> Pipelines (loc, [ cmd ])
       | Some op ->
-          let _, end_ = wrap_loc op in
+          let _, end_ = AST_bash_loc.wrap_loc op in
           let loc2 = (fst loc, end_) in
           Pipelines (loc2, [ Control_operator (loc2, cmd, op) ]))
 
@@ -888,12 +895,12 @@ and pipeline_statement (env : env) (x : CST.statement) : pipeline =
   match statement env x with
   | Tmp_pipeline x -> x
   | Tmp_command (cmd_r, control_op) -> (
-      let loc = cmd_redir_loc cmd_r in
+      let loc = AST_bash_loc.cmd_redir_loc cmd_r in
       let cmd = Command cmd_r in
       match control_op with
       | None -> cmd
       | Some op ->
-          let _, end_ = wrap_loc op in
+          let _, end_ = AST_bash_loc.wrap_loc op in
           let loc2 = (fst loc, end_) in
           Control_operator (loc, cmd, op))
 
@@ -937,12 +944,15 @@ and statement (env : env) (x : CST.statement) : tmp_stmt =
                 None)
           v2
       in
-      let pip = add_redirects_to_last_command_of_pipeline pip redirects in
+      let pip =
+        AST_bash_builder.add_redirects_to_last_command_of_pipeline pip redirects
+      in
       Tmp_pipeline pip
   | `Var_assign x ->
       let a = variable_assignment env x in
       let command = Assignment a in
-      Tmp_command ({ loc = assignment_loc a; command; redirects = [] }, None)
+      Tmp_command
+        ({ loc = AST_bash_loc.assignment_loc a; command; redirects = [] }, None)
   | `Cmd x -> Tmp_command (command env x, None)
   | `Decl_cmd (v1, v2) ->
       let (attrs1 : declaration_attribute wrap list), tok =
@@ -984,16 +994,16 @@ and statement (env : env) (x : CST.statement) : tmp_stmt =
                      last_tok := tok
                  | e ->
                      Common.push e unknowns;
-                     last_tok := snd (expression_loc e))
+                     last_tok := snd (AST_bash_loc.expression_loc e))
              | `Choice_semg_meta x ->
                  (* x, $X *)
                  let var = simple_variable_name env x in
-                 last_tok := variable_name_loc var |> snd;
+                 last_tok := AST_bash_loc.variable_name_loc var |> snd;
                  Common.push var decls
              | `Var_assign x ->
                  (* x=42, $X=42 *)
                  let assign = variable_assignment env x in
-                 last_tok := assignment_loc assign |> snd;
+                 last_tok := AST_bash_loc.assignment_loc assign |> snd;
                  Common.push assign assigns);
       let decls = List.rev !decls in
       let assigns = List.rev !assigns in
@@ -1030,7 +1040,7 @@ and statement (env : env) (x : CST.statement) : tmp_stmt =
              | `Choice_conc x ->
                  let e = literal env x in
                  Common.push e unknowns;
-                 last_tok := expression_loc e |> snd
+                 last_tok := AST_bash_loc.expression_loc e |> snd
              | `Choice_semg_meta tok ->
                  let var = simple_variable_name env tok in
                  Common.push var decls;
@@ -1049,7 +1059,7 @@ and statement (env : env) (x : CST.statement) : tmp_stmt =
       Tmp_command ({ loc; command; redirects = [] }, None)
   | `Test_cmd x ->
       let command = test_command env x in
-      let loc = command_loc command in
+      let loc = AST_bash_loc.command_loc command in
       Tmp_command ({ loc; command; redirects = [] }, None)
   | `Nega_cmd (v1, v2) ->
       let excl = token env v1 (* "!" *) in
@@ -1060,11 +1070,11 @@ and statement (env : env) (x : CST.statement) : tmp_stmt =
             (loc, command, redirects)
         | `Test_cmd x ->
             let command = test_command env x in
-            let loc = command_loc command in
+            let loc = AST_bash_loc.command_loc command in
             (loc, command, [])
         | `Subs x ->
             let sub = subshell env x in
-            let loc = bracket_loc sub in
+            let loc = AST_bash_loc.bracket_loc sub in
             (loc, Subshell (loc, sub), [])
       in
       let loc = Tok_range.extend loc excl in
@@ -1195,7 +1205,7 @@ and statement (env : env) (x : CST.statement) : tmp_stmt =
         | `BARAMP tok -> (Bar_ampersand, token env tok (* "|&" *))
       in
       let extra_cmd, control_op = command_statement env v3 in
-      let start, _ = pipeline_loc left_pipeline in
+      let start, _ = AST_bash_loc.pipeline_loc left_pipeline in
       let _, end_ = extra_cmd.loc in
       let loc = (start, end_) in
       let pipeline = Pipeline (loc, left_pipeline, bar, extra_cmd) in
@@ -1210,7 +1220,11 @@ and statement (env : env) (x : CST.statement) : tmp_stmt =
   | `List (v1, v2, v3) ->
       let left = pipeline_statement env v1 in
       let right = pipeline_statement env v3 in
-      let loc = Tok_range.range (pipeline_loc left) (pipeline_loc right) in
+      let loc =
+        Tok_range.range
+          (AST_bash_loc.pipeline_loc left)
+          (AST_bash_loc.pipeline_loc right)
+      in
       let command =
         match v2 with
         | `AMPAMP tok -> And (loc, left, token env tok, right)
@@ -1219,12 +1233,12 @@ and statement (env : env) (x : CST.statement) : tmp_stmt =
       Tmp_command ({ loc; command; redirects = [] }, None)
   | `Subs x ->
       let sub = subshell env x in
-      let loc = bracket_loc sub in
+      let loc = AST_bash_loc.bracket_loc sub in
       let command = Subshell (loc, sub) in
       Tmp_command ({ loc; command; redirects = [] }, None)
   | `Comp_stmt x ->
       let res = compound_statement env x in
-      let loc = bracket_loc res in
+      let loc = AST_bash_loc.bracket_loc res in
       let command = Command_group (loc, res) in
       Tmp_command ({ loc; command; redirects = [] }, None)
   | `Func_defi (v1, v2) ->
@@ -1252,18 +1266,20 @@ and statement (env : env) (x : CST.statement) : tmp_stmt =
         match v2 with
         | `Comp_stmt x ->
             let br = compound_statement env x in
-            Command_group (bracket_loc br, br)
+            Command_group (AST_bash_loc.bracket_loc br, br)
         | `Subs x ->
             let br = subshell env x in
-            Subshell (bracket_loc br, br)
+            Subshell (AST_bash_loc.bracket_loc br, br)
         | `Test_cmd x -> test_command env x
       in
-      let loc = Tok_range.extend (command_loc body) start in
+      let loc = Tok_range.extend (AST_bash_loc.command_loc body) start in
       let command = Function_definition (loc, { loc; function_; name; body }) in
       Tmp_command ({ loc; command; redirects = [] }, None)
 
 and statements (env : env) ((v1, v2, v3, v4) : CST.statements) : blist =
-  let blist = Common.map (stmt_with_opt_heredoc env) v1 |> concat_blists in
+  let blist =
+    Common.map (stmt_with_opt_heredoc env) v1 |> AST_bash_builder.concat_blists
+  in
   (* See stmt_with_opt_heredoc, which is almost identical except for
      the optional trailing newline. *)
   let last_blist = blist_statement env v2 in
@@ -1286,11 +1302,15 @@ and statements (env : env) ((v1, v2, v3, v4) : CST.statements) : blist =
     | None -> last_blist
     | Some term -> add_terminator_to_blist last_blist term
   in
-  let loc = Tok_range.range (blist_loc blist) (blist_loc last_blist) in
+  let loc =
+    Tok_range.range
+      (AST_bash_loc.blist_loc blist)
+      (AST_bash_loc.blist_loc last_blist)
+  in
   Seq (loc, blist, last_blist)
 
 and statements2 (env : env) (xs : CST.statements2) : blist =
-  Common.map (stmt_with_opt_heredoc env) xs |> concat_blists
+  Common.map (stmt_with_opt_heredoc env) xs |> AST_bash_builder.concat_blists
 
 and string_ (env : env) ((v1, v2, v3, v4) : CST.string_) :
     string_fragment list bracket =
@@ -1312,7 +1332,7 @@ and string_ (env : env) ((v1, v2, v3, v4) : CST.string_) :
               dollar @ content
           | `Expa x ->
               let e = expansion env x in
-              let loc = bracket_loc e in
+              let loc = AST_bash_loc.bracket_loc e in
               [ Expansion (loc, Complex_expansion e) ]
           | `Simple_expa x ->
               let frag = simple_expansion env x in
@@ -1363,7 +1383,7 @@ and terminated_statement (env : env) ((v1, v2) : CST.terminated_statement) :
     pipeline =
   let pip = pipeline_statement env v1 in
   let op = terminator env v2 in
-  Control_operator (pipeline_loc pip, pip, op)
+  Control_operator (AST_bash_loc.pipeline_loc pip, pip, op)
 
 and test_command (env : env) (v1 : CST.test_command) : command =
   match v1 with
@@ -1434,7 +1454,7 @@ and variable_assignment (env : env) (x : CST.variable_assignment) : assignment =
         (var, assign_op, v3)
   in
   let rhs = right_hand_side env rhs in
-  let loc = (snd lhs, snd (expression_loc rhs)) in
+  let loc = (snd lhs, snd (AST_bash_loc.expression_loc rhs)) in
   { loc; lhs; assign_op; rhs }
 
 and right_hand_side (env : env) (x : CST.anon_choice_lit_bbf16c7) : expression =


### PR DESCRIPTION
I usually try to have a small and readable AST_xxx and move
separate concerns in other files

I started this cleanup as I was trying to add support for
Makefile/Bash in semgrep, and looking how were handling Docker/Bash
and just started to cleanup code as I was seeing things that could
be improved.

test plan:
make core


PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)