### PR TITLE
nit: Use semgrep for program name

### DIFF
--- a/cli/src/semgrep/__main__.py
+++ b/cli/src/semgrep/__main__.py
@@ -3,7 +3,10 @@ import sys
 
 from semgrep.cli import cli
 
-
+# NOTE: This is the entrypoint for the `pysemgrep` command.
+# To match the program usage help between pysemgrep (legacy)
+# and osemgrep (new) – and to hide complexity for our users -
+# here we specify `semgrep` as the program name for pysemgrep.
 def main() -> int:
     cli(prog_name="semgrep")
     return 0

--- a/cli/src/semgrep/__main__.py
+++ b/cli/src/semgrep/__main__.py
@@ -5,7 +5,7 @@ from semgrep.cli import cli
 
 
 def main() -> int:
-    cli(prog_name='semgrep')
+    cli(prog_name="semgrep")
     return 0
 
 

--- a/cli/src/semgrep/__main__.py
+++ b/cli/src/semgrep/__main__.py
@@ -5,7 +5,7 @@ from semgrep.cli import cli
 
 
 def main() -> int:
-    cli()
+    cli(prog_name='semgrep')
     return 0
 
 


### PR DESCRIPTION
## Description

Running different semgrep commands was showing different program names which was a little confusing (to me).


```
./cli/bin/semgrep publish --help                                                                                                                        
Usage: pysemgrep publish [OPTIONS] TARGET
```

vs.

```
./cli/bin/semgrep --help                                                                                                                        
Usage: semgrep [OPTIONS] COMMAND [ARGS]...
```


See https://semgrepinc.slack.com/archives/C01NXGX2EHZ/p1691013559954119

With this change

```
./cli/bin/semgrep publish --help                                                                                                                        
Usage: semgrep publish [OPTIONS] TARGET
```
