### PR TITLE
Fix autocomplete

### DIFF
--- a/cli/bin/semgrep
+++ b/cli/bin/semgrep
@@ -89,4 +89,5 @@ if "--experimental" in sys.argv:
     sys.argv[0] = "osemgrep"
     os.execvp(str(path), sys.argv)
 else:
-    os.execvp("pysemgrep", sys.argv)
+    import semgrep.__main__
+    sys.exit(semgrep.__main__.main())


### PR DESCRIPTION
Calling pysemgrep through os.exec breaks autocomplete see [here](https://click.palletsprojects.com/en/8.1.x/shell-completion/#enabling-completion). This fixes it

## Test plan

```bash
cd semgrep/cli
pipenv install
pipenv shell
eval "$(_SEMGREP_COMPLETE=zsh_source semgrep)"
semgrep --co<tab>
```

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
