### PR TITLE
feat(git wrapper): Run with git worktree

### DIFF
--- a/libs/git_wrapper/Git_wrapper.mli
+++ b/libs/git_wrapper/Git_wrapper.mli
@@ -16,6 +16,24 @@ type status = {
 *)
 val files_from_git_ls : cwd:Fpath.t -> Fpath.t list
 
+(* Executing a function inside a directory created from git-worktree.
+
+   `git worktree` is doing 90% of the heavy lifting here. Docs:
+   https://git-scm.com/docs/git-worktree
+
+   In short, git allows you to have multiple working trees checked out at
+   the same time. This means you can essentially have X different
+   branches/commits checked out from the same repo, in different locations
+
+   Different worktrees share the same .git directory, so this is a lot
+   faster/cheaper than cloning the repo multiple times
+
+   This also allows us to not worry about git state, since
+   unstaged/staged files are not shared between worktrees. This means we
+   don't need to git stash anything, or expect a clean working tree.
+*)
+val run_with_worktree : commit:string -> (unit -> 'a) -> 'a
+
 (* git status *)
 val status : cwd:Fpath.t -> commit:string -> status
 

--- a/libs/git_wrapper/dune
+++ b/libs/git_wrapper/dune
@@ -6,6 +6,7 @@
   (libraries
      fpath
      bos
+     uuidm
 
      commons
   )


### PR DESCRIPTION
OCaml port of BaselineHandler.baseline_context from pysemgrep

Test plan: manually tested by running `scan_files` function with different worktree snapshots of semgrep repo

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
