### PR TITLE
fix(SSC): Correctly parse pnpm-lock v6+ packages

### DIFF
--- a/changelog.d/sc-1033.fixed
+++ b/changelog.d/sc-1033.fixed
@@ -1,0 +1,1 @@
+Fixed bug where dependencies in (pnpm-lock.yaml at version 6.0 or above) files were not parsed.

--- a/cli/src/semdep/parsers/pnpm.py
+++ b/cli/src/semdep/parsers/pnpm.py
@@ -34,10 +34,20 @@ def parse_direct_pre_6(yaml: YamlTree[YamlMap]) -> List[str]:
     return get_key_values(yaml, "specifiers")
 
 
+def parse_package_key_pre_6(key: str) -> Optional[tuple[str, str]]:
+    match = re.compile(r"/(.+)/([^/]+)").match(key)
+    return match.groups() if match else None  # type: ignore
+
+
 def parse_direct_post_6(yaml: YamlTree[YamlMap]) -> List[str]:
     return get_key_values(yaml, "dependencies") + get_key_values(
         yaml, "devDependencies"
     )
+
+
+def parse_package_key_post_6(key: str) -> Optional[tuple[str, str]]:
+    match = re.compile(r"/(.+?)@([^(@]+)").match(key)
+    return match.groups() if match else None  # type: ignore
 
 
 def parse_pnpm(
@@ -61,10 +71,12 @@ def parse_pnpm(
         lockfile_version = float(parsed_lockfile.value["lockfileVersion"].value)
     except KeyError:
         return [], errors
-    if lockfile_version <= 5.4:
-        parse_direct = parse_direct_pre_6
-    else:
-        parse_direct = parse_direct_post_6
+
+    parse_direct, parse_package_key = (
+        (parse_direct_pre_6, parse_package_key_pre_6)
+        if lockfile_version <= 5.4
+        else (parse_direct_post_6, parse_package_key_post_6)
+    )
 
     if "importers" in parsed_lockfile.value:
         direct_deps = {
@@ -88,10 +100,18 @@ def parse_pnpm(
                     )
                 )
             else:
-                match = re.compile(r"/(.+)/([^/]+)").match(key.value)
-                if match:
+                data = parse_package_key(key.value)
+                if data:
                     # re does not have a way for us to refine the type of the match to what we know it is
-                    all_deps.append((key.span.start.line, match.groups()))  # type: ignore
+                    all_deps.append((key.span.start.line, data))
+                else:
+                    errors.append(
+                        DependencyParserError(
+                            str(lockfile_path),
+                            key.span.start.line,
+                            f"Could not parse package key {key.value}",
+                        )
+                    )
 
     except KeyError:
         return [], errors

--- a/cli/src/semdep/parsers/pnpm.py
+++ b/cli/src/semdep/parsers/pnpm.py
@@ -34,7 +34,7 @@ def parse_direct_pre_6(yaml: YamlTree[YamlMap]) -> List[str]:
     return get_key_values(yaml, "specifiers")
 
 
-def parse_package_key_pre_6(key: str) -> Optional[tuple[str, str]]:
+def parse_package_key_pre_6(key: str) -> Optional[Tuple[str, str]]:
     match = re.compile(r"/(.+)/([^/]+)").match(key)
     return match.groups() if match else None  # type: ignore
 
@@ -45,7 +45,7 @@ def parse_direct_post_6(yaml: YamlTree[YamlMap]) -> List[str]:
     )
 
 
-def parse_package_key_post_6(key: str) -> Optional[tuple[str, str]]:
+def parse_package_key_post_6(key: str) -> Optional[Tuple[str, str]]:
     match = re.compile(r"/(.+?)@([^(@]+)").match(key)
     return match.groups() if match else None  # type: ignore
 
@@ -90,7 +90,7 @@ def parse_pnpm(
         package_map = parsed_lockfile.value["packages"].value
         if not package_map:
             return [], errors
-        all_deps: List[tuple[int, tuple[str, str]]] = []
+        all_deps: List[Tuple[int, Tuple[str, str]]] = []
         for key, map in package_map.items():
             if map.value and "name" in map.value and "version" in map.value:
                 all_deps.append(

--- a/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awarejs-pnpm-sca.yaml-dependency_awarepnpm-v6/results.txt
+++ b/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awarejs-pnpm-sca.yaml-dependency_awarepnpm-v6/results.txt
@@ -15,7 +15,53 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
       "targets/dependency_aware/pnpm-v6/pnpm-lock.yaml"
     ]
   },
-  "results": [],
+  "results": [
+    {
+      "check_id": "rules.dependency_aware.js-pnpm-workspaces-sca",
+      "end": {
+        "col": 0,
+        "line": 44,
+        "offset": 0
+      },
+      "extra": {
+        "engine_kind": "OSS",
+        "fingerprint": "0x42",
+        "is_ignored": false,
+        "lines": "  /vercel@28.16.12:\n    resolution: {integrity: sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==}",
+        "message": "oh no",
+        "metadata": {},
+        "metavars": {},
+        "sca_info": {
+          "dependency_match": {
+            "dependency_pattern": {
+              "ecosystem": "npm",
+              "package": "vercel",
+              "semver_range": "< 28.16.13"
+            },
+            "found_dependency": {
+              "allowed_hashes": {},
+              "ecosystem": "npm",
+              "line_number": 43,
+              "package": "vercel",
+              "transitivity": "transitive",
+              "version": "28.16.12"
+            },
+            "lockfile": "targets/dependency_aware/pnpm-v6/pnpm-lock.yaml"
+          },
+          "reachability_rule": false,
+          "reachable": false,
+          "sca_finding_schema": 20220913
+        },
+        "severity": "WARNING"
+      },
+      "path": "targets/dependency_aware/pnpm-v6/pnpm-lock.yaml",
+      "start": {
+        "col": 0,
+        "line": 43,
+        "offset": 0
+      }
+    }
+  ],
   "version": "0.42"
 }
 === end of stdout - plain
@@ -40,6 +86,6 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
 │ Scan Summary │
 └──────────────┘
 
-Ran 2 rules on 1 file: 0 findings.
+Ran 2 rules on 1 file: 1 finding.
 
 === end of stderr - plain

--- a/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awarejs-pnpm-sca.yaml-dependency_awarepnpm-v6/results.txt
+++ b/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awarejs-pnpm-sca.yaml-dependency_awarepnpm-v6/results.txt
@@ -1,0 +1,45 @@
+=== command
+SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERSION_CACHE_PATH="<MASKED>" SEMGREP_ENABLE_VERSION_CHECK="0" SEMGREP_SEND_METRICS="off" semgrep --strict --config rules/dependency_aware/js-pnpm-sca.yaml --json targets/dependency_aware/pnpm-v6
+=== end of command
+
+=== exit code
+0
+=== end of exit code
+
+=== stdout - plain
+{
+  "errors": [],
+  "paths": {
+    "_comment": "<add --verbose for a list of skipped paths>",
+    "scanned": [
+      "targets/dependency_aware/pnpm-v6/pnpm-lock.yaml"
+    ]
+  },
+  "results": [],
+  "version": "0.42"
+}
+=== end of stdout - plain
+
+=== stderr - plain
+
+
+┌─────────────┐
+│ Scan Status │
+└─────────────┘
+  Scanning 1 file tracked by git with 0 Code rules, 2 Supply Chain rules:
+
+
+  CODE RULES
+  Nothing to scan.
+
+  SUPPLY CHAIN RULES
+  Nothing to scan.
+
+
+┌──────────────┐
+│ Scan Summary │
+└──────────────┘
+
+Ran 2 rules on 1 file: 0 findings.
+
+=== end of stderr - plain

--- a/cli/tests/e2e/targets/dependency_aware/pnpm-v6/pnpm-lock.yaml
+++ b/cli/tests/e2e/targets/dependency_aware/pnpm-v6/pnpm-lock.yaml
@@ -1,0 +1,76 @@
+lockfileVersion: '6.1'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+dependencies:
+  acorn:
+    specifier: ^8.8.0
+    version: 8.8.2
+
+devDependencies:
+  tslint:
+    specifier: ^5.10.0
+    version: 5.10.0(typescript@4.9.5)
+  'typescript':
+    specifier: ^4.9.5
+    version: 4.9.5
+
+packages:
+  /tsutils@2.29.0(typescript@4.9.5):
+    resolution: {integrity: sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==}
+    peerDependencies:
+      typescript: '>=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >= 3.0.0-dev || >= 3.1.0-dev'
+    dependencies:
+      tslib: 1.14.1
+      typescript: 4.9.5
+    dev: true
+
+  
+  /@types/node@14.14.6:
+    resolution: {integrity: sha512-6QlRuqsQ/Ox/aJEQWBEJG7A9+u7oSYl3mem/K8IzxXG/kAGbV1YPD9Bg9Zw3vyxC/YP+zONKwy8hGkSt1jxFMw==}
+    dev: true
+
+
+  /acorn@8.8.2:
+    resolution: {integrity: sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+    dev: true
+
+
+  /ansi-regex@2.1.1:
+    resolution: {integrity: sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+
+  /tslint@5.10.0(typescript@4.9.5):
+    resolution: {integrity: sha512-4Mra0B0RFVnof0oFMU0MDyclKmzNyFiZJHzAH6vJ28srZ+dXa/6a6prSJZHyJygrH72yVV2or3dY59EdXCnPaA==}
+    engines: {node: '>=4.8.0'}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev'
+    dependencies:
+      babel-code-frame: 6.26.0
+      builtin-modules: 1.1.1
+      chalk: 2.4.2
+      commander: 2.20.3
+      diff: 3.5.0
+      glob: 7.2.3
+      js-yaml: 3.14.1
+      minimatch: 3.1.2
+      resolve: 1.22.2
+      semver: 5.7.1
+      tslib: 1.14.1
+      tsutils: 2.29.0(typescript@4.9.5)
+      typescript: 4.9.5
+    dev: true
+
+
+  /typescript@4.9.5:
+    resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
+    engines: {node: '>=4.2.0'}
+    hasBin: true
+    dev: true

--- a/cli/tests/e2e/targets/dependency_aware/pnpm-v6/pnpm-lock.yaml
+++ b/cli/tests/e2e/targets/dependency_aware/pnpm-v6/pnpm-lock.yaml
@@ -40,10 +40,9 @@ packages:
     dev: true
 
 
-  /ansi-regex@2.1.1:
+  /vercel@28.16.12:
     resolution: {integrity: sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
 
   /tslint@5.10.0(typescript@4.9.5):

--- a/cli/tests/e2e/test_dependency_aware_rules.py
+++ b/cli/tests/e2e/test_dependency_aware_rules.py
@@ -287,8 +287,15 @@ def test_maven_version_comparison(version, specifier, outcome):
 def test_osv_parsing(parse_lockfile_path_in_tmp, caplog, target):
     caplog.set_level(logging.ERROR)
     _, error = parse_lockfile_path_in_tmp(Path(target))
+    # These two files have some packages we cannot really make sense of, so we ignore them
+    # We include our failures in the error output for informational purposes
+    if target.endswith("files/pnpm-lock.yaml"):
+        assert len(error) == 1
+    elif target.endswith("exotic/pnpm-lock.yaml"):
+        assert len(error) == 5
+    else:
+        assert len(error) == 0
     assert len(caplog.records) == 0
-    assert len(error) == 0
 
 
 # Quite awkward. To test that we can handle a target whose toplevel parent

--- a/cli/tests/e2e/test_dependency_aware_rules.py
+++ b/cli/tests/e2e/test_dependency_aware_rules.py
@@ -81,6 +81,7 @@ pytestmark = pytest.mark.kinda_slow
         ("rules/dependency_aware/js-yarn2-sca.yaml", "dependency_aware/yarn2"),
         ("rules/dependency_aware/js-pnpm-sca.yaml", "dependency_aware/pnpm"),
         ("rules/dependency_aware/js-pnpm-sca.yaml", "dependency_aware/pnpm-workspaces"),
+        ("rules/dependency_aware/js-pnpm-sca.yaml", "dependency_aware/pnpm-v6"),
         (
             "rules/dependency_aware/python-requirements-sca.yaml",
             "dependency_aware/requirements",


### PR DESCRIPTION
`pnpm-lock.yaml` files that are version `6.0` and up name their packages like this:
```
/package@version
```
instead of like this
```
/package/version
````

Sometimes a peer dependency is included, like this:
```
/tsutils@2.29.0(typescript@4.9.5)
```
The peer dependency should appear elsewhere in the lockfile as it's own entry and is ignored here.

We weren't handling this, now we do. We also now include any packages we failed to parse in the list of errors.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
