### PR TITLE
Bug fix for merging findings

### DIFF
--- a/changelog.d/gh-8557.fixed
+++ b/changelog.d/gh-8557.fixed
@@ -1,0 +1,1 @@
+Fixed CLI output to display matches from different rules with the same message.

--- a/cli/src/semgrep/formatter/text.py
+++ b/cli/src/semgrep/formatter/text.py
@@ -577,8 +577,12 @@ def print_text_output(
         if (
             rule_match.rule_id
             and rule_match.rule_id != CLI_RULE_ID
-            and (last_rule_id is None or last_rule_id != rule_match.rule_id)
-            and (last_message is None or last_message != message)
+            and (
+                last_rule_id is None
+                or last_rule_id != rule_match.rule_id
+                or last_message is None
+                or last_message != message
+            )
         ):
             shortlink = get_details_shortlink(rule_match)
             shortlink_text = (8 * " " + shortlink + "\n") if shortlink else ""
@@ -613,8 +617,12 @@ def print_text_output(
         elif (
             "sca_info" in rule_match.extra
             and "sca-fix-versions" in rule_match.metadata
-            and (last_rule_id is None or last_rule_id != rule_match.rule_id)
-            and (last_message is None or last_message != message)
+            and (
+                last_rule_id is None
+                or last_rule_id != rule_match.rule_id
+                or last_message is None
+                or last_message != message
+            )
         ):
             # this is a list of objects like [{'minimist': '0.2.4'}, {'minimist': '1.2.6'}]
             fixes = rule_match.metadata["sca-fix-versions"]

--- a/cli/src/semgrep/formatter/text.py
+++ b/cli/src/semgrep/formatter/text.py
@@ -549,6 +549,7 @@ def print_text_output(
     dataflow_traces: bool,
 ) -> None:
     last_file = None
+    last_rule_id = None
     last_message = None
     sorted_rule_matches = sorted(rule_matches, key=lambda r: (r.path, r.rule_id))
     for rule_index, rule_match in enumerate(sorted_rule_matches):
@@ -570,11 +571,13 @@ def print_text_output(
                     else ""
                 )
             )
+            last_rule_id = None
             last_message = None
         # don't display the rule line if the check is empty
         if (
             rule_match.rule_id
             and rule_match.rule_id != CLI_RULE_ID
+            and (last_rule_id is None or last_rule_id != rule_match.rule_id)
             and (last_message is None or last_message != message)
         ):
             shortlink = get_details_shortlink(rule_match)
@@ -610,6 +613,7 @@ def print_text_output(
         elif (
             "sca_info" in rule_match.extra
             and "sca-fix-versions" in rule_match.metadata
+            and (last_rule_id is None or last_rule_id != rule_match.rule_id)
             and (last_message is None or last_message != message)
         ):
             # this is a list of objects like [{'minimist': '0.2.4'}, {'minimist': '1.2.6'}]
@@ -635,6 +639,7 @@ def print_text_output(
             )
 
         last_file = current_file
+        last_rule_id = rule_match.rule_id
         last_message = message
         next_rule_match = (
             sorted_rule_matches[rule_index + 1]

--- a/cli/tests/e2e/rules/cli_test/match_diff_rules_same_msg/src.py
+++ b/cli/tests/e2e/rules/cli_test/match_diff_rules_same_msg/src.py
@@ -1,0 +1,2 @@
+def main():
+    return "hello"

--- a/cli/tests/e2e/rules/cli_test/match_rules_same_message/rules.yml
+++ b/cli/tests/e2e/rules/cli_test/match_rules_same_message/rules.yml
@@ -1,0 +1,11 @@
+rules:
+  - id: rule1
+    pattern: $X == $X
+    message: Same message as other rule.
+    severity: ERROR
+    languages: [python]
+  - id: rule2
+    pattern: $X == $X
+    message: Same message as other rule.
+    severity: ERROR
+    languages: [python]

--- a/cli/tests/e2e/snapshots/test_cli_test/test_cli_test_match_rules_same_message/result.txt
+++ b/cli/tests/e2e/snapshots/test_cli_test/test_cli_test_match_rules_same_message/result.txt
@@ -1,0 +1,14 @@
+                   
+                   
+┌─────────────────┐
+│ 2 Code Findings │
+└─────────────────┘
+                                                             
+  [36m[22m[24m  tests/e2e/targets/cli_test/basic/basic.py [0m
+       [1m[24mtests.e2e.rules.cli_test.match_rules_same_message.rule1[0m
+          Same message as other rule.                                   
+                                                                        
+            2┆ print([1m[24m1 == 1[0m)
+            ⋮┆----------------------------------------
+            2┆ print([1m[24m1 == 1[0m)
+

--- a/cli/tests/e2e/snapshots/test_cli_test/test_cli_test_match_rules_same_message/results.txt
+++ b/cli/tests/e2e/snapshots/test_cli_test/test_cli_test_match_rules_same_message/results.txt
@@ -1,0 +1,17 @@
+
+
+┌─────────────────┐
+│ 2 Code Findings │
+└─────────────────┘
+
+  [36m[22m[24m  targets/cli_test/basic/basic.py [0m
+       [1m[24mrules.cli_test.match_rules_same_message.rule1[0m
+          Same message as other rule.
+
+            2┆ print([1m[24m1 == 1[0m)
+            ⋮┆----------------------------------------
+       [1m[24mrules.cli_test.match_rules_same_message.rule2[0m
+          Same message as other rule.
+
+            2┆ print([1m[24m1 == 1[0m)
+

--- a/cli/tests/e2e/test_cli_test.py
+++ b/cli/tests/e2e/test_cli_test.py
@@ -174,3 +174,17 @@ def test_cli_test_from_entrypoint(snapshot):
         timeout=15,
     )
     snapshot.assert_match(result.stdout, "output.txt")
+
+
+@pytest.mark.kinda_slow
+def test_cli_test_match_rules_same_message(run_semgrep_in_tmp: RunSemgrep, snapshot):
+    results, _ = run_semgrep_in_tmp(
+        "rules/cli_test/match_rules_same_message/rules.yml",
+        target_name="cli_test/basic/",
+        output_format=OutputFormat.TEXT,
+        force_color=True,
+    )
+    snapshot.assert_match(
+        results,
+        "results.txt",
+    )


### PR DESCRIPTION
# What
Adds prevents rules with the same message but different rule ids from being merged by the CLI.

before:
<img width="951" alt="Screenshot 2023-08-30 at 1 14 19 PM" src="https://github.com/returntocorp/semgrep/assets/4377138/68ad4b62-0ca6-4f2b-a663-22a77ae750e0">

after:
![image](https://github.com/returntocorp/semgrep/assets/4377138/57315729-b4de-4330-ace4-d9e860587b54)


# Testing
Added end to end test in CLI.
`make test`


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
