### PR TITLE
retry on 504s

### DIFF
--- a/changelog.d/gh-8629.fixed
+++ b/changelog.d/gh-8629.fixed
@@ -1,0 +1,1 @@
+Request retry logic now includes 504's

--- a/cli/src/semgrep/app/session.py
+++ b/cli/src/semgrep/app/session.py
@@ -151,7 +151,7 @@ class AppSession(requests.Session):
                 total=3,
                 backoff_factor=4,
                 allowed_methods=["GET", "POST"],
-                status_forcelist=(413, 429, 500, 502, 503),
+                status_forcelist=(413, 429, 500, 502, 503, 504),
             ),
         )
 


### PR DESCRIPTION
A customer reported failures with `semgrep scan` where requests received a 504.
504 is "Gateway timeout" which should be retry-able but isn't currently in the list.

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
