### PR TITLE
sym-prop: Inspect 'id_svalue's during cycle checks

### DIFF
--- a/changelog.d/pa-2933.fixed
+++ b/changelog.d/pa-2933.fixed
@@ -1,0 +1,1 @@
+Fixed stack overflow caused by symbolic propagation.

--- a/src/analyzing/Dataflow_svalue.ml
+++ b/src/analyzing/Dataflow_svalue.ml
@@ -406,18 +406,32 @@ let no_cycles_in_svalue (id_info : G.id_info) svalue =
      * we can have a single visitor for all calls, given that the old
      * `mk_visitor` was pretty expensive, and constructing a visitor object may
      * be as well. *)
+    let i = ref 0 in
     let ff = ref (fun _ -> assert false) in
     let ok = ref true in
     let vout =
-      object
-        inherit [_] G.iter
+      object (self : 'self)
+        inherit [_] G.iter_no_id_info
 
-        method! visit_id_info _env ii =
+        method! visit_id_info env ii =
           ok := !ok && !ff ii;
+          (match !(ii.id_svalue) with
+          | Some (Sym e) when !ok ->
+              (* Following `id_svalue`s can explode in pathological cases,
+               * see 'tests/rules/sym_prop_explosion.js', so we need to
+               * set a bound. *)
+              if !i < 1000 then (
+                incr i;
+                self#visit_expr env e)
+              else ok := false
+          | None
+          | Some _ ->
+              ());
           if not !ok then raise Exit
       end
     in
     fun f ast ->
+      i := 0;
       ff := f;
       ok := true;
       try
@@ -436,7 +450,7 @@ let no_cycles_in_svalue (id_info : G.id_info) svalue =
       for_all_id_info
         (fun ii ->
           (* Note the use of physical equality, we are looking for the *same*
-           * id_svalue ref, that tells us it's the same variable occurrence. *)
+                * id_svalue ref, that tells us it's the same variable occurrence. *)
           not (phys_equal id_info.id_svalue ii.id_svalue))
         (G.E e)
   | G.NotCst
@@ -449,9 +463,8 @@ let set_svalue_ref id_info c' =
     match !(id_info.id_svalue) with
     | None -> id_info.id_svalue := Some c'
     | Some c -> id_info.id_svalue := Some (refine c c')
-  else
-    logger#error "Cycle check failed for %s := %s" (G.show_id_info id_info)
-      (G.show_svalue c')
+  else logger#error "Cycle check failed for %s := ..." (G.show_id_info id_info)
+(* (G.show_svalue c') *)
 
 (*****************************************************************************)
 (* Transfer *)

--- a/src/analyzing/Dataflow_svalue.ml
+++ b/src/analyzing/Dataflow_svalue.ml
@@ -420,7 +420,8 @@ let no_cycles_in_svalue (id_info : G.id_info) svalue =
               (* Following `id_svalue`s can explode in pathological cases,
                * see 'tests/rules/sym_prop_explosion.js', so we need to
                * set a bound. *)
-              if !i < 1000 then (
+              if !i < Limits_semgrep.svalue_prop_MAX_VISIT_SYM_IN_CYCLE_CHECK
+              then (
                 incr i;
                 self#visit_expr env e)
               else ok := false
@@ -450,7 +451,7 @@ let no_cycles_in_svalue (id_info : G.id_info) svalue =
       for_all_id_info
         (fun ii ->
           (* Note the use of physical equality, we are looking for the *same*
-                * id_svalue ref, that tells us it's the same variable occurrence. *)
+           * id_svalue ref, that tells us it's the same variable occurrence. *)
           not (phys_equal id_info.id_svalue ii.id_svalue))
         (G.E e)
   | G.NotCst

--- a/src/configuring/Limits_semgrep.ml
+++ b/src/configuring/Limits_semgrep.ml
@@ -8,6 +8,10 @@
  * Note that 'Time_limit.set_timeout' cannot be nested. *)
 let svalue_prop_FIXPOINT_TIMEOUT = 0.1
 
+(* Bounds the number of times that we will follow an 'id_svalue' during
+ * a cycle check. See 'Dataflow_svalue.no_cycles_in_svalue'. *)
+let svalue_prop_MAX_VISIT_SYM_IN_CYCLE_CHECK = 1000
+
 (*****************************************************************************)
 (* Taint analysis *)
 (*****************************************************************************)

--- a/tests/rules/sym_prop_no_cycle1.js
+++ b/tests/rules/sym_prop_no_cycle1.js
@@ -1,0 +1,9 @@
+function foo() {
+    sink("safe");
+}
+
+function bad_for_sym_prop(t) {
+    for(;t=f(t);)
+        t=g(t);
+    return t;
+}

--- a/tests/rules/sym_prop_no_cycle1.yaml
+++ b/tests/rules/sym_prop_no_cycle1.yaml
@@ -1,0 +1,18 @@
+rules:
+  - id: test
+    message: Test
+    severity: WARNING
+    languages:
+      - javascript
+      - typescript
+    mode: taint
+    options:
+      symbolic_propagation: true
+    pattern-sources:
+    - pattern: f(...)
+    pattern-sinks:
+      # Unclear why, but the stack overflow was only reproducible with the ending `...` !
+      - pattern: |
+          sink(...)
+          ...
+

--- a/tests/rules/sym_prop_no_merge2.py
+++ b/tests/rules/sym_prop_no_merge2.py
@@ -2,15 +2,15 @@ def test1():
     if cond():
         y = f(x)
         # ruleid: test
-        x = g(y)
+        z = g(y)
     # OK:
-    return x
+    return z
 
 def test2():
     while cond():
         y = f(x)
         # ruleid: test
-        x = g(y)
+        z = g(y)
     # OK:
-    return x
+    return z
 


### PR DESCRIPTION
We were overwriting `visit_id_info` in a way that it was not visiting 'id_svalue's, therefore the cycle checks did not detect transitive dependencies.

Closes PA-2933

test plan:
make test # new test
See PA-2933 reproduction

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
