### PR TITLE
osemgrep: unify core_match_trace with cli_match_trace

### DIFF
--- a/cli/src/semgrep/join_rule.py
+++ b/cli/src/semgrep/join_rule.py
@@ -363,73 +363,17 @@ def generate_recursive_cte(model: Type[BaseModel], column1: str, column2: str) -
     return cte
 
 
-def cli_intermediate_vars_to_core_intermediate_vars(
-    i_vars: List[core.CliMatchIntermediateVar],
-) -> List[core.CoreMatchIntermediateVar]:
-    return [core.CoreMatchIntermediateVar(location=v.location) for v in i_vars]
-
-
-def cli_call_trace_to_core_call_trace(
-    trace: core.CliMatchCallTrace,
-) -> core.CoreMatchCallTrace:
-    value = trace.value
-    if isinstance(value, core.CliLoc):
-        return core.CoreMatchCallTrace(core.CoreLoc(value.value[0]))
-    elif isinstance(value, core.CliCall):
-        data, intermediate_vars, call_trace = value.value
-
-        return core.CoreMatchCallTrace(
-            core.CoreCall(
-                (
-                    data[0],
-                    cli_intermediate_vars_to_core_intermediate_vars(intermediate_vars),
-                    cli_call_trace_to_core_call_trace(call_trace),
-                )
-            )
-        )
-    else:
-        # unreachable, theoretically
-        logger.error("Reached unreachable code in cli call trace to core call trace")
-        return None
-
-
-def cli_trace_to_core_trace(
-    trace: core.CliMatchDataflowTrace,
-) -> core.CoreMatchDataflowTrace:
-    taint_source = trace.taint_source if trace.taint_source else None
-    taint_sink = trace.taint_sink if trace.taint_sink else None
-    intermediate_vars = (
-        cli_intermediate_vars_to_core_intermediate_vars(trace.intermediate_vars)
-        if trace.intermediate_vars
-        else None
-    )
-    return core.CoreMatchDataflowTrace(
-        taint_source=cli_call_trace_to_core_call_trace(taint_source)
-        if taint_source
-        else None,
-        intermediate_vars=intermediate_vars,
-        taint_sink=cli_call_trace_to_core_call_trace(taint_sink)
-        if taint_sink
-        else None,
-    )
-
-
 # For join mode, we get the final output of Semgrep and then need to construct
 # RuleMatches from that. Ideally something would be refactored so that we don't
 # need to move backwards in the pipeline like this.
 def json_to_rule_match(join_rule: Dict[str, Any], match: Dict[str, Any]) -> RuleMatch:
     cli_match_extra = core.CliMatchExtra.from_json(match.get("extra", {}))
-    dataflow_trace = (
-        cli_trace_to_core_trace(cli_match_extra.dataflow_trace)
-        if cli_match_extra.dataflow_trace
-        else None
-    )
     extra = core.CoreMatchExtra(
         message=cli_match_extra.message,
         # cli_match_extra.metavars is optional, but core_match_extra.metavars is
         # not. This is unsafe, but before it was just implicitly unsafe.
         metavars=cli_match_extra.metavars,  # type: ignore[arg-type]
-        dataflow_trace=dataflow_trace,
+        dataflow_trace=cli_match_extra.dataflow_trace,
         engine_kind=cli_match_extra.engine_kind
         if cli_match_extra.engine_kind
         else core.EngineKind(core.OSS()),

--- a/cli/tests/unit/test_formatters.py
+++ b/cli/tests/unit/test_formatters.py
@@ -30,31 +30,38 @@ def create_taint_rule_match():
             ),
             extra=core.CoreMatchExtra(
                 metavars=core.Metavars({}),
-                dataflow_trace=core.CoreMatchDataflowTrace(
-                    taint_source=core.CoreMatchCallTrace(
-                        core.CoreLoc(
-                            core.Location(
-                                path=core.Fpath("foo.py"),
-                                start=core.Position(8, 9, 11),
-                                end=core.Position(8, 10, 12),
+                dataflow_trace=core.CliMatchDataflowTrace(
+                    taint_source=core.CliMatchCallTrace(
+                        core.CliLoc(
+                            (
+                                core.Location(
+                                    path=core.Fpath("foo.py"),
+                                    start=core.Position(8, 9, 11),
+                                    end=core.Position(8, 10, 12),
+                                ),
+                                "??",
                             )
                         )
                     ),
                     intermediate_vars=[
-                        core.CoreMatchIntermediateVar(
+                        core.CliMatchIntermediateVar(
                             location=core.Location(
                                 path=core.Fpath("foo.py"),
                                 start=core.Position(13, 14, 16),
                                 end=core.Position(13, 15, 17),
-                            )
+                            ),
+                            content="??",
                         )
                     ],
-                    taint_sink=core.CoreMatchCallTrace(
-                        core.CoreLoc(
-                            core.Location(
-                                path=core.Fpath("foo.py"),
-                                start=core.Position(15, 16, 20),
-                                end=core.Position(15, 17, 21),
+                    taint_sink=core.CliMatchCallTrace(
+                        core.CliLoc(
+                            (
+                                core.Location(
+                                    path=core.Fpath("foo.py"),
+                                    start=core.Position(15, 16, 20),
+                                    end=core.Position(15, 17, 21),
+                                ),
+                                "??",
                             )
                         )
                     ),

--- a/src/reporting/JSON_report.mli
+++ b/src/reporting/JSON_report.mli
@@ -22,5 +22,7 @@ val metavar_string_of_any : AST_generic.any -> string
 (* now used also in osemgrep *)
 val error_to_error : Semgrep_error_code.error -> Semgrep_output_v1_t.core_error
 
-(* internal *)
+(* This is used only in the testing code, to reuse the
+ * Semgrep_error_code.compare_actual_to_expected
+ *)
 val match_to_error : Pattern_match.t -> unit


### PR DESCRIPTION
No need to have 2 types.

test plan:
make
make e2e


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)