### PR TITLE
chore: kill numeric capture metavars for real

### DIFF
--- a/changelog.d/pa-3012.changed
+++ b/changelog.d/pa-3012.changed
@@ -1,0 +1,5 @@
+Rule syntax: Numeric capture group metavariables in regex patterns
+have been removed. Now, in order to introduce metavariables in
+regular expressions, you must use named capture groups.
+
+This was something deprecated in 1.30, that has finally been removed.

--- a/cli/tests/e2e/snapshots/test_nosemgrep/test_regex_rule__nosemgrep/results.json
+++ b/cli/tests/e2e/snapshots/test_nosemgrep/test_regex_rule__nosemgrep/results.json
@@ -25,58 +25,6 @@
           "source-rule-url": "https://github.com/grab/secret-scanner/blob/master/scanner/signatures/pattern.go"
         },
         "metavars": {
-          "$2": {
-            "abstract_content": "aws",
-            "end": {
-              "col": 4,
-              "line": 3,
-              "offset": 47
-            },
-            "start": {
-              "col": 1,
-              "line": 3,
-              "offset": 44
-            }
-          },
-          "$3": {
-            "abstract_content": "account",
-            "end": {
-              "col": 12,
-              "line": 3,
-              "offset": 55
-            },
-            "start": {
-              "col": 5,
-              "line": 3,
-              "offset": 48
-            }
-          },
-          "$4": {
-            "abstract_content": "id",
-            "end": {
-              "col": 15,
-              "line": 3,
-              "offset": 58
-            },
-            "start": {
-              "col": 13,
-              "line": 3,
-              "offset": 56
-            }
-          },
-          "$6": {
-            "abstract_content": ":",
-            "end": {
-              "col": 16,
-              "line": 3,
-              "offset": 59
-            },
-            "start": {
-              "col": 15,
-              "line": 3,
-              "offset": 58
-            }
-          },
           "$ACCOUNT": {
             "abstract_content": "account",
             "end": {


### PR DESCRIPTION
## What:
This PR finally removes numeric capture group metavariables, as it's been about two months since we said we would, in Release 1.30: https://github.com/returntocorp/semgrep/releases/tag/v1.30.0

## Why:
We agreed to wait for a bit to sunset the feature, and it's about time.

## How:
Removed the code and then updated the tests.

## Test plan:
`make test`

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
