### PR TITLE
feat: Temporary CLI UI to display secrets validation.

### DIFF
--- a/cli/src/semgrep/formatter/text.py
+++ b/cli/src/semgrep/formatter/text.py
@@ -656,6 +656,7 @@ def print_text_output(
         ):
             console.print(line)
 
+        # Temporary CLI UI until a more thorough implementation.
         if "validation_state" in rule_match.extra:
             validation_state = rule_match.extra["validation_state"]
             if validation_state == "NO_VALIDATOR":

--- a/cli/src/semgrep/formatter/text.py
+++ b/cli/src/semgrep/formatter/text.py
@@ -549,6 +549,7 @@ def print_text_output(
     dataflow_traces: bool,
 ) -> None:
     last_file = None
+    last_rule_id = None
     last_message = None
     sorted_rule_matches = sorted(rule_matches, key=lambda r: (r.path, r.rule_id))
     for rule_index, rule_match in enumerate(sorted_rule_matches):
@@ -570,11 +571,13 @@ def print_text_output(
                     else ""
                 )
             )
+            last_rule_id = None
             last_message = None
         # don't display the rule line if the check is empty
         if (
             rule_match.rule_id
             and rule_match.rule_id != CLI_RULE_ID
+            and (last_rule_id is None or last_rule_id != rule_match.rule_id)
             and (last_message is None or last_message != message)
         ):
             shortlink = get_details_shortlink(rule_match)
@@ -610,6 +613,7 @@ def print_text_output(
         elif (
             "sca_info" in rule_match.extra
             and "sca-fix-versions" in rule_match.metadata
+            and (last_rule_id is None or last_rule_id != rule_match.rule_id)
             and (last_message is None or last_message != message)
         ):
             # this is a list of objects like [{'minimist': '0.2.4'}, {'minimist': '1.2.6'}]
@@ -635,6 +639,7 @@ def print_text_output(
             )
 
         last_file = current_file
+        last_rule_id = rule_match.rule_id
         last_message = message
         next_rule_match = (
             sorted_rule_matches[rule_index + 1]

--- a/cli/src/semgrep/formatter/text.py
+++ b/cli/src/semgrep/formatter/text.py
@@ -659,11 +659,8 @@ def print_text_output(
         # Temporary CLI UI until a more thorough implementation.
         if "validation_state" in rule_match.extra:
             validation_state = rule_match.extra["validation_state"]
-            if validation_state == "NO_VALIDATOR":
-                # Just printing a line to seperate different findings
-                # since they are now intermixed with these messages.
-                console.print("\n")
-            else:
+            # Do nothing for NO_VALIDATOR to preserve previous UI.
+            if validation_state != "NO_VALIDATOR":
                 msg = ""
                 if validation_state == "CONFIRMED_VALID":
                     msg = "Semgrep confirmed this secret is still valid."
@@ -672,10 +669,8 @@ def print_text_output(
                 elif validation_state == "CONFIRMED_ERROR":
                     msg = "Semgrep encountered a network error while trying to validate this secret."
                 console.print(
-                    f"{8 * ' '}{with_color(Colors.foreground, msg, bold=True)}"
+                    f"{8 * ' '}{with_color(Colors.foreground, msg, bold=True)}\n"
                 )
-        else:
-            console.print("\n")
 
         if dataflow_traces:
             for line in dataflow_trace_to_lines(

--- a/cli/src/semgrep/formatter/text.py
+++ b/cli/src/semgrep/formatter/text.py
@@ -661,6 +661,24 @@ def print_text_output(
         ):
             console.print(line)
 
+        if "validation_state" in rule_match.extra:
+            validation_state = rule_match.extra['validation_state']
+            if  validation == 'NO_VALIDATOR':
+                # Just printing a line to seperate different findings
+                # since they are now intermixed with these messages.
+                console.print("\n") 
+            else:
+               msg = ""
+               if rule_match.extra['validation_state'] == 'CONFIRMED_VALID':
+                   msg = "Semgrep confirmed this secret is still valid."
+               elif rule_match.extra['validation_state'] == 'CONFIRMED_INVALID':
+                   msg = "Semgrep confirmed this secret is invalid."
+               elif rule_match.extra['validation_state'] == 'CONFIRMED_ERROR':
+                   msg = "Semgrep encountered a network error while trying to validate this secret."
+                console.print(f"{8 * ' '}{with_color(Colors.foreground, msg, bold=True)}")
+            else:
+                console.print("\n")
+            
         if dataflow_traces:
             for line in dataflow_trace_to_lines(
                 rule_match.path,


### PR DESCRIPTION
# What
Adds textual output to the CLI when a validation_state is returned besides the default `NO_VALIDATOR`. This is a temporary change and is slated to be replaced in a week or two. This is just to give some feedback on the CLI for alpha and beta testers.

## PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
  - Not sure if this is considered user facing since it is only for beta testing purposes.
- [x] Change has no security implications (otherwise, ping security team)

# Testing
Manual test in [this PR for semgrep-proprietary](https://github.com/returntocorp/semgrep-proprietary/pull/934).

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
