### PR TITLE
chore: Replace @r2c.dev with @semgrep.com

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -59,7 +59,7 @@ representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement at semgrep@r2c.dev.
+reported to the community leaders responsible for enforcement at semgrep@semgrep.com.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,4 +10,4 @@ This project is under active development and we do our best to support the lates
 
 ## Reporting a Vulnerability
 
-Please email security@r2c.dev with any security issues in Semgrep. We take all reports seriously.
+Please email security@semgrep.com with any security issues in Semgrep. We take all reports seriously.

--- a/changelog.d/gh-8437.fixed
+++ b/changelog.d/gh-8437.fixed
@@ -1,0 +1,1 @@
+Convert all '@r2c.dev' email addresses to '@semgrep.com'.

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -113,7 +113,7 @@ setuptools.setup(
     name="semgrep",
     version="1.34.1",
     author="Return To Corporation",
-    author_email="support@r2c.dev",
+    author_email="support@semgrep.com",
     description="Lightweight static analysis for many languages. Find bug variants with patterns that look like source code.",
     cmdclass=cmdclass,
     install_requires=install_requires,

--- a/cli/src/semgrep/commands/install.py
+++ b/cli/src/semgrep/commands/install.py
@@ -139,7 +139,7 @@ def run_install_semgrep_pro() -> None:
         if semgrep_pro_path_tmp.exists():
             semgrep_pro_path_tmp.unlink()
         abort(
-            "Downloaded binary failed version check, try again or contact support@r2c.dev"
+            "Downloaded binary failed version check, try again or contact support@semgrep.com"
         )
 
     # Version check worked so we now install the binary

--- a/cli/src/semgrep/commands/login.py
+++ b/cli/src/semgrep/commands/login.py
@@ -82,14 +82,14 @@ def login() -> NoReturn:
                 sys.exit(FATAL_EXIT_CODE)
         elif r.status_code != 404:
             click.echo(
-                f"Unexpected failure from {state.env.semgrep_url}: status code {r.status_code}; please contact support@r2c.dev if this persists",
+                f"Unexpected failure from {state.env.semgrep_url}: status code {r.status_code}; please contact support@semgrep.com if this persists",
                 err=True,
             )
 
         time.sleep(WAIT_BETWEEN_RETRY_IN_SEC)
 
     click.echo(
-        f"Failed to login: please check your internet connection or contact support@r2c.dev",
+        f"Failed to login: please check your internet connection or contact support@semgrep.com",
         err=True,
     )
     sys.exit(FATAL_EXIT_CODE)

--- a/cli/src/semgrep/commands/scan.py
+++ b/cli/src/semgrep/commands/scan.py
@@ -518,21 +518,21 @@ _scan_options: List[Callable] = [
         "requested_engine",
         type=EngineType,
         flag_value=EngineType.PRO_INTERFILE,
-        help="Inter-file analysis and Pro languages (currently just Apex). Requires Semgrep Pro Engine, contact support@r2c.dev for more information on this.",
+        help="Inter-file analysis and Pro languages (currently just Apex). Requires Semgrep Pro Engine, contact support@semgrep.com for more information on this.",
     ),
     optgroup.option(
         "--pro-intrafile",
         "requested_engine",
         type=EngineType,
         flag_value=EngineType.PRO_INTRAFILE,
-        help="Intra-file inter-procedural taint analysis. Implies --pro-languages. Requires Semgrep Pro Engine, contact support@r2c.dev for more information on this.",
+        help="Intra-file inter-procedural taint analysis. Implies --pro-languages. Requires Semgrep Pro Engine, contact support@semgrep.com for more information on this.",
     ),
     optgroup.option(
         "--pro-languages",
         "requested_engine",
         type=EngineType,
         flag_value=EngineType.PRO_LANG,
-        help="Enable Pro languages (currently just Apex). Requires Semgrep Pro Engine, contact support@r2c.dev for more information on this.",
+        help="Enable Pro languages (currently just Apex). Requires Semgrep Pro Engine, contact support@semgrep.com for more information on this.",
     ),
     optgroup.option(
         "--oss-only",
@@ -663,7 +663,7 @@ def scan_options(func: Callable) -> Callable:
     "--dump-engine-path",
     is_flag=True,
     hidden=True
-    # help="contact support@r2c.dev for more information on this"
+    # help="contact support@semgrep.com for more information on this"
 )
 @scan_options
 @handle_command_errors

--- a/cli/src/semgrep/lsp/server.py
+++ b/cli/src/semgrep/lsp/server.py
@@ -155,7 +155,7 @@ class SemgrepCoreLSServer:
             elif r.status_code != 404:
                 self.notify_show_message(
                     1,
-                    f"Unexpected failure from {state.env.semgrep_url}: status code {r.status_code}; please contact support@r2c.dev if this persists",
+                    f"Unexpected failure from {state.env.semgrep_url}: status code {r.status_code}; please contact support@semgrep.com if this persists",
                 )
 
             time.sleep(WAIT_BETWEEN_RETRY_IN_SEC)

--- a/cli/tests/conftest.py
+++ b/cli/tests/conftest.py
@@ -442,7 +442,7 @@ def git_tmp_path(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
     # Initialize State
     subprocess.run(["git", "init"], check=True, capture_output=True)
     subprocess.run(
-        ["git", "config", "user.email", "baselinetest@r2c.dev"],
+        ["git", "config", "user.email", "baselinetest@semgrep.com"],
         check=True,
         capture_output=True,
     )

--- a/cli/tests/unit/test_baseline.py
+++ b/cli/tests/unit/test_baseline.py
@@ -16,7 +16,7 @@ def test_baseline_context(monkeypatch, tmp_path):
 
     # Initialize State
     subprocess.check_call(["git", "init"])
-    subprocess.check_call(["git", "config", "user.email", "baselinetest@r2c.dev"])
+    subprocess.check_call(["git", "config", "user.email", "baselinetest@semgrep.com"])
     subprocess.check_call(["git", "config", "user.name", "Baseline Test"])
     subprocess.check_call(["git", "checkout", "-B", "main"])
 

--- a/src/osemgrep/cli_login/Login_subcommand.ml
+++ b/src/osemgrep/cli_login/Login_subcommand.ml
@@ -85,7 +85,7 @@ let run (conf : Login_CLI.conf) : Exit_code.t =
                   Logs.err (fun m ->
                       m
                         "Failed to login: please check your internet \
-                         connection or contact support@r2c.dev");
+                         connection or contact support@semgrep.com");
                   Exit_code.fatal
               | n -> (
                   let url =
@@ -128,7 +128,8 @@ let run (conf : Login_CLI.conf) : Exit_code.t =
                         Logs.err (fun m ->
                             m
                               "Unexpected failure from %s: status code %d; \
-                               please contact support@r2c.dev if this persists"
+                               please contact support@semgrep.com if this \
+                               persists"
                               (Uri.to_string Semgrep_envvars.v.semgrep_url)
                               status_code);
                         Logs.info (fun m -> m "HTTP error: %s" msg);

--- a/src/osemgrep/core/CLI_common.ml
+++ b/src/osemgrep/core/CLI_common.ml
@@ -183,7 +183,7 @@ let o_common : conf Term.t =
 let help_page_bottom =
   [
     `S Manpage.s_authors;
-    `P "r2c <support@r2c.dev>";
+    `P "r2c <support@semgrep.com>";
     `S Manpage.s_bugs;
     `P
       "If you encounter an issue, please report it at\n\

--- a/tests/parsing/dockerfile/semgrep.dockerfile
+++ b/tests/parsing/dockerfile/semgrep.dockerfile
@@ -56,7 +56,7 @@ RUN ./_build/install/default/bin/semgrep-core -version
 #
 
 FROM python:3.9.1-alpine3.13
-LABEL maintainer="support@r2c.dev"
+LABEL maintainer="support@semgrep.com"
 
 # ugly: circle CI requires valid git and ssh programs in the container
 # when running semgrep on a repository containing submodules


### PR DESCRIPTION
Closes #8437

test plan:
semgrep scan --help # see --pro for example

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
