### PR TITLE
feat: Collect scan contributions from git logs

### DIFF
--- a/changelog.d/scp-313.added
+++ b/changelog.d/scp-313.added
@@ -1,0 +1,1 @@
+Added `-dump_contributions` flag to semgrep-core and include contributions when posting findings to Scan API.

--- a/cli/src/semgrep/app/scans.py
+++ b/cli/src/semgrep/app/scans.py
@@ -263,6 +263,7 @@ class ScanHandler:
         commit_date: str,
         lockfile_dependencies: Dict[str, List[out.FoundDependency]],
         dependency_parser_errors: List[DependencyParserError],
+        contributions: out.Contributions,
         engine_requested: "EngineType",
         progress_bar: "Progress",
     ) -> Tuple[bool, str]:
@@ -314,6 +315,7 @@ class ScanHandler:
             searched_paths=[str(t) for t in sorted(targets)],
             renamed_paths=[str(rt) for rt in sorted(renamed_targets)],
             rule_ids=rule_ids,
+            contributions=contributions,
         )
         if self._dependency_query:
             ci_scan_results.dependencies = out.CiScanDependencies(lockfile_dependencies)

--- a/cli/src/semgrep/commands/ci.py
+++ b/cli/src/semgrep/commands/ci.py
@@ -442,6 +442,7 @@ def ci(
             optimizations=optimizations,
             baseline_commit=metadata.merge_base_ref,
             baseline_commit_is_mergebase=True,
+            dump_contributions=True,
         )
     except SemgrepError as e:
         output_handler.handle_semgrep_errors([e])

--- a/cli/src/semgrep/commands/ci.py
+++ b/cli/src/semgrep/commands/ci.py
@@ -412,6 +412,7 @@ def ci(
             dependencies,
             dependency_parser_errors,
             num_executed_rules,
+            contributions,
         ) = semgrep.run_scan.run_scan(
             core_opts_str=core_opts,
             engine_type=engine_type,
@@ -554,6 +555,7 @@ def ci(
                 metadata.commit_datetime,
                 dependencies,
                 dependency_parser_errors,
+                contributions,
                 engine_type,
                 progress_bar,
             )

--- a/cli/src/semgrep/commands/scan.py
+++ b/cli/src/semgrep/commands/scan.py
@@ -862,6 +862,7 @@ def scan(
                     _dependencies,
                     _dependency_parser_errors,
                     _num_executed_rules,
+                    _,
                 ) = semgrep.run_scan.run_scan(
                     core_opts_str=core_opts,
                     dump_command_for_core=dump_command_for_core,

--- a/cli/src/semgrep/core_runner.py
+++ b/cli/src/semgrep/core_runner.py
@@ -1239,7 +1239,7 @@ Exception raised: `{e}`
             [], returncode, " ".join(cmd), runner.stdout, runner.stderr
         )
         contributions = core.Contributions.from_json(output_json)
-        logger.debug(f"semgrep ran in {datetime.now() - start}")
+        logger.debug(f"semgrep contributions ran in {datetime.now() - start}")
         return contributions
 
     def invoke_semgrep_core(

--- a/cli/src/semgrep/core_runner.py
+++ b/cli/src/semgrep/core_runner.py
@@ -1221,6 +1221,27 @@ Exception raised: `{e}`
 
     # end _run_rules_direct_to_semgrep_core
 
+    def invoke_semgrep_dump_contributions(self) -> core.Contributions:
+        start = datetime.now()
+        if self._binary_path is None:  # should never happen, doing this for mypy
+            raise SemgrepError("semgrep engine not found.")
+        cmd = [
+            str(self._binary_path),
+            "-json",
+            "-dump_contributions",
+        ]
+        # only scanning combined rules
+        runner = StreamingSemgrepCore(cmd, 1, self._engine_type)
+        returncode = runner.execute()
+
+        # Process output
+        output_json = self._extract_core_output(
+            [], returncode, " ".join(cmd), runner.stdout, runner.stderr
+        )
+        contributions = core.Contributions.from_json(output_json)
+        logger.debug(f"semgrep ran in {datetime.now() - start}")
+        return contributions
+
     def invoke_semgrep_core(
         self,
         target_manager: TargetManager,

--- a/cli/src/semgrep/core_runner.py
+++ b/cli/src/semgrep/core_runner.py
@@ -62,6 +62,7 @@ from semgrep.rule import Rule
 from semgrep.rule import RuleProduct
 from semgrep.rule_match import OrderedRuleMatchList
 from semgrep.rule_match import RuleMatchMap
+from semgrep.semgrep_interfaces.semgrep_output_v1 import Contributions
 from semgrep.semgrep_interfaces.semgrep_output_v1 import Ecosystem
 from semgrep.semgrep_types import Language
 from semgrep.state import get_state
@@ -1221,7 +1222,7 @@ Exception raised: `{e}`
 
     # end _run_rules_direct_to_semgrep_core
 
-    def invoke_semgrep_dump_contributions(self) -> core.Contributions:
+    def invoke_semgrep_dump_contributions(self) -> Contributions:
         start = datetime.now()
         if self._binary_path is None:  # should never happen, doing this for mypy
             raise SemgrepError("semgrep engine not found.")
@@ -1238,7 +1239,7 @@ Exception raised: `{e}`
         output_json = self._extract_core_output(
             [], returncode, " ".join(cmd), runner.stdout, runner.stderr
         )
-        contributions = core.Contributions.from_json(output_json)
+        contributions = Contributions.from_json(output_json)
         logger.debug(f"semgrep contributions ran in {datetime.now() - start}")
         return contributions
 

--- a/cli/src/semgrep/run_scan.py
+++ b/cli/src/semgrep/run_scan.py
@@ -1,4 +1,3 @@
-
 ##############################################################################
 # Prelude
 ##############################################################################
@@ -383,6 +382,7 @@ def run_scan(
     optimizations: str = "none",
     baseline_commit: Optional[str] = None,
     baseline_commit_is_mergebase: bool = False,
+    dump_contributions: bool = False,
 ) -> Tuple[
     RuleMatchMap,
     List[SemgrepError],
@@ -517,6 +517,11 @@ def run_scan(
         optimizations=optimizations,
         core_opts_str=core_opts_str,
     )
+
+    if dump_contributions:
+        contributions = core_runner.invoke_semgrep_dump_contributions()
+    else:
+        contributions = Contributions([])
 
     experimental_rules, unexperimental_rules = partition(
         filtered_rules, lambda rule: rule.severity == RuleSeverity.EXPERIMENT
@@ -663,6 +668,7 @@ def run_scan(
         dependencies,
         dependency_parser_errors,
         num_executed_rules,
+        contributions,
     )
 
 
@@ -696,6 +702,7 @@ def run_scan_and_return_json(
         profiler,
         output_extra,
         shown_severities,
+        _,
         _,
         _,
         _,

--- a/cli/src/semgrep/run_scan.py
+++ b/cli/src/semgrep/run_scan.py
@@ -1,3 +1,4 @@
+
 ##############################################################################
 # Prelude
 ##############################################################################
@@ -62,6 +63,7 @@ from semgrep.rule import Rule
 from semgrep.rule import RuleProduct
 from semgrep.rule_match import RuleMatchMap
 from semgrep.rule_match import RuleMatchSet
+from semgrep.semgrep_interfaces.semgrep_output_v1 import Contributions
 from semgrep.semgrep_interfaces.semgrep_output_v1 import FoundDependency
 from semgrep.semgrep_types import JOIN_MODE
 from semgrep.state import get_state
@@ -393,6 +395,7 @@ def run_scan(
     Dict[str, List[FoundDependency]],
     List[DependencyParserError],
     int,
+    Contributions,
 ]:
     logger.debug(f"semgrep version {__VERSION__}")
 

--- a/cli/tests/e2e/snapshots/test_ci/test_dryrun/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_dryrun/results.txt
@@ -683,6 +683,24 @@ Would have sent findings and ignores blob: {
         "supply-chain1",
         "supply-chain2",
         "supply-chain3"
+    ],
+    "contributions": [
+        {
+            "commit_hash": "<MASKED>",
+            "commit_timestamp": "<MASKED>",
+            "contributor": {
+                "commit_author_name": "Environment Test",
+                "commit_author_email": "test_environment@test.r2c.dev"
+            }
+        },
+        {
+            "commit_hash": "<MASKED>",
+            "commit_timestamp": "<MASKED>",
+            "contributor": {
+                "commit_author_name": "Environment Test",
+                "commit_author_email": "test_environment@test.r2c.dev"
+            }
+        }
     ]
 }
 Would have sent complete blob: {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines-overwrite-autodetected-variables/findings_and_ignores.json
@@ -582,5 +582,23 @@
     "supply-chain1",
     "supply-chain2",
     "supply-chain3"
+  ],
+  "contributions": [
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    },
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines/findings_and_ignores.json
@@ -582,5 +582,23 @@
     "supply-chain1",
     "supply-chain2",
     "supply-chain3"
+  ],
+  "contributions": [
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    },
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket-overwrite-autodetected-variables/findings_and_ignores.json
@@ -582,5 +582,23 @@
     "supply-chain1",
     "supply-chain2",
     "supply-chain3"
+  ],
+  "contributions": [
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    },
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket/findings_and_ignores.json
@@ -582,5 +582,23 @@
     "supply-chain1",
     "supply-chain2",
     "supply-chain3"
+  ],
+  "contributions": [
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    },
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite-overwrite-autodetected-variables/findings_and_ignores.json
@@ -582,5 +582,23 @@
     "supply-chain1",
     "supply-chain2",
     "supply-chain3"
+  ],
+  "contributions": [
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    },
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite/findings_and_ignores.json
@@ -582,5 +582,23 @@
     "supply-chain1",
     "supply-chain2",
     "supply-chain3"
+  ],
+  "contributions": [
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    },
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci-overwrite-autodetected-variables/findings_and_ignores.json
@@ -582,5 +582,23 @@
     "supply-chain1",
     "supply-chain2",
     "supply-chain3"
+  ],
+  "contributions": [
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    },
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci/findings_and_ignores.json
@@ -582,5 +582,23 @@
     "supply-chain1",
     "supply-chain2",
     "supply-chain3"
+  ],
+  "contributions": [
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    },
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/findings_and_ignores.json
@@ -582,5 +582,23 @@
     "supply-chain1",
     "supply-chain2",
     "supply-chain3"
+  ],
+  "contributions": [
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    },
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr-semgrepconfig/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr-semgrepconfig/findings_and_ignores.json
@@ -534,5 +534,23 @@
     "supply-chain1",
     "supply-chain2",
     "supply-chain3"
+  ],
+  "contributions": [
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    },
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr/findings_and_ignores.json
@@ -534,5 +534,23 @@
     "supply-chain1",
     "supply-chain2",
     "supply-chain3"
+  ],
+  "contributions": [
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    },
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push-special-env-vars/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push-special-env-vars/findings_and_ignores.json
@@ -582,5 +582,23 @@
     "supply-chain1",
     "supply-chain2",
     "supply-chain3"
+  ],
+  "contributions": [
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    },
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/findings_and_ignores.json
@@ -582,5 +582,23 @@
     "supply-chain1",
     "supply-chain2",
     "supply-chain3"
+  ],
+  "contributions": [
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    },
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-push/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-push/findings_and_ignores.json
@@ -582,5 +582,23 @@
     "supply-chain1",
     "supply-chain2",
     "supply-chain3"
+  ],
+  "contributions": [
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    },
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-special-env-vars/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-special-env-vars/findings_and_ignores.json
@@ -534,5 +534,23 @@
     "supply-chain1",
     "supply-chain2",
     "supply-chain3"
+  ],
+  "contributions": [
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    },
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab/findings_and_ignores.json
@@ -534,5 +534,23 @@
     "supply-chain1",
     "supply-chain2",
     "supply-chain3"
+  ],
+  "contributions": [
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    },
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/findings_and_ignores.json
@@ -582,5 +582,23 @@
     "supply-chain1",
     "supply-chain2",
     "supply-chain3"
+  ],
+  "contributions": [
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    },
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-overwrite-autodetected-variables/findings_and_ignores.json
@@ -582,5 +582,23 @@
     "supply-chain1",
     "supply-chain2",
     "supply-chain3"
+  ],
+  "contributions": [
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    },
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins/findings_and_ignores.json
@@ -582,5 +582,23 @@
     "supply-chain1",
     "supply-chain2",
     "supply-chain3"
+  ],
+  "contributions": [
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    },
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/findings_and_ignores.json
@@ -582,5 +582,23 @@
     "supply-chain1",
     "supply-chain2",
     "supply-chain3"
+  ],
+  "contributions": [
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    },
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-self-hosted/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-self-hosted/findings_and_ignores.json
@@ -582,5 +582,23 @@
     "supply-chain1",
     "supply-chain2",
     "supply-chain3"
+  ],
+  "contributions": [
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    },
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis-overwrite-autodetected-variables/findings_and_ignores.json
@@ -582,5 +582,23 @@
     "supply-chain1",
     "supply-chain2",
     "supply-chain3"
+  ],
+  "contributions": [
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    },
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis/findings_and_ignores.json
@@ -582,5 +582,23 @@
     "supply-chain1",
     "supply-chain2",
     "supply-chain3"
+  ],
+  "contributions": [
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    },
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-unparsable_url/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-unparsable_url/findings_and_ignores.json
@@ -582,5 +582,23 @@
     "supply-chain1",
     "supply-chain2",
     "supply-chain3"
+  ],
+  "contributions": [
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    },
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines-overwrite-autodetected-variables/findings_and_ignores.json
@@ -576,5 +576,23 @@
     "supply-chain1",
     "supply-chain2",
     "supply-chain3"
+  ],
+  "contributions": [
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    },
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines/findings_and_ignores.json
@@ -576,5 +576,23 @@
     "supply-chain1",
     "supply-chain2",
     "supply-chain3"
+  ],
+  "contributions": [
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    },
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket-overwrite-autodetected-variables/findings_and_ignores.json
@@ -576,5 +576,23 @@
     "supply-chain1",
     "supply-chain2",
     "supply-chain3"
+  ],
+  "contributions": [
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    },
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket/findings_and_ignores.json
@@ -576,5 +576,23 @@
     "supply-chain1",
     "supply-chain2",
     "supply-chain3"
+  ],
+  "contributions": [
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    },
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite-overwrite-autodetected-variables/findings_and_ignores.json
@@ -576,5 +576,23 @@
     "supply-chain1",
     "supply-chain2",
     "supply-chain3"
+  ],
+  "contributions": [
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    },
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite/findings_and_ignores.json
@@ -576,5 +576,23 @@
     "supply-chain1",
     "supply-chain2",
     "supply-chain3"
+  ],
+  "contributions": [
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    },
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci-overwrite-autodetected-variables/findings_and_ignores.json
@@ -576,5 +576,23 @@
     "supply-chain1",
     "supply-chain2",
     "supply-chain3"
+  ],
+  "contributions": [
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    },
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci/findings_and_ignores.json
@@ -576,5 +576,23 @@
     "supply-chain1",
     "supply-chain2",
     "supply-chain3"
+  ],
+  "contributions": [
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    },
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/findings_and_ignores.json
@@ -576,5 +576,23 @@
     "supply-chain1",
     "supply-chain2",
     "supply-chain3"
+  ],
+  "contributions": [
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    },
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr-semgrepconfig/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr-semgrepconfig/findings_and_ignores.json
@@ -528,5 +528,23 @@
     "supply-chain1",
     "supply-chain2",
     "supply-chain3"
+  ],
+  "contributions": [
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    },
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr/findings_and_ignores.json
@@ -528,5 +528,23 @@
     "supply-chain1",
     "supply-chain2",
     "supply-chain3"
+  ],
+  "contributions": [
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    },
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push-special-env-vars/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push-special-env-vars/findings_and_ignores.json
@@ -576,5 +576,23 @@
     "supply-chain1",
     "supply-chain2",
     "supply-chain3"
+  ],
+  "contributions": [
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    },
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/findings_and_ignores.json
@@ -576,5 +576,23 @@
     "supply-chain1",
     "supply-chain2",
     "supply-chain3"
+  ],
+  "contributions": [
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    },
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-push/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-push/findings_and_ignores.json
@@ -576,5 +576,23 @@
     "supply-chain1",
     "supply-chain2",
     "supply-chain3"
+  ],
+  "contributions": [
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    },
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-special-env-vars/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-special-env-vars/findings_and_ignores.json
@@ -528,5 +528,23 @@
     "supply-chain1",
     "supply-chain2",
     "supply-chain3"
+  ],
+  "contributions": [
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    },
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab/findings_and_ignores.json
@@ -528,5 +528,23 @@
     "supply-chain1",
     "supply-chain2",
     "supply-chain3"
+  ],
+  "contributions": [
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    },
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/findings_and_ignores.json
@@ -576,5 +576,23 @@
     "supply-chain1",
     "supply-chain2",
     "supply-chain3"
+  ],
+  "contributions": [
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    },
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-overwrite-autodetected-variables/findings_and_ignores.json
@@ -576,5 +576,23 @@
     "supply-chain1",
     "supply-chain2",
     "supply-chain3"
+  ],
+  "contributions": [
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    },
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins/findings_and_ignores.json
@@ -576,5 +576,23 @@
     "supply-chain1",
     "supply-chain2",
     "supply-chain3"
+  ],
+  "contributions": [
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    },
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/findings_and_ignores.json
@@ -576,5 +576,23 @@
     "supply-chain1",
     "supply-chain2",
     "supply-chain3"
+  ],
+  "contributions": [
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    },
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-self-hosted/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-self-hosted/findings_and_ignores.json
@@ -576,5 +576,23 @@
     "supply-chain1",
     "supply-chain2",
     "supply-chain3"
+  ],
+  "contributions": [
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    },
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis-overwrite-autodetected-variables/findings_and_ignores.json
@@ -576,5 +576,23 @@
     "supply-chain1",
     "supply-chain2",
     "supply-chain3"
+  ],
+  "contributions": [
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    },
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis/findings_and_ignores.json
@@ -576,5 +576,23 @@
     "supply-chain1",
     "supply-chain2",
     "supply-chain3"
+  ],
+  "contributions": [
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    },
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-unparsable_url/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-unparsable_url/findings_and_ignores.json
@@ -576,5 +576,23 @@
     "supply-chain1",
     "supply-chain2",
     "supply-chain3"
+  ],
+  "contributions": [
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    },
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_lockfile_parse_failure_reporting/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_lockfile_parse_failure_reporting/findings_and_ignores.json
@@ -577,5 +577,31 @@
     "supply-chain1",
     "supply-chain2",
     "supply-chain3"
+  ],
+  "contributions": [
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    },
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    },
+    {
+      "commit_hash": "sanitized",
+      "commit_timestamp": "sanitized",
+      "contributor": {
+        "commit_author_name": "Environment Test",
+        "commit_author_email": "test_environment@test.r2c.dev"
+      }
+    }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_metrics/test_metrics_payload/pro_flag0/metrics-payload.json
+++ b/cli/tests/e2e/snapshots/test_metrics/test_metrics_payload/pro_flag0/metrics-payload.json
@@ -37,7 +37,6 @@
     "numTargets": 1,
     "profilingTimes": {
       "config_time": 0.0,
-      "contributions_time": 0.0,
       "core_time": 0.0,
       "ignores_time": 0.0,
       "total_time": 0.0

--- a/cli/tests/e2e/snapshots/test_metrics/test_metrics_payload/pro_flag0/metrics-payload.json
+++ b/cli/tests/e2e/snapshots/test_metrics/test_metrics_payload/pro_flag0/metrics-payload.json
@@ -37,6 +37,7 @@
     "numTargets": 1,
     "profilingTimes": {
       "config_time": 0.0,
+      "contributions_time": 0.0,
       "core_time": 0.0,
       "ignores_time": 0.0,
       "total_time": 0.0

--- a/cli/tests/e2e/snapshots/test_output/test_debug_experimental_rule/results.txt
+++ b/cli/tests/e2e/snapshots/test_output/test_debug_experimental_rule/results.txt
@@ -34,7 +34,7 @@ No .semgrepignore found. Using default .semgrepignore rules. See the docs for th
 --- semgrep-core stderr ---
 fatal: not a git repository (or any of the parent directories): .git
 --- end semgrep-core stderr ---
-semgrep ran in 0:00:00.176939
+semgrep contributions ran in <MASKED>
 Rules:
 Experimental Rules:
 - rules.experiment.research-experiment

--- a/cli/tests/e2e/snapshots/test_output/test_debug_experimental_rule/results.txt
+++ b/cli/tests/e2e/snapshots/test_output/test_debug_experimental_rule/results.txt
@@ -31,10 +31,6 @@ Done loading local config from rules/experiment/experiment.yaml
 loaded 1 configs in<MASKED>
 running 1 rules from 1 config rules/experiment/experiment.yaml_0
 No .semgrepignore found. Using default .semgrepignore rules. See the docs for the list of default ignores: https://semgrep.dev<MASKED>
---- semgrep-core stderr ---
-fatal: not a git repository (or any of the parent directories): .git
---- end semgrep-core stderr ---
-semgrep contributions ran in <MASKED>
 Rules:
 Experimental Rules:
 - rules.experiment.research-experiment

--- a/cli/tests/e2e/snapshots/test_output/test_debug_experimental_rule/results.txt
+++ b/cli/tests/e2e/snapshots/test_output/test_debug_experimental_rule/results.txt
@@ -31,6 +31,10 @@ Done loading local config from rules/experiment/experiment.yaml
 loaded 1 configs in<MASKED>
 running 1 rules from 1 config rules/experiment/experiment.yaml_0
 No .semgrepignore found. Using default .semgrepignore rules. See the docs for the list of default ignores: https://semgrep.dev<MASKED>
+--- semgrep-core stderr ---
+fatal: not a git repository (or any of the parent directories): .git
+--- end semgrep-core stderr ---
+semgrep ran in 0:00:00.176939
 Rules:
 Experimental Rules:
 - rules.experiment.research-experiment

--- a/cli/tests/e2e/snapshots/test_semgrep_core_parse_error/test_file_parser__failure__error_messages/settings1/error.txt
+++ b/cli/tests/e2e/snapshots/test_semgrep_core_parse_error/test_file_parser__failure__error_messages/settings1/error.txt
@@ -45,7 +45,7 @@ Files skipped:
 
   [1m[24mPartially analyzed due to parsing or internal Semgrep errors[0m
 
-   • [36m[22m[24mtargets/bad/invalid_python.py (3 lines skipped)[0m
+   • [36m[22m[24mtargets/bad/invalid_python.py (2 lines skipped)[0m
 
 
 

--- a/cli/tests/e2e/snapshots/test_semgrep_core_parse_error/test_file_parser__failure__error_messages/settings1/error.txt
+++ b/cli/tests/e2e/snapshots/test_semgrep_core_parse_error/test_file_parser__failure__error_messages/settings1/error.txt
@@ -45,7 +45,7 @@ Files skipped:
 
   [1m[24mPartially analyzed due to parsing or internal Semgrep errors[0m
 
-   • [36m[22m[24mtargets/bad/invalid_python.py (2 lines skipped)[0m
+   • [36m[22m[24mtargets/bad/invalid_python.py (3 lines skipped)[0m
 
 
 

--- a/cli/tests/e2e/snapshots/test_semgrep_core_parse_error/test_file_parser__failure__error_messages/settings1/out.json
+++ b/cli/tests/e2e/snapshots/test_semgrep_core_parse_error/test_file_parser__failure__error_messages/settings1/out.json
@@ -3,13 +3,13 @@
     {
       "code": 3,
       "level": "warn",
-      "message": "Syntax error at line targets/bad/invalid_python.py:1:\n `def foo(a)\n    tree = ElementTree.parse('country_data.xml')` was unexpected",
+      "message": "Syntax error at line targets/bad/invalid_python.py:1:\n `def foo(a)\n    tree = ElementTree.parse('country_data.xml')\n    root = tree.getroot()` was unexpected",
       "path": "targets/bad/invalid_python.py",
       "spans": [
         {
           "end": {
-            "col": 49,
-            "line": 2,
+            "col": 26,
+            "line": 3,
             "offset": 59
           },
           "file": "targets/bad/invalid_python.py",

--- a/cli/tests/e2e/snapshots/test_semgrep_core_parse_error/test_file_parser__failure__error_messages/settings1/out.json
+++ b/cli/tests/e2e/snapshots/test_semgrep_core_parse_error/test_file_parser__failure__error_messages/settings1/out.json
@@ -3,13 +3,13 @@
     {
       "code": 3,
       "level": "warn",
-      "message": "Syntax error at line targets/bad/invalid_python.py:1:\n `def foo(a)\n    tree = ElementTree.parse('country_data.xml')\n    root = tree.getroot()` was unexpected",
+      "message": "Syntax error at line targets/bad/invalid_python.py:1:\n `def foo(a)\n    tree = ElementTree.parse('country_data.xml')` was unexpected",
       "path": "targets/bad/invalid_python.py",
       "spans": [
         {
           "end": {
-            "col": 26,
-            "line": 3,
+            "col": 49,
+            "line": 2,
             "offset": 59
           },
           "file": "targets/bad/invalid_python.py",

--- a/cli/tests/e2e/test_ci.py
+++ b/cli/tests/e2e/test_ci.py
@@ -764,6 +764,8 @@ def test_full_run(
                 re.compile(
                     r"\(<MagicMock name='post\(\)\.json\(\)\.get\(\)' id='\d+'>\)"
                 ),
+                re.compile(r'"commit_hash": "(.*)",?'),
+                re.compile(r'"commit_timestamp": "(.*)",?'),
             ]
         ),
         "results.txt",
@@ -805,6 +807,11 @@ def test_full_run(
     for f in findings_and_ignores_json["ignores"]:
         assert f["commit_date"] is not None
         f["commit_date"] = "sanitized"
+    for f in findings_and_ignores_json["contributions"]:
+        assert f["commit_hash"] is not None
+        f["commit_hash"] = "sanitized"
+        assert f["commit_timestamp"] is not None
+        f["commit_timestamp"] = "sanitized"
     snapshot.assert_match(
         json.dumps(findings_and_ignores_json, indent=2), "findings_and_ignores.json"
     )
@@ -889,6 +896,8 @@ def test_lockfile_parse_failure_reporting(
                 re.compile(
                     r"\(<MagicMock name='post\(\)\.json\(\)\.get\(\)' id='\d+'>\)"
                 ),
+                re.compile(r'"commit_hash": "(.*)",?'),
+                re.compile(r'"commit_timestamp": "(.*)",?'),
             ]
         ),
         "results.txt",
@@ -904,6 +913,11 @@ def test_lockfile_parse_failure_reporting(
     for f in findings_and_ignores_json["ignores"]:
         assert f["commit_date"] is not None
         f["commit_date"] = "sanitized"
+    for f in findings_and_ignores_json["contributions"]:
+        assert f["commit_hash"] is not None
+        f["commit_hash"] = "sanitized"
+        assert f["commit_timestamp"] is not None
+        f["commit_timestamp"] = "sanitized"
     snapshot.assert_match(
         json.dumps(findings_and_ignores_json, indent=2), "findings_and_ignores.json"
     )
@@ -1324,6 +1338,7 @@ def test_dryrun(tmp_path, git_tmp_path_with_commit, snapshot, run_semgrep: RunSe
                 head_commit[:7],
                 base_commit,
                 re.compile(r'"commit_date": (.*),?'),
+                re.compile(r'"commit_timestamp": "(.*)",?'),
                 re.compile(r'"total_time": (.*),?'),
                 re.compile(r'"event_id": (.*),?'),
             ]

--- a/cli/tests/e2e/test_output.py
+++ b/cli/tests/e2e/test_output.py
@@ -242,6 +242,7 @@ def test_debug_experimental_rule(run_semgrep_in_tmp: RunSemgrep, snapshot):
                 re.compile(r"(.*Main\.Parse_target.*)"),
                 re.compile(r"(.*Main\.Core_CLI.*)"),
                 re.compile(r"semgrep ran in (.*) on 1 files"),
+                re.compile(r"semgrep contributions ran in (.*)"),
                 re.compile(r"\"total_time\":(.*)"),
                 re.compile(r"\"commit_date\":(.*)"),
                 re.compile(r"-targets (.*) -timeout"),

--- a/libs/git_wrapper/Git_wrapper.ml
+++ b/libs/git_wrapper/Git_wrapper.ml
@@ -74,6 +74,11 @@ exception Error of string
 let _git_diff_lines_re = {|@@ -\d*,?\d* \+(?P<lines>\d*,?\d*) @@|}
 let git_diff_lines_re = SPcre.regexp _git_diff_lines_re
 
+let git_log_json_format =
+  "--pretty=format:{\"commit_hash\": \"%H\", \"commit_timestamp\": \"%ai\", \
+   \"contributor\": {\"commit_author_name\": \"%an\", \"commit_author_email\": \
+   \"%ae\"}}"
+
 (** Given some git diff ranges (see above), extract the range info *)
 let range_of_git_diff lines =
   let range_of_substrings substrings =
@@ -341,3 +346,15 @@ let get_project_url () =
    environment variable. I just copied what [pysemgrep] does.
    [git ls-remote --get-url] is also enough and if we can not get such
    information, that's fine - the metadata is used only [Metrics_] actually. *)
+
+let get_git_logs () : string list =
+  let cmd = Bos.Cmd.(v "git" % "log" % git_log_json_format) in
+  let lines_r = Bos.OS.Cmd.run_out cmd in
+  let lines = Bos.OS.Cmd.out_lines ~trim:true lines_r in
+  let lines =
+    match lines with
+    | Ok (lines, (_, `Exited 0)) -> lines
+    | _ -> []
+  in
+  (* out_lines splits on newlines, so we always have an extra space at the end *)
+  List.filter (fun f -> not (String.trim f = "")) lines

--- a/libs/git_wrapper/Git_wrapper.mli
+++ b/libs/git_wrapper/Git_wrapper.mli
@@ -66,3 +66,7 @@ val get_project_url : unit -> string option
 (** [get_project_url ()] tries to get the URL of the project from
     [git ls-remote] or from the [.git/config] file. It returns [None] if it
     found nothing relevant. *)
+
+val get_git_logs : unit -> string list
+(** [get_git_logs ()] tries to get the git logs of the project from
+    [git log]. It returns an empty list if it found nothing relevant. *)

--- a/semgrep.opam
+++ b/semgrep.opam
@@ -39,8 +39,8 @@ depends: [
   "ppx_deriving"
   "ppx_hash"
   "ppx_inline_test"
-  "ppx_expect"
   "ppx_sexp_conv" {= "v0.16.0"}
+  "ppx_expect"
   "visitors" {= "20210608"}
   "re"
   "pcre"

--- a/src/core_cli/Core_CLI.ml
+++ b/src/core_cli/Core_CLI.ml
@@ -213,6 +213,12 @@ let dump_ast ?(naming = false) lang file =
         dump_parsing_errors file res;
         Runner_exit.(exit_semgrep False)))
 
+let dump_contributions () =
+  let contributions = Parse_contribution.get_contributions () in
+  pr (Semgrep_output_v1_j.string_of_contributions contributions)
+
+        
+
 (*****************************************************************************)
 (* Experiments *)
 (*****************************************************************************)
@@ -362,6 +368,9 @@ let all_actions () =
     ( "-diff_pfff_tree_sitter",
       " <file>",
       Arg_helpers.mk_action_n_arg Test_parsing.diff_pfff_tree_sitter );
+    ( "-dump_contributions",
+      " dump on stdout the commit contributions in JSON",
+      Arg_helpers.mk_action_0_arg dump_contributions );
     (* Misc stuff *)
     ( "-expr_at_range",
       " <l:c-l:c> <file>",

--- a/src/core_cli/Core_CLI.ml
+++ b/src/core_cli/Core_CLI.ml
@@ -213,12 +213,6 @@ let dump_ast ?(naming = false) lang file =
         dump_parsing_errors file res;
         Runner_exit.(exit_semgrep False)))
 
-let dump_contributions () =
-  let contributions = Parse_contribution.get_contributions () in
-  pr (Semgrep_output_v1_j.string_of_contributions contributions)
-
-        
-
 (*****************************************************************************)
 (* Experiments *)
 (*****************************************************************************)
@@ -370,7 +364,7 @@ let all_actions () =
       Arg_helpers.mk_action_n_arg Test_parsing.diff_pfff_tree_sitter );
     ( "-dump_contributions",
       " dump on stdout the commit contributions in JSON",
-      Arg_helpers.mk_action_0_arg dump_contributions );
+      Arg_helpers.mk_action_0_arg Core_actions.dump_contributions );
     (* Misc stuff *)
     ( "-expr_at_range",
       " <l:c-l:c> <file>",

--- a/src/core_cli/Core_actions.ml
+++ b/src/core_cli/Core_actions.ml
@@ -168,3 +168,7 @@ let prefilter_of_rules file =
   in
   let s = Semgrep_prefilter_j.string_of_prefilters xs in
   pr s
+
+let dump_contributions () =
+  let contributions = Parse_contribution.get_contributions () in
+  pr (Semgrep_output_v1_j.string_of_contributions contributions)

--- a/src/osemgrep/cli_ci/Ci_subcommand.ml
+++ b/src/osemgrep/cli_ci/Ci_subcommand.ml
@@ -381,8 +381,8 @@ let run_conf (conf : Ci_CLI.conf) : Exit_code.t =
         | Some t -> Ok (Some (token, t)))
   in
   (* TODO: pass baseline commit! *)
-  let contributions = Parse_contribution.get_contributions () in
   let metadata = generate_meta_from_environment None in
+  let contributions = Parse_contribution.get_contributions () in
   match deployment with
   | Error e -> e
   | Ok depl -> (

--- a/src/osemgrep/cli_ci/Ci_subcommand.ml
+++ b/src/osemgrep/cli_ci/Ci_subcommand.ml
@@ -211,7 +211,8 @@ let finding_of_cli_match _commit_date index (m : Out.cli_match) : Out.finding =
 
 (* from scans.py *)
 let prepare_for_report ~blocking_findings findings errors rules ~targets
-    ~(ignored_targets : Out.skipped_target list option) ~commit_date
+    ~(contributions : Out.contributions option)
+    ~(ignored_targets : Out.cli_skipped_target list option) ~commit_date
     ~engine_requested =
   let rule_ids =
     Common.map (fun r -> Rule_ID.to_string (fst r.Rule.id)) rules
@@ -265,7 +266,7 @@ let prepare_for_report ~blocking_findings findings errors rules ~targets
         (* TODO: get renamed_paths, depends on baseline_commit *)
         renamed_paths = [];
         rule_ids;
-        contributions = None;
+        contributions;
         (* TODO: Figure out correct value for this. *)
         dependencies = None;
       }
@@ -380,6 +381,7 @@ let run_conf (conf : Ci_CLI.conf) : Exit_code.t =
         | Some t -> Ok (Some (token, t)))
   in
   (* TODO: pass baseline commit! *)
+  let contributions = Parse_contribution.get_contributions () in
   let metadata = generate_meta_from_environment None in
   match deployment with
   | Error e -> e
@@ -568,6 +570,7 @@ let run_conf (conf : Ci_CLI.conf) : Exit_code.t =
                           ~targets:cli_output.Out.paths.Out.scanned
                           ~ignored_targets:cli_output.Out.paths.skipped
                           ~commit_date:"" ~engine_requested:`OSS
+                          ~contributions:(Some contributions)
                       in
                       let result =
                         match

--- a/src/osemgrep/cli_ci/Ci_subcommand.ml
+++ b/src/osemgrep/cli_ci/Ci_subcommand.ml
@@ -212,7 +212,7 @@ let finding_of_cli_match _commit_date index (m : Out.cli_match) : Out.finding =
 (* from scans.py *)
 let prepare_for_report ~blocking_findings findings errors rules ~targets
     ~(contributions : Out.contributions option)
-    ~(ignored_targets : Out.cli_skipped_target list option) ~commit_date
+    ~(ignored_targets : Out.skipped_target list option) ~commit_date
     ~engine_requested =
   let rule_ids =
     Common.map (fun r -> Rule_ID.to_string (fst r.Rule.id)) rules

--- a/src/parsing/Parse_contribution.ml
+++ b/src/parsing/Parse_contribution.ml
@@ -1,26 +1,7 @@
 (** Collect information about the project contributions from git log. *)
 
-open Common
-
-let git_json_format =
-  "--pretty=format:{\"commit_hash\": \"%H\", \"commit_timestamp\": \"%ai\", \
-   \"contributor\": {\"commit_author_name\": \"%an\", \"commit_author_email\": \
-   \"%ae\"}}"
-
-let get_git_logs () : string list =
-  let cmd = Bos.Cmd.(v "git" % "log" % git_json_format) in
-  let lines_r = Bos.OS.Cmd.run_out cmd in
-  let lines = Bos.OS.Cmd.out_lines ~trim:true lines_r in
-  let lines =
-    match lines with
-    | Ok (lines, (_, `Exited 0)) -> lines
-    | _ -> []
-  in
-  (* out_lines splits on newlines, so we always have an extra space at the end *)
-  List.filter (fun f -> not (String.trim f = "")) lines
-
 let get_contributions () : Semgrep_output_v1_j.contributions =
-  let logs = get_git_logs () in
+  let logs = Git_wrapper.get_git_logs () in
   let contributions =
     Common.map (fun f -> Semgrep_output_v1_j.contribution_of_string f) logs
   in

--- a/src/parsing/Parse_contribution.ml
+++ b/src/parsing/Parse_contribution.ml
@@ -1,0 +1,26 @@
+(** Collect information about the project contributions from git log. *)
+
+open Common
+
+let git_json_format =
+  "--pretty=format:{\"commit_hash\": \"%H\", \"commit_author_name\": \"%an\", \
+   \"commit_author_email\": \"%ae\", \"commit_timestamp\": \"%ai\"}"
+
+let get_git_logs () : string list =
+  let cmd = Bos.Cmd.(v "git" % "log" % git_json_format) in
+  let lines_r = Bos.OS.Cmd.run_out cmd in
+  let lines = Bos.OS.Cmd.out_lines ~trim:true lines_r in
+  let lines =
+    match lines with
+    | Ok (lines, (_, `Exited 0)) -> lines
+    | _ -> []
+  in
+  (* out_lines splits on newlines, so we always have an extra space at the end *)
+  List.filter (fun f -> not (String.trim f = "")) lines
+
+let get_contributions () : Semgrep_output_v1_j.contributions =
+  let logs = get_git_logs () in
+  let contributions =
+    List.map (fun f -> Semgrep_output_v1_j.contribution_of_string f) logs
+  in
+  { contributions }

--- a/src/parsing/Parse_contribution.ml
+++ b/src/parsing/Parse_contribution.ml
@@ -3,8 +3,9 @@
 open Common
 
 let git_json_format =
-  "--pretty=format:{\"commit_hash\": \"%H\", \"commit_author_name\": \"%an\", \
-   \"commit_author_email\": \"%ae\", \"commit_timestamp\": \"%ai\"}"
+  "--pretty=format:{\"commit_hash\": \"%H\", \"commit_timestamp\": \"%ai\", \
+   \"contributor\": {\"commit_author_name\": \"%an\", \"commit_author_email\": \
+   \"%ae\"}}"
 
 let get_git_logs () : string list =
   let cmd = Bos.Cmd.(v "git" % "log" % git_json_format) in
@@ -23,4 +24,4 @@ let get_contributions () : Semgrep_output_v1_j.contributions =
   let contributions =
     List.map (fun f -> Semgrep_output_v1_j.contribution_of_string f) logs
   in
-  { contributions }
+  contributions

--- a/src/parsing/Parse_contribution.ml
+++ b/src/parsing/Parse_contribution.ml
@@ -22,6 +22,6 @@ let get_git_logs () : string list =
 let get_contributions () : Semgrep_output_v1_j.contributions =
   let logs = get_git_logs () in
   let contributions =
-    List.map (fun f -> Semgrep_output_v1_j.contribution_of_string f) logs
+    Common.map (fun f -> Semgrep_output_v1_j.contribution_of_string f) logs
   in
   contributions

--- a/src/parsing/Parse_contribution.mli
+++ b/src/parsing/Parse_contribution.mli
@@ -1,0 +1,4 @@
+(** Collect information about the project contributions from git log. *)
+
+val get_git_logs : unit -> string list
+val get_contributions : unit -> Semgrep_output_v1_j.contributions

--- a/src/parsing/Parse_contribution.mli
+++ b/src/parsing/Parse_contribution.mli
@@ -1,4 +1,3 @@
 (** Collect information about the project contributions from git log. *)
 
-val get_git_logs : unit -> string list
 val get_contributions : unit -> Semgrep_output_v1_j.contributions

--- a/src/parsing/dune
+++ b/src/parsing/dune
@@ -8,6 +8,7 @@
    yaml pcre
 
    commons
+   git_wrapper
    paths
    lib_parsing
    process_limits


### PR DESCRIPTION
## Background
Semgrep Code collects the contributor count from CI scans today based on the latest commit author. However, both diff-scans and full scans can have multiple commits from multiple contributors. 

## Solution
- Implement a _very basic_ wrapper around the git log command and parse the output into a Contributions model
- Add new `-dump_contributions` flag to CI command that only dumps the contributions
- Update pysemgrep to call retrieve contributions before running CI scan. Also update the upload-findings POST to include contributions

## Manual testing
- Build semgrep-core
- Run `semgrep-core -dump_contributions` on test repo
- Run `SEMGREP_APP_URL=http://localhost:3000 semgrep ci` on test repo and verify the backend receives the contributions

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
