### PR TITLE
feat(comparison): add in and not in for strings

### DIFF
--- a/changelog.d/pa-2979.added
+++ b/changelog.d/pa-2979.added
@@ -1,0 +1,2 @@
+metavariable-comparison: You can now use "in" and "not in" for strings
+in the same sense as in Python, for substring checking.

--- a/src/engine/Eval_generic.ml
+++ b/src/engine/Eval_generic.ml
@@ -334,12 +334,17 @@ and eval_op op values code =
   (* TODO? dangerous use of polymorphic <> ? *)
   | G.NotEq, [ v1; v2 ] -> Bool (v1 <> v2)
   | G.In, [ v1; v2 ] -> (
-      match v2 with
-      | List xs -> Bool (List.mem v1 xs)
+      match (v1, v2) with
+      | _, List xs -> Bool (List.mem v1 xs)
+      | String v1, String v2 ->
+          Bool (Common2.string_match_substring (Str.regexp v1) v2)
       | _ -> Bool false)
   | G.NotIn, [ v1; v2 ] -> (
-      match v2 with
-      | List xs -> Bool (not (List.mem v1 xs))
+      match (v1, v2) with
+      | _, List _
+      | String _, String _ ->
+          (* Just negate the "in" *)
+          eval_op G.Not [ eval_op G.In values code ] code
       | _ -> Bool false)
   (* less: it would be better to show the actual values not handled,
    * rather than the code, because this may differ as the code does not

--- a/src/engine/Eval_generic.ml
+++ b/src/engine/Eval_generic.ml
@@ -337,7 +337,7 @@ and eval_op op values code =
       match (v1, v2) with
       | _, List xs -> Bool (List.mem v1 xs)
       | String v1, String v2 ->
-          Bool (Common2.string_match_substring (Str.regexp v1) v2)
+          Bool (Common2.string_match_substring (Str.regexp_string v1) v2)
       | _ -> Bool false)
   | G.NotIn, [ v1; v2 ] -> (
       match (v1, v2) with

--- a/tests/rules/string_in_comparison.py
+++ b/tests/rules/string_in_comparison.py
@@ -33,10 +33,10 @@ bar(x)
 # ruleid: string-in-comparison
 bar(xyz)
 
-# ok: string-in-comparison
 # this shouldn't parse as a regexp, it should just be a literal string
+# ok: string-in-comparison
 baz(".*")
 
-# ruleid: string-in-comparison
 # this one's OK though
+# ruleid: string-in-comparison
 qux(".*")

--- a/tests/rules/string_in_comparison.py
+++ b/tests/rules/string_in_comparison.py
@@ -1,15 +1,15 @@
 
-# ERROR: match
+# ruleid: string-in-comparison
 foo(a)
-# ERROR: match
+# ruleid: string-in-comparison
 foo(b)
-# ERROR: match
+# ruleid: string-in-comparison
 foo(c)
-# ERROR: match
+# ruleid: string-in-comparison
 foo(ab)
-# ERROR: match
+# ruleid: string-in-comparison
 foo(bc)
-# ERROR: match
+# ruleid: string-in-comparison
 foo(abc)
 
 foo()
@@ -24,11 +24,11 @@ bar(ab)
 bar(bc)
 bar(abc)
 
-# ERROR: match
+# ruleid: string-in-comparison
 bar(ac)
-# ERROR: match
+# ruleid: string-in-comparison
 bar(abcd)
-# ERROR: match
+# ruleid: string-in-comparison
 bar(x)
-# ERROR: match
+# ruleid: string-in-comparison
 bar(xyz)

--- a/tests/rules/string_in_comparison.py
+++ b/tests/rules/string_in_comparison.py
@@ -1,0 +1,34 @@
+
+# ERROR: match
+foo(a)
+# ERROR: match
+foo(b)
+# ERROR: match
+foo(c)
+# ERROR: match
+foo(ab)
+# ERROR: match
+foo(bc)
+# ERROR: match
+foo(abc)
+
+foo()
+foo(ac)
+foo(abcd)
+
+bar()
+bar(a)
+bar(b)
+bar(c)
+bar(ab)
+bar(bc)
+bar(abc)
+
+# ERROR: match
+bar(ac)
+# ERROR: match
+bar(abcd)
+# ERROR: match
+bar(x)
+# ERROR: match
+bar(xyz)

--- a/tests/rules/string_in_comparison.py
+++ b/tests/rules/string_in_comparison.py
@@ -32,3 +32,11 @@ bar(abcd)
 bar(x)
 # ruleid: string-in-comparison
 bar(xyz)
+
+# ok: string-in-comparison
+# this shouldn't parse as a regexp, it should just be a literal string
+baz(".*")
+
+# ruleid: string-in-comparison
+# this one's OK though
+qux(".*")

--- a/tests/rules/string_in_comparison.yaml
+++ b/tests/rules/string_in_comparison.yaml
@@ -13,6 +13,18 @@ rules:
         - metavariable-comparison:
             metavariable: $B
             comparison: str($B) not in "abc"
+    - patterns:
+        - pattern: |
+            baz("$C")
+        - metavariable-comparison:
+            metavariable: $C
+            comparison: str($C) in "abc"
+    - patterns:
+        - pattern: |
+            qux("$D")
+        - metavariable-comparison:
+            metavariable: $D
+            comparison: str($D) in ".*"
   message: Test
   languages:
   - python

--- a/tests/rules/string_in_comparison.yaml
+++ b/tests/rules/string_in_comparison.yaml
@@ -1,0 +1,19 @@
+rules:
+- id: string-in-comparison
+  pattern-either:
+    - patterns:
+        - pattern: |
+            foo($A)
+        - metavariable-comparison:
+            metavariable: $A
+            comparison: str($A) in "abc"
+    - patterns:
+        - pattern: |
+            bar($B)
+        - metavariable-comparison:
+            metavariable: $B
+            comparison: str($B) not in "abc"
+  message: Test
+  languages:
+  - python
+  severity: WARNING


### PR DESCRIPTION
## What:
This PR makes it so that you can use `in` and `not in` in the Python sense, for strings.

## Why:
Feature request from community, see https://semgrep.slack.com/archives/C018NJRRCJ0/p1690862677954849

## How:
Just added the operators, and tests. Cleaned up some code while I was at it.

## Test plan:
`make test`

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
