### PR TITLE
[feat:CLI] 🎨 Update Login and Logout Subcommands

### DIFF
--- a/libs/commons/Logs_helpers.ml
+++ b/libs/commons/Logs_helpers.ml
@@ -104,3 +104,18 @@ let setup_logging ~force_color ~level =
          (* those are the one we are really interested in *)
          | "application" -> ()
          | s -> failwith ("Logs library not handled: " ^ s))
+
+let with_err_tag ?(tag = " ERROR ") () =
+  ANSITerminal.sprintf
+    [ ANSITerminal.white; ANSITerminal.Bold; ANSITerminal.on_red ]
+    "%s" tag
+
+let with_warn_tag ?(tag = " WARN ") () =
+  ANSITerminal.sprintf
+    [ ANSITerminal.white; ANSITerminal.Bold; ANSITerminal.on_yellow ]
+    "%s" tag
+
+let with_success_tag ?(tag = " SUCCESS ") () =
+  ANSITerminal.sprintf
+    [ ANSITerminal.white; ANSITerminal.Bold; ANSITerminal.on_green ]
+    "%s" tag

--- a/libs/commons/Logs_helpers.mli
+++ b/libs/commons/Logs_helpers.mli
@@ -31,6 +31,11 @@ val enable_logging : unit -> unit
    calls, otherwise your log will not go anywhere (not even on stderr).
 *)
 val setup_logging : force_color:bool -> level:Logs.level option -> unit
+
+(* TODO:
+   Logs.Error, Logs.Warning, and friends should apply the appropriate color and tag prefix (e.g. ERROR)
+   to the message. For now, we prepend the tag manually before the log message.
+*)
 val with_err_tag : ?tag:string -> unit -> string
 val with_warn_tag : ?tag:string -> unit -> string
 val with_success_tag : ?tag:string -> unit -> string

--- a/libs/commons/Logs_helpers.mli
+++ b/libs/commons/Logs_helpers.mli
@@ -31,3 +31,6 @@ val enable_logging : unit -> unit
    calls, otherwise your log will not go anywhere (not even on stderr).
 *)
 val setup_logging : force_color:bool -> level:Logs.level option -> unit
+val with_err_tag : ?tag:string -> unit -> string
+val with_warn_tag : ?tag:string -> unit -> string
+val with_success_tag : ?tag:string -> unit -> string

--- a/libs/networking/http_helpers.ml
+++ b/libs/networking/http_helpers.ml
@@ -15,17 +15,17 @@ let get_async ?(headers = []) url =
   let headers = Header.of_list headers in
   let%lwt response, body = Client.get ~headers url in
   let%lwt body = Cohttp_lwt.Body.to_string body in
-  let status = response |> Response.status |> Code.code_of_status in
-  match status with
-  | _ when Code.is_success status -> Lwt.return (Ok body)
-  | _ when Code.is_error status ->
+  let code = response |> Response.status |> Code.code_of_status in
+  match code with
+  | _ when Code.is_success code -> Lwt.return (Ok body)
+  | _ when Code.is_error code ->
       let code_str = Code.string_of_status response.status in
-      let err = "HTTP GET failed, return code " ^ code_str ^ ":\n" ^ body in
+      let err = "HTTP GET failed: " ^ code_str ^ ":\n" ^ body in
       Logs.debug (fun m -> m "%s" err);
       Lwt.return (Error err)
   | _ ->
       let code_str = Code.string_of_status response.status in
-      let err = "HTTP GET failed, return code " ^ code_str ^ ":\n" ^ body in
+      let err = "HTTP GET unexpected response: " ^ code_str ^ ":\n" ^ body in
       Logs.debug (fun m -> m "%s" err);
       Lwt.return (Error err)
   [@@profiling]
@@ -36,19 +36,19 @@ let post_async ~body ?(headers = [ ("content-type", "application/json") ]) url =
     Client.post ~headers ~body:(Cohttp_lwt.Body.of_string body) url
   in
   let%lwt body = Cohttp_lwt.Body.to_string body in
-  let status = response |> Response.status |> Code.code_of_status in
-  match status with
-  | _ when Code.is_success status -> Lwt.return (Ok body)
-  | _ when Code.is_error status ->
+  let code = response |> Response.status |> Code.code_of_status in
+  match code with
+  | _ when Code.is_success code -> Lwt.return (Ok body)
+  | _ when Code.is_error code ->
       let code_str = Code.string_of_status response.status in
-      let err = "HTTP POST failed, return code " ^ code_str ^ ":\n" ^ body in
+      let err = "HTTP POST failed: " ^ code_str ^ ":\n" ^ body in
       Logs.debug (fun m -> m "%s" err);
-      Lwt.return (Error (-1, err))
+      Lwt.return (Error (code, err))
   | _ ->
       let code_str = Code.string_of_status response.status in
-      let err = "HTTP POST failed, return code " ^ code_str ^ ":\n" ^ body in
+      let err = "HTTP POST unexpected response: " ^ code_str ^ ":\n" ^ body in
       Logs.debug (fun m -> m "%s" err);
-      Lwt.return (Error (-1, err))
+      Lwt.return (Error (code, err))
   [@@profiling]
 
 (*****************************************************************************)

--- a/src/osemgrep/cli_login/Login_subcommand.ml
+++ b/src/osemgrep/cli_login/Login_subcommand.ml
@@ -209,12 +209,10 @@ Plus, you can manage your rules and code findings with Semgrep Cloud Platform.
   | Some _ ->
       Logs.app (fun m ->
           m
-            "%s API token already exists in %s. To login with a different \
-             token logout use `semgrep logout`"
-            (Logs_helpers.with_err_tag ())
-            (Fpath.to_string Semgrep_envvars.v.user_settings_file));
+            "%s You're already logged in. Use `semgrep logout` to log out \
+             first, and then you can login with a new access token."
+            (Logs_helpers.with_err_tag ()));
       Exit_code.fatal
-
 (*****************************************************************************)
 (* Entry point *)
 (*****************************************************************************)

--- a/src/osemgrep/cli_login/Login_subcommand.ml
+++ b/src/osemgrep/cli_login/Login_subcommand.ml
@@ -24,19 +24,23 @@ let make_login_url () =
         ]) )
 
 (* from login.py *)
-let save_token ~echo_token settings token =
+let save_token settings token =
   if Semgrep_App.get_deployment_from_token token <> None then
     let settings = Semgrep_settings.{ settings with api_token = Some token } in
     if Semgrep_settings.save settings then (
       Logs.app (fun m ->
-          m "Saved login token@.@.\t%s@.@.in %a"
-            (if echo_token then token else "<redacted>")
-            Fpath.pp Semgrep_envvars.v.user_settings_file);
-      Logs.app (fun m ->
-          m
-            "Note: You can always generate more tokens at \
-             %s/orgs/-/settings/tokens"
-            (Uri.to_string Semgrep_envvars.v.semgrep_url));
+          m "\nSaved access token in %a" Fpath.pp
+            Semgrep_envvars.v.user_settings_file);
+      let epilog =
+        Ocolor_format.asprintf
+          {|
+💡 From now on you can run @{<cyan>`semgrep ci`@} to start a Semgrep scan.
+   Supply Chain, Secrets and Pro rules will be applied in your scans automatically.
+
+💎 Happy scanning!
+|}
+      in
+      Logs.app (fun m -> m "%s" epilog);
       true)
     else false
   else (
@@ -44,11 +48,35 @@ let save_token ~echo_token settings token =
     false)
 
 (*****************************************************************************)
+(* Console Experience *)
+(*****************************************************************************)
+
+let spinner = [| "⠋"; "⠙"; "⠹"; "⠸"; "⠼"; "⠴"; "⠦"; "⠧"; "⠇"; "⠏" |]
+
+let show_spinner ~frame_index:i =
+  let spinner = spinner.(i mod Array.length spinner) in
+  ANSITerminal.set_cursor 1 (-1);
+  ANSITerminal.printf [ ANSITerminal.green ] "%s Waiting for sign in..." spinner
+
+let erase_spinner () =
+  ANSITerminal.move_cursor 0 (-1);
+  ANSITerminal.move_bol ();
+  ANSITerminal.erase ANSITerminal.Below
+
+(*****************************************************************************)
 (* Main logic *)
 (*****************************************************************************)
 
-let wait_between_retry_in_sec = 6 (* So every 10 retries is a minute *)
-let max_retries = 30 (* Give users 3 minutes to log in / open link *)
+let min_wait_between_retry_in_ms = 2000 (* initially start with 2 seconds *)
+
+let next_wait_offset_in_ms =
+  ref 1000 (* increase wait time relative to number of attempts *)
+
+let max_retries = 12 (* Give users ~2 minutes to log in *)
+
+let apply_backoff () =
+  next_wait_offset_in_ms :=
+    Float.to_int (Float.ceil (Float.of_int !next_wait_offset_in_ms *. 1.3))
 
 (* All the business logic after command-line parsing. Return the desired
    exit code. *)
@@ -59,8 +87,7 @@ let run (conf : Login_CLI.conf) : Exit_code.t =
   | None -> (
       match Semgrep_envvars.v.app_token with
       | Some token when String.length token > 0 ->
-          if save_token ~echo_token:false settings token then Exit_code.ok
-          else Exit_code.fatal
+          if save_token settings token then Exit_code.ok else Exit_code.fatal
       | None
       | Some _ ->
           if not Unix.(isatty stdin) then (
@@ -71,21 +98,45 @@ let run (conf : Login_CLI.conf) : Exit_code.t =
             Exit_code.fatal)
           else
             let session_id, url = make_login_url () in
-            Logs.app (fun m ->
-                m
-                  "Login enables additional proprietary Semgrep Registry rules \
-                   and running custom policies from Semgrep App.");
-            Logs.app (fun m -> m "Login at: %s" (Uri.to_string url));
-            Logs.app (fun m ->
-                m
-                  "@.Once you've logged in, return here and you'll be ready to \
-                   start using new Semgrep rules.");
+            Logs.app (fun m -> m "%a" Fmt_helpers.pp_heading "Login");
+            let preamble =
+              Ocolor_format.asprintf
+                {|
+Logging in gives you access to Supply Chain, Secrets and Pro rules.
+
+Plus, you can manage your rules and code findings with Semgrep Cloud Platform.
+
+@{<ul>Steps@}
+1. Sign in with your authentication provider
+2. Activate your access token
+3. Return here and start scanning!
+|}
+            in
+            Logs.app (fun m -> m "%s" preamble);
+            let cmd = Bos.Cmd.(v "open" % Uri.to_string url) in
+            let () =
+              let res = Bos.OS.Cmd.run_out cmd |> Bos.OS.Cmd.to_string in
+              match res with
+              | Ok _ ->
+                  Logs.app (fun m ->
+                      m "Opening your sign-in link automatically...");
+                  let msg =
+                    Ocolor_format.asprintf
+                      "If nothing happened, please open this link in your \
+                       browser:\n\n\
+                       @{<cyan;ul>%s@}\n"
+                      (Uri.to_string url)
+                  in
+                  Logs.app (fun m -> m "%s" msg)
+              | __else__ -> ()
+            in
             let rec fetch = function
               | 0 ->
                   Logs.err (fun m ->
                       m
-                        "Failed to login: please check your internet \
-                         connection or contact support@semgrep.com");
+                        "%s Failed to login: please check your internet \
+                         connection or contact support@semgrep.com"
+                        (Logs_helpers.with_err_tag ()));
                   Exit_code.fatal
               | n -> (
                   let url =
@@ -98,22 +149,29 @@ let run (conf : Login_CLI.conf) : Exit_code.t =
                   in
                   match Http_helpers.post ~body url with
                   | Ok body -> (
+                      erase_spinner ();
+                      (* Remove the spinner from the console *)
                       try
-                        match Yojson.Basic.from_string body with
-                        | `Assoc e -> (
-                            match List.assoc_opt "token" e with
-                            | Some (`String token) ->
-                                if save_token ~echo_token:true settings token
-                                then Exit_code.ok
-                                else Exit_code.fatal
-                            | None
-                            | Some _ ->
-                                Logs.debug (fun m ->
-                                    m "failed to decode json token %s" body);
-                                Exit_code.fatal)
+                        let json = Yojson.Basic.from_string body in
+                        let open Yojson.Basic.Util in
+                        match json |> member "token" with
+                        | `String token ->
+                            if save_token settings token then (
+                              let user_name =
+                                json |> member "user_name" |> to_string
+                              in
+                              Logs.app (fun m ->
+                                  m
+                                    "%s Successfully logged in as %s! You can \
+                                     now run `semgrep ci` to start a scan."
+                                    (Logs_helpers.with_success_tag ())
+                                    user_name);
+                              Exit_code.ok)
+                            else Exit_code.fatal
+                        | `Null
                         | _ ->
                             Logs.debug (fun m ->
-                                m "failed to decode json %s" body);
+                                m "failed to decode json token %s" body);
                             Exit_code.fatal
                       with
                       | Yojson.Json_error msg ->
@@ -122,25 +180,38 @@ let run (conf : Login_CLI.conf) : Exit_code.t =
                           Exit_code.fatal)
                   | Error (status_code, msg) ->
                       if status_code = 404 then (
-                        Unix.sleep wait_between_retry_in_sec;
+                        let steps = 100 in
+                        for i = 1 to steps do
+                          (* 100 steps for each iteration with variable sleep time between *)
+                          show_spinner ~frame_index:i;
+                          Unix.sleepf
+                            (Float.of_int
+                               (min_wait_between_retry_in_ms
+                              + !next_wait_offset_in_ms)
+                            /. Float.of_int (1000 * steps))
+                        done;
+                        apply_backoff ();
                         fetch (n - 1))
                       else (
                         Logs.err (fun m ->
                             m
-                              "Unexpected failure from %s: status code %d; \
+                              "%s Unexpected failure from %s: status code %d; \
                                please contact support@semgrep.com if this \
                                persists"
-                              (Uri.to_string Semgrep_envvars.v.semgrep_url)
-                              status_code);
+                              (Logs_helpers.with_err_tag ())
+                              (Uri.to_string url) status_code);
                         Logs.info (fun m -> m "HTTP error: %s" msg);
                         Exit_code.fatal))
             in
+            Unix.sleepf 0.1;
+            (* wait 100ms for the browser to open and then start showing the spinner *)
             fetch max_retries)
   | Some _ ->
       Logs.app (fun m ->
           m
-            "API token already exists in %s. To login with a different token \
-             logout use `semgrep logout`"
+            "%s API token already exists in %s. To login with a different \
+             token logout use `semgrep logout`"
+            (Logs_helpers.with_err_tag ())
             (Fpath.to_string Semgrep_envvars.v.user_settings_file));
       Exit_code.fatal
 

--- a/src/osemgrep/cli_login/Logout_subcommand.ml
+++ b/src/osemgrep/cli_login/Logout_subcommand.ml
@@ -18,7 +18,9 @@ let run (conf : Login_CLI.conf) : Exit_code.t =
   let settings = Semgrep_settings.load () in
   let settings = Semgrep_settings.{ settings with api_token = None } in
   if Semgrep_settings.save settings then (
-    Logs.app (fun m -> m "Logged out (log back in with `semgrep login`)");
+    Logs.app (fun m ->
+        m "%s Logged out! Log back in with `semgrep login`"
+          (Logs_helpers.with_success_tag ()));
     Exit_code.ok)
   else Exit_code.fatal
 

--- a/src/osemgrep/cli_login/Logout_subcommand.ml
+++ b/src/osemgrep/cli_login/Logout_subcommand.ml
@@ -16,13 +16,20 @@
 let run (conf : Login_CLI.conf) : Exit_code.t =
   CLI_common.setup_logging ~force_color:false ~level:conf.logging_level;
   let settings = Semgrep_settings.load () in
-  let settings = Semgrep_settings.{ settings with api_token = None } in
-  if Semgrep_settings.save settings then (
-    Logs.app (fun m ->
-        m "%s Logged out! Log back in with `semgrep login`"
-          (Logs_helpers.with_success_tag ()));
-    Exit_code.ok)
-  else Exit_code.fatal
+  match settings.Semgrep_settings.api_token with
+  | None ->
+      Logs.app (fun m ->
+          m "%s You are not logged in! This command had no effect."
+            (Logs_helpers.with_warn_tag ()));
+      Exit_code.ok
+  | Some _ ->
+      let settings = Semgrep_settings.{ settings with api_token = None } in
+      if Semgrep_settings.save settings then (
+        Logs.app (fun m ->
+            m "%s Logged out! Log back in with `semgrep login`"
+              (Logs_helpers.with_success_tag ()));
+        Exit_code.ok)
+      else Exit_code.fatal
 
 (*****************************************************************************)
 (* Entry point *)

--- a/src/osemgrep/cli_login/dune
+++ b/src/osemgrep/cli_login/dune
@@ -5,7 +5,10 @@
   (name osemgrep_cli_login)
   (wrapped false)
   (libraries
+  ; External libraries
+    ANSITerminal
     cmdliner
+    ocolor
     commons
 
     osemgrep_configuring


### PR DESCRIPTION
## Description
This PR updates our `login` and `logout` subcommands with the **new** ✨ design treaments  ✨.


https://github.com/returntocorp/semgrep/assets/5779832/4808c062-f618-4a6e-8447-a9be2590e974


Addresses: https://linear.app/semgrep/issue/GROW-29

## Changes

### Fixes
- HTTP status codes on POST failure were not being returned

### Adds
- Improves the login experience by adjusting the wait times between successive retries to make it feel snappier
- Opens the login link automatically
- Shows the username that the token belongs to
- A cute little spinner to show that something is happening when we are waiting for our users to login
- Bold success / error messaging
- Updates the help text and messaging

### Removes
- Access token will not be printed to stdout

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
