### PR TITLE
fix(yaml,extract): remove style and chomp indicators from raw string tokens

### DIFF
--- a/changelog.d/gh-8348.fixed
+++ b/changelog.d/gh-8348.fixed
@@ -1,0 +1,1 @@
+yaml: exclude style markers from matched token in block scalars

--- a/cli/tests/e2e/snapshots/test_metavariable_pattern/test1/results.json
+++ b/cli/tests/e2e/snapshots/test_metavariable_pattern/test1/results.json
@@ -67,16 +67,16 @@
         },
         "metavars": {
           "$SHELL": {
-            "abstract_content": "|\n          if ${{ steps.pss.outcome=='failure' }}; then FAILED=pss; fi\n          if ${{ steps.soc.outcome=='failure' }}; then FAILED=soc; fi\n          if ${{ steps.pushsync-chunks-1.outcome=='failure' }}; then FAILED=pushsync-chunks-1; fi\n          if ${{ steps.pushsync-chunks-2.outcome=='failure' }}; then FAILED=pushsync-chunks-2; fi\n          if ${{ steps.retrieval.outcome=='failure' }}; then FAILED=retrieval; fi\n          if ${{ steps.manifest.outcome=='failure' }}; then FAILED=manifest; fi\n          if ${{ steps.content-availability.outcome=='failure' }}; then FAILED=content-availability; fi\n          curl -sSf -X POST -H \"Content-Type: application/json\" -d \"{\\\"text\\\": \\\"**${RUN_TYPE}** Test Error\\nBranch: \\`${{ github.head_ref }}\\`\\nUser: @${{ github.event.pull_request.user.login }}\\nDebugging artifacts: [click](https://$BUCKET_NAME.$AWS_ENDPOINT/artifacts_$VERTAG.tar.gz)\\nStep failed: \\`${FAILED}\\`\\\"}\" https://foobar.test.org/hooks/${{ secrets.TUNSHELL_KEY }}\n",
+            "abstract_content": "\n          if ${{ steps.pss.outcome=='failure' }}; then FAILED=pss; fi\n          if ${{ steps.soc.outcome=='failure' }}; then FAILED=soc; fi\n          if ${{ steps.pushsync-chunks-1.outcome=='failure' }}; then FAILED=pushsync-chunks-1; fi\n          if ${{ steps.pushsync-chunks-2.outcome=='failure' }}; then FAILED=pushsync-chunks-2; fi\n          if ${{ steps.retrieval.outcome=='failure' }}; then FAILED=retrieval; fi\n          if ${{ steps.manifest.outcome=='failure' }}; then FAILED=manifest; fi\n          if ${{ steps.content-availability.outcome=='failure' }}; then FAILED=content-availability; fi\n          curl -sSf -X POST -H \"Content-Type: application/json\" -d \"{\\\"text\\\": \\\"**${RUN_TYPE}** Test Error\\nBranch: \\`${{ github.head_ref }}\\`\\nUser: @${{ github.event.pull_request.user.login }}\\nDebugging artifacts: [click](https://$BUCKET_NAME.$AWS_ENDPOINT/artifacts_$VERTAG.tar.gz)\\nStep failed: \\`${FAILED}\\`\\\"}\" https://foobar.test.org/hooks/${{ secrets.TUNSHELL_KEY }}\n",
             "end": {
               "col": 1,
               "line": 16,
               "offset": 1093
             },
             "start": {
-              "col": 14,
+              "col": 15,
               "line": 7,
-              "offset": 112
+              "offset": 113
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_output/test_yaml_metavariables/report.json
+++ b/cli/tests/e2e/snapshots/test_output/test_yaml_metavariables/report.json
@@ -95,20 +95,20 @@
         "fingerprint": "0x42",
         "is_ignored": false,
         "lines": "- key: |\n    three",
-        "message": "|\n    three\n\n",
+        "message": "\n    three\n\n",
         "metadata": {},
         "metavars": {
           "$VALUE": {
-            "abstract_content": "|\n    three\n",
+            "abstract_content": "\n    three\n",
             "end": {
               "col": 1,
               "line": 5,
               "offset": 45
             },
             "start": {
-              "col": 8,
+              "col": 9,
               "line": 3,
-              "offset": 33
+              "offset": 34
             }
           }
         },
@@ -133,20 +133,20 @@
         "fingerprint": "0x42",
         "is_ignored": false,
         "lines": "- key: |\n   four",
-        "message": "|\n   four\n\n",
+        "message": "\n   four\n\n",
         "metadata": {},
         "metavars": {
           "$VALUE": {
-            "abstract_content": "|\n   four\n",
+            "abstract_content": "\n   four\n",
             "end": {
               "col": 1,
               "line": 7,
               "offset": 62
             },
             "start": {
-              "col": 8,
+              "col": 9,
               "line": 5,
-              "offset": 52
+              "offset": 53
             }
           }
         },
@@ -171,20 +171,20 @@
         "fingerprint": "0x42",
         "is_ignored": false,
         "lines": "- key: |       \n    fi\n\n    ve",
-        "message": "|       \n    fi\n\n    ve\n\n",
+        "message": "       \n    fi\n\n    ve\n\n",
         "metadata": {},
         "metavars": {
           "$VALUE": {
-            "abstract_content": "|       \n    fi\n\n    ve\n",
+            "abstract_content": "       \n    fi\n\n    ve\n",
             "end": {
               "col": 1,
               "line": 11,
               "offset": 93
             },
             "start": {
-              "col": 8,
+              "col": 9,
               "line": 7,
-              "offset": 69
+              "offset": 70
             }
           }
         },
@@ -209,20 +209,20 @@
         "fingerprint": "0x42",
         "is_ignored": false,
         "lines": "- key: |\n    si\n\n      x",
-        "message": "|\n    si\n\n      x\n    \n\n",
+        "message": "\n    si\n\n      x\n    \n\n",
         "metadata": {},
         "metavars": {
           "$VALUE": {
-            "abstract_content": "|\n    si\n\n      x\n    \n",
+            "abstract_content": "\n    si\n\n      x\n    \n",
             "end": {
               "col": 1,
               "line": 16,
               "offset": 123
             },
             "start": {
-              "col": 8,
+              "col": 9,
               "line": 11,
-              "offset": 100
+              "offset": 101
             }
           }
         },
@@ -247,20 +247,20 @@
         "fingerprint": "0x42",
         "is_ignored": false,
         "lines": "- key: >\n    seven",
-        "message": ">\n    seven\n\n",
+        "message": "\n    seven\n\n",
         "metadata": {},
         "metavars": {
           "$VALUE": {
-            "abstract_content": ">\n    seven\n",
+            "abstract_content": "\n    seven\n",
             "end": {
               "col": 1,
               "line": 18,
               "offset": 142
             },
             "start": {
-              "col": 8,
+              "col": 9,
               "line": 16,
-              "offset": 130
+              "offset": 131
             }
           }
         },
@@ -285,20 +285,20 @@
         "fingerprint": "0x42",
         "is_ignored": false,
         "lines": "- key: >\n    eig\n\n    ht",
-        "message": ">\n    eig\n\n    ht\n",
+        "message": "\n    eig\n\n    ht\n",
         "metadata": {},
         "metavars": {
           "$VALUE": {
-            "abstract_content": ">\n    eig\n\n    ht",
+            "abstract_content": "\n    eig\n\n    ht",
             "end": {
               "col": 7,
               "line": 21,
               "offset": 166
             },
             "start": {
-              "col": 8,
+              "col": 9,
               "line": 18,
-              "offset": 149
+              "offset": 150
             }
           }
         },

--- a/src/parsing/yaml_to_generic.ml
+++ b/src/parsing/yaml_to_generic.ml
@@ -106,16 +106,25 @@ let mk_tok ?(style = `Plain)
       E.end_mark = { M.index = e_index; _ };
       _;
     } str env =
-  let str =
+  let index, line, column, str =
     match style with
-    (* This is for strings that use `|`, `>`, or quotes.
+    (* This is for strings that use `|`, `>` and strip markers `+`, `-`
      *)
     | `Literal
-    | `Folded
+    | `Folded ->
+        let s = String.sub env.text (index + 1) (e_index - index - 1) in
+        let l = String.length s in
+        if String.starts_with "+" s then
+          (index + 2, line, column + 2, String.sub s 1 (l - 1))
+        else if String.starts_with "-" s then
+          (index + 2, line, column + 2, String.sub s 1 (l - 1))
+        else (index + 1, line, column + 1, s)
+    (* This is for strings that use quotes.
+     *)
     | `Double_quoted
     | `Single_quoted ->
-        String.sub env.text index (e_index - index)
-    | __else__ -> str
+        (index, line, column, String.sub env.text index (e_index - index))
+    | __else__ -> (index, line, column, str)
   in
   (* their tokens are 0 indexed for line and column, AST_generic's are 1
    * indexed for line, 0 for column *)

--- a/tests/extract/promql_prometheus.test.yaml
+++ b/tests/extract/promql_prometheus.test.yaml
@@ -1,0 +1,14 @@
+groups:
+- name: test
+  rules:
+  - alert: ExtractMeFirst
+    # ruleid: never-sum-then-rate
+    expr: rate(sum by (job) (http_requests_total{job="node"})[5m:])
+  - alert: ExtractMeSecond
+    expr: |
+      # ruleid: never-sum-then-rate
+      rate(sum by (job) (http_requests_total{job="node"})[5m:])
+  - alert: ExtractMeThird
+    expr: |-
+      # ruleid: never-sum-then-rate
+      rate(sum by (job) (http_requests_total{job="node"})[5m:])

--- a/tests/extract/promql_prometheus.yaml
+++ b/tests/extract/promql_prometheus.yaml
@@ -1,0 +1,19 @@
+rules:
+  - id: extract-alerting-rule-expression-to-promql
+    mode: extract
+    languages:
+      - yaml
+    pattern: |
+      expr: $PROMQL
+    extract: $PROMQL
+    dest-language: promql
+  - id: never-sum-then-rate
+    message: testing
+    severity: ERROR
+    languages:
+      - promql
+    patterns:
+    - pattern-either:
+      - pattern: rate(sum(...)[$DURATION:])
+      - pattern: rate(sum(...)[$DURATION:$STEP])
+


### PR DESCRIPTION
Previously the tokens for raw or folded yaml strings would include style ( `|` or `>` ) and chomp ( `+` or `-` ) markers which breaks extractions since they do not technically belong to the matched string. 

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
