### PR TITLE
Automatically update semgrep.opam when running 'make setup'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -214,14 +214,21 @@ core-test-e2e:
 # other build-essential tools and a working OCaml (e.g., ocamlc) switch setup.
 # Note that this target is now called from our Dockerfile, so do not
 # run 'opam update' below to not slow down things.
-install-deps-for-semgrep-core:
+install-deps-for-semgrep-core: semgrep.opam
 	# Fetch, build and install the tree-sitter runtime library locally.
 	cd libs/ocaml-tree-sitter-core \
 	&& ./configure \
 	&& ./scripts/install-tree-sitter-lib
-	# Install OCaml dependencies (globally).
+	# Install OCaml dependencies (globally)
 	opam install -y --deps-only ./libs/ocaml-tree-sitter-core
+	# Use semgrep.opam to install dependencies, include dune.
 	opam install -y --deps-only ./
+
+# This will fail if semgrep.opam isn't up-to-date (in git),
+# and dune isn't installed yet.
+semgrep.opam: dune-project
+	dune build $@
+	chmod a-w semgrep.opam
 
 # The bytecode version of semgrep-core needs dlls for tree-sitter
 # stubs installed into ~/.opam/<switch>/lib/stublibs to be able to run.
@@ -336,10 +343,10 @@ homebrew-setup:
 # As a developer you should not run frequently 'make setup', only when
 # important dependencies change.
 .PHONY: setup
-setup:
+setup: semgrep.opam
 	git submodule update --init
 	opam update -y
-	make install-deps-for-semgrep-core
+	$(MAKE) install-deps-for-semgrep-core
 
 # Install development dependencies in addition to build dependencies.
 .PHONY: dev-setup

--- a/Makefile
+++ b/Makefile
@@ -219,15 +219,15 @@ install-deps-for-semgrep-core: semgrep.opam
 	cd libs/ocaml-tree-sitter-core \
 	&& ./configure \
 	&& ./scripts/install-tree-sitter-lib
-	# Install OCaml dependencies (globally)
-	opam install -y --deps-only ./libs/ocaml-tree-sitter-core
-	# Use semgrep.opam to install dependencies, include dune.
-	opam install -y --deps-only ./
+	# Install OCaml dependencies (globally) from *.opam files.
+	opam install -y --deps-only ./ ./libs/ocaml-tree-sitter-core
 
 # This will fail if semgrep.opam isn't up-to-date (in git),
-# and dune isn't installed yet.
+# and dune isn't installed yet. You can always install dune with
+# 'opam install dune' to get started.
 semgrep.opam: dune-project
 	dune build $@
+	# Foolproofing
 	chmod a-w semgrep.opam
 
 # The bytecode version of semgrep-core needs dlls for tree-sitter


### PR DESCRIPTION
`semgrep.opam` is generated from `dune-project` but unfortunately, we have to keep it under git control. This is explained in the makefile. Previously, I didn't know how to generate `semgrep.opam` in one fast command.

Another fix I made is that the dependencies of ocaml-tree-sitter-core and semgrep are installed in a single `opam install` invocation, ensuring we satisfy all the version constraints.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
