### PR TITLE
feat: support ocaml earlybird

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,29 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Semgrep Core: Help",
+      "type": "ocaml.earlybird",
+      "request": "launch",
+      "program": "${workspaceFolder}/bin/semgrep-core.bc",
+      "arguments": ["--help"],
+      "preLaunchTask": "Build Core Bytecode"
+    },
+    {
+      "name": "OSemgrep: Help",
+      "type": "ocaml.earlybird",
+      "request": "launch",
+      "program": "${workspaceFolder}/bin/osemgrep.bc",
+      "arguments": ["--help"],
+      "preLaunchTask": "Build Core Bytecode"
+    },
+    {
+      "name": "OSemgrep: LSP",
+      "type": "ocaml.earlybird",
+      "request": "launch",
+      "program": "${workspaceFolder}/bin/osemgrep.bc",
+      "arguments": ["lsp", "--experimental"],
+      "preLaunchTask": "Build Core Bytecode"
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -5,16 +5,31 @@
     {
       "label": "Build",
       "type": "shell",
-      "command": "dune build",
+      "command": "make",
       "group": {
-        "kind": "build",
-        "isDefault": true
+        "kind": "build"
+      }
+    },
+    {
+      "label": "Build Core",
+      "type": "shell",
+      "command": "make core",
+      "group": {
+        "kind": "build"
+      }
+    },
+    {
+      "label": "Build Core Bytecode",
+      "type": "shell",
+      "command": "make core-bc",
+      "group": {
+        "kind": "build"
       }
     },
     {
       "label": "Test",
       "type": "shell",
-      "command": "dune runtest -f",
+      "command": "make test",
       "group": {
         "kind": "test",
         "isDefault": true

--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,15 @@ core:
 	test -e bin || ln -s _build/install/default/bin .
 	ln -s semgrep-core bin/osemgrep
 
+#history: was called the 'all' target in semgrep-core/Makefile before
+.PHONY: core-bc
+core-bc: minimal-build-bc
+	# make executables easily accessible for manual testing:
+	test -e bin || ln -s _build/install/default/bin .
+	dune build @install # Generate the treesitter stubs for below
+	dune install # Needed to install treesitter_<lang> stubs for use by bytecode
+	ln -s semgrep-core.bc bin/osemgrep.bc
+
 # Make binaries available to pysemgrep
 .PHONY: copy-core-for-cli
 copy-core-for-cli:
@@ -94,6 +103,11 @@ copy-core-for-cli:
 .PHONY: minimal-build
 minimal-build:
 	dune build _build/install/default/bin/semgrep-core
+
+
+.PHONY: minimal-build-bc
+minimal-build-bc:
+	dune build _build/install/default/bin/semgrep-core.bc
 
 # It is better to run this from a fresh repo or after a 'make clean',
 # to not send too much data to the Docker daemon.

--- a/dune
+++ b/dune
@@ -16,7 +16,9 @@
     ; -6 is to allow to omit labels in function application
     ; -52 is to allow to match on Failure "precise_string"
     ; -58 is to allow missing cmx files (only a problem with Dyp)
-    (flags (:standard  -w -6-52-58))
+    ; -67 is to allow unused functor paramaters (introduced by dune 3.7)
+    ; -69 allows unused structure fields (introduced by dune 3.7)
+    (flags (:standard  -w -6-52-58-67-69))
     ; TODO: I've tried this, but this does not work so I've added --table in
     ; the few dune files using menhir
     ;(menhir_flags (--table))

--- a/dune-project
+++ b/dune-project
@@ -1,6 +1,9 @@
-(lang dune 2.7)
+(lang dune 3.7)
 (name semgrep)
 (using menhir 2.1)
+; disable mangling of of workspace root, to preserve debugging information
+; needed to support earlybird debugger
+(map_workspace_root false)
 
 ; Opam package declarations for public libraries and public executables
 ; defined in various dune files.

--- a/dune-project
+++ b/dune-project
@@ -3,6 +3,7 @@
 (using menhir 2.1)
 ; disable mangling of of workspace root, to preserve debugging information
 ; needed to support earlybird debugger
+; See https://dune.readthedocs.io/en/stable/dune-files.html#map-workspace-root
 (map_workspace_root false)
 
 ; Opam package declarations for public libraries and public executables

--- a/src/main/Main.ml
+++ b/src/main/Main.ml
@@ -52,6 +52,7 @@
 let () =
   match Filename.basename Sys.argv.(0) with
   (* osemgrep!! *)
+  | "osemgrep.bc"
   | "osemgrep" ->
       Core_CLI.register_exception_printers ();
       let exit_code = CLI.main Sys.argv |> Exit_code.to_int in

--- a/src/main/dune
+++ b/src/main/dune
@@ -21,5 +21,8 @@
  (package semgrep)
  (section bin)
  ; LATER: at some point we should copy it as osemgrep instead
- (files (Main.exe as semgrep-core))
+ (files
+  (Main.exe as semgrep-core)
+  (Main.bc as semgrep-core.bc)
+ )
 )


### PR DESCRIPTION
This PR adds support for running osemgrep/semgrep-core with the debugger [earlybird](https://github.com/hackwaly/ocamlearlybird).

Changes needed:

- Upgrade to dune 3.7 to disable map_workspace_root (see comments)
- Added bytecode makefile targets
- Added vscode tasks to build bytecode targets + launch debugger
- Check for osemgrep.bc in entrypoint to correctly enter osemgrep in bytecode mode
- Disable warnings introduced in the new version of dune

We may want to circle back and fix the warnings introduced by upgrading dune, but I figured that can happen in a separate PR.

Note that to test this PR one must run `opam install earlybird`

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
