### PR TITLE
Simplify exception printer registration

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -390,7 +390,13 @@ For more information see https://semsgrep.dev
     stdcompat
     (menhir (= 20211128)) ; Newer versions cause massive build slowdowns
     grain_dypgen
-    base
+
+    ; We don't use Base directly. If it's being used indirectly
+    ; (is it, though?), we need a version that doesn't register
+    ; rogue exception printers.
+    ; See https://github.com/janestreet/base/issues/146
+    (base (>= v0.15.1))
+
     fpath
     alcotest
     ANSITerminal

--- a/libs/commons/SPcre.ml
+++ b/libs/commons/SPcre.ml
@@ -141,5 +141,7 @@ let string_of_exn (e : exn) =
          |> assert false
        with e -> Printexc.to_string e;;
      - : string = "Pcre.Error(MatchLimit)"
+
+   See Exception.mli for notes on exception printer registration.
 *)
 let register_exception_printer () = Printexc.register_printer string_of_exn

--- a/libs/lib_parsing/Parsing_error.ml
+++ b/libs/lib_parsing/Parsing_error.ml
@@ -109,5 +109,6 @@ let string_of_exn e =
       Some (spf "Parsing_error.Other_error (%s, %s)" msg (p tok))
   | _ -> None
 
-(* val register_exception_printer : unit -> unit *)
-let register_exception_printer () = Printexc.register_printer string_of_exn
+(* It's appropriate to register the exception printers here because they
+   were freshly defined and nobody expects other printers to be active. *)
+let () = Printexc.register_printer string_of_exn

--- a/src/core/Rule.ml
+++ b/src/core/Rule.ml
@@ -631,10 +631,7 @@ let opt_string_of_exn (exn : exn) =
   | Err x -> Some (string_of_error x)
   | _else_ -> None
 
-(* To be called by the application's main().
- * TODO? why not evaluate it now like let () = Printexc.register_printer ...?
- *)
-let register_exception_printer () = Printexc.register_printer opt_string_of_exn
+let () = Printexc.register_printer opt_string_of_exn
 
 (*****************************************************************************)
 (* Visitor/extractor *)

--- a/src/core_cli/Core_CLI.ml
+++ b/src/core_cli/Core_CLI.ml
@@ -572,12 +572,13 @@ let options actions =
 (*****************************************************************************)
 
 (*
-   Restore reasonable exception printers for the exceptions of the
-   OCaml standard library.
+   Slightly nicer exception printers than the default.
 *)
-let override_janestreet_exn_printers () =
+let register_stdlib_exn_printers () =
   Printexc.register_printer (function
-    | Failure msg -> Some ("Failure: " ^ msg)
+    | Failure msg ->
+        (* Avoid unnecessary quoting of the error message *)
+        Some ("Failure: " ^ msg)
     | Invalid_argument msg -> Some ("Invalid_argument: " ^ msg)
     | _ -> None)
 
@@ -600,11 +601,9 @@ let register_unix_exn_printers () =
    can be tricky.
 *)
 let register_exception_printers () =
-  override_janestreet_exn_printers ();
+  register_stdlib_exn_printers ();
   register_unix_exn_printers ();
-  Parsing_error.register_exception_printer ();
-  SPcre.register_exception_printer ();
-  Rule.register_exception_printer ()
+  SPcre.register_exception_printer ()
 
 (*****************************************************************************)
 (* Main entry point *)

--- a/src/main/Main.ml
+++ b/src/main/Main.ml
@@ -36,26 +36,6 @@
  *)
 
 (*****************************************************************************)
-(* Exn pretty printers *)
-(*****************************************************************************)
-
-(* TODO: maybe we should update our dependencies to use a more recent
- * Base so we don't need those hacks and every module can independentely
- * register exn printers.
- * TODO? should we just call/reuse Core_CLI.override_janestreet_exn_printers
- * instead?
- *)
-let register_stdlib_exception_printers () =
-  (* Needs to take place after JaneStreet Base does its own registration.
-   * See https://github.com/janestreet/base/issues/146 for more info
-   *)
-  Printexc.register_printer (function
-    | Failure msg ->
-        (* Avoid unnecessary quoting of the error message *)
-        Some ("Failure: " ^ msg)
-    | _else_ -> None)
-
-(*****************************************************************************)
 (* Entry point *)
 (*****************************************************************************)
 
@@ -73,8 +53,7 @@ let () =
   match Filename.basename Sys.argv.(0) with
   (* osemgrep!! *)
   | "osemgrep" ->
-      (* TODO? What about the Core_CLI.register_exception_printers? *)
-      register_stdlib_exception_printers ();
+      Core_CLI.register_exception_printers ();
       let exit_code = CLI.main Sys.argv |> Exit_code.to_int in
       (* TODO: remove or make debug-only *)
       if exit_code <> 0 then

--- a/src/osemgrep/core/Error.ml
+++ b/src/osemgrep/core/Error.ml
@@ -69,18 +69,23 @@ exception Exit of Exit_code.t
 (* string of/registering exns *)
 (*****************************************************************************)
 
-(* TODO
-   let register_exception_printer () =
-     Printexc.register_printer (function
-       | Semgrep_error err -> Some (string_of_error err)
-       | _else_ -> None)
-
-   (*
-      Modify the behavior of 'Printexc.to_string' to print Semgrep exceptions
-      nicely.
-   *)
-   let () = register_exception_printer ()
-*)
+let () =
+  Printexc.register_printer (function
+    | Semgrep_error (msg, opt_exit_code) ->
+        let base_msg = Printf.sprintf "Fatal error: %s" msg in
+        Some
+          (match opt_exit_code with
+          | None -> base_msg
+          | Some exit_code ->
+              Printf.sprintf "%s\nExit code %i: %s" base_msg
+                (Exit_code.to_int exit_code)
+                (Exit_code.to_message exit_code))
+    | Exit exit_code ->
+        Some
+          (Printf.sprintf "Exit code %i: %s"
+             (Exit_code.to_int exit_code)
+             (Exit_code.to_message exit_code))
+    | _ -> None)
 
 (*****************************************************************************)
 (* Misc *)

--- a/src/osemgrep/core/Exit_code.ml
+++ b/src/osemgrep/core/Exit_code.ml
@@ -34,3 +34,23 @@ let scan_fail = 14
 
 (* Temporary until either osemgrep dies or replaces semgrep. *)
 let not_implemented_in_osemgrep = 99
+
+let to_message code =
+  match code with
+  | 0 -> "OK"
+  | 1 -> "some findings"
+  | 2 -> "fatal error"
+  | 3 -> "invalid target code"
+  | 4 -> "invalid pattern"
+  | 5 -> "unparseable YAML"
+  | 6 -> "need arbitrary code execution"
+  | 7 -> "missing configuration"
+  | 8 -> "invalid language"
+  | 9 -> "match timeout"
+  | 10 -> "match memory limit exceeded"
+  | 11 -> "lexical error"
+  | 12 -> "too many matches"
+  | 13 -> "invalid API key"
+  | 14 -> "scan failure"
+  | 99 -> "not implemented in osemgrep"
+  | n -> Printf.sprintf "<unknown exit code %i>" n

--- a/src/osemgrep/core/Exit_code.mli
+++ b/src/osemgrep/core/Exit_code.mli
@@ -12,6 +12,9 @@ type t = private int
 val to_int : t -> int
 val of_int : int -> t
 
+(* Short error message describing the meaning of each exit code *)
+val to_message : t -> string
+
 (*
    Standard exit codes.
    All calls to exit must use one of these.

--- a/src/reporting/Semgrep_error_code.ml
+++ b/src/reporting/Semgrep_error_code.ml
@@ -88,12 +88,12 @@ let error rule_id loc msg err =
 
    TODO: why not capture AST_generic.error here? So we could get rid
    of Run_semgrep.exn_to_error wrapper.
-
-   TODO: register exception printers in their modules of origin
-   (using Printexc.register_printer).
- *)
+*)
 let known_exn_to_error ?(rule_id = None) file (e : Exception.t) : error option =
   match Exception.get_exn e with
+  (* TODO: Move the cases handling Parsing_error.XXX to the Parsing_error
+     module so that we can use it for the exception printers that are
+     registered there. *)
   | Parsing_error.Lexical_error (s, tok) ->
       Some (mk_error_tok ~rule_id tok s Out.LexicalError)
   | Parsing_error.Syntax_error tok ->


### PR DESCRIPTION
* Add a version constraint on the Base library to avoid problems due to https://github.com/janestreet/base/issues/146
* Register exception printers in the module where the exception is declared when possible.
* Add good exception printers for osemgrep fatal errors (probably only useful in case of a bug when the exception isn't caught properly)
* Add notice on how to register exception printers in the file `Exception.mli` (distinguishing locally-defined exceptions from external exceptions with bad printers)

test plan: I don't think we have tests for checking the formatting of exceptions since exceptions shouldn't be thrown into the user's face when everything works as expected. I think it's ok how it is. If some exception isn't perfectly formatted, we can fix it later.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
