### PR TITLE
fix(rust): enhanced macro args

### DIFF
--- a/changelog.d/pa-2951.fixed
+++ b/changelog.d/pa-2951.fixed
@@ -1,0 +1,2 @@
+Rust: Macro calls which involve dereferencing and reference operators
+(such as `foo!(&x)` and `foo!(*x)`) now properly transmit taint

--- a/languages/rust/generic/Parse_rust_tree_sitter.ml
+++ b/languages/rust/generic/Parse_rust_tree_sitter.ml
@@ -132,6 +132,17 @@ let rec macro_items_to_anys (xs : rust_macro_item list) : G.any list =
          * We may extend this if there are more prefix operators that are
          * important to allow within macros.
          *)
+        (* NOTE: We only deal with the case where there is one on the front,
+           because as it turns out, the Rust tree-sitter parser will parse
+           something like
+
+           &*x
+           as
+           &* x
+
+           as in, with &* as a single token. So let's just not deal with
+           that for now.
+        *)
         let* change_expr =
           match str with
           | "&" -> Some (fun e -> Ref (tk, e) |> G.e)

--- a/languages/rust/generic/Parse_rust_tree_sitter.ml
+++ b/languages/rust/generic/Parse_rust_tree_sitter.ml
@@ -156,8 +156,11 @@ let rec macro_items_to_anys (xs : rust_macro_item list) : G.any list =
         let* arg = macro_item_to_arg ~change_expr:Fun.id mac in
         let* args = try_as_normal_args' rest in
         Some (arg :: args)
+  (* This function just deals with immediately after consuming an arg.
+   *)
   and try_as_normal_args' = function
     | [] -> Some []
+    | [ MacAny (G.Tk (Tok.OriginTok { str = ","; _ })) ] -> None
     | MacAny (G.Tk (Tok.OriginTok { str = ","; _ })) :: rest ->
         try_as_normal_args rest
     | _ -> None

--- a/languages/rust/generic/Parse_rust_tree_sitter.ml
+++ b/languages/rust/generic/Parse_rust_tree_sitter.ml
@@ -99,10 +99,6 @@ let rec macro_items_to_anys (xs : rust_macro_item list) : G.any list =
      arguments, so we produce a single `Any`, which is `Args`.
      Note that <expr> can also occur once with no commas, or zero times.
   *)
-  (* `change_expr` is needed for if we end up parsing a prefix operator like
-   * or &, and we need to modify the next expression. This doesn't associate
-   * properly to the expression itself, so we need to do a little parsing of our own.
-   *)
   let macro_item_to_expr = function
     | MacAny (G.E e) -> Some e
     | MacAny (G.I e) -> Some (G.N (G.Id (e, G.empty_id_info ())) |> G.e)
@@ -113,6 +109,12 @@ let rec macro_items_to_anys (xs : rust_macro_item list) : G.any list =
     | MacTree _ ->
         None
   in
+  (* try_as_normal_exprs just tries to parse all of the arguments to a
+     macro as expressions. In anticipation of dealing with the case
+     where such an argument is either followed by a `.` or prefixed by
+     an operator like `&` and `*`, we carry an accumulator argument and
+     straightforwardly recurse upon the list.
+  *)
   let rec try_as_normal_exprs acc macros =
     match (acc, macros) with
     (* If we end with a comma, that's pretty weird and probably wrong. *)

--- a/tests/rules/rust_macro_token_args.rs
+++ b/tests/rules/rust_macro_token_args.rs
@@ -1,0 +1,31 @@
+fn test() -> () {
+  let x = source;
+
+  let a1 = foo!(&x);
+  let a2 = foo!(&x, 0);
+  let a3 = foo!(0, &x);
+  let a_bad = foo!(&x,);
+
+  let b1 = foo!(*x);
+  let b2 = foo!(*x, 0);
+  let b3 = foo!(0, *x);
+  let b_bad = foo!(*x,);
+
+  // ruleid: rust-macro-token-args
+  sink(a1);
+  // ruleid: rust-macro-token-args
+  sink(a2);
+  // ruleid: rust-macro-token-args
+  sink(a3);
+  // ruleid: rust-macro-token-args
+  sink(b1);
+  // ruleid: rust-macro-token-args
+  sink(b2);
+  // ruleid: rust-macro-token-args
+  sink(b3);
+
+  // ok: rust-macro-token-args
+  sink(a_bad);
+  // ok: rust-macro-token-args
+  sink(b_bad);
+}

--- a/tests/rules/rust_macro_token_args.rs
+++ b/tests/rules/rust_macro_token_args.rs
@@ -5,11 +5,20 @@ fn test() -> () {
   let a2 = foo!(&x, 0);
   let a3 = foo!(0, &x);
   let a_bad = foo!(&x,);
+  // *& is parsed as one token, TODO
+  let a_bad2 = foo!(*&x);
 
   let b1 = foo!(*x);
   let b2 = foo!(*x, 0);
   let b3 = foo!(0, *x);
   let b_bad = foo!(*x,);
+
+  let c1 = foo!(x.y);
+  let c2 = foo!(0, x.y);
+  let c3 = foo!(x.y, 0);
+  let c_bad = foo!(x..y);
+
+  let all = foo!(&x.y.z);
 
   // ruleid: rust-macro-token-args
   sink(a1);
@@ -24,8 +33,22 @@ fn test() -> () {
   // ruleid: rust-macro-token-args
   sink(b3);
 
+  // ruleid: rust-macro-token-args
+  sink(c1);
+  // ruleid: rust-macro-token-args
+  sink(c2);
+  // ruleid: rust-macro-token-args
+  sink(c3);
+
+  // ruleid: rust-macro-token-args
+  sink(all);
+
   // ok: rust-macro-token-args
   sink(a_bad);
   // ok: rust-macro-token-args
+  sink(a_bad2);
+  // ok: rust-macro-token-args
   sink(b_bad);
+  // ok: rust-macro-token-args
+  sink(c_bad);
 }

--- a/tests/rules/rust_macro_token_args.yaml
+++ b/tests/rules/rust_macro_token_args.yaml
@@ -1,0 +1,15 @@
+rules:
+  - id: rust-macro-token-args
+    message: Semgrep found a match
+    languages:
+      - rust
+    severity: WARNING
+    mode: taint
+    pattern-sources:
+      - patterns:
+          - pattern: |
+              source
+    pattern-sinks:
+      - patterns:
+          - pattern: |
+              sink(...)


### PR DESCRIPTION
## What:
This PR fixes a bug where macro calls that had `&` or `*` inside would not transmit taint properly, as well as macro args with `.` due to dot accesses.

## Why:
Rust support.

## How:
Added logic to deal with an arg has a `*` or `&` in front of it, as well as when there is `.` after an arg.

This ends up being a "bidirectional" thing where we try to carry our arguments forward in anticipation of seeing a `.`, but we carry them backwards and apply the prefix operators after, if we see them.

Note that we only deal with the case where there is one such prefix token. This is because if there are multiple, they end up
getting folded into a single token, so the logic becomes gross. For instance, `&*x` is parsed as a single token `&*` before `x`, so this would need to be treated more carefully.

## Test plan:
`make test`

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
