### PR TITLE
fix: [ci] improve caching for opam

### DIFF
--- a/.github/workflows/build-test-osx-arm64.yaml
+++ b/.github/workflows/build-test-osx-arm64.yaml
@@ -54,9 +54,9 @@ jobs:
         with:
           path: ~/.opam
           #TODO: we should add the md5sum of opam.lock as part of the key
-          key: "${{ runner.os }}-${{ runner.arch }}-${{ env.OPAM_SWITCH_NAME }}-opam-deps-${{ github.run_id }}"
+          key: ${{ runner.os }}-${{ runner.arch }}-${{ env.OPAM_SWITCH_NAME }}-opam-deps-${{ github.run_id }}
           restore-keys: |
-            "${{ runner.os }}-${{ runner.arch }}-${{ env.OPAM_SWITCH_NAME }}-opam-deps"
+            ${{ runner.os }}-${{ runner.arch }}-${{ env.OPAM_SWITCH_NAME }}-opam-deps
       - name: Install dependencies
         run: |
           ./scripts/osx-setup-for-release.sh "${{ env.OPAM_SWITCH_NAME }}"

--- a/.github/workflows/build-test-osx-arm64.yaml
+++ b/.github/workflows/build-test-osx-arm64.yaml
@@ -45,16 +45,18 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - name: Restore Opam Cache
-        id: restore-opam-cache
-        uses: actions/cache/restore@v3
+      # Note that this actions does cache read and cache write.
+      - name: Cache Opam
+        uses: actions/cache@v3
         if: ${{ inputs.use-cache }}
         env:
           SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
         with:
           path: ~/.opam
           #TODO: we should add the md5sum of opam.lock as part of the key
-          key: "${{ runner.os }}-${{ runner.arch }}-${{ env.OPAM_SWITCH_NAME }}-opam-deps"
+          key: "${{ runner.os }}-${{ runner.arch }}-${{ env.OPAM_SWITCH_NAME }}-opam-deps-${{ github.run_id }}"
+          restore-keys: |
+            "${{ runner.os }}-${{ runner.arch }}-${{ env.OPAM_SWITCH_NAME }}-opam-deps"
       - name: Install dependencies
         run: |
           ./scripts/osx-setup-for-release.sh "${{ env.OPAM_SWITCH_NAME }}"
@@ -68,18 +70,6 @@ jobs:
         with:
           path: artifacts.zip
           name: semgrep-osx-arm64-${{ github.sha }}
-      # By default, the actions/cache workflow will not save the directory to the cache if a cache hit occurs in
-      # restore-opam-cache. This allows us to manually save off the ~/.opam dir, keeping things up to date and speedy.
-      - name: Save Opam Cache
-        id: save-opam-cache
-        uses: actions/cache/save@v3
-        if: ${{ inputs.use-cache }}
-        env:
-          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
-        with:
-          path: ~/.opam
-          #TODO: we should add the md5sum of opam.lock as part of the key
-          key: "${{ runner.os }}-${{ runner.arch }}-${{ env.OPAM_SWITCH_NAME }}-opam-deps"
 
   build-wheels-osx-arm64:
     runs-on:

--- a/.github/workflows/build-test-osx-x86.yaml
+++ b/.github/workflows/build-test-osx-x86.yaml
@@ -88,9 +88,9 @@ jobs:
         with:
           path: ~/.opam
           #TODO: we should add the md5sum of opam.lock as part of the key
-          key: "${{ runner.os }}-${{ runner.arch }}-${{ env.OPAM_SWITCH_NAME }}-opam-deps-${{ github.run_id }}"
+          key: ${{ runner.os }}-${{ runner.arch }}-${{ env.OPAM_SWITCH_NAME }}-opam-deps-${{ github.run_id }}
           restore-keys: |
-            "${{ runner.os }}-${{ runner.arch }}-${{ env.OPAM_SWITCH_NAME }}-opam-deps"
+            ${{ runner.os }}-${{ runner.arch }}-${{ env.OPAM_SWITCH_NAME }}-opam-deps
       - name: Install dependencies
         run: |
           ./scripts/osx-setup-for-release.sh "${{ env.OPAM_SWITCH_NAME }}"

--- a/.github/workflows/build-test-osx-x86.yaml
+++ b/.github/workflows/build-test-osx-x86.yaml
@@ -69,6 +69,8 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
+
+      # Note that this actions does cache read and cache write.
       # See https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows for more information on GHA caching.
       # Note that this works and speedup things because of the way OPAM works
       # and osx-setup-for-release.sh is written. Indeed, this script checks
@@ -78,20 +80,17 @@ jobs:
       # hit the cache unfortunately, but we would spend time only for installing
       # those new packages (ideally we would want to regenerate the cache by
       # using an opam.pock in the cache key).
-      - name: Restore Opam Cache
-        id: restore-opam-cache
-        uses: actions/cache/restore@v3
+      - name: Cache Opam
+        uses: actions/cache@v3
         if: ${{ inputs.use-cache }}
-        # The size of the tgz of ~/.opam is around 500MB, which usually takes less than
-        # 2min to download from GHA. If it takes more than that, that means something
-        # wrong is going on in which case it's better to timeout early than spend
-        # 10min (the default timeout) and then still timeout.
         env:
           SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
         with:
           path: ~/.opam
           #TODO: we should add the md5sum of opam.lock as part of the key
-          key: "${{ runner.os }}-${{ runner.arch }}-${{ env.OPAM_SWITCH_NAME }}-opam-deps"
+          key: "${{ runner.os }}-${{ runner.arch }}-${{ env.OPAM_SWITCH_NAME }}-opam-deps-${{ github.run_id }}"
+          restore-keys: |
+            "${{ runner.os }}-${{ runner.arch }}-${{ env.OPAM_SWITCH_NAME }}-opam-deps"
       - name: Install dependencies
         run: |
           ./scripts/osx-setup-for-release.sh "${{ env.OPAM_SWITCH_NAME }}"
@@ -105,18 +104,6 @@ jobs:
         with:
           path: artifacts.zip
           name: semgrep-osx-${{ github.sha }}
-      # By default, the actions/cache workflow will not save the directory to the cache if a cache hit occurs in
-      # restore-opam-cache. This allows us to manually save off the ~/.opam dir, keeping things up to date and speedy.
-      - name: Save Opam Cache
-        id: save-opam-cache
-        uses: actions/cache/save@v3
-        if: ${{ inputs.use-cache }}
-        env:
-          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
-        with:
-          path: ~/.opam
-          #TODO: we should add the md5sum of opam.lock as part of the key
-          key: "${{ runner.os }}-${{ runner.arch }}-${{ env.OPAM_SWITCH_NAME }}-opam-deps"
 
   build-wheels-osx:
     runs-on: macos-12


### PR DESCRIPTION
Our CI for OSX has slowed down, due to the fact that the cache was being read successfully, but was never being updated, and therefore was out of date. This means that the `opam update` step had considerable amounts of work to do on each run. 

This PR improves caching for the `~/.opam` dir. Testing shows that the prefix-based `restore-keys` is working as expected. 

We may see cache miss on this PR until this is merged into `develop` - caches from feature branches will use the default branches cache, but until that gets populated, we won't see the benefit. 

Test Plan:
- CI on this PR
- Ensure develop checks run
- Monitor follow-on PRs for speedup

PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
