### PR TITLE
pysemgrep: remove some docstrings used for --help

### DIFF
--- a/cli/src/semgrep/cli.py
+++ b/cli/src/semgrep/cli.py
@@ -46,13 +46,7 @@ def maybe_set_git_safe_directories() -> None:
 @click.help_option("--help", "-h")
 @click.pass_context
 def cli(ctx: click.Context) -> None:
-    """
-    To get started quickly, run `semgrep scan --config auto`
-
-    Run `semgrep SUBCOMMAND --help` for more information on each subcommand
-
-    If no subcommand is passed, will run `scan` subcommand by default
-    """
+    """ """
     state = get_state()
     state.terminal.init_for_cli()
 

--- a/cli/src/semgrep/commands/scan.py
+++ b/cli/src/semgrep/commands/scan.py
@@ -701,24 +701,7 @@ def scan(
     verbose: bool,
     version: bool,
 ) -> ScanReturn:
-    """
-    Run semgrep rules on files
-
-    Searches TARGET paths for matches to rules or patterns. Defaults to searching entire current working directory.
-
-    To get started quickly, run
-
-        semgrep --config auto .
-
-    This will automatically fetch rules for your project from the Semgrep Registry. NOTE: Using `--config auto` will
-    log in to the Semgrep Registry with your project URL.
-
-    For more information about Semgrep, go to https://semgrep.dev.
-
-    NOTE: By default, Semgrep will report pseudonymous usage metrics to its server if you pull your configuration from
-    the Semgrep registry. To learn more about how and why these metrics are collected, please see
-    https://semgrep.dev/docs/metrics. To modify this behavior, see the --metrics option below.
-    """
+    """ """
 
     if version:
         print(__VERSION__)


### PR DESCRIPTION
This is now handled by osemgrep, no need to duplicate those
help string in pysemgrep and osemgrep. osemgrep is now
the source of truth for semgrep --help

test plan:
semgrep
semgrep --help
semgrep scan --help


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)