### PR TITLE
Fix: testing error

### DIFF
--- a/changelog.d/pa-2963.fixed
+++ b/changelog.d/pa-2963.fixed
@@ -1,0 +1,1 @@
+Semgrep no longer crashes when running --test

--- a/cli/bin/semgrep
+++ b/cli/bin/semgrep
@@ -68,25 +68,27 @@ def find_semgrep_core_path():
     sys.exit(2)
        
 
-if "--experimental" in sys.argv:
-    #alt: we could  extend osemgrep (and pysemgrep) to accept a new --experimental
-    # flag instead of removing the flag below. However, in osemgrep we do a few
-    # pattern matching of Sys.argv and if we have 'osemgrep --experimental --help'
-    # this would be interpreted as 'osemgrep scan --experimental --help' (because
-    # scan is the default command), and we would not get the simple semgrep --help
-    # message showing all the subcommands. So simpler to just remove --experimental.
-    sys.argv.remove("--experimental")
-    # We could have moved the code below in a separate 'osemgrep', like for 'pysemgrep',
-    # but we don't want users to be exposed to another command, so better to hide it.
-    # We expose 'pysemgrep' because osemgrep itself might need to fallback to pysemgrep
-    # and it's better to avoid the possibility of an infinite loop by simply using
-    # a different program name. Morever, in case of big problems, we can always
-    # tell users to run pysemgrep instead of semgrep and be sure they'll get the
-    # old behavior.
-    path = find_semgrep_core_path()
-    # If you call semgrep-core as osemgrep, then we get osemgrep behavior,
-    # see src/main/Main.ml
-    sys.argv[0] = "osemgrep"
-    os.execvp(str(path), sys.argv)
-else:
-    os.execvp("pysemgrep", sys.argv)
+if __name__ == "__main__":
+    if "--experimental" in sys.argv:
+        #alt: we could  extend osemgrep (and pysemgrep) to accept a new --experimental
+        # flag instead of removing the flag below. However, in osemgrep we do a few
+        # pattern matching of Sys.argv and if we have 'osemgrep --experimental --help'
+        # this would be interpreted as 'osemgrep scan --experimental --help' (because
+        # scan is the default command), and we would not get the simple semgrep --help
+        # message showing all the subcommands. So simpler to just remove --experimental.
+        sys.argv.remove("--experimental")
+        # We could have moved the code below in a separate 'osemgrep', like for 'pysemgrep',
+        # but we don't want users to be exposed to another command, so better to hide it.
+        # We expose 'pysemgrep' because osemgrep itself might need to fallback to pysemgrep
+        # and it's better to avoid the possibility of an infinite loop by simply using
+        # a different program name. Morever, in case of big problems, we can always
+        # tell users to run pysemgrep instead of semgrep and be sure they'll get the
+        # old behavior.
+        path = find_semgrep_core_path()
+        # If you call semgrep-core as osemgrep, then we get osemgrep behavior,
+        # see src/main/Main.ml
+        sys.argv[0] = "osemgrep"
+        os.execvp(str(path), sys.argv)
+    else:
+        import semgrep.__main__
+        sys.exit(semgrep.__main__.main())

--- a/cli/bin/semgrep
+++ b/cli/bin/semgrep
@@ -68,6 +68,15 @@ def find_semgrep_core_path():
     sys.exit(2)
        
 
+# when python imports a module, i.e. `import semgrep.FOO`, it runs the module's
+# top-level code, which is the code that is not inside any function or class.
+#
+# This means that if we try and run a function from the semgrep package in a subprocess,
+# we would end up calling os.execvp or main(), which causes a bunch of errors. So
+# we need to make sure that we only run the below code when this file is run as an executable.
+#
+# The above explanation is my understanding, but tbh I think python is weirder under the hood
+# with this stuff.
 if __name__ == "__main__":
     if "--experimental" in sys.argv:
         #alt: we could  extend osemgrep (and pysemgrep) to accept a new --experimental


### PR DESCRIPTION

TL;DR; we were calling semgrep without a main guard, and as a process, causing some weird exec error see [this SO issue](https://stackoverflow.com/questions/24374288/where-to-put-freeze-support-in-a-python-script)


This PR also fixes the same bug that https://github.com/returntocorp/semgrep/pull/8359 fixes, in the same way, so if we merge this we can close that PR and accompanying issue.

## Test plan

```bash
cd semgrep/cli
pipenv install
pipenv shell
semgrep --test --pro --config=. # in archive.zip provided on linear
```


PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
