### PR TITLE
refactor: Generalize id_hidden to id_flags

### DIFF
--- a/cli/tests/e2e/snapshots/test_dump_ast/test_dump_ast/results.json
+++ b/cli/tests/e2e/snapshots/test_dump_ast/test_dump_ast/results.json
@@ -12,7 +12,9 @@
                   "()"
                 ],
                 {
-                  "id_hidden": "false",
+                  "id_flags": {
+                    "ref@": 0
+                  },
                   "id_info_id": 7,
                   "id_resolved": {
                     "ref@": null
@@ -70,7 +72,9 @@
                                                 "()"
                                               ],
                                               {
-                                                "id_hidden": "false",
+                                                "id_flags": {
+                                                  "ref@": 0
+                                                },
                                                 "id_info_id": 3,
                                                 "id_resolved": {
                                                   "ref@": null
@@ -95,7 +99,9 @@
                                                 "()"
                                               ],
                                               {
-                                                "id_hidden": "false",
+                                                "id_flags": {
+                                                  "ref@": 0
+                                                },
                                                 "id_info_id": 4,
                                                 "id_resolved": {
                                                   "ref@": null
@@ -136,7 +142,9 @@
                                                 "()"
                                               ],
                                               {
-                                                "id_hidden": "false",
+                                                "id_flags": {
+                                                  "ref@": 0
+                                                },
                                                 "id_info_id": 5,
                                                 "id_resolved": {
                                                   "ref@": null
@@ -161,7 +169,9 @@
                                                 "()"
                                               ],
                                               {
-                                                "id_hidden": "false",
+                                                "id_flags": {
+                                                  "ref@": 0
+                                                },
                                                 "id_info_id": 6,
                                                 "id_resolved": {
                                                   "ref@": null
@@ -201,7 +211,9 @@
                   "pattrs": [],
                   "pdefault": null,
                   "pinfo": {
-                    "id_hidden": "false",
+                    "id_flags": {
+                      "ref@": 0
+                    },
                     "id_info_id": 1,
                     "id_resolved": {
                       "ref@": {
@@ -232,7 +244,9 @@
                   "pattrs": [],
                   "pdefault": null,
                   "pinfo": {
-                    "id_hidden": "false",
+                    "id_flags": {
+                      "ref@": 0
+                    },
                     "id_info_id": 2,
                     "id_resolved": {
                       "ref@": {
@@ -276,7 +290,9 @@
                   "()"
                 ],
                 {
-                  "id_hidden": "false",
+                  "id_flags": {
+                    "ref@": 0
+                  },
                   "id_info_id": 12,
                   "id_resolved": {
                     "ref@": null
@@ -320,7 +336,9 @@
                                       "()"
                                     ],
                                     {
-                                      "id_hidden": "false",
+                                      "id_flags": {
+                                        "ref@": 0
+                                      },
                                       "id_info_id": 10,
                                       "id_resolved": {
                                         "ref@": null
@@ -345,7 +363,9 @@
                                       "()"
                                     ],
                                     {
-                                      "id_hidden": "false",
+                                      "id_flags": {
+                                        "ref@": 0
+                                      },
                                       "id_info_id": 11,
                                       "id_resolved": {
                                         "ref@": null
@@ -380,7 +400,9 @@
                   "pattrs": [],
                   "pdefault": null,
                   "pinfo": {
-                    "id_hidden": "false",
+                    "id_flags": {
+                      "ref@": 0
+                    },
                     "id_info_id": 8,
                     "id_resolved": {
                       "ref@": {
@@ -411,7 +433,9 @@
                   "pattrs": [],
                   "pdefault": null,
                   "pinfo": {
-                    "id_hidden": "false",
+                    "id_flags": {
+                      "ref@": 0
+                    },
                     "id_info_id": 9,
                     "id_resolved": {
                       "ref@": {
@@ -455,7 +479,9 @@
                     "()"
                   ],
                   {
-                    "id_hidden": "false",
+                    "id_flags": {
+                      "ref@": 0
+                    },
                     "id_info_id": 13,
                     "id_resolved": {
                       "ref@": null
@@ -492,7 +518,9 @@
                                 "()"
                               ],
                               {
-                                "id_hidden": "false",
+                                "id_flags": {
+                                  "ref@": 0
+                                },
                                 "id_info_id": 14,
                                 "id_resolved": {
                                   "ref@": null
@@ -517,7 +545,9 @@
                                 "()"
                               ],
                               {
-                                "id_hidden": "false",
+                                "id_flags": {
+                                  "ref@": 0
+                                },
                                 "id_info_id": 15,
                                 "id_resolved": {
                                   "ref@": null

--- a/libs/ast_generic/AST_generic.ml
+++ b/libs/ast_generic/AST_generic.ml
@@ -173,7 +173,7 @@
  * convenient to correspond mostly to Semgrep versions. So version below
  * can jump from "1.12.1" to "1.20.0" and that's fine.
  *)
-let version = "1.32.0"
+let version = "1.35.0"
 
 (*****************************************************************************)
 (* Some notes on deriving *)
@@ -589,7 +589,8 @@ and id_info = {
   (* THINK: Drop option? *)
   (* See module 'IdFlags'. *)
   id_flags : id_flags ref;
-      [@equal AST_generic_equals.equal_id_info (fun a b -> a = b)]
+      [@equal
+        AST_generic_equals.equal_id_info (fun f1 f2 -> IdFlags.equal !f1 !f2)]
   (* this is used by Naming_X in deep-semgrep *)
   id_info_id : id_info_id; [@equal fun _a _b -> true]
 }

--- a/libs/ast_generic/AST_generic_to_v1.ml
+++ b/libs/ast_generic/AST_generic_to_v1.ml
@@ -122,7 +122,7 @@ and map_id_info x =
    G.id_resolved = v_id_resolved;
    id_type = v_id_type;
    id_svalue = v3;
-   id_hidden = _not_available_in_v1;
+   id_flags = _not_available_in_v1;
    id_info_id = _IGNORED;
   } ->
       let v3 = map_of_ref (map_of_option map_svalue) v3 in

--- a/libs/ast_generic/IdFlags.ml
+++ b/libs/ast_generic/IdFlags.ml
@@ -1,0 +1,23 @@
+(* Copyright (C) 2023-present Semgrep Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * version 2.1 as published by the Free Software Foundation, with the
+ * special exception on linking described in file LICENSE.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
+ * LICENSE for more details.
+ *)
+
+open Ppx_hash_lib.Std.Hash.Builtin
+
+let bitmask_HIDDEN = 0x01
+
+type t = int [@@deriving show, eq, ord, hash]
+
+let empty = 0
+let is_hidden flags = Int.logand flags bitmask_HIDDEN <> 0
+let set_hidden flags = Int.logor flags bitmask_HIDDEN
+let to_int x = x

--- a/libs/ast_generic/IdFlags.mli
+++ b/libs/ast_generic/IdFlags.mli
@@ -1,0 +1,30 @@
+type t [@@deriving show, eq, ord, hash]
+(** A bit-vector encoding id-related flags, see 'AST_generic.id_info'. *)
+
+val empty : t
+(** No flags set *)
+
+val is_hidden : t -> bool
+(**
+     Flag 'hidden' must be set for any artificial identifier that never
+     appears in source code but is introduced in the AST after parsing.
+
+     Don't use this for syntax desugaring or transpilation because the
+     resulting function name might exist in some source code. Consider the
+     following normalization:
+
+       !foo -> foo.contents
+                   ^^^^^^^^
+                 should not be marked as hidden because it could appear
+                 in target source code.
+
+     However, an artificial identifier like "!sh_quoted_expand!" should
+     be marked as hidden in bash.
+
+     This allows not breaking the -fast/-filter_irrelevant_rules optimization
+     that skips a target file if some identifier in the pattern AST doesn't
+     exist in the source of the target.
+ *)
+
+val set_hidden : t -> t
+val to_int : t -> int

--- a/libs/ast_generic/Meta_AST.ml
+++ b/libs/ast_generic/Meta_AST.ml
@@ -195,7 +195,7 @@ and vof_id_info
       id_resolved = v_id_resolved;
       id_type = v_id_type;
       id_svalue = v3;
-      id_hidden;
+      id_flags;
       id_info_id;
     } =
   let bnds = [] in
@@ -208,8 +208,12 @@ and vof_id_info
   let arg = OCaml.vof_ref (OCaml.vof_option vof_resolved_name) v_id_resolved in
   let bnd = ("id_resolved", arg) in
   let bnds = bnd :: bnds in
-  let arg = OCaml.vof_bool id_hidden in
-  let bnd = ("id_hidden", arg) in
+  let arg =
+    OCaml.vof_ref
+      (fun id_flags -> OCaml.vof_int (IdFlags.to_int id_flags))
+      id_flags
+  in
+  let bnd = ("id_flags", arg) in
   let bnds = bnd :: bnds in
   let arg = OCaml.vof_int (IdInfoId.to_int id_info_id) in
   let bnd = ("id_info_id", arg) in

--- a/libs/ast_generic/dune
+++ b/libs/ast_generic/dune
@@ -12,6 +12,7 @@
    (pps
       ppx_deriving.show
       ppx_deriving.eq
+      ppx_deriving.ord
       ppx_hash
       profiling.ppx
       visitors.ppx

--- a/src/core/Pattern.ml
+++ b/src/core/Pattern.ml
@@ -56,8 +56,8 @@ let is_js lang =
 
 (* This is used in Analyze_pattern.ml to skip
  * semgrep special identifiers.
- * new TODO: instead of relying on this list of exceptions, set id_hidden=true
- * in the AST.
+ * new TODO: instead of relying on this list of exceptions, set 'hidden' flag
+ * in the 'id_info'.
  *)
 let is_special_identifier ?lang str =
   Metavariable.is_metavar_name str

--- a/src/engine/Eval_generic.ml
+++ b/src/engine/Eval_generic.ml
@@ -426,7 +426,7 @@ let text_of_binding mvar mval =
    * In that case, it's better to pretty print the code rather than using
    * Visitor_AST.range_of_any_opt and Range.contents_at_range below.
    *
-   * The 'id_hidden = false' guard is to avoid to pretty print
+   * The 'not is_hidden' guard is to avoid to pretty print
    * artificial identifiers such as "builtin__include" in PHP that
    * we generate during parsing.
    * TODO: get rid of the ugly __builtin__ once we've fixed
@@ -435,9 +435,10 @@ let text_of_binding mvar mval =
    * TODO: handle also MV.Name, MV.E of DotAccess; maybe use
    * Pretty_print/Ugly_print to factorize work.
    *)
-  | MV.Id ((s, _tok), (None | Some { id_hidden = false; _ }))
-    when not (s =~ "^__builtin.*") ->
+  | MV.Id ((s, _tok), Some { id_flags; _ })
+    when (not (s =~ "^__builtin.*")) && not (IdFlags.is_hidden !id_flags) ->
       Some s
+  | MV.Id ((s, _tok), None) when not (s =~ "^__builtin.*") -> Some s
   | _ -> (
       let any = MV.mvalue_to_any mval in
       match AST_generic_helpers.range_of_any_opt any with

--- a/src/experiments/synthesizing/Pattern_from_Code.ml
+++ b/src/experiments/synthesizing/Pattern_from_Code.ml
@@ -72,7 +72,7 @@ let default_id str =
            id_resolved = ref None;
            id_type = ref None;
            id_svalue = ref None;
-           id_hidden = false;
+           id_flags = ref IdFlags.empty;
            id_info_id = IdInfoId.unsafe_default;
          } ))
   |> G.e

--- a/src/experiments/synthesizing/Pattern_from_Targets.ml
+++ b/src/experiments/synthesizing/Pattern_from_Targets.ml
@@ -131,7 +131,7 @@ let default_id str =
            id_resolved = ref None;
            id_type = ref None;
            id_svalue = ref None;
-           id_hidden = false;
+           id_flags = ref IdFlags.empty;
            id_info_id = IdInfoId.unsafe_default;
          } ))
   |> G.e

--- a/src/matching/Generic_vs_generic.ml
+++ b/src/matching/Generic_vs_generic.ml
@@ -589,14 +589,14 @@ and m_id_info a b =
         G.id_resolved = _a1;
         id_type = _a2;
         id_svalue = _a3;
-        id_hidden = _a4;
+        id_flags = _a4;
         id_info_id = _a5;
       },
       {
         B.id_resolved = _b1;
         id_type = _b2;
         id_svalue = _b3;
-        id_hidden = _b4;
+        id_flags = _b4;
         id_info_id = _b5;
       } ) ->
       (* old: (m_ref m_resolved_name) a3 b3  >>= (fun () ->

--- a/src/optimizing/Analyze_pattern.ml
+++ b/src/optimizing/Analyze_pattern.ml
@@ -55,7 +55,7 @@ let extract_strings_and_mvars ?lang any =
 
       method! visit_name env x =
         match x with
-        | Id (_id, { id_hidden = true; _ }) ->
+        | Id (_id, { id_flags; _ }) when IdFlags.is_hidden !id_flags ->
             (* This identifier is not present in the pattern source.
                 We assume a match is possible without the identifier
                 being present in the target source, so we ignore it. *)

--- a/src/printing/Pretty_print_AST.ml
+++ b/src/printing/Pretty_print_AST.ml
@@ -552,7 +552,7 @@ and def_stmt env (entity, def_kind) =
   | VarDef def -> var_def (entity, def)
   | _ -> todo (S (DefStmt (entity, def_kind) |> G.s))
 
-(* TODO? maybe we should check id_info.id_hidden *)
+(* TODO? maybe we should check IdFlags.is_hidden !(id_info.id_flags) *)
 and ident_or_dynamic = function
   | EN (Id (x, _idinfo)) -> ident x
   | EN _


### PR DESCRIPTION
We can store more flags in the same space by using an `int` as a bit-vector instead of individual `bool` fields. (I am planning to add an extra flag to record whether a `VarDef' is constant, which is useful for taint analysis.)

Also, made `id_flags' a ref so it can be updated.

test plan:
make test

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
