### PR TITLE
fix(julia): avoid singleton seq for julia parenexpr

### DIFF
--- a/changelog.d/pa-2991.fixed
+++ b/changelog.d/pa-2991.fixed
@@ -1,0 +1,2 @@
+Julia: Fixed a bug where parenthesized expressions would sometimes
+not match in constructs like `metavariable-comparison`.

--- a/languages/julia/generic/Parse_julia_tree_sitter.ml
+++ b/languages/julia/generic/Parse_julia_tree_sitter.ml
@@ -1853,7 +1853,14 @@ and map_quotable (env : env) (x : CST.quotable) : expr =
             v2)
           v3
       in
-      let base = Seq (v2 :: v3) |> G.e in
+      let base =
+        match v3 with
+        (* This means we would produce a singleton Seq. Let's not do that, and just
+           take the expression itself.
+        *)
+        | [] -> v2
+        | _ -> Seq (v2 :: v3) |> G.e
+      in
       let _v5 =
         match v5 with
         | Some tok -> (* ";" *) Some (token env tok)

--- a/languages/julia/generic/Parse_julia_tree_sitter.ml
+++ b/languages/julia/generic/Parse_julia_tree_sitter.ml
@@ -1853,12 +1853,15 @@ and map_quotable (env : env) (x : CST.quotable) : expr =
             v2)
           v3
       in
+      let v6 = (* ")" *) token env v6 in
       let base =
         match v3 with
         (* This means we would produce a singleton Seq. Let's not do that, and just
-           take the expression itself.
+           take the expression itself, with the parens around it.
         *)
-        | [] -> v2
+        | [] ->
+            AST_generic_helpers.set_e_range v1 v6 v2;
+            v2
         | _ -> Seq (v2 :: v3) |> G.e
       in
       let _v5 =
@@ -1866,7 +1869,6 @@ and map_quotable (env : env) (x : CST.quotable) : expr =
         | Some tok -> (* ";" *) Some (token env tok)
         | None -> None
       in
-      let v6 = (* ")" *) token env v6 in
       match v4 with
       | Some x ->
           let comp = map_comprehension_clause env x in

--- a/tests/rules/bitwise_metavar_compare.jl
+++ b/tests/rules/bitwise_metavar_compare.jl
@@ -1,0 +1,8 @@
+f(x) = x & 2
+
+# ruleid: bitwise-metavar-compare
+f(1|2)
+# ruleid: bitwise-metavar-compare
+f((1|2))
+# ruleid: bitwise-metavar-compare
+f((1|2)::Int64)

--- a/tests/rules/bitwise_metavar_compare.yaml
+++ b/tests/rules/bitwise_metavar_compare.yaml
@@ -1,0 +1,11 @@
+rules:
+  - id: bitwise-op-demo
+    patterns:
+      - pattern: $F($X)
+      - metavariable-comparison:
+          comparison: $X & 2 == 2
+          metavariable: $X
+    message: Demo $X. This also demonstrates Julia singleton parens.
+    languages:
+      - julia
+    severity: WARNING


### PR DESCRIPTION
## What:
This PR allows Julia code containing singleton parentheses expressions to be parsed correctly.

## Why:
We were parsing singleton paren exprs as singleton `Seq`s, which messed with some semantic stuff, like `metavariable-comparison`.

## How:
Cased on it so we don't produce singleton `Seq`s.

## Test plan:
`make test`

Closes PA-2991

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
