### PR TITLE
osemgrep: remove the use of a default .semgrep.yml

### DIFF
--- a/cli/src/semgrep/config_resolver.py
+++ b/cli/src/semgrep/config_resolver.py
@@ -27,8 +27,6 @@ from semgrep.app import auth
 from semgrep.console import console
 from semgrep.constants import CLI_RULE_ID
 from semgrep.constants import Colors
-from semgrep.constants import DEFAULT_CONFIG_FILE
-from semgrep.constants import DEFAULT_CONFIG_FOLDER
 from semgrep.constants import DEFAULT_SEMGREP_APP_CONFIG_URL
 from semgrep.constants import DEFAULT_SEMGREP_CONFIG_NAME
 from semgrep.constants import ID_KEY
@@ -374,12 +372,6 @@ class Config:
         config_dict: Dict[str, YamlTree] = {}
         errors: List[SemgrepError] = []
 
-        if not configs:
-            try:
-                config_dict.update(load_default_config())
-            except SemgrepError as e:
-                errors.append(e)
-
         for i, config in enumerate(configs):
             try:
                 # Patch config_id to fix https://github.com/returntocorp/semgrep/issues/1912
@@ -699,20 +691,6 @@ def _is_hidden_config(loc: Path) -> bool:
     )
 
 
-def load_default_config() -> Dict[str, YamlTree]:
-    """
-    Load config from DEFAULT_CONFIG_FILE or DEFAULT_CONFIG_FOLDER
-    """
-    default_file = Path(DEFAULT_CONFIG_FILE)
-    default_folder = Path(DEFAULT_CONFIG_FOLDER)
-    config_infos = []
-    if default_file.exists():
-        config_infos = [read_config_at_path(default_file)]
-    elif default_folder.exists():
-        config_infos = read_config_folder(default_folder, relative=True)
-    return parse_config_files(config_infos)
-
-
 def is_registry_id(config_str: str) -> bool:
     """
     Starts with r/, p/, s/ for registry, pack, and snippet respectively
@@ -826,7 +804,7 @@ def get_config(
 
     if not config:
         raise SemgrepError(
-            f"No config given and {DEFAULT_CONFIG_FILE} was not found. Try running with --help to debug or if you want to download a default config, try running with --config r2c"
+            f"No config given. Try running with --help to debug or if you want to download a default config, try running with --config r2c"
         )
 
     return config, errors

--- a/cli/src/semgrep/constants.py
+++ b/cli/src/semgrep/constants.py
@@ -9,8 +9,6 @@ CLI_RULE_ID = "-"
 PLEASE_FILE_ISSUE_TEXT = "An error occurred while invoking the Semgrep engine. Please help us fix this by creating an issue at https://github.com/returntocorp/semgrep"
 
 DEFAULT_SEMGREP_CONFIG_NAME = "semgrep"
-DEFAULT_CONFIG_FILE = f".{DEFAULT_SEMGREP_CONFIG_NAME}.yml"
-DEFAULT_CONFIG_FOLDER = f".{DEFAULT_SEMGREP_CONFIG_NAME}"
 DEFAULT_SEMGREP_APP_CONFIG_URL = "api/agent/deployments/scans/config"
 
 DEFAULT_TIMEOUT = 30  # seconds

--- a/src/osemgrep/core/Constants.ml
+++ b/src/osemgrep/core/Constants.ml
@@ -1,7 +1,6 @@
 (*
    translated from constants.py
 *)
-open Common
 
 let _rules_key = "rules"
 let _id_key = "id"
@@ -11,9 +10,7 @@ let _please_file_issue_text =
   "An error occurred while invoking the Semgrep engine. Please help us fix \
    this by creating an issue at https://github.com/returntocorp/semgrep"
 
-let default_semgrep_config_name = "semgrep"
-let _default_config_file = spf ".%s.yml" default_semgrep_config_name
-let _default_config_folder = spf ".%s" default_semgrep_config_name
+let _default_semgrep_config_name = "semgrep"
 
 let _returntocorp_lever_url =
   "https://api.lever.co/v0/postings/returntocorp?mode=json"


### PR DESCRIPTION
The changelog and tests were modified in a previous PR.
This just removes the code.

test plan:
make e2e


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)