### PR TITLE
osemgrep: fix SEMGREP_BASE_COMMAND to also use --experimental

### DIFF
--- a/cli/tests/semgrep_runner.py
+++ b/cli/tests/semgrep_runner.py
@@ -31,20 +31,21 @@ from click.testing import CliRunner
 ##############################################################################
 
 # Environment variable that trigger the use of osemgrep
-USE_OSEMGREP = "PYTEST_USE_OSEMGREP" in os.environ
+_USE_OSEMGREP = "PYTEST_USE_OSEMGREP" in os.environ
 
 # The --project-root option is used to prevent the .semgrepignore
 # at the root of the git project to be taken into account when testing,
 # which is a new behavior in osemgrep.
-OSEMGREP_EXTRA_ARGS = ["--experimental", "--project-root", "."]
+_OSEMGREP_EXTRA_ARGS = ["--experimental", "--project-root", "."]
 
-# The semgrep command suitable to run semgrep as a separate process.
-SEMGREP_BASE_COMMAND_STR: str = str(
-    (Path(__file__).parent.parent / "bin" / "semgrep").absolute()
+_SEMGREP_PATH = str((Path(__file__).parent.parent / "bin" / "semgrep").absolute())
+
+# Exported constant, convenient to use in a list context.
+SEMGREP_BASE_COMMAND: List[str] = (
+    [_SEMGREP_PATH] + _OSEMGREP_EXTRA_ARGS if _USE_OSEMGREP else [_SEMGREP_PATH]
 )
 
-# More convenient to use when used in a list context
-SEMGREP_BASE_COMMAND: List[str] = [SEMGREP_BASE_COMMAND_STR]
+SEMGREP_BASE_COMMAND_STR: str = " ".join(SEMGREP_BASE_COMMAND)
 
 ##############################################################################
 # Helpers
@@ -93,9 +94,9 @@ def fork_semgrep(
 
     # ugly: adding --project-root for --help would trigger the wrong help message
     if "-h" in arg_list or "--help" in arg_list:
-        argv = SEMGREP_BASE_COMMAND + arg_list
+        argv = [_SEMGREP_PATH] + arg_list
     else:
-        argv = SEMGREP_BASE_COMMAND + OSEMGREP_EXTRA_ARGS + arg_list
+        argv = [_SEMGREP_PATH] + _OSEMGREP_EXTRA_ARGS + arg_list
 
     # env preparation
     env_dict = {}
@@ -122,7 +123,7 @@ class SemgrepRunner:
     """
 
     def __init__(self, env=None, mix_stderr=True):
-        self._use_osemgrep = USE_OSEMGREP
+        self._use_osemgrep = _USE_OSEMGREP
         self._output = ""
         self._env = env
         self._mix_stderr = mix_stderr


### PR DESCRIPTION
there was 43 new tests that seem to be passing with osemgrep
before this PR, but because those tests were using
directly SEMGREP_BASE_COMMAND instead of using the SemgrepRunner
so they were just really calling pysemgrep.

test plan:
make osempass-check-if-new-osempass now returns only 8 new passed
instead of 43


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)