### PR TITLE
Fix develop

### DIFF
--- a/cli/tests/e2e/test_ci.py
+++ b/cli/tests/e2e/test_ci.py
@@ -1813,6 +1813,7 @@ def test_enabled_products(
         strict=False,
         assert_exit_code=None,
         env={"SEMGREP_APP_TOKEN": "fake_key"},
+        use_click_runner=True,  # TODO: probably because rely on some mocking
     )
 
     if not enabled_products:


### PR DESCRIPTION
The regression in CI was introduced because #8524 CI was based
on an old develop and in the mean time another PR #8521 got
merged that made the first PR now fail

test plan:
cd cli
make e2e


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)