### PR TITLE
tainting: Add `by-side-effect: only` option to sources

### DIFF
--- a/changelog.d/pa-2980.added
+++ b/changelog.d/pa-2980.added
@@ -1,0 +1,33 @@
+taint-mode: The `by-side-effect` option for taint sources (only) now accepts a
+third value `only` (besides `true` and `false`). Setting `by-side-effect: only`
+will define a taint source that *only* propagates by side effect. This option
+should allow (ab)using taint-mode for writing some typestate rules.
+
+For example, this taint rule:
+
+```yaml
+pattern-sources:
+  - by-side-effect: only
+    patterns:
+    - pattern: lock($L)
+    - focus-metavariable: $L
+pattern-sanitizers:
+  - by-side-effect: true
+    patterns:
+    - pattern: unlock($L)
+    - focus-metavariable: $L
+pattern-sinks:
+  - pattern: lock($L)
+```
+
+will match the second `lock(x)` in this code:
+
+```python
+lock(x) # no finding
+lock(x) # finding
+```
+
+The first `lock(x)` will not result in any finding, because the occurrence of `x` in
+itself will not be tainted. Only after the function call we will record that `x` is
+tainted (as a side-effect of `lock`). The second `lock(x)` will result in a finding
+because the `x` has been tainted by the previous `lock(x)`.

--- a/src/core/Rule.ml
+++ b/src/core/Rule.ml
@@ -152,6 +152,8 @@ type precondition_with_range = {
 }
 [@@deriving show]
 
+type by_side_effect = Only | Yes | No [@@deriving show]
+
 (* The sources/sanitizers/sinks used to be a simple 'formula list',
  * but with taint labels things are bit more complicated.
  *)
@@ -166,7 +168,7 @@ and taint_source = {
   source_id : string;  (** See 'Parse_rule.parse_taint_source'. *)
   source_formula : formula;
   source_exact : bool;
-  source_by_side_effect : bool;
+  source_by_side_effect : by_side_effect;
   source_control : bool;
   label : string;
       (* The label to attach to the data.

--- a/src/metachecking/Translate_rule.ml
+++ b/src/metachecking/Translate_rule.ml
@@ -102,7 +102,10 @@ and translate_taint_source
   in
   let exact_obj = if source_exact then [ ("exact", `Bool true) ] else [] in
   let side_effect_obj =
-    if source_by_side_effect then [ ("by-side-effect", `Bool true) ] else []
+    match source_by_side_effect with
+    | Yes -> [ ("by-side-effect", `Bool true) ]
+    | Only -> [ ("by-side-effect", `String "only") ]
+    | No -> []
   in
   let control_obj =
     if source_control then [ ("control", `Bool true) ] else []

--- a/src/parsing/Parse_rule.ml
+++ b/src/parsing/Parse_rule.ml
@@ -1322,6 +1322,14 @@ and parse_pair env ((key, value) : key * G.expr) : R.formula =
 (* Parsers for taint *)
 (*****************************************************************************)
 
+let parse_by_side_effect env (key : key) x =
+  match x.G.e with
+  | G.L (String (_, ("true", _), _)) -> R.Yes
+  | G.L (String (_, ("false", _), _)) -> R.No
+  | G.L (String (_, ("only", _), _)) -> R.Only
+  | G.L (Bool (b, _)) -> if b then R.Yes else R.No
+  | _x -> error_at_key env.id key (spf "parse_by_side_effect for %s" (fst key))
+
 let requires_expr_to_precondition env key e =
   let invalid_requires () =
     error_at_key env.id key
@@ -1368,8 +1376,8 @@ let parse_taint_source ~(is_old : bool) env (key : key) (value : G.expr) :
       take_opt dict env parse_bool "exact" |> Option.value ~default:false
     in
     let source_by_side_effect =
-      take_opt dict env parse_bool "by-side-effect"
-      |> Option.value ~default:false
+      take_opt dict env parse_by_side_effect "by-side-effect"
+      |> Option.value ~default:R.No
     in
     let source_control =
       take_opt dict env parse_bool "control" |> Option.value ~default:false
@@ -1401,7 +1409,7 @@ let parse_taint_source ~(is_old : bool) env (key : key) (value : G.expr) :
           source_id;
           source_formula;
           source_exact = false;
-          source_by_side_effect = false;
+          source_by_side_effect = R.No;
           source_control = false;
           label = R.default_source_label;
           source_requires = None;

--- a/src/tainting/Dataflow_tainting.ml
+++ b/src/tainting/Dataflow_tainting.ml
@@ -340,10 +340,17 @@ let merge_source_sink_mvars env source_mvars sink_mvars =
     (* The union of both sets, but taking the sink mvars in case of collision. *)
     sink_biased_union_mvars source_mvars sink_mvars
 
-let partition_mutating_sources sources_matches =
+let partition_sources_by_side_effect_oyn sources_matches =
   sources_matches
-  |> List.partition (fun (m : R.taint_source TM.t) ->
-         m.spec.source_by_side_effect && TM.is_exact m)
+  |> Common.partition_either3 (fun (m : R.taint_source TM.t) ->
+         match m.spec.source_by_side_effect with
+         (* We require an exact match for `by-side-effect` to take effect. *)
+         | R.Only when TM.is_exact m -> Left3 m
+         | R.Yes when TM.is_exact m -> Middle3 m
+         | R.No
+         | R.Only
+         | R.Yes ->
+             Right3 m)
 
 (*****************************************************************************)
 (* Types *)
@@ -825,24 +832,30 @@ let handle_taint_propagators env thing taints =
   (taints_propagated, lval_env)
 
 let find_lval_taint_sources env incoming_taints lval =
+  let taints_of_pms env = taints_of_matches env ~incoming:incoming_taints in
   let source_pms = lval_is_source env lval in
-  let mut_source_pms, reg_source_pms =
-    (* If the lvalue is an exact match (overlap > 0.99) for a source
-       * annotation, then we infer that the lvalue itself is now tainted
-       * (presumably by side-effect) and we will update the `lval_env`
-       * accordingly. Otherwise the lvalue belongs to a piece of code that
-       * is a source of taint, but it is not tainted on its own. *)
-    partition_mutating_sources source_pms
+  (* Partition sources according to the value of `by-side-effect:`,
+   * either `only`, `yes`, or `no`. *)
+  let by_side_effect_only_pms, by_side_effect_yes_pms, by_side_effect_no_pms =
+    partition_sources_by_side_effect_oyn source_pms
   in
-  let taints_sources_reg, lval_env =
-    reg_source_pms |> taints_of_matches env ~incoming:incoming_taints
+  let by_side_effect_only_taints, lval_env =
+    by_side_effect_only_pms |> taints_of_pms env
   in
-  let taints_sources_mut, lval_env =
-    mut_source_pms
-    |> taints_of_matches { env with lval_env } ~incoming:incoming_taints
+  let by_side_effect_no_taints, lval_env =
+    by_side_effect_no_pms |> taints_of_pms { env with lval_env }
   in
-  let lval_env = Lval_env.add lval_env lval taints_sources_mut in
-  (Taints.union taints_sources_reg taints_sources_mut, lval_env)
+  let by_side_effect_yes_taints, lval_env =
+    by_side_effect_yes_pms |> taints_of_pms { env with lval_env }
+  in
+  let taints_to_add_to_env =
+    by_side_effect_only_taints |> Taints.union by_side_effect_yes_taints
+  in
+  let lval_env = Lval_env.add lval_env lval taints_to_add_to_env in
+  let taints_to_return =
+    Taints.union by_side_effect_no_taints by_side_effect_yes_taints
+  in
+  (taints_to_return, lval_env)
 
 let rec check_tainted_lval env (lval : IL.lval) : Taints.t * Lval_env.t =
   let new_taints, lval_in_env, lval_env = check_tainted_lval_aux env lval in
@@ -1077,11 +1090,11 @@ and check_tainted_expr env exp : Taints.t * Lval_env.t =
   let check env = check_tainted_expr env in
   let check_subexpr exp =
     match exp.e with
-    | Fetch lval -> check_tainted_lval env lval
-    | FixmeExp (_, _, Some e) -> check env e
+    | Fetch _
     | Literal _
     | FixmeExp (_, _, None) ->
         (Taints.empty, env.lval_env)
+    | FixmeExp (_, _, Some e) -> check env e
     | Composite (_, (_, es, _)) -> union_map_taints_and_vars env check es
     | Operator ((op, _), es) ->
         let _, args_taints, lval_env = check_function_call_arguments env es in
@@ -1158,8 +1171,11 @@ and check_tainted_expr env exp : Taints.t * Lval_env.t =
   | None ->
       let taints_exp, lval_env = check_subexpr exp in
       let taints_sources, lval_env =
-        orig_is_best_source env exp.eorig
-        |> taints_of_matches { env with lval_env } ~incoming:taints_exp
+        match exp.e with
+        | Fetch lval -> check_tainted_lval env lval
+        | __else__ ->
+            orig_is_best_source env exp.eorig
+            |> taints_of_matches { env with lval_env } ~incoming:taints_exp
       in
       let taints = Taints.union taints_exp taints_sources in
       let taints_propagated, var_env =

--- a/tests/rules/taint_typestate.py
+++ b/tests/rules/taint_typestate.py
@@ -1,0 +1,7 @@
+def test():
+    lock(l)
+    unlock(l)
+    #ok: test
+    lock(l)
+    #ruleid: test
+    lock(l)

--- a/tests/rules/taint_typestate.yaml
+++ b/tests/rules/taint_typestate.yaml
@@ -1,0 +1,20 @@
+rules:
+  - id: test
+    languages:
+      - python
+    message: Test
+    mode: taint
+    pattern-sources:
+      - by-side-effect: only
+        patterns:
+        - pattern: lock($L)
+        - focus-metavariable: $L
+    pattern-sanitizers:
+      - by-side-effect: true
+        patterns:
+        - pattern: unlock($L)
+        - focus-metavariable: $L
+    pattern-sinks:
+      - pattern: lock($L)
+    severity: WARNING
+

--- a/tests/rules/taint_typestate1.py
+++ b/tests/rules/taint_typestate1.py
@@ -1,0 +1,20 @@
+def foo():
+    f = open()
+    f.write("bar")
+    f.close()
+    # ruleid: test
+    f.close()
+    # the following has no effect on the double-closing of `f`
+    # that already happened
+    f = open()
+    f.write("baz")
+    f.close()
+
+def bar():
+    f = open()
+    f.write("bar")
+    f.close()
+    # we reopen `f` so it's fine to close it again
+    f = open()
+    # ok: test
+    f.close()

--- a/tests/rules/taint_typestate1.yaml
+++ b/tests/rules/taint_typestate1.yaml
@@ -1,0 +1,21 @@
+rules:
+  - id: test
+    message: Test
+    severity: INFO
+    languages: [python]
+    mode: taint
+    pattern-sources:
+    - by-side-effect: only
+      patterns:
+        - pattern: $FILE.close()
+        - focus-metavariable: $FILE
+    pattern-sanitizers:
+      - by-side-effect: true
+        patterns:
+          - pattern: |
+              $FILE = open(...)
+          - focus-metavariable: $FILE
+    pattern-sinks:
+      - patterns:
+          - pattern: $FILE.close(...)
+          - focus-metavariable: $FILE


### PR DESCRIPTION
This specifies a taint source that _only_ propagates taint by side-effect, which is useful to write "double-op" kind of rules (e.g., double-free).

Closes PA-2980
Closes PA-3124

test plan:
make test # new tests