### PR TITLE
osemgrep: new 'semgrep show' subcommand

### DIFF
--- a/cli/tests/e2e/snapshots/test_help/test_help_text/--help/help.txt
+++ b/cli/tests/e2e/snapshots/test_help/test_help_text/--help/help.txt
@@ -14,6 +14,7 @@ Commands:
   install-semgrep-pro  Install the Semgrep Pro Engine
   login                Obtain and save credentials for semgrep.dev
   logout               Remove locally stored credentials to semgrep.dev
-  lsp                  [EXPERIMENTAL] Start the Semgrep LSP server
+  lsp                  Start the Semgrep LSP server (useful for IDEs)
   publish              Upload rule to semgrep.dev
   scan                 Run semgrep rules on files
+  show                 Show various information about Semgrep

--- a/cli/tests/e2e/snapshots/test_help/test_help_text/-h/help.txt
+++ b/cli/tests/e2e/snapshots/test_help/test_help_text/-h/help.txt
@@ -14,6 +14,7 @@ Commands:
   install-semgrep-pro  Install the Semgrep Pro Engine
   login                Obtain and save credentials for semgrep.dev
   logout               Remove locally stored credentials to semgrep.dev
-  lsp                  [EXPERIMENTAL] Start the Semgrep LSP server
+  lsp                  Start the Semgrep LSP server (useful for IDEs)
   publish              Upload rule to semgrep.dev
   scan                 Run semgrep rules on files
+  show                 Show various information about Semgrep

--- a/src/osemgrep/cli/CLI.ml
+++ b/src/osemgrep/cli/CLI.ml
@@ -56,6 +56,7 @@ let known_subcommands =
     "scan";
     (* osemgrep-only *)
     "interactive";
+    "show";
   ]
 
 (* Exit with a code that a proper semgrep implementation would never return.
@@ -123,7 +124,8 @@ let dispatch_subcommand argv =
         | "scan" -> Scan_subcommand.main subcmd_argv
         (* osemgrep-only: and by default! no need experimental! *)
         | "interactive" -> Interactive_subcommand.main subcmd_argv
-        (* LATER: "dump", "test", "validate" *)
+        | "show" -> Show_subcommand.main subcmd_argv
+        (* LATER: "test" *)
         | _else_ ->
             if experimental then
               (* this should never happen because we default to 'scan',

--- a/src/osemgrep/cli/Help.ml
+++ b/src/osemgrep/cli/Help.ml
@@ -23,7 +23,7 @@
  * generate it manually, but anyway we want full control of the help
  * message so this isn't too bad.
  *
- * LATER: add 'interactive', 'test', 'validate', and 'dump' new osemgrep-only
+ * LATER: add 'interactive' and 'test' new osemgrep-only
  * subcommands (not added yet to avoid regressions in tests/e2e/test_help.py).
  *)
 
@@ -79,7 +79,8 @@ Commands:
   install-semgrep-pro  Install the Semgrep Pro Engine
   login                Obtain and save credentials for semgrep.dev
   logout               Remove locally stored credentials to semgrep.dev
-  lsp                  [EXPERIMENTAL] Start the Semgrep LSP server
+  lsp                  Start the Semgrep LSP server (useful for IDEs)
   publish              Upload rule to semgrep.dev
   scan                 Run semgrep rules on files
+  show                 Show various information about Semgrep
 |}

--- a/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -3,7 +3,7 @@ module Arg = Cmdliner.Arg
 module Term = Cmdliner.Term
 module Cmd = Cmdliner.Cmd
 module H = Cmdliner_helpers
-module Show = Show_subcommand
+module Show = Show_CLI
 
 (*****************************************************************************)
 (* Prelude *)
@@ -63,7 +63,7 @@ type conf = {
   (* Ugly: should be in separate subcommands *)
   version : bool;
   show_supported_languages : bool;
-  show : Show_subcommand.conf option;
+  show : Show_CLI.conf option;
   validate : Validate_subcommand.conf option;
   test : Test_subcommand.conf option;
 }

--- a/src/osemgrep/cli_scan/Scan_CLI.mli
+++ b/src/osemgrep/cli_scan/Scan_CLI.mli
@@ -43,7 +43,7 @@ type conf = {
   (* Ugly: should be in separate subcommands *)
   version : bool;
   show_supported_languages : bool;
-  show : Show_subcommand.conf option;
+  show : Show_CLI.conf option;
   validate : Validate_subcommand.conf option;
   test : Test_subcommand.conf option;
 }

--- a/src/osemgrep/cli_show/Show_CLI.ml
+++ b/src/osemgrep/cli_show/Show_CLI.ml
@@ -1,0 +1,84 @@
+module Arg = Cmdliner.Arg
+module Term = Cmdliner.Term
+module Cmd = Cmdliner.Cmd
+
+(*****************************************************************************)
+(* Prelude *)
+(*****************************************************************************)
+(*
+   'semgrep show' command-line arguments processing.
+*)
+
+(*****************************************************************************)
+(* Types and constants *)
+(*****************************************************************************)
+(*
+   The result of parsing a 'semgrep show' command.
+   This is also used in Scan_CLI.ml to transform legacy
+   commands such as 'semgrep scan --show-supported-languages' into the
+   new 'semgrep show supported-languages'
+*)
+type conf = {
+  (* mix of --dump-ast/--dump-rule/... *)
+  target : target_kind;
+  json : bool;
+}
+
+and target_kind =
+  (* alt: we could accept XLang.t to dump extended patterns *)
+  | Pattern of string * Lang.t
+  (* alt: we could accept multiple Files via multiple target_roots *)
+  | File of Fpath.t * Lang.t
+  | Config of Semgrep_dashdash_config.config_string
+  (* LATER: get rid of it? *)
+  | EnginePath of bool (* pro = true *)
+  (* LATER: get rid of it *)
+  | CommandForCore
+[@@deriving show]
+
+(*************************************************************************)
+(* Command-line flags *)
+(*************************************************************************)
+
+(* ------------------------------------------------------------------ *)
+(* Flags *)
+(* ------------------------------------------------------------------ *)
+
+let o_json : bool Term.t =
+  let info = Arg.info [ "json" ] ~doc:{|Output results in JSON format.|} in
+  Arg.value (Arg.flag info)
+
+(* ------------------------------------------------------------------ *)
+(* Positional arguments *)
+(* ------------------------------------------------------------------ *)
+let o_args : string list Term.t =
+  let info =
+    Arg.info [] ~docv:"STRINGS"
+      ~doc:{|Commands used to show internal information.|}
+  in
+  Arg.value (Arg.pos_all Arg.string [] info)
+
+(*************************************************************************)
+(* Command-line parsing: turn argv into conf *)
+(*************************************************************************)
+let cmdline_term : conf Term.t =
+  (* !The parameters must be in alphabetic orders to match the order
+   * of the corresponding '$ o_xx $' further below! *)
+  let combine _args _json = failwith "TODO" in
+  Term.(const combine $ o_args $ o_json)
+
+let doc = "Show various information"
+
+let man : Cmdliner.Manpage.block list =
+  [ `S Cmdliner.Manpage.s_description; `P "Display various information" ]
+  @ CLI_common.help_page_bottom
+
+let cmdline_info : Cmd.info = Cmd.info "semgrep show" ~doc ~man
+
+(*****************************************************************************)
+(* Entry point *)
+(*****************************************************************************)
+
+let parse_argv (argv : string array) : conf =
+  let cmd : conf Cmd.t = Cmd.v cmdline_info cmdline_term in
+  CLI_common.eval_value ~argv cmd

--- a/src/osemgrep/cli_show/Show_CLI.mli
+++ b/src/osemgrep/cli_show/Show_CLI.mli
@@ -1,0 +1,37 @@
+(*
+   'semgrep show' command-line parsing.
+*)
+
+(*
+   The result of parsing a 'semgrep show' command.
+   This is also used in Scan_CLI.ml to transform legacy
+   commands such as 'semgrep scan --show-supported-languages' into the
+   new 'semgrep show supported-languages'
+*)
+type conf = {
+  (* mix of --dump-ast/--dump-rule/... *)
+  target : target_kind;
+  json : bool;
+}
+
+and target_kind =
+  (* alt: we could accept XLang.t to dump extended patterns *)
+  | Pattern of string * Lang.t
+  (* alt: we could accept multiple Files via multiple target_roots *)
+  | File of Fpath.t * Lang.t
+  | Config of Semgrep_dashdash_config.config_string
+  (* LATER: get rid of it? *)
+  | EnginePath of bool (* pro = true *)
+  (* LATER: get rid of it *)
+  | CommandForCore
+[@@deriving show]
+
+(*
+   Usage: parse_argv [| "semgrep-show"; <args> |]
+
+   Turn argv into a conf structure.
+
+   This function may raise an exn in case of an error parsing argv
+   but this should be caught by CLI.safe_run.
+*)
+val parse_argv : string array -> conf

--- a/src/osemgrep/cli_show/Show_subcommand.mli
+++ b/src/osemgrep/cli_show/Show_subcommand.mli
@@ -1,16 +1,13 @@
-(* There is currently no 'semgrep dump' subcommand. Dumps are run via
- * 'semgrep scan --dump-ast ...' but internally it's quite similar to
- * a subcommand.
+(*
+   Parse a semgrep-show command, execute it and exit.
+
+   Usage: main [| "semgrep-show"; ... |]
+
+   This function returns an exit code to be passed to the 'exit' function.
+*)
+val main : string array -> Exit_code.t
+
+(* called from main() but also from Scan_subcommand.ml to manage the legacy
+ * way to show things (e.g., 'semgrep scan --show-supported-languages')
  *)
-
-type conf = { target : target_kind; json : bool }
-
-and target_kind =
-  | Pattern of string * Lang.t
-  | File of Fpath.t * Lang.t
-  | Config of Semgrep_dashdash_config.config_string
-  | EnginePath of bool (* pro = true *)
-  | CommandForCore
-[@@deriving show]
-
-val run : conf -> Exit_code.t
+val run : Show_CLI.conf -> Exit_code.t


### PR DESCRIPTION
For now this is mostly skeleton code, but it's gonna
be field in future PRs

test plan:
semgrep show --help
should show a man page

semgrep --help
should also show the new command


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)