### PR TITLE
Re-apply "refactor(tainting): Base Taint_set on Set rather than on Map. (#8395)"

### DIFF
--- a/src/tainting/Taint.ml
+++ b/src/tainting/Taint.ml
@@ -388,29 +388,22 @@ module Taint_set = struct
    * we want to pick "the best". This is what this data structure is for, the
    * key functions are 'add' and 'pick_best_taint'.
    *)
-  module Taint_map = Map.Make (struct
-    type t = orig
+  module Taints = Set.Make (struct
+    type t = taint
 
-    let compare = compare_orig
+    let compare = compare_taint
   end)
-  (* TODO: Use a 'Set' instead, 'Map' is error prone, the same problem in 'map'
-   * may apply to 'union' as well. Not even clear that using a 'Map' here has any
-   * advantages. *)
 
-  type t = taint Taint_map.t
+  type t = Taints.t
 
-  let empty = Taint_map.empty
-  let is_empty set = Taint_map.is_empty set
-  let cardinal set = Taint_map.cardinal set
-
-  let equal set1 set2 =
-    let eq t1 t2 = compare_taint t1 t2 =|= 0 in
-    Taint_map.equal eq set1 set2
-
-  let to_seq set = set |> Taint_map.to_seq |> Seq.map snd
+  let empty = Taints.empty
+  let is_empty set = Taints.is_empty set
+  let cardinal set = Taints.cardinal set
+  let equal set1 set2 = Taints.equal set1 set2
+  let to_seq set = set |> Taints.to_seq
   let elements set = set |> to_seq |> List.of_seq
 
-  let rec add taint set =
+  let rec add alt_taint set =
     (* If two taints are "the same", we still want to pick "the best", e.g.
      * the one with the shortest trace.
      *
@@ -436,18 +429,17 @@ module Taint_set = struct
      *
      * coupling: If this changes, make sure to update docs for the `Taint.signature` type.
      *)
-    set
-    |> Taint_map.update taint.orig (function
-         | None -> Some taint
-         | Some taint' -> Some (pick_best_taint taint taint'))
+    match Taints.find_opt alt_taint set with
+    | None -> Taints.add alt_taint set
+    | Some curr_taint ->
+        let best = pick_best_taint alt_taint curr_taint in
+        if Common.phys_equal best curr_taint then set
+        else set |> Taints.remove curr_taint |> Taints.add alt_taint
 
-  and union set1 set2 =
-    Taint_map.union
-      (fun _k taint1 taint2 -> Some (pick_best_taint taint1 taint2))
-      set1 set2
+  and union set1 set2 = Taints.fold add set1 set2
 
   and of_list taints =
-    List.fold_left (fun set taint -> add taint set) Taint_map.empty taints
+    List.fold_left (fun set taint -> add taint set) Taints.empty taints
 
   and pick_best_taint taint1 taint2 =
     (* Here we assume that 'compare taint1 taint2 = 0' so we could keep any
@@ -502,9 +494,7 @@ module Taint_set = struct
         logger#error "Taint_set.pick_taint: Ooops, the impossible happened!";
         taint2
 
-  let diff set1 set2 =
-    set1 |> Taint_map.filter (fun k _ -> not (Taint_map.mem k set2))
-
+  let diff set1 set2 = Taints.diff set1 set2
   let singleton taint = add taint empty
 
   (* Because `Taint_set` is internally represented with a map, we cannot just
@@ -516,27 +506,10 @@ module Taint_set = struct
      `orig` of the domain and codomain should be the same. So it should be fine
      to simply map the codomain taint, and then take its `orig` as the key.
   *)
-  let map f set =
-    let bindings = Taint_map.bindings set in
-    bindings
-    (* Here, we assume the invariant that the orig must be
-       the same in the domain and codomain.
-    *)
-    |> Common.map (fun (_, t2) ->
-           let new_taint = f t2 in
-           (new_taint.orig, new_taint))
-    |> List.to_seq |> Taint_map.of_seq
-
-  let iter f set = Taint_map.iter (fun _k -> f) set
-  let fold f set acc = Taint_map.fold (fun _k -> f) set acc
-  let filter f set = Taint_map.filter (fun _k -> f) set
-
-  let concat_map f set =
-    let bindings = Taint_map.bindings set in
-    bindings
-    |> List.concat_map (fun (_, t2) ->
-           f t2 |> elements |> Common.map (fun t -> (t.orig, t)))
-    |> List.to_seq |> Taint_map.of_seq
+  let map f set = set |> Taints.to_seq |> Seq.map f |> Taints.of_seq
+  let iter f set = Taints.iter f set
+  let fold f set acc = Taints.fold f set acc
+  let filter f set = Taints.filter f set
 end
 
 type taints = Taint_set.t

--- a/src/tainting/Taint.mli
+++ b/src/tainting/Taint.mli
@@ -129,7 +129,6 @@ module Taint_set : sig
   val union : t -> t -> t
   val diff : t -> t -> t
   val map : (taint -> taint) -> t -> t
-  val concat_map : (taint -> t) -> t -> t
   val iter : (taint -> unit) -> t -> unit
   val fold : (taint -> 'a -> 'a) -> t -> 'a -> 'a
   val of_list : taint list -> t


### PR DESCRIPTION
Revert "fix(regression): Revert "refactor(tainting): Base Taint_set on Set rather than on Map. (#8395)"

There was a bug when trying to share that is now fixed, also improved sharing for preconditions.

This reverts commit cf4a293e93eb40cfc5e9eac726d71a536e8ef6f3.

test plan:
make test
See returntocorp/semgrep-proprietary#882

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
