### PR TITLE
feat(git wrapper): adding git status to git wrapper

### DIFF
--- a/libs/git_wrapper/Git_wrapper.mli
+++ b/libs/git_wrapper/Git_wrapper.mli
@@ -2,7 +2,14 @@
 
 exception Error of string
 
-type status [@@deriving show]
+type status = {
+  added : string list;
+  modified : string list;
+  removed : string list;
+  unmerged : string list;
+  renamed : (string * string) list;
+}
+[@@deriving show]
 
 (* precondition: cwd must be a directory
    This returns a list of paths relative to cwd.

--- a/libs/git_wrapper/Git_wrapper.mli
+++ b/libs/git_wrapper/Git_wrapper.mli
@@ -2,10 +2,15 @@
 
 exception Error of string
 
+type status [@@deriving show]
+
 (* precondition: cwd must be a directory
    This returns a list of paths relative to cwd.
 *)
 val files_from_git_ls : cwd:Fpath.t -> Fpath.t list
+
+(* git status *)
+val status : cwd:Fpath.t -> commit:string -> status
 
 (* precondition: cwd must be a directory *)
 val is_git_repo : Fpath.t -> bool


### PR DESCRIPTION
Ported the git status function from pysemgrep to OCaml.

Manually tested on the semgrep repository by executing a search to identify the modified files within the last 200 commits.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
