### PR TITLE
fix: [ci] ensure that at least one sdist is unzipped

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,12 +175,13 @@ jobs:
         run: |
           unzip ./manylinux-x86-wheel/dist.zip
       - name: Unzip aarch64 Wheel
+        # Don't unzip tar.gz because it already exists from ./manylinux-x86-wheel/dist.zip.
         run: unzip ./manylinux-aarch64-wheel/dist.zip "*.whl"
       - name: Unzip OSX x86 Wheel
-        # Don't unzip tar.gz because it already exists from ./manylinux-wheel/dist.zip.
+        # Don't unzip tar.gz because it already exists from ./manylinux-x86-wheel/dist.zip.
         run: unzip ./osx-x86-wheel/dist.zip "*.whl"
       - name: Unzip OSX ARM64 Wheel
-        # Don't unzip tar.gz because it already exists from ./manylinux-wheel/dist.zip.
+        # Don't unzip tar.gz because it already exists from ./manylinux-x86-wheel/dist.zip.
         run: unzip ./osx-arm64-wheel/dist.zip "*.whl"
       - name: Publish to Pypi
         uses: pypa/gh-action-pypi-publish@master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,7 +172,8 @@ jobs:
           name: osx-arm64-wheel
           path: osx-arm64-wheel
       - name: Unzip x86_64 Wheel
-        run: unzip ./manylinux-x86-wheel/dist.zip "*.whl"
+        run: |
+          unzip ./manylinux-x86-wheel/dist.zip
       - name: Unzip aarch64 Wheel
         run: unzip ./manylinux-aarch64-wheel/dist.zip "*.whl"
       - name: Unzip OSX x86 Wheel


### PR DESCRIPTION
Release for 1.33.1 did not have the sdist attached to it, since #8336 accidentally remove all but the wheels from the `dist/` directory that gets uploaded to PyPI. This should re-introduce those source files, but a dry-run will confirm.  

PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
