### PR TITLE
osemgrep: introduce Pysemgrep.FallbackToPysemgrep exn

### DIFF
--- a/src/osemgrep/cli/CLI.ml
+++ b/src/osemgrep/cli/CLI.ml
@@ -76,11 +76,6 @@ let missing_subcommand () =
   Logs.err (fun m -> m "This semgrep subcommand is not implemented\n%!");
   Exit_code.not_implemented_in_osemgrep
 
-(* dispatch back to pysemgrep! *)
-let pysemgrep argv =
-  (* pysemgrep should be in the PATH, thx to the code in ../../../cli/bin/semgrep *)
-  Unix.execvp "pysemgrep" argv
-
 let dispatch_subcommand argv =
   match Array.to_list argv with
   (* impossible because argv[0] contains the program name *)
@@ -107,30 +102,33 @@ let dispatch_subcommand argv =
       (* coupling: with known_subcommands if you add an entry below.
        * coupling: with the main_help_msg if you add an entry below.
        *)
-      match subcmd with
-      (* TODO: gradually remove those 'when experimental' guards as
-       * we progress in osemgrep port (or move the dispatch back
-       * to pysemgrep futher down, when we know we don't handle
-       * certain kind of arguments.
-       *)
-      | "ci" when experimental -> Ci_subcommand.main subcmd_argv
-      | "install-semgrep-pro" when experimental -> missing_subcommand ()
-      | "login" when experimental -> Login_subcommand.main subcmd_argv
-      | "logout" when experimental -> Logout_subcommand.main subcmd_argv
-      | "publish" when experimental -> missing_subcommand ()
-      | "scan" when experimental -> Scan_subcommand.main subcmd_argv
-      (* TODO: next target for not requiring the 'when experimental' guard! *)
-      | "lsp" when experimental -> Lsp_subcommand.main subcmd_argv
-      (* osemgrep-only: and by default! no need experimental! *)
-      | "interactive" -> Interactive_subcommand.main subcmd_argv
-      (* LATER: "dump", "test", "validate" *)
-      | _else_ ->
-          if experimental then
-            (* this should never happen because we default to 'scan',
-             * but better to be safe than sorry.
-             *)
-            Error.abort (spf "unknown semgrep command: %s" subcmd)
-          else pysemgrep argv)
+      try
+        match subcmd with
+        (* TODO: gradually remove those 'when experimental' guards as
+         * we progress in osemgrep port (or move the dispatch back
+         * to pysemgrep futher down, when we know we don't handle
+         * certain kind of arguments.
+         *)
+        | "ci" when experimental -> Ci_subcommand.main subcmd_argv
+        | "install-semgrep-pro" when experimental -> missing_subcommand ()
+        | "login" when experimental -> Login_subcommand.main subcmd_argv
+        | "logout" when experimental -> Logout_subcommand.main subcmd_argv
+        | "publish" when experimental -> missing_subcommand ()
+        | "scan" when experimental -> Scan_subcommand.main subcmd_argv
+        (* TODO: next target for not requiring the 'when experimental' guard! *)
+        | "lsp" when experimental -> Lsp_subcommand.main subcmd_argv
+        (* osemgrep-only: and by default! no need experimental! *)
+        | "interactive" -> Interactive_subcommand.main subcmd_argv
+        (* LATER: "dump", "test", "validate" *)
+        | _else_ ->
+            if experimental then
+              (* this should never happen because we default to 'scan',
+               * but better to be safe than sorry.
+               *)
+              Error.abort (spf "unknown semgrep command: %s" subcmd)
+            else raise Pysemgrep.FallbackToPysemgrep
+      with
+      | Pysemgrep.FallbackToPysemgrep -> Pysemgrep.pysemgrep argv)
   [@@profiling]
 
 (*****************************************************************************)

--- a/src/osemgrep/cli/CLI.ml
+++ b/src/osemgrep/cli/CLI.ml
@@ -126,9 +126,9 @@ let dispatch_subcommand argv =
                * but better to be safe than sorry.
                *)
               Error.abort (spf "unknown semgrep command: %s" subcmd)
-            else raise Pysemgrep.FallbackToPysemgrep
+            else raise Pysemgrep.Fallback
       with
-      | Pysemgrep.FallbackToPysemgrep -> Pysemgrep.pysemgrep argv)
+      | Pysemgrep.Fallback -> Pysemgrep.pysemgrep argv)
   [@@profiling]
 
 (*****************************************************************************)

--- a/src/osemgrep/core/Pysemgrep.ml
+++ b/src/osemgrep/core/Pysemgrep.ml
@@ -1,0 +1,18 @@
+(*************************************************************************)
+(* Prelude *)
+(*************************************************************************)
+(* Temporary module while migrating code to osemgrep to fallback to
+ * pysemgrep.
+ *
+ *)
+
+(*************************************************************************)
+(* Entry points *)
+(*************************************************************************)
+
+exception FallbackToPysemgrep
+
+(* dispatch back to pysemgrep! *)
+let pysemgrep argv =
+  (* pysemgrep should be in the PATH, thx to the code in ../../../cli/bin/semgrep *)
+  Unix.execvp "pysemgrep" argv

--- a/src/osemgrep/core/Pysemgrep.ml
+++ b/src/osemgrep/core/Pysemgrep.ml
@@ -10,7 +10,7 @@
 (* Entry points *)
 (*************************************************************************)
 
-exception FallbackToPysemgrep
+exception Fallback
 
 (* dispatch back to pysemgrep! *)
 let pysemgrep argv =


### PR DESCRIPTION
This will be helpful in further PR when we refine when
to fallback to pysemgrep

test plan:
make core


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)