### PR TITLE
simplify build-test-docker workflow

### DIFF
--- a/.github/workflows/build-test-docker.yaml
+++ b/.github/workflows/build-test-docker.yaml
@@ -27,10 +27,6 @@ on:
         required: true
         type: boolean
         description: Whether or not to run validation on the built image
-      use-depot-for-docker-build:
-        type: boolean
-        description: Whether or not to use depot.dev instead of docker buildx to build the docker image
-        default: true
 
   workflow_call:
     inputs:
@@ -54,11 +50,6 @@ on:
         required: true
         type: boolean
         description: Whether or not to run validation on the built image
-      use-depot-for-docker-build:
-        type: boolean
-        description: Whether or not to use depot.dev instead of docker buildx to build the docker image
-        default: true
-
 jobs:
   build-test-docker:
     name: Build and test Semgrep Docker image
@@ -82,10 +73,8 @@ jobs:
           images: ${{ inputs.repository-name }}
           tags: ${{ inputs.docker-tags }}
       - uses: depot/setup-action@v1
-        if: ${{ inputs.use-depot-for-docker-build }}
-      - name: Build image (via depot.dev)
-        id: build-image-depot
-        if: ${{ inputs.use-depot-for-docker-build }}
+      - name: Build image
+        id: build-image
         uses: depot/build-push-action@v1.8.0
         with:
           project: fhmxj6w9z8
@@ -95,19 +84,6 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           file: ${{ inputs.file }}
           buildx-fallback: true
-      - name: Build image (via docker buildx)
-        id: build-image-docker
-        if: ${{ ! inputs.use-depot-for-docker-build }}
-        uses: docker/build-push-action@v4.1.1
-        with:
-          platforms: linux/${{ matrix.architecture }}
-          outputs: type=docker,dest=/tmp/image.tar
-          cache-from: type=gha,src=/tmp/.buildx-cache
-          cache-to: type=gha,dest=/tmp/.buildx-cache,mode=max
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          file: ${{ inputs.file }}
-          provenance: false
       - name: Load image
         if: ${{ inputs.enable-tests }}
         run: |
@@ -116,7 +92,7 @@ jobs:
         if: ${{ inputs.enable-tests }}
       - name: Test Image
         if: ${{ inputs.enable-tests }}
-        run: ./scripts/validate-docker-build.sh ${{ inputs.use-depot-for-docker-build && steps.build-image-depot.outputs.imageid || steps.build-image-docker.outputs.imageid }} linux/${{ matrix.architecture }}
+        run: ./scripts/validate-docker-build.sh ${{ steps.build-image.outputs.imageid }} linux/${{ matrix.architecture }}
       - uses: actions/upload-artifact@v3
         with:
           name: ${{ inputs.artifact-name }}-arch-${{ matrix.architecture }}


### PR DESCRIPTION
`depot/build-push-action` has been working well and will fall back to `docker/build-push-action` in case of failure, so we're good to remove all the `docker/build-push-action` steps and related conditionals

test plan:
- checks pass