### PR TITLE
fix(release): fix path to semgrep homebrew formula

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,5 +1,5 @@
 # Cron to verify that the Homebrew Core Formula Works.
-# This formula is stored in https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/semgrep.rb
+# This formula is stored in https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/s/semgrep.rb
 # and "bumped" in release.yml by dawidd6/action-homebrew-bump-formula@v3
 #
 # This formula is created by our release process with the PR to homebrew/homebrew-core.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -331,7 +331,7 @@ jobs:
           gh auth setup-git
           git remote add r2c "${R2C_HOMEBREW_CORE_FORK_HTTPS_URL}"
           git checkout -b bump-semgrep-${{ steps.get-version.outputs.VERSION }}
-          git add Formula/semgrep.rb
+          git add Formula/s/semgrep.rb
           git commit -m "semgrep ${{ steps.get-version.outputs.VERSION }}"
       - name: Push Branch to Fork
         env:


### PR DESCRIPTION
Homebrew changed its formulae folder structure so we need to change our path

Test plan: nightly verification for release

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
