### PR TITLE
cleanup cli/Makefile and add time estimation for the make xxx-tests

### DIFF
--- a/cli/Makefile
+++ b/cli/Makefile
@@ -42,7 +42,7 @@ clean:
 # - 'make quick-tests' (=~ 30s)
 # - 'make e2e' (=~ 1m14s)
 # - 'make kinda-quick-tests' (=~ 2min30s )
-# - 'make test' (=~ )
+# - 'make test' (=~ 10min)
 
 PYTEST ?= pipenv run pytest -v --tb=short --durations=10
 

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -1,4 +1,6 @@
-PYTEST ?= pipenv run pytest -v --tb=short --durations=10
+###############################################################################
+# Main target
+###############################################################################
 
 # Run everything that makes sense to run.
 .PHONY: default
@@ -36,6 +38,14 @@ clean:
 # Tests
 ###############################################################################
 
+# From fastest to slowest (on pad's machine):
+# - 'make quick-tests' (=~ 30s)
+# - 'make e2e' (=~ 1m14s)
+# - 'make kinda-quick-tests' (=~ 2min30s )
+# - 'make test' (=~ )
+
+PYTEST ?= pipenv run pytest -v --tb=short --durations=10
+
 # Typecheck and run all basic tests from quickest to slowest.
 .PHONY: test
 test:
@@ -49,8 +59,7 @@ test:
 # We exclude the few tests that don't invoke the semgrep command directly.
 .PHONY: e2e
 e2e:
-	$(PYTEST) -n auto -v \
-	  -m 'not no_semgrep_cli and not todo' tests/e2e
+	$(PYTEST) -n auto -v -m 'not no_semgrep_cli and not todo' tests/e2e
 
 # Run the extra tests on public repos and semgrep-rules
 .PHONY: qa


### PR DESCRIPTION
test plan:
cd cli; make


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)