### PR TITLE
Python import weirdness

### DIFF
--- a/changelog.d/pa-2963.fixed
+++ b/changelog.d/pa-2963.fixed
@@ -1,0 +1,1 @@
+Fixed multiprocess testing crash due to new osemgrep entrypoint

--- a/cli/bin/pysemgrep
+++ b/cli/bin/pysemgrep
@@ -12,5 +12,38 @@
 # (e.g., in /opt/local/lib/site-packages/python3.11/semgrep/)
 
 import sys
-import semgrep.__main__
-sys.exit(semgrep.__main__.main())
+# This file is not part of the Python 'semgrep' package; it's a script.
+# escape hatch for users to pysemgrep in case of problems (they
+# can also call directly 'pysemgrep').
+
+
+# Python module system and multiprocessing weirdness below
+# --------------------------------------------------------
+# When python imports a module, i.e. `import semgrep.FOO`, it runs the module's
+# top-level code, which is the code that is not inside any function or class.
+# This means that if we try and run a function from the semgrep package in a
+# subprocess, we would end up calling os.execvp() above or main() below, which
+# cause a bunch of errors. So we need to make sure that we only run the code
+# below when this file is run as an executable, hence the guard below.
+# This fix a crash when using semgrep --test (which apparently triggers
+# execution of this file).
+# Austin: the above explanation is my understanding, but I think Python
+# is weirder under the hood with this stuff.
+# Pad: I don't understand why the use of '--test' triggers the code here;
+# if '--test' use semgrep.Foo, it should execute code in cli/src/semgrep/__init__.php
+# Austin: I don't understand either. What's even weirder is this script also needs it
+# even though it's not the same mainspace as the semgrep package. After encountering
+# this error again my best guess is that python multiprocessing actually clones the
+# OS process, instead of just starting a new python process and importing the semgrep
+# module before running the function given to multiprocessing. I.e. you would expect
+# multiprocessing under the hood to do something like
+# python3 -m semgrep.MULTI_PROCESS_FUNCTION
+# for each process, but instead it most likely does something like
+# os.execvp(sys.argv[0], sys.argv + [MULTI_PROCESS_FUNCTION])
+#
+# See safe importing of main modules here:
+# https://docs.python.org/3/library/multiprocessing.html#the-spawn-and-forkserver-start-methods
+# It doesn't explain in enough detail to give a real answer, hence the guess above.
+if __name__ == "__main__":
+    import semgrep.__main__
+    sys.exit(semgrep.__main__.main())

--- a/cli/bin/semgrep
+++ b/cli/bin/semgrep
@@ -30,7 +30,6 @@ import os
 import sys
 import importlib.resources
 import shutil
-
 #alt: you can also add '-W ignore::DeprecationWarning' after the python3 above,
 # but setuptools and pip adjust this line when installing semgrep so we need
 # to do this instead.
@@ -89,20 +88,8 @@ def exec_osemgrep():
     sys.argv[0] = "osemgrep"
     os.execvp(str(path), sys.argv)
 
-
-# When python imports a module, i.e. `import semgrep.FOO`, it runs the module's
-# top-level code, which is the code that is not inside any function or class.
-# This means that if we try and run a function from the semgrep package in a
-# subprocess, we would end up calling os.execvp() above or main() below, which
-# cause a bunch of errors. So we need to make sure that we only run the code
-# below when this file is run as an executable, hence the guard below.
-# This fix a crash when using semgrep --test (which apparently triggers
-# execution of this file).
-# Austin: the above explanation is my understanding, but I think Python
-# is weirder under the hood with this stuff.
-# Pad: I don't understand why the use of '--test' triggers the code here;
-# if '--test' use semgrep.Foo, it should execute code in cli/src/semgrep/__init__.php
-# This file is not part of the Python 'semgrep' package; it's a script.
+# Needed for similar reasons as in pysemgrep, but only for the legacy
+# flag to work
 if __name__ == "__main__":
     # escape hatch for users to pysemgrep in case of problems (they
     # can also call directly 'pysemgrep').

--- a/cli/tests/e2e/snapshots/test_cli_test/test_cli_test_from_entrypoint/output.txt
+++ b/cli/tests/e2e/snapshots/test_cli_test/test_cli_test_from_entrypoint/output.txt
@@ -1,0 +1,2 @@
+2/2: ✓ All tests passed 
+No tests for fixes found.


### PR DESCRIPTION
See #8360 for the initial issue. I'm 99% sure #8370 broke #8360 since the first PR was merged, then the 2nd, and they were in the same release. I spent ~30 minutes trying to understand this issue after I fixed it, and left a comment explaining why I think this fixes it, but I couldn't find real documentation on this and I suspect only a deep understanding of the import system, GIL, and how multiprocessing works could explain this. I think we should be fine until osemgrep, but we should be extra careful about touching these files until then.

One note is that when we support/switch to the scan command from osemgrep, we'll need to be careful that we handle all the other places semgrep is invoked on the python side (such as test).


## Test plan

```bash
cd cli && pipenv install
pipenv shell
cd EXTRACT_PATH #path of archive from linear issue
semgrep --legacy --test --pro --config=. # all 4 tests pass
semgrep --test --pro --config=. # all 4 tests pass
```

PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
