### PR TITLE
cleanup: split AST_dockerfile.ml

### DIFF
--- a/languages/dockerfile/ast/AST_dockerfile.ml
+++ b/languages/dockerfile/ast/AST_dockerfile.ml
@@ -1,13 +1,29 @@
+(* Martin Jambon
+ *
+ * Copyright (C) 2021 Semgrep Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * version 2.1 as published by the Free Software Foundation, with the
+ * special exception on linking described in file license.txt.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
+ * license.txt for more details.
+ *)
+
+(*****************************************************************************)
+(* Prelude *)
+(*****************************************************************************)
 (*
    Dockerfile AST type definition.
 
    Language reference:
    https://docs.docker.com/engine/reference/builder/
 
-   Extends AST_bash.
+   Extends AST_bash!
 *)
-
-module B = AST_bash
 
 (*****************************************************************************)
 (* Token info *)
@@ -114,10 +130,11 @@ type string_array = array_elt list bracket
    which changes the shell to an unsupported shell (i.e. not sh or bash).
 *)
 type argv_or_shell =
-  | Command_semgrep_ellipsis of tok
   | Argv of loc * (* [ "cmd", "arg1", "arg2$X" ] *) string_array
+  (* !!! This is where we embed Bash constructs (Bash lists) !!! *)
   | Sh_command of loc * AST_bash.blist
   | Other_shell_command of shell_compatibility * string wrap
+  | Command_semgrep_ellipsis of tok
 
 type param =
   loc * (tok (* -- *) * string wrap (* name *) * tok (* = *) * string wrap)
@@ -132,8 +149,8 @@ type image_spec = {
 }
 
 type label_pair =
-  | Label_semgrep_ellipsis of tok
   | Label_pair of loc * var_or_metavar (* key *) * tok (* = *) * docker_string
+  | Label_semgrep_ellipsis of tok
 
 (* value *)
 
@@ -151,14 +168,14 @@ type run_param =
 type cmd = loc * string wrap * run_param list * argv_or_shell
 
 type healthcheck =
-  | Healthcheck_semgrep_metavar of string wrap
   | Healthcheck_none of tok
   | Healthcheck_cmd of loc * param list * cmd
+  | Healthcheck_semgrep_metavar of string wrap
 
 type expose_port =
-  | Expose_semgrep_ellipsis of tok
   | Expose_port of (* port/protocol *) string wrap * string wrap option
   | Expose_fragment of docker_string_fragment
+  | Expose_semgrep_ellipsis of tok
 
 type instruction =
   | From of
@@ -199,115 +216,12 @@ type instruction =
 
 type program = instruction list
 
-(***************************************************************************)
-(* Location extraction *)
-(***************************************************************************)
+(*****************************************************************************)
+(* Helpers (see also AST_dockerfile_loc.ml) *)
+(*****************************************************************************)
 
 let wrap_tok ((_, tok) : _ wrap) = tok
-let wrap_loc ((_, tok) : _ wrap) = (tok, tok)
-let bracket_loc ((open_, _, close) : _ bracket) = (open_, close)
 
 let var_or_metavar_tok = function
   | Var_ident (_, tok) -> tok
   | Var_semgrep_metavar (_, tok) -> tok
-
-let var_or_metavar_loc x =
-  let tok = var_or_metavar_tok x in
-  (tok, tok)
-
-let expansion_tok = function
-  | Expand_var (_, tok) -> tok
-  | Expand_semgrep_metavar (_, tok) -> tok
-
-let expansion_loc x =
-  let tok = expansion_tok x in
-  (tok, tok)
-
-let double_quoted_string_fragment_loc = function
-  | Dbl_string_content (_, tok) -> (tok, tok)
-  | Dbl_expansion (loc, _) -> loc
-  | Dbl_frag_semgrep_metavar (_, tok) -> (tok, tok)
-
-let docker_string_fragment_loc (x : docker_string_fragment) =
-  match x with
-  | Unquoted (_, tok) -> (tok, tok)
-  | Single_quoted (loc, _) -> loc
-  | Double_quoted (loc, _) -> loc
-  | Expansion (loc, _) -> loc
-  | Frag_semgrep_metavar (_, tok) -> (tok, tok)
-
-let docker_string_loc ((loc, _) : docker_string) = loc
-
-let str_or_ellipsis_loc = function
-  | Str_str str -> docker_string_loc str
-  | Str_semgrep_ellipsis tok -> (tok, tok)
-
-(* Re-using the type used for double-quoted strings in bash *)
-let quoted_string_loc = bracket_loc
-
-(*
-   The default shell depends on the platform on which docker runs (Unix or
-   Windows). For now, we assume the shell is the Bourne shell which we
-   treat as Bash. In the future, we could require the caller to specify
-   if the dockerfile is for Windows and call is a dockerfile-windows dialect.
-   Guessing the platform from the base image name would be possible in
-   some cases but always, so that may not be a good solution.
-
-   Here we have an Other case which is used after a SHELL directive
-   which changes the shell to an unsupported shell (i.e. not sh or bash).
-*)
-let argv_or_shell_loc = function
-  | Command_semgrep_ellipsis tok -> (tok, tok)
-  | Argv (loc, _) -> loc
-  | Sh_command (loc, _) -> loc
-  | Other_shell_command (_, x) -> wrap_loc x
-
-let param_loc ((loc, _) : param) : loc = loc
-let image_spec_loc (x : image_spec) = x.loc
-
-let label_pair_loc = function
-  | Label_semgrep_ellipsis tok -> (tok, tok)
-  | Label_pair (loc, _, _, _) -> loc
-
-let string_array_loc = bracket_loc
-
-let array_or_paths_loc = function
-  | Array (loc, _)
-  | Paths (loc, _) ->
-      loc
-
-let cmd_loc ((loc, _, _, _) : cmd) = loc
-
-let healthcheck_loc = function
-  | Healthcheck_semgrep_metavar (_, tok) -> (tok, tok)
-  | Healthcheck_none tok -> (tok, tok)
-  | Healthcheck_cmd (loc, _, _) -> loc
-
-let expose_port_loc = function
-  | Expose_semgrep_ellipsis tok -> (tok, tok)
-  | Expose_port ((_, tok1), Some (_, tok2)) -> (tok1, tok2)
-  | Expose_port ((_, tok), None) -> (tok, tok)
-  | Expose_fragment x -> docker_string_fragment_loc x
-
-let instruction_loc = function
-  | From (loc, _, _, _, _) -> loc
-  | Run (loc, _, _, _) -> loc
-  | Cmd cmd -> cmd_loc cmd
-  | Label (loc, _, _) -> loc
-  | Expose (loc, _, _) -> loc
-  | Env (loc, _, _) -> loc
-  | Add (loc, _, _, _, _) -> loc
-  | Copy (loc, _, _, _, _) -> loc
-  | Entrypoint (loc, _, _) -> loc
-  | Volume (loc, _, _) -> loc
-  | User (loc, _, _, _) -> loc
-  | Workdir (loc, _, _) -> loc
-  | Arg (loc, _, _, _) -> loc
-  | Onbuild (loc, _, _) -> loc
-  | Stopsignal (loc, _, _) -> loc
-  | Healthcheck (loc, _, _) -> loc
-  | Shell (loc, _, _) -> loc
-  | Maintainer (loc, _, _) -> loc
-  | Cross_build_xxx (loc, _, _) -> loc
-  | Instr_semgrep_ellipsis tok -> (tok, tok)
-  | Instr_semgrep_metavar (_, tok) -> (tok, tok)

--- a/languages/dockerfile/ast/AST_dockerfile_loc.ml
+++ b/languages/dockerfile/ast/AST_dockerfile_loc.ml
@@ -1,0 +1,124 @@
+(* Martin Jambon
+ *
+ * Copyright (C) 2021 Semgrep Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * version 2.1 as published by the Free Software Foundation, with the
+ * special exception on linking described in file license.txt.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
+ * license.txt for more details.
+ *)
+
+open AST_dockerfile
+
+(***************************************************************************)
+(* Location extraction *)
+(***************************************************************************)
+
+let wrap_loc ((_, tok) : _ wrap) = (tok, tok)
+let bracket_loc ((open_, _, close) : _ bracket) = (open_, close)
+
+let _var_or_metavar_loc x =
+  let tok = var_or_metavar_tok x in
+  (tok, tok)
+
+let expansion_tok = function
+  | Expand_var (_, tok) -> tok
+  | Expand_semgrep_metavar (_, tok) -> tok
+
+let _expansion_loc x =
+  let tok = expansion_tok x in
+  (tok, tok)
+
+let _double_quoted_string_fragment_loc = function
+  | Dbl_string_content (_, tok) -> (tok, tok)
+  | Dbl_expansion (loc, _) -> loc
+  | Dbl_frag_semgrep_metavar (_, tok) -> (tok, tok)
+
+let docker_string_fragment_loc (x : docker_string_fragment) =
+  match x with
+  | Unquoted (_, tok) -> (tok, tok)
+  | Single_quoted (loc, _) -> loc
+  | Double_quoted (loc, _) -> loc
+  | Expansion (loc, _) -> loc
+  | Frag_semgrep_metavar (_, tok) -> (tok, tok)
+
+let docker_string_loc ((loc, _) : docker_string) = loc
+
+let str_or_ellipsis_loc = function
+  | Str_str str -> docker_string_loc str
+  | Str_semgrep_ellipsis tok -> (tok, tok)
+
+(* Re-using the type used for double-quoted strings in bash *)
+let _quoted_string_loc = bracket_loc
+
+(*
+   The default shell depends on the platform on which docker runs (Unix or
+   Windows). For now, we assume the shell is the Bourne shell which we
+   treat as Bash. In the future, we could require the caller to specify
+   if the dockerfile is for Windows and call is a dockerfile-windows dialect.
+   Guessing the platform from the base image name would be possible in
+   some cases but always, so that may not be a good solution.
+
+   Here we have an Other case which is used after a SHELL directive
+   which changes the shell to an unsupported shell (i.e. not sh or bash).
+*)
+let argv_or_shell_loc = function
+  | Command_semgrep_ellipsis tok -> (tok, tok)
+  | Argv (loc, _) -> loc
+  | Sh_command (loc, _) -> loc
+  | Other_shell_command (_, x) -> wrap_loc x
+
+let param_loc ((loc, _) : param) : loc = loc
+let image_spec_loc (x : image_spec) = x.loc
+
+let label_pair_loc = function
+  | Label_semgrep_ellipsis tok -> (tok, tok)
+  | Label_pair (loc, _, _, _) -> loc
+
+let _string_array_loc = bracket_loc
+
+let array_or_paths_loc = function
+  | Array (loc, _)
+  | Paths (loc, _) ->
+      loc
+
+let cmd_loc ((loc, _, _, _) : cmd) = loc
+
+let healthcheck_loc = function
+  | Healthcheck_semgrep_metavar (_, tok) -> (tok, tok)
+  | Healthcheck_none tok -> (tok, tok)
+  | Healthcheck_cmd (loc, _, _) -> loc
+
+let expose_port_loc = function
+  | Expose_semgrep_ellipsis tok -> (tok, tok)
+  | Expose_port ((_, tok1), Some (_, tok2)) -> (tok1, tok2)
+  | Expose_port ((_, tok), None) -> (tok, tok)
+  | Expose_fragment x -> docker_string_fragment_loc x
+
+let instruction_loc = function
+  | From (loc, _, _, _, _) -> loc
+  | Run (loc, _, _, _) -> loc
+  | Cmd cmd -> cmd_loc cmd
+  | Label (loc, _, _) -> loc
+  | Expose (loc, _, _) -> loc
+  | Env (loc, _, _) -> loc
+  | Add (loc, _, _, _, _) -> loc
+  | Copy (loc, _, _, _, _) -> loc
+  | Entrypoint (loc, _, _) -> loc
+  | Volume (loc, _, _) -> loc
+  | User (loc, _, _, _) -> loc
+  | Workdir (loc, _, _) -> loc
+  | Arg (loc, _, _, _) -> loc
+  | Onbuild (loc, _, _) -> loc
+  | Stopsignal (loc, _, _) -> loc
+  | Healthcheck (loc, _, _) -> loc
+  | Shell (loc, _, _) -> loc
+  | Maintainer (loc, _, _) -> loc
+  | Cross_build_xxx (loc, _, _) -> loc
+  | Instr_semgrep_ellipsis tok -> (tok, tok)
+  | Instr_semgrep_metavar (_, tok) -> (tok, tok)

--- a/languages/dockerfile/ast/AST_dockerfile_loc.mli
+++ b/languages/dockerfile/ast/AST_dockerfile_loc.mli
@@ -1,0 +1,16 @@
+(* Location extraction for different AST_dockerfile constructs *)
+
+val docker_string_fragment_loc :
+  AST_dockerfile.docker_string_fragment -> Tok_range.t
+
+val docker_string_loc : AST_dockerfile.docker_string -> Tok_range.t
+val instruction_loc : AST_dockerfile.instruction -> Tok_range.t
+val argv_or_shell_loc : AST_dockerfile.argv_or_shell -> Tok_range.t
+val param_loc : AST_dockerfile.param -> Tok_range.t
+val image_spec_loc : AST_dockerfile.image_spec -> Tok_range.t
+val label_pair_loc : AST_dockerfile.label_pair -> Tok_range.t
+val expose_port_loc : AST_dockerfile.expose_port -> Tok_range.t
+val str_or_ellipsis_loc : AST_dockerfile.str_or_ellipsis -> Tok_range.t
+val array_or_paths_loc : AST_dockerfile.array_or_paths -> Tok_range.t
+val healthcheck_loc : AST_dockerfile.healthcheck -> Tok_range.t
+val wrap_loc : 'a * Tok.t -> Tok_range.t

--- a/languages/dockerfile/generic/Dockerfile_to_generic.ml
+++ b/languages/dockerfile/generic/Dockerfile_to_generic.ml
@@ -4,6 +4,7 @@
 
 module G = AST_generic
 open AST_dockerfile
+module DLoc = AST_dockerfile_loc
 
 type env = AST_bash.input_kind
 
@@ -164,7 +165,7 @@ let argv_or_shell (env : env) (x : argv_or_shell) : G.expr list =
       [ call_shell loc Sh [ args ] ]
   | Other_shell_command (shell_compat, code) ->
       let args = [ unquoted_string_expr code ] in
-      let loc = wrap_loc code in
+      let loc = DLoc.wrap_loc code in
       [ call_shell loc shell_compat args ]
 
 let param_arg (x : param) : G.argument =
@@ -369,7 +370,7 @@ let instruction env (x : instruction) : G.stmt =
   let expr = instruction_expr env x in
   match expr.e with
   | StmtExpr stmt -> stmt
-  | _ -> stmt_of_expr (instruction_loc x) expr
+  | _ -> stmt_of_expr (DLoc.instruction_loc x) expr
 
 let program_with_env (env : env) (x : program) : G.stmt list =
   Common.map (instruction env) x


### PR DESCRIPTION
Similar to the previous PR about AST_bash.ml

test plan:
make core


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)