### PR TITLE
const-prop: Recognize constants initialized in constructors

### DIFF
--- a/changelog.d/pa-3006.added
+++ b/changelog.d/pa-3006.added
@@ -1,0 +1,3 @@
+const-prop: Semgrep can now identify as constants private class attributes
+that are assigned just once in a class constructor, e.g.:
+https://semgrep.dev/playground/s/R1re.

--- a/src/analyzing/Iter_with_context.ml
+++ b/src/analyzing/Iter_with_context.ml
@@ -1,0 +1,83 @@
+(* Iago Abal
+ *
+ * Copyright (C) 2023 r2c
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * version 2.1 as published by the Free Software Foundation, with the
+ * special exception on linking described in file license.txt.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
+ * license.txt for more details.
+ *)
+
+module G = AST_generic
+
+type context = {
+  in_class : G.ident option;
+  in_static_block : bool;
+  in_constructor : bool;
+  in_lvalue : bool;
+}
+
+let initial_context =
+  {
+    in_class = None;
+    in_static_block = false;
+    in_constructor = false;
+    in_lvalue = false;
+  }
+
+(* In principle you should just override the 'visit_xyz' methods and call
+ * 'super#visit_xyz' to recurse, so you could mostly ignore the
+ * 'with_context_visit_xyz' methods.
+ *)
+class virtual ['self] iter_with_context =
+  object (self : 'self)
+    inherit ['self] AST_generic.iter_no_id_info as super
+
+    method with_context_visit_definition (env, ctx) x =
+      super#visit_definition (env, ctx) x
+
+    method! visit_definition (env, ctx) x =
+      match x with
+      | { name = EN (Id (id, _ii)); _ }, ClassDef _cdef ->
+          self#with_context_visit_definition
+            (env, { ctx with in_class = Some id })
+            x
+      | { name = EN (Id (id, _ii)); _ }, FuncDef _fdef -> (
+          match ctx.in_class with
+          | Some in_class_id when fst in_class_id = fst id ->
+              self#with_context_visit_definition
+                (env, { ctx with in_constructor = true })
+                x
+          | Some _
+          | None ->
+              self#with_context_visit_definition (env, ctx) x)
+      | __else__ -> self#with_context_visit_definition (env, ctx) x
+
+    method with_context_visit_stmt (env, ctx) x = super#visit_stmt (env, ctx) x
+
+    method! visit_stmt (env, ctx) x =
+      match x.s with
+      | OtherStmtWithStmt (OSWS_Block ("Static", _), [], _block) ->
+          self#with_context_visit_stmt
+            (env, { ctx with in_static_block = true })
+            x
+      | __else__ -> self#with_context_visit_stmt (env, ctx) x
+
+    method with_context_visit_expr (env, ctx) x = super#visit_expr (env, ctx) x
+
+    method! visit_expr (env, ctx) x =
+      match x.e with
+      | ArrayAccess (e1, (_, e2, _)) ->
+          self#with_context_visit_expr (env, ctx) e1;
+          self#with_context_visit_expr (env, { ctx with in_lvalue = false }) e2
+      | Assign (e1, _, e2)
+      | AssignOp (e1, _, e2) ->
+          self#with_context_visit_expr (env, { ctx with in_lvalue = true }) e1;
+          self#with_context_visit_expr (env, ctx) e2
+      | __else__ -> self#with_context_visit_expr (env, ctx) x
+  end

--- a/tests/rules/cp_private_class_attr3.java
+++ b/tests/rules/cp_private_class_attr3.java
@@ -1,0 +1,51 @@
+class Test1 {
+
+    private int c;
+    private int x;
+    private int y;
+
+    public Test1() {
+        this.c = 42;
+        this.y = 42;
+    }
+
+    public void doSomething1() {
+        x = 42;
+        y = 0;
+    }
+
+    public void doSomething2(){
+        //ok:test
+        foo(x);
+        //ok:test
+        foo(y);
+    }
+
+    public void doSomething3(){
+        //ruleid:test
+        foo(c);
+    }
+
+}
+
+class Test2 {
+
+    private int x;
+
+    public Test2() {
+        this.x = 42;
+    }
+
+    public Test2(int v) {
+        // nothing
+    }
+
+    public void doSomething4() {
+        // If there are two or more constructors we just do not recognize
+        // it as a constant, even though in some cases we could. For now
+        // we just handle the case where it is a single constructor.
+        //ok:test
+        foo(x);
+    }
+
+}

--- a/tests/rules/cp_private_class_attr3.yaml
+++ b/tests/rules/cp_private_class_attr3.yaml
@@ -1,0 +1,7 @@
+rules:
+  - id: test
+    severity: ERROR
+    message: Test
+    languages:
+      - java
+    pattern: foo(42)


### PR DESCRIPTION
Closes PA-3006

test plan:
make test # new test

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
