### PR TITLE
osemgrep: rename core_match_results to core_output

### DIFF
--- a/cli/src/semgrep/core_output.py
+++ b/cli/src/semgrep/core_output.py
@@ -91,8 +91,8 @@ def core_error_to_semgrep_error(err: core.CoreError) -> SemgrepCoreError:
     return SemgrepCoreError(code, level, spans, err)
 
 
-def parse_core_output(raw_json: JsonObject) -> core.CoreMatchResults:
-    match_results = core.CoreMatchResults.from_json(raw_json)
+def parse_core_output(raw_json: JsonObject) -> core.CoreOutput:
+    match_results = core.CoreOutput.from_json(raw_json)
     if match_results.skipped_targets:
         for skip in match_results.skipped_targets:
             if skip.rule_id:
@@ -106,7 +106,7 @@ def parse_core_output(raw_json: JsonObject) -> core.CoreMatchResults:
 
 
 def core_matches_to_rule_matches(
-    rules: List[Rule], res: core.CoreMatchResults
+    rules: List[Rule], res: core.CoreOutput
 ) -> Dict[Rule, List[RuleMatch]]:
     """
     Convert core_match objects into RuleMatch objects that the rest of the codebase
@@ -205,7 +205,7 @@ def core_matches_to_rule_matches(
     # TODO: Dict[core.RuleId, RuleMatchSet]
     findings: Dict[Rule, RuleMatchSet] = {rule: RuleMatchSet(rule) for rule in rules}
     seen_cli_unique_keys: Set[Tuple] = set()
-    for match in res.matches:
+    for match in res.results:
         rule = rule_table[match.rule_id.value]
         rule_match = convert_to_rule_match(match)
         if rule_match.cli_unique_key in seen_cli_unique_keys:

--- a/cli/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badpattern/error-in-color.txt
+++ b/cli/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badpattern/error-in-color.txt
@@ -10,5 +10,5 @@
 --- pattern ---
 $X == $X 3
 --- end pattern ---
-Pattern error: Parsing.Parse_error
+Pattern error: Stdlib.Parsing.Parse_error
 

--- a/cli/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badpattern/error.json
+++ b/cli/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badpattern/error.json
@@ -3,7 +3,7 @@
     {
       "code": 2,
       "level": "error",
-      "message": "Pattern parse error in rule rules.syntax.eqeq-is-bad:\n Invalid pattern for Python:\n--- pattern ---\n$X == $X 3\n--- end pattern ---\nPattern error: Parsing.Parse_error\n",
+      "message": "Pattern parse error in rule rules.syntax.eqeq-is-bad:\n Invalid pattern for Python:\n--- pattern ---\n$X == $X 3\n--- end pattern ---\nPattern error: Stdlib.Parsing.Parse_error\n",
       "rule_id": "rules.syntax.eqeq-is-bad",
       "spans": [
         {

--- a/cli/tests/e2e/snapshots/test_rule_parser/test_rule_parser_cli_pattern/error.json
+++ b/cli/tests/e2e/snapshots/test_rule_parser/test_rule_parser_cli_pattern/error.json
@@ -3,7 +3,7 @@
     {
       "code": 2,
       "level": "error",
-      "message": "Pattern parse error in rule -:\n Invalid pattern for C:\n--- pattern ---\n#include<asdf><<>>><$X>\n--- end pattern ---\nPattern error: Parsing.Parse_error\n",
+      "message": "Pattern parse error in rule -:\n Invalid pattern for C:\n--- pattern ---\n#include<asdf><<>>><$X>\n--- end pattern ---\nPattern error: Stdlib.Parsing.Parse_error\n",
       "rule_id": "-",
       "spans": [
         {

--- a/cli/tests/e2e/snapshots/test_rule_parser/test_rule_parser_cli_pattern/error.txt
+++ b/cli/tests/e2e/snapshots/test_rule_parser/test_rule_parser_cli_pattern/error.txt
@@ -10,5 +10,5 @@
 --- pattern ---
 #include<asdf><<>>><$X>
 --- end pattern ---
-Pattern error: Parsing.Parse_error
+Pattern error: Stdlib.Parsing.Parse_error
 

--- a/cli/tests/e2e/snapshots/test_rule_validation/test_validation_of_invalid_rules/rulesinvalid-rulesinvalid-pattern.yaml/results.txt
+++ b/cli/tests/e2e/snapshots/test_rule_validation/test_validation_of_invalid_rules/rulesinvalid-rulesinvalid-pattern.yaml/results.txt
@@ -4,5 +4,5 @@ Configuration is invalid - found 1 configuration error(s), and 2 rule(s).
 --- pattern ---
 print..);
 --- end pattern ---
-Pattern error: Parsing.Parse_error
+Pattern error: Stdlib.Parsing.Parse_error
 

--- a/cli/tests/e2e/snapshots/test_semgrep_core_parse_error/test_rule_parser__failure__error_messages/settings0/out.json
+++ b/cli/tests/e2e/snapshots/test_semgrep_core_parse_error/test_rule_parser__failure__error_messages/settings0/out.json
@@ -3,7 +3,7 @@
     {
       "code": 2,
       "level": "error",
-      "message": "Pattern parse error in rule rules.broken-rule:\n Invalid pattern for Java:\n--- pattern ---\n@$HTTP_METHOD\npublic $RET $FUNC(..., @Auth $REQ, ...) { ... }\n\n--- end pattern ---\nPattern error: Parsing.Parse_error\n",
+      "message": "Pattern parse error in rule rules.broken-rule:\n Invalid pattern for Java:\n--- pattern ---\n@$HTTP_METHOD\npublic $RET $FUNC(..., @Auth $REQ, ...) { ... }\n\n--- end pattern ---\nPattern error: Stdlib.Parsing.Parse_error\n",
       "rule_id": "rules.broken-rule",
       "spans": [
         {

--- a/js/README.md
+++ b/js/README.md
@@ -7,12 +7,12 @@ After running:
 ```
 $ source libs/ocaml-tree-sitter-core/tree-sitter-config.sh
 $ make core
-$ dune build --profile=release
+$ make build-semgrep-jsoo # run dune build js --profile=release
 ```
 
 you should get a few MB files in `_build/default/js/engine/Main.bc.js`
 
-Building with `dune build --profile=release` (instead of the default --profile=dev)
+Building with `dune build js --profile=release` (instead of the default --profile=dev)
 has a significant impact on the size of the generated JS file. You can go
 from 110MB to 16MB!
 See https://discuss.ocaml.org/t/tutorial-full-stack-web-dev-in-ocaml-w-dream-bonsai-and-graphql/9963/8?u=aryx for more information

--- a/js/engine/Main.ml
+++ b/js/engine/Main.ml
@@ -122,8 +122,8 @@ let _ =
          let timed_rules = (rules_and_errors, 0.) in
          let res, files = Run_semgrep.semgrep_with_rules config timed_rules in
          let res =
-           JSON_report.match_results_of_matches_and_errors
+           JSON_report.core_output_of_matches_and_errors
              (Some Autofix.render_fix) (List.length files) res
          in
-         Semgrep_output_v1_j.string_of_core_match_results res
+         Semgrep_output_v1_j.string_of_core_output res
     end)

--- a/js/engine/tests/__snapshots__/index.test.js.snap
+++ b/js/engine/tests/__snapshots__/index.test.js.snap
@@ -50,7 +50,7 @@ exports[`yaml parser parses a pattern with pattern-regex 1`] = `
       ],
     },
   ],
-  "matches": [
+  "results": [
     {
       "extra": {
         "engine_kind": "OSS",
@@ -152,7 +152,7 @@ exports[`yaml parser parses a simple pattern 1`] = `
       ],
     },
   ],
-  "matches": [
+  "results": [
     {
       "extra": {
         "engine_kind": "OSS",

--- a/libs/commons/File_type.ml
+++ b/libs/commons/File_type.ml
@@ -1,6 +1,7 @@
 (* Yoann Padioleau
  *
  * Copyright (C) 2010-2013 Facebook
+ * Copyright (C) 2023 Semgrep Inc.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
@@ -69,24 +70,24 @@ and pl_type =
   | Rust
   | Beta
   | Pascal
-  | Web of webpl_type
   | Haxe
-  | Opa
-  | Flash
   | Bytecode of string
   | Asm
-  | Thrift
+  | Web of webpl_type
+  | IDL of idl_type
   | MiscPL of string
 
 and config_type =
   | Makefile
   | Dockerfile
+  (* note: XML is in webpl_type below *)
   | Json
   | Jsonnet
   (* kinda pl_type *)
   | Yaml
   | Terraform
   | Sexp (* e.g., dune files *)
+  | Toml
 
 and lisp_type = CommonLisp | Elisp | Scheme | Clojure
 
@@ -100,8 +101,11 @@ and webpl_type =
   | Css
   | Html
   | Xml
+  | Opa
+  | Flash
   | Sql
 
+and idl_type = Thrift | ATD | Protobuf
 and media_type = Sound of string | Picture of string | Video of string
 
 (*****************************************************************************)
@@ -145,9 +149,9 @@ let file_type_of_file file =
   | "hxp"
   | "hxml" ->
       PL Haxe
-  | "opa" -> PL Opa
+  | "opa" -> PL (Web Opa)
   | "sk" -> PL Skip
-  | "as" -> PL Flash
+  | "as" -> PL (Web Flash)
   | "bet" -> PL Beta
   (* todo detect false C file, look for "Mode: Objective-C++" string in file ?
    * can also be a c++, use Parser_cplusplus.is_problably_cplusplus_file
@@ -175,7 +179,9 @@ let file_type_of_file file =
   | "kt" -> PL Kotlin
   | "cs" -> PL Csharp
   | "p" -> PL Pascal
-  | "thrift" -> PL Thrift
+  | "thrift" -> PL (IDL Thrift)
+  | "atd" -> PL (IDL ATD)
+  | "proto" -> PL (IDL Protobuf)
   | "scm"
   | "rkt"
   | "ss"
@@ -246,6 +252,7 @@ let file_type_of_file file =
   | "yaml" ->
       Config Yaml
   | "tf" -> Config Terraform
+  | "toml" -> Config Toml
   (* sometimes people use foo.Dockerfile *)
   | "Dockerfile" -> Config Dockerfile
   | "sql" -> PL (Web Sql)

--- a/libs/commons/File_type.mli
+++ b/libs/commons/File_type.mli
@@ -36,13 +36,11 @@ and pl_type =
   | Rust
   | Beta
   | Pascal
-  | Web of webpl_type
   | Haxe
-  | Opa
-  | Flash
   | Bytecode of string
   | Asm
-  | Thrift
+  | Web of webpl_type
+  | IDL of idl_type
   | MiscPL of string
 
 and config_type =
@@ -53,6 +51,7 @@ and config_type =
   | Yaml
   | Terraform
   | Sexp
+  | Toml
 
 and lisp_type = CommonLisp | Elisp | Scheme | Clojure
 
@@ -66,8 +65,11 @@ and webpl_type =
   | Css
   | Html
   | Xml
+  | Opa
+  | Flash
   | Sql
 
+and idl_type = Thrift | ATD | Protobuf
 and media_type = Sound of string | Picture of string | Video of string
 
 (* main entry point *)

--- a/semgrep.opam
+++ b/semgrep.opam
@@ -15,11 +15,11 @@ homepage: "https://semgrep.dev"
 bug-reports: "https://github.com/returntocorp/semgrep/issues"
 depends: [
   "ocaml" {>= "4.12.0"}
-  "dune" {>= "2.7" & >= "2.7.0"}
+  "dune" {>= "3.7" & >= "2.7.0"}
   "stdcompat"
   "menhir" {= "20211128"}
   "grain_dypgen"
-  "base"
+  "base" {>= "v0.15.1"}
   "fpath"
   "alcotest"
   "ANSITerminal"

--- a/src/experiments/misc/Raja_experiment.ml
+++ b/src/experiments/misc/Raja_experiment.ml
@@ -55,10 +55,9 @@ let ranges_of_path (path : Fpath.t) : Function_range.ranges =
 (* Entry point *)
 (*****************************************************************************)
 
-let adjust_core_match_results (x : Out.core_match_results) :
-    Out.core_match_results =
-  let matches =
-    x.matches
+let adjust_core_match_results (x : Out.core_output) : Out.core_output =
+  let results =
+    x.results
     |> Common.map (fun (m : Out.core_match) ->
            let _rule_id = m.rule_id in
            let path = Fpath.v m.location.path in
@@ -91,4 +90,4 @@ let adjust_core_match_results (x : Out.core_match_results) :
                in
                { m with extra })
   in
-  { x with matches }
+  { x with results }

--- a/src/experiments/misc/Raja_experiment.ml
+++ b/src/experiments/misc/Raja_experiment.ml
@@ -55,7 +55,7 @@ let ranges_of_path (path : Fpath.t) : Function_range.ranges =
 (* Entry point *)
 (*****************************************************************************)
 
-let adjust_core_match_results (x : Out.core_output) : Out.core_output =
+let adjust_core_output (x : Out.core_output) : Out.core_output =
   let results =
     x.results
     |> Common.map (fun (m : Out.core_match) ->

--- a/src/experiments/misc/Raja_experiment.mli
+++ b/src/experiments/misc/Raja_experiment.mli
@@ -1,3 +1,2 @@
 val adjust_core_match_results :
-  Semgrep_output_v1_j.core_match_results ->
-  Semgrep_output_v1_j.core_match_results
+  Semgrep_output_v1_t.core_output -> Semgrep_output_v1_t.core_output

--- a/src/experiments/misc/Raja_experiment.mli
+++ b/src/experiments/misc/Raja_experiment.mli
@@ -1,2 +1,2 @@
-val adjust_core_match_results :
+val adjust_core_output :
   Semgrep_output_v1_t.core_output -> Semgrep_output_v1_t.core_output

--- a/src/metachecking/Check_rule.ml
+++ b/src/metachecking/Check_rule.ml
@@ -287,7 +287,7 @@ let check_files mk_config fparser input =
       let json =
         JSON_report.match_results_of_matches_and_errors None nfiles res
       in
-      pr (SJ.string_of_core_match_results json)
+      pr (SJ.string_of_core_output json)
 
 let stat_files fparser xs =
   let fullxs, _skipped_paths =

--- a/src/metachecking/Check_rule.ml
+++ b/src/metachecking/Check_rule.ml
@@ -285,7 +285,7 @@ let check_files mk_config fparser input =
       (* for the stats.okfiles, but we don't care? *)
       let nfiles = 0 in
       let json =
-        JSON_report.match_results_of_matches_and_errors None nfiles res
+        JSON_report.core_output_of_matches_and_errors None nfiles res
       in
       pr (SJ.string_of_core_output json)
 

--- a/src/osemgrep/cli_scan/Cli_json_output.ml
+++ b/src/osemgrep/cli_scan/Cli_json_output.ml
@@ -432,7 +432,7 @@ let cli_output_of_core_results ~logging_level (res : Core_runner.result) :
     Out.cli_output =
   match res.core with
   | {
-   matches;
+   results = matches;
    errors;
    skipped_targets;
    (* LATER *)

--- a/src/osemgrep/cli_scan/Core_runner.ml
+++ b/src/osemgrep/cli_scan/Core_runner.ml
@@ -38,7 +38,7 @@ type result = {
   (* ocaml: not in original python implem, but just enough to get
    * Semgrep_scan.cli_output_of_core_results to work
    *)
-  core : Out.core_match_results;
+  core : Out.core_output;
   hrules : Rule.hrules;
   scanned : Fpath.t Set_.t;
       (* in python implem *)

--- a/src/osemgrep/cli_scan/Core_runner.ml
+++ b/src/osemgrep/cli_scan/Core_runner.ml
@@ -193,7 +193,7 @@ let prepare_config_for_semgrep_core (config : Runner_config.t)
  *)
 let create_core_result all_rules (_exns, res, scanned) =
   let match_results =
-    JSON_report.match_results_of_matches_and_errors (Some Autofix.render_fix)
+    JSON_report.core_output_of_matches_and_errors (Some Autofix.render_fix)
       (Set_.cardinal scanned) res
   in
 

--- a/src/osemgrep/cli_scan/Core_runner.mli
+++ b/src/osemgrep/cli_scan/Core_runner.mli
@@ -12,7 +12,7 @@ type conf = {
 
 (* output *)
 type result = {
-  core : Semgrep_output_v1_t.core_match_results;
+  core : Semgrep_output_v1_t.core_output;
   hrules : Rule.hrules;
   scanned : Fpath.t Set_.t;
 }

--- a/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -177,7 +177,7 @@ let rules_and_counted_matches (res : Core_runner.result) : (Rule.t * int) list =
   let fold acc (core_match : Out.core_match) =
     Map_.update core_match.Out.rule_id update acc
   in
-  let map = List.fold_left fold Map_.empty res.core.Out.matches in
+  let map = List.fold_left fold Map_.empty res.core.Out.results in
   Map_.fold
     (fun rule_id n acc ->
       match Rule_ID.of_string_opt rule_id with

--- a/src/osemgrep/language_server/Processed_run.ml
+++ b/src/osemgrep/language_server/Processed_run.ml
@@ -49,7 +49,7 @@ let filter_clean_lines matches =
 (*************************************************************************)
 
 let of_matches ?(only_git_dirty = true) (result : Core_runner.result) =
-  let matches = result.core.matches in
+  let matches = result.core.results in
   let hrules = result.hrules in
   let env = { Cli_json_output.hrules } in
   (* Match up the rules with the matches so we can get fixes, rule ids, messages *)

--- a/src/osemgrep/language_server/Unit_LS.ml
+++ b/src/osemgrep/language_server/Unit_LS.ml
@@ -57,7 +57,7 @@ let mock_run_results (files : string list) : Core_runner.result =
   let core =
     Out.
       {
-        matches;
+        results = matches;
         errors = [];
         skipped_targets = None;
         skipped_rules = None;

--- a/src/reporting/JSON_report.ml
+++ b/src/reporting/JSON_report.ml
@@ -375,7 +375,7 @@ let match_results_of_matches_and_errors render_fix nfiles res =
     | RP.No_info -> (None, None)
   in
   {
-    Out.matches;
+    Out.results = matches;
     errors = errs |> Common.map error_to_error;
     skipped_targets;
     skipped_rules =

--- a/src/reporting/JSON_report.ml
+++ b/src/reporting/JSON_report.ml
@@ -354,7 +354,7 @@ let json_time_of_profiling_data profiling_data =
     max_memory_bytes = profiling_data.max_memory_bytes;
   }
 
-let match_results_of_matches_and_errors render_fix nfiles res =
+let core_output_of_matches_and_errors render_fix nfiles res =
   let matches, new_errs =
     Common.partition_either (match_to_match render_fix) res.RP.matches
   in

--- a/src/reporting/JSON_report.mli
+++ b/src/reporting/JSON_report.mli
@@ -12,7 +12,7 @@ val match_results_of_matches_and_errors :
   render_fix option ->
   int (* number of files processed, for the stats.okfiles *) ->
   Report.final_result ->
-  Semgrep_output_v1_t.core_match_results
+  Semgrep_output_v1_t.core_output
 
 (* for abstract_content and subpatterns matching-explanations
  * TODO: should not use! the result may miss some commas

--- a/src/reporting/JSON_report.mli
+++ b/src/reporting/JSON_report.mli
@@ -8,7 +8,7 @@ val match_to_match :
   Pattern_match.t ->
   (Semgrep_output_v1_t.core_match, Semgrep_error_code.error) Common.either
 
-val match_results_of_matches_and_errors :
+val core_output_of_matches_and_errors :
   render_fix option ->
   int (* number of files processed, for the stats.okfiles *) ->
   Report.final_result ->

--- a/src/reporting/Output_from_core_util.ml
+++ b/src/reporting/Output_from_core_util.ml
@@ -101,5 +101,5 @@ let sort_match_list (matches : core_match list) : core_match list =
   in
   List.stable_sort compare_match matches
 
-let sort_match_results (res : core_match_results) : core_match_results =
-  { res with matches = sort_match_list res.matches }
+let sort_match_results (res : core_output) : core_output =
+  { res with results = sort_match_list res.results }

--- a/src/reporting/Output_from_core_util.mli
+++ b/src/reporting/Output_from_core_util.mli
@@ -16,5 +16,4 @@ val location_of_token_location : Tok.location -> Semgrep_output_v1_t.location
    match location first.
 *)
 val sort_match_results :
-  Semgrep_output_v1_t.core_match_results ->
-  Semgrep_output_v1_t.core_match_results
+  Semgrep_output_v1_t.core_output -> Semgrep_output_v1_t.core_output

--- a/src/reporting/Unit_reporting.ml
+++ b/src/reporting/Unit_reporting.ml
@@ -36,7 +36,7 @@ let semgrep_core_output () =
             ( file,
               fun () ->
                 let s = Common.read_file file in
-                let _res = Out.core_match_results_of_string s in
+                let _res = Out.core_output_of_string s in
                 () )))
 
 (*****************************************************************************)

--- a/src/runner/Run_semgrep.ml
+++ b/src/runner/Run_semgrep.ml
@@ -925,7 +925,7 @@ let output_semgrep_results (exn, res, files) config =
         User should use an external tool like jq or ydump (latter comes with
         yojson) for pretty-printing json.
       *)
-      let s = Out.string_of_core_match_results res in
+      let s = Out.string_of_core_output res in
       logger#info "size of returned JSON string: %d" (String.length s);
       pr s;
       match exn with
@@ -1012,7 +1012,7 @@ let semgrep_with_one_pattern config =
         JSON_report.match_results_of_matches_and_errors
           (Some Autofix.render_fix) (List.length files) res
       in
-      let s = Out.string_of_core_match_results json in
+      let s = Out.string_of_core_output json in
       pr s
   | Text ->
       let minirule, _rules_parse_time =

--- a/src/runner/Run_semgrep.ml
+++ b/src/runner/Run_semgrep.ml
@@ -910,12 +910,12 @@ let output_semgrep_results (exn, res, files) config =
   match config.output_format with
   | Json _ -> (
       let res =
-        JSON_report.match_results_of_matches_and_errors
-          (Some Autofix.render_fix) (List.length files) res
+        JSON_report.core_output_of_matches_and_errors (Some Autofix.render_fix)
+          (List.length files) res
       in
       (* one-off experiment, delete it at some point (March 2023) *)
       let res =
-        if !Flag_semgrep.raja then Raja_experiment.adjust_core_match_results res
+        if !Flag_semgrep.raja then Raja_experiment.adjust_core_output res
         else res
       in
       (*
@@ -1009,8 +1009,8 @@ let semgrep_with_one_pattern config =
         semgrep_with_rules config (([ rule ], []), rules_parse_time)
       in
       let json =
-        JSON_report.match_results_of_matches_and_errors
-          (Some Autofix.render_fix) (List.length files) res
+        JSON_report.core_output_of_matches_and_errors (Some Autofix.render_fix)
+          (List.length files) res
       in
       let s = Out.string_of_core_output json in
       pr s

--- a/tests/semgrep_output/core_output/core_output1.json
+++ b/tests/semgrep_output/core_output/core_output1.json
@@ -1,5 +1,5 @@
 {
-  "matches": [
+  "results": [
     {
       "rule_id": "-e/-f",
       "location": {


### PR DESCRIPTION
This will help merge core_output with cli_output

test plan:
make
make test


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)