### PR TITLE
osemgrep: add actual cron schedule for pysemgrep_loc_stats

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,7 +194,7 @@ workflows:
                 - develop
     triggers:
       - schedule:
-          cron: "0 0 * * *"
+          cron: "0 12 * * *"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,6 +125,17 @@ workflows:
   #----------------------------------------
   # Crons
   #----------------------------------------
+  # cron table memento below
+  # (src: https://dev.to/anshuman_bhardwaj/free-cron-jobs-with-github-actions-31d6)
+  # ┌────────── minute (0 - 59)
+  # │ ┌────────── hour (0 - 23)
+  # │ │ ┌────────── day of the month (1 - 31)
+  # │ │ │ ┌────────── month (1 - 12)
+  # │ │ │ │ ┌────────── day of the week (0 - 6)
+  # │ │ │ │ │
+  # │ │ │ │ │
+  # │ │ │ │ │
+  # * * * * *
 
   # Daily semgrep benchmarks
   benchmarks:
@@ -147,14 +158,12 @@ workflows:
   scheduled-parsing-stats:
     jobs:
       - parsing-stats:
-          # Run only on these branches
           filters:
             branches:
               only:
                 - develop
     triggers:
       - schedule:
-          # Run at 00:00 every day, UTC.
           cron: "0 0 * * *"
           filters:
             branches:
@@ -164,14 +173,27 @@ workflows:
   scheduled-autofix-printing-stats:
     jobs:
       - autofix-printing-stats:
-          # Run only on these branches
           filters:
             branches:
               only:
                 - develop
     triggers:
       - schedule:
-          # Run at 00:00 every day, UTC.
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - develop
+
+  scheduled-pysemgrep-loc-stats:
+    jobs:
+      - pysemgrep-loc-stats:
+          filters:
+            branches:
+              only:
+                - develop
+    triggers:
+      - schedule:
           cron: "0 0 * * *"
           filters:
             branches:


### PR DESCRIPTION
test plan:
wait for midnight and check if tomorrow the job ran in
app.circleci


PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)