### PR TITLE
feat: implicit return support (for ruby and julia)

### DIFF
--- a/changelog.d/gh-8408.added
+++ b/changelog.d/gh-8408.added
@@ -1,0 +1,15 @@
+Added support in Ruby and Julia to match implicit return statement inside functions.
+
+For example:
+
+```julia
+return 0
+```
+
+can now match 0 in
+
+```julia
+function f()
+  0
+end
+```

--- a/interfaces/Rule_options.atd
+++ b/interfaces/Rule_options.atd
@@ -153,6 +153,12 @@ type t = {
   (* Whether a rule should be considered for interfile analysis. *)
   ~interfile <ocaml default="false"> : bool;
 
+  (* Whether last expression of a block is treated the same as a return statement.
+     This option is specific only to languages that treat the last statement of
+     a block inside functions as a return statement, such as Ruby and Julia.
+  *)
+  ~implicit_return <ocaml default="true"> : bool;
+
   (* TODO: equivalences:
    *   - require_to_import (but need pass config to Js_to_generic)
    *)

--- a/src/matching/Matching_generic.mli
+++ b/src/matching/Matching_generic.mli
@@ -9,7 +9,10 @@ type tin = {
   config : Rule_options.t;
   deref_sym_vals : int;
       (** Counts the number of times that we "follow" symbollically propagated
-    * values. This is bound to prevent potential infinite loops. *)
+       * values. This is bound to prevent potential infinite loops. *)
+  inside_function : bool;
+  parent_is_last_stmt_trans : bool;
+  self_is_last_stmt : bool;
 }
 
 (* list of possible outcoming matching environments *)

--- a/tests/patterns/julia/implicit_return.jl
+++ b/tests/patterns/julia/implicit_return.jl
@@ -1,0 +1,77 @@
+# ERROR:
+f() = "implicit return for function definition without function keyword"
+
+# ERROR:
+() -> "implicit return for lambda"
+
+function f()
+  nothing
+  # ERROR:
+  "implicit return last statement"
+end
+
+function f(x)
+  if x < 0
+    # ERROR:
+    "implicit return if"
+  elseif x == 0
+    # ERROR:
+    "implicit return elsif"
+  else
+    # ERROR:
+    "implicit return else"
+  end
+end
+
+function f(x)
+  if x == 0
+    "no implicit return because not the last statement"
+  else
+    "no implicit return because not the last statement"
+  end
+  # ERROR:
+  "implicit return last statement after non trivial"
+end
+
+function f()
+  function f()
+    nil
+    # ERROR:
+    "implicit return nested function even when function is not the last statement"
+  end
+  # ERROR:
+  "implicit return last statement after nested function"
+end
+
+function f()
+  try
+    # ERROR:
+    "implicit return in try clause"
+  catch e
+    # ERROR:
+    "implicit return in catch clause"
+  end
+end
+
+function f()
+  try
+    "no implicit return in try clause if ensure is present"
+  catch e
+    "no implicit return in catch clause if ensure is present"
+  finally
+    # ERROR:
+    "implicit return in ensure clause"
+  end
+end
+
+module M
+  function f()
+    # ERROR:
+    "implicit return function inside module"
+  end
+end
+
+function f()
+  # ERROR:
+  return "explicit return should still work"
+end

--- a/tests/patterns/julia/implicit_return.sgrep
+++ b/tests/patterns/julia/implicit_return.sgrep
@@ -1,0 +1,1 @@
+return $X

--- a/tests/patterns/ruby/implicit_return.rb
+++ b/tests/patterns/ruby/implicit_return.rb
@@ -1,0 +1,85 @@
+def f()
+  nil
+  # ERROR:
+  "implicit return last statement"
+end
+
+def f(x)
+  if x < 0
+    # ERROR:
+    "implicit return if"
+  elsif x == 0
+    # ERROR:
+    "implicit return elsif"
+  else
+    # ERROR:
+    "implicit return else"
+  end
+end
+
+def f(x)
+  if x == 0
+    "no implicit return because not the last statement"
+  else
+    "no implicit return because not the last statement"
+  end
+  # ERROR:
+  "implicit return last statement after non trivial"
+end
+
+def f()
+  def f()
+    nil
+    # ERROR:
+    "implicit return nested function even when function is not the last statement"
+  end
+  # ERROR:
+  "implicit return last statement after nested function"
+end
+
+def f()
+  begin
+    # ERROR:
+    "implicit return in try clause"
+  rescue Error=>e
+    # ERROR:
+    "implicit return in catch clause"
+  end
+end
+
+def f()
+  begin
+    "no implicit return in try clause if ensure is present"
+  rescue Error=>e
+    "no implicit return in catch clause if ensure is present"
+  ensure
+    # ERROR:
+    "implicit return in ensure clause"
+  end
+end
+
+def f(x)
+  case x
+  when 0
+    # ERROR:
+    "implicit return case"
+  else
+    # ERROR:
+    "implicit return else case"
+  end
+end
+
+class C
+  def f()
+    # ERROR:
+    "implicit return function inside class"
+  end
+end
+
+module M
+  def f()
+    # ERROR:
+    "implicit return function inside module"
+  end
+end
+

--- a/tests/patterns/ruby/implicit_return.sgrep
+++ b/tests/patterns/ruby/implicit_return.sgrep
@@ -1,0 +1,1 @@
+return $X


### PR DESCRIPTION
The implementation revolves around 3 new fields added to `tin`
* inside_function
* parent_is_last_stmt_trans
* self_is_last_stmt

`inside_function` is initialized to false and becomes true whenever a function is visited.

`parent_is_last_stmt_trans` is initialized to true and when visiting each substmt, it tells the substmt whether itself upto root is true. This means that as soon as it hits the first false, this value will always be false when visiting the substmts.

`self_is_last_stmt` is initialized to true except for blocks. When we enter a block, it is set to false, except for only the last statement in that block which is set to true.

All of this is to figure out whether a statement is (transitively) the last statement inside a function or not.

Started with 2 languages which is Ruby and Julia. This feature is now enabled by default, but I also added a rule option to allow users to turn this off.

This is one of the sub-tasks for #8408.

Added new tests and tested for regressions with `make core-test`.
