### PR TITLE
fix: prevent nonroot docker builds from being tagged as latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,7 +108,7 @@ jobs:
     secrets: inherit
     with:
       docker-flavor: |
-        latest=auto
+        latest=false
         suffix=-nonroot
       docker-tags: |
         type=semver,pattern={{version}}


### PR DESCRIPTION
## Description
Customers have reported issues with running our `latest` semgrep release versions `1.38.0` and `1.38.2`. This is due to our non-root docker image having the `latest` tag applied.

<img width="619" alt="Screenshot 2023-09-01 at 6 21 05 PM" src="https://github.com/returntocorp/semgrep/assets/5779832/010d172f-ffb7-4674-ac24-87aaf0c7c302">

As noted in https://github.com/actions/checkout/issues/956 and https://github.com/actions/checkout/issues/1014, non-root containers seem to fail during the checkout step with an error message like

```
/usr/bin/docker exec  5b033937ed15061a8f606fa5f3805d0794caf9e04e3c12576fda15d25bde22ab sh -c "cat /etc/*release | grep ^ID"
node:internal/fs/utils:344
    throw err;
    ^

Error: EACCES: permission denied, open '/__w/_temp/_runner_file_commands/save_state_c7001c04-a974-4f62-8e53-a488[14](https://github.com/SensoftInc/imx8mp_yocto/actions/runs/3490287639/jobs/5841522655#step:3:15)7475c5'
```

**Addresses** #8601 

## Fix
- Apply `false` to `latest` field (see [docs](https://github.com/docker/metadata-action#latest-tag)) and community note https://github.com/docker/metadata-action/issues/161 

PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
