### PR TITLE
fix: Separate tasks for generating bytecode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,8 +86,6 @@ core:
 core-bc: minimal-build-bc
 	# make executables easily accessible for manual testing:
 	test -e bin || ln -s _build/install/default/bin .
-	dune build @install # Generate the treesitter stubs for below
-	dune install # Needed to install treesitter_<lang> stubs for use by bytecode
 	ln -s semgrep-core.bc bin/osemgrep.bc
 
 # Make binaries available to pysemgrep
@@ -247,6 +245,12 @@ install-deps-for-semgrep-core:
 	# Install OCaml dependencies (globally).
 	opam install -y --deps-only ./libs/ocaml-tree-sitter-core
 	opam install -y --deps-only ./
+
+# The bytecode version of semgrep-core needs dlls for tree-sitter
+# stubs installed into ~/.opam/<switch>/lib/stublibs to be able to run.
+install-deps-for-semgrep-core-bc: install-deps-for-semgrep-core
+	dune build @install # Generate the treesitter stubs for below
+	dune install # Needed to install treesitter_<lang> stubs for use by bytecode
 
 # We could also add python dependencies at some point
 # and an 'install-deps-for-semgrep-cli' target


### PR DESCRIPTION
I didn't like having to rebuild and reinstall tree-sitter related deps everytime we build the bytecode version of semgrep-core. This step is only needed when parsers are updated/added, so I separated it into a separate makefile target.

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
