### PR TITLE
osemgrep: fallback to pysemgrep after processing the CLI args!

### DIFF
--- a/changelog.d/dotsemgrep.changed
+++ b/changelog.d/dotsemgrep.changed
@@ -1,0 +1,3 @@
+The option to omit --config and to look for the presence of a .semgrep.yml
+or .semgrep/.semgrep.yml in the current directory has been removed. You now
+have to explicitely use --config.

--- a/changelog.d/dotsemgrep.changed
+++ b/changelog.d/dotsemgrep.changed
@@ -1,3 +1,3 @@
 The option to omit --config and to look for the presence of a .semgrep.yml
 or .semgrep/.semgrep.yml in the current directory has been removed. You now
-have to explicitely use --config.
+have to explicitly use --config.

--- a/changelog.d/enable_metrics.changed
+++ b/changelog.d/enable_metrics.changed
@@ -1,0 +1,2 @@
+The deprecated --enable-metrics and --disable-metrics flags have finally been
+removed. Use --metrics=on or --metrics=off instead (or --metrics=auto).

--- a/cli/tests/e2e/snapshots/test_max_target_bytes/test_max_target_bytes/1.3R/error.txt
+++ b/cli/tests/e2e/snapshots/test_max_target_bytes/test_max_target_bytes/1.3R/error.txt
@@ -1,3 +1,5 @@
-Usage: semgrep --max-target-bytes [OPTIONS] [TARGETS]...
-
-Error: could not convert string to float: '1.3R'
+semgrep scan: option '--max-target-bytes': Invalid representation for a
+              number of bytes: 1.3R
+Usage: semgrep scan [OPTION]… [TARGETS]…
+Try 'semgrep scan --help' for more information.
+exiting with error status 2: osemgrep --max-target-bytes 1.3R --strict --config rules/eqeq.yaml --json targets/basic

--- a/cli/tests/e2e/test_check.py
+++ b/cli/tests/e2e/test_check.py
@@ -337,20 +337,6 @@ def test_hidden_rule__implicit(run_semgrep_in_tmp: RunSemgrep, snapshot):
 
 
 @pytest.mark.kinda_slow
-def test_default_rule__file(run_semgrep_in_tmp: RunSemgrep, snapshot):
-    Path(".semgrep.yml").symlink_to(Path("rules/eqeq.yaml").resolve())
-    snapshot.assert_match(run_semgrep_in_tmp().stdout, "results.json")
-
-
-@pytest.mark.kinda_slow
-def test_default_rule__folder(run_semgrep_in_tmp: RunSemgrep, snapshot):
-    Path(".semgrep").mkdir()
-    Path(".semgrep/.semgrep.yml").symlink_to(Path("rules/eqeq.yaml").resolve())
-
-    snapshot.assert_match(run_semgrep_in_tmp().stdout, "results.json")
-
-
-@pytest.mark.kinda_slow
 @pytest.mark.osempass
 def test_regex_rule__top(run_semgrep_in_tmp: RunSemgrep, snapshot):
     snapshot.assert_match(

--- a/cli/tests/e2e/test_metrics.py
+++ b/cli/tests/e2e/test_metrics.py
@@ -168,68 +168,6 @@ def test_flags_actual_send(run_semgrep_in_tmp: RunSemgrep):
     assert "Failed to send pseudonymous metrics" not in stderr
 
 
-@pytest.mark.slow
-def test_legacy_flags(run_semgrep_in_tmp: RunSemgrep):
-    """
-    Test metrics sending respects legacy flags. Flags take precedence over envvar
-    """
-    _, stderr = run_semgrep_in_tmp(
-        "rules/eqeq.yaml",
-        options=["--debug", "--enable-metrics"],
-        force_metrics_off=False,
-    )
-    assert "Sending pseudonymous metrics" in stderr
-
-    _, stderr = run_semgrep_in_tmp(
-        "rules/eqeq.yaml",
-        options=["--debug", "--enable-metrics"],
-        env={"SEMGREP_SEND_METRICS": ""},
-        force_metrics_off=False,
-    )
-    assert "Sending pseudonymous metrics" in stderr
-
-    _, stderr = run_semgrep_in_tmp(
-        "rules/eqeq.yaml",
-        options=["--debug", "--disable-metrics"],
-        force_metrics_off=False,
-    )
-    assert "Sending pseudonymous metrics" not in stderr
-
-    _, stderr = run_semgrep_in_tmp(
-        "rules/eqeq.yaml",
-        options=["--disable-metrics"],
-        env={"SEMGREP_SEND_METRICS": "1"},
-        force_metrics_off=False,
-        assert_exit_code=2,
-    )
-    assert (
-        "--enable-metrics/--disable-metrics can not be used with either --metrics or SEMGREP_SEND_METRICS"
-        in stderr
-    )
-
-    _, stderr = run_semgrep_in_tmp(
-        "rules/eqeq.yaml",
-        options=["--disable-metrics"],
-        env={"SEMGREP_SEND_METRICS": "off"},
-        force_metrics_off=False,
-    )
-    assert (
-        "--enable-metrics/--disable-metrics can not be used with either --metrics or SEMGREP_SEND_METRICS"
-        not in stderr
-    )
-
-    _, stderr = run_semgrep_in_tmp(
-        "rules/eqeq.yaml",
-        options=["--enable-metrics"],
-        env={"SEMGREP_SEND_METRICS": "on"},
-        force_metrics_off=False,
-    )
-    assert (
-        "--enable-metrics/--disable-metrics can not be used with either --metrics or SEMGREP_SEND_METRICS"
-        not in stderr
-    )
-
-
 def _mask_version(value: str) -> str:
     return re.sub(r"\d+", "x", value)
 

--- a/perf/run-benchmarks
+++ b/perf/run-benchmarks
@@ -232,7 +232,7 @@ def run_semgrep(
         "--json",
         "--timeout",
         "0",
-        "--disable-metrics",
+        "--metrics=off",
         "--no-git-ignore",  # because files in bench/*/input/ are git-ignored
     ]
     if docker:

--- a/src/osemgrep/cli/CLI.ml
+++ b/src/osemgrep/cli/CLI.ml
@@ -105,18 +105,18 @@ let dispatch_subcommand argv =
       try
         match subcmd with
         (* TODO: gradually remove those 'when experimental' guards as
-         * we progress in osemgrep port (or move the dispatch back
-         * to pysemgrep futher down, when we know we don't handle
-         * certain kind of arguments.
+         * we progress in osemgrep port (or use Pysemgrep.Fallback further
+         * down when we know we don't handle certain kind of arguments).
          *)
         | "ci" when experimental -> Ci_subcommand.main subcmd_argv
         | "install-semgrep-pro" when experimental -> missing_subcommand ()
         | "login" when experimental -> Login_subcommand.main subcmd_argv
         | "logout" when experimental -> Logout_subcommand.main subcmd_argv
         | "publish" when experimental -> missing_subcommand ()
-        | "scan" when experimental -> Scan_subcommand.main subcmd_argv
-        (* TODO: next target for not requiring the 'when experimental' guard! *)
+        (* TODO: next target for not requiring the 'when experimental' guard!*)
         | "lsp" when experimental -> Lsp_subcommand.main subcmd_argv
+        (* partial support, still use Pysemgrep.Fallback in it *)
+        | "scan" -> Scan_subcommand.main subcmd_argv
         (* osemgrep-only: and by default! no need experimental! *)
         | "interactive" -> Interactive_subcommand.main subcmd_argv
         (* LATER: "dump", "test", "validate" *)

--- a/src/osemgrep/cli_ci/Ci_CLI.ml
+++ b/src/osemgrep/cli_ci/Ci_CLI.ml
@@ -1,4 +1,4 @@
-open Cmdliner
+module Cmd = Cmdliner.Cmd
 
 (*****************************************************************************)
 (* Prelude *)
@@ -22,9 +22,9 @@ type conf = Scan_CLI.conf
 
 let doc = "the recommended way to run semgrep in CI"
 
-let man : Manpage.block list =
+let man : Cmdliner.Manpage.block list =
   [
-    `S Manpage.s_description;
+    `S Cmdliner.Manpage.s_description;
     `P
       "In pull_request/merge_request (PR/MR) contexts, `semgrep ci` will only \
        report findings that were introduced by the PR/MR.";

--- a/src/osemgrep/cli_dump/Dump_subcommand.ml
+++ b/src/osemgrep/cli_dump/Dump_subcommand.ml
@@ -25,6 +25,9 @@ and target_kind =
   | Pattern of string * Lang.t
   | File of Fpath.t * Lang.t
   | Config of Semgrep_dashdash_config.config_string
+  | EnginePath of bool (* pro = true *)
+  (* LATER: get rid of it *)
+  | CommandForCore
 [@@deriving show]
 
 (*****************************************************************************)
@@ -102,3 +105,5 @@ let run (conf : conf) : Exit_code.t =
       |> List.iter (fun x ->
              Logs.app (fun m -> m "%s" (Rule_fetching.show_rules_and_origin x)));
       Exit_code.ok
+  | EnginePath _pro -> failwith "TODO: dump-engine-path not implemented yet"
+  | CommandForCore -> failwith "TODO: dump-command-for-core not implemented yet"

--- a/src/osemgrep/cli_dump/Dump_subcommand.mli
+++ b/src/osemgrep/cli_dump/Dump_subcommand.mli
@@ -9,6 +9,8 @@ and target_kind =
   | Pattern of string * Lang.t
   | File of Fpath.t * Lang.t
   | Config of Semgrep_dashdash_config.config_string
+  | EnginePath of bool (* pro = true *)
+  | CommandForCore
 [@@deriving show]
 
 val run : conf -> Exit_code.t

--- a/src/osemgrep/cli_interactive/Interactive_CLI.ml
+++ b/src/osemgrep/cli_interactive/Interactive_CLI.ml
@@ -1,4 +1,5 @@
-open Cmdliner
+module Term = Cmdliner.Term
+module Cmd = Cmdliner.Cmd
 module H = Cmdliner_helpers
 
 (*****************************************************************************)
@@ -75,8 +76,8 @@ let cmdline_term : conf Term.t =
 
 let doc = "Interactive mode!!"
 
-let man : Manpage.block list =
-  [ `S Manpage.s_description; `P "Interactive mode!!" ]
+let man : Cmdliner.Manpage.block list =
+  [ `S Cmdliner.Manpage.s_description; `P "Interactive mode!!" ]
   @ CLI_common.help_page_bottom
 
 let cmdline_info : Cmd.info = Cmd.info "semgrep interactive" ~doc ~man

--- a/src/osemgrep/cli_login/Login_CLI.ml
+++ b/src/osemgrep/cli_login/Login_CLI.ml
@@ -1,5 +1,6 @@
-(* Provides the 'Arg', 'Cmd', 'Manpage', and 'Term' modules. *)
-open Cmdliner
+module Arg = Cmdliner.Arg
+module Term = Cmdliner.Term
+module Cmd = Cmdliner.Cmd
 
 (*****************************************************************************)
 (* Prelude *)
@@ -19,9 +20,9 @@ type conf = { logging_level : Logs.level option } [@@deriving show]
 
 let login_doc = "Obtain and save credentials for semgrep.dev"
 
-let login_man : Manpage.block list =
+let login_man : Cmdliner.Manpage.block list =
   [
-    `S Manpage.s_description;
+    `S Cmdliner.Manpage.s_description;
     `P
       "Obtain and save credentials for semgrep.dev\n\n\
       \    Looks for an semgrep.dev API token in the environment variable \
@@ -40,9 +41,9 @@ let login_cmdline_info : Cmd.info =
 
 let logout_doc = "Remove locally stored credentials to semgrep.dev"
 
-let logout_man : Manpage.block list =
+let logout_man : Cmdliner.Manpage.block list =
   [
-    `S Manpage.s_description;
+    `S Cmdliner.Manpage.s_description;
     `P "Remove locally stored credentials to semgrep.dev";
   ]
   @ CLI_common.help_page_bottom

--- a/src/osemgrep/cli_lsp/Lsp_CLI.ml
+++ b/src/osemgrep/cli_lsp/Lsp_CLI.ml
@@ -1,4 +1,5 @@
-open Cmdliner
+module Term = Cmdliner.Term
+module Cmd = Cmdliner.Cmd
 
 (*****************************************************************************)
 (* Prelude *)
@@ -23,8 +24,8 @@ let cmdline_term : conf Term.t =
 
 let doc = "Language server mode!!"
 
-let man : Manpage.block list =
-  [ `S Manpage.s_description; `P "Language server mode!!" ]
+let man : Cmdliner.Manpage.block list =
+  [ `S Cmdliner.Manpage.s_description; `P "Language server mode!!" ]
   @ CLI_common.help_page_bottom
 
 let cmdline_info : Cmd.info = Cmd.info "semgrep lsp" ~doc ~man

--- a/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -1,7 +1,7 @@
 open Common
-
-(* Provides the 'Arg', 'Cmd', 'Manpage', and 'Term' modules. *)
-open Cmdliner
+module Arg = Cmdliner.Arg
+module Term = Cmdliner.Term
+module Cmd = Cmdliner.Cmd
 module H = Cmdliner_helpers
 
 (*****************************************************************************)
@@ -12,12 +12,10 @@ module H = Cmdliner_helpers
 
    Translated partially from scan.py
 
-   TOPORT? all those shell_complete() click functions?
-*)
-
-(* TODO: use parser/printer pair for file paths using Fpath.t so that
+   TODO: use parser/printer pair for file paths using Fpath.t so that
    we don't have to convert manually from string to fpath for each
-   file option offered by the CLI. Add it to CLI_common. *)
+   file option offered by the CLI. Add it to CLI_common.
+*)
 
 (*****************************************************************************)
 (* Types and constants *)
@@ -27,7 +25,8 @@ module H = Cmdliner_helpers
 
    LATER: we could actually define this structure in ATD, so people could
    programmatically set the command-line arguments they want if they
-   want to programmatically call Semgrep.
+   want to programmatically call Semgrep. This structure could also
+   be versioned so people can rely on a stable CLI "API".
 *)
 type conf = {
   (* Main configuration options *)
@@ -53,6 +52,9 @@ type conf = {
   (* Display options *)
   (* mix of --json, --emacs, --vim, etc. *)
   output_format : Output_format.t;
+  (* maybe should define an Output_option.t, or add a record to
+   * Output_format.Text *)
+  dataflow_traces : bool;
   force_color : bool;
   max_chars_per_line : int;
   max_lines_per_finding : int;
@@ -130,6 +132,7 @@ let default : conf =
     time_flag = false;
     engine_type = OSS;
     output_format = Output_format.Text;
+    dataflow_traces = false;
     force_color = false;
     max_chars_per_line = 160;
     max_lines_per_finding = 10;
@@ -148,21 +151,14 @@ let default : conf =
   }
 
 (*************************************************************************)
-(* Helpers *)
-(*************************************************************************)
-
-(*************************************************************************)
 (* Command-line flags *)
 (*************************************************************************)
 (* The o_ below stands for option (as in command-line argument option) *)
 
 (* ------------------------------------------------------------------ *)
-(* Networking related options (New) *)
+(* Networking related options *)
 (* ------------------------------------------------------------------ *)
 
-(* TOPORT? there's also a --disable-metrics and --enable-metrics
- * but they are marked as legacy flags, so maybe not worth porting
- *)
 let o_metrics : Metrics_.config Term.t =
   let info =
     Arg.info [ "metrics" ]
@@ -190,7 +186,7 @@ let o_version_check : bool Term.t =
 |}
 
 (* ------------------------------------------------------------------ *)
-(* TOPORT "Path options" *)
+(* Path options *)
 (* ------------------------------------------------------------------ *)
 (* TOPORT:
  * "By default, Semgrep scans all git-tracked files with extensions matching
@@ -270,7 +266,7 @@ in --lang. If --skip-unknown-extensions, these files will not be scanned.
 (* alt: could be put in the Display options with nosem *)
 let o_baseline_commit : string option Term.t =
   let info =
-    Arg.info [ "baseline_commit" ]
+    Arg.info [ "baseline-commit" ]
       ~doc:
         {|Only show results that are not found in this commit hash. Aborts run
 if not currently in a git directory, there are unstaged changes, or
@@ -283,7 +279,7 @@ given baseline hash doesn't exist.
   Arg.value (Arg.opt Arg.(some string) None info)
 
 (* ------------------------------------------------------------------ *)
-(* TOPORT: "Performance and memory options" *)
+(* Performance and memory options *)
 (* ------------------------------------------------------------------ *)
 
 let o_num_jobs : int Term.t =
@@ -349,7 +345,7 @@ the file is skipped. If set to 0 will not have limit. Defaults to 3.
   Arg.value (Arg.opt Arg.int default.core_runner_conf.timeout_threshold info)
 
 (* ------------------------------------------------------------------ *)
-(* TOPORT "Display options" *)
+(* Display options *)
 (* ------------------------------------------------------------------ *)
 
 (* alt: could use Fmt_cli.style_renderer, which supports --color=xxx but
@@ -384,6 +380,14 @@ trimming (set to 0 for unlimited).|}
   in
   Arg.value (Arg.opt Arg.int default.max_lines_per_finding info)
 
+let o_dataflow_traces : bool Term.t =
+  let info =
+    Arg.info [ "dataflow-traces" ]
+      ~doc:
+        {|Explain how non-local values reach the location of a finding (only affects text and SARIF output).|}
+  in
+  Arg.value (Arg.flag info)
+
 let o_rewrite_rule_ids : bool Term.t =
   H.negatable_flag [ "rewrite-rule-ids" ] ~neg_options:[ "no-rewrite-rule-ids" ]
     ~default:default.rewrite_rule_ids
@@ -408,7 +412,7 @@ let o_nosem : bool Term.t =
           a 'nosem' comment at the end. Enabled by default.|}
 
 (* ------------------------------------------------------------------ *)
-(* TOPORT "Output formats" (mutually exclusive) *)
+(* Output formats (mutually exclusive) *)
 (* ------------------------------------------------------------------ *)
 let o_json : bool Term.t =
   let info =
@@ -428,8 +432,31 @@ let o_vim : bool Term.t =
   in
   Arg.value (Arg.flag info)
 
+let o_sarif : bool Term.t =
+  let info = Arg.info [ "sarif" ] ~doc:{|Output results in SARIF format.|} in
+  Arg.value (Arg.flag info)
+
+let o_gitlab_sast : bool Term.t =
+  let info =
+    Arg.info [ "gitlab-sast" ] ~doc:{|Output results in GitLab SAST format.|}
+  in
+  Arg.value (Arg.flag info)
+
+let o_gitlab_secrets : bool Term.t =
+  let info =
+    Arg.info [ "gitlab-secrets" ]
+      ~doc:{|Output results in GitLab Secrets format.|}
+  in
+  Arg.value (Arg.flag info)
+
+let o_junit_xml : bool Term.t =
+  let info =
+    Arg.info [ "junit-xml" ] ~doc:{|Output results in JUnit XML format.|}
+  in
+  Arg.value (Arg.flag info)
+
 (* ------------------------------------------------------------------ *)
-(* TOPORT "Engine type" (mutually exclusive) *)
+(* Engine type (mutually exclusive) *)
 (* ------------------------------------------------------------------ *)
 
 let o_oss : bool Term.t =
@@ -459,7 +486,7 @@ let o_pro : bool Term.t =
   Arg.value (Arg.flag info)
 
 (* ------------------------------------------------------------------ *)
-(* TOPORT "Configuration options" *)
+(* Configuration options *)
 (* ------------------------------------------------------------------ *)
 let o_config : string list Term.t =
   let info =
@@ -548,16 +575,20 @@ let o_exclude_rule_ids : string list Term.t =
   Arg.value (Arg.opt_all Arg.string [] info)
 
 (* ------------------------------------------------------------------ *)
-(* TOPORT "Alternate modes" *)
+(* Alternate modes *)
 (* ------------------------------------------------------------------ *)
-(* TOPORT: "No search is performed in these modes" *)
+(* TOPORT: "No search is performed in these modes"
+ * coupling: if you add an option here, you probably also need to modify
+ * the sanity checking code around --config to allow empty --config
+ * with this new alternate mode.
+ *)
 
 let o_version : bool Term.t =
   let info = Arg.info [ "version" ] ~doc:{|Show the version and exit.|} in
   Arg.value (Arg.flag info)
 
 (* ugly: this should be a separate subcommand, not a flag of semgrep scan,
- * like 'semgrep info supported-languages'
+ * like 'semgrep show supported-languages'
  *)
 let o_show_supported_languages : bool Term.t =
   let info =
@@ -591,8 +622,24 @@ and then exit (can use --json).
   in
   Arg.value (Arg.flag info)
 
+(* ugly: this should be a separate subcommand, not a flag of semgrep scan.
+ * python: Click offer the hidden=True flag to not show it in --help
+ * but cmdliner does not have an equivalent I think. Anyway this
+ * command should soon disappear anyway.
+ *)
+let o_dump_engine_path : bool Term.t =
+  let info = Arg.info [ "dump-engine-path" ] ~doc:{|<internal, do not use>|} in
+  Arg.value (Arg.flag info)
+
+(* LATER: this should not be needed *)
+let o_dump_command_for_core : bool Term.t =
+  let info =
+    Arg.info [ "d"; "dump-command-for-core" ] ~doc:{|<internal, do not use>|}
+  in
+  Arg.value (Arg.flag info)
+
 (* ------------------------------------------------------------------ *)
-(* TOPORT "Test and debug options" *)
+(* Test and debug options *)
 (* ------------------------------------------------------------------ *)
 
 (* alt: could be in the "alternate modes" section
@@ -678,44 +725,43 @@ let o_registry_caching : bool Term.t =
 let cmdline_term ~allow_empty_config : conf Term.t =
   (* !The parameters must be in alphabetic orders to match the order
    * of the corresponding '$ o_xx $' further below! *)
-  let combine ast_caching autofix baseline_commit common config dryrun dump_ast
-      dump_config emacs error exclude exclude_rule_ids force_color include_ json
-      lang max_chars_per_line max_lines_per_finding max_memory_mb
-      max_target_bytes metrics num_jobs nosem optimizations oss pattern pro
-      project_root pro_intrafile pro_lang registry_caching replacement
-      respect_git_ignore rewrite_rule_ids scan_unknown_extensions severity
-      show_supported_languages strict target_roots test test_ignore_todo
-      time_flag timeout timeout_threshold validate version version_check vim =
+  let combine ast_caching autofix baseline_commit common config dataflow_traces
+      dryrun dump_ast dump_command_for_core dump_config dump_engine_path emacs
+      error exclude exclude_rule_ids force_color gitlab_sast gitlab_secrets
+      include_ json junit_xml lang max_chars_per_line max_lines_per_finding
+      max_memory_mb max_target_bytes metrics num_jobs nosem optimizations oss
+      pattern pro project_root pro_intrafile pro_lang registry_caching
+      replacement respect_git_ignore rewrite_rule_ids sarif
+      scan_unknown_extensions severity show_supported_languages strict
+      target_roots test test_ignore_todo time_flag timeout timeout_threshold
+      validate version version_check vim =
     (* ugly: call setup_logging ASAP so the Logs.xxx below are displayed
      * correctly *)
     Logs_helpers.setup_logging ~force_color
       ~level:common.CLI_common.logging_level;
 
-    (* to remove at some point *)
-    let registry_caching, ast_caching =
-      match common.maturity with
-      | Maturity.Develop -> (registry_caching, ast_caching)
-      | _else_ ->
-          Logs.debug (fun m ->
-              m "disabling registry and AST caching unless --develop");
-          (false, false)
-    in
-    let include_ =
-      match include_ with
-      | [] -> None
-      | nonempty -> Some nonempty
-    in
     let target_roots = target_roots |> File.Path.of_strings in
 
     let output_format =
-      match (json, emacs, vim) with
-      | false, false, false -> default.output_format
-      | true, false, false -> Output_format.Json
-      | false, true, false -> Output_format.Emacs
-      | false, false, true -> Output_format.Vim
-      | _else_ ->
-          (* TOPORT: list the possibilities *)
-          Error.abort "Mutually exclusive options --json/--emacs/--vim"
+      let all_flags =
+        [ json; emacs; vim; sarif; gitlab_sast; gitlab_secrets; junit_xml ]
+      in
+      let cnt =
+        all_flags |> Common.map (fun b -> if b then 1 else 0) |> Common2.sum_int
+      in
+      if cnt >= 2 then
+        (* TOPORT: list the possibilities *)
+        Error.abort
+          "Mutually exclusive options --json/--emacs/--vim/--sarif/...";
+      match () with
+      | _ when json -> Output_format.Json
+      | _ when emacs -> Output_format.Emacs
+      | _ when vim -> Output_format.Vim
+      | _ when sarif -> Output_format.Sarif
+      | _ when gitlab_sast -> Output_format.Gitlab_sast
+      | _ when gitlab_secrets -> Output_format.Gitlab_secrets
+      | _ when junit_xml -> Output_format.Junit_xml
+      | _else_ -> default.output_format
     in
     let engine_type =
       match (oss, pro_lang, pro_intrafile, pro) with
@@ -735,12 +781,12 @@ let cmdline_term ~allow_empty_config : conf Term.t =
       (* ugly: when using --dump-ast, we can pass a pattern or a target,
        * but in the case of a target that means there is no config
        * but we still don't want to abort, hence this empty Configs.
-       * Same for --version, --show-supported-langages, hence
+       * Same for --version, --show-supported-langages, etc., hence
        * this ugly special case returning an empty Configs.
        *)
       | [], (None, _, _)
-        when dump_ast || dump_config <> None || validate || test || version
-             || show_supported_languages ->
+        when dump_ast || dump_config <> None || dump_engine_path || validate
+             || test || version || show_supported_languages ->
           Rules_source.Configs []
       (* TOPORT: handle get_project_url() if empty Configs? *)
       | [], (None, _, _) ->
@@ -777,6 +823,26 @@ let cmdline_term ~allow_empty_config : conf Term.t =
       | _ :: _, (Some _, _, _) ->
           Error.abort "Mutually exclusive options --config/--pattern"
     in
+    (* to remove at some point *)
+    let registry_caching, ast_caching =
+      match common.maturity with
+      | Maturity.Develop -> (registry_caching, ast_caching)
+      (* ugly: TODO some of our e2e tests rely on --debug but
+       * our Logs message are still different with pysemgrep. Moreover,
+       * we now by default parse the CLI args also with osemgrep,
+       * but we don't to print anything in the parse-the-CLI-args part
+       * so that our e2e tests still pass, hence this special case here.
+       * Once we remove the sanity check in pysemgrep, we can just rely
+       * on osemgrep to do it and adjust the e2e snapshots.
+       *)
+      | Maturity.Default
+      | Maturity.Legacy ->
+          (false, false)
+      | Maturity.Experimental ->
+          Logs.debug (fun m ->
+              m "disabling registry and AST caching unless --develop");
+          (false, false)
+    in
     let core_runner_conf =
       {
         Core_runner.num_jobs;
@@ -786,6 +852,11 @@ let cmdline_term ~allow_empty_config : conf Term.t =
         max_memory_mb;
         ast_caching;
       }
+    in
+    let include_ =
+      match include_ with
+      | [] -> None
+      | nonempty -> Some nonempty
     in
     let targeting_conf =
       {
@@ -844,6 +915,10 @@ let cmdline_term ~allow_empty_config : conf Term.t =
       | _ when dump_config <> None ->
           let config = Common2.some dump_config in
           Some { Dump_subcommand.target = Dump_subcommand.Config config; json }
+      | _ when dump_engine_path ->
+          Some { Dump_subcommand.target = Dump_subcommand.EnginePath pro; json }
+      | _ when dump_command_for_core ->
+          Some { Dump_subcommand.target = Dump_subcommand.CommandForCore; json }
       | _else_ -> None
     in
     (* ugly: validate should be a separate subcommand.
@@ -902,14 +977,19 @@ let cmdline_term ~allow_empty_config : conf Term.t =
       else None
     in
 
-    (* sanity checks *)
+    (* more sanity checks *)
     if List.mem "auto" config && metrics =*= Metrics_.Off then
       Error.abort
         "Cannot create auto config when metrics are off. Please allow metrics \
          or run with a specific config.";
 
-    (* warnings *)
-    if include_ <> None && exclude <> [] then
+    (* warnings.
+     * ugly: TODO: remove the Default guard once we get the warning message
+     * in osemgrep equal to the one in pysemgrep or when we remove
+     * this sanity checks in pysemgrep and just rely on osemgrep to do it.
+     *)
+    if include_ <> None && exclude <> [] && common.maturity <> Maturity.Default
+    then
       Logs.warn (fun m ->
           m
             "Paths that match both --include and --exclude will be skipped by \
@@ -924,6 +1004,7 @@ let cmdline_term ~allow_empty_config : conf Term.t =
       autofix;
       dryrun;
       error_on_findings = error;
+      dataflow_traces;
       force_color;
       max_chars_per_line;
       max_lines_per_finding;
@@ -950,13 +1031,15 @@ let cmdline_term ~allow_empty_config : conf Term.t =
     (* !the o_xxx must be in alphabetic orders to match the parameters of
      * combine above! *)
     const combine $ o_ast_caching $ o_autofix $ o_baseline_commit
-    $ CLI_common.o_common $ o_config $ o_dryrun $ o_dump_ast $ o_dump_config
-    $ o_emacs $ o_error $ o_exclude $ o_exclude_rule_ids $ o_force_color
-    $ o_include $ o_json $ o_lang $ o_max_chars_per_line
-    $ o_max_lines_per_finding $ o_max_memory_mb $ o_max_target_bytes $ o_metrics
-    $ o_num_jobs $ o_nosem $ o_optimizations $ o_oss $ o_pattern $ o_pro
-    $ o_project_root $ o_pro_intrafile $ o_pro_languages $ o_registry_caching
-    $ o_replacement $ o_respect_git_ignore $ o_rewrite_rule_ids
+    $ CLI_common.o_common $ o_config $ o_dataflow_traces $ o_dryrun $ o_dump_ast
+    $ o_dump_command_for_core $ o_dump_config $ o_dump_engine_path $ o_emacs
+    $ o_error $ o_exclude $ o_exclude_rule_ids $ o_force_color $ o_gitlab_sast
+    $ o_gitlab_secrets $ o_include $ o_json $ o_junit_xml $ o_lang
+    $ o_max_chars_per_line $ o_max_lines_per_finding $ o_max_memory_mb
+    $ o_max_target_bytes $ o_metrics $ o_num_jobs $ o_nosem $ o_optimizations
+    $ o_oss $ o_pattern $ o_pro $ o_project_root $ o_pro_intrafile
+    $ o_pro_languages $ o_registry_caching $ o_replacement
+    $ o_respect_git_ignore $ o_rewrite_rule_ids $ o_sarif
     $ o_scan_unknown_extensions $ o_severity $ o_show_supported_languages
     $ o_strict $ o_target_roots $ o_test $ o_test_ignore_todo $ o_time
     $ o_timeout $ o_timeout_threshold $ o_validate $ o_version $ o_version_check
@@ -965,9 +1048,9 @@ let cmdline_term ~allow_empty_config : conf Term.t =
 let doc = "run semgrep rules on files"
 
 (* TODO: document the exit codes as defined in Exit_code.mli *)
-let man : Manpage.block list =
+let man : Cmdliner.Manpage.block list =
   [
-    `S Manpage.s_description;
+    `S Cmdliner.Manpage.s_description;
     `P
       "Searches TARGET paths for matches to rules or patterns. Defaults to \
        searching entire current working directory.";

--- a/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -11,10 +11,6 @@ module H = Cmdliner_helpers
    'semgrep scan' command-line arguments processing.
 
    Translated partially from scan.py
-
-   TODO: use parser/printer pair for file paths using Fpath.t so that
-   we don't have to convert manually from string to fpath for each
-   file option offered by the CLI. Add it to CLI_common.
 *)
 
 (*****************************************************************************)

--- a/src/osemgrep/cli_scan/Scan_CLI.mli
+++ b/src/osemgrep/cli_scan/Scan_CLI.mli
@@ -28,8 +28,11 @@ type conf = {
   (* Display options *)
   (* mix of --json, --emacs, --vim, etc. *)
   output_format : Output_format.t;
+  dataflow_traces : bool;
   force_color : bool;
-  (* text output config (TODO: make a separate type gathering all of them) *)
+  (* text output config (TODO: make a separate type gathering all of them)
+   * or add them under Output_format.Text
+   *)
   max_chars_per_line : int;
   max_lines_per_finding : int;
   (* Networking options *)

--- a/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -394,6 +394,14 @@ let run_scan_conf (conf : Scan_CLI.conf) (settings : Semgrep_settings.t)
 (* All the business logic after command-line parsing. Return the desired
    exit code. *)
 let run_conf (conf : Scan_CLI.conf) : Exit_code.t =
+  (* TODO: move this further down! *)
+  (match conf.common.maturity with
+  | Maturity.Default
+  | Maturity.Legacy ->
+      raise Pysemgrep.Fallback
+  | Maturity.Experimental
+  | Maturity.Develop ->
+      ());
   setup_logging conf;
   (* return a new conf because can adjust conf.num_jobs (-j) *)
   let conf = setup_profiling conf in

--- a/src/osemgrep/core/Maturity.ml
+++ b/src/osemgrep/core/Maturity.ml
@@ -1,4 +1,5 @@
-open Cmdliner
+module Arg = Cmdliner.Arg
+module Term = Cmdliner.Term
 
 (*************************************************************************)
 (* Prelude *)

--- a/src/osemgrep/reporting/Output_format.ml
+++ b/src/osemgrep/reporting/Output_format.ml
@@ -6,12 +6,12 @@
 type t =
   | Text
   | Json
+  | Emacs
+  | Vim
+  | Sarif
   | Gitlab_sast
   | Gitlab_secrets
   | Junit_xml
-  | Sarif
-  | Emacs
-  | Vim
   (* used to disable the final display of match results because
    * we displayed them incrementally instead
    *)

--- a/src/osemgrep/reporting/Output_format.mli
+++ b/src/osemgrep/reporting/Output_format.mli
@@ -1,12 +1,12 @@
 type t =
   | Text
   | Json
+  | Emacs
+  | Vim
+  | Sarif
   | Gitlab_sast
   | Gitlab_secrets
   | Junit_xml
-  | Sarif
-  | Emacs
-  | Vim
   (* used to disable the final display of match results because
    * we displayed them incrementally instead
    *)


### PR DESCRIPTION
A significant step towards the migration. That means we now
handle all the CLI args that pysemgrep does (and are exercised
by a e2e test).

test plan:
make e2e


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)