### PR TITLE
fix(rust): various translation issues

### DIFF
--- a/changelog.d/pa-2936.fixed
+++ b/changelog.d/pa-2936.fixed
@@ -1,0 +1,2 @@
+Rust: Fixed an issue where implicit returns did not allow taint to flow,
+and various other small translation issues that would affect taint.

--- a/languages/rust/generic/Parse_rust_tree_sitter.ml
+++ b/languages/rust/generic/Parse_rust_tree_sitter.ml
@@ -1527,16 +1527,22 @@ and map_expression_ending_with_block (env : env)
 
 and map_expression_statement (env : env) (x : CST.expression_statement) : G.stmt
     =
+  (* We don't want to get ExprStmt of StmtExpr, if possible. *)
+  let simplify sc expr =
+    match expr with
+    | { G.e = G.StmtExpr stmt; _ } -> stmt
+    | expr -> G.ExprStmt (expr, sc) |> G.s
+  in
   match x with
   | `Choice_exp_SEMI x -> (
       match x with
       | `Exp_SEMI (v1, v2) ->
           let expr = map_expression env v1 in
-          let semicolon = token env v2 (* ";" *) in
-          G.ExprStmt (expr, semicolon) |> G.s
+          let sc = token env v2 (* ";" *) in
+          simplify sc expr
       | `Choice_unsafe_blk x ->
           let expr = map_expression_ending_with_block env x in
-          G.ExprStmt (expr, sc) |> G.s)
+          simplify sc expr)
   | `Ellips_SEMI (v1, v2) ->
       let ellipsis = token env v1 (* "..." *) in
       let sc = token env v2 (* ";" *) in

--- a/src/analyzing/AST_to_IL.ml
+++ b/src/analyzing/AST_to_IL.ml
@@ -1598,7 +1598,8 @@ and stmt env st =
 and function_body env fbody =
   let implicit_return_hack body_stmt =
     match body_stmt with
-    | G.Block (_, ss, _) when env.lang =*= Lang.Ruby -> (
+    | G.Block (_, ss, _) when env.lang =*= Lang.Ruby || env.lang =*= Lang.Rust
+      -> (
         match List.rev ss with
         | { s = G.ExprStmt (e, tok); _ } :: rev_ss' ->
             Some (List.rev rev_ss', (e, tok))

--- a/src/parsing/Parse_pattern.ml
+++ b/src/parsing/Parse_pattern.ml
@@ -50,6 +50,7 @@ let rec normalize_any (lang : Lang.t) (any : G.any) : G.any =
   | G.E { e = G.N name; _ } when lang =*= Lang.Rust ->
       normalize_any lang (G.Name name)
   | G.E { e = G.RawExpr x; _ } -> normalize_any lang (G.Raw x)
+  | G.E { e = G.StmtExpr s; _ } -> normalize_any lang (G.S s)
   | G.Raw (List [ x ]) -> normalize_any lang (G.Raw x)
   (* TODO: taken from ml_to_generic.ml:
    * | G.E {e = G.StmtExpr s; _} -> G.S s?

--- a/tests/rules/taint_implicit_return.rs
+++ b/tests/rules/taint_implicit_return.rs
@@ -1,0 +1,23 @@
+
+// ruleid: taint-implicit-return
+fn foo(s : String) -> String{
+  s
+}
+
+// ruleid: taint-implicit-return
+fn foo(s : String) -> String{
+  let some_var = s;
+  some_var
+}
+
+// ruleid: taint-implicit-return
+fn foo(s : String) -> String{
+  let some_var = s;
+  s
+}
+
+// ruleid: taint-implicit-return
+fn foo(s : String) -> String{
+  let some_var = "s";
+  s
+}

--- a/tests/rules/taint_implicit_return.yaml
+++ b/tests/rules/taint_implicit_return.yaml
@@ -1,0 +1,19 @@
+rules:
+  - id: taint-implicit-return
+    message: Semgrep found a match
+    languages:
+      - rust
+    severity: WARNING
+    mode: taint
+    pattern-sources:
+      - patterns:
+          - pattern-inside: |
+              fn $F(..., $S : String, ...) -> String {
+                ...
+              }
+          - pattern: $S
+    pattern-sinks:
+      - pattern: |
+          fn $F(...) -> String{
+              ...
+          }

--- a/tests/rules/taint_rust_returns.rs
+++ b/tests/rules/taint_rust_returns.rs
@@ -1,0 +1,12 @@
+fn foo() -> () {
+
+  let x = source;
+
+  if condition == 1 {
+      // ruleid: taint-rust-returns
+      return x;
+  }
+
+  // ruleid: taint-rust-returns
+  return x;
+}

--- a/tests/rules/taint_rust_returns.yaml
+++ b/tests/rules/taint_rust_returns.yaml
@@ -1,0 +1,19 @@
+rules:
+  - id: taint-rust-returns
+    message: Semgrep found a match
+    languages:
+      - rust
+    severity: WARNING
+    mode: taint
+    pattern-sources:
+      - patterns:
+          - pattern-inside: |
+              fn $FUNC(...) -> $RET {
+                ...
+              }
+          - pattern: |
+              source
+    pattern-sinks:
+      - patterns:
+          - pattern: |
+              return ...


### PR DESCRIPTION
## What:
This PR fixes a few translation issues that we had, related to Rust support. These were degenerate `ExprStmt`s, implicit returns, and degenerate `StmtExpr` patterns.

## Why:
These are blocking Rust support.

## How:
Made the degenerate translations no longer degenerate, and allowed Rust as a language with implicit return `ExprStmt`s.

## Test plan:
`make test`

Closes PA-2936

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
