### PR TITLE
osemgrep: factorize command-line parsing of common flags

### DIFF
--- a/libs/commons/Cmdliner_helpers.ml
+++ b/libs/commons/Cmdliner_helpers.ml
@@ -1,6 +1,30 @@
 open Common
 open Cmdliner
 
+(*************************************************************************)
+(* Prelude *)
+(*************************************************************************)
+(* Cmdliner helpers not found in the default API.
+
+   TODO: parser+printer for file path so we can write things like:
+
+        Arg.value (Arg.opt (Arg.some fpath) None info)
+
+      instead of
+
+        Arg.value (Arg.opt (Arg.some Arg.string) None info)
+        (* + having to convert the string to an fpath by hand *)
+
+      The main benefit would be to clarify error messages by having Fpath.t
+      instead of string.
+
+   val fpath : Fpath.t Cmdliner.conv????
+*)
+
+(*************************************************************************)
+(* Entry points *)
+(*************************************************************************)
+
 let uri =
   let parser str = Ok (Uri.of_string str) in
   let pp = Fmt.(using Uri.to_string string) in

--- a/src/osemgrep/cli_ci/Ci_subcommand.ml
+++ b/src/osemgrep/cli_ci/Ci_subcommand.ml
@@ -1,3 +1,5 @@
+open Common
+
 (*****************************************************************************)
 (* Prelude *)
 (*****************************************************************************)
@@ -347,9 +349,13 @@ let prepare_for_report ~blocking_findings findings errors rules ~targets
    exit code. *)
 let run (conf : Ci_CLI.conf) : Exit_code.t =
   CLI_common.setup_logging ~force_color:conf.force_color
-    ~level:conf.logging_level;
+    ~level:conf.common.logging_level;
   Metrics_.configure conf.metrics;
-  let settings = Semgrep_settings.load ~legacy:conf.legacy () in
+  let settings =
+    Semgrep_settings.load
+      ~legacy:(conf.common.maturity =*= Some CLI_common.Legacy)
+      ()
+  in
   let deployment =
     match (settings.api_token, conf.rules_source) with
     | None, Rules_source.Configs [] ->

--- a/src/osemgrep/cli_interactive/Interactive_CLI.ml
+++ b/src/osemgrep/cli_interactive/Interactive_CLI.ml
@@ -19,9 +19,8 @@ type conf = {
   targeting_conf : Find_targets.conf;
   (* LATER: nosem *)
   core_runner_conf : Core_runner.conf;
-  logging_level : Logs.level option;
-  profile : bool;
   turbo : bool;
+  common : CLI_common.conf;
 }
 [@@deriving show]
 
@@ -42,8 +41,7 @@ let cmdline_term : conf Term.t =
   (* those parameters must be in alphabetic order, like in the 'const combine'
    * further below, so it's easy to add new options.
    *)
-  let combine ast_caching exclude include_ lang logging_level profile
-      target_roots turbo =
+  let combine ast_caching common exclude include_ lang target_roots turbo =
     let lang =
       match lang with
       (* TODO? we could omit the language like for -e and try all languages?*)
@@ -66,15 +64,14 @@ let cmdline_term : conf Term.t =
       targeting_conf =
         { Scan_CLI.default.targeting_conf with include_; exclude };
       core_runner_conf = { Scan_CLI.default.core_runner_conf with ast_caching };
-      logging_level;
-      profile;
       turbo;
+      common;
     }
   in
   Term.(
-    const combine $ Scan_CLI.o_ast_caching $ Scan_CLI.o_exclude
-    $ Scan_CLI.o_include $ Scan_CLI.o_lang $ CLI_common.o_logging
-    $ CLI_common.o_profile $ Scan_CLI.o_target_roots $ o_turbo)
+    const combine $ Scan_CLI.o_ast_caching $ CLI_common.o_common
+    $ Scan_CLI.o_exclude $ Scan_CLI.o_include $ Scan_CLI.o_lang
+    $ Scan_CLI.o_target_roots $ o_turbo)
 
 let doc = "Interactive mode!!"
 

--- a/src/osemgrep/cli_interactive/Interactive_CLI.mli
+++ b/src/osemgrep/cli_interactive/Interactive_CLI.mli
@@ -12,9 +12,8 @@ type conf = {
   target_roots : Fpath.t list;
   targeting_conf : Find_targets.conf;
   core_runner_conf : Core_runner.conf;
-  logging_level : Logs.level option;
-  profile : bool;
   turbo : bool;
+  common : CLI_common.conf;
 }
 [@@deriving show]
 

--- a/src/osemgrep/cli_interactive/Interactive_subcommand.ml
+++ b/src/osemgrep/cli_interactive/Interactive_subcommand.ml
@@ -1229,7 +1229,7 @@ let interactive_loop ~turbo xlang xtargets =
 (* All the business logic after command-line parsing. Return the desired
    exit code. *)
 let run (conf : Interactive_CLI.conf) : Exit_code.t =
-  CLI_common.setup_logging ~force_color:false ~level:conf.logging_level;
+  CLI_common.setup_logging ~force_color:false ~level:conf.common.logging_level;
   let targets, _skipped =
     Find_targets.get_targets conf.targeting_conf conf.target_roots
   in

--- a/src/osemgrep/cli_scan/Output.ml
+++ b/src/osemgrep/cli_scan/Output.ml
@@ -164,8 +164,8 @@ let output_result (conf : Scan_CLI.conf) (profiler : Profiler.t)
    * it here.
    *)
   let cli_output : Out.cli_output =
-    Cli_json_output.cli_output_of_core_results ~logging_level:conf.logging_level
-      res
+    Cli_json_output.cli_output_of_core_results
+      ~logging_level:conf.common.logging_level res
   in
   let cli_output () =
     let keep_ignored =

--- a/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -46,24 +46,13 @@ type conf = {
   strict : bool;
   rewrite_rule_ids : bool;
   time_flag : bool;
-  profile : bool;
   (* Engine selection *)
   engine_type : Engine_type.t;
-  (* osemgrep-only: whether to keep pysemgrep behavior/limitations/errors *)
-  legacy : bool;
-  (* osemgrep-only: currently to explicitely choose osemgrep over pysemgrep.
-   * The flag is actually removed in cli/bin/semgrep when calling osemgrep,
-   * but if people explicitely call osemgrep, it's nice to also accept
-   * the --experimental flag
-   *)
-  experimental : bool;
   (* Performance options *)
   core_runner_conf : Core_runner.conf;
   (* Display options *)
   (* mix of --json, --emacs, --vim, etc. *)
   output_format : Output_format.t;
-  (* mix of --debug, --quiet, --verbose *)
-  logging_level : Logs.level option;
   force_color : bool;
   max_chars_per_line : int;
   max_lines_per_finding : int;
@@ -71,6 +60,7 @@ type conf = {
   metrics : Metrics_.config;
   registry_caching : bool; (* similar to core_runner_conf.ast_caching *)
   version_check : bool;
+  common : CLI_common.conf;
   (* Ugly: should be in separate subcommands *)
   version : bool;
   show_supported_languages : bool;
@@ -129,20 +119,23 @@ let default : conf =
     dryrun = false;
     error_on_findings = false;
     strict = false;
-    profile = false;
+    (* could be move in CLI_common.default_conf? *)
+    common =
+      {
+        profile = false;
+        logging_level = Some Logs.Warning;
+        (* or set to Experimental by default when we release osemgrep? *)
+        maturity = None;
+      };
     time_flag = false;
     engine_type = OSS;
-    (* ultimately should be set to true when we release osemgrep *)
-    legacy = false;
-    experimental = false;
     output_format = Output_format.Text;
-    logging_level = Some Logs.Warning;
     force_color = false;
     max_chars_per_line = 160;
     max_lines_per_finding = 10;
     rewrite_rule_ids = true;
     metrics = Metrics_.Auto;
-    (* like legacy, should maybe be set to false when we release osemgrep *)
+    (* like maturity, should maybe be set to false when we release osemgrep *)
     registry_caching = false;
     version_check = true;
     (* ugly: should be separate subcommands *)
@@ -648,11 +641,6 @@ let o_target_roots : string list Term.t =
 (* !!NEW arguments!! not in pysemgrep *)
 (* ------------------------------------------------------------------ *)
 
-let o_legacy : bool Term.t =
-  H.negatable_flag [ "legacy" ] ~neg_options:[ "no-legacy" ]
-    ~default:default.legacy
-    ~doc:{|Keep the pysemgrep behaviors/limitations/errors|}
-
 let o_dump_config : string option Term.t =
   let info = Arg.info [ "dump-config" ] ~doc:{|<undocumented>|} in
   Arg.value (Arg.opt Arg.(some string) None info)
@@ -690,25 +678,26 @@ let o_registry_caching : bool Term.t =
 let cmdline_term ~allow_empty_config : conf Term.t =
   (* !The parameters must be in alphabetic orders to match the order
    * of the corresponding '$ o_xx $' further below! *)
-  let combine ast_caching autofix baseline_commit config dryrun dump_ast
-      dump_config emacs error exclude exclude_rule_ids experimental force_color
-      include_ json lang legacy logging_level max_chars_per_line
-      max_lines_per_finding max_memory_mb max_target_bytes metrics num_jobs
-      nosem optimizations oss pattern pro profile project_root pro_intrafile
-      pro_lang registry_caching replacement respect_git_ignore rewrite_rule_ids
-      scan_unknown_extensions severity show_supported_languages strict
-      target_roots test test_ignore_todo time_flag timeout timeout_threshold
-      validate version version_check vim =
+  let combine ast_caching autofix baseline_commit common config dryrun dump_ast
+      dump_config emacs error exclude exclude_rule_ids force_color include_ json
+      lang max_chars_per_line max_lines_per_finding max_memory_mb
+      max_target_bytes metrics num_jobs nosem optimizations oss pattern pro
+      project_root pro_intrafile pro_lang registry_caching replacement
+      respect_git_ignore rewrite_rule_ids scan_unknown_extensions severity
+      show_supported_languages strict target_roots test test_ignore_todo
+      time_flag timeout timeout_threshold validate version version_check vim =
     (* ugly: call setup_logging ASAP so the Logs.xxx below are displayed
      * correctly *)
-    Logs_helpers.setup_logging ~force_color ~level:logging_level;
+    Logs_helpers.setup_logging ~force_color
+      ~level:common.CLI_common.logging_level;
 
     let registry_caching, ast_caching =
-      if legacy then (
-        Logs.debug (fun m ->
-            m "disabling registry and AST caching in legacy mode");
-        (false, false))
-      else (registry_caching, ast_caching)
+      match common.maturity with
+      | Some CLI_common.Legacy ->
+          Logs.debug (fun m ->
+              m "disabling registry and AST caching in legacy mode");
+          (false, false)
+      | _else_ -> (registry_caching, ast_caching)
     in
     let include_ =
       match include_ with
@@ -768,13 +757,13 @@ let cmdline_term ~allow_empty_config : conf Term.t =
           (* may raise a Failure (will be caught in CLI.safe_run) *)
           let xlang = Xlang.of_string str in
           Rules_source.Pattern (pat, Some xlang, fix)
-      | _, (Some pat, None, fix) ->
-          if
-            legacy
-            (* alt: "language must be specified when a pattern is passed" *)
-          then Error.abort "-e/--pattern and -l/--lang must both be specified"
-            (* osemgrep-only: better: can use -e without -l! *)
-          else Rules_source.Pattern (pat, None, fix)
+      | _, (Some pat, None, fix) -> (
+          match common.maturity with
+          | Some CLI_common.Legacy ->
+              (* alt: "language must be specified when a pattern is passed" *)
+              Error.abort "-e/--pattern and -l/--lang must both be specified"
+              (* osemgrep-only: better: can use -e without -l! *)
+          | _else_ -> Rules_source.Pattern (pat, None, fix))
       | _, (None, Some _, _) ->
           (* stricter: error not detected in original semgrep *)
           Error.abort "-e/--pattern and -l/--lang must both be specified"
@@ -869,12 +858,7 @@ let cmdline_term ~allow_empty_config : conf Term.t =
                specify a rule"
         | Configs (_ :: _)
         | Pattern _ ->
-            Some
-              {
-                Validate_subcommand.rules_source;
-                logging_level;
-                core_runner_conf;
-              }
+            Some { Validate_subcommand.rules_source; core_runner_conf; common }
       else None
     in
     (* ugly: test should be a separate subcommand.
@@ -942,18 +926,15 @@ let cmdline_term ~allow_empty_config : conf Term.t =
       force_color;
       max_chars_per_line;
       max_lines_per_finding;
-      logging_level;
       metrics;
       registry_caching;
       version_check;
       output_format;
       engine_type;
-      profile;
       rewrite_rule_ids;
       strict;
       time_flag;
-      legacy;
-      experimental;
+      common;
       (* ugly: *)
       version;
       show_supported_languages;
@@ -967,18 +948,18 @@ let cmdline_term ~allow_empty_config : conf Term.t =
   Term.(
     (* !the o_xxx must be in alphabetic orders to match the parameters of
      * combine above! *)
-    const combine $ o_ast_caching $ o_autofix $ o_baseline_commit $ o_config
-    $ o_dryrun $ o_dump_ast $ o_dump_config $ o_emacs $ o_error $ o_exclude
-    $ o_exclude_rule_ids $ CLI_common.o_experimental $ o_force_color $ o_include
-    $ o_json $ o_lang $ o_legacy $ CLI_common.o_logging $ o_max_chars_per_line
+    const combine $ o_ast_caching $ o_autofix $ o_baseline_commit
+    $ CLI_common.o_common $ o_config $ o_dryrun $ o_dump_ast $ o_dump_config
+    $ o_emacs $ o_error $ o_exclude $ o_exclude_rule_ids $ o_force_color
+    $ o_include $ o_json $ o_lang $ o_max_chars_per_line
     $ o_max_lines_per_finding $ o_max_memory_mb $ o_max_target_bytes $ o_metrics
     $ o_num_jobs $ o_nosem $ o_optimizations $ o_oss $ o_pattern $ o_pro
-    $ CLI_common.o_profile $ o_project_root $ o_pro_intrafile $ o_pro_languages
-    $ o_registry_caching $ o_replacement $ o_respect_git_ignore
-    $ o_rewrite_rule_ids $ o_scan_unknown_extensions $ o_severity
-    $ o_show_supported_languages $ o_strict $ o_target_roots $ o_test
-    $ o_test_ignore_todo $ o_time $ o_timeout $ o_timeout_threshold $ o_validate
-    $ o_version $ o_version_check $ o_vim)
+    $ o_project_root $ o_pro_intrafile $ o_pro_languages $ o_registry_caching
+    $ o_replacement $ o_respect_git_ignore $ o_rewrite_rule_ids
+    $ o_scan_unknown_extensions $ o_severity $ o_show_supported_languages
+    $ o_strict $ o_target_roots $ o_test $ o_test_ignore_todo $ o_time
+    $ o_timeout $ o_timeout_threshold $ o_validate $ o_version $ o_version_check
+    $ o_vim)
 
 let doc = "run semgrep rules on files"
 

--- a/src/osemgrep/cli_scan/Scan_CLI.mli
+++ b/src/osemgrep/cli_scan/Scan_CLI.mli
@@ -22,19 +22,12 @@ type conf = {
   strict : bool;
   rewrite_rule_ids : bool;
   time_flag : bool;
-  profile : bool;
   engine_type : Engine_type.t;
-  (* osemgrep-only: whether to keep pysemgrep behavior/limitations/errors *)
-  legacy : bool;
-  (* osemgrep-only: currently to explicitely choose osemgrep over pysemgrep *)
-  experimental : bool;
   (* Performance options *)
   core_runner_conf : Core_runner.conf;
   (* Display options *)
   (* mix of --json, --emacs, --vim, etc. *)
   output_format : Output_format.t;
-  (* mix of --debug, --quiet, --verbose *)
-  logging_level : Logs.level option;
   force_color : bool;
   (* text output config (TODO: make a separate type gathering all of them) *)
   max_chars_per_line : int;
@@ -43,6 +36,7 @@ type conf = {
   metrics : Metrics_.config;
   registry_caching : bool; (* similar to core_runner_conf.ast_caching *)
   version_check : bool;
+  common : CLI_common.conf;
   (* Ugly: should be in separate subcommands *)
   version : bool;
   show_supported_languages : bool;

--- a/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -1,3 +1,5 @@
+open Common
+
 (*****************************************************************************)
 (* Prelude *)
 (*****************************************************************************)
@@ -23,7 +25,7 @@ let invoke_semgrep_core_proprietary = ref None
 
 let setup_logging (conf : Scan_CLI.conf) =
   CLI_common.setup_logging ~force_color:conf.force_color
-    ~level:conf.logging_level;
+    ~level:conf.common.logging_level;
   Logs.debug (fun m -> m "Semgrep version: %s" Version.version);
   ()
 
@@ -34,7 +36,7 @@ let setup_profiling (conf : Scan_CLI.conf) =
       else if config.report_time then Report.mode := MTime
       else Report.mode := MNo_info;
   *)
-  if conf.profile then (
+  if conf.common.profile then (
     (* ugly: no need to set Common.profile, this was done in CLI.ml *)
     Logs.debug (fun m -> m "Profile mode On");
     Logs.debug (fun m -> m "disabling -j when in profiling mode");
@@ -56,7 +58,7 @@ let exit_code_of_errors ~strict (errors : Out.core_error list) : Exit_code.t =
       (* alt: raise a Semgrep_error that would be catched by CLI_Common
        * wrapper instead of returning an exit code directly? *)
       match () with
-      | _ when x.severity = Out.Error ->
+      | _ when x.severity =*= Out.Error ->
           Cli_json_output.exit_code_of_error_type x.error_type
       | _ when strict -> Cli_json_output.exit_code_of_error_type x.error_type
       | _else_ -> Exit_code.ok)
@@ -220,7 +222,11 @@ let scan_files rules_and_origins profiler (conf : Scan_CLI.conf) =
     (* step3: running the engine *)
     let output_format, file_match_results_hook =
       match conf with
-      | { output_format = Output_format.Text; legacy = false; _ } ->
+      | {
+       output_format = Output_format.Text;
+       common = { maturity = Some CLI_common.Experimental; _ };
+       _;
+      } ->
           ( Output_format.TextIncremental,
             Some (file_match_results_hook conf filtered_rules) )
       | { output_format; _ } -> (output_format, None)
@@ -289,7 +295,7 @@ let scan_files rules_and_origins profiler (conf : Scan_CLI.conf) =
     Logs.info (fun m ->
         m "%a" Skipped_report.pp_skipped
           ( conf.targeting_conf.respect_git_ignore,
-            conf.legacy,
+            conf.common.maturity,
             conf.targeting_conf.max_target_bytes,
             semgrepignored,
             included,
@@ -300,7 +306,7 @@ let scan_files rules_and_origins profiler (conf : Scan_CLI.conf) =
     Logs.app (fun m ->
         m "%a" Summary_report.pp_summary
           ( conf.targeting_conf.respect_git_ignore,
-            conf.legacy,
+            conf.common.maturity,
             conf.targeting_conf.max_target_bytes,
             semgrepignored,
             included,
@@ -340,7 +346,11 @@ let run (conf : Scan_CLI.conf) : Exit_code.t =
   Profiler.start profiler ~name:"total_time";
   let config () =
     Metrics_.configure conf.metrics;
-    let settings = Semgrep_settings.load ~legacy:conf.legacy () in
+    let settings =
+      Semgrep_settings.load
+        ~legacy:(conf.common.maturity =*= Some CLI_common.Legacy)
+        ()
+    in
     if Metrics_.is_enabled conf.metrics then
       Metrics_.add_project_url (Git_wrapper.get_project_url ());
     Metrics_.add_integration_name (Sys.getenv_opt "SEMGREP_INTEGRATION_NAME");
@@ -381,10 +391,10 @@ let run (conf : Scan_CLI.conf) : Exit_code.t =
       (* Let's go *)
       (* --------------------------------------------------------- *)
       (* step0: potentially notify user about metrics *)
-      if not (settings.has_shown_metrics_notification = Some true) then (
+      if not (settings.has_shown_metrics_notification =*= Some true) then (
         (* python compatibility: the 22m and 24m are "normal color or intensity", and "underline off" *)
         let esc =
-          if Fmt.style_renderer Fmt.stderr = `Ansi_tty then "\027[22m\027[24m"
+          if Fmt.style_renderer Fmt.stderr =*= `Ansi_tty then "\027[22m\027[24m"
           else ""
         in
         Logs.warn (fun m ->

--- a/src/osemgrep/cli_scan/Validate_subcommand.ml
+++ b/src/osemgrep/cli_scan/Validate_subcommand.ml
@@ -46,7 +46,7 @@ type conf = {
    *)
   rules_source : Rules_source.t;
   core_runner_conf : Core_runner.conf;
-  logging_level : Logs.level option;
+  common : CLI_common.conf;
 }
 [@@deriving show]
 
@@ -110,7 +110,7 @@ let run (conf : conf) : Exit_code.t =
         (* TODO? sanity check errors below too? *)
         let { Out.results; errors = _; _ } =
           Cli_json_output.cli_output_of_core_results
-            ~logging_level:conf.logging_level res
+            ~logging_level:conf.common.logging_level res
         in
         (* TOPORT?
                 ... run -check_rules in semgrep-core ...

--- a/src/osemgrep/cli_scan/Validate_subcommand.mli
+++ b/src/osemgrep/cli_scan/Validate_subcommand.mli
@@ -6,7 +6,7 @@
 type conf = {
   rules_source : Rules_source.t;
   core_runner_conf : Core_runner.conf;
-  logging_level : Logs.level option;
+  common : CLI_common.conf;
 }
 [@@deriving show]
 

--- a/src/osemgrep/core/CLI_common.ml
+++ b/src/osemgrep/core/CLI_common.ml
@@ -6,21 +6,28 @@ open Cmdliner
 (*
    Shared CLI flags, CLI processing helpers, and help messages for the
    semgrep CLI.
-
-   TODO: parser+printer for file path so we can write things like:
-
-        Arg.value (Arg.opt (Arg.some CLI_common.fpath) None info)
-
-      instead of
-
-        Arg.value (Arg.opt (Arg.some Arg.string) None info)
-        (* + having to convert the string to an fpath by hand *)
-
-      The main benefit would be to clarify error messages by having Fpath.t
-      instead of string.
-
-   val fpath : Fpath.t Cmdliner.conv????
 *)
+
+(*************************************************************************)
+(* Types *)
+(*************************************************************************)
+
+(* Used mostly to decide between pysemgrep and osemgrep for now (could be
+ * used for different things later).
+ * Legacy is also used to specify whether to keep pysemgrep
+ * behavior/limitations/errors even when we stay in osemgrep land.
+ *)
+type maturity = Experimental | Legacy [@@deriving show]
+
+type conf = {
+  (* mix of --debug, --quiet, --verbose *)
+  logging_level : Logs.level option;
+  (* osemgrep-only: pad poor's man profiling info for now *)
+  profile : bool;
+  (* osemgrep-only: mix of --experimental, --legacy *)
+  maturity : maturity option;
+}
+[@@deriving show]
 
 (*************************************************************************)
 (* Verbosity options (mutually exclusive) *)
@@ -113,14 +120,58 @@ let o_profile : bool Term.t =
   Arg.value (Arg.flag info)
 
 (*************************************************************************)
-(* Misc *)
+(* Maturity options *)
 (*************************************************************************)
 
+(* We could remove the flags below and handle them manually in
+ * cli/bin/semgrep or in ../cli/CLI.ml and remove them from Sys.argv
+ * before going further in the individual cli_xxx/
+ * (especially because they're mostly used for the pysemgrep/osemgrep
+ * dispatch for now), but it's still useful to have them as explicit flags
+ * so they show up in the man pages (e.g., in 'semgrep scan --help').
+ * It's also nice to accept the --experimental flag for people explicitely
+ * calling osemgrep directly.
+ *)
+
+(* osemgrep-only:  *)
 let o_experimental : bool Term.t =
   let info =
     Arg.info [ "experimental" ] ~doc:{|Enable experimental features.|}
   in
   Arg.value (Arg.flag info)
+
+(* osemgrep-only:  *)
+let o_legacy : bool Term.t =
+  let info =
+    (* alt: Keep the pysemgrep behaviors/limitations/errors *)
+    Arg.info [ "legacy" ] ~doc:{|Prefer old (legacy) behavior.|}
+  in
+  Arg.value (Arg.flag info)
+
+let o_maturity : maturity option Term.t =
+  let combine experimental legacy =
+    match (experimental, legacy) with
+    | false, false -> None
+    | true, false -> Some Experimental
+    | false, true -> Some Legacy
+    | true, true ->
+        Error.abort "mutually exclusive options --experimental/--legacy"
+  in
+  Term.(const combine $ o_experimental $ o_legacy)
+
+(*************************************************************************)
+(* Term for all common CLI flags *)
+(*************************************************************************)
+
+let o_common : conf Term.t =
+  let combine logging profile maturity =
+    { logging_level = logging; profile; maturity }
+  in
+  Term.(const combine $ o_logging $ o_profile $ o_maturity)
+
+(*************************************************************************)
+(* Misc *)
+(*************************************************************************)
 
 let help_page_bottom =
   [

--- a/src/osemgrep/core/CLI_common.mli
+++ b/src/osemgrep/core/CLI_common.mli
@@ -1,23 +1,34 @@
 (*
-   Shared utilities to help with command-line parsing and handling
-   (relies on the cmdliner library)
+   Shared flags across the different Semgrep commands and utilities to help
+   with command-line parsing and handling (relies on the cmdliner library)
 
    The o_ below stands for option (as in command-line argument option).
 *)
 
-val help_page_bottom : Cmdliner.Manpage.block list
+type maturity = Experimental | Legacy [@@deriving show]
 
-(* small wrapper around Cmdliner.Cmd.eval_value *)
-val eval_value : argv:string array -> 'a Cmdliner.Cmd.t -> 'a
-
-(* small wrapper around Logs_helper.setup_logging and Logging_helpers.setup *)
-val setup_logging : force_color:bool -> level:Logs.level option -> unit
+type conf = {
+  (* mix of --debug, --quiet, --verbose *)
+  logging_level : Logs.level option;
+  profile : bool;
+  (* mix of --experimental, --legacy *)
+  maturity : maturity option;
+}
+[@@deriving show]
 
 (* handles logging arguments (--quiet/--verbose/--debug) *)
 val o_logging : Logs.level option Cmdliner.Term.t
 
+(* small wrapper around Logs_helper.setup_logging and Logging_helpers.setup *)
+val setup_logging : force_color:bool -> level:Logs.level option -> unit
+
 (* for --profile *)
 val o_profile : bool Cmdliner.Term.t
 
-(* for --experimental *)
-val o_experimental : bool Cmdliner.Term.t
+(* for --experimental and --legacy *)
+val o_maturity : maturity option Cmdliner.Term.t
+val o_common : conf Cmdliner.Term.t
+val help_page_bottom : Cmdliner.Manpage.block list
+
+(* small wrapper around Cmdliner.Cmd.eval_value *)
+val eval_value : argv:string array -> 'a Cmdliner.Cmd.t -> 'a

--- a/src/osemgrep/reporting/Skipped_report.ml
+++ b/src/osemgrep/reporting/Skipped_report.ml
@@ -17,7 +17,7 @@ module Out = Semgrep_output_v1_t
 
 let pp_skipped ppf
     ( respect_git_ignore,
-      legacy,
+      maturity,
       max_target_bytes,
       semgrep_ignored,
       include_ignored,
@@ -87,10 +87,14 @@ let pp_skipped ppf
   pp_list file_size_ignored;
   Fmt.pf ppf "@.";
 
-  if not legacy then (
-    Fmt.pf ppf " %a@.@." Fmt.(styled `Bold string) "Skipped for other reasons:";
-    pp_list other_ignored;
-    Fmt.pf ppf "@.");
+  (match maturity with
+  | Some CLI_common.Legacy -> ()
+  | _else_ ->
+      Fmt.pf ppf " %a@.@."
+        Fmt.(styled `Bold string)
+        "Skipped for other reasons:";
+      pp_list other_ignored;
+      Fmt.pf ppf "@.");
 
   Fmt.pf ppf " %a@.@."
     Fmt.(styled `Bold string)

--- a/src/osemgrep/reporting/Skipped_report.mli
+++ b/src/osemgrep/reporting/Skipped_report.mli
@@ -2,7 +2,7 @@
 val pp_skipped :
   Format.formatter ->
   bool
-  * bool
+  * CLI_common.maturity option
   * int
   * Semgrep_output_v1_t.skipped_target list
   * Semgrep_output_v1_t.skipped_target list

--- a/src/osemgrep/reporting/Summary_report.ml
+++ b/src/osemgrep/reporting/Summary_report.ml
@@ -17,7 +17,7 @@ module Out = Semgrep_output_v1_t
 
 let pp_summary ppf
     (( respect_git_ignore,
-       legacy,
+       maturity,
        max_target_bytes,
        semgrep_ignored,
        include_ignored,
@@ -26,7 +26,7 @@ let pp_summary ppf
        other_ignored,
        errors ) :
       bool
-      * bool
+      * CLI_common.maturity option
       * int
       * Out.skipped_target list
       * Out.skipped_target list
@@ -72,7 +72,9 @@ let pp_summary ppf
         opt_msg "files matching --exclude patterns" exclude_ignored;
         opt_msg ("files larger than " ^ mb ^ " MB") file_size_ignored;
         opt_msg "files matching .semgrepignore patterns" semgrep_ignored;
-        (if legacy then None else opt_msg "other files ignored" other_ignored);
+        (match maturity with
+        | Some CLI_common.Legacy -> None
+        | _else_ -> opt_msg "other files ignored" other_ignored);
       ]
   in
   let out_partial =

--- a/src/osemgrep/reporting/Summary_report.mli
+++ b/src/osemgrep/reporting/Summary_report.mli
@@ -1,7 +1,7 @@
 val pp_summary :
   Format.formatter ->
   bool
-  * bool
+  * CLI_common.maturity option
   * int
   * Semgrep_output_v1_t.skipped_target list
   * Semgrep_output_v1_t.skipped_target list


### PR DESCRIPTION
Most commands are taking common flags like --debug, --quiet,
--profile, so it makes sense to factorize those flags
in a common data-structure.
The nice thing about Cmdliner is that it's compositional
so we can even define an o_common option that can be reused
in the different cli_xxx/Xxx_CLI.ml

test plan:
make core
make core-test
make core-install
cd cli; make osempass


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)