### PR TITLE
feat: Add secrets flag.

### DIFF
--- a/cli/src/semgrep/commands/ci.py
+++ b/cli/src/semgrep/commands/ci.py
@@ -148,6 +148,7 @@ def fix_head_if_github_action(metadata: GitMeta) -> None:
     is_flag=True,
     hidden=True,
 )
+@click.option("--beta-testing-secrets", is_flag=True, hidden=True)
 @click.option(
     "--suppress-errors/--no-suppress-errors",
     "suppress_errors",
@@ -166,6 +167,7 @@ def ci(
     audit_on: Sequence[str],
     autofix: bool,
     baseline_commit: Optional[str],
+    beta_testing_secrets: bool,
     core_opts: Optional[str],
     config: Optional[Tuple[str, ...]],
     debug: bool,
@@ -250,6 +252,24 @@ def ci(
     else:  # impossible state… until we break the code above
         raise RuntimeError("The token and/or config are misconfigured")
 
+    if beta_testing_secrets:
+        if supply_chain:
+            # Not logged in and no explicit config
+            logger.info("Cannot use both `--supply-chain` and `--beta-testing-secrets`")
+            sys.exit(FATAL_EXIT_CODE)
+
+        # TODO: I think this eventually be EngineType.PRO_INTRAFILE, but the
+        # secrets code currently hooks into the interfile search.
+        if requested_engine is EngineType.PRO_INTERFILE:
+            logger.info("No need to specify `--beta-testing-secrets` and `--pro`")
+        elif requested_engine is None:
+            requested_engine = EngineType.PRO_INTERFILE
+        else:
+            logger.info(
+                "Cannot use both `--beta-testing-secrets` and engine types besided `--pro`"
+            )
+            sys.exit(FATAL_EXIT_CODE)
+
     output_settings = OutputSettings(
         output_format=output_format,
         output_destination=output,
@@ -287,6 +307,7 @@ def ci(
             console.print(Title("Connection", order=2))
             metadata_dict = metadata.to_dict()
             metadata_dict["is_sca_scan"] = supply_chain
+            metadata_dict["is_secrets_scan"] = beta_testing_secrets
             proj_config = ProjectConfig.load_all()
             metadata_dict = {**metadata_dict, **proj_config.to_dict()}
             with Progress(
@@ -349,6 +370,10 @@ def ci(
                 markup=True,
             )
         else:
+            if beta_testing_secrets:
+                console.print(
+                    "Secrets currently requires the pro-engine, installing now."
+                )
             run_install_semgrep_pro()
 
     try:

--- a/cli/src/semgrep/commands/ci.py
+++ b/cli/src/semgrep/commands/ci.py
@@ -266,7 +266,7 @@ def ci(
             requested_engine = EngineType.PRO_INTERFILE
         else:
             logger.info(
-                "Cannot use both `--beta-testing-secrets` and engine types besided `--pro`"
+                "Cannot use the `--beta-testing-secrets` flag with engine types besides `--pro`"
             )
             sys.exit(FATAL_EXIT_CODE)
 

--- a/cli/src/semgrep/commands/ci.py
+++ b/cli/src/semgrep/commands/ci.py
@@ -253,13 +253,8 @@ def ci(
         raise RuntimeError("The token and/or config are misconfigured")
 
     if beta_testing_secrets:
-        if supply_chain:
-            # Not logged in and no explicit config
-            logger.info("Cannot use both `--supply-chain` and `--beta-testing-secrets`")
-            sys.exit(FATAL_EXIT_CODE)
-
-        # TODO: I think this eventually be EngineType.PRO_INTRAFILE, but the
-        # secrets code currently hooks into the interfile search.
+        # TODO: I think this should eventually be PRO_INTRAFILE, but
+        # the secrets code currently hooks into the interfile search.
         if requested_engine is EngineType.PRO_INTERFILE:
             logger.info("No need to specify `--beta-testing-secrets` and `--pro`")
         elif requested_engine is None:

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines-overwrite-autodetected-variables/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines-overwrite-autodetected-variables/meta.json
@@ -18,6 +18,7 @@
     "pull_request_title": null,
     "scan_environment": "azure-pipelines",
     "is_full_scan": true,
-    "is_sca_scan": false
+    "is_sca_scan": false,
+    "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines/meta.json
@@ -18,6 +18,7 @@
     "pull_request_title": null,
     "scan_environment": "azure-pipelines",
     "is_full_scan": true,
-    "is_sca_scan": false
+    "is_sca_scan": false,
+    "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket-overwrite-autodetected-variables/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket-overwrite-autodetected-variables/meta.json
@@ -18,6 +18,7 @@
     "pull_request_title": null,
     "scan_environment": "bitbucket",
     "is_full_scan": true,
-    "is_sca_scan": false
+    "is_sca_scan": false,
+    "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket/meta.json
@@ -18,6 +18,7 @@
     "pull_request_title": null,
     "scan_environment": "bitbucket",
     "is_full_scan": true,
-    "is_sca_scan": false
+    "is_sca_scan": false,
+    "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite-overwrite-autodetected-variables/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite-overwrite-autodetected-variables/meta.json
@@ -18,6 +18,7 @@
     "pull_request_title": null,
     "scan_environment": "buildkite",
     "is_full_scan": true,
-    "is_sca_scan": false
+    "is_sca_scan": false,
+    "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite/meta.json
@@ -18,6 +18,7 @@
     "pull_request_title": null,
     "scan_environment": "buildkite",
     "is_full_scan": true,
-    "is_sca_scan": false
+    "is_sca_scan": false,
+    "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci-overwrite-autodetected-variables/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci-overwrite-autodetected-variables/meta.json
@@ -18,6 +18,7 @@
     "pull_request_title": null,
     "scan_environment": "circleci",
     "is_full_scan": true,
-    "is_sca_scan": false
+    "is_sca_scan": false,
+    "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci/meta.json
@@ -18,6 +18,7 @@
     "pull_request_title": null,
     "scan_environment": "circleci",
     "is_full_scan": true,
-    "is_sca_scan": false
+    "is_sca_scan": false,
+    "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/meta.json
@@ -18,6 +18,7 @@
     "pull_request_title": null,
     "scan_environment": "github-actions",
     "is_full_scan": true,
-    "is_sca_scan": false
+    "is_sca_scan": false,
+    "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr-semgrepconfig/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr-semgrepconfig/meta.json
@@ -19,6 +19,7 @@
     "scan_environment": "github-actions",
     "is_full_scan": false,
     "is_sca_scan": false,
+    "is_secrets_scan": false,
     "tags": [
       "tag1",
       "tag_key:tag_val"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr/meta.json
@@ -18,6 +18,7 @@
     "pull_request_title": null,
     "scan_environment": "github-actions",
     "is_full_scan": false,
-    "is_sca_scan": false
+    "is_sca_scan": false,
+    "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push-special-env-vars/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push-special-env-vars/meta.json
@@ -18,6 +18,7 @@
     "pull_request_title": "PR_TITLE",
     "scan_environment": "github-actions",
     "is_full_scan": true,
-    "is_sca_scan": false
+    "is_sca_scan": false,
+    "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/meta.json
@@ -18,6 +18,7 @@
     "pull_request_title": null,
     "scan_environment": "github-actions",
     "is_full_scan": true,
-    "is_sca_scan": false
+    "is_sca_scan": false,
+    "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-push/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-push/meta.json
@@ -20,6 +20,7 @@
     "is_full_scan": true,
     "base_sha": "sanitized",
     "start_sha": null,
-    "is_sca_scan": false
+    "is_sca_scan": false,
+    "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-special-env-vars/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-special-env-vars/meta.json
@@ -20,6 +20,7 @@
     "is_full_scan": false,
     "base_sha": "sanitized",
     "start_sha": "unused-commit-test-placeholder",
-    "is_sca_scan": false
+    "is_sca_scan": false,
+    "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab/meta.json
@@ -20,6 +20,7 @@
     "is_full_scan": false,
     "base_sha": "sanitized",
     "start_sha": "unused-commit-test-placeholder",
-    "is_sca_scan": false
+    "is_sca_scan": false,
+    "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/meta.json
@@ -18,6 +18,7 @@
     "pull_request_title": null,
     "scan_environment": "jenkins",
     "is_full_scan": true,
-    "is_sca_scan": false
+    "is_sca_scan": false,
+    "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-overwrite-autodetected-variables/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-overwrite-autodetected-variables/meta.json
@@ -18,6 +18,7 @@
     "pull_request_title": null,
     "scan_environment": "jenkins",
     "is_full_scan": true,
-    "is_sca_scan": false
+    "is_sca_scan": false,
+    "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins/meta.json
@@ -18,6 +18,7 @@
     "pull_request_title": null,
     "scan_environment": "jenkins",
     "is_full_scan": true,
-    "is_sca_scan": false
+    "is_sca_scan": false,
+    "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/meta.json
@@ -18,6 +18,7 @@
     "pull_request_title": null,
     "scan_environment": "git",
     "is_full_scan": true,
-    "is_sca_scan": false
+    "is_sca_scan": false,
+    "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-self-hosted/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-self-hosted/meta.json
@@ -18,6 +18,7 @@
     "pull_request_title": null,
     "scan_environment": "git",
     "is_full_scan": true,
-    "is_sca_scan": false
+    "is_sca_scan": false,
+    "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis-overwrite-autodetected-variables/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis-overwrite-autodetected-variables/meta.json
@@ -18,6 +18,7 @@
     "pull_request_title": null,
     "scan_environment": "travis-ci",
     "is_full_scan": true,
-    "is_sca_scan": false
+    "is_sca_scan": false,
+    "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis/meta.json
@@ -18,6 +18,7 @@
     "pull_request_title": null,
     "scan_environment": "travis-ci",
     "is_full_scan": true,
-    "is_sca_scan": false
+    "is_sca_scan": false,
+    "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-unparsable_url/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-unparsable_url/meta.json
@@ -18,6 +18,7 @@
     "pull_request_title": null,
     "scan_environment": "git",
     "is_full_scan": true,
-    "is_sca_scan": false
+    "is_sca_scan": false,
+    "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines-overwrite-autodetected-variables/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines-overwrite-autodetected-variables/meta.json
@@ -18,6 +18,7 @@
     "pull_request_title": null,
     "scan_environment": "azure-pipelines",
     "is_full_scan": true,
-    "is_sca_scan": false
+    "is_sca_scan": false,
+    "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines/meta.json
@@ -18,6 +18,7 @@
     "pull_request_title": null,
     "scan_environment": "azure-pipelines",
     "is_full_scan": true,
-    "is_sca_scan": false
+    "is_sca_scan": false,
+    "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket-overwrite-autodetected-variables/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket-overwrite-autodetected-variables/meta.json
@@ -18,6 +18,7 @@
     "pull_request_title": null,
     "scan_environment": "bitbucket",
     "is_full_scan": true,
-    "is_sca_scan": false
+    "is_sca_scan": false,
+    "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket/meta.json
@@ -18,6 +18,7 @@
     "pull_request_title": null,
     "scan_environment": "bitbucket",
     "is_full_scan": true,
-    "is_sca_scan": false
+    "is_sca_scan": false,
+    "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite-overwrite-autodetected-variables/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite-overwrite-autodetected-variables/meta.json
@@ -18,6 +18,7 @@
     "pull_request_title": null,
     "scan_environment": "buildkite",
     "is_full_scan": true,
-    "is_sca_scan": false
+    "is_sca_scan": false,
+    "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite/meta.json
@@ -18,6 +18,7 @@
     "pull_request_title": null,
     "scan_environment": "buildkite",
     "is_full_scan": true,
-    "is_sca_scan": false
+    "is_sca_scan": false,
+    "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci-overwrite-autodetected-variables/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci-overwrite-autodetected-variables/meta.json
@@ -18,6 +18,7 @@
     "pull_request_title": null,
     "scan_environment": "circleci",
     "is_full_scan": true,
-    "is_sca_scan": false
+    "is_sca_scan": false,
+    "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci/meta.json
@@ -18,6 +18,7 @@
     "pull_request_title": null,
     "scan_environment": "circleci",
     "is_full_scan": true,
-    "is_sca_scan": false
+    "is_sca_scan": false,
+    "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/meta.json
@@ -18,6 +18,7 @@
     "pull_request_title": null,
     "scan_environment": "github-actions",
     "is_full_scan": true,
-    "is_sca_scan": false
+    "is_sca_scan": false,
+    "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr-semgrepconfig/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr-semgrepconfig/meta.json
@@ -19,6 +19,7 @@
     "scan_environment": "github-actions",
     "is_full_scan": false,
     "is_sca_scan": false,
+    "is_secrets_scan": false,
     "tags": [
       "tag1",
       "tag_key:tag_val"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr/meta.json
@@ -18,6 +18,7 @@
     "pull_request_title": null,
     "scan_environment": "github-actions",
     "is_full_scan": false,
-    "is_sca_scan": false
+    "is_sca_scan": false,
+    "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push-special-env-vars/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push-special-env-vars/meta.json
@@ -18,6 +18,7 @@
     "pull_request_title": "PR_TITLE",
     "scan_environment": "github-actions",
     "is_full_scan": true,
-    "is_sca_scan": false
+    "is_sca_scan": false,
+    "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/meta.json
@@ -18,6 +18,7 @@
     "pull_request_title": null,
     "scan_environment": "github-actions",
     "is_full_scan": true,
-    "is_sca_scan": false
+    "is_sca_scan": false,
+    "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-push/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-push/meta.json
@@ -20,6 +20,7 @@
     "is_full_scan": true,
     "base_sha": "sanitized",
     "start_sha": null,
-    "is_sca_scan": false
+    "is_sca_scan": false,
+    "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-special-env-vars/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-special-env-vars/meta.json
@@ -20,6 +20,7 @@
     "is_full_scan": false,
     "base_sha": "sanitized",
     "start_sha": "unused-commit-test-placeholder",
-    "is_sca_scan": false
+    "is_sca_scan": false,
+    "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab/meta.json
@@ -20,6 +20,7 @@
     "is_full_scan": false,
     "base_sha": "sanitized",
     "start_sha": "unused-commit-test-placeholder",
-    "is_sca_scan": false
+    "is_sca_scan": false,
+    "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/meta.json
@@ -18,6 +18,7 @@
     "pull_request_title": null,
     "scan_environment": "jenkins",
     "is_full_scan": true,
-    "is_sca_scan": false
+    "is_sca_scan": false,
+    "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-overwrite-autodetected-variables/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-overwrite-autodetected-variables/meta.json
@@ -18,6 +18,7 @@
     "pull_request_title": null,
     "scan_environment": "jenkins",
     "is_full_scan": true,
-    "is_sca_scan": false
+    "is_sca_scan": false,
+    "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins/meta.json
@@ -18,6 +18,7 @@
     "pull_request_title": null,
     "scan_environment": "jenkins",
     "is_full_scan": true,
-    "is_sca_scan": false
+    "is_sca_scan": false,
+    "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/meta.json
@@ -18,6 +18,7 @@
     "pull_request_title": null,
     "scan_environment": "git",
     "is_full_scan": true,
-    "is_sca_scan": false
+    "is_sca_scan": false,
+    "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-self-hosted/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-self-hosted/meta.json
@@ -18,6 +18,7 @@
     "pull_request_title": null,
     "scan_environment": "git",
     "is_full_scan": true,
-    "is_sca_scan": false
+    "is_sca_scan": false,
+    "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis-overwrite-autodetected-variables/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis-overwrite-autodetected-variables/meta.json
@@ -18,6 +18,7 @@
     "pull_request_title": null,
     "scan_environment": "travis-ci",
     "is_full_scan": true,
-    "is_sca_scan": false
+    "is_sca_scan": false,
+    "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis/meta.json
@@ -18,6 +18,7 @@
     "pull_request_title": null,
     "scan_environment": "travis-ci",
     "is_full_scan": true,
-    "is_sca_scan": false
+    "is_sca_scan": false,
+    "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-unparsable_url/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-unparsable_url/meta.json
@@ -18,6 +18,7 @@
     "pull_request_title": null,
     "scan_environment": "git",
     "is_full_scan": true,
-    "is_sca_scan": false
+    "is_sca_scan": false,
+    "is_secrets_scan": false
   }
 }


### PR DESCRIPTION
## What
Adds a flag to communicate with the backend that only secrets rules should be sent for CI. The flag is hidden, and currently doesn't do anything but the regular scan, because the backend doesn't curate the rule for secrets yet, that is coming in a later release.

## Testing
I ran the following commands:
```
# These ran a regular CI scan
$ semgrep ci
$ semgrep ci --beta-testing-secrets 
$ semgrep ci --beta-testing-secrets --pro
# These error with a terse message.
$ semgrep ci --beta-testing-secrets --oss-only
$ semgrep ci --beta-testing-secrets --supply-chain
```

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
  - Not user facing right now.
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
