### PR TITLE
Look for version change in Version.ml rather than version.ml during release

### DIFF
--- a/scripts/release/bump
+++ b/scripts/release/bump
@@ -106,7 +106,7 @@ fi
 
 bump
 
-if git status -s | grep -vq 'cli/src/semgrep/__init__.py\|cli/setup.py\|setup.py\|src/core_cli/version.ml'; then
+if git status -s | grep -vq 'cli/src/semgrep/__init__.py\|cli/setup.py\|setup.py\|src/core_cli/Version.ml'; then
   error <<EOF
 The release branch contains unexpected changes, cancelling release.
 EOF


### PR DESCRIPTION
Release 1.38.0 is failing because the `version.ml` was renamed `Version.ml`.
Error: https://github.com/returntocorp/semgrep/actions/runs/6041791459/job/16395552619

Test: try the release flow again at https://github.com/returntocorp/semgrep/actions/workflows/start-release.yml

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
