### PR TITLE
Remove module alias: Output_from_core_{t,j} -> Semgrep_output_v1_{t,j}

### DIFF
--- a/js/engine/Main.ml
+++ b/js/engine/Main.ml
@@ -125,5 +125,5 @@ let _ =
            JSON_report.match_results_of_matches_and_errors
              (Some Autofix.render_fix) (List.length files) res
          in
-         Output_from_core_j.string_of_core_match_results res
+         Semgrep_output_v1_j.string_of_core_match_results res
     end)

--- a/src/engine/Match_env.ml
+++ b/src/engine/Match_env.ml
@@ -14,7 +14,7 @@
  *)
 open File.Operators
 module E = Semgrep_error_code
-module Out = Output_from_core_t
+module Out = Semgrep_output_v1_t
 module PM = Pattern_match
 
 (*****************************************************************************)

--- a/src/engine/Match_extract_mode.ml
+++ b/src/engine/Match_extract_mode.ml
@@ -291,7 +291,7 @@ let map_res map_loc tmpfile file
     | Debug { skipped_targets; profiling } ->
         let skipped_targets =
           Common.map
-            (fun (st : Output_from_core_t.skipped_target) ->
+            (fun (st : Semgrep_output_v1_t.skipped_target) ->
               { st with path = (if st.path = tmpfile then file else st.path) })
             skipped_targets
         in

--- a/src/engine/Match_rules.ml
+++ b/src/engine/Match_rules.ml
@@ -16,9 +16,9 @@ open Common
 open File.Operators
 module R = Rule
 module RP = Report
-module Resp = Output_from_core_t
+module Resp = Semgrep_output_v1_t
 module E = Semgrep_error_code
-module Out = Output_from_core_t
+module Out = Semgrep_output_v1_t
 
 let logger = Logging.get_logger [ __MODULE__ ]
 

--- a/src/engine/Match_tainting_mode.ml
+++ b/src/engine/Match_tainting_mode.ml
@@ -26,7 +26,7 @@ module T = Taint
 module Lval_env = Taint_lval_env
 module MV = Metavariable
 module ME = Matching_explanation
-module Out = Output_from_core_t
+module Out = Semgrep_output_v1_t
 module Labels = Set.Make (String)
 
 let logger = Logging.get_logger [ __MODULE__ ]

--- a/src/engine/Unit_engine.ml
+++ b/src/engine/Unit_engine.ml
@@ -5,7 +5,7 @@ module R = Rule
 module MR = Mini_rule
 module P = Pattern_match
 module E = Semgrep_error_code
-module Out = Output_from_core_t
+module Out = Semgrep_output_v1_t
 
 let logger = Logging.get_logger [ __MODULE__ ]
 

--- a/src/experiments/misc/Raja_experiment.ml
+++ b/src/experiments/misc/Raja_experiment.ml
@@ -1,5 +1,5 @@
 open File.Operators
-module Out = Output_from_core_j
+module Out = Semgrep_output_v1_j
 
 let logger = Logging.get_logger [ __MODULE__ ]
 

--- a/src/experiments/misc/Raja_experiment.mli
+++ b/src/experiments/misc/Raja_experiment.mli
@@ -1,2 +1,3 @@
 val adjust_core_match_results :
-  Output_from_core_j.core_match_results -> Output_from_core_j.core_match_results
+  Semgrep_output_v1_j.core_match_results ->
+  Semgrep_output_v1_j.core_match_results

--- a/src/experiments/synthesizing/Pattern_from_diff.ml
+++ b/src/experiments/synthesizing/Pattern_from_diff.ml
@@ -1,5 +1,5 @@
 module In = Input_to_core_j
-module Out = Output_from_core_j
+module Out = Semgrep_output_v1_j
 module R = Range
 module Set = Set_
 

--- a/src/experiments/synthesizing/Pattern_from_diff.mli
+++ b/src/experiments/synthesizing/Pattern_from_diff.mli
@@ -1,2 +1,2 @@
 val pattern_from_diff :
-  Input_to_core_t.diff_file -> Output_from_core_t.cve_result
+  Input_to_core_t.diff_file -> Semgrep_output_v1_t.cve_result

--- a/src/experiments/synthesizing/Synthesizer.ml
+++ b/src/experiments/synthesizing/Synthesizer.ml
@@ -2,7 +2,7 @@ open Common
 open File.Operators
 module J = JSON
 module In = Input_to_core_j
-module Out = Output_from_core_j
+module Out = Semgrep_output_v1_j
 
 let range_to_ast file lang s =
   let r = Range.range_of_linecol_spec s !!file in

--- a/src/experiments/synthesizing/Unit_synthesizer_targets.ml
+++ b/src/experiments/synthesizing/Unit_synthesizer_targets.ml
@@ -2,7 +2,7 @@
 open Common
 module R = Rule
 module E = Semgrep_error_code
-module Out = Output_from_core_t
+module Out = Semgrep_output_v1_t
 
 (* ran from the root of the semgrep repository *)
 let test_path = "tests/synthesizing/targets/"

--- a/src/metachecking/Check_rule.ml
+++ b/src/metachecking/Check_rule.ml
@@ -20,9 +20,9 @@ module R = Rule
 module E = Semgrep_error_code
 module P = Pattern_match
 module RP = Report
-module SJ = Output_from_core_j
+module SJ = Semgrep_output_v1_j
 module Set = Set_
-module Out = Output_from_core_t
+module Out = Semgrep_output_v1_t
 
 let logger = Logging.get_logger [ __MODULE__ ]
 

--- a/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -213,11 +213,11 @@ let run_scan_files (conf : Scan_CLI.conf) profiler rules_and_origins
           (conf.target_roots, semgrepignored_targets, targets));
     Logs.info (fun m ->
         semgrepignored_targets
-        |> List.iter (fun (x : Output_from_core_t.skipped_target) ->
-               m "Ignoring %s due to %s (%s)" x.Output_from_core_t.path
-                 (Output_from_core_t.show_skip_reason
-                    x.Output_from_core_t.reason)
-                 x.Output_from_core_t.details));
+        |> List.iter (fun (x : Semgrep_output_v1_t.skipped_target) ->
+               m "Ignoring %s due to %s (%s)" x.Semgrep_output_v1_t.path
+                 (Semgrep_output_v1_t.show_skip_reason
+                    x.Semgrep_output_v1_t.reason)
+                 x.Semgrep_output_v1_t.details));
 
     (* step3: choose the right engine and right hooks *)
     let output_format, file_match_results_hook =

--- a/src/osemgrep/core/Error.ml
+++ b/src/osemgrep/core/Error.ml
@@ -24,7 +24,7 @@ exception Semgrep_error of string * Exit_code.t option
 exception Exit of Exit_code.t
 
 (* TOPORT?
-   exception Semgrep_core_error of Output_from_core_t.core_error
+   exception Semgrep_core_error of Semgrep_output_v1_t.core_error
 
    (*
       python: class ErrorWithSpan(SemgrepError)

--- a/src/osemgrep/reporting/Targets_report.ml
+++ b/src/osemgrep/reporting/Targets_report.ml
@@ -7,7 +7,7 @@ let pp_targets_debug ppf (target_roots, semgrepignored_targets, targets) =
   Fmt.pf ppf "skipped targets: [@.";
   semgrepignored_targets
   |> List.iter (fun x ->
-         Fmt.pf ppf "  %s" (Output_from_core_t.show_skipped_target x));
+         Fmt.pf ppf "  %s" (Semgrep_output_v1_t.show_skipped_target x));
   Fmt.pf ppf "]@.";
   Fmt.pf ppf "selected targets: [@.";
   targets |> List.iter (fun file -> Fmt.pf ppf "target = %s@." !!file);

--- a/src/parsing/Parse_target.ml
+++ b/src/parsing/Parse_target.ml
@@ -19,7 +19,7 @@ open Pfff_or_tree_sitter
 open Parsing_result2
 module Flag = Flag_semgrep
 module E = Semgrep_error_code
-module Out = Output_from_core_t
+module Out = Semgrep_output_v1_t
 module OutH = Output_from_core_util
 
 let logger = Logging.get_logger [ __MODULE__ ]

--- a/src/parsing/tests/Test_parsing.ml
+++ b/src/parsing/tests/Test_parsing.ml
@@ -18,7 +18,7 @@ module PS = Parsing_stat
 module G = AST_generic
 module J = JSON
 module FT = File_type
-module Resp = Output_from_core_t
+module Resp = Semgrep_output_v1_t
 
 let logger = Logging.get_logger [ __MODULE__ ]
 

--- a/src/reporting/JSON_report.ml
+++ b/src/reporting/JSON_report.ml
@@ -20,8 +20,8 @@ module J = JSON
 module MV = Metavariable
 module RP = Report
 open Pattern_match
-module SJ = Output_from_core_j (* JSON conversions *)
-module Out = Output_from_core_t (* atdgen definitions *)
+module SJ = Semgrep_output_v1_j (* JSON conversions *)
+module Out = Semgrep_output_v1_t (* atdgen definitions *)
 module OutH = Output_from_core_util
 
 (*****************************************************************************)

--- a/src/reporting/JSON_report.mli
+++ b/src/reporting/JSON_report.mli
@@ -6,13 +6,13 @@ type render_fix = Pattern_match.t -> Textedit.t option
 val match_to_match :
   render_fix option ->
   Pattern_match.t ->
-  (Output_from_core_t.core_match, Semgrep_error_code.error) Common.either
+  (Semgrep_output_v1_t.core_match, Semgrep_error_code.error) Common.either
 
 val match_results_of_matches_and_errors :
   render_fix option ->
   int (* number of files processed, for the stats.okfiles *) ->
   Report.final_result ->
-  Output_from_core_t.core_match_results
+  Semgrep_output_v1_t.core_match_results
 
 (* for abstract_content and subpatterns matching-explanations
  * TODO: should not use! the result may miss some commas
@@ -20,7 +20,7 @@ val match_results_of_matches_and_errors :
 val metavar_string_of_any : AST_generic.any -> string
 
 (* now used also in osemgrep *)
-val error_to_error : Semgrep_error_code.error -> Output_from_core_t.core_error
+val error_to_error : Semgrep_error_code.error -> Semgrep_output_v1_t.core_error
 
 (* internal *)
 val match_to_error : Pattern_match.t -> unit

--- a/src/reporting/Matching_explanation.ml
+++ b/src/reporting/Matching_explanation.ml
@@ -13,7 +13,7 @@
  * LICENSE for more details.
  *)
 open Common
-module Out = Output_from_core_j
+module Out = Semgrep_output_v1_j
 module Out2 = Output_from_core_util
 
 (*****************************************************************************)

--- a/src/reporting/Output_from_core_j.ml
+++ b/src/reporting/Output_from_core_j.ml
@@ -1,2 +1,0 @@
-(* TODO: when ATD will gets its module system we will not need this anymore *)
-include Semgrep_output_v1_j

--- a/src/reporting/Output_from_core_t.ml
+++ b/src/reporting/Output_from_core_t.ml
@@ -1,2 +1,0 @@
-(* TODO: when ATD will gets its module system we will not need this anymore *)
-include Semgrep_output_v1_t

--- a/src/reporting/Output_from_core_util.ml
+++ b/src/reporting/Output_from_core_util.ml
@@ -6,7 +6,7 @@
 
    TODO: ideally once osemgrep is done we should get rid of this module
 *)
-open Output_from_core_t
+open Semgrep_output_v1_t
 
 (* pfff (and Emacs) have the first column at index 0, but not r2c *)
 let adjust_column x = x + 1

--- a/src/reporting/Output_from_core_util.mli
+++ b/src/reporting/Output_from_core_util.mli
@@ -2,18 +2,19 @@
    Utilities for working with the types defined in Semgrep_output_v1.atd
 *)
 
-val position_of_token_location : Tok.location -> Output_from_core_t.position
+val position_of_token_location : Tok.location -> Semgrep_output_v1_t.position
 
 val position_range :
   Tok.location ->
   Tok.location ->
-  Output_from_core_t.position * Output_from_core_t.position
+  Semgrep_output_v1_t.position * Semgrep_output_v1_t.position
 
-val location_of_token_location : Tok.location -> Output_from_core_t.location
+val location_of_token_location : Tok.location -> Semgrep_output_v1_t.location
 
 (*
    Sort results in the most natural way possible, typically preferring
    match location first.
 *)
 val sort_match_results :
-  Output_from_core_t.core_match_results -> Output_from_core_t.core_match_results
+  Semgrep_output_v1_t.core_match_results ->
+  Semgrep_output_v1_t.core_match_results

--- a/src/reporting/Report.ml
+++ b/src/reporting/Report.ml
@@ -60,7 +60,7 @@ type debug_mode = MDebug | MTime | MNo_info [@@deriving show]
 type 'a debug_info =
   (* -debug: save all the information that could be useful *)
   | Debug of {
-      skipped_targets : Output_from_core_t.skipped_target list;
+      skipped_targets : Semgrep_output_v1_t.skipped_target list;
       profiling : 'a;
     }
   (* -json_time: save just profiling information; currently our metrics record this *)

--- a/src/reporting/Report.mli
+++ b/src/reporting/Report.mli
@@ -4,7 +4,7 @@ type debug_mode = MDebug | MTime | MNo_info [@@deriving show]
 
 type 'a debug_info =
   | Debug of {
-      skipped_targets : Output_from_core_t.skipped_target list;
+      skipped_targets : Semgrep_output_v1_t.skipped_target list;
       profiling : 'a;
     }
   | Time of { profiling : 'a }

--- a/src/reporting/Semgrep_error_code.ml
+++ b/src/reporting/Semgrep_error_code.ml
@@ -12,7 +12,7 @@
  * LICENSE for more details.
  *)
 open Common
-module Out = Output_from_core_j
+module Out = Semgrep_output_v1_j
 module R = Rule
 
 let logger = Logging.get_logger [ __MODULE__ ]

--- a/src/reporting/Semgrep_error_code.mli
+++ b/src/reporting/Semgrep_error_code.mli
@@ -8,7 +8,7 @@
 
 type error = {
   rule_id : Rule_ID.t option;
-  typ : Output_from_core_t.core_error_kind;
+  typ : Semgrep_output_v1_t.core_error_kind;
   loc : Tok.location;
   msg : string;
   (* ?? diff with msg? *)
@@ -26,14 +26,14 @@ val mk_error :
   ?rule_id:Rule_ID.t option ->
   Tok.location ->
   string ->
-  Output_from_core_t.core_error_kind ->
+  Semgrep_output_v1_t.core_error_kind ->
   error
 
 val error :
   Rule_ID.t ->
   Tok.location ->
   string ->
-  Output_from_core_t.core_error_kind ->
+  Semgrep_output_v1_t.core_error_kind ->
   unit
 
 (* Convert a caught exception and its stack trace to a Semgrep error. *)
@@ -54,7 +54,7 @@ val try_with_print_exn_and_reraise : Common.filename -> (unit -> unit) -> unit
 val string_of_error : error -> string
 
 val severity_of_error :
-  Output_from_core_t.core_error_kind -> Output_from_core_t.core_severity
+  Semgrep_output_v1_t.core_error_kind -> Semgrep_output_v1_t.core_severity
 
 (*****************************************************************************)
 (* Helpers for unit testing *)

--- a/src/reporting/Unit_reporting.ml
+++ b/src/reporting/Unit_reporting.ml
@@ -1,6 +1,6 @@
 open Common
 open Testutil
-module Out = Output_from_core_j
+module Out = Semgrep_output_v1_j
 
 (*****************************************************************************)
 (* Purpose *)

--- a/src/runner/Run_semgrep.ml
+++ b/src/runner/Run_semgrep.ml
@@ -21,7 +21,7 @@ module MR = Mini_rule
 module R = Rule
 module RP = Report
 module In = Input_to_core_j
-module Out = Output_from_core_j
+module Out = Semgrep_output_v1_j
 
 let logger = Logging.get_logger [ __MODULE__ ]
 let debug_extract_mode = ref false
@@ -300,7 +300,7 @@ let filter_files_with_too_many_matches_and_transform_as_timeout
                         max_match_per_file
                     in
                     {
-                      Output_from_core_t.path = file;
+                      Semgrep_output_v1_t.path = file;
                       reason = Too_many_matches;
                       details;
                       rule_id = Some (rule_id :> string);

--- a/src/runner/Run_semgrep.mli
+++ b/src/runner/Run_semgrep.mli
@@ -203,7 +203,7 @@ val rules_from_rule_source :
 val targets_of_config :
   Runner_config.t ->
   Rule_ID.t list ->
-  Input_to_core_t.targets * Output_from_core_t.skipped_target list
+  Input_to_core_t.targets * Semgrep_output_v1_t.skipped_target list
 (**
   Compute the set of targets, either by reading what was passed
   in -target, or by using Find_target.files_of_dirs_or_files.
@@ -215,7 +215,7 @@ val filter_files_with_too_many_matches_and_transform_as_timeout :
   Pattern_match.t list ->
   Pattern_match.t list
   * Semgrep_error_code.error list
-  * Output_from_core_j.skipped_target list
+  * Semgrep_output_v1_j.skipped_target list
 
 (* TODO: This is used by semgrep-pro and not by semgrep. What is it?
    TODO: Explain what it does if xlang contains multiple langs. *)

--- a/src/targeting/Find_targets.ml
+++ b/src/targeting/Find_targets.ml
@@ -1,6 +1,6 @@
 open Common
 open File.Operators
-module Out = Output_from_core_t
+module Out = Semgrep_output_v1_t
 
 (*************************************************************************)
 (* Prelude *)

--- a/src/targeting/Find_targets.mli
+++ b/src/targeting/Find_targets.mli
@@ -43,8 +43,8 @@ type conf = {
 val get_targets :
   conf ->
   Fpath.t list (* scanning roots *) ->
-  Fpath.t list * Output_from_core_t.skipped_target list
+  Fpath.t list * Semgrep_output_v1_t.skipped_target list
 
 (* internals used also in Find_targets_old.ml *)
 val get_reason_for_exclusion :
-  Gitignore.selection_event list -> Output_from_core_t.skip_reason
+  Gitignore.selection_event list -> Semgrep_output_v1_t.skip_reason

--- a/src/targeting/Find_targets_old.ml
+++ b/src/targeting/Find_targets_old.ml
@@ -1,8 +1,8 @@
 open Common
 open File.Operators
 module In = Input_to_core_t
-module Out = Output_from_core_t
-module Resp = Output_from_core_t
+module Out = Semgrep_output_v1_t
+module Resp = Semgrep_output_v1_t
 open Find_targets (* conf type *)
 
 (*************************************************************************)

--- a/src/targeting/Find_targets_old.mli
+++ b/src/targeting/Find_targets_old.mli
@@ -4,7 +4,7 @@
 val get_targets :
   Find_targets.conf ->
   Fpath.t list (* scanning roots *) ->
-  Fpath.t list * Output_from_core_t.skipped_target list
+  Fpath.t list * Semgrep_output_v1_t.skipped_target list
 
 (*
    [legacy implementation used in semgrep-core]
@@ -33,4 +33,4 @@ val files_of_dirs_or_files :
   ?sort_by_decr_size:bool ->
   Lang.t option ->
   Fpath.t list ->
-  Fpath.t list * Output_from_core_t.skipped_target list
+  Fpath.t list * Semgrep_output_v1_t.skipped_target list

--- a/src/targeting/Guess_lang.ml
+++ b/src/targeting/Guess_lang.ml
@@ -281,7 +281,7 @@ let inspect_file_p (lang : Lang.t) path =
   eval test path
 
 let wrap_with_error_message lang path bool_res :
-    (Fpath.t, Output_from_core_t.skipped_target) result =
+    (Fpath.t, Semgrep_output_v1_t.skipped_target) result =
   match bool_res with
   | true -> Ok path
   | false ->

--- a/src/targeting/Guess_lang.mli
+++ b/src/targeting/Guess_lang.mli
@@ -14,7 +14,7 @@
 val inspect_file_p : Lang.t -> Fpath.t -> bool
 
 val inspect_file :
-  Lang.t -> Fpath.t -> (Fpath.t, Output_from_core_t.skipped_target) result
+  Lang.t -> Fpath.t -> (Fpath.t, Semgrep_output_v1_t.skipped_target) result
 
 (*
    Split selected files (left) from excluded files (right).
@@ -22,7 +22,7 @@ val inspect_file :
 val inspect_files :
   Lang.t ->
   Fpath.t list ->
-  Fpath.t list * Output_from_core_t.skipped_target list
+  Fpath.t list * Semgrep_output_v1_t.skipped_target list
 
 (*
    Get the first 'block_size' bytes of the file, which is ideally obtained

--- a/src/targeting/Skip_target.ml
+++ b/src/targeting/Skip_target.ml
@@ -4,7 +4,7 @@
 *)
 open Common
 open File.Operators
-module Resp = Output_from_core_t
+module Resp = Semgrep_output_v1_t
 
 (****************************************************************************)
 (* Minified files detection (via whitespace stats) *)

--- a/src/targeting/Skip_target.mli
+++ b/src/targeting/Skip_target.mli
@@ -1,7 +1,7 @@
 (* This is using Flag_semgrep.max_target_bytes *)
 val exclude_big_files :
-  Fpath.t list -> Fpath.t list * Output_from_core_t.skipped_target list
+  Fpath.t list -> Fpath.t list * Semgrep_output_v1_t.skipped_target list
 
 (* Detecting and filtering minified files (for Javascript) *)
 val exclude_minified_files :
-  Fpath.t list -> Fpath.t list * Output_from_core_t.skipped_target list
+  Fpath.t list -> Fpath.t list * Semgrep_output_v1_t.skipped_target list


### PR DESCRIPTION
This module alias was confusing (as brought up in Slack).

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
