### PR TITLE
feat(SSC): add dependencies to /results

### DIFF
--- a/changelog.d/sc-async.added
+++ b/changelog.d/sc-async.added
@@ -1,0 +1,1 @@
+Dependency data is now also sent to the /results endpoint of semgrep app. It is still sent to the /complete endpoint.

--- a/cli/src/semgrep/app/scans.py
+++ b/cli/src/semgrep/app/scans.py
@@ -306,7 +306,7 @@ class ScanHandler:
             rule_ids=rule_ids,
         )
         if self._dependency_query:
-            out.CiScanDependencies(lockfile_dependencies)
+            ci_scan_results.dependencies = out.CiScanDependencies(lockfile_dependencies)
 
         findings_and_ignores = ci_scan_results.to_json()
 

--- a/cli/src/semgrep/app/scans.py
+++ b/cli/src/semgrep/app/scans.py
@@ -305,6 +305,9 @@ class ScanHandler:
             renamed_paths=[str(rt) for rt in sorted(renamed_targets)],
             rule_ids=rule_ids,
         )
+        if self._dependency_query:
+            out.CiScanDependencies(lockfile_dependencies)
+
         findings_and_ignores = ci_scan_results.to_json()
 
         if any(match.severity == RuleSeverity.EXPERIMENT for match in new_ignored):

--- a/cli/tests/e2e/snapshots/test_ci/test_query_dependency/dependencies.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_query_dependency/dependencies.json
@@ -1,0 +1,43 @@
+{
+  "poetry.lock": [
+    {
+      "package": "badlib",
+      "version": "99.99.99",
+      "ecosystem": "pypi",
+      "allowed_hashes": {},
+      "transitivity": "unknown",
+      "line_number": 1
+    },
+    {
+      "package": "mypy",
+      "version": "0.950",
+      "ecosystem": "pypi",
+      "allowed_hashes": {},
+      "transitivity": "unknown",
+      "line_number": 9
+    },
+    {
+      "package": "python-dateutil",
+      "version": "2.8.2",
+      "ecosystem": "pypi",
+      "allowed_hashes": {},
+      "transitivity": "unknown",
+      "line_number": 17
+    }
+  ],
+  "yarn.lock": [
+    {
+      "package": "lodash",
+      "version": "4.17.20",
+      "ecosystem": "npm",
+      "allowed_hashes": {
+        "sha512": [
+          "6aee0bd6ad0729c69a6b7eea39da565a1c330e707fb5a6097d188a50b9da4fe325f5468122327648e24c78bb5279e2d3fb351dc85326d3eb6cfa3e1e7ae52920"
+        ]
+      },
+      "transitivity": "unknown",
+      "resolved_url": "https://registry.yarnpkg.com/lodash/-/lodash-4.17.18.tgz",
+      "line_number": 5
+    }
+  ]
+}

--- a/cli/tests/e2e/test_ci.py
+++ b/cli/tests/e2e/test_ci.py
@@ -1578,6 +1578,15 @@ def test_query_dependency(
     # see https://linear.app/r2c/issue/PA-2461/restore-flaky-e2e-tests for more info
     complete_json["stats"]["lockfile_scan_info"] = {}
     snapshot.assert_match(json.dumps(complete_json, indent=2), "complete.json")
+    complete_dependency_json = complete_json["dependencies"]
+    results_json = post_calls[1].kwargs["json"]
+    results_dependency_json = results_json["dependencies"]
+    snapshot.assert_match(
+        json.dumps(complete_dependency_json, indent=2), "dependencies.json"
+    )
+    snapshot.assert_match(
+        json.dumps(results_dependency_json, indent=2), "dependencies.json"
+    )
 
 
 def test_metrics_enabled(run_semgrep: RunSemgrep, mocker):


### PR DESCRIPTION
When running `semgrep ci`, we want to start sending dependency data to `/results` in semgrep app, so that we can process it asynchronously in a celery task, instead of processing it synchronously in `/complete`.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
