### PR TITLE
cleanup: move Rule.ID in separate file Rule_ID.ml

### DIFF
--- a/src/core/Mini_rule.ml
+++ b/src/core/Mini_rule.ml
@@ -32,7 +32,7 @@
 (*****************************************************************************)
 
 type rule = {
-  id : Rule.ID.t;
+  id : Rule_ID.t;
   pattern : Pattern.t;
   inside : bool;
   (* originates from pattern-inside or pattern-not-inside *)

--- a/src/core/Pattern_match.ml
+++ b/src/core/Pattern_match.ml
@@ -120,7 +120,7 @@ and rule_id = {
    * Note that when we process a full rule, this id can temporarily
    * contain a Rule.pattern_id.
    *)
-  id : Rule.ID.t;
+  id : Rule_ID.t;
   (* other parts of a rule (or mini_rule) used in JSON_report.ml.
    *
    * TODO should we remove these fields and just pass around a Rule.t or

--- a/src/core/Rule.ml
+++ b/src/core/Rule.ml
@@ -28,74 +28,6 @@ open Ppx_hash_lib.Std.Hash.Builtin
  * See also Mini_rule.ml where formula and many other features disappear.
  *)
 
-(*
-   A rule ID is a string. This creates a dedicated type to clarify interfaces
-   and error messages. The coercion operator can be used as an alternative
-   to 'to_string x': '(x :> string)' to obtain a plain string.
-*)
-module ID : sig
-  type t = private string [@@deriving show, eq]
-
-  exception Malformed_rule_ID of string
-
-  val to_string : t -> string
-  val of_string : string -> t
-  val of_string_opt : string -> t option
-  val to_string_list : t list -> string list
-  val of_string_list : string list -> t list
-  val compare : t -> t -> int
-
-  (* Validation function called by of_string.
-     Checks for the format [a-zA-Z0-9._-]* *)
-  val validate : string -> bool
-
-  (* Remove any forbidden characters to produce a valid rule ID fragment. *)
-  val sanitize_string : string -> string
-
-  (*
-     Rule ids are prepended with the `path.to.the.rules.file.`, so
-     when comparing a rule (r) with the rule to be included or excluded,
-     allow for a preceding path
-
-       "path.to.foo.bar" ~suffix:"foo.bar" -> true
-       "foo.bar" ~suffix:"foo.bar" -> true
-       "xfoo.bar" ~suffix:"foo.bar" -> false
-  *)
-  val ends_with : t -> suffix:t -> bool
-end = struct
-  type t = string [@@deriving show, eq]
-
-  exception Malformed_rule_ID of string
-
-  let to_string x = x
-
-  let validate =
-    let rex = SPcre.regexp "^[a-zA-Z0-9._-]*$" in
-    fun str -> SPcre.pmatch_noerr ~rex str
-
-  let sanitize_string str =
-    let buf = Buffer.create (String.length str) in
-    String.iter
-      (function
-        | ('a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '.' | '_' | '-') as c ->
-            Buffer.add_char buf c
-        | _junk -> ())
-      str;
-    Buffer.contents buf
-
-  let of_string x = if not (validate x) then raise (Malformed_rule_ID x) else x
-  let of_string_opt x = if validate x then Some x else None
-  let to_string_list x = x
-  let of_string_list x = x
-  let compare = String.compare
-
-  let ends_with r ~suffix:inc_or_exc_rule =
-    r = inc_or_exc_rule
-    || Stdcompat.String.ends_with ~suffix:("." ^ inc_or_exc_rule) r
-end
-
-type rule_id = ID.t [@@deriving show, eq]
-
 (*****************************************************************************)
 (* Position information *)
 (*****************************************************************************)
@@ -113,6 +45,12 @@ type 'a loc = {
   path : string list; (* path to pattern in YAML rule *)
 }
 [@@deriving show, eq]
+
+(*****************************************************************************)
+(* Rule IDs (now defined in Rule_ID.ml) *)
+(*****************************************************************************)
+
+type rule_id = Rule_ID.t [@@deriving show, eq]
 
 (*****************************************************************************)
 (* Formula (patterns boolean composition) *)
@@ -697,7 +635,7 @@ let split_and (xs : formula list) : formula list * (tok * formula) list =
 let rule_of_xpattern (xlang : Xlang.t) (xpat : Xpattern.t) : rule =
   let fk = Tok.unsafe_fake_tok "" in
   {
-    id = (ID.of_string "-e", fk);
+    id = (Rule_ID.of_string "-e", fk);
     mode = `Search (P xpat);
     (* alt: could put xpat.pstr for the message *)
     message = "";
@@ -728,4 +666,4 @@ let rule_of_xpattern (xlang : Xlang.t) (xpat : Xpattern.t) : rule =
    which is clearly not enough comparing to the Python code. But, again, we can
    improve that by serialize everything and compute a hash from it. *)
 let sha256_of_rule rule =
-  Digestif.SHA256.digest_string (ID.to_string (fst rule.id))
+  Digestif.SHA256.digest_string (Rule_ID.to_string (fst rule.id))

--- a/src/core/Rule.ml
+++ b/src/core/Rule.ml
@@ -1,6 +1,6 @@
 (* Yoann Padioleau
  *
- * Copyright (C) 2019-2022 r2c
+ * Copyright (C) 2019-2023 Semgrep Inc.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
@@ -45,12 +45,6 @@ type 'a loc = {
   path : string list; (* path to pattern in YAML rule *)
 }
 [@@deriving show, eq]
-
-(*****************************************************************************)
-(* Rule IDs (now defined in Rule_ID.ml) *)
-(*****************************************************************************)
-
-type rule_id = Rule_ID.t [@@deriving show, eq]
 
 (*****************************************************************************)
 (* Formula (patterns boolean composition) *)
@@ -283,8 +277,8 @@ type extract_spec = {
 (* SR wants to be able to choose rules to run on
    Behaves the same as paths *)
 and extract_rule_ids = {
-  required_rules : rule_id wrap list;
-  excluded_rules : rule_id wrap list;
+  required_rules : Rule_ID.t wrap list;
+  excluded_rules : Rule_ID.t wrap list;
 }
 
 (* Method to combine extracted ranges within a file:
@@ -395,7 +389,7 @@ type steps = step list [@@deriving show]
 
 type 'mode rule_info = {
   (* MANDATORY fields *)
-  id : rule_id wrap;
+  id : Rule_ID.t wrap;
   mode : 'mode;
   (* Currently a dummy value for extract mode rules *)
   message : string;
@@ -440,7 +434,7 @@ type rule = mode rule_info [@@deriving show]
 (* aliases *)
 type t = rule [@@deriving show]
 type rules = rule list [@@deriving show]
-type hrules = (rule_id, t) Hashtbl.t
+type hrules = (Rule_ID.t, t) Hashtbl.t
 
 (*****************************************************************************)
 (* Helpers *)
@@ -473,12 +467,12 @@ let partition_rules (rules : rules) :
 (* This is used to let the user know which rule the engine was using when
  * a Timeout or OutOfMemory exn occured.
  *)
-let last_matched_rule : rule_id option ref = ref None
+let last_matched_rule : Rule_ID.t option ref = ref None
 
 (* Those are recoverable errors; We can just skip the rules containing them.
  * TODO? put in Output_from_core.atd?
  *)
-type invalid_rule_error = invalid_rule_error_kind * rule_id * Tok.t
+type invalid_rule_error = invalid_rule_error_kind * Rule_ID.t * Tok.t
 
 and invalid_rule_error_kind =
   | InvalidLanguage of string (* the language string *)

--- a/src/core/Rule_ID.ml
+++ b/src/core/Rule_ID.ml
@@ -1,0 +1,61 @@
+(* Martin Jambon
+ *
+ * Copyright (C) 2023 Semgrep Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * version 2.1 as published by the Free Software Foundation, with the
+ * special exception on linking described in file LICENSE.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
+ * LICENSE for more details.
+ *)
+
+(*****************************************************************************)
+(* Prelude *)
+(*****************************************************************************)
+(* Rule identifiers (rule IDs), e.g., "ocaml.lang.list-no-map".
+ *
+ * History: this used to be defined in Rule.ml as a simple type alias,
+ * but better to provide a precise API to manipulate Rule IDs.
+ *)
+
+(*****************************************************************************)
+(* Types *)
+(*****************************************************************************)
+
+type t = string [@@deriving show, eq]
+
+exception Malformed_rule_ID of string
+
+(*****************************************************************************)
+(* Entry points *)
+(*****************************************************************************)
+
+let to_string x = x
+
+let validate =
+  let rex = SPcre.regexp "^[a-zA-Z0-9._-]*$" in
+  fun str -> SPcre.pmatch_noerr ~rex str
+
+let sanitize_string str =
+  let buf = Buffer.create (String.length str) in
+  String.iter
+    (function
+      | ('a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '.' | '_' | '-') as c ->
+          Buffer.add_char buf c
+      | _junk -> ())
+    str;
+  Buffer.contents buf
+
+let of_string x = if not (validate x) then raise (Malformed_rule_ID x) else x
+let of_string_opt x = if validate x then Some x else None
+let to_string_list x = x
+let of_string_list x = x
+let compare = String.compare
+
+let ends_with r ~suffix:inc_or_exc_rule =
+  r = inc_or_exc_rule
+  || Stdcompat.String.ends_with ~suffix:("." ^ inc_or_exc_rule) r

--- a/src/core/Rule_ID.mli
+++ b/src/core/Rule_ID.mli
@@ -1,0 +1,36 @@
+(*
+   A rule ID is a string. This creates a dedicated type to clarify interfaces
+   and error messages. The coercion operator can be used as an alternative
+   to 'to_string x': '(x :> string)' to obtain a plain string.
+*)
+type t = private string [@@deriving show, eq]
+
+exception Malformed_rule_ID of string
+
+(* conversion functions *)
+val to_string : t -> string
+val of_string : string -> t
+val of_string_opt : string -> t option
+
+(* there are a few places where we need to convert list of rule IDs *)
+val to_string_list : t list -> string list
+val of_string_list : string list -> t list
+val compare : t -> t -> int
+
+(* Validation function called by of_string.
+   Checks for the format [a-zA-Z0-9._-]* *)
+val validate : string -> bool
+
+(* Remove any forbidden characters to produce a valid rule ID fragment. *)
+val sanitize_string : string -> string
+
+(*
+   Rule ids are prepended with the `path.to.the.rules.file.`, so
+   when comparing a rule (r) with the rule to be included or excluded,
+   allow for a preceding path
+
+     "path.to.foo.bar" ~suffix:"foo.bar" -> true
+     "foo.bar" ~suffix:"foo.bar" -> true
+     "xfoo.bar" ~suffix:"foo.bar" -> false
+*)
+val ends_with : t -> suffix:t -> bool

--- a/src/engine/Match_env.ml
+++ b/src/engine/Match_env.ml
@@ -83,7 +83,7 @@ let error env msg =
 (* this will be adjusted later in range_to_pattern_match_adjusted *)
 let fake_rule_id (id, str) =
   {
-    PM.id = Rule.ID.of_string (string_of_int id);
+    PM.id = Rule_ID.of_string (string_of_int id);
     pattern_string = str;
     message = "";
     fix = None;

--- a/src/engine/Match_extract_mode.ml
+++ b/src/engine/Match_extract_mode.ml
@@ -192,7 +192,7 @@ let convert_from_json_array_to_string json =
 (* Error reporting *)
 (*****************************************************************************)
 
-let report_unbound_mvar (ruleid : Rule.rule_id) mvar m =
+let report_unbound_mvar (ruleid : Rule_ID.t) mvar m =
   let { Range.start; end_ } = Pattern_match.range m in
   logger#warning
     "The extract metavariable for rule %s (%s) wasn't bound in a match; \

--- a/src/engine/Match_extract_mode.ml
+++ b/src/engine/Match_extract_mode.ml
@@ -111,11 +111,11 @@ let check_includes_and_excludes rule extract_rule_ids =
           counterproductive semgrep rules that prevent us from doing so. *)
        List.length required_rules =|= 0
       || List.exists
-           (fun r' -> Rule.ID.ends_with (fst r) ~suffix:(fst r'))
+           (fun r' -> Rule_ID.ends_with (fst r) ~suffix:(fst r'))
            required_rules)
       && not
            (List.exists
-              (fun r' -> Rule.ID.ends_with (fst r) ~suffix:(fst r'))
+              (fun r' -> Rule_ID.ends_with (fst r) ~suffix:(fst r'))
               excluded_rules)
 
 (* Compute the rules that should be run for the extracted

--- a/src/engine/Match_search_mode.ml
+++ b/src/engine/Match_search_mode.ml
@@ -165,7 +165,7 @@ let (mini_rule_of_pattern :
       MR.t) =
  fun xlang rule (pattern, inside, id, pstr) ->
   {
-    MR.id = Rule.ID.of_string (string_of_int id);
+    MR.id = Rule_ID.of_string (string_of_int id);
     pattern;
     inside;
     (* parts that are not really needed I think in this context, since

--- a/src/engine/Unit_engine.ml
+++ b/src/engine/Unit_engine.ml
@@ -283,7 +283,7 @@ let match_pattern ~lang ~hook ~file ~pattern ~fix_pattern =
   in
   let rule =
     {
-      MR.id = Rule.ID.of_string "unit-testing";
+      MR.id = Rule_ID.of_string "unit-testing";
       pattern;
       inside = false;
       message = "";
@@ -348,7 +348,7 @@ let regression_tests_for_lang ~polyglot_pattern_path files lang =
                  ~hook:(fun { Pattern_match.range_loc; _ } ->
                    let start_loc, _end_loc = range_loc in
                    E.error
-                     (Rule.ID.of_string "test-pattern")
+                     (Rule_ID.of_string "test-pattern")
                      start_loc "" Out.SemgrepMatchFound)
                  ~file ~pattern ~fix_pattern
              in

--- a/src/experiments/synthesizing/Unit_synthesizer_targets.ml
+++ b/src/experiments/synthesizing/Unit_synthesizer_targets.ml
@@ -59,7 +59,7 @@ let ranges_matched lang file pattern : Range.t list =
   let ast = parse_file lang file in
   let rule =
     {
-      Mini_rule.id = Rule.ID.of_string "unit-testing";
+      Mini_rule.id = Rule_ID.of_string "unit-testing";
       pattern;
       inside = false;
       message = "";
@@ -78,7 +78,7 @@ let ranges_matched lang file pattern : Range.t list =
         let minii, _maxii = Tok_range.min_max_toks_by_pos toks in
         let minii_loc = Tok.unsafe_loc_of_tok minii in
         E.error
-          (Rule.ID.of_string "Synthesizer-tests")
+          (Rule_ID.of_string "Synthesizer-tests")
           minii_loc "" Out.SemgrepMatchFound)
       (Rule_options.default_config, equiv)
       [ rule ] (file, lang, ast)

--- a/src/language_server/Processed_run.ml
+++ b/src/language_server/Processed_run.ml
@@ -121,7 +121,7 @@ let of_matches ?(only_git_dirty = true) matches (hrules : Rule.hrules) files =
   let matches =
     Common.map
       (fun (m : Out.core_match) ->
-        let rule = Hashtbl.find_opt hrules (Rule.ID.of_string m.rule_id) in
+        let rule = Hashtbl.find_opt hrules (Rule_ID.of_string m.rule_id) in
         let rule =
           match rule with
           | Some rule -> rule

--- a/src/language_server/Unit_LS.ml
+++ b/src/language_server/Unit_LS.ml
@@ -36,7 +36,7 @@ let mock_run_results (files : string list) : Pattern_match.t list * Rule.t list
   let xpat = Xpattern.mk_xpat (Xpattern.Sem (lazy pattern, lang)) in
   let xpat = xpat (pattern_string, fk) in
   let rule = Rule.rule_of_xpattern xlang xpat in
-  let rule = { rule with id = (Rule.ID.of_string "print", fk) } in
+  let rule = { rule with id = (Rule_ID.of_string "print", fk) } in
   let rule_id =
     {
       Pattern_match.id = fst rule.id;

--- a/src/language_server/custom_requests/Search.ml
+++ b/src/language_server/custom_requests/Search.ml
@@ -51,7 +51,7 @@ let rules_of_pattern pat lang_opt =
     | XP.Regexp _ ->
         ());
     let rule = Rule.rule_of_xpattern xlang xpat in
-    { rule with id = (Rule.ID.of_string "-", fk) }
+    { rule with id = (Rule_ID.of_string "-", fk) }
   in
   match lang_opt with
   | Some lang ->
@@ -94,12 +94,12 @@ let search_semgrep config targets pat lang_opt =
       (fun i r ->
         {
           r with
-          Rule.id = (Rule.ID.of_string (string_of_int i), Tok.unsafe_fake_tok "");
+          Rule.id = (Rule_ID.of_string (string_of_int i), Tok.unsafe_fake_tok "");
         })
       rules
   in
   let rule_ids =
-    Common.map (fun r -> fst r.Rule.id |> Rule.ID.to_string) rules
+    Common.map (fun r -> fst r.Rule.id |> Rule_ID.to_string) rules
   in
   let rules_by_lang =
     Common.group_by (fun r -> r.Rule.languages.target_analyzer) rules
@@ -114,7 +114,7 @@ let search_semgrep config targets pat lang_opt =
         in
         let rule_nums =
           Common.map
-            (fun r -> fst r.Rule.id |> Rule.ID.to_string |> int_of_string)
+            (fun r -> fst r.Rule.id |> Rule_ID.to_string |> int_of_string)
             rules
         in
         { t with In.rule_nums })

--- a/src/osemgrep/cli_ci/Ci_subcommand.ml
+++ b/src/osemgrep/cli_ci/Ci_subcommand.ml
@@ -134,7 +134,7 @@ let partition_rules (filtered_rules : Rule.t list) =
       (fun r ->
         Common2.string_match_substring
           (Str.regexp "r2c-internal-cai")
-          (Rule.ID.to_string (fst r.Rule.id)))
+          (Rule_ID.to_string (fst r.Rule.id)))
       filtered_rules
   in
   let blocking_rules, non_blocking_rules =
@@ -215,7 +215,7 @@ let prepare_for_report ~blocking_findings findings errors rules ~targets
     ~(ignored_targets : Out.cli_skipped_target list option) ~commit_date
     ~engine_requested =
   let rule_ids =
-    Common.map (fun r -> Rule.ID.to_string (fst r.Rule.id)) rules
+    Common.map (fun r -> Rule_ID.to_string (fst r.Rule.id)) rules
   in
   (*
       we want date stamps assigned by the app to be assigned such that the
@@ -584,7 +584,7 @@ let run (conf : Ci_CLI.conf) : Exit_code.t =
                         List.exists
                           (fun r ->
                             String.equal "r2c-internal-project-depends-on"
-                              (Rule.ID.to_string (fst r.Rule.id)))
+                              (Rule_ID.to_string (fst r.Rule.id)))
                           filtered_rules
                       then
                         Logs.app (fun m ->

--- a/src/osemgrep/cli_interactive/Interactive_subcommand.ml
+++ b/src/osemgrep/cli_interactive/Interactive_subcommand.ml
@@ -492,7 +492,7 @@ let translate_formula iformula =
 
 let mk_fake_rule lang formula =
   {
-    Rule.id = (Rule.ID.of_string "-i", fk);
+    Rule.id = (Rule_ID.of_string "-i", fk);
     mode = `Search formula;
     (* alt: could put xpat.pstr for the message *)
     message = "";

--- a/src/osemgrep/cli_scan/Cli_json_output.ml
+++ b/src/osemgrep/cli_scan/Cli_json_output.ml
@@ -126,7 +126,7 @@ let render_fix (env : env) (x : Out.core_match) : string option =
   match x with
   | { rule_id; location; extra = { metavars; rendered_fix; _ }; _ } -> (
       let rule =
-        try Hashtbl.find env.hrules (Rule.ID.of_string rule_id) with
+        try Hashtbl.find env.hrules (Rule_ID.of_string rule_id) with
         | Not_found -> raise Impossible
       in
       let path = location.path in
@@ -321,7 +321,7 @@ let cli_match_of_core_match (env : env) (m : Out.core_match) : Out.cli_match =
      };
   } ->
       let rule =
-        try Hashtbl.find env.hrules (Rule.ID.of_string rule_id) with
+        try Hashtbl.find env.hrules (Rule_ID.of_string rule_id) with
         | Not_found -> raise Impossible
       in
       let path = location.path in

--- a/src/osemgrep/cli_scan/Core_runner.ml
+++ b/src/osemgrep/cli_scan/Core_runner.ml
@@ -178,7 +178,7 @@ let prepare_config_for_semgrep_core (config : Runner_config.t)
   let target_mappings = List.concat target_mappings in
   let rules = rules |> List.rev |> List.concat in
   let rule_ids =
-    Common.map (fun r -> fst r.Rule.id |> Rule.ID.to_string) rules
+    Common.map (fun r -> fst r.Rule.id |> Rule_ID.to_string) rules
   in
   let targets : Input_to_core_t.targets = { target_mappings; rule_ids } in
   {

--- a/src/osemgrep/cli_scan/Rule_filtering.ml
+++ b/src/osemgrep/cli_scan/Rule_filtering.ml
@@ -16,7 +16,7 @@
 (* Types *)
 (*****************************************************************************)
 type conf = {
-  exclude_rule_ids : Rule.rule_id list;
+  exclude_rule_ids : Rule_ID.t list;
   severity : Severity.rule_severity list;
 }
 [@@deriving show]

--- a/src/osemgrep/cli_scan/Rule_filtering.mli
+++ b/src/osemgrep/cli_scan/Rule_filtering.mli
@@ -1,5 +1,5 @@
 type conf = {
-  exclude_rule_ids : Rule.rule_id list;
+  exclude_rule_ids : Rule_ID.t list;
   severity : Severity.rule_severity list;
 }
 [@@deriving show]

--- a/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -800,7 +800,7 @@ let cmdline_term ~allow_empty_config : conf Term.t =
     let rule_filtering_conf =
       {
         Rule_filtering.exclude_rule_ids =
-          Common.map Rule.ID.of_string exclude_rule_ids;
+          Common.map Rule_ID.of_string exclude_rule_ids;
         severity;
       }
     in

--- a/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -177,7 +177,7 @@ let rules_and_counted_matches (res : Core_runner.result) : (Rule.t * int) list =
   let map = List.fold_left fold Map_.empty res.core.Out.matches in
   Map_.fold
     (fun rule_id n acc ->
-      match Rule.ID.of_string_opt rule_id with
+      match Rule_ID.of_string_opt rule_id with
       | Some rule_id -> (Hashtbl.find res.hrules rule_id, n) :: acc
       | None -> acc)
     map []
@@ -193,7 +193,7 @@ let scan_files rules_and_origins profiler (conf : Scan_CLI.conf) =
   (* TODO: we should probably warn the user about rules using the same id *)
   let rules =
     Common.uniq_by
-      (fun r1 r2 -> Rule.ID.equal (fst r1.Rule.id) (fst r2.Rule.id))
+      (fun r1 r2 -> Rule_ID.equal (fst r1.Rule.id) (fst r2.Rule.id))
       rules
   in
   if Common.null rules then Error Exit_code.missing_config

--- a/src/osemgrep/core/Constants.ml
+++ b/src/osemgrep/core/Constants.ml
@@ -5,7 +5,7 @@ open Common
 
 let _rules_key = "rules"
 let _id_key = "id"
-let rule_id_for_dash_e = Rule.ID.of_string "-"
+let rule_id_for_dash_e = Rule_ID.of_string "-"
 
 let _please_file_issue_text =
   "An error occurred while invoking the Semgrep engine. Please help us fix \

--- a/src/osemgrep/core/Constants.mli
+++ b/src/osemgrep/core/Constants.mli
@@ -1,2 +1,2 @@
 (* "-", the rule id for interactive rule? via -e ? *)
-val rule_id_for_dash_e : Rule.ID.t
+val rule_id_for_dash_e : Rule_ID.t

--- a/src/osemgrep/networking/Rule_fetching.ml
+++ b/src/osemgrep/networking/Rule_fetching.ml
@@ -99,8 +99,8 @@ let prefix_for_fpath_opt (fpath : Fpath.t) : string option =
       in
       Some prefix
 
-let add_prefix prefix (rule_id : Rule.ID.t) =
-  Rule.ID.of_string (Rule.ID.sanitize_string prefix ^ (rule_id :> string))
+let add_prefix prefix (rule_id : Rule_ID.t) =
+  Rule_ID.of_string (Rule_ID.sanitize_string prefix ^ (rule_id :> string))
 
 let rules_rewrite_rule_ids ~rewrite_rule_ids (x : rules_and_origin) :
     rules_and_origin =

--- a/src/osemgrep/reporting/Rules_report.ml
+++ b/src/osemgrep/reporting/Rules_report.ml
@@ -30,7 +30,7 @@ let pp_rules ppf (rules_source, filtered_rules) =
 
   let rule_id r = fst r.Rule.id in
   let sorted =
-    List.sort (fun r1 r2 -> Rule.ID.compare (rule_id r1) (rule_id r2))
+    List.sort (fun r1 r2 -> Rule_ID.compare (rule_id r1) (rule_id r2))
   in
   sorted normal
   |> List.iter (fun rule -> Fmt.pf ppf "- %s@." (rule_id rule :> string));

--- a/src/parsing/Parse_rule.ml
+++ b/src/parsing/Parse_rule.ml
@@ -1513,10 +1513,10 @@ let parse_rules_to_run_with_extract env key value =
   let ruleids_dict = yaml_to_dict env key value in
   let inc_opt, exc_opt =
     ( take_opt ruleids_dict env
-        (parse_string_wrap_list Rule.ID.of_string)
+        (parse_string_wrap_list Rule_ID.of_string)
         "include",
       take_opt ruleids_dict env
-        (parse_string_wrap_list Rule.ID.of_string)
+        (parse_string_wrap_list Rule_ID.of_string)
         "exclude" )
   in
   (* alt: we could use report_unparsed_fields(), but better to raise an error for now
@@ -1598,7 +1598,7 @@ let parse_step_fields env key (value : G.expr) : R.step =
   in
   let step_id_str, tok = key in
   let id =
-    (Rule.ID.of_string (* TODO: is this really a rule ID? *) step_id_str, tok)
+    (Rule_ID.of_string (* TODO: is this really a rule ID? *) step_id_str, tok)
   in
   let step_languages = parse_languages ~id rule_options languages in
   let env = { env with languages = step_languages } in
@@ -1700,7 +1700,7 @@ let parse_one_rule (t : G.tok) (i : int) (rule : G.expr) : Rule.t =
   (* We need a rule ID early to produce useful error messages. *)
   let ((rule_id, _) as id) =
     let rule_id_str, tok = take_no_env rd parse_string_wrap_no_env "id" in
-    (Rule.ID.of_string rule_id_str, tok)
+    (Rule_ID.of_string rule_id_str, tok)
   in
   let languages = take_no_env rd parse_string_wrap_list_no_env "languages" in
   let options_opt, options_key =
@@ -1885,7 +1885,7 @@ let parse_and_filter_invalid_rules file = parse_file ~error_recovery:true file
 let parse_xpattern xlang (str, tok) =
   let env =
     {
-      id = Rule.ID.of_string "anon-pattern";
+      id = Rule_ID.of_string "anon-pattern";
       languages = Rule.languages_of_xlang xlang;
       in_metavariable_pattern = false;
       path = [];

--- a/src/parsing/Parse_rule.ml
+++ b/src/parsing/Parse_rule.ml
@@ -56,7 +56,7 @@ type key = string R.wrap
 
 type env = {
   (* id of the current rule (needed by some exns) *)
-  id : Rule.rule_id;
+  id : Rule_ID.t;
   (* languages of the current rule (needed by parse_pattern) *)
   languages : Rule.languages;
   (* whether we are underneath a `metavariable-pattern` *)

--- a/src/reporting/JSON_report.ml
+++ b/src/reporting/JSON_report.ml
@@ -299,7 +299,7 @@ let match_to_match render_fix (x : Pattern_match.t) :
 let error_to_error err =
   let file = err.E.loc.pos.file in
   let startp, endp = OutH.position_range err.E.loc err.E.loc in
-  let rule_id = Option.map Rule.ID.to_string err.E.rule_id in
+  let rule_id = Option.map Rule_ID.to_string err.E.rule_id in
   let error_type = err.E.typ in
   let severity = E.severity_of_error err.E.typ in
   let message = err.E.msg in

--- a/src/reporting/Report.ml
+++ b/src/reporting/Report.ml
@@ -127,7 +127,7 @@ type final_profiling = {
 }
 [@@deriving show]
 
-type rule_id_and_engine_kind = Rule.ID.t * Pattern_match.engine_kind
+type rule_id_and_engine_kind = Rule_ID.t * Pattern_match.engine_kind
 [@@deriving show]
 
 type final_result = {

--- a/src/reporting/Report.ml
+++ b/src/reporting/Report.ml
@@ -83,7 +83,7 @@ let mode = ref MNo_info
 (* Save time information as we run each rule *)
 
 type rule_profiling = {
-  rule_id : Rule.rule_id;
+  rule_id : Rule_ID.t;
   parse_time : float;
   match_time : float;
 }

--- a/src/reporting/Report.mli
+++ b/src/reporting/Report.mli
@@ -46,7 +46,7 @@ type file_profiling = {
 }
 [@@deriving show]
 
-type rule_id_and_engine_kind = Rule.ID.t * Pattern_match.engine_kind
+type rule_id_and_engine_kind = Rule_ID.t * Pattern_match.engine_kind
 [@@deriving show]
 
 (* Substitute in the profiling type we have *)

--- a/src/reporting/Report.mli
+++ b/src/reporting/Report.mli
@@ -25,7 +25,7 @@ val mode : debug_mode ref
 type times = { parse_time : float; match_time : float }
 
 type rule_profiling = {
-  rule_id : Rule.rule_id;
+  rule_id : Rule_ID.t;
   parse_time : float;
   match_time : float;
 }

--- a/src/reporting/Semgrep_error_code.ml
+++ b/src/reporting/Semgrep_error_code.ml
@@ -32,7 +32,7 @@ let logger = Logging.get_logger [ __MODULE__ ]
  * less: we should define everything in Output_from_core.atd, not just typ:
  *)
 type error = {
-  rule_id : Rule.rule_id option;
+  rule_id : Rule_ID.t option;
   typ : Out.core_error_kind;
   loc : Tok.location;
   msg : string;

--- a/src/reporting/Semgrep_error_code.mli
+++ b/src/reporting/Semgrep_error_code.mli
@@ -7,7 +7,7 @@
 (*****************************************************************************)
 
 type error = {
-  rule_id : Rule.rule_id option;
+  rule_id : Rule_ID.t option;
   typ : Output_from_core_t.core_error_kind;
   loc : Tok.location;
   msg : string;
@@ -23,14 +23,14 @@ val g_errors : error list ref
 (*****************************************************************************)
 
 val mk_error :
-  ?rule_id:Rule.rule_id option ->
+  ?rule_id:Rule_ID.t option ->
   Tok.location ->
   string ->
   Output_from_core_t.core_error_kind ->
   error
 
 val error :
-  Rule.rule_id ->
+  Rule_ID.t ->
   Tok.location ->
   string ->
   Output_from_core_t.core_error_kind ->
@@ -38,7 +38,7 @@ val error :
 
 (* Convert a caught exception and its stack trace to a Semgrep error. *)
 val exn_to_error :
-  ?rule_id:Rule.rule_id option -> Common.filename -> Exception.t -> error
+  ?rule_id:Rule_ID.t option -> Common.filename -> Exception.t -> error
 
 (*****************************************************************************)
 (* Try with error *)

--- a/src/runner/Run_semgrep.ml
+++ b/src/runner/Run_semgrep.ml
@@ -382,7 +382,7 @@ let parse_pattern lang_pattern str =
            (R.InvalidRule
               ( R.InvalidPattern
                   (str, Xlang.of_lang lang_pattern, Common.exn_to_s exn, []),
-                Rule.ID.of_string "no-id",
+                Rule_ID.of_string "no-id",
                 Tok.unsafe_fake_tok "no loc" )))
   [@@profiling]
 
@@ -541,7 +541,7 @@ let mk_rule_table (rules : Rule.t list) (list_of_rule_ids : string list) :
   in
   let id_pairs =
     list_of_rule_ids
-    |> Common.mapi (fun i x -> (i, Rule.ID.of_string x))
+    |> Common.mapi (fun i x -> (i, Rule_ID.of_string x))
     (* We filter out rules here if they don't exist, because we might have a
      * rule_id for an extract mode rule, but extract mode rules won't appear in
      * rule pairs, because they won't be in the table we make for search
@@ -947,7 +947,7 @@ let semgrep_with_rules_and_formatted_output config =
 
 let minirule_of_pattern lang pattern_string pattern =
   {
-    MR.id = Rule.ID.of_string "anon-pattern";
+    MR.id = Rule_ID.of_string "anon-pattern";
     pattern_string;
     pattern;
     inside = false;

--- a/src/runner/Run_semgrep.ml
+++ b/src/runner/Run_semgrep.ml
@@ -290,7 +290,7 @@ let filter_files_with_too_many_matches_and_transform_as_timeout
            in
            let skipped =
              sorted_offending_rules
-             |> Common.map (fun (((rule_id : Rule.rule_id), _pat), n) ->
+             |> Common.map (fun (((rule_id : Rule_ID.t), _pat), n) ->
                     let details =
                       spf
                         "found %i matches for rule %s, which exceeds the \
@@ -592,7 +592,7 @@ let xtarget_of_file (config : Runner_config.t) (xlang : Xlang.t)
  * by using the include/exclude fields.).
  *)
 let targets_of_config (config : Runner_config.t)
-    (all_rule_ids_when_no_target_file : Rule.rule_id list) :
+    (all_rule_ids_when_no_target_file : Rule_ID.t list) :
     In.targets * Out.skipped_target list =
   match (config.target_source, config.roots, config.lang) with
   (* We usually let semgrep-python computes the list of targets (and pass it

--- a/src/runner/Run_semgrep.mli
+++ b/src/runner/Run_semgrep.mli
@@ -202,7 +202,7 @@ val rules_from_rule_source :
 
 val targets_of_config :
   Runner_config.t ->
-  Rule.rule_id list ->
+  Rule_ID.t list ->
   Input_to_core_t.targets * Output_from_core_t.skipped_target list
 (**
   Compute the set of targets, either by reading what was passed

--- a/src/tainting/Dataflow_tainting.ml
+++ b/src/tainting/Dataflow_tainting.ml
@@ -80,7 +80,7 @@ type a_propagator = {
 
 type config = {
   filepath : Common.filename;
-  rule_id : R.rule_id;
+  rule_id : Rule_ID.t;
   is_source : G.any -> R.taint_source tmatch list;
   is_propagator : AST_generic.any -> a_propagator tmatch list;
   is_sink : G.any -> R.taint_sink tmatch list;

--- a/src/tainting/Dataflow_tainting.mli
+++ b/src/tainting/Dataflow_tainting.mli
@@ -28,7 +28,7 @@ type a_propagator = {
 
 type config = {
   filepath : Common.filename;  (** File under analysis, for Deep Semgrep. *)
-  rule_id : Rule.rule_id;  (** Taint rule id, for Deep Semgrep. *)
+  rule_id : Rule_ID.t;  (** Taint rule id, for Deep Semgrep. *)
   is_source : AST_generic.any -> Rule.taint_source tmatch list;
       (** Test whether 'any' is a taint source, this corresponds to
       * 'pattern-sources:' in taint-mode. *)


### PR DESCRIPTION
I try to reduce the size of Rule.ml which is getting big.
Separate concerns should be in separate files.

test plan:
make core


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)