### PR TITLE
cli: simplify python wheel building + properly publish aarch64 musllinux wheel

### DIFF
--- a/changelog.d/gh-8565.fixed
+++ b/changelog.d/gh-8565.fixed
@@ -1,0 +1,1 @@
+Semgrep PyPI package can now be pip install-ed on aarch64 libmusl platforms (e.g. Alpine)

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -33,6 +33,8 @@ if WHEEL_CMD in sys.argv:
             abi = "none"
             if plat == "linux_x86_64":
                 plat = "any"
+            elif plat == "linux_aarch64":
+                plat = "musllinux1_0_aarch64.manylinux2014_aarch64"
             return python, abi, plat
 
     cmdclass = {WHEEL_CMD: BdistWheel}

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -33,24 +33,25 @@ if WHEEL_CMD in sys.argv:
             # For more information about python compatibility tags, check out:
             # https://packaging.python.org/en/latest/specifications/platform-compatibility-tags/
 
-            # we support Python 3.7+
+            # We support Python 3.7+
             python = "cp37.cp38.cp39.cp310.cp311.py37.py38.py39.py310.py311"
 
-            # we don't require a specific Python ABI
+            # We don't require a specific Python ABI
             abi = "none"
 
-            # To prevent potential compatibility issues that could arise when mixing glibc and libmusl,
-            # PyPI does not accept the default linux_x86_64 and linux_aarch64 platform tags. Instead,
-            # package maintainers must explicity identify whether their package supports glibc or
-            # libmusl. Semgrep-core is statically compiled, so this isn't a concern for us.
+            # To prevent potential compatibility issues when mixing glibc and libmusl,
+            # PyPI does not accept the default linux_x86_64 and linux_aarch64 platform
+            # tags. Instead, package maintainers must explicity identify if their package
+            # supports glibc and/or libmusl. Semgrep-core is statically compiled,
+            # so this isn't a concern for us.
             #
-            # For linux_aarch64, we explicitly indicate that we support both platforms
-            #   (musllinux_10 == libmusl, manylinux2014 == glibc)
+            # For linux_aarch64, we indicate that we support both platforms
+            #   (musllinux_1_0 == libmusl, manylinux2014 == glibc)
             #
             # For linux_x86_64, we use the catch-all "any" tag
             #
             if plat == "linux_aarch64":
-                plat = "musllinux1_0_aarch64.manylinux2014_aarch64"
+                plat = "musllinux_1_0_aarch64.manylinux2014_aarch64"
             elif plat == "linux_x86_64":
                 plat = "any"
             return python, abi, plat

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -29,12 +29,30 @@ if WHEEL_CMD in sys.argv:
 
         def get_tag(self):
             _, _, plat = bdist_wheel.get_tag(self)
+
+            # For more information about python compatibility tags, check out:
+            # https://packaging.python.org/en/latest/specifications/platform-compatibility-tags/
+
+            # we support Python 3.7+
             python = "cp37.cp38.cp39.cp310.cp311.py37.py38.py39.py310.py311"
+
+            # we don't require a specific Python ABI
             abi = "none"
-            if plat == "linux_x86_64":
-                plat = "any"
-            elif plat == "linux_aarch64":
+
+            # To prevent potential compatibility issues that could arise when mixing glibc and libmusl,
+            # PyPI does not accept the default linux_x86_64 and linux_aarch64 platform tags. Instead,
+            # package maintainers must explicity identify whether their package supports glibc or
+            # libmusl. Semgrep-core is statically compiled, so this isn't a concern for us.
+            #
+            # For linux_aarch64, we explicitly indicate that we support both platforms
+            #   (musllinux_10 == libmusl, manylinux2014 == glibc)
+            #
+            # For linux_x86_64, we use the catch-all "any" tag
+            #
+            if plat == "linux_aarch64":
                 plat = "musllinux1_0_aarch64.manylinux2014_aarch64"
+            elif plat == "linux_x86_64":
+                plat = "any"
             return python, abi, plat
 
     cmdclass = {WHEEL_CMD: BdistWheel}

--- a/scripts/build-wheels.sh
+++ b/scripts/build-wheels.sh
@@ -11,32 +11,5 @@ set -e
 pip3 install setuptools wheel
 cd cli && python3 setup.py sdist bdist_wheel "$@"
 
-# We have to tweak our architecture-specific Python wheels in order for them to be accepted by PyPI.
-# The output of setup.py bdist_wheel is a file formatted like this: (example is for amd64, but arm64 is similar)
-# semgrep-1.32.0-cp37.cp38.cp39.cp310.cp311.py37.py38.py39.py310.py311-none-linux_x86_64.whl
-#
-# linux_x64_64 is the wheel's "platform tag." PyPI doesn't allow it because it's non-standard
-#
-# The solution here is to re-tag by making copies of the wheel with "proper" platform tags:
-# - manylinux2014_x86_64 for glibc platforms (e.g. Debian)
-# - musllinux_1_0_x86_64 for musl platforms (e.g. Alpine)
-#
-# Check out https://packaging.python.org/en/latest/specifications/platform-compatibility-tags/ for more info about platform tags
-#
-
-for wheel_filename in dist/*.whl; do
-    if [[ ! $wheel_filename =~ ^(.*-)linux(_[a-z0-9_]+\.whl)$ ]]; then
-        echo "Skipping wheel: $wheel_filename"
-        continue
-    fi
-
-    manylinux_filename="${BASH_REMATCH[1]}manylinux2014${BASH_REMATCH[2]}"
-    musllinux_filename="${BASH_REMATCH[1]}musllinux_1_0${BASH_REMATCH[2]}"
-
-    cp -v "$wheel_filename" "$manylinux_filename"
-    cp -v "$wheel_filename" "$musllinux_filename"
-    rm "$wheel_filename"
-done
-
 # Zipping for a stable name to upload as an artifact
 zip -r dist.zip dist


### PR DESCRIPTION
2 improvements:
1. I forgot that you can set multiple compatibility tags at once (separated by dots) in setup.py -- let's do that instead of manually hacking the wheel file in `build-wheels.sh`
2. It turns out renaming the wheel file wasn't enough to get PyPI to recognize the updated platform tags, so setting them in `setup.py` _also_ makes the aarch64 libmusl wheel get published correctly

test plan:
- manually ran, confirmed platform tags were set properly
- tests pass
- release dry run

Re: https://github.com/returntocorp/semgrep/issues/2252
