### PR TITLE
osemgrep: switching to real e2e testing, part 1

### DIFF
--- a/cli/tests/conftest.py
+++ b/cli/tests/conftest.py
@@ -322,6 +322,7 @@ def _run_semgrep(
     force_metrics_off: bool = True,
     stdin: Optional[str] = None,
     clean_fingerprint: bool = True,
+    use_click_runner: bool = True,  # TODO: change to False. deprecated! Avoid using! see semgrep_runner.py
 ) -> SemgrepResult:
     """Run the semgrep CLI.
 
@@ -391,7 +392,7 @@ def _run_semgrep(
     args = " ".join(shlex.quote(str(c)) for c in [*options, *targets])
     env_string = " ".join(f'{k}="{v}"' for k, v in env.items())
 
-    runner = SemgrepRunner(env=env, mix_stderr=False)
+    runner = SemgrepRunner(env=env, mix_stderr=False, use_click_runner=use_click_runner)
     click_result = runner.invoke(cli, args, input=stdin)
     result = SemgrepResult(
         # the actual executable was either semgrep or osemgrep. Is it bad?

--- a/cli/tests/e2e/test_config_resolver.py
+++ b/cli/tests/e2e/test_config_resolver.py
@@ -33,7 +33,8 @@ def test_new_feature_registry_config(monkeypatch, snapshot, mocker, tmp_path):
         env={
             "SEMGREP_SETTINGS_FILE": str(tmp_path / ".settings.yaml"),
             "SEMGREP_APP_TOKEN": "",
-        }
+        },
+        use_click_runner=True,
     )
     result = runner.invoke(cli, ["scan", "--config", "p/ci"])
     snapshot.assert_match(result.output, "output.txt")
@@ -61,7 +62,8 @@ def test_fallback_config_works(monkeypatch, snapshot, mocker, tmp_path):
         env={
             "SEMGREP_SETTINGS_FILE": str(tmp_path / ".settings.yaml"),
             "SEMGREP_APP_TOKEN": "",
-        }
+        },
+        use_click_runner=True,
     )
     result = runner.invoke(cli, ["scan", "--debug", "--config", "supply-chain"])
 

--- a/cli/tests/e2e/test_login.py
+++ b/cli/tests/e2e/test_login.py
@@ -9,7 +9,8 @@ from semgrep.config_resolver import ConfigLoader
 @pytest.mark.slow
 def test_login(tmp_path, mocker):
     runner = SemgrepRunner(
-        env={"SEMGREP_SETTINGS_FILE": str(tmp_path / ".settings.yaml")}
+        env={"SEMGREP_SETTINGS_FILE": str(tmp_path / ".settings.yaml")},
+        use_click_runner=True,
     )
 
     expected_logout_str = "Logged out (log back in with `semgrep login`)\n"

--- a/cli/tests/e2e/test_metrics.py
+++ b/cli/tests/e2e/test_metrics.py
@@ -271,7 +271,8 @@ def test_metrics_payload(tmp_path, snapshot, mocker, monkeypatch, pro_flag):
         env={
             "SEMGREP_SETTINGS_FILE": str(tmp_path / ".settings.yaml"),
             "SEMGREP_INTEGRATION_NAME": "funkyintegration",
-        }
+        },
+        use_click_runner=True,
     )
     runner.invoke(
         cli, ["scan", "--config=rule.yaml", "--metrics=on", "code.py"] + pro_flag

--- a/cli/tests/e2e/test_parse_rate_metrics.py
+++ b/cli/tests/e2e/test_parse_rate_metrics.py
@@ -45,7 +45,9 @@ def test_parse_metrics(tmp_path, snapshot, mocker, monkeypatch):
     )
 
     monkeypatch.chdir(tmp_path / "parse_metrics")
-    SemgrepRunner().invoke(cli, ["scan", "--config=rules.yaml", "--metrics=on"])
+    SemgrepRunner(use_click_runner=True).invoke(
+        cli, ["scan", "--config=rules.yaml", "--metrics=on"]
+    )
 
     payload = json.loads(mock_post.call_args.kwargs["data"])
 

--- a/cli/tests/e2e/test_publish.py
+++ b/cli/tests/e2e/test_publish.py
@@ -10,7 +10,8 @@ from semgrep.cli import cli
 @pytest.mark.kinda_slow
 def test_publish(tmp_path, mocker):
     runner = SemgrepRunner(
-        env={"SEMGREP_SETTINGS_FILE": str(tmp_path / ".settings.yaml")}
+        env={"SEMGREP_SETTINGS_FILE": str(tmp_path / ".settings.yaml")},
+        use_click_runner=True,
     )
 
     tests_path = Path(TESTS_PATH / "e2e" / "targets" / "semgrep-publish" / "valid")


### PR DESCRIPTION
our end-to-end (e2e) tests ran by 'make e2e' are not
fully end-to-end because they often don't call semgrep
but instead use an optimization hack called the ClickRunner
to avoid a fork. To be real e2e, we need the fork instead,
and we need to call cli/bin/semgrep, especially if we want
to port more code to osemgrep; otherwise the test will just
exercise the pysemgrep code

This is just the first part of the process of moving away
from the ClickRunner to a real fork.

test plan:
make e2e


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)