### PR TITLE
tainting: Add experimental control sources

### DIFF
--- a/changelog.d/pa-2958.added
+++ b/changelog.d/pa-2958.added
@@ -1,0 +1,22 @@
+taint-mode: Added **experimental** `control: true` option to `pattern-sources`,
+e.g.:
+
+```yaml
+    pattern-sources:
+      - control: true
+        pattern: source(...)
+```
+
+Such sources taint the "control flow" (or the program counter) so that it is
+possible to implement reachability queries that do not require the flow of any
+data. Thus, Semgrep reports a finding in the code below, because after `source()`
+the flow of control will reach `sink()`, even if no data is flowing between both:
+
+```python
+def test():
+  source()
+  foo()
+  bar()
+  #ruleid: test
+  sink()
+```

--- a/src/core/Rule.ml
+++ b/src/core/Rule.ml
@@ -235,6 +235,7 @@ type taint_spec = {
 and taint_source = {
   source_formula : formula;
   source_by_side_effect : bool;
+  source_control : bool;
   label : string;
       (* The label to attach to the data.
        * Alt: We could have an optional label instead, allow taint that is not

--- a/src/engine/Test_dataflow_tainting.ml
+++ b/src/engine/Test_dataflow_tainting.ml
@@ -39,6 +39,7 @@ let test_tainting lang file options config def =
           let r = Range.range_of_token_locations tok1 tok2 in
           Range.content_at_range file r
       | Taint.Arg arg -> Taint._show_arg arg
+      | Taint.Control -> "<control>"
     in
     taint |> Taint.Taint_set.elements |> Common.map show_taint
     |> String.concat ", "

--- a/src/parsing/Parse_rule.ml
+++ b/src/parsing/Parse_rule.ml
@@ -1322,6 +1322,9 @@ let parse_taint_source ~(is_old : bool) env (key : key) (value : G.expr) :
       take_opt dict env parse_bool "by-side-effect"
       |> Option.value ~default:false
     in
+    let source_control =
+      take_opt dict env parse_bool "control" |> Option.value ~default:false
+    in
     let label =
       take_opt dict env parse_string "label"
       |> Option.value ~default:R.default_source_label
@@ -1331,7 +1334,13 @@ let parse_taint_source ~(is_old : bool) env (key : key) (value : G.expr) :
       |> Option.value ~default:default_source_requires
     in
     let source_formula = f env dict in
-    { R.source_formula; source_by_side_effect; label; source_requires }
+    {
+      R.source_formula;
+      source_by_side_effect;
+      source_control;
+      label;
+      source_requires;
+    }
   in
   if is_old then
     let dict = yaml_to_dict env key value in
@@ -1343,6 +1352,7 @@ let parse_taint_source ~(is_old : bool) env (key : key) (value : G.expr) :
         {
           source_formula;
           source_by_side_effect = false;
+          source_control = false;
           label = R.default_source_label;
           source_requires = default_source_requires;
         }

--- a/src/tainting/Dataflow_tainting.ml
+++ b/src/tainting/Dataflow_tainting.ml
@@ -299,8 +299,26 @@ let lval_is_sanitized config lval = config.is_sanitizer (any_of_lval lval)
 let lval_is_sink config lval = config.is_sink (any_of_lval lval)
 let sink_of_match x = { T.pm = x.spec_pm; rule_sink = x.spec }
 
-let taints_of_matches ~incoming xs =
-  xs |> Common.map (fun x -> (x.spec_pm, x.spec)) |> T.taints_of_pms ~incoming
+let taints_of_matches env ~incoming sources =
+  let control_sources, data_sources =
+    sources
+    |> List.partition (fun (m : R.taint_source tmatch) -> m.spec.source_control)
+  in
+  (* THINK: It could make sense to merge `incoming` with `control_incoming`, so
+   * a control source could influence a data source and vice-versa. *)
+  let data_taints =
+    data_sources
+    |> Common.map (fun x -> (x.spec_pm, x.spec))
+    |> T.taints_of_pms ~incoming
+  in
+  let control_incoming = Lval_env.get_control_taints env.lval_env in
+  let control_taints =
+    control_sources
+    |> Common.map (fun x -> (x.spec_pm, x.spec))
+    |> T.taints_of_pms ~incoming:control_incoming
+  in
+  let lval_env = Lval_env.add_control_taints env.lval_env control_taints in
+  (data_taints, lval_env)
 
 let report_findings env findings =
   if findings <> [] then
@@ -533,8 +551,7 @@ let propagate_taint_to_label replace_labels label (taint : T.taint) =
     | Src src, None -> T.Src { src with label }
     | Src src, Some replace_labels when List.mem src.T.label replace_labels ->
         T.Src { src with label }
-    | Src src, _ -> Src src
-    | Arg arg, _ -> Arg arg
+    | ((Src _ | Arg _ | Control) as orig), _ -> orig
   in
   { taint with orig = new_orig }
 
@@ -566,10 +583,12 @@ let findings_of_tainted_sink env taints_with_traces (sink : T.sink) :
         |> Common.map (fun ({ T.taint; _ } as item) ->
                let bindings =
                  match taint.T.orig with
-                 | T.Arg _ -> []
-                 | Src source ->
+                 | T.Src source ->
                      let src_pm, _ = T.pm_of_trace source.call_trace in
                      src_pm.PM.env
+                 | Arg _
+                 | Control ->
+                     []
                in
                let new_taint = { taint with tokens = List.rev taint.tokens } in
                ({ item with taint = new_taint }, bindings))
@@ -630,6 +649,10 @@ let findings_of_tainted_sink env taints_with_traces (sink : T.sink) :
 
 (* Produces a finding for every unifiable source-sink pair. *)
 let findings_of_tainted_sinks env taints sinks : T.finding list =
+  let taints =
+    let control_taints = Lval_env.get_control_taints env.lval_env in
+    taints |> Taints.union control_taints
+  in
   if Taints.is_empty taints then []
   else
     sinks
@@ -787,8 +810,9 @@ let fix_poly_taint_with_field env lval st =
                                { arg with offset = arg.offset @ [ n ] }
                              in
                              { taint with orig = Arg arg' }
+                         | Src _
                          | Arg _
-                         | Src _ ->
+                         | Control ->
                              taint)
                 in
                 `Tainted taints'))
@@ -945,12 +969,14 @@ let find_lval_taint_sources env incoming_taints lval =
        * is a source of taint, but it is not tainted on its own. *)
     partition_mutating_sources source_pms
   in
-  let taints_sources_reg =
-    reg_source_pms |> taints_of_matches ~incoming:incoming_taints
-  and taints_sources_mut =
-    mut_source_pms |> taints_of_matches ~incoming:incoming_taints
+  let taints_sources_reg, lval_env =
+    reg_source_pms |> taints_of_matches env ~incoming:incoming_taints
   in
-  let lval_env = Lval_env.add env.lval_env lval taints_sources_mut in
+  let taints_sources_mut, lval_env =
+    mut_source_pms
+    |> taints_of_matches { env with lval_env } ~incoming:incoming_taints
+  in
+  let lval_env = Lval_env.add lval_env lval taints_sources_mut in
   (Taints.union taints_sources_reg taints_sources_mut, lval_env)
 
 let rec check_tainted_lval env (lval : IL.lval) : Taints.t * Lval_env.t =
@@ -1266,9 +1292,9 @@ and check_tainted_expr env exp : Taints.t * Lval_env.t =
       (Taints.empty, lval_env)
   | None ->
       let taints_exp, lval_env = check_subexpr exp in
-      let taints_sources =
+      let taints_sources, lval_env =
         orig_is_source env.config exp.eorig
-        |> taints_of_matches ~incoming:taints_exp
+        |> taints_of_matches { env with lval_env } ~incoming:taints_exp
       in
       let taints = Taints.union taints_exp taints_sources in
       let taints_propagated, var_env =
@@ -1410,7 +1436,9 @@ let check_function_signature env fun_exp args args_taints =
                  | Src _ -> [ t ]
                  | Arg arg ->
                      let+ arg_taints = arg_to_taints arg in
-                     Taints.elements arg_taints)
+                     Taints.elements arg_taints
+                 | Control ->
+                     Lval_env.get_control_taints env.lval_env |> Taints.elements)
         in
         T.map_preconditions subst taint
       in
@@ -1463,7 +1491,10 @@ let check_function_signature env fun_exp args args_taints =
                                     List.rev_append t.tokens
                                       (snd ident :: taint.tokens)
                                   in
-                                  { taint with tokens }))))
+                                  { taint with tokens })))
+                   | Control ->
+                       (* Control taint does not need to propagate via `return`s. *)
+                       None)
         | T.ToSink { taints_with_precondition = taints, _requires; sink; _ } ->
             let incoming_taints =
               taints
@@ -1502,14 +1533,21 @@ let check_function_signature env fun_exp args args_taints =
                          let+ taint = taint |> subst_in_precondition in
                          [ { T.taint; sink_trace } ]
                      | Arg arg ->
-                         (* Here, we modify the call trace associated to the argument,
-                            and then we replace it by all the taints that correspond to it.
-                         *)
                          let sink_trace =
                            T.Call (eorig, taint.tokens, sink_trace)
                          in
                          let+ arg_taints = arg_to_taints arg in
                          Taints.elements arg_taints
+                         |> Common.map (fun x -> { T.taint = x; sink_trace })
+                     | Control ->
+                         (* coupling: how to best refactor with Arg's case? *)
+                         let sink_trace =
+                           T.Call (eorig, taint.tokens, sink_trace)
+                         in
+                         let control_taints =
+                           Lval_env.get_control_taints env.lval_env
+                         in
+                         Taints.elements control_taints
                          |> Common.map (fun x -> { T.taint = x; sink_trace }))
             in
             findings_of_tainted_sink env incoming_taints sink
@@ -1545,6 +1583,9 @@ let check_function_signature env fun_exp args args_taints =
                                     (snd dst_obj.ident :: taint.T.tokens)
                                 in
                                 { taint with tokens })
+                     | Control ->
+                         (* control taints do not propagate to arguments *)
+                         Taints.empty
                    in
                    if Taints.is_empty dst_taints then []
                    else [ `UpdateEnv (dst_lval, dst_taints) ])
@@ -1653,16 +1694,14 @@ let check_tainted_instr env instr : Taints.t * Lval_env.t =
       (* TODO: We should check that taint and sanitizer(s) are unifiable. *)
       (Taints.empty, env.lval_env)
   | [] ->
-      let taints_instr, lval_env' = check_instr instr.i in
-      let taint_sources =
+      let taints_instr, lval_env = check_instr instr.i in
+      let taint_sources, lval_env =
         orig_is_source env.config instr.iorig
-        |> taints_of_matches ~incoming:taints_instr
+        |> taints_of_matches { env with lval_env } ~incoming:taints_instr
       in
       let taints = Taints.union taints_instr taint_sources in
-      let taints_propagated, lval_env' =
-        handle_taint_propagators
-          { env with lval_env = lval_env' }
-          (`Ins instr) taints
+      let taints_propagated, lval_env =
+        handle_taint_propagators { env with lval_env } (`Ins instr) taints
       in
       let taints = Taints.union taints taints_propagated in
       check_orig_if_sink env instr.iorig taints;
@@ -1673,7 +1712,7 @@ let check_tainted_instr env instr : Taints.t * Lval_env.t =
             check_type_and_drop_taints_if_bool_or_number env taints type_of_lval
               lval
       in
-      (taints, lval_env')
+      (taints, lval_env)
 
 (* Test whether a `return' is tainted, and if it is also a sink,
  * report the finding too (by side effect). *)

--- a/src/tainting/Taint.mli
+++ b/src/tainting/Taint.mli
@@ -87,6 +87,7 @@ and orig =
   | Arg of arg
       (** Polymorphic taint variable: arbitrary taint coming through one of the
        * arguments in a function definition. *)
+  | Control
 [@@deriving show]
 
 and taint = { orig : orig; tokens : tainted_tokens } [@@deriving show]

--- a/src/tainting/Taint_lval_env.mli
+++ b/src/tainting/Taint_lval_env.mli
@@ -57,6 +57,9 @@ val clean : env -> IL.lval -> env
     clean the entire array! This seems drastic but it should help reducing FPs.
  *)
 
+val add_control_taints : env -> Taint.taints -> env
+val get_control_taints : env -> Taint.taints
+
 val union : env -> env -> env
 (** Compute the environment for the join of two branches.
 

--- a/tests/rules/taint_control.py
+++ b/tests/rules/taint_control.py
@@ -1,0 +1,22 @@
+def test1():
+  source()
+  foo()
+  bar()
+  #ruleid: test
+  sink()
+
+def test2():
+  source()
+  foo()
+  bar()
+  if baz():
+    #ruleid: test
+    sink()
+
+def test2():
+  if foo():
+    source()
+  bar()
+  if baz():
+    #ruleid: test
+    sink()

--- a/tests/rules/taint_control.yaml
+++ b/tests/rules/taint_control.yaml
@@ -1,0 +1,12 @@
+rules:
+  - id: test
+    languages:
+      - python
+    severity: WARNING
+    mode: taint
+    message: Test
+    pattern-sources:
+      - control: true
+        pattern: source(...)
+    pattern-sinks:
+      - pattern: sink(...)


### PR DESCRIPTION
These sources taint the "control" (the program counter, sort to speak) rather than the data. They allow writing reachability queries, do we reach B from A ?

test plan:
make test # new test

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
