### PR TITLE
cli: print an error explaining that the python package entrypoint is no longer supported

### DIFF
--- a/changelog.d/gh-8605.fixed
+++ b/changelog.d/gh-8605.fixed
@@ -1,0 +1,1 @@
+Adds an error message clarifying the removal of `python -m semgrep`. This change originated in https://github.com/returntocorp/semgrep/pull/8504.

--- a/cli/src/semgrep/__main__.py
+++ b/cli/src/semgrep/__main__.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+import sys
+
+from semgrep.main import main
+
+# NOTE: This is the entrypoint for the `pysemgrep` command.
+# To match the program usage help between pysemgrep (legacy)
+# and osemgrep (new) – and to hide complexity for our users -
+# here we specify `semgrep` as the program name for pysemgrep.
+#
+# This entrypoint is deprecated and may be removed in the future.
+#
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/cli/src/semgrep/__main__.py
+++ b/cli/src/semgrep/__main__.py
@@ -1,15 +1,9 @@
 #!/usr/bin/env python3
 import sys
 
-from semgrep.main import main
-
-# NOTE: This is the entrypoint for the `pysemgrep` command.
-# To match the program usage help between pysemgrep (legacy)
-# and osemgrep (new) – and to hide complexity for our users -
-# here we specify `semgrep` as the program name for pysemgrep.
-#
-# This entrypoint is deprecated and may be removed in the future.
-#
 
 if __name__ == "__main__":
-    sys.exit(main())
+    sys.stderr.write(
+        "Using `python -m semgrep` to run Semgrep is deprecated as of 1.38.0. Please simply run `semgrep` instead.\n"
+    )
+    sys.exit(2)


### PR DESCRIPTION
The removal of `semgrep/__main__.py` is catching some people by surprise. ~~Let's bring it back to unblock people while we work on a more public deprecation plan for the python package entrypoint.~~ Let's print an error message explaining why.

test plan:
- checks pass
- manually verified `python -m semgrep`