### PR TITLE
Simple fixes following PR #8190

### DIFF
--- a/cli/tests/qa/test_public_repos.py
+++ b/cli/tests/qa/test_public_repos.py
@@ -66,8 +66,12 @@ def assert_sentinel_results(repo_path, sentinel_path, language):
         "--optimizations=none",
     ]
 
-    # nosemgrep: python.lang.security.audit.dangerous-subprocess-use.dangerous-subprocess-use
+    # This is useful for debugging. I don't see a downside to printing
+    # such important debugging info when running tests so I'm leaving it
+    # -- Martin
     print(f"semgrep command: {cmd}")
+
+    # nosemgrep: python.lang.security.audit.dangerous-subprocess-use.dangerous-subprocess-use
     semgrep_run = subprocess.run(cmd, capture_output=True, encoding="utf-8")
     assert semgrep_run.returncode == 0
 
@@ -158,7 +162,6 @@ def test_semgrep_on_repo(monkeypatch, tmp_path, repo):
         sentinel_path = repo_path / sentinel_info["filename"]
         with sentinel_path.open("w") as sentinel_file:
             sentinel_file.write(sentinel_info["file_contents"])
-        print(f"assert_sentinel_results({repo_path}, {sentinel_path}, {language})")
         assert_sentinel_results(repo_path, sentinel_path, language)
 
     cmd = SEMGREP_BASE_COMMAND + [

--- a/js/languages/cpp/Parser.ml
+++ b/js/languages/cpp/Parser.ml
@@ -7,6 +7,7 @@ let parse_pattern print_errors _ str =
   let any =
     str
     |> Pfff_or_tree_sitter.run_pattern ~print_errors
+         (* coupling: check src/parsing_languages/Parse_pattern2.ml *)
          [
            PfffPat (Parse_cpp.any_of_string Flag_parsing_cpp.Cplusplus);
            TreeSitterPat Parse_cpp_tree_sitter.parse_pattern;

--- a/js/languages/java/Parser.ml
+++ b/js/languages/java/Parser.ml
@@ -11,6 +11,7 @@ let parse_pattern print_errors _ str =
 
 let parse_target _ file =
   Pfff_or_tree_sitter.run file
+    (* coupling: check src/parsing_languages/Parse_pattern2.ml *)
     [
       (* we used to start with the pfff one; it was quite good and faster
        * than tree-sitter (because we need to wrap tree-sitter inside

--- a/js/languages/python/Parser.ml
+++ b/js/languages/python/Parser.ml
@@ -12,6 +12,7 @@ let parse_pattern _ lang str =
 let parse_target lang file =
   let parsing_mode = lang_to_python_parsing_mode lang in
   Pfff_or_tree_sitter.run file
+    (* coupling: check src/parsing_languages/Parse_pattern2.ml *)
     [
       Pfff (Pfff_or_tree_sitter.throw_tokens (Parse_python.parse ~parsing_mode));
       TreeSitter Parse_python_tree_sitter.parse;

--- a/js/languages/typescript/Parser.ml
+++ b/js/languages/typescript/Parser.ml
@@ -17,6 +17,7 @@ let parse_pattern print_errors _ str =
   let js_ast =
     str
     |> Pfff_or_tree_sitter.run_pattern ~print_errors
+         (* coupling: check src/parsing_languages/Parse_pattern2.ml *)
          [
            PfffPat Parse_js.any_of_string;
            TreeSitterPat Parse_typescript_tree_sitter.parse_pattern;

--- a/src/parsing/Pfff_or_tree_sitter.ml
+++ b/src/parsing/Pfff_or_tree_sitter.ml
@@ -36,7 +36,13 @@ type 'ast parser =
   | Pfff of (Common.filename -> 'ast * Parsing_stat.t)
   | TreeSitter of (Common.filename -> 'ast Tree_sitter_run.Parsing_result.t)
 
-(* This type is parametrized by the AST type because ??? *)
+(*
+   This type is parametrized by the AST type because we don't always
+   generate directly generic ASTs. We sometimes generate intermediate
+   ASTs hence the need for polymorphic type (so you can have
+   Ast_cpp.program internal_result, or Ast_php.program
+   internal_result).
+*)
 type 'ast internal_result =
   | ResOk of ('ast * Parsing_stat.t)
   | ResPartial of

--- a/src/parsing/Pfff_or_tree_sitter.ml
+++ b/src/parsing/Pfff_or_tree_sitter.ml
@@ -103,8 +103,15 @@ let extract_pattern_from_tree_sitter_result
 (* Run target parsers *)
 (*****************************************************************************)
 
-(* Serious error = any parsing error that causes us to resort to an alternate
-   parser. *)
+(*
+   Serious error = any parsing error that causes us to resort to an
+   alternate parser. Missing nodes aren't considered serious enough to
+   warrant another parsing attempt. Otherwise, doing so would result
+   in slowdowns due to the other parser being usually slower
+   (observed: 3 s -> 30 s parsing time on big JS file when retrying
+   due to missing/inserted tokens and falling back to the menhir
+   parser).
+*)
 let is_serious_error (err : Tree_sitter_run.Tree_sitter_error.t) =
   match err.kind with
   | Internal

--- a/src/parsing_languages/Parse_pattern2.ml
+++ b/src/parsing_languages/Parse_pattern2.ml
@@ -60,6 +60,7 @@ let parse_pattern print_errors lang str =
       let any =
         str
         |> run_pattern ~print_errors
+             (* coupling: semgrep/js/languages/python/Parser.ml *)
              [
                PfffPat
                  (let parsing_mode =
@@ -76,6 +77,7 @@ let parse_pattern print_errors lang str =
       let any =
         str
         |> run_pattern ~print_errors
+             (* coupling: semgrep/js/languages/cpp/Parser.ml *)
              [
                PfffPat
                  (fun x -> Parse_cpp.any_of_string Flag_parsing_cpp.Cplusplus x);
@@ -87,6 +89,7 @@ let parse_pattern print_errors lang str =
       let any =
         str
         |> run_pattern ~print_errors
+             (* coupling: semgrep/js/languages/java/Parser.ml *)
              [
                (* TODO: we should switch to TreeSitterPat first, but
                 * we get regressions on generic_args.sgrep because
@@ -104,6 +107,7 @@ let parse_pattern print_errors lang str =
       let js_ast =
         str
         |> run_pattern ~print_errors
+             (* coupling: semgrep/js/languages/typescript/Parser.ml *)
              [
                PfffPat Parse_js.any_of_string;
                TreeSitterPat Parse_typescript_tree_sitter.parse_pattern;


### PR DESCRIPTION
This addresses the simple concerns left by @aryx on https://github.com/returntocorp/semgrep/pull/8190

This PR does not address the issue of many parsers being revealed as broken with known failing test cases. I'll work on this separately.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
