### PR TITLE
osemgrep: cleanup cli.py and move git safe dir to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -221,10 +221,17 @@ RUN addgroup --system semgrep \
 # We can set it by default once we fix the circle ci workflows
 #USER semgrep
 
+# Configure Git to be willing to run in /src when we're in Docker.
 # Workaround for rootless containers as git operations may fail due to dubious
 # ownership of /src
-RUN printf "[safe]\n	directory = /src"  > ~root/.gitconfig
-RUN printf "[safe]\n	directory = /src"  > ~semgrep/.gitconfig && \
+# In docker, every path is trusted:
+# - the user explicitly mounts their trusted code directory
+# - Semgrep provides every other path
+# More info:
+# - https://github.blog/2022-04-12-git-security-vulnerability-announced/
+# - https://github.com/actions/checkout/issues/766
+RUN printf "[safe]\n	directory = /src\n"  > ~root/.gitconfig
+RUN printf "[safe]\n	directory = /src\n"  > ~semgrep/.gitconfig && \
 	chown semgrep:semgrep ~semgrep/.gitconfig
 
 

--- a/cli/src/semgrep/cli.py
+++ b/cli/src/semgrep/cli.py
@@ -12,48 +12,15 @@ from semgrep.commands.publish import publish
 from semgrep.commands.scan import scan
 from semgrep.default_group import DefaultGroup
 from semgrep.state import get_state
-from semgrep.util import git_check_output
 from semgrep.verbose_logging import getLogger
 
 logger = getLogger(__name__)
-
-
-def maybe_set_git_safe_directories() -> None:
-    """
-    Configure Git to be willing to run in any directory when we're in Docker.
-
-    In docker, every path is trusted:
-    - the user explicitly mounts their trusted code directory
-    - r2c provides every other path
-
-    More info:
-    - https://github.blog/2022-04-12-git-security-vulnerability-announced/
-    - https://github.com/actions/checkout/issues/766
-    """
-    env = get_state().env
-    if not env.in_docker:
-        return
-
-    try:
-        # "*" is used over Path.cwd() in case the user targets an absolute path instead of setting --workdir
-        git_check_output(["git", "config", "--global", "--add", "safe.directory", "*"])
-    except Exception as e:
-        logger.info(
-            f"Semgrep failed to set the safe.directory Git config option. Git commands might fail: {e}"
-        )
 
 
 @click.group(cls=DefaultGroup, default_command="scan", name="semgrep")
 @click.help_option("--help", "-h")
 @click.pass_context
 def cli(ctx: click.Context) -> None:
-    """
-    To get started quickly, run `semgrep scan --config auto`
-
-    Run `semgrep SUBCOMMAND --help` for more information on each subcommand
-
-    If no subcommand is passed, will run `scan` subcommand by default
-    """
     state = get_state()
     state.terminal.init_for_cli()
 
@@ -67,8 +34,6 @@ def cli(ctx: click.Context) -> None:
     state.app_session.user_agent.tags.add(f"command/{subcommand}")
     state.metrics.add_feature("subcommand", subcommand)
     state.command.set_subcommand(subcommand)
-
-    maybe_set_git_safe_directories()
 
 
 cli.add_command(ci)

--- a/src/osemgrep/cli/CLI.ml
+++ b/src/osemgrep/cli/CLI.ml
@@ -52,45 +52,6 @@ Commands:
 let default_subcommand = "scan"
 
 (*****************************************************************************)
-(* TOPORT *)
-(*****************************************************************************)
-
-(* TOPORT:
-      def maybe_set_git_safe_directories() -> None:
-          """
-          Configure Git to be willing to run in any directory when we're in Docker.
-
-          In docker, every path is trusted:
-          - the user explicitly mounts their trusted code directory
-          - r2c provides every other path
-
-          More info:
-          - https://github.blog/2022-04-12-git-security-vulnerability-announced/
-          - https://github.com/actions/checkout/issues/766
-          """
-          env = get_state().env
-          if not env.in_docker:
-              return
-
-          try:
-              # "*" is used over Path.cwd() in case the user targets an absolute path instead of setting --workdir
-              git_check_output(["git", "config", "--global", "--add", "safe.directory", "*"])
-          except Exception as e:
-              logger.info(
-                  f"Semgrep failed to set the safe.directory Git config option. Git commands might fail: {e}"
-              )
-
-   def abort_if_linux_arm64() -> None:
-       """
-       Exit with FATAL_EXIT_CODE if the user is running on Linux ARM64.
-       Print helpful error message.
-       """
-       if platform.machine() in {"arm64", "aarch64"} and platform.system() == "Linux":
-           logger.error("Semgrep does not support Linux ARM64")
-           sys.exit(FATAL_EXIT_CODE)
-*)
-
-(*****************************************************************************)
 (* Subcommands dispatch *)
 (*****************************************************************************)
 


### PR DESCRIPTION
Not sure why this was done in cli.py but it seems a better
separation of concern and least suprising to do this
git config in the Dockerfile instead.

test plan:
make e2e


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)