### PR TITLE
chore: update registry urls

### DIFF
--- a/cli/src/semgrep/app/registry.py
+++ b/cli/src/semgrep/app/registry.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 def list_current_public_rulesets() -> List[JsonObject]:
     state = get_state()
-    api_full_url = f"{state.env.semgrep_url}/api/registry/ruleset"
+    api_full_url = f"{state.env.semgrep_url}/api/registry/rulesets"
     try:
         r = state.app_session.get(api_full_url)
     except Exception:

--- a/cli/src/semgrep/commands/publish.py
+++ b/cli/src/semgrep/commands/publish.py
@@ -189,7 +189,7 @@ def _upload_rule(
         "registry_check_id": registry_id,
     }
     response = state.app_session.post(
-        f"{state.env.semgrep_url}/api/registry/rule", json=request_json
+        f"{state.env.semgrep_url}/api/registry/rules", json=request_json
     )
 
     if not response.ok:


### PR DESCRIPTION
Over a year ago, we standardized the semgrep.dev backend URL convention to use plural nouns. I just discovered that we never updated the CLI to start using this convention as well, which is necessary if we are ever going to delete the singular-noun versions of our API endpoints. This PR helps with that by changing 2 singular-noun endpoints to use the plural-noun versions (both are still supported on the app for now) 😄  

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
