### PR TITLE
refactor: Separate partitions for Gensym

### DIFF
--- a/libs/commons/Gensym.mli
+++ b/libs/commons/Gensym.mli
@@ -18,4 +18,17 @@ module MkId () : sig
      generate already-generated identifiers.
   *)
   val unsafe_reset_counter : unit -> unit
+
+  type partition = A | B
+
+  (* Defaults to partition A. IDs generated from different partitions are
+   * guaranteed to be distinct from each other even across different runs of the
+   * binary.
+   *
+   * This is useful if we want to serialize a data structure that includes IDs,
+   * then deserialize it in a different run for use alongside fresh IDs. Using
+   * one partition when constructing the serialized data, and another for a
+   * normal run ensures that we will avoid collisions.
+   * *)
+  val set_partition : partition -> unit
 end


### PR DESCRIPTION
As noted in the comments, this allows us to generate a data structure that uses IDs, serialize  it, and then load it in a future run without fear of collisions.

Specifically, I plan to use this for library definitions in the Pro Engine, where I will create a SIG using partition B for sids, serialize it, and then load it. Because normal runs use partition A, the sids generated for the libdef SIG will not collide.

Test plan: Existing automated tests ensure that partition A continues to work as expected. I have also tested with my work in progress on libdefs, which are generated with partition B, and all tests pass.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
