### PR TITLE
tainting: Fix Visit_pattern_ids

### DIFF
--- a/changelog.d/pro-119.fixed
+++ b/changelog.d/pro-119.fixed
@@ -1,0 +1,3 @@
+Pro: JS/TS: taint-mode: Fix bug introduced in 1.33.1 that had the side-effect of
+hurting performance of taint rules on JS/TS repos that used destructuring in
+functions formal parameters.

--- a/src/analyzing/Visit_pattern_ids.ml
+++ b/src/analyzing/Visit_pattern_ids.ml
@@ -68,8 +68,8 @@ class ['self] pat_id_visitor =
 
 let visit : AST_generic.any -> (G.ident * G.id_info) list =
   let v = new pat_id_visitor in
-  let ids = ref [] in
   fun any ->
+    let ids = ref [] in
     v#visit_any ids any;
     !ids
   [@@profiling]


### PR DESCRIPTION
The accumulator must be declared inside the closure otherwise we are storing ids from previous calls!

Fixes 0d72cdcde3d ("feat(tainting): allow pattern params as sources (#8216)")

test plan:
Run on some JS/TS project while debugging the output of Visit_pattern_ids.visit

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
