### PR TITLE
refactor(matching): clean up matching env

### DIFF
--- a/src/matching/Match_patterns.ml
+++ b/src/matching/Match_patterns.ml
@@ -141,12 +141,10 @@ let (rule_id_of_mini_rule : Mini_rule.t -> Pattern_match.rule_id) =
     languages = mr.languages;
   }
 
-let match_rules_and_recurse lang config (file, hook, matches) rules matcher k
-    any x =
+let match_rules_and_recurse m_env (file, hook, matches) rules matcher k any x =
   rules
   |> List.iter (fun (pattern, rule) ->
-         let env = MG.empty_environment lang config in
-         let matches_with_env = matcher rule pattern x env in
+         let matches_with_env = matcher rule pattern x m_env in
          if matches_with_env <> [] then
            (* Found a match *)
            matches_with_env
@@ -215,6 +213,10 @@ let check2 ~hook mvar_context range_filter (config, equivs) rules
   if rules = [] then []
   else
     let matches = ref [] in
+    (* Our matching environment. We can augment this with new information based on the AST,
+     * but we should only need to create it once.
+     *)
+    let m_env = MG.empty_environment lang config in
 
     (* old: let prog = Normalize_AST.normalize (Pr ast) lang in
        * we were rewriting code, e.g., A != B was rewritten as !(A == B),
@@ -307,7 +309,15 @@ let check2 ~hook mvar_context range_filter (config, equivs) rules
                        (show_expr_kind x.e);
                      ()
                  | Some range_loc when range_filter range_loc ->
-                     let env = MG.empty_environment ~mvar_context lang config in
+                     let env =
+                       {
+                         m_env with
+                         mv =
+                           (match mvar_context with
+                           | None -> []
+                           | Some mvs -> mvs);
+                       }
+                     in
                      let matches_with_env = match_e_e rule pattern x env in
                      if matches_with_env <> [] then
                        (* Found a match *)
@@ -355,8 +365,7 @@ let check2 ~hook mvar_context range_filter (config, equivs) rules
           let visit_stmt () =
             !stmt_rules
             |> List.iter (fun (pattern, rule) ->
-                   let env = MG.empty_environment lang config in
-                   let matches_with_env = match_st_st rule pattern x env in
+                   let matches_with_env = match_st_st rule pattern x m_env in
                    if matches_with_env <> [] then
                      (* Found a match *)
                      matches_with_env
@@ -407,8 +416,9 @@ let check2 ~hook mvar_context range_filter (config, equivs) rules
           !stmts_rules
           |> List.iter (fun (pattern, rule) ->
                  Profiling.profile_code "Semgrep_generic.kstmts" (fun () ->
-                     let env = MG.empty_environment lang config in
-                     let matches_with_env = match_sts_sts rule pattern x env in
+                     let matches_with_env =
+                       match_sts_sts rule pattern x m_env
+                     in
                      if matches_with_env <> [] then
                        (* Found a match *)
                        matches_with_env
@@ -438,33 +448,33 @@ let check2 ~hook mvar_context range_filter (config, equivs) rules
           super#v_stmts env x
 
         method! visit_type_ env x =
-          match_rules_and_recurse lang config (file, hook, matches) !type_rules
+          match_rules_and_recurse m_env (file, hook, matches) !type_rules
             match_t_t (super#visit_type_ env)
             (fun x -> T x)
             x
 
         method! visit_pattern env x =
-          match_rules_and_recurse lang config (file, hook, matches)
-            !pattern_rules match_p_p (super#visit_pattern env)
+          match_rules_and_recurse m_env (file, hook, matches) !pattern_rules
+            match_p_p (super#visit_pattern env)
             (fun x -> P x)
             x
 
         method! visit_attribute env x =
-          match_rules_and_recurse lang config (file, hook, matches)
-            !attribute_rules match_at_at
+          match_rules_and_recurse m_env (file, hook, matches) !attribute_rules
+            match_at_at
             (super#visit_attribute env)
             (fun x -> At x)
             x
 
         method! visit_xml_attribute env x =
-          match_rules_and_recurse lang config (file, hook, matches)
+          match_rules_and_recurse m_env (file, hook, matches)
             !xml_attribute_rules match_xml_attribute_xml_attribute
             (super#visit_xml_attribute env)
             (fun x -> XmlAt x)
             x
 
         method! visit_field env x =
-          match_rules_and_recurse lang config (file, hook, matches) !fld_rules
+          match_rules_and_recurse m_env (file, hook, matches) !fld_rules
             match_fld_fld (super#visit_field env)
             (fun x -> Fld x)
             x
@@ -498,8 +508,9 @@ let check2 ~hook mvar_context range_filter (config, equivs) rules
           |> List.iter (fun (pattern, rule) ->
                  Profiling.profile_code "Semgrep_generic.kfields" (fun () ->
                      let x = Common.map (fun (F x) -> x) x in
-                     let env = MG.empty_environment lang config in
-                     let matches_with_env = match_sts_sts rule pattern x env in
+                     let matches_with_env =
+                       match_sts_sts rule pattern x m_env
+                     in
                      if matches_with_env <> [] then
                        (* Found a match *)
                        matches_with_env
@@ -526,26 +537,26 @@ let check2 ~hook mvar_context range_filter (config, equivs) rules
                                   in
                                   Common.push pm matches;
                                   hook pm)));
-          match_rules_and_recurse lang config (file, hook, matches) !flds_rules
+          match_rules_and_recurse m_env (file, hook, matches) !flds_rules
             match_flds_flds (super#v_fields env)
             (fun x -> Flds x)
             x
 
         method! v_partial ~recurse env x =
-          match_rules_and_recurse lang config (file, hook, matches)
-            !partial_rules match_partial_partial
+          match_rules_and_recurse m_env (file, hook, matches) !partial_rules
+            match_partial_partial
             (super#v_partial ~recurse env)
             (fun x -> Partial x)
             x
 
         method! visit_name env x =
-          match_rules_and_recurse lang config (file, hook, matches) !name_rules
+          match_rules_and_recurse m_env (file, hook, matches) !name_rules
             match_name_name (super#visit_name env)
             (fun x -> Name x)
             x
 
         method! visit_raw_tree env x =
-          match_rules_and_recurse lang config (file, hook, matches) !raw_rules
+          match_rules_and_recurse m_env (file, hook, matches) !raw_rules
             match_raw_raw (super#visit_raw_tree env)
             (fun x -> Raw x)
             x

--- a/src/matching/Matching_generic.ml
+++ b/src/matching/Matching_generic.ml
@@ -114,7 +114,6 @@ type tin = {
   lang : Lang.t;
   config : Rule_options.t;
   deref_sym_vals : int;
-  wildcard_imports : AST_generic.ident list list;
 }
 
 (* list of possible outcoming matching environments *)
@@ -391,14 +390,7 @@ let (envf : MV.mvar G.wrap -> MV.mvalue -> tin -> tout) =
       return new_binding
 
 let empty_environment lang config =
-  {
-    mv = [];
-    stmts_matched = [];
-    lang;
-    config;
-    deref_sym_vals = 0;
-    wildcard_imports = [];
-  }
+  { mv = []; stmts_matched = []; lang; config; deref_sym_vals = 0 }
 
 (*****************************************************************************)
 (* Helpers *)

--- a/src/matching/Matching_generic.ml
+++ b/src/matching/Matching_generic.ml
@@ -114,6 +114,7 @@ type tin = {
   lang : Lang.t;
   config : Rule_options.t;
   deref_sym_vals : int;
+  wildcard_imports : AST_generic.ident list list;
 }
 
 (* list of possible outcoming matching environments *)
@@ -389,13 +390,15 @@ let (envf : MV.mvar G.wrap -> MV.mvalue -> tin -> tout) =
         (lazy (spf "envf: success, %s (%s)" mvar (MV.str_of_mval any)));
       return new_binding
 
-let empty_environment ?(mvar_context = None) lang config =
-  let mv =
-    match mvar_context with
-    | None -> []
-    | Some bindings -> bindings
-  in
-  { mv; stmts_matched = []; lang; config; deref_sym_vals = 0 }
+let empty_environment lang config =
+  {
+    mv = [];
+    stmts_matched = [];
+    lang;
+    config;
+    deref_sym_vals = 0;
+    wildcard_imports = [];
+  }
 
 (*****************************************************************************)
 (* Helpers *)

--- a/src/matching/Matching_generic.mli
+++ b/src/matching/Matching_generic.mli
@@ -10,7 +10,6 @@ type tin = {
   deref_sym_vals : int;
       (** Counts the number of times that we "follow" symbollically propagated
     * values. This is bound to prevent potential infinite loops. *)
-  wildcard_imports : AST_generic.ident list list;
 }
 
 (* list of possible outcoming matching environments *)

--- a/src/matching/Matching_generic.mli
+++ b/src/matching/Matching_generic.mli
@@ -10,6 +10,7 @@ type tin = {
   deref_sym_vals : int;
       (** Counts the number of times that we "follow" symbollically propagated
     * values. This is bound to prevent potential infinite loops. *)
+  wildcard_imports : AST_generic.ident list list;
 }
 
 (* list of possible outcoming matching environments *)
@@ -48,10 +49,7 @@ val or_list : 'a matcher -> 'a -> 'a list -> tin -> tout
 
 (* Shortcut for >>=. Since OCaml 4.08, you can define those "extended-let" *)
 val ( let* ) : (tin -> tout) -> (unit -> tin -> tout) -> tin -> tout
-
-val empty_environment :
-  ?mvar_context:Metavariable.bindings option -> Lang.t -> Rule_options.t -> tin
-
+val empty_environment : Lang.t -> Rule_options.t -> tin
 val add_mv_capture : Metavariable.mvar -> Metavariable.mvalue -> tin -> tin
 
 (* Update the matching list of statements by providing a new matching


### PR DESCRIPTION
## What:
This PR just removes all the excessive calls to `empty_environment`, which creates a functional environment value that doesn't change, and simply calls it once and passes it down.

## Why:
This has the advantage that if we add program-specific information into the environment, we will not need to compute it multiple times / pass it down excessively. This will be the case for matching wildcard imports, which I would like to be able to do.

## How:
Killed all the `empty_environment` calls and just made it one call, at the beginning of `check2`. I also renamed it to `m_env` so as to distinguish it from the `env` passed down by the visitor.

## Test plan:
`make test`

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
