### PR TITLE
fix: extract semgrep python wheel in a more robust way

### DIFF
--- a/.github/workflows/build-test-manylinux-aarch64.yaml
+++ b/.github/workflows/build-test-manylinux-aarch64.yaml
@@ -38,6 +38,13 @@ jobs:
 
           # clean up after ourselves
           docker rm $CONTAINER_ID
+
+          # note: this was originally accomplished by running `cat` from within the container and redirecting stdout to a file:
+          #
+          # docker run --platform linux/arm64 --rm ${{ steps.build-semgrep-wheel.outputs.imageid }} cat cli/dist.zip > /tmp/dist.zip
+          #
+          # we ended up hitting an edge case where the final ~100kb doesn't always get written to disk, which results in a corrupted zip file.
+          # our theory is that the pipe between the container and the host is being closed prematurely.
       - uses: actions/upload-artifact@v3
         with:
           name: manylinux-aarch64-wheel

--- a/.github/workflows/build-test-manylinux-aarch64.yaml
+++ b/.github/workflows/build-test-manylinux-aarch64.yaml
@@ -26,9 +26,19 @@ jobs:
           buildx-fallback: true
       - name: Extract wheel from docker image
         run: |
+          # load the docker image containing the semgrep python wheel
           docker load --input /tmp/image.tar
-          docker run --platform linux/arm64 --rm ${{ steps.build-semgrep-wheel.outputs.imageid }} cat cli/dist.zip > /tmp/dist.zip
+
+          # create a new docker container using the image we just loaded
+          # note: `docker create` simply prepares the container filesystem -- nothing is executed!
+          CONTAINER_ID=$(docker create ${{ steps.build-semgrep-wheel.outputs.imageid }})
+
+          # use `docker export` to extract the python wheel zipfile out of the container
+          docker export $CONTAINER_ID | tar xv semgrep/cli/dist.zip
+
+          # clean up after ourselves
+          docker rm $CONTAINER_ID
       - uses: actions/upload-artifact@v3
         with:
           name: manylinux-aarch64-wheel
-          path: /tmp/dist.zip
+          path: semgrep/cli/dist.zip


### PR DESCRIPTION
We've been seeing nightly verification failures due to the zip file containing the aarch64 python wheel being corrupted: https://github.com/returntocorp/semgrep/actions/runs/6002039013/job/16278300160

It turns out we're hitting an edge case with how we're extracting the zip file out of the semgrep image: In `docker run --platform linux/arm64 --rm ${{ steps.build-semgrep-wheel.outputs.imageid }} cat cli/dist.zip > /tmp/dist.zip`, not all of stdout is being written to `/tmp/dist.zip`.

This PR takes a different approach which should be more robust (and also doesn't require us running anything inside the semgrep container):
1. Create a new container based on the semgrep image
2. Use `docker export` to export the container's filesystem as a tarball
3. Only keep `dist.zip`

/cc @brandonspark 

test plan:
- confirmed commands worked locally and that the resulting zipfile was valid
- checks pass

PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
