### PR TITLE
osemgrep: switch to real e2e testing, part 2

### DIFF
--- a/cli/Makefile
+++ b/cli/Makefile
@@ -40,9 +40,9 @@ clean:
 
 # From fastest to slowest (on pad's machine):
 # - 'make quick-tests' (=~ 30s)
-# - 'make e2e' (=~ 1m14s)
-# - 'make kinda-quick-tests' (=~ 2min30s )
-# - 'make test' (=~ 10min)
+# - 'make e2e' (=~ 2m20s)
+# - 'make kinda-quick-tests' (=~ 3min40s )
+# - 'make test' (=~ 11min)
 
 PYTEST ?= pipenv run pytest -v --tb=short --durations=10
 

--- a/cli/tests/conftest.py
+++ b/cli/tests/conftest.py
@@ -322,7 +322,7 @@ def _run_semgrep(
     force_metrics_off: bool = True,
     stdin: Optional[str] = None,
     clean_fingerprint: bool = True,
-    use_click_runner: bool = True,  # TODO: change to False. deprecated! Avoid using! see semgrep_runner.py
+    use_click_runner: bool = False,  # TODO: change to False. deprecated! Avoid using! see semgrep_runner.py
 ) -> SemgrepResult:
     """Run the semgrep CLI.
 

--- a/cli/tests/conftest.py
+++ b/cli/tests/conftest.py
@@ -322,7 +322,7 @@ def _run_semgrep(
     force_metrics_off: bool = True,
     stdin: Optional[str] = None,
     clean_fingerprint: bool = True,
-    use_click_runner: bool = False,  # TODO: change to False. deprecated! Avoid using! see semgrep_runner.py
+    use_click_runner: bool = False,  # Deprecated! see semgrep_runner.py toplevel comment
 ) -> SemgrepResult:
     """Run the semgrep CLI.
 

--- a/cli/tests/e2e/test_ci.py
+++ b/cli/tests/e2e/test_ci.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Prelude
+##############################################################################
+# Testing 'semgrep ci' "end-to-end".
+#
+# TODO: actually most of the tests in this file rely on use_click_runner=True
+# because of some mocking and monkeypatching. Thus, this is this not
+# a real e2e test because cli/bin/semgrep is not invoked.
+# Try to use environment variables instead of Python monkey patching
+# so that those tests can also pass with osemgrep.
 import json
 import re
 import shutil
@@ -24,6 +34,9 @@ from semgrep.meta import GitlabMeta
 from semgrep.meta import GitMeta
 from semgrep.metrics import Metrics
 
+##############################################################################
+# Constants
+##############################################################################
 
 pytestmark = pytest.mark.kinda_slow
 
@@ -46,6 +59,11 @@ BAD_CONFIG = dedent(
       severity: ERROR
 """
 ).lstrip()
+
+
+##############################################################################
+# Fixtures
+##############################################################################
 
 
 @pytest.fixture
@@ -340,6 +358,11 @@ def automocks(mocker):
 @pytest.fixture(params=[True, False], ids=["autofix", "noautofix"])
 def mock_autofix(request, mocker):
     mocker.patch.object(ScanHandler, "autofix", request.param)
+
+
+##############################################################################
+# The tests
+##############################################################################
 
 
 @pytest.mark.parametrize(
@@ -716,6 +739,7 @@ def test_full_run(
         strict=False,
         assert_exit_code=None,
         env=env,
+        use_click_runner=True,  # TODO: probably because rely on some mocking
     )
 
     snapshot.assert_match(
@@ -839,6 +863,7 @@ def test_lockfile_parse_failure_reporting(
         strict=False,
         assert_exit_code=None,
         env={"SEMGREP_APP_TOKEN": "fake-key-from-tests"},
+        use_click_runner=True,  # TODO: probably because rely on some mocking
     )
     snapshot.assert_match(
         result.as_snapshot(
@@ -1141,6 +1166,7 @@ def test_shallow_wrong_merge_base(
         strict=False,
         assert_exit_code=None,
         env=env,
+        use_click_runner=True,  # TODO: probably because rely on some mocking
     )
     snapshot.assert_match(
         result.as_snapshot(
@@ -1165,6 +1191,7 @@ def test_shallow_wrong_merge_base(
         strict=False,
         assert_exit_code=None,
         env={**env, "SEMGREP_GHA_MIN_FETCH_DEPTH": "100"},
+        use_click_runner=True,  # TODO: probably because rely on some mocking
     )
 
     snapshot.assert_match(
@@ -1196,6 +1223,7 @@ def test_config_run(
         strict=False,
         assert_exit_code=None,
         env={"SEMGREP_APP_TOKEN": ""},
+        use_click_runner=True,  # TODO: probably because rely on some mocking
     )
     snapshot.assert_match(
         result.as_snapshot(
@@ -1224,6 +1252,7 @@ def test_outputs(
         assert_exit_code=None,
         output_format=None,
         env={"SEMGREP_APP_TOKEN": "fake_key"},
+        use_click_runner=True,  # TODO: probably because rely on some mocking
     )
     snapshot.assert_match(
         result.as_snapshot(
@@ -1248,6 +1277,7 @@ def test_nosem(
         strict=False,
         assert_exit_code=None,
         env={"SEMGREP_APP_TOKEN": ""},
+        use_click_runner=True,  # TODO: probably because rely on some mocking
     )
     snapshot.assert_match(
         result.as_snapshot(
@@ -1269,6 +1299,7 @@ def test_dryrun(tmp_path, git_tmp_path_with_commit, snapshot, run_semgrep: RunSe
         strict=False,
         assert_exit_code=None,
         env={"SEMGREP_APP_TOKEN": "fake-key-from-tests"},
+        use_click_runner=True,  # TODO: probably because rely on some mocking
     )
 
     AppSession.post.assert_not_called()  # type: ignore
@@ -1298,6 +1329,7 @@ def test_fail_auth(run_semgrep: RunSemgrep, mocker, git_tmp_path_with_commit):
         strict=False,
         assert_exit_code=13,
         env={"SEMGREP_APP_TOKEN": "fake-key-from-tests"},
+        use_click_runner=True,  # TODO: probably because rely on some mocking
     )
 
     mocker.patch("semgrep.app.auth.get_deployment_from_token", side_effect=Exception)
@@ -1307,6 +1339,7 @@ def test_fail_auth(run_semgrep: RunSemgrep, mocker, git_tmp_path_with_commit):
         strict=False,
         assert_exit_code=2,
         env={"SEMGREP_APP_TOKEN": "fake-key-from-tests"},
+        use_click_runner=True,  # TODO: probably because rely on some mocking
     )
 
 
@@ -1324,6 +1357,7 @@ def test_fail_auth_error_handler(
         strict=False,
         assert_exit_code=0,
         env={"SEMGREP_APP_TOKEN": "fake-key-from-tests"},
+        use_click_runner=True,  # TODO: probably because rely on some mocking
     )
 
     mock_send.assert_called_once_with(mocker.ANY, 2)
@@ -1342,6 +1376,7 @@ def test_fail_start_scan(run_semgrep: RunSemgrep, mocker, git_tmp_path_with_comm
         strict=False,
         assert_exit_code=2,
         env={"SEMGREP_APP_TOKEN": "fake-key-from-tests"},
+        use_click_runner=True,  # TODO: probably because rely on some mocking
     )
 
 
@@ -1359,6 +1394,7 @@ def test_fail_start_scan_error_handler(
         strict=False,
         assert_exit_code=0,
         env={"SEMGREP_APP_TOKEN": "fake-key-from-tests"},
+        use_click_runner=True,  # TODO: probably because rely on some mocking
     )
 
     mock_send.assert_called_once_with(mocker.ANY, 2)
@@ -1385,6 +1421,7 @@ def test_bad_config(run_semgrep: RunSemgrep, mocker, git_tmp_path_with_commit):
         strict=False,
         assert_exit_code=7,
         env={"SEMGREP_APP_TOKEN": "fake-key-from-tests"},
+        use_click_runner=True,  # TODO: probably because rely on some mocking
     )
     assert "Invalid rule schema" in result.stderr
 
@@ -1413,6 +1450,7 @@ def test_bad_config_error_handler(
         strict=False,
         assert_exit_code=0,
         env={"SEMGREP_APP_TOKEN": "fake-key-from-tests"},
+        use_click_runner=True,  # TODO: probably because rely on some mocking
     )
     assert "Invalid rule schema" in result.stderr
     mock_send.assert_called_once_with(mocker.ANY, 7)
@@ -1432,6 +1470,7 @@ def test_fail_scan_findings(run_semgrep: RunSemgrep, mocker, git_tmp_path_with_c
         strict=False,
         assert_exit_code=1,
         env={"SEMGREP_APP_TOKEN": "fake-key-from-tests"},
+        use_click_runner=True,  # TODO: probably because rely on some mocking
     )
     mock_send.assert_called_once_with(mocker.ANY, 1)
     mock_request_post.assert_not_called()
@@ -1450,6 +1489,7 @@ def test_fail_finish_scan(run_semgrep: RunSemgrep, mocker, git_tmp_path_with_com
         strict=False,
         assert_exit_code=2,
         env={"SEMGREP_APP_TOKEN": "fake-key-from-tests"},
+        use_click_runner=True,  # TODO: probably because rely on some mocking
     )
 
 
@@ -1466,6 +1506,7 @@ def test_backend_exit_code(run_semgrep: RunSemgrep, mocker, git_tmp_path_with_co
         strict=False,
         assert_exit_code=1,
         env={"SEMGREP_APP_TOKEN": "fake-key-from-tests"},
+        use_click_runner=True,  # TODO: probably because rely on some mocking
     )
 
 
@@ -1483,6 +1524,7 @@ def test_fail_finish_scan_error_handler(
         strict=False,
         assert_exit_code=0,
         env={"SEMGREP_APP_TOKEN": "fake-key-from-tests"},
+        use_click_runner=True,  # TODO: probably because rely on some mocking
     )
     mock_send.assert_called_once_with(mocker.ANY, 2)
 
@@ -1500,6 +1542,7 @@ def test_git_failure(run_semgrep: RunSemgrep, git_tmp_path_with_commit, mocker):
         strict=False,
         assert_exit_code=2,
         env={"SEMGREP_APP_TOKEN": "fake-key-from-tests"},
+        use_click_runner=True,  # TODO: probably because rely on some mocking
     )
 
 
@@ -1517,6 +1560,7 @@ def test_git_failure_error_handler(
         strict=False,
         assert_exit_code=0,
         env={"SEMGREP_APP_TOKEN": "fake-key-from-tests"},
+        use_click_runner=True,  # TODO: probably because rely on some mocking
     )
     mock_send.assert_called_once_with(mocker.ANY, 2)
 
@@ -1569,6 +1613,7 @@ def test_query_dependency(
         strict=False,
         assert_exit_code=None,
         env={"SEMGREP_APP_TOKEN": "fake_key"},
+        use_click_runner=True,  # TODO: probably because rely on some mocking
     )
     snapshot.assert_match(
         result.as_snapshot(
@@ -1599,6 +1644,7 @@ def test_metrics_enabled(run_semgrep: RunSemgrep, mocker):
         assert_exit_code=1,
         force_metrics_off=False,
         env={"SEMGREP_APP_TOKEN": "fake-key-from-tests"},
+        use_click_runner=True,  # TODO: probably because rely on some mocking
     )
     mock_send.assert_called_once()
 
@@ -1646,6 +1692,7 @@ def test_existing_supply_chain_finding(
         strict=False,
         assert_exit_code=None,
         env={"SEMGREP_APP_TOKEN": "fake_key"},
+        use_click_runner=True,  # TODO: probably because rely on some mocking
     )
     snapshot.assert_match(
         result.as_snapshot(
@@ -1718,6 +1765,7 @@ def test_existing_supply_chain_finding(
         strict=False,
         assert_exit_code=None,
         env={"SEMGREP_APP_TOKEN": "fake_key"},
+        use_click_runner=True,  # TODO: probably because rely on some mocking
     )
     snapshot.assert_match(
         result.as_snapshot(

--- a/cli/tests/e2e/test_fixtest.py
+++ b/cli/tests/e2e/test_fixtest.py
@@ -94,6 +94,7 @@ def test_fixtest_test4_no_json(run_semgrep_in_tmp: RunSemgrep, snapshot):
         options=["--test"],
         output_format=OutputFormat.TEXT,
         assert_exit_code=1,
+        use_click_runner=True,  # TODO: does not seem related to mocking but still fail with False
     )
     snapshot.assert_match(
         results.as_snapshot(
@@ -111,6 +112,7 @@ def test_fixtest_test4_json(run_semgrep_in_tmp: RunSemgrep, snapshot):
         options=["--test"],
         output_format=OutputFormat.JSON,
         assert_exit_code=1,
+        use_click_runner=True,  # TODO: does not seem related to mocking but still fail with False
     )
     snapshot.assert_match(
         results.as_snapshot(

--- a/cli/tests/e2e/test_ignores.py
+++ b/cli/tests/e2e/test_ignores.py
@@ -34,7 +34,11 @@ def test_default_semgrepignore(run_semgrep_in_tmp: RunSemgrep, snapshot):
 # Input from stdin will not have a path that is relative to tmp_path, where we're running semgrep
 @pytest.mark.kinda_slow
 def test_file_not_relative_to_base_path(run_semgrep: RunSemgrep, snapshot):
-    results = run_semgrep(options=["--json", "-e", "a", "--lang", "js", "-"], stdin="a")
+    results = run_semgrep(
+        options=["--json", "-e", "a", "--lang", "js", "-"],
+        stdin="a",
+        use_click_runner=True,  # TODO: probably because of stdin?
+    )
     results.raw_stdout = _clean_output_json(results.raw_stdout, True)
     snapshot.assert_match(results.as_snapshot(), "results.txt")
 

--- a/cli/tests/fixtures.py
+++ b/cli/tests/fixtures.py
@@ -29,5 +29,6 @@ class RunSemgrep(Protocol):
         force_metrics_off: bool = True,
         stdin: str | None = None,
         clean_fingerprint: bool = True,
+        use_click_runner: bool = False,
     ) -> SemgrepResult:
         ...

--- a/cli/tests/semgrep_runner.py
+++ b/cli/tests/semgrep_runner.py
@@ -3,15 +3,16 @@
 ##############################################################################
 # Small wrapper around 'semgrep' useful for writing end-to-end (e2e) tests.
 #
-# TODO: This file was originally introduced to optimize the way we were running
+# old: This file was originally introduced to optimize the way we were running
 # semgrep in tests by using Click and its CliRunner to avoid an extra fork.
 # However, with the introduction of osemgrep and the new cli/bin/semgrep (which
 # dispatch to osemgrep), we actually want to avoid to use the CliRunner which
 # only run pysemgrep code. Otherwise, our e2e tests would not be really end-to
 # -end and may not represent what the user would get by using semgrep directly.
-# This is why using the CliRunner option is now deprecated. The option is still
-# kept because a few of our tests still rely on Click-specific features that
-# the regular call-semgrep-in-a-subprocess does not provide yet.
+# This is why using the CliRunner option is now deprecated.
+# TODO: The option is still kept because a few of our tests still rely on
+# Click-specific features (e.g., mocking)  that the regular
+# call-semgrep-in-a-subprocess does not provide yet.
 import os
 import shlex
 from dataclasses import dataclass
@@ -89,13 +90,11 @@ def fork_semgrep(
         arg_list = shlex.split(args)
     elif isinstance(args, List):
         arg_list = args
-    argv: List[str] = []
 
+    argv: List[str] = SEMGREP_BASE_COMMAND + arg_list
     # ugly: adding --project-root for --help would trigger the wrong help message
     if "-h" in arg_list or "--help" in arg_list:
         argv = [_SEMGREP_PATH] + arg_list
-    else:
-        argv = [_SEMGREP_PATH] + _OSEMGREP_EXTRA_ARGS + arg_list
 
     # env preparation
     env_dict = {}


### PR DESCRIPTION
This is a followup to #8492.
Our end-to-end (e2e) tests ran by 'make e2e' were not
fully end-to-end because they often didn't call semgrep
but instead use an optimization hack called the ClickRunner
to avoid a fork.
With this PR, we switch back to a real fork, which is slower,
but correct.
There's only a few remaining e2e tests that still use the
Click_runner (mostly test_ci.py because of heavy use of Python
mocking).

test plan:
make e2e!


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)