### PR TITLE
semgrep.js: implement pcre_get_stringnumber_stub_bc + add test

### DIFF
--- a/changelog.d/gh-8520.fixed
+++ b/changelog.d/gh-8520.fixed
@@ -1,0 +1,1 @@
+Implement missing pcre-ocaml stub (pcre_get_stringnumber_stub_bc) in JavaScript

--- a/js/libpcre/Makefile.include
+++ b/js/libpcre/Makefile.include
@@ -1,1 +1,1 @@
-PCRE_EXPORTED_METHODS := _pcre_version,_pcre_config,_pcre_compile,_pcre_study,_pcre_fullinfo,_pcre_exec
+PCRE_EXPORTED_METHODS := _pcre_version,_pcre_config,_pcre_compile,_pcre_study,_pcre_fullinfo,_pcre_exec,_pcre_get_stringnumber

--- a/js/libpcre/runtime.test.js
+++ b/js/libpcre/runtime.test.js
@@ -96,4 +96,24 @@ describe("pcre-ocaml stubs", () => {
       stubs.pcre_exec_stub_bc(0, regex, ovec[2], 0, subject, ovec, 0, 0)
     ).toThrow(NotFoundError);
   });
+
+  test("pcre_get_stringnumber works with named capture groups", async () => {
+    await libpcrePromise;
+    const stubs = require("../libpcre");
+    const regex = stubs.pcre_compile_stub_bc(
+      0,
+      0,
+      "(?<numbers>[0-9]+)(?<letters>[a-z]+)"
+    );
+    const subject = "123abc";
+
+    stubs.pcre_exec_stub_bc(0, regex, 0, 0, subject, [0, 0, 0, 0], 0, 0);
+
+    expect(stubs.pcre_get_stringnumber_stub_bc(regex, "numbers")).toEqual(1);
+    expect(stubs.pcre_get_stringnumber_stub_bc(regex, "letters")).toEqual(2);
+
+    expect(() => stubs.pcre_get_stringnumber_stub_bc(regex, "foobar")).toThrow(
+      "invalid argument"
+    );
+  });
 });


### PR DESCRIPTION
Running semgrep.js against a regex pattern containing named capture groups fails because of an unimplemented method (`pcre_get_stringnumber_stub_bc()`). This PR implements that method and adds a test to confirm it works.

test plan:
- [x] new test passes
- [x] checks pass
- [x] regex pattern with named capture groups doesnt error out in playground

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
