### PR TITLE
refactor http requests in secrets

### DIFF
--- a/libs/networking/dune
+++ b/libs/networking/dune
@@ -6,7 +6,7 @@
     uri
     cohttp
     cohttp-lwt-unix
-
+    commons
 
     profiling
   )

--- a/libs/networking/http_request.ml
+++ b/libs/networking/http_request.ml
@@ -7,7 +7,7 @@ open Common
 open Cohttp
 open Cohttp_lwt_unix
 
-let logger = Logging.get_logger[__MODULE__]
+let logger = Logging.get_logger [ __MODULE__ ]
 
 (* This type encodes a basic HTTP request; mainly used for in the secrets
  * post-processor; such that a basic http request like
@@ -42,10 +42,7 @@ type t = {
 }
 [@@deriving show]
 
-type response = {
-  response_code : int;
-  response_body : string
-}
+type response = { response_code : int; response_body : string }
 [@@deriving show]
 
 let to_cohttp_headers (headers : header list) =
@@ -58,10 +55,11 @@ let perform_async (req : t) =
   let body = Option.map (fun x -> (`String x :> Cohttp_lwt.Body.t)) req.body in
   let%lwt res, body = Client.call meth uri ~headers ?body in
   let%lwt response_body = Cohttp_lwt.Body.to_string body in
-  Lwt.return {
-    response_code = Response.status res |> Code.code_of_status;
-    response_body;
-  }
+  Lwt.return
+    {
+      response_code = Response.status res |> Code.code_of_status;
+      response_body;
+    }
 
 let perform_blocking (req : t) =
   (* cohttp-lwt-unix is super fragile, its behavior changes based on
@@ -75,7 +73,7 @@ let perform_blocking (req : t) =
     (* TODO: Investigate why these two don't show up in the logs. *)
     logger#info "Http response: %s" (show_response res);
     Result.ok res
-  with e -> begin
-    logger#info "Http exception: %s" (Printexc.to_string e);
-    Result.error (Exception.catch e)
-  end
+  with
+  | e ->
+      logger#info "Http exception: %s" (Printexc.to_string e);
+      Result.error (Exception.catch e)

--- a/libs/networking/http_request.ml
+++ b/libs/networking/http_request.ml
@@ -1,0 +1,81 @@
+(* Yosef Alsuhaibani
+ *
+ * Copyright (C) 2023 semgrep
+ *)
+
+open Common
+open Cohttp
+open Cohttp_lwt_unix
+
+let logger = Logging.get_logger[__MODULE__]
+
+(* This type encodes a basic HTTP request; mainly used for in the secrets
+ * post-processor; such that a basic http request like
+ * GET semgrep.dev
+ * Auth: ok
+ * Type: tau
+ * would be represented as
+ * {
+ *   url     = semgrep.dev/user;
+ *   meth    = `GET;
+ *   headers =
+ *  [
+ *    { n = Auth, v = ok};
+ *    { n = Type, v = tau};
+ *  ]
+ * }
+ * NOTE: we don't reuse cohttp's abstract type Cohttp.Headers.t; we still need
+ * it to not be abstract for metavariable substitution.
+ *)
+
+type header = { name : string; value : string } [@@deriving show]
+type meth = [ `DELETE | `GET | `POST | `HEAD | `PUT ] [@@deriving show]
+
+(* why is url : string? metavariables (i.e http://$X) are present at parsing; which
+ * if parsed with Uri.of_string translates it to http://%24x
+ *)
+type t = {
+  url : string;
+  meth : meth;
+  headers : header list;
+  body : string option;
+}
+[@@deriving show]
+
+type response = {
+  response_code : int;
+  response_body : string
+}
+[@@deriving show]
+
+let to_cohttp_headers (headers : header list) =
+  map (fun h -> (h.name, h.value)) headers |> Header.of_list
+
+let perform_async (req : t) =
+  let uri = Uri.of_string req.url in
+  let meth = (req.meth :> Code.meth) in
+  let headers = to_cohttp_headers req.headers in
+  let body = Option.map (fun x -> (`String x :> Cohttp_lwt.Body.t)) req.body in
+  let%lwt res, body = Client.call meth uri ~headers ?body in
+  let%lwt response_body = Cohttp_lwt.Body.to_string body in
+  Lwt.return {
+    response_code = Response.status res |> Code.code_of_status;
+    response_body;
+  }
+
+let perform_blocking (req : t) =
+  (* cohttp-lwt-unix is super fragile, its behavior changes based on
+     what packages you have installed. *)
+  (* TLS exceptions that come from here can indicate that you are
+     using ocaml-tls or ocaml-tls-lwt which doesn't support tls 1.3.
+     To fix uninstall tls from opam. *)
+  logger#linfo (lazy (spf "Http request: %s" (show req)));
+  try
+    let res = Lwt_main.run (perform_async req) in
+    (* TODO: Investigate why these two don't show up in the logs. *)
+    logger#info "Http response: %s" (show_response res);
+    Result.ok res
+  with e -> begin
+    logger#info "Http exception: %s" (Printexc.to_string e);
+    Result.error (Exception.catch e)
+  end

--- a/src/core/Rule.ml
+++ b/src/core/Rule.ml
@@ -296,41 +296,7 @@ and extract_reduction = Separate | Concat [@@deriving show]
 (* secrets mode *)
 (*****************************************************************************)
 
-(* This type encodes a basic HTTP request; mainly used for in the secrets
- * post-processor; such that a basic http request like
- * GET semgrep.dev
- * Auth: ok
- * Type: tau
- * would be represented as
- * {
- *   url     = semgrep.dev/user;
- *   meth    = `GET;
- *   headers =
- *  [
- *    { n = Auth, v = ok};
- *    { n = Type, v = tau};
- *  ]
- * }
- * NOTE: we don't reuse cohttp's abstract type Cohttp.Headers.t; we still need
- * it to not be abstract for metavariable substitution.
- *)
-
-type header = { name : string; value : string } [@@deriving show]
-type meth = [ `DELETE | `GET | `POST | `HEAD | `PUT ] [@@deriving show]
-
-(* why is url : string? metavariables (i.e http://$X) are present at parsing; which
- * if parsed with Uri.of_string translates it to http://%24x
- *)
-type request = {
-  url : string;
-  meth : meth;
-  headers : header list;
-  body : string option;
-}
-[@@deriving show]
-
-(* Used to match on the returned response of some request *)
-type response = { return_code : int; regex : Xpattern.regexp_string option }
+type expected_response = { return_code : int; regex : Xpattern.regexp_string option }
 [@@deriving show]
 
 type secrets = {
@@ -339,8 +305,8 @@ type secrets = {
    * bindings made available in the request post matching.
    *)
   secrets : formula list;
-  request : request;
-  response : response;
+  request : Http_request.t;
+  response : expected_response;
 }
 [@@deriving show]
 

--- a/src/core/Rule.ml
+++ b/src/core/Rule.ml
@@ -296,7 +296,10 @@ and extract_reduction = Separate | Concat [@@deriving show]
 (* secrets mode *)
 (*****************************************************************************)
 
-type expected_response = { return_code : int; regex : Xpattern.regexp_string option }
+type expected_response = {
+  return_code : int;
+  regex : Xpattern.regexp_string option;
+}
 [@@deriving show]
 
 type secrets = {

--- a/src/core/dune
+++ b/src/core/dune
@@ -16,6 +16,7 @@
    glob
    lib_parsing ; Parse_info.ml
    ast_generic
+   networking
    parser_javascript.ast ; TODO remove this, ugly dependency to Ast_js.default_entity in Pattern.ml
    ;note: we should not depend on pfff-lang_GENERIC-analyze in core
    ;note: we should also not depend on any other semgrep libs

--- a/src/parsing/Parse_rule.ml
+++ b/src/parsing/Parse_rule.ml
@@ -1660,7 +1660,8 @@ let parse_secrets_fields env rule_dict : R.secrets =
     take req env yaml_to_dict "headers" |> fun { h; _ } ->
     Hashtbl.fold
       (fun name value lst ->
-        Http_request.{ name; value = parse_string env (fst value) (snd value) } :: lst)
+        Http_request.{ name; value = parse_string env (fst value) (snd value) }
+        :: lst)
       h []
   in
   let body = take_opt req env parse_string "body" in

--- a/src/parsing/Parse_rule.ml
+++ b/src/parsing/Parse_rule.ml
@@ -1656,11 +1656,11 @@ let parse_secrets_fields env rule_dict : R.secrets =
   let res = take rule_dict env yaml_to_dict "response" in
   let url = take req env parse_string "url" in
   let meth = take req env method_ "method" in
-  let headers : Rule.header list =
+  let headers : Http_request.header list =
     take req env yaml_to_dict "headers" |> fun { h; _ } ->
     Hashtbl.fold
       (fun name value lst ->
-        { Rule.name; value = parse_string env (fst value) (snd value) } :: lst)
+        Http_request.{ name; value = parse_string env (fst value) (snd value) } :: lst)
       h []
   in
   let body = take_opt req env parse_string "body" in


### PR DESCRIPTION
# What
Factors out the http requests from secrets to clean up code and make it more easily mocked for testing purposes.

# Testing
In semgrep-proprietary in [this PR](https://github.com/returntocorp/semgrep-proprietary/pull/933).
```bash
$ make test
# Manually check that the result is equivalent to tests/secrets/unverified/result.json
$ semgrep --pro --json --config tests/secrets/unverified/rules.yaml tests/secrets/unverified/src
```

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
