### PR TITLE
set proper platform tag for python wheels

### DIFF
--- a/.github/workflows/build-test-manylinux-aarch64.yaml
+++ b/.github/workflows/build-test-manylinux-aarch64.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Extract wheel from docker image
         run: |
           docker load --input /tmp/image.tar
-          docker run --platform linux/arm64 --rm ${{ steps.build-semgrep-wheel.outputs.imageid }} zip -r - dist > /tmp/dist.zip
+          docker run --platform linux/arm64 --rm ${{ steps.build-semgrep-wheel.outputs.imageid }} cat cli/dist.zip > /tmp/dist.zip
       - uses: actions/upload-artifact@v3
         with:
           name: manylinux-aarch64-wheel

--- a/.github/workflows/build-test-manylinux-x86.yaml
+++ b/.github/workflows/build-test-manylinux-x86.yaml
@@ -35,7 +35,7 @@ jobs:
 
   test-wheels-manylinux:
     runs-on: ubuntu-latest
-    container: quay.io/pypa/manylinux1_x86_64
+    container: quay.io/pypa/manylinux2014_x86_64
     needs: [build-wheels-manylinux]
     steps:
       - uses: actions/download-artifact@v1
@@ -43,7 +43,7 @@ jobs:
           name: manylinux-x86-wheel
       - run: unzip ./manylinux-x86-wheel/dist.zip
       - name: install package
-        run: /opt/python/cp37-cp37m/bin/pip install dist/*.whl
+        run: /opt/python/cp37-cp37m/bin/pip install dist/*manylinux*.whl
       - name: test package
         run: |
           export PATH=/opt/python/cp37-cp37m/bin:$PATH

--- a/.github/workflows/build-test-manylinux-x86.yaml
+++ b/.github/workflows/build-test-manylinux-x86.yaml
@@ -43,7 +43,8 @@ jobs:
           name: manylinux-x86-wheel
       - run: unzip ./manylinux-x86-wheel/dist.zip
       - name: install package
-        run: /opt/python/cp37-cp37m/bin/pip install dist/*manylinux*.whl
+        # *.whl is fine here because we're building one wheel with the "any" platform compatibility tag
+        run: /opt/python/cp37-cp37m/bin/pip install dist/*.whl
       - name: test package
         run: |
           export PATH=/opt/python/cp37-cp37m/bin:$PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -115,22 +115,20 @@ FROM python:3.11-alpine AS semgrep-wheel
 
 WORKDIR /semgrep
 
-# Install some deps (build-base because ruamel.yaml has native code, zip because we need zip)
-RUN apk add --no-cache build-base zip
+# Install some deps (build-base because ruamel.yaml has native code)
+RUN apk add --no-cache build-base zip bash
 
 # Copy in the CLI
-COPY cli ./
+COPY cli ./cli
 
 # Copy in semgrep-core executable
-COPY --from=semgrep-core-container /src/semgrep/_build/default/src/main/Main.exe src/semgrep/bin/semgrep-core
+COPY --from=semgrep-core-container /src/semgrep/_build/default/src/main/Main.exe cli/src/semgrep/bin/semgrep-core
+
+# Copy in scripts folder
+COPY scripts/ ./scripts/
 
 # Build the source distribution and binary wheel
-# TODO: do we actually need the sdist?
-RUN python setup.py sdist bdist_wheel
-
-# Copy and run scripts/validate-wheel.sh to ensure that the generated wheel works properly
-COPY scripts/validate-wheel.sh ./scripts/validate-wheel.sh
-RUN ./scripts/validate-wheel.sh dist/*.whl
+RUN scripts/build-wheels.sh && scripts/validate-wheel.sh cli/dist/*musllinux*.whl
 
 ###############################################################################
 # Step3: Build the final docker image with Python wrapper and semgrep-core bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -127,7 +127,8 @@ COPY --from=semgrep-core-container /src/semgrep/_build/default/src/main/Main.exe
 # Copy in scripts folder
 COPY scripts/ ./scripts/
 
-# Build the source distribution and binary wheel
+# Build the source distribution and binary wheel, validate that the wheel installs correctly
+# We're only checking the musllinux wheel because this is an Alpine container. It shouldnt be a problem because the content of the wheels are identical.
 RUN scripts/build-wheels.sh && scripts/validate-wheel.sh cli/dist/*musllinux*.whl
 
 ###############################################################################

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -31,6 +31,8 @@ if WHEEL_CMD in sys.argv:
             _, _, plat = bdist_wheel.get_tag(self)
             python = "cp37.cp38.cp39.cp310.cp311.py37.py38.py39.py310.py311"
             abi = "none"
+            if plat == "linux_x86_64":
+                plat = "any"
             return python, abi, plat
 
     cmdclass = {WHEEL_CMD: BdistWheel}

--- a/scripts/build-wheels.sh
+++ b/scripts/build-wheels.sh
@@ -11,6 +11,19 @@ set -e
 pip3 install setuptools wheel
 cd cli && python3 setup.py sdist bdist_wheel "$@"
 
+# We have to tweak our architecture-specific Python wheels in order for them to be accepted by PyPI.
+# The output of setup.py bdist_wheel is a file formatted like this: (example is for amd64, but arm64 is similar)
+# semgrep-1.32.0-cp37.cp38.cp39.cp310.cp311.py37.py38.py39.py310.py311-none-linux_x86_64.whl
+#
+# linux_x64_64 is the wheel's "platform tag." PyPI doesn't allow it because it's non-standard
+#
+# The solution here is to re-tag by making copies of the wheel with "proper" platform tags:
+# - manylinux2014_x86_64 for glibc platforms (e.g. Debian)
+# - musllinux_1_0_x86_64 for musl platforms (e.g. Alpine)
+#
+# Check out https://packaging.python.org/en/latest/specifications/platform-compatibility-tags/ for more info about platform tags
+#
+
 for wheel_filename in dist/*.whl; do
     if [[ ! $wheel_filename =~ ^(.*-)linux(_[a-z0-9_]+\.whl)$ ]]; then
         echo "Skipping wheel: $wheel_filename"

--- a/scripts/build-wheels.sh
+++ b/scripts/build-wheels.sh
@@ -10,5 +10,20 @@
 set -e
 pip3 install setuptools wheel
 cd cli && python3 setup.py sdist bdist_wheel "$@"
+
+for wheel_filename in dist/*.whl; do
+    if [[ ! $wheel_filename =~ ^(.*-)linux(_[a-z0-9_]+\.whl)$ ]]; then
+        echo "Skipping wheel: $wheel_filename"
+        continue
+    fi
+
+    manylinux_filename="${BASH_REMATCH[1]}manylinux2014${BASH_REMATCH[2]}"
+    musllinux_filename="${BASH_REMATCH[1]}musllinux_1_0${BASH_REMATCH[2]}"
+
+    cp -v "$wheel_filename" "$manylinux_filename"
+    cp -v "$wheel_filename" "$musllinux_filename"
+    rm "$wheel_filename"
+done
+
 # Zipping for a stable name to upload as an artifact
 zip -r dist.zip dist


### PR DESCRIPTION
Backstory: Prior to supporting linux/arm64, we published a semgrep Python wheel with the [platform compatibility tag](https://packaging.python.org/en/latest/specifications/platform-compatibility-tags/) set to `any`, which tells pip to fall back to this if there are no other platform-specific wheels available.

When we started publishing wheels for both architectures, I naively assumed that things would Just Work. Unfortunately, the platform compatibility tags that setup.py was setting by default (`linux_x86_64` and `linux_aarch64`) are not accepted by PyPI (the reason why is kind of a long story and has to do with incompatibilities between glibc and musl).

It turns out the platform compatibility tag is literally just the suffix on the wheel filename (no changes to the actual content of the wheel), so this PR basically just updates the generated wheel to have the proper filenames.

The key word here is filename**s**. In order to support both glibc (e.g. Debian) and musl (e.g. Alpine) platforms, we need to publish wheels targeting `manylinux2014` and `musllinux_1_0`, which is why we have the two-copies-and-a-delete in build-wheels.sh


NOTE: After typing all this out I realized that we should really have _something_ as the fallback `any` wheel, so I just updated the PR have `linux_x86_64` wheels remapped to `any`. Doing this ensures that this change only affects ARM users -- Intel users will keep using the `any` package as usual

test plan:
- [x] checks pass
- [x] grabbed artifacts from GHA and published to test.pypi.org