### PR TITLE
fix(SSC): Allow nothing after `empty=` in `gradle.lockfile`

### DIFF
--- a/changelog.d/sc-987.fixed
+++ b/changelog.d/sc-987.fixed
@@ -1,0 +1,1 @@
+Fixed bug in gradle.lockfile parser where we would error on `empty=` with nothing after it

--- a/cli/src/semdep/parsers/gradle.py
+++ b/cli/src/semdep/parsers/gradle.py
@@ -67,7 +67,7 @@ manifest = (
 
 gradle = (
     string(PREFIX)
-    >> (dep | (string("empty=") >> consume_line))
+    >> (dep | (regex("empty=[^\n]*").result(None)))
     .sep_by(string("\n"))
     .map(lambda xs: [x for x in xs if x])
     << string("\n").optional()

--- a/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awarejava-gradle-sca.yaml-dependency_awaregradle_empty/results.txt
+++ b/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awarejava-gradle-sca.yaml-dependency_awaregradle_empty/results.txt
@@ -1,0 +1,91 @@
+=== command
+SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERSION_CACHE_PATH="<MASKED>" SEMGREP_ENABLE_VERSION_CHECK="0" SEMGREP_SEND_METRICS="off" semgrep --strict --config rules/dependency_aware/java-gradle-sca.yaml --json targets/dependency_aware/gradle_empty=
+=== end of command
+
+=== exit code
+0
+=== end of exit code
+
+=== stdout - plain
+{
+  "errors": [],
+  "paths": {
+    "_comment": "<add --verbose for a list of skipped paths>",
+    "scanned": [
+      "targets/dependency_aware/gradle_empty=/gradle.lockfile"
+    ]
+  },
+  "results": [
+    {
+      "check_id": "rules.dependency_aware.java-gradle-sca",
+      "end": {
+        "col": 0,
+        "line": 5,
+        "offset": 0
+      },
+      "extra": {
+        "engine_kind": "OSS",
+        "fingerprint": "0x42",
+        "is_ignored": false,
+        "lines": "org.webjars.npm:swagger-ui-dist:3.35.2=productionRuntimeClasspath,runtimeClasspath,testRuntimeClasspath\norg.xmlunit:xmlunit-core:2.8.4=testCompileClasspath,testRuntimeClasspath",
+        "message": "oh no",
+        "metadata": {},
+        "metavars": {},
+        "sca_info": {
+          "dependency_match": {
+            "dependency_pattern": {
+              "ecosystem": "maven",
+              "package": "org.webjars.npm:swagger-ui-dist",
+              "semver_range": "<= 3.35.2"
+            },
+            "found_dependency": {
+              "allowed_hashes": {},
+              "ecosystem": "maven",
+              "line_number": 4,
+              "package": "org.webjars.npm:swagger-ui-dist",
+              "transitivity": "unknown",
+              "version": "3.35.2"
+            },
+            "lockfile": "targets/dependency_aware/gradle_empty=/gradle.lockfile"
+          },
+          "reachability_rule": true,
+          "reachable": false,
+          "sca_finding_schema": 20220913
+        },
+        "severity": "WARNING"
+      },
+      "path": "targets/dependency_aware/gradle_empty=/gradle.lockfile",
+      "start": {
+        "col": 0,
+        "line": 4,
+        "offset": 0
+      }
+    }
+  ],
+  "version": "0.42"
+}
+=== end of stdout - plain
+
+=== stderr - plain
+
+
+┌─────────────┐
+│ Scan Status │
+└─────────────┘
+  Scanning 1 file tracked by git with 0 Code rules, 1 Supply Chain rule:
+
+
+  CODE RULES
+  Nothing to scan.
+
+  SUPPLY CHAIN RULES
+  Nothing to scan.
+
+
+┌──────────────┐
+│ Scan Summary │
+└──────────────┘
+
+Ran 1 rule on 1 file: 1 finding.
+
+=== end of stderr - plain

--- a/cli/tests/e2e/targets/dependency_aware/gradle_empty=/gradle.lockfile
+++ b/cli/tests/e2e/targets/dependency_aware/gradle_empty=/gradle.lockfile
@@ -1,0 +1,7 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+org.webjars.npm:swagger-ui-dist:3.35.2=productionRuntimeClasspath,runtimeClasspath,testRuntimeClasspath
+org.xmlunit:xmlunit-core:2.8.4=testCompileClasspath,testRuntimeClasspath
+org.yaml:snakeyaml:1.29=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+empty=

--- a/cli/tests/e2e/test_dependency_aware_rules.py
+++ b/cli/tests/e2e/test_dependency_aware_rules.py
@@ -59,6 +59,10 @@ pytestmark = pytest.mark.kinda_slow
             "dependency_aware/gradle_trailing_newline",
         ),
         (
+            "rules/dependency_aware/java-gradle-sca.yaml",
+            "dependency_aware/gradle_empty=",
+        ),
+        (
             "rules/dependency_aware/python-poetry-sca.yaml",
             "dependency_aware/poetry",
         ),


### PR DESCRIPTION
The `consume_line` parser expects at least one character to read, which caused errors on the line
```
empty=
```
Just replaced it with a regex that does not have this problem.

test plan: see added test

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
