### PR TITLE
return an error if people rely on the use of an implict .semgrep.yml

### DIFF
--- a/src/osemgrep/cli/CLI.ml
+++ b/src/osemgrep/cli/CLI.ml
@@ -75,23 +75,8 @@ let dispatch_subcommand argv =
   | [ _ ]
   | [ _; "--experimental" ] ->
       Help.print_help ();
-      (* warn people if they still rely on the deprecated .semgrep.yml
-       * or .semgrep/ rules folder (except if it's the usual ~/.semgrep).
-       *)
-      if
-        Sys.file_exists ".semgrep.yml"
-        || Sys.file_exists ".semgrep"
-           && not (Sys.file_exists ".semgrep/settings.yml")
-      then (
-        flush stdout;
-        Logs.err (fun m ->
-            m
-              "The implicit use of .semgrep.yml (or .semgrep/) has been \
-               deprecated in Semgrep 1.38.0.\n\
-               Please use an explicit --config .semgrep.yml (or --config \
-               .semgrep/)");
-        Exit_code.fatal)
-      else Exit_code.ok
+      Migration.abort_if_use_of_legacy_dot_semgrep_yml ();
+      Exit_code.ok
   | [ _; ("-h" | "--help") ]
   (* ugly: this --experimental management here is a bit ugly, to allow the
    * different combination.

--- a/src/osemgrep/cli/CLI.ml
+++ b/src/osemgrep/cli/CLI.ml
@@ -75,7 +75,23 @@ let dispatch_subcommand argv =
   | [ _ ]
   | [ _; "--experimental" ] ->
       Help.print_help ();
-      Exit_code.ok
+      (* warn people if they still rely on the deprecated .semgrep.yml
+       * or .semgrep/ rules folder (except if it's the usual ~/.semgrep).
+       *)
+      if
+        Sys.file_exists ".semgrep.yml"
+        || Sys.file_exists ".semgrep"
+           && not (Sys.file_exists ".semgrep/settings.yml")
+      then (
+        flush stdout;
+        Logs.err (fun m ->
+            m
+              "The implicit use of .semgrep.yml (or .semgrep/) has been \
+               deprecated in Semgrep 1.38.0.\n\
+               Please use an explicit --config .semgrep.yml (or --config \
+               .semgrep/)");
+        Exit_code.fatal)
+      else Exit_code.ok
   | [ _; ("-h" | "--help") ]
   (* ugly: this --experimental management here is a bit ugly, to allow the
    * different combination.

--- a/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -791,11 +791,12 @@ let cmdline_term ~allow_empty_config : conf Term.t =
           (* TOPORT? use instead
              "No config given and {DEFAULT_CONFIG_FILE} was not found. Try running with --help to debug or if you want to download a default config, try running with --config r2c" *)
           if allow_empty_config then Rules_source.Configs []
-          else
+          else (
+            Migration.abort_if_use_of_legacy_dot_semgrep_yml ();
             Error.abort
               "No config given. Run with `--config auto` or see \
                https://semgrep.dev/docs/running-rules/ for instructions on \
-               running with a specific config"
+               running with a specific config")
       | [], (Some pat, Some str, fix) ->
           (* may raise a Failure (will be caught in CLI.safe_run) *)
           let xlang = Xlang.of_string str in

--- a/src/osemgrep/core/Migration.ml
+++ b/src/osemgrep/core/Migration.ml
@@ -1,0 +1,27 @@
+(*************************************************************************)
+(* Prelude *)
+(*************************************************************************)
+(* Anything that can help deprecate old features and teach users how to
+ * migrate to the new way to do things.
+ *)
+
+(*************************************************************************)
+(* Entry points *)
+(*************************************************************************)
+
+(* warn people if they still rely on the deprecated .semgrep.yml
+ * or .semgrep/ rules folder (except if it's the usual ~/.semgrep).
+ *)
+let abort_if_use_of_legacy_dot_semgrep_yml () =
+  if
+    Sys.file_exists ".semgrep.yml"
+    || Sys.file_exists ".semgrep"
+       && not (Sys.file_exists ".semgrep/settings.yml")
+  then (
+    flush stdout;
+    Logs.err (fun m ->
+        m
+          "The implicit use of .semgrep.yml (or .semgrep/) has been deprecated \
+           in Semgrep 1.38.0.\n\
+           Please use an explicit --config .semgrep.yml (or --config .semgrep/)");
+    Error.exit Exit_code.fatal)

--- a/src/osemgrep/core/Migration.mli
+++ b/src/osemgrep/core/Migration.mli
@@ -1,0 +1,6 @@
+(* Anything that can help deprecate old features and help users migrate
+ * to the new way to do things.
+ *)
+
+(* may raise Error.Exit if we detect the presence of a .semgrep.yml *)
+val abort_if_use_of_legacy_dot_semgrep_yml : unit -> unit


### PR DESCRIPTION
test plan:
created a .semgrep.yml
semgrep
=> help message and then
```
The implicit use of .semgrep.yml (or .semgrep/) has been deprecated.
Please use an explicit --config .semgrep.yml
...
````


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)