### PR TITLE
ojsonnet: small cleanup, adding comments at the right place

### DIFF
--- a/languages/jsonnet/ast/AST_jsonnet.ml
+++ b/languages/jsonnet/ast/AST_jsonnet.ml
@@ -31,9 +31,11 @@
  * used in https://github.com/sourcegraph/lsif-jsonnet
  *
  * The main uses for this file are:
- *  - for Semgrep to allow people to use Jsonnet patterns to match
- *    over Jsonnet code
- *  - For advanced Semgrep users to write Semgrep rules in jsonnet instead
+ *  - to support the language Jsonnet in Semgrep,
+ *    that is to give the ability for jsonnet developers to use Jsonnet patterns
+ *    to match over Jsonnet code, that is to write jsonnet rules (just like
+ *    C developers can write C rules).
+ *  - for advanced Semgrep users to write Semgrep rules in jsonnet instead
  *    of YAML (Semgrep 2.0).
  *  - for ojsonnet, a Jsonnet interpreter written in OCaml,
  *    so we can use it in osemgrep instead of having to write an OCaml
@@ -41,8 +43,8 @@
  *    better error messages when there is an error in a Jsonnet
  *    semgrep rule. Indeed, right now the error will be mostly
  *    reported on the resulting (also called "manifested") JSON.
- *    This could also enable certain holistic optimizations or
- *    static checks at some point.
+ *    This could also enable at some point certain holistic optimizations or
+ *    static checks.
  *)
 
 (*****************************************************************************)

--- a/languages/jsonnet/ast/AST_jsonnet.ml
+++ b/languages/jsonnet/ast/AST_jsonnet.ml
@@ -1,6 +1,6 @@
 (* Yoann Padioleau
  *
- * Copyright (C) 2022-2023 r2c
+ * Copyright (C) 2022-2023 Semgrep Inc.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
@@ -33,11 +33,13 @@
  * The main uses for this file are:
  *  - for Semgrep to allow people to use Jsonnet patterns to match
  *    over Jsonnet code
- *  - potentially for implementing a Jsonnet interpreter in OCaml,
+ *  - For advanced Semgrep users to write Semgrep rules in jsonnet instead
+ *    of YAML (Semgrep 2.0).
+ *  - for ojsonnet, a Jsonnet interpreter written in OCaml,
  *    so we can use it in osemgrep instead of having to write an OCaml
  *    binding to the Jsonnet C library. This could allow in turn to provide
  *    better error messages when there is an error in a Jsonnet
- *    semgrep rule. Indeed right now the error will be mostly
+ *    semgrep rule. Indeed, right now the error will be mostly
  *    reported on the resulting (also called "manifested") JSON.
  *    This could also enable certain holistic optimizations or
  *    static checks at some point.

--- a/libs/ojsonnet/Eval_jsonnet.ml
+++ b/libs/ojsonnet/Eval_jsonnet.ml
@@ -147,6 +147,9 @@ and eval_expr (env : V.env) (v : expr) : V.value_ =
   | O v -> eval_obj_inside env v
   | Id (s, tk) -> lookup env tk (V.LId s)
   | IdSpecial (Self, tk) -> lookup env tk V.LSelf
+  (* TODO: check if super is in the environment and if not error with
+   * RUNTIME ERROR: attempt to use super when there is no super class.
+   *)
   | IdSpecial (Super, tk) -> lookup env tk V.LSuper
   | Call
       ( (ArrayAccess
@@ -181,9 +184,9 @@ and eval_expr (env : V.env) (v : expr) : V.value_ =
             | _else_ ->
                 error tkf (spf "Out of bound for array index: %s" (sv index))
           else error tkf (spf "Not an integer: %s" (sv index))
-      (* TODO: THIS NEEDS TO BE MORE COMPLEX  *)
-      | V.Object (_l, (_assertsTODO, fields), _r), Primitive (Str (fld, tk))
-        -> (
+      (* Field access! A tricky operation. *)
+      | ( (V.Object (_l, (_assertsTODO, fields), _r) as obj),
+          Primitive (Str (fld, tk)) ) -> (
           match
             fields
             |> List.find_opt (fun (field : V.value_field) ->
@@ -191,15 +194,35 @@ and eval_expr (env : V.env) (v : expr) : V.value_ =
           with
           | None -> error tk (spf "field '%s' not present in %s" fld (sv e))
           | Some fld -> (
-              let new_self = V.Object (_l, (_assertsTODO, fields), _r) in
-              let locals =
-                env.locals
-                |> Map_.add V.LSelf { V.value = V.Val new_self; env }
-                |> Map_.add V.LSuper { V.value = Val V.empty_obj; env }
-              in
               match fld.fld_value.value with
               | V.Val v -> v
-              | Unevaluated e -> eval_expr { env with locals } e))
+              | V.Unevaluated e ->
+                  (* Late-bound self.
+                   * We need to do the self assignment on field access rather
+                   * than on object creation, because when objects are merged,
+                   * we need self to reference the new merged object rather
+                   * than the original. Here's such an example:
+                   *
+                   *    ({ name : self.y } + {y : 42})["name"]
+                   *
+                   * If we were to do the assignment of self before doing the
+                   * field access, we would have the following (incorrect)
+                   * evaluation where o = { name : self.y }
+                   *       ({name : o.y} + {y : 42})["name"]
+                   *       o.y
+                   *       {name : self.y}.y
+                   *       Error no such field.
+                   * However, if we only assign self on access, we get the
+                   * following (correct) evaluation
+                   *      ({ name : self.y } + {y : 42})["name"]
+                   *      { name : self.y, y : 42 }["name"]
+                   *      {name: self.y, y : 42}[y]
+                   *      42
+                   *)
+                  let locals =
+                    env.locals |> Map_.add V.LSelf { V.value = V.Val obj; env }
+                  in
+                  eval_expr { env with locals } e))
       (* TODO? support ArrayAccess for Strings? *)
       | _else_ -> error l (spf "Invalid ArrayAccess: %s[%s]" (sv e) (sv index)))
   | Call (e0, args) -> eval_call env e0 args
@@ -418,8 +441,7 @@ and eval_call env e0 (largs, args, _rargs) =
 
 (* This is a very naive implementation of plus for objects that
  * just merge the fields.
- * TODO: handle inheritance with complex self/super semantic in the presence
- * of plus
+ * TODO: handle "inheritance" with complex super semantic with plus
  *)
 and eval_plus_object _env _tk objl objr : V.object_ A.bracket =
   let l, (lassert, lflds), _r = objl in
@@ -435,8 +457,10 @@ and eval_plus_object _env _tk objl objr : V.object_ A.bracket =
     lflds
     |> List.filter (fun { V.fld_name = s, _; _ } -> not (Hashtbl.mem hobjr s))
   in
-  let flds = lflds' @ rflds in
-  (l, (asserts, flds), r)
+  (* TODO: should bind Super and adjust the env in all rflds *)
+  let rflds' = rflds in
+  let flds' = lflds' @ rflds' in
+  (l, (asserts, flds'), r)
 
 and eval_binary_op env el (op, tk) er =
   match op with
@@ -599,6 +623,11 @@ and eval_obj_inside env (l, x, r) : V.value_ =
                      {
                        V.fld_name;
                        fld_hidden;
+                       (* fields are evaluated lazily! Sometimes with an
+                        * env adjusted (see eval_plus_object()).
+                        * We do not bind Self here! This is done on field
+                        * access instead (late bound).
+                        *)
                        fld_value = { value = Unevaluated fld_value; env };
                      }
                | v -> error tk (spf "field name was not a string: %s" (sv v)))
@@ -641,6 +670,10 @@ and eval_program (e : Core_jsonnet.program) : V.value_ =
 (*****************************************************************************)
 (* Manfestation *)
 (*****************************************************************************)
+(* After we switched to explicitely representing the environment in
+ * Value_jsonnet.ml, this function became mutually recursive with
+ * eval_expr() and so need to be defined in the same file.
+ *)
 and manifest_value (v : V.value_) : JSON.t =
   match v with
   | Primitive x -> (
@@ -655,7 +688,7 @@ and manifest_value (v : V.value_) : JSON.t =
         (arr |> Array.to_list
         |> Common.map (fun (entry : V.lazy_value) ->
                manifest_value (evaluate_lazy_value_ entry)))
-  | V.Object (_l, (_assertsTODO, fields), _r) as _o ->
+  | V.Object (_l, (_assertsTODO, fields), _r) as obj ->
       (* TODO: evaluate asserts *)
       let xs =
         fields
@@ -664,30 +697,11 @@ and manifest_value (v : V.value_) : JSON.t =
                | A.Hidden -> None
                | A.Visible
                | A.ForcedVisible ->
-                   (*let v = Lazy.force fld_value.v*)
-                   let new_self = V.Object (_l, (_assertsTODO, fields), _r) in
+                   (* similar to what we do in eval_expr on field access *)
                    let locals =
                      fld_value.env.locals
-                     (* We need to do these assignment on field access rather than on
-                        object creation, since when objects are merged, we need self to
-                        reference the new merged object rather than the original. Here's
-                        such an example:
-                        ({ name : self.y } + {y : 42})["name"]
-                        If we were to do the assignment of self before doing the field access
-                        we would have the following (incorrect) evaluation where o = { name : self.y }
-                        ({name : o.y} + {y : 42})["name"]
-                        o.y
-                        {name : self.y}.y
-                        Error no such field.
-                        However, if we only assign self on access, we get the following (correct) evaluation
-                        ({ name : self.y } + {y : 42})["name"]
-                        { name : self.y, y : 42 }["name"]
-                        {name: self.y, y : 42}[y]
-                        42 *)
                      |> Map_.add V.LSelf
-                          { V.value = Val new_self; env = fld_value.env }
-                     |> Map_.add V.LSuper
-                          { V.value = Val V.empty_obj; env = fld_value.env }
+                          { V.value = Val obj; env = fld_value.env }
                    in
                    let v =
                      match fld_value.value with

--- a/libs/ojsonnet/Manifest_jsonnet.ml
+++ b/libs/ojsonnet/Manifest_jsonnet.ml
@@ -1,1 +1,34 @@
+(* Yoann Padioleau
+ *
+ * Copyright (C) 2022-2023 r2c
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * version 2.1 as published by the Free Software Foundation, with the
+ * special exception on linking described in file LICENSE.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
+ * LICENSE for more details.
+ *)
+
+(*****************************************************************************)
+(* Prelude *)
+(*****************************************************************************)
+(* See https://jsonnet.org/ref/spec.html#manifestation
+ *
+ * This file used to contain lots of code but after switching to
+ * store explicit environment in Value_jsonnet.ml, the manifest_value()
+ * function had to be mutually recursive with eval_expr() and so was
+ * moved in Eval_jsonnet.ml
+ * Still it's nice to hide this implememtation detail and still provide
+ * a separate Manufest_jsonnet.ml file, even if it's just wrapping
+ * Eval_jsonnet.manifest_value()
+ *)
+
+(*****************************************************************************)
+(* Entry point *)
+(*****************************************************************************)
+
 let manifest_value = Eval_jsonnet.manifest_value

--- a/libs/ojsonnet/Manifest_jsonnet.mli
+++ b/libs/ojsonnet/Manifest_jsonnet.mli
@@ -1,1 +1,5 @@
+(* TODO: at some point we probably would prefer an AST_generic.program
+ * which could track the origin of tokens through import, eval, and
+ * manifestation and that we could pass to osemgrep to evaluate the rules.
+ *)
 val manifest_value : Value_jsonnet.value_ -> JSON.t

--- a/libs/ojsonnet/Value_jsonnet.ml
+++ b/libs/ojsonnet/Value_jsonnet.ml
@@ -31,7 +31,8 @@ type env = {
   (* The spec uses a lambda-calculus inspired substitution model, but
    * it is probably simpler and more efficient to use a classic
    * environment where the locals are defined. Jsonnet uses lazy
-   * evaluation so we model this by allowing unevaluated expressions in environment below.
+   * evaluation so we model this by allowing unevaluated expressions in
+   * environment below.
    *)
   locals : (local_id, lazy_value) Map_.t;
   (* for call tracing *)
@@ -40,11 +41,14 @@ type env = {
 
 and local_id = LSelf | LSuper | LId of string
 
-(* This used to be wrapped in an explicit "lazy" rather than keeping around an environment
-   however, this does not work with the object merge + operator, since we need to be able
-   to access the environment in which fields of the object are evaluated in. It is also neccesary
-   to keep around and environment even for values, since there could be nested objects/arrays which
-   also have lazy semantics themselves, and thus again need to be able to modify a specifc environment *)
+(* This used to be wrapped in an explicit "lazy" rather than keeping around an
+   environment however, this does not work with the object merge + operator,
+   since we need to be able to access the environment in which fields of the
+   object are evaluated in. It is also neccesary to keep around and
+   environment even for values, since there could be nested objects/arrays
+   which also have lazy semantics themselves, and thus again need to be able
+   to modify a specifc environment
+*)
 and val_or_unevaluated_ = Val of value_ | Unevaluated of Core_jsonnet.expr
 and lazy_value = { value : val_or_unevaluated_; env : env }
 


### PR DESCRIPTION
test plan:
make core-test


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)