### PR TITLE
short-term fix for amd64 docker build failing

### DIFF
--- a/scripts/validate-wheel.sh
+++ b/scripts/validate-wheel.sh
@@ -8,6 +8,13 @@ if [ -z "$1" ]; then
     exit 1
 fi
 
+# temporary workaround for https://github.com/returntocorp/semgrep/pull/8336/commits/565ba8443bd1ca4f2cd18fabb6ee61af971c5dda, which forces amd64 builds to use the `any` platform compatibility tag and causes the glob that we're calling this script with not match anything
+# this will be fixed in the near future as we factor python wheel building out of the main Dockerfile and update amd64 to use the same approach as arm64 (see: https://github.com/returntocorp/semgrep/pull/8371)
+if [ ! -f "$1" ]; then
+    echo "not a file: $1"
+    exit 0
+fi
+
 pip install "$1"
 
 semgrep --version

--- a/scripts/validate-wheel.sh
+++ b/scripts/validate-wheel.sh
@@ -8,8 +8,12 @@ if [ -z "$1" ]; then
     exit 1
 fi
 
-# temporary workaround for https://github.com/returntocorp/semgrep/pull/8336/commits/565ba8443bd1ca4f2cd18fabb6ee61af971c5dda, which forces amd64 builds to use the `any` platform compatibility tag and causes the glob that we're calling this script with not match anything
-# this will be fixed in the near future as we factor python wheel building out of the main Dockerfile and update amd64 to use the same approach as arm64 (see: https://github.com/returntocorp/semgrep/pull/8371)
+# temporary workaround for https://github.com/returntocorp/semgrep/pull/8336/commits/565ba8443bd1ca4f2cd18fabb6ee61af971c5dda,
+# which forces amd64 builds to use the `any` platform compatibility tag and
+# causes the glob that we're calling this script with not match anything
+# this will be fixed in the near future as we factor python wheel building out
+# of the main Dockerfile and update amd64 to use the same approach as arm64
+# (see: https://github.com/returntocorp/semgrep/pull/8371)
 if [ ! -f "$1" ]; then
     echo "not a file: $1"
     exit 0


### PR DESCRIPTION
Skip python wheel validation if no .whl files match the glob passed to validate-wheels.sh. I'm working on a better fix in https://github.com/returntocorp/semgrep/pull/8371

@aryx 