### PR TITLE
:sparkles: feat(cli): Open login url in the default browser automatically

### DIFF
--- a/cli/src/semgrep/commands/login.py
+++ b/cli/src/semgrep/commands/login.py
@@ -62,7 +62,8 @@ def login() -> NoReturn:
     click.echo(
         "Login enables additional proprietary Semgrep Registry rules and running custom policies from Semgrep Cloud Platform."
     )
-    click.echo(f"Login at: {url}")
+    click.echo(f"Opening login at: {url}")
+    click.launch(url)
     click.echo(
         "\nOnce you've logged in, return here and you'll be ready to start using new Semgrep rules."
     )


### PR DESCRIPTION
Rather than making users copy and paste or command-click the login url, open it automatically when `semgrep login` is run.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
