### PR TITLE
feat(julia): add deep expr operator

### DIFF
--- a/changelog.d/pa-3018.added
+++ b/changelog.d/pa-3018.added
@@ -1,0 +1,3 @@
+Julia: Added the deep expression operator, so now you can write patterns like
+foo(<... 42 ...>) to find instances of calls to `foo` that contain `42` somewhere
+inside of it.

--- a/languages/julia/generic/Parse_julia_tree_sitter.ml
+++ b/languages/julia/generic/Parse_julia_tree_sitter.ml
@@ -1329,6 +1329,7 @@ and map_operation (env : env) (x : CST.operation) =
 
 and map_expression (env : env) (x : CST.expression) : expr =
   match x with
+  | `Deep_exp (l, e, r) -> G.DeepEllipsis (token env l, map_expression env e, token env r) |> G.e
   | `Semg_ellips tok -> Ellipsis (token env tok) |> G.e
   | `Choice_choice_module_defi x -> (
       match x with

--- a/languages/julia/generic/Parse_julia_tree_sitter.ml
+++ b/languages/julia/generic/Parse_julia_tree_sitter.ml
@@ -1329,7 +1329,8 @@ and map_operation (env : env) (x : CST.operation) =
 
 and map_expression (env : env) (x : CST.expression) : expr =
   match x with
-  | `Deep_exp (l, e, r) -> G.DeepEllipsis (token env l, map_expression env e, token env r) |> G.e
+  | `Deep_exp (l, e, r) ->
+      G.DeepEllipsis (token env l, map_expression env e, token env r) |> G.e
   | `Semg_ellips tok -> Ellipsis (token env tok) |> G.e
   | `Choice_choice_module_defi x -> (
       match x with

--- a/tests/patterns/julia/deep_expr_operator.jl
+++ b/tests/patterns/julia/deep_expr_operator.jl
@@ -1,0 +1,2 @@
+# ERROR: match
+foo(bar(1 + 42))


### PR DESCRIPTION
## What:
This PR adds in the deep expression operator for the Julia language.

## Why:
Community request.

## How:
Added the necessary tree-sitter changes to make it parse correctly, and the generic translation also.

## Test plan:
`make test`

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
