### PR TITLE
osemgrep: remove need for PYTEST_OSEMGREP_PATH

### DIFF
--- a/cli/Makefile
+++ b/cli/Makefile
@@ -85,22 +85,22 @@ kinda-quick-tests:
 # Osemgrep tests
 ###############################################################################
 
-# Run the end-to-end tests using osemgrep instead of the Python CLI.
+# Run the end-to-end tests using osemgrep instead of pysemgrep.
 # See tests/semgrep_runner.py for the use of the environment variables below.
-# To run individual tests, export PYTEST_OSEMGREP=... export PYTEST_USE_OSEMGREP=true
+# To run individual tests, export PYTEST_USE_OSEMGREP=true
 # and run 'pytest tests/e2e/test_output.py' in a shell for example.
 .PHONY: osemgrep-e2e
 osemgrep-e2e:
-	PYTEST_OSEMGREP=$(PWD)/../bin/osemgrep PYTEST_USE_OSEMGREP=true $(MAKE) e2e
+	PYTEST_USE_OSEMGREP=true $(MAKE) e2e
 
 # Run all the known passing-with-osemgrep tests (tagged with osempass)
 # coupling: this is run in CI in .github/workflows/tests.yml
 osempass:
-	PYTEST_OSEMGREP=$(PWD)/../bin/osemgrep PYTEST_USE_OSEMGREP=true  $(PYTEST) -n auto -m 'osempass and not todo' tests/e2e
+	PYTEST_USE_OSEMGREP=true  $(PYTEST) -n auto -m 'osempass and not todo' tests/e2e
 
 # to be used to discover tests that we should add the osempass pytest mark
 osempass-check-if-new-osempass:
-	PYTEST_OSEMGREP=$(PWD)/../bin/osemgrep PYTEST_USE_OSEMGREP=true  $(PYTEST) -n auto -v --no-summary -m 'not no_semgrep_cli and not todo and not osempass' tests/e2e
+	PYTEST_USE_OSEMGREP=true  $(PYTEST) -n auto -v --no-summary -m 'not no_semgrep_cli and not todo and not osempass' tests/e2e
 
 # Run the quality assurance tests using osemgrep instead of the Python CLI.
 .PHONY: osemgrep-qa


### PR DESCRIPTION
Now that osemgrep can be run directly via semgrep --experimental,
we don't need those extra env variables

test plan:
make osemgrep-e2e
still 172 passed
make osempass
still 129 passed


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)