### PR TITLE
js: add distclean recipe

### DIFF
--- a/js/Makefile
+++ b/js/Makefile
@@ -46,3 +46,10 @@ clean:
 	cd libyaml; $(MAKE) clean
 	cd engine; $(MAKE) clean
 	cd languages; $(MAKE) clean
+
+.PHONY: distclean
+distclean:
+	cd libpcre; $(MAKE) distclean
+	cd libyaml; $(MAKE) distclean
+	cd engine; $(MAKE) distclean
+	cd languages; $(MAKE) distclean

--- a/js/engine/Makefile
+++ b/js/engine/Makefile
@@ -30,6 +30,10 @@ package: build
 clean:
 	rm -rf dist
 
+.PHONY: distclean
+distclean:
+	rm -rf dist node_modules
+
 ../libyaml/dist/libyaml.o:
 	cd ../libyaml; $(MAKE) dist/libyaml.o
 

--- a/js/languages/Makefile
+++ b/js/languages/Makefile
@@ -28,3 +28,7 @@ package-%:
 .PHONY: clean
 clean:
 	rm -rf **/dist
+
+.PHONY: distclean
+distclean:
+	rm -rf **/dist **/node_modules

--- a/js/languages/shared/Makefile.include
+++ b/js/languages/shared/Makefile.include
@@ -44,6 +44,10 @@ package: build
 clean:
 	rm -rf dist
 
+.PHONY: distclean
+distclean:
+	rm -rf dist node_modules
+
 ifndef NO_WASM
 dist/semgrep-parser.js dist/semgrep-parser.wasm: $(TREESITTER_SRCDIR)/lib.c $(TREE_SITTER_SOURCES) $(EXTRA_TREE_SITTER_SOURCES)
 	mkdir -p dist

--- a/js/libpcre/Makefile
+++ b/js/libpcre/Makefile
@@ -13,6 +13,10 @@ clean:
 	rm -rf dist
 	cd downloads/pcre-8.45; $(MAKE) clean
 
+.PHONY: distclean
+distclean:
+	rm -rf dist downloads node_modules
+
 .PHONY: test
 test: build
 	npm ci

--- a/js/libyaml/Makefile
+++ b/js/libyaml/Makefile
@@ -17,6 +17,10 @@ test: build
 clean:
 	rm -rf dist
 
+.PHONY: distclean
+distclean:
+	rm -rf dist node_modules
+
 dist/libyaml.o: *.c
 	mkdir -p dist
 	emcc \


### PR DESCRIPTION
- adds `distclean` makefile recipe, which clears out additional folders like `node_modules` and the libpcre downloads folder

test plan:
- local `make distclean` succeeds
- local `make test` succeeds after distclean
- checks pass
