### PR TITLE
Add validation state to finding

### DIFF
--- a/cli/src/semgrep/formatter/text.py
+++ b/cli/src/semgrep/formatter/text.py
@@ -239,7 +239,7 @@ def match_to_lines(
 
 def call_trace_to_lines(
     ref_path: Path,
-    call_trace: out.CliMatchCallTrace,
+    call_trace: out.MatchCallTrace,
     color_output: bool,
     per_finding_max_lines_limit: Optional[int],
     per_line_max_chars_limit: Optional[int],
@@ -309,7 +309,7 @@ def call_trace_to_lines(
 
 def dataflow_trace_to_lines(
     rule_match_path: Path,
-    dataflow_trace: Optional[out.CliMatchDataflowTrace],
+    dataflow_trace: Optional[out.MatchDataflowTrace],
     color_output: bool,
     per_finding_max_lines_limit: Optional[int],
     per_line_max_chars_limit: Optional[int],

--- a/cli/src/semgrep/rule_match.py
+++ b/cli/src/semgrep/rule_match.py
@@ -511,7 +511,10 @@ class RuleMatch:
             metadata=out.RawJson(self.metadata),
             is_blocking=self.is_blocking,
             dataflow_trace=self.dataflow_trace,
-            validation_state=self.extra.get("validation_state"),
+            # TODO: Currently bypassing extra because it stores a
+            # string instead of a ValidationState. Fix the monkey
+            # patchable version if you want monkey patching to work.
+            validation_state=self.match.extra.validation_state,
         )
 
         if self.extra.get("fixed_lines"):

--- a/cli/src/semgrep/rule_match.py
+++ b/cli/src/semgrep/rule_match.py
@@ -511,6 +511,7 @@ class RuleMatch:
             metadata=out.RawJson(self.metadata),
             is_blocking=self.is_blocking,
             dataflow_trace=self.dataflow_trace,
+            validation_state=self.extra.get("validation_state"),
         )
 
         if self.extra.get("fixed_lines"):

--- a/cli/src/semgrep/rule_match.py
+++ b/cli/src/semgrep/rule_match.py
@@ -447,7 +447,7 @@ class RuleMatch:
             return blocking
 
     @property
-    def dataflow_trace(self) -> Optional[core.CliMatchDataflowTrace]:
+    def dataflow_trace(self) -> Optional[core.MatchDataflowTrace]:
         return self.match.extra.dataflow_trace
 
     @property

--- a/cli/tests/e2e/snapshots/test_ci/test_dryrun/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_dryrun/results.txt
@@ -198,7 +198,8 @@ Would have sent findings and ignores blob: {
                         "sink(d2)"
                     ]
                 ]
-            }
+            },
+            "validation_state": "NO_VALIDATOR"
         },
         {
             "check_id": "supply-chain1",
@@ -278,7 +279,8 @@ Would have sent findings and ignores blob: {
                 "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
                 "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
                 "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-            }
+            },
+            "validation_state": "NO_VALIDATOR"
         },
         {
             "check_id": "eqeq-four",
@@ -313,7 +315,8 @@ Would have sent findings and ignores blob: {
                 "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
                 "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
                 "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-            }
+            },
+            "validation_state": "NO_VALIDATOR"
         },
         {
             "check_id": "eqeq-five",
@@ -346,7 +349,8 @@ Would have sent findings and ignores blob: {
                 "end_line_hash": "27937fb6c73e88412e7e39647557d4c03fda0ea04b91cecb3852355f387d03c8",
                 "code_hash": "2005925cbb09029b2f5c8700dcae5c9a8b9a4324a15643853626afd0bf65c052",
                 "pattern_hash": "2005925cbb09029b2f5c8700dcae5c9a8b9a4324a15643853626afd0bf65c052"
-            }
+            },
+            "validation_state": "NO_VALIDATOR"
         },
         {
             "check_id": "eqeq-bad",
@@ -368,7 +372,8 @@ Would have sent findings and ignores blob: {
                 "end_line_hash": "510108a9aab34209e18dc5b9bba20dee69d9981b536ac1c927db223d8b0cb5bf",
                 "code_hash": "bbe58d6d77d6bcf2aba1a2ea780990cc922fab514445048b3bf5b50a7a7c0250",
                 "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-            }
+            },
+            "validation_state": "NO_VALIDATOR"
         },
         {
             "check_id": "eqeq-bad",
@@ -390,7 +395,8 @@ Would have sent findings and ignores blob: {
                 "end_line_hash": "60f5f1fb9303e4f18ddcada8deb88cb2ac20c7d95cfcd424b65934545481a1a9",
                 "code_hash": "97c1aa56d43d22e7ec10a8ca99ceab7e02749262a4be0c51683dd353b3b1a868",
                 "pattern_hash": "06b2540894e5b13085b613a69a474505628594986504f246b7a521b99ce10bf2"
-            }
+            },
+            "validation_state": "NO_VALIDATOR"
         },
         {
             "check_id": "eqeq-bad",
@@ -412,7 +418,8 @@ Would have sent findings and ignores blob: {
                 "end_line_hash": "1ca20045d4e8968c3774538d54b138132fa83b7b18e0137435f3108f40ae163e",
                 "code_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241",
                 "pattern_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241"
-            }
+            },
+            "validation_state": "NO_VALIDATOR"
         },
         {
             "check_id": "eqeq-bad",
@@ -434,7 +441,8 @@ Would have sent findings and ignores blob: {
                 "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
                 "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
                 "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-            }
+            },
+            "validation_state": "NO_VALIDATOR"
         },
         {
             "check_id": "eqeq-bad",
@@ -456,7 +464,8 @@ Would have sent findings and ignores blob: {
                 "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
                 "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
                 "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-            }
+            },
+            "validation_state": "NO_VALIDATOR"
         },
         {
             "check_id": "eqeq-bad",
@@ -478,7 +487,8 @@ Would have sent findings and ignores blob: {
                 "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
                 "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
                 "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-            }
+            },
+            "validation_state": "NO_VALIDATOR"
         }
     ],
     "ignores": [
@@ -514,7 +524,8 @@ Would have sent findings and ignores blob: {
                 "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
                 "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
                 "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-            }
+            },
+            "validation_state": "NO_VALIDATOR"
         },
         {
             "check_id": "eqeq-four",
@@ -549,7 +560,8 @@ Would have sent findings and ignores blob: {
                 "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
                 "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
                 "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-            }
+            },
+            "validation_state": "NO_VALIDATOR"
         },
         {
             "check_id": "eqeq-five",
@@ -582,7 +594,8 @@ Would have sent findings and ignores blob: {
                 "end_line_hash": "889792ca5269732e125f6abb0d0245a7dcb83862e34d797a5ee890a4a7a5eae7",
                 "code_hash": "d2c95171288a258009c5187392c5e2122e2640e0431af8b1cad77d5b403ed850",
                 "pattern_hash": "d2c95171288a258009c5187392c5e2122e2640e0431af8b1cad77d5b403ed850"
-            }
+            },
+            "validation_state": "NO_VALIDATOR"
         },
         {
             "check_id": "eqeq-bad",
@@ -604,7 +617,8 @@ Would have sent findings and ignores blob: {
                 "end_line_hash": "0f1b9301a089bbcbbb0dd563a4a01270919f60a5bfd3d738788a8bbb1f7e0a59",
                 "code_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613",
                 "pattern_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613"
-            }
+            },
+            "validation_state": "NO_VALIDATOR"
         },
         {
             "check_id": "eqeq-bad",
@@ -626,7 +640,8 @@ Would have sent findings and ignores blob: {
                 "end_line_hash": "c772c5c0ca842b8e194eca4ed7bf1333c1e67bab038e9ac76c788d0e819c51ba",
                 "code_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f",
                 "pattern_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f"
-            }
+            },
+            "validation_state": "NO_VALIDATOR"
         },
         {
             "check_id": "eqeq-bad",
@@ -648,7 +663,8 @@ Would have sent findings and ignores blob: {
                 "end_line_hash": "e89b663d624741879a65668fed6c6dce5c9823fa17962ff69ae19b369b09e77c",
                 "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
                 "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-            }
+            },
+            "validation_state": "NO_VALIDATOR"
         }
     ],
     "token": null,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines-overwrite-autodetected-variables/findings_and_ignores.json
@@ -91,7 +91,8 @@
             "sink(d2)"
           ]
         ]
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "supply-chain1",
@@ -171,7 +172,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -206,7 +208,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -242,7 +245,8 @@
       },
       "fixed_lines": [
         "    (x == 2)"
-      ]
+      ],
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -264,7 +268,8 @@
         "end_line_hash": "510108a9aab34209e18dc5b9bba20dee69d9981b536ac1c927db223d8b0cb5bf",
         "code_hash": "bbe58d6d77d6bcf2aba1a2ea780990cc922fab514445048b3bf5b50a7a7c0250",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -286,7 +291,8 @@
         "end_line_hash": "60f5f1fb9303e4f18ddcada8deb88cb2ac20c7d95cfcd424b65934545481a1a9",
         "code_hash": "97c1aa56d43d22e7ec10a8ca99ceab7e02749262a4be0c51683dd353b3b1a868",
         "pattern_hash": "06b2540894e5b13085b613a69a474505628594986504f246b7a521b99ce10bf2"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -308,7 +314,8 @@
         "end_line_hash": "1ca20045d4e8968c3774538d54b138132fa83b7b18e0137435f3108f40ae163e",
         "code_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241",
         "pattern_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -330,7 +337,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -352,7 +360,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -374,7 +383,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "ignores": [
@@ -410,7 +420,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -445,7 +456,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -481,7 +493,8 @@
       },
       "fixed_lines": [
         "    (y == 2)  # nosemgrep"
-      ]
+      ],
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -503,7 +516,8 @@
         "end_line_hash": "0f1b9301a089bbcbbb0dd563a4a01270919f60a5bfd3d738788a8bbb1f7e0a59",
         "code_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613",
         "pattern_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -525,7 +539,8 @@
         "end_line_hash": "c772c5c0ca842b8e194eca4ed7bf1333c1e67bab038e9ac76c788d0e819c51ba",
         "code_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f",
         "pattern_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -547,7 +562,8 @@
         "end_line_hash": "e89b663d624741879a65668fed6c6dce5c9823fa17962ff69ae19b369b09e77c",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "token": null,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines/findings_and_ignores.json
@@ -91,7 +91,8 @@
             "sink(d2)"
           ]
         ]
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "supply-chain1",
@@ -171,7 +172,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -206,7 +208,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -242,7 +245,8 @@
       },
       "fixed_lines": [
         "    (x == 2)"
-      ]
+      ],
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -264,7 +268,8 @@
         "end_line_hash": "510108a9aab34209e18dc5b9bba20dee69d9981b536ac1c927db223d8b0cb5bf",
         "code_hash": "bbe58d6d77d6bcf2aba1a2ea780990cc922fab514445048b3bf5b50a7a7c0250",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -286,7 +291,8 @@
         "end_line_hash": "60f5f1fb9303e4f18ddcada8deb88cb2ac20c7d95cfcd424b65934545481a1a9",
         "code_hash": "97c1aa56d43d22e7ec10a8ca99ceab7e02749262a4be0c51683dd353b3b1a868",
         "pattern_hash": "06b2540894e5b13085b613a69a474505628594986504f246b7a521b99ce10bf2"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -308,7 +314,8 @@
         "end_line_hash": "1ca20045d4e8968c3774538d54b138132fa83b7b18e0137435f3108f40ae163e",
         "code_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241",
         "pattern_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -330,7 +337,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -352,7 +360,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -374,7 +383,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "ignores": [
@@ -410,7 +420,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -445,7 +456,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -481,7 +493,8 @@
       },
       "fixed_lines": [
         "    (y == 2)  # nosemgrep"
-      ]
+      ],
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -503,7 +516,8 @@
         "end_line_hash": "0f1b9301a089bbcbbb0dd563a4a01270919f60a5bfd3d738788a8bbb1f7e0a59",
         "code_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613",
         "pattern_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -525,7 +539,8 @@
         "end_line_hash": "c772c5c0ca842b8e194eca4ed7bf1333c1e67bab038e9ac76c788d0e819c51ba",
         "code_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f",
         "pattern_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -547,7 +562,8 @@
         "end_line_hash": "e89b663d624741879a65668fed6c6dce5c9823fa17962ff69ae19b369b09e77c",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "token": null,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket-overwrite-autodetected-variables/findings_and_ignores.json
@@ -91,7 +91,8 @@
             "sink(d2)"
           ]
         ]
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "supply-chain1",
@@ -171,7 +172,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -206,7 +208,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -242,7 +245,8 @@
       },
       "fixed_lines": [
         "    (x == 2)"
-      ]
+      ],
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -264,7 +268,8 @@
         "end_line_hash": "510108a9aab34209e18dc5b9bba20dee69d9981b536ac1c927db223d8b0cb5bf",
         "code_hash": "bbe58d6d77d6bcf2aba1a2ea780990cc922fab514445048b3bf5b50a7a7c0250",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -286,7 +291,8 @@
         "end_line_hash": "60f5f1fb9303e4f18ddcada8deb88cb2ac20c7d95cfcd424b65934545481a1a9",
         "code_hash": "97c1aa56d43d22e7ec10a8ca99ceab7e02749262a4be0c51683dd353b3b1a868",
         "pattern_hash": "06b2540894e5b13085b613a69a474505628594986504f246b7a521b99ce10bf2"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -308,7 +314,8 @@
         "end_line_hash": "1ca20045d4e8968c3774538d54b138132fa83b7b18e0137435f3108f40ae163e",
         "code_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241",
         "pattern_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -330,7 +337,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -352,7 +360,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -374,7 +383,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "ignores": [
@@ -410,7 +420,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -445,7 +456,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -481,7 +493,8 @@
       },
       "fixed_lines": [
         "    (y == 2)  # nosemgrep"
-      ]
+      ],
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -503,7 +516,8 @@
         "end_line_hash": "0f1b9301a089bbcbbb0dd563a4a01270919f60a5bfd3d738788a8bbb1f7e0a59",
         "code_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613",
         "pattern_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -525,7 +539,8 @@
         "end_line_hash": "c772c5c0ca842b8e194eca4ed7bf1333c1e67bab038e9ac76c788d0e819c51ba",
         "code_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f",
         "pattern_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -547,7 +562,8 @@
         "end_line_hash": "e89b663d624741879a65668fed6c6dce5c9823fa17962ff69ae19b369b09e77c",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "token": null,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket/findings_and_ignores.json
@@ -91,7 +91,8 @@
             "sink(d2)"
           ]
         ]
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "supply-chain1",
@@ -171,7 +172,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -206,7 +208,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -242,7 +245,8 @@
       },
       "fixed_lines": [
         "    (x == 2)"
-      ]
+      ],
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -264,7 +268,8 @@
         "end_line_hash": "510108a9aab34209e18dc5b9bba20dee69d9981b536ac1c927db223d8b0cb5bf",
         "code_hash": "bbe58d6d77d6bcf2aba1a2ea780990cc922fab514445048b3bf5b50a7a7c0250",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -286,7 +291,8 @@
         "end_line_hash": "60f5f1fb9303e4f18ddcada8deb88cb2ac20c7d95cfcd424b65934545481a1a9",
         "code_hash": "97c1aa56d43d22e7ec10a8ca99ceab7e02749262a4be0c51683dd353b3b1a868",
         "pattern_hash": "06b2540894e5b13085b613a69a474505628594986504f246b7a521b99ce10bf2"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -308,7 +314,8 @@
         "end_line_hash": "1ca20045d4e8968c3774538d54b138132fa83b7b18e0137435f3108f40ae163e",
         "code_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241",
         "pattern_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -330,7 +337,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -352,7 +360,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -374,7 +383,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "ignores": [
@@ -410,7 +420,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -445,7 +456,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -481,7 +493,8 @@
       },
       "fixed_lines": [
         "    (y == 2)  # nosemgrep"
-      ]
+      ],
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -503,7 +516,8 @@
         "end_line_hash": "0f1b9301a089bbcbbb0dd563a4a01270919f60a5bfd3d738788a8bbb1f7e0a59",
         "code_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613",
         "pattern_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -525,7 +539,8 @@
         "end_line_hash": "c772c5c0ca842b8e194eca4ed7bf1333c1e67bab038e9ac76c788d0e819c51ba",
         "code_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f",
         "pattern_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -547,7 +562,8 @@
         "end_line_hash": "e89b663d624741879a65668fed6c6dce5c9823fa17962ff69ae19b369b09e77c",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "token": null,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite-overwrite-autodetected-variables/findings_and_ignores.json
@@ -91,7 +91,8 @@
             "sink(d2)"
           ]
         ]
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "supply-chain1",
@@ -171,7 +172,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -206,7 +208,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -242,7 +245,8 @@
       },
       "fixed_lines": [
         "    (x == 2)"
-      ]
+      ],
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -264,7 +268,8 @@
         "end_line_hash": "510108a9aab34209e18dc5b9bba20dee69d9981b536ac1c927db223d8b0cb5bf",
         "code_hash": "bbe58d6d77d6bcf2aba1a2ea780990cc922fab514445048b3bf5b50a7a7c0250",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -286,7 +291,8 @@
         "end_line_hash": "60f5f1fb9303e4f18ddcada8deb88cb2ac20c7d95cfcd424b65934545481a1a9",
         "code_hash": "97c1aa56d43d22e7ec10a8ca99ceab7e02749262a4be0c51683dd353b3b1a868",
         "pattern_hash": "06b2540894e5b13085b613a69a474505628594986504f246b7a521b99ce10bf2"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -308,7 +314,8 @@
         "end_line_hash": "1ca20045d4e8968c3774538d54b138132fa83b7b18e0137435f3108f40ae163e",
         "code_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241",
         "pattern_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -330,7 +337,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -352,7 +360,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -374,7 +383,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "ignores": [
@@ -410,7 +420,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -445,7 +456,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -481,7 +493,8 @@
       },
       "fixed_lines": [
         "    (y == 2)  # nosemgrep"
-      ]
+      ],
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -503,7 +516,8 @@
         "end_line_hash": "0f1b9301a089bbcbbb0dd563a4a01270919f60a5bfd3d738788a8bbb1f7e0a59",
         "code_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613",
         "pattern_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -525,7 +539,8 @@
         "end_line_hash": "c772c5c0ca842b8e194eca4ed7bf1333c1e67bab038e9ac76c788d0e819c51ba",
         "code_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f",
         "pattern_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -547,7 +562,8 @@
         "end_line_hash": "e89b663d624741879a65668fed6c6dce5c9823fa17962ff69ae19b369b09e77c",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "token": null,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite/findings_and_ignores.json
@@ -91,7 +91,8 @@
             "sink(d2)"
           ]
         ]
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "supply-chain1",
@@ -171,7 +172,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -206,7 +208,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -242,7 +245,8 @@
       },
       "fixed_lines": [
         "    (x == 2)"
-      ]
+      ],
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -264,7 +268,8 @@
         "end_line_hash": "510108a9aab34209e18dc5b9bba20dee69d9981b536ac1c927db223d8b0cb5bf",
         "code_hash": "bbe58d6d77d6bcf2aba1a2ea780990cc922fab514445048b3bf5b50a7a7c0250",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -286,7 +291,8 @@
         "end_line_hash": "60f5f1fb9303e4f18ddcada8deb88cb2ac20c7d95cfcd424b65934545481a1a9",
         "code_hash": "97c1aa56d43d22e7ec10a8ca99ceab7e02749262a4be0c51683dd353b3b1a868",
         "pattern_hash": "06b2540894e5b13085b613a69a474505628594986504f246b7a521b99ce10bf2"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -308,7 +314,8 @@
         "end_line_hash": "1ca20045d4e8968c3774538d54b138132fa83b7b18e0137435f3108f40ae163e",
         "code_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241",
         "pattern_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -330,7 +337,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -352,7 +360,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -374,7 +383,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "ignores": [
@@ -410,7 +420,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -445,7 +456,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -481,7 +493,8 @@
       },
       "fixed_lines": [
         "    (y == 2)  # nosemgrep"
-      ]
+      ],
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -503,7 +516,8 @@
         "end_line_hash": "0f1b9301a089bbcbbb0dd563a4a01270919f60a5bfd3d738788a8bbb1f7e0a59",
         "code_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613",
         "pattern_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -525,7 +539,8 @@
         "end_line_hash": "c772c5c0ca842b8e194eca4ed7bf1333c1e67bab038e9ac76c788d0e819c51ba",
         "code_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f",
         "pattern_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -547,7 +562,8 @@
         "end_line_hash": "e89b663d624741879a65668fed6c6dce5c9823fa17962ff69ae19b369b09e77c",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "token": null,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci-overwrite-autodetected-variables/findings_and_ignores.json
@@ -91,7 +91,8 @@
             "sink(d2)"
           ]
         ]
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "supply-chain1",
@@ -171,7 +172,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -206,7 +208,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -242,7 +245,8 @@
       },
       "fixed_lines": [
         "    (x == 2)"
-      ]
+      ],
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -264,7 +268,8 @@
         "end_line_hash": "510108a9aab34209e18dc5b9bba20dee69d9981b536ac1c927db223d8b0cb5bf",
         "code_hash": "bbe58d6d77d6bcf2aba1a2ea780990cc922fab514445048b3bf5b50a7a7c0250",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -286,7 +291,8 @@
         "end_line_hash": "60f5f1fb9303e4f18ddcada8deb88cb2ac20c7d95cfcd424b65934545481a1a9",
         "code_hash": "97c1aa56d43d22e7ec10a8ca99ceab7e02749262a4be0c51683dd353b3b1a868",
         "pattern_hash": "06b2540894e5b13085b613a69a474505628594986504f246b7a521b99ce10bf2"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -308,7 +314,8 @@
         "end_line_hash": "1ca20045d4e8968c3774538d54b138132fa83b7b18e0137435f3108f40ae163e",
         "code_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241",
         "pattern_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -330,7 +337,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -352,7 +360,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -374,7 +383,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "ignores": [
@@ -410,7 +420,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -445,7 +456,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -481,7 +493,8 @@
       },
       "fixed_lines": [
         "    (y == 2)  # nosemgrep"
-      ]
+      ],
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -503,7 +516,8 @@
         "end_line_hash": "0f1b9301a089bbcbbb0dd563a4a01270919f60a5bfd3d738788a8bbb1f7e0a59",
         "code_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613",
         "pattern_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -525,7 +539,8 @@
         "end_line_hash": "c772c5c0ca842b8e194eca4ed7bf1333c1e67bab038e9ac76c788d0e819c51ba",
         "code_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f",
         "pattern_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -547,7 +562,8 @@
         "end_line_hash": "e89b663d624741879a65668fed6c6dce5c9823fa17962ff69ae19b369b09e77c",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "token": null,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci/findings_and_ignores.json
@@ -91,7 +91,8 @@
             "sink(d2)"
           ]
         ]
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "supply-chain1",
@@ -171,7 +172,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -206,7 +208,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -242,7 +245,8 @@
       },
       "fixed_lines": [
         "    (x == 2)"
-      ]
+      ],
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -264,7 +268,8 @@
         "end_line_hash": "510108a9aab34209e18dc5b9bba20dee69d9981b536ac1c927db223d8b0cb5bf",
         "code_hash": "bbe58d6d77d6bcf2aba1a2ea780990cc922fab514445048b3bf5b50a7a7c0250",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -286,7 +291,8 @@
         "end_line_hash": "60f5f1fb9303e4f18ddcada8deb88cb2ac20c7d95cfcd424b65934545481a1a9",
         "code_hash": "97c1aa56d43d22e7ec10a8ca99ceab7e02749262a4be0c51683dd353b3b1a868",
         "pattern_hash": "06b2540894e5b13085b613a69a474505628594986504f246b7a521b99ce10bf2"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -308,7 +314,8 @@
         "end_line_hash": "1ca20045d4e8968c3774538d54b138132fa83b7b18e0137435f3108f40ae163e",
         "code_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241",
         "pattern_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -330,7 +337,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -352,7 +360,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -374,7 +383,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "ignores": [
@@ -410,7 +420,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -445,7 +456,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -481,7 +493,8 @@
       },
       "fixed_lines": [
         "    (y == 2)  # nosemgrep"
-      ]
+      ],
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -503,7 +516,8 @@
         "end_line_hash": "0f1b9301a089bbcbbb0dd563a4a01270919f60a5bfd3d738788a8bbb1f7e0a59",
         "code_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613",
         "pattern_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -525,7 +539,8 @@
         "end_line_hash": "c772c5c0ca842b8e194eca4ed7bf1333c1e67bab038e9ac76c788d0e819c51ba",
         "code_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f",
         "pattern_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -547,7 +562,8 @@
         "end_line_hash": "e89b663d624741879a65668fed6c6dce5c9823fa17962ff69ae19b369b09e77c",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "token": null,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/findings_and_ignores.json
@@ -91,7 +91,8 @@
             "sink(d2)"
           ]
         ]
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "supply-chain1",
@@ -171,7 +172,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -206,7 +208,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -242,7 +245,8 @@
       },
       "fixed_lines": [
         "    (x == 2)"
-      ]
+      ],
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -264,7 +268,8 @@
         "end_line_hash": "510108a9aab34209e18dc5b9bba20dee69d9981b536ac1c927db223d8b0cb5bf",
         "code_hash": "bbe58d6d77d6bcf2aba1a2ea780990cc922fab514445048b3bf5b50a7a7c0250",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -286,7 +291,8 @@
         "end_line_hash": "60f5f1fb9303e4f18ddcada8deb88cb2ac20c7d95cfcd424b65934545481a1a9",
         "code_hash": "97c1aa56d43d22e7ec10a8ca99ceab7e02749262a4be0c51683dd353b3b1a868",
         "pattern_hash": "06b2540894e5b13085b613a69a474505628594986504f246b7a521b99ce10bf2"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -308,7 +314,8 @@
         "end_line_hash": "1ca20045d4e8968c3774538d54b138132fa83b7b18e0137435f3108f40ae163e",
         "code_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241",
         "pattern_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -330,7 +337,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -352,7 +360,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -374,7 +383,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "ignores": [
@@ -410,7 +420,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -445,7 +456,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -481,7 +493,8 @@
       },
       "fixed_lines": [
         "    (y == 2)  # nosemgrep"
-      ]
+      ],
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -503,7 +516,8 @@
         "end_line_hash": "0f1b9301a089bbcbbb0dd563a4a01270919f60a5bfd3d738788a8bbb1f7e0a59",
         "code_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613",
         "pattern_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -525,7 +539,8 @@
         "end_line_hash": "c772c5c0ca842b8e194eca4ed7bf1333c1e67bab038e9ac76c788d0e819c51ba",
         "code_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f",
         "pattern_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -547,7 +562,8 @@
         "end_line_hash": "e89b663d624741879a65668fed6c6dce5c9823fa17962ff69ae19b369b09e77c",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "token": null,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr-semgrepconfig/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr-semgrepconfig/findings_and_ignores.json
@@ -91,7 +91,8 @@
             "sink(d2)"
           ]
         ]
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "abceversion1",
@@ -125,7 +126,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -160,7 +162,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -196,7 +199,8 @@
       },
       "fixed_lines": [
         "    (x == 2)"
-      ]
+      ],
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -218,7 +222,8 @@
         "end_line_hash": "510108a9aab34209e18dc5b9bba20dee69d9981b536ac1c927db223d8b0cb5bf",
         "code_hash": "bbe58d6d77d6bcf2aba1a2ea780990cc922fab514445048b3bf5b50a7a7c0250",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -240,7 +245,8 @@
         "end_line_hash": "60f5f1fb9303e4f18ddcada8deb88cb2ac20c7d95cfcd424b65934545481a1a9",
         "code_hash": "97c1aa56d43d22e7ec10a8ca99ceab7e02749262a4be0c51683dd353b3b1a868",
         "pattern_hash": "06b2540894e5b13085b613a69a474505628594986504f246b7a521b99ce10bf2"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -262,7 +268,8 @@
         "end_line_hash": "1ca20045d4e8968c3774538d54b138132fa83b7b18e0137435f3108f40ae163e",
         "code_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241",
         "pattern_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -284,7 +291,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -306,7 +314,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -328,7 +337,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "ignores": [
@@ -364,7 +374,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -399,7 +410,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -435,7 +447,8 @@
       },
       "fixed_lines": [
         "    (y == 2)  # nosemgrep"
-      ]
+      ],
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -457,7 +470,8 @@
         "end_line_hash": "0f1b9301a089bbcbbb0dd563a4a01270919f60a5bfd3d738788a8bbb1f7e0a59",
         "code_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613",
         "pattern_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -479,7 +493,8 @@
         "end_line_hash": "c772c5c0ca842b8e194eca4ed7bf1333c1e67bab038e9ac76c788d0e819c51ba",
         "code_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f",
         "pattern_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -501,7 +516,8 @@
         "end_line_hash": "e89b663d624741879a65668fed6c6dce5c9823fa17962ff69ae19b369b09e77c",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "token": null,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr/findings_and_ignores.json
@@ -91,7 +91,8 @@
             "sink(d2)"
           ]
         ]
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "abceversion1",
@@ -125,7 +126,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -160,7 +162,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -196,7 +199,8 @@
       },
       "fixed_lines": [
         "    (x == 2)"
-      ]
+      ],
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -218,7 +222,8 @@
         "end_line_hash": "510108a9aab34209e18dc5b9bba20dee69d9981b536ac1c927db223d8b0cb5bf",
         "code_hash": "bbe58d6d77d6bcf2aba1a2ea780990cc922fab514445048b3bf5b50a7a7c0250",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -240,7 +245,8 @@
         "end_line_hash": "60f5f1fb9303e4f18ddcada8deb88cb2ac20c7d95cfcd424b65934545481a1a9",
         "code_hash": "97c1aa56d43d22e7ec10a8ca99ceab7e02749262a4be0c51683dd353b3b1a868",
         "pattern_hash": "06b2540894e5b13085b613a69a474505628594986504f246b7a521b99ce10bf2"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -262,7 +268,8 @@
         "end_line_hash": "1ca20045d4e8968c3774538d54b138132fa83b7b18e0137435f3108f40ae163e",
         "code_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241",
         "pattern_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -284,7 +291,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -306,7 +314,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -328,7 +337,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "ignores": [
@@ -364,7 +374,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -399,7 +410,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -435,7 +447,8 @@
       },
       "fixed_lines": [
         "    (y == 2)  # nosemgrep"
-      ]
+      ],
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -457,7 +470,8 @@
         "end_line_hash": "0f1b9301a089bbcbbb0dd563a4a01270919f60a5bfd3d738788a8bbb1f7e0a59",
         "code_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613",
         "pattern_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -479,7 +493,8 @@
         "end_line_hash": "c772c5c0ca842b8e194eca4ed7bf1333c1e67bab038e9ac76c788d0e819c51ba",
         "code_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f",
         "pattern_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -501,7 +516,8 @@
         "end_line_hash": "e89b663d624741879a65668fed6c6dce5c9823fa17962ff69ae19b369b09e77c",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "token": null,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push-special-env-vars/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push-special-env-vars/findings_and_ignores.json
@@ -91,7 +91,8 @@
             "sink(d2)"
           ]
         ]
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "supply-chain1",
@@ -171,7 +172,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -206,7 +208,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -242,7 +245,8 @@
       },
       "fixed_lines": [
         "    (x == 2)"
-      ]
+      ],
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -264,7 +268,8 @@
         "end_line_hash": "510108a9aab34209e18dc5b9bba20dee69d9981b536ac1c927db223d8b0cb5bf",
         "code_hash": "bbe58d6d77d6bcf2aba1a2ea780990cc922fab514445048b3bf5b50a7a7c0250",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -286,7 +291,8 @@
         "end_line_hash": "60f5f1fb9303e4f18ddcada8deb88cb2ac20c7d95cfcd424b65934545481a1a9",
         "code_hash": "97c1aa56d43d22e7ec10a8ca99ceab7e02749262a4be0c51683dd353b3b1a868",
         "pattern_hash": "06b2540894e5b13085b613a69a474505628594986504f246b7a521b99ce10bf2"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -308,7 +314,8 @@
         "end_line_hash": "1ca20045d4e8968c3774538d54b138132fa83b7b18e0137435f3108f40ae163e",
         "code_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241",
         "pattern_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -330,7 +337,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -352,7 +360,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -374,7 +383,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "ignores": [
@@ -410,7 +420,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -445,7 +456,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -481,7 +493,8 @@
       },
       "fixed_lines": [
         "    (y == 2)  # nosemgrep"
-      ]
+      ],
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -503,7 +516,8 @@
         "end_line_hash": "0f1b9301a089bbcbbb0dd563a4a01270919f60a5bfd3d738788a8bbb1f7e0a59",
         "code_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613",
         "pattern_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -525,7 +539,8 @@
         "end_line_hash": "c772c5c0ca842b8e194eca4ed7bf1333c1e67bab038e9ac76c788d0e819c51ba",
         "code_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f",
         "pattern_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -547,7 +562,8 @@
         "end_line_hash": "e89b663d624741879a65668fed6c6dce5c9823fa17962ff69ae19b369b09e77c",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "token": null,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/findings_and_ignores.json
@@ -91,7 +91,8 @@
             "sink(d2)"
           ]
         ]
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "supply-chain1",
@@ -171,7 +172,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -206,7 +208,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -242,7 +245,8 @@
       },
       "fixed_lines": [
         "    (x == 2)"
-      ]
+      ],
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -264,7 +268,8 @@
         "end_line_hash": "510108a9aab34209e18dc5b9bba20dee69d9981b536ac1c927db223d8b0cb5bf",
         "code_hash": "bbe58d6d77d6bcf2aba1a2ea780990cc922fab514445048b3bf5b50a7a7c0250",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -286,7 +291,8 @@
         "end_line_hash": "60f5f1fb9303e4f18ddcada8deb88cb2ac20c7d95cfcd424b65934545481a1a9",
         "code_hash": "97c1aa56d43d22e7ec10a8ca99ceab7e02749262a4be0c51683dd353b3b1a868",
         "pattern_hash": "06b2540894e5b13085b613a69a474505628594986504f246b7a521b99ce10bf2"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -308,7 +314,8 @@
         "end_line_hash": "1ca20045d4e8968c3774538d54b138132fa83b7b18e0137435f3108f40ae163e",
         "code_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241",
         "pattern_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -330,7 +337,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -352,7 +360,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -374,7 +383,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "ignores": [
@@ -410,7 +420,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -445,7 +456,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -481,7 +493,8 @@
       },
       "fixed_lines": [
         "    (y == 2)  # nosemgrep"
-      ]
+      ],
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -503,7 +516,8 @@
         "end_line_hash": "0f1b9301a089bbcbbb0dd563a4a01270919f60a5bfd3d738788a8bbb1f7e0a59",
         "code_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613",
         "pattern_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -525,7 +539,8 @@
         "end_line_hash": "c772c5c0ca842b8e194eca4ed7bf1333c1e67bab038e9ac76c788d0e819c51ba",
         "code_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f",
         "pattern_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -547,7 +562,8 @@
         "end_line_hash": "e89b663d624741879a65668fed6c6dce5c9823fa17962ff69ae19b369b09e77c",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "token": null,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-push/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-push/findings_and_ignores.json
@@ -91,7 +91,8 @@
             "sink(d2)"
           ]
         ]
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "supply-chain1",
@@ -171,7 +172,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -206,7 +208,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -242,7 +245,8 @@
       },
       "fixed_lines": [
         "    (x == 2)"
-      ]
+      ],
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -264,7 +268,8 @@
         "end_line_hash": "510108a9aab34209e18dc5b9bba20dee69d9981b536ac1c927db223d8b0cb5bf",
         "code_hash": "bbe58d6d77d6bcf2aba1a2ea780990cc922fab514445048b3bf5b50a7a7c0250",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -286,7 +291,8 @@
         "end_line_hash": "60f5f1fb9303e4f18ddcada8deb88cb2ac20c7d95cfcd424b65934545481a1a9",
         "code_hash": "97c1aa56d43d22e7ec10a8ca99ceab7e02749262a4be0c51683dd353b3b1a868",
         "pattern_hash": "06b2540894e5b13085b613a69a474505628594986504f246b7a521b99ce10bf2"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -308,7 +314,8 @@
         "end_line_hash": "1ca20045d4e8968c3774538d54b138132fa83b7b18e0137435f3108f40ae163e",
         "code_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241",
         "pattern_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -330,7 +337,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -352,7 +360,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -374,7 +383,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "ignores": [
@@ -410,7 +420,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -445,7 +456,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -481,7 +493,8 @@
       },
       "fixed_lines": [
         "    (y == 2)  # nosemgrep"
-      ]
+      ],
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -503,7 +516,8 @@
         "end_line_hash": "0f1b9301a089bbcbbb0dd563a4a01270919f60a5bfd3d738788a8bbb1f7e0a59",
         "code_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613",
         "pattern_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -525,7 +539,8 @@
         "end_line_hash": "c772c5c0ca842b8e194eca4ed7bf1333c1e67bab038e9ac76c788d0e819c51ba",
         "code_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f",
         "pattern_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -547,7 +562,8 @@
         "end_line_hash": "e89b663d624741879a65668fed6c6dce5c9823fa17962ff69ae19b369b09e77c",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "token": null,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-special-env-vars/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-special-env-vars/findings_and_ignores.json
@@ -91,7 +91,8 @@
             "sink(d2)"
           ]
         ]
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "abceversion1",
@@ -125,7 +126,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -160,7 +162,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -196,7 +199,8 @@
       },
       "fixed_lines": [
         "    (x == 2)"
-      ]
+      ],
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -218,7 +222,8 @@
         "end_line_hash": "510108a9aab34209e18dc5b9bba20dee69d9981b536ac1c927db223d8b0cb5bf",
         "code_hash": "bbe58d6d77d6bcf2aba1a2ea780990cc922fab514445048b3bf5b50a7a7c0250",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -240,7 +245,8 @@
         "end_line_hash": "60f5f1fb9303e4f18ddcada8deb88cb2ac20c7d95cfcd424b65934545481a1a9",
         "code_hash": "97c1aa56d43d22e7ec10a8ca99ceab7e02749262a4be0c51683dd353b3b1a868",
         "pattern_hash": "06b2540894e5b13085b613a69a474505628594986504f246b7a521b99ce10bf2"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -262,7 +268,8 @@
         "end_line_hash": "1ca20045d4e8968c3774538d54b138132fa83b7b18e0137435f3108f40ae163e",
         "code_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241",
         "pattern_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -284,7 +291,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -306,7 +314,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -328,7 +337,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "ignores": [
@@ -364,7 +374,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -399,7 +410,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -435,7 +447,8 @@
       },
       "fixed_lines": [
         "    (y == 2)  # nosemgrep"
-      ]
+      ],
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -457,7 +470,8 @@
         "end_line_hash": "0f1b9301a089bbcbbb0dd563a4a01270919f60a5bfd3d738788a8bbb1f7e0a59",
         "code_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613",
         "pattern_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -479,7 +493,8 @@
         "end_line_hash": "c772c5c0ca842b8e194eca4ed7bf1333c1e67bab038e9ac76c788d0e819c51ba",
         "code_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f",
         "pattern_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -501,7 +516,8 @@
         "end_line_hash": "e89b663d624741879a65668fed6c6dce5c9823fa17962ff69ae19b369b09e77c",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "token": null,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab/findings_and_ignores.json
@@ -91,7 +91,8 @@
             "sink(d2)"
           ]
         ]
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "abceversion1",
@@ -125,7 +126,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -160,7 +162,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -196,7 +199,8 @@
       },
       "fixed_lines": [
         "    (x == 2)"
-      ]
+      ],
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -218,7 +222,8 @@
         "end_line_hash": "510108a9aab34209e18dc5b9bba20dee69d9981b536ac1c927db223d8b0cb5bf",
         "code_hash": "bbe58d6d77d6bcf2aba1a2ea780990cc922fab514445048b3bf5b50a7a7c0250",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -240,7 +245,8 @@
         "end_line_hash": "60f5f1fb9303e4f18ddcada8deb88cb2ac20c7d95cfcd424b65934545481a1a9",
         "code_hash": "97c1aa56d43d22e7ec10a8ca99ceab7e02749262a4be0c51683dd353b3b1a868",
         "pattern_hash": "06b2540894e5b13085b613a69a474505628594986504f246b7a521b99ce10bf2"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -262,7 +268,8 @@
         "end_line_hash": "1ca20045d4e8968c3774538d54b138132fa83b7b18e0137435f3108f40ae163e",
         "code_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241",
         "pattern_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -284,7 +291,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -306,7 +314,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -328,7 +337,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "ignores": [
@@ -364,7 +374,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -399,7 +410,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -435,7 +447,8 @@
       },
       "fixed_lines": [
         "    (y == 2)  # nosemgrep"
-      ]
+      ],
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -457,7 +470,8 @@
         "end_line_hash": "0f1b9301a089bbcbbb0dd563a4a01270919f60a5bfd3d738788a8bbb1f7e0a59",
         "code_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613",
         "pattern_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -479,7 +493,8 @@
         "end_line_hash": "c772c5c0ca842b8e194eca4ed7bf1333c1e67bab038e9ac76c788d0e819c51ba",
         "code_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f",
         "pattern_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -501,7 +516,8 @@
         "end_line_hash": "e89b663d624741879a65668fed6c6dce5c9823fa17962ff69ae19b369b09e77c",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "token": null,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/findings_and_ignores.json
@@ -91,7 +91,8 @@
             "sink(d2)"
           ]
         ]
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "supply-chain1",
@@ -171,7 +172,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -206,7 +208,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -242,7 +245,8 @@
       },
       "fixed_lines": [
         "    (x == 2)"
-      ]
+      ],
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -264,7 +268,8 @@
         "end_line_hash": "510108a9aab34209e18dc5b9bba20dee69d9981b536ac1c927db223d8b0cb5bf",
         "code_hash": "bbe58d6d77d6bcf2aba1a2ea780990cc922fab514445048b3bf5b50a7a7c0250",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -286,7 +291,8 @@
         "end_line_hash": "60f5f1fb9303e4f18ddcada8deb88cb2ac20c7d95cfcd424b65934545481a1a9",
         "code_hash": "97c1aa56d43d22e7ec10a8ca99ceab7e02749262a4be0c51683dd353b3b1a868",
         "pattern_hash": "06b2540894e5b13085b613a69a474505628594986504f246b7a521b99ce10bf2"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -308,7 +314,8 @@
         "end_line_hash": "1ca20045d4e8968c3774538d54b138132fa83b7b18e0137435f3108f40ae163e",
         "code_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241",
         "pattern_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -330,7 +337,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -352,7 +360,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -374,7 +383,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "ignores": [
@@ -410,7 +420,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -445,7 +456,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -481,7 +493,8 @@
       },
       "fixed_lines": [
         "    (y == 2)  # nosemgrep"
-      ]
+      ],
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -503,7 +516,8 @@
         "end_line_hash": "0f1b9301a089bbcbbb0dd563a4a01270919f60a5bfd3d738788a8bbb1f7e0a59",
         "code_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613",
         "pattern_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -525,7 +539,8 @@
         "end_line_hash": "c772c5c0ca842b8e194eca4ed7bf1333c1e67bab038e9ac76c788d0e819c51ba",
         "code_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f",
         "pattern_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -547,7 +562,8 @@
         "end_line_hash": "e89b663d624741879a65668fed6c6dce5c9823fa17962ff69ae19b369b09e77c",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "token": null,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-overwrite-autodetected-variables/findings_and_ignores.json
@@ -91,7 +91,8 @@
             "sink(d2)"
           ]
         ]
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "supply-chain1",
@@ -171,7 +172,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -206,7 +208,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -242,7 +245,8 @@
       },
       "fixed_lines": [
         "    (x == 2)"
-      ]
+      ],
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -264,7 +268,8 @@
         "end_line_hash": "510108a9aab34209e18dc5b9bba20dee69d9981b536ac1c927db223d8b0cb5bf",
         "code_hash": "bbe58d6d77d6bcf2aba1a2ea780990cc922fab514445048b3bf5b50a7a7c0250",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -286,7 +291,8 @@
         "end_line_hash": "60f5f1fb9303e4f18ddcada8deb88cb2ac20c7d95cfcd424b65934545481a1a9",
         "code_hash": "97c1aa56d43d22e7ec10a8ca99ceab7e02749262a4be0c51683dd353b3b1a868",
         "pattern_hash": "06b2540894e5b13085b613a69a474505628594986504f246b7a521b99ce10bf2"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -308,7 +314,8 @@
         "end_line_hash": "1ca20045d4e8968c3774538d54b138132fa83b7b18e0137435f3108f40ae163e",
         "code_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241",
         "pattern_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -330,7 +337,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -352,7 +360,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -374,7 +383,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "ignores": [
@@ -410,7 +420,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -445,7 +456,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -481,7 +493,8 @@
       },
       "fixed_lines": [
         "    (y == 2)  # nosemgrep"
-      ]
+      ],
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -503,7 +516,8 @@
         "end_line_hash": "0f1b9301a089bbcbbb0dd563a4a01270919f60a5bfd3d738788a8bbb1f7e0a59",
         "code_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613",
         "pattern_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -525,7 +539,8 @@
         "end_line_hash": "c772c5c0ca842b8e194eca4ed7bf1333c1e67bab038e9ac76c788d0e819c51ba",
         "code_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f",
         "pattern_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -547,7 +562,8 @@
         "end_line_hash": "e89b663d624741879a65668fed6c6dce5c9823fa17962ff69ae19b369b09e77c",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "token": null,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins/findings_and_ignores.json
@@ -91,7 +91,8 @@
             "sink(d2)"
           ]
         ]
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "supply-chain1",
@@ -171,7 +172,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -206,7 +208,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -242,7 +245,8 @@
       },
       "fixed_lines": [
         "    (x == 2)"
-      ]
+      ],
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -264,7 +268,8 @@
         "end_line_hash": "510108a9aab34209e18dc5b9bba20dee69d9981b536ac1c927db223d8b0cb5bf",
         "code_hash": "bbe58d6d77d6bcf2aba1a2ea780990cc922fab514445048b3bf5b50a7a7c0250",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -286,7 +291,8 @@
         "end_line_hash": "60f5f1fb9303e4f18ddcada8deb88cb2ac20c7d95cfcd424b65934545481a1a9",
         "code_hash": "97c1aa56d43d22e7ec10a8ca99ceab7e02749262a4be0c51683dd353b3b1a868",
         "pattern_hash": "06b2540894e5b13085b613a69a474505628594986504f246b7a521b99ce10bf2"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -308,7 +314,8 @@
         "end_line_hash": "1ca20045d4e8968c3774538d54b138132fa83b7b18e0137435f3108f40ae163e",
         "code_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241",
         "pattern_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -330,7 +337,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -352,7 +360,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -374,7 +383,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "ignores": [
@@ -410,7 +420,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -445,7 +456,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -481,7 +493,8 @@
       },
       "fixed_lines": [
         "    (y == 2)  # nosemgrep"
-      ]
+      ],
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -503,7 +516,8 @@
         "end_line_hash": "0f1b9301a089bbcbbb0dd563a4a01270919f60a5bfd3d738788a8bbb1f7e0a59",
         "code_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613",
         "pattern_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -525,7 +539,8 @@
         "end_line_hash": "c772c5c0ca842b8e194eca4ed7bf1333c1e67bab038e9ac76c788d0e819c51ba",
         "code_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f",
         "pattern_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -547,7 +562,8 @@
         "end_line_hash": "e89b663d624741879a65668fed6c6dce5c9823fa17962ff69ae19b369b09e77c",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "token": null,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/findings_and_ignores.json
@@ -91,7 +91,8 @@
             "sink(d2)"
           ]
         ]
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "supply-chain1",
@@ -171,7 +172,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -206,7 +208,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -242,7 +245,8 @@
       },
       "fixed_lines": [
         "    (x == 2)"
-      ]
+      ],
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -264,7 +268,8 @@
         "end_line_hash": "510108a9aab34209e18dc5b9bba20dee69d9981b536ac1c927db223d8b0cb5bf",
         "code_hash": "bbe58d6d77d6bcf2aba1a2ea780990cc922fab514445048b3bf5b50a7a7c0250",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -286,7 +291,8 @@
         "end_line_hash": "60f5f1fb9303e4f18ddcada8deb88cb2ac20c7d95cfcd424b65934545481a1a9",
         "code_hash": "97c1aa56d43d22e7ec10a8ca99ceab7e02749262a4be0c51683dd353b3b1a868",
         "pattern_hash": "06b2540894e5b13085b613a69a474505628594986504f246b7a521b99ce10bf2"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -308,7 +314,8 @@
         "end_line_hash": "1ca20045d4e8968c3774538d54b138132fa83b7b18e0137435f3108f40ae163e",
         "code_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241",
         "pattern_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -330,7 +337,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -352,7 +360,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -374,7 +383,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "ignores": [
@@ -410,7 +420,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -445,7 +456,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -481,7 +493,8 @@
       },
       "fixed_lines": [
         "    (y == 2)  # nosemgrep"
-      ]
+      ],
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -503,7 +516,8 @@
         "end_line_hash": "0f1b9301a089bbcbbb0dd563a4a01270919f60a5bfd3d738788a8bbb1f7e0a59",
         "code_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613",
         "pattern_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -525,7 +539,8 @@
         "end_line_hash": "c772c5c0ca842b8e194eca4ed7bf1333c1e67bab038e9ac76c788d0e819c51ba",
         "code_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f",
         "pattern_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -547,7 +562,8 @@
         "end_line_hash": "e89b663d624741879a65668fed6c6dce5c9823fa17962ff69ae19b369b09e77c",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "token": null,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-self-hosted/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-self-hosted/findings_and_ignores.json
@@ -91,7 +91,8 @@
             "sink(d2)"
           ]
         ]
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "supply-chain1",
@@ -171,7 +172,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -206,7 +208,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -242,7 +245,8 @@
       },
       "fixed_lines": [
         "    (x == 2)"
-      ]
+      ],
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -264,7 +268,8 @@
         "end_line_hash": "510108a9aab34209e18dc5b9bba20dee69d9981b536ac1c927db223d8b0cb5bf",
         "code_hash": "bbe58d6d77d6bcf2aba1a2ea780990cc922fab514445048b3bf5b50a7a7c0250",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -286,7 +291,8 @@
         "end_line_hash": "60f5f1fb9303e4f18ddcada8deb88cb2ac20c7d95cfcd424b65934545481a1a9",
         "code_hash": "97c1aa56d43d22e7ec10a8ca99ceab7e02749262a4be0c51683dd353b3b1a868",
         "pattern_hash": "06b2540894e5b13085b613a69a474505628594986504f246b7a521b99ce10bf2"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -308,7 +314,8 @@
         "end_line_hash": "1ca20045d4e8968c3774538d54b138132fa83b7b18e0137435f3108f40ae163e",
         "code_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241",
         "pattern_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -330,7 +337,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -352,7 +360,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -374,7 +383,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "ignores": [
@@ -410,7 +420,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -445,7 +456,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -481,7 +493,8 @@
       },
       "fixed_lines": [
         "    (y == 2)  # nosemgrep"
-      ]
+      ],
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -503,7 +516,8 @@
         "end_line_hash": "0f1b9301a089bbcbbb0dd563a4a01270919f60a5bfd3d738788a8bbb1f7e0a59",
         "code_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613",
         "pattern_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -525,7 +539,8 @@
         "end_line_hash": "c772c5c0ca842b8e194eca4ed7bf1333c1e67bab038e9ac76c788d0e819c51ba",
         "code_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f",
         "pattern_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -547,7 +562,8 @@
         "end_line_hash": "e89b663d624741879a65668fed6c6dce5c9823fa17962ff69ae19b369b09e77c",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "token": null,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis-overwrite-autodetected-variables/findings_and_ignores.json
@@ -91,7 +91,8 @@
             "sink(d2)"
           ]
         ]
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "supply-chain1",
@@ -171,7 +172,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -206,7 +208,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -242,7 +245,8 @@
       },
       "fixed_lines": [
         "    (x == 2)"
-      ]
+      ],
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -264,7 +268,8 @@
         "end_line_hash": "510108a9aab34209e18dc5b9bba20dee69d9981b536ac1c927db223d8b0cb5bf",
         "code_hash": "bbe58d6d77d6bcf2aba1a2ea780990cc922fab514445048b3bf5b50a7a7c0250",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -286,7 +291,8 @@
         "end_line_hash": "60f5f1fb9303e4f18ddcada8deb88cb2ac20c7d95cfcd424b65934545481a1a9",
         "code_hash": "97c1aa56d43d22e7ec10a8ca99ceab7e02749262a4be0c51683dd353b3b1a868",
         "pattern_hash": "06b2540894e5b13085b613a69a474505628594986504f246b7a521b99ce10bf2"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -308,7 +314,8 @@
         "end_line_hash": "1ca20045d4e8968c3774538d54b138132fa83b7b18e0137435f3108f40ae163e",
         "code_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241",
         "pattern_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -330,7 +337,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -352,7 +360,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -374,7 +383,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "ignores": [
@@ -410,7 +420,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -445,7 +456,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -481,7 +493,8 @@
       },
       "fixed_lines": [
         "    (y == 2)  # nosemgrep"
-      ]
+      ],
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -503,7 +516,8 @@
         "end_line_hash": "0f1b9301a089bbcbbb0dd563a4a01270919f60a5bfd3d738788a8bbb1f7e0a59",
         "code_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613",
         "pattern_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -525,7 +539,8 @@
         "end_line_hash": "c772c5c0ca842b8e194eca4ed7bf1333c1e67bab038e9ac76c788d0e819c51ba",
         "code_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f",
         "pattern_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -547,7 +562,8 @@
         "end_line_hash": "e89b663d624741879a65668fed6c6dce5c9823fa17962ff69ae19b369b09e77c",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "token": null,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis/findings_and_ignores.json
@@ -91,7 +91,8 @@
             "sink(d2)"
           ]
         ]
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "supply-chain1",
@@ -171,7 +172,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -206,7 +208,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -242,7 +245,8 @@
       },
       "fixed_lines": [
         "    (x == 2)"
-      ]
+      ],
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -264,7 +268,8 @@
         "end_line_hash": "510108a9aab34209e18dc5b9bba20dee69d9981b536ac1c927db223d8b0cb5bf",
         "code_hash": "bbe58d6d77d6bcf2aba1a2ea780990cc922fab514445048b3bf5b50a7a7c0250",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -286,7 +291,8 @@
         "end_line_hash": "60f5f1fb9303e4f18ddcada8deb88cb2ac20c7d95cfcd424b65934545481a1a9",
         "code_hash": "97c1aa56d43d22e7ec10a8ca99ceab7e02749262a4be0c51683dd353b3b1a868",
         "pattern_hash": "06b2540894e5b13085b613a69a474505628594986504f246b7a521b99ce10bf2"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -308,7 +314,8 @@
         "end_line_hash": "1ca20045d4e8968c3774538d54b138132fa83b7b18e0137435f3108f40ae163e",
         "code_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241",
         "pattern_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -330,7 +337,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -352,7 +360,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -374,7 +383,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "ignores": [
@@ -410,7 +420,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -445,7 +456,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -481,7 +493,8 @@
       },
       "fixed_lines": [
         "    (y == 2)  # nosemgrep"
-      ]
+      ],
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -503,7 +516,8 @@
         "end_line_hash": "0f1b9301a089bbcbbb0dd563a4a01270919f60a5bfd3d738788a8bbb1f7e0a59",
         "code_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613",
         "pattern_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -525,7 +539,8 @@
         "end_line_hash": "c772c5c0ca842b8e194eca4ed7bf1333c1e67bab038e9ac76c788d0e819c51ba",
         "code_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f",
         "pattern_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -547,7 +562,8 @@
         "end_line_hash": "e89b663d624741879a65668fed6c6dce5c9823fa17962ff69ae19b369b09e77c",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "token": null,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-unparsable_url/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-unparsable_url/findings_and_ignores.json
@@ -91,7 +91,8 @@
             "sink(d2)"
           ]
         ]
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "supply-chain1",
@@ -171,7 +172,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -206,7 +208,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -242,7 +245,8 @@
       },
       "fixed_lines": [
         "    (x == 2)"
-      ]
+      ],
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -264,7 +268,8 @@
         "end_line_hash": "510108a9aab34209e18dc5b9bba20dee69d9981b536ac1c927db223d8b0cb5bf",
         "code_hash": "bbe58d6d77d6bcf2aba1a2ea780990cc922fab514445048b3bf5b50a7a7c0250",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -286,7 +291,8 @@
         "end_line_hash": "60f5f1fb9303e4f18ddcada8deb88cb2ac20c7d95cfcd424b65934545481a1a9",
         "code_hash": "97c1aa56d43d22e7ec10a8ca99ceab7e02749262a4be0c51683dd353b3b1a868",
         "pattern_hash": "06b2540894e5b13085b613a69a474505628594986504f246b7a521b99ce10bf2"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -308,7 +314,8 @@
         "end_line_hash": "1ca20045d4e8968c3774538d54b138132fa83b7b18e0137435f3108f40ae163e",
         "code_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241",
         "pattern_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -330,7 +337,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -352,7 +360,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -374,7 +383,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "ignores": [
@@ -410,7 +420,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -445,7 +456,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -481,7 +493,8 @@
       },
       "fixed_lines": [
         "    (y == 2)  # nosemgrep"
-      ]
+      ],
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -503,7 +516,8 @@
         "end_line_hash": "0f1b9301a089bbcbbb0dd563a4a01270919f60a5bfd3d738788a8bbb1f7e0a59",
         "code_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613",
         "pattern_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -525,7 +539,8 @@
         "end_line_hash": "c772c5c0ca842b8e194eca4ed7bf1333c1e67bab038e9ac76c788d0e819c51ba",
         "code_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f",
         "pattern_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -547,7 +562,8 @@
         "end_line_hash": "e89b663d624741879a65668fed6c6dce5c9823fa17962ff69ae19b369b09e77c",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "token": null,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines-overwrite-autodetected-variables/findings_and_ignores.json
@@ -91,7 +91,8 @@
             "sink(d2)"
           ]
         ]
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "supply-chain1",
@@ -171,7 +172,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -206,7 +208,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -239,7 +242,8 @@
         "end_line_hash": "27937fb6c73e88412e7e39647557d4c03fda0ea04b91cecb3852355f387d03c8",
         "code_hash": "2005925cbb09029b2f5c8700dcae5c9a8b9a4324a15643853626afd0bf65c052",
         "pattern_hash": "2005925cbb09029b2f5c8700dcae5c9a8b9a4324a15643853626afd0bf65c052"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -261,7 +265,8 @@
         "end_line_hash": "510108a9aab34209e18dc5b9bba20dee69d9981b536ac1c927db223d8b0cb5bf",
         "code_hash": "bbe58d6d77d6bcf2aba1a2ea780990cc922fab514445048b3bf5b50a7a7c0250",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -283,7 +288,8 @@
         "end_line_hash": "60f5f1fb9303e4f18ddcada8deb88cb2ac20c7d95cfcd424b65934545481a1a9",
         "code_hash": "97c1aa56d43d22e7ec10a8ca99ceab7e02749262a4be0c51683dd353b3b1a868",
         "pattern_hash": "06b2540894e5b13085b613a69a474505628594986504f246b7a521b99ce10bf2"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -305,7 +311,8 @@
         "end_line_hash": "1ca20045d4e8968c3774538d54b138132fa83b7b18e0137435f3108f40ae163e",
         "code_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241",
         "pattern_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -327,7 +334,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -349,7 +357,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -371,7 +380,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "ignores": [
@@ -407,7 +417,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -442,7 +453,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -475,7 +487,8 @@
         "end_line_hash": "889792ca5269732e125f6abb0d0245a7dcb83862e34d797a5ee890a4a7a5eae7",
         "code_hash": "d2c95171288a258009c5187392c5e2122e2640e0431af8b1cad77d5b403ed850",
         "pattern_hash": "d2c95171288a258009c5187392c5e2122e2640e0431af8b1cad77d5b403ed850"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -497,7 +510,8 @@
         "end_line_hash": "0f1b9301a089bbcbbb0dd563a4a01270919f60a5bfd3d738788a8bbb1f7e0a59",
         "code_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613",
         "pattern_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -519,7 +533,8 @@
         "end_line_hash": "c772c5c0ca842b8e194eca4ed7bf1333c1e67bab038e9ac76c788d0e819c51ba",
         "code_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f",
         "pattern_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -541,7 +556,8 @@
         "end_line_hash": "e89b663d624741879a65668fed6c6dce5c9823fa17962ff69ae19b369b09e77c",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "token": null,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines/findings_and_ignores.json
@@ -91,7 +91,8 @@
             "sink(d2)"
           ]
         ]
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "supply-chain1",
@@ -171,7 +172,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -206,7 +208,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -239,7 +242,8 @@
         "end_line_hash": "27937fb6c73e88412e7e39647557d4c03fda0ea04b91cecb3852355f387d03c8",
         "code_hash": "2005925cbb09029b2f5c8700dcae5c9a8b9a4324a15643853626afd0bf65c052",
         "pattern_hash": "2005925cbb09029b2f5c8700dcae5c9a8b9a4324a15643853626afd0bf65c052"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -261,7 +265,8 @@
         "end_line_hash": "510108a9aab34209e18dc5b9bba20dee69d9981b536ac1c927db223d8b0cb5bf",
         "code_hash": "bbe58d6d77d6bcf2aba1a2ea780990cc922fab514445048b3bf5b50a7a7c0250",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -283,7 +288,8 @@
         "end_line_hash": "60f5f1fb9303e4f18ddcada8deb88cb2ac20c7d95cfcd424b65934545481a1a9",
         "code_hash": "97c1aa56d43d22e7ec10a8ca99ceab7e02749262a4be0c51683dd353b3b1a868",
         "pattern_hash": "06b2540894e5b13085b613a69a474505628594986504f246b7a521b99ce10bf2"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -305,7 +311,8 @@
         "end_line_hash": "1ca20045d4e8968c3774538d54b138132fa83b7b18e0137435f3108f40ae163e",
         "code_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241",
         "pattern_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -327,7 +334,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -349,7 +357,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -371,7 +380,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "ignores": [
@@ -407,7 +417,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -442,7 +453,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -475,7 +487,8 @@
         "end_line_hash": "889792ca5269732e125f6abb0d0245a7dcb83862e34d797a5ee890a4a7a5eae7",
         "code_hash": "d2c95171288a258009c5187392c5e2122e2640e0431af8b1cad77d5b403ed850",
         "pattern_hash": "d2c95171288a258009c5187392c5e2122e2640e0431af8b1cad77d5b403ed850"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -497,7 +510,8 @@
         "end_line_hash": "0f1b9301a089bbcbbb0dd563a4a01270919f60a5bfd3d738788a8bbb1f7e0a59",
         "code_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613",
         "pattern_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -519,7 +533,8 @@
         "end_line_hash": "c772c5c0ca842b8e194eca4ed7bf1333c1e67bab038e9ac76c788d0e819c51ba",
         "code_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f",
         "pattern_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -541,7 +556,8 @@
         "end_line_hash": "e89b663d624741879a65668fed6c6dce5c9823fa17962ff69ae19b369b09e77c",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "token": null,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket-overwrite-autodetected-variables/findings_and_ignores.json
@@ -91,7 +91,8 @@
             "sink(d2)"
           ]
         ]
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "supply-chain1",
@@ -171,7 +172,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -206,7 +208,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -239,7 +242,8 @@
         "end_line_hash": "27937fb6c73e88412e7e39647557d4c03fda0ea04b91cecb3852355f387d03c8",
         "code_hash": "2005925cbb09029b2f5c8700dcae5c9a8b9a4324a15643853626afd0bf65c052",
         "pattern_hash": "2005925cbb09029b2f5c8700dcae5c9a8b9a4324a15643853626afd0bf65c052"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -261,7 +265,8 @@
         "end_line_hash": "510108a9aab34209e18dc5b9bba20dee69d9981b536ac1c927db223d8b0cb5bf",
         "code_hash": "bbe58d6d77d6bcf2aba1a2ea780990cc922fab514445048b3bf5b50a7a7c0250",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -283,7 +288,8 @@
         "end_line_hash": "60f5f1fb9303e4f18ddcada8deb88cb2ac20c7d95cfcd424b65934545481a1a9",
         "code_hash": "97c1aa56d43d22e7ec10a8ca99ceab7e02749262a4be0c51683dd353b3b1a868",
         "pattern_hash": "06b2540894e5b13085b613a69a474505628594986504f246b7a521b99ce10bf2"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -305,7 +311,8 @@
         "end_line_hash": "1ca20045d4e8968c3774538d54b138132fa83b7b18e0137435f3108f40ae163e",
         "code_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241",
         "pattern_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -327,7 +334,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -349,7 +357,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -371,7 +380,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "ignores": [
@@ -407,7 +417,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -442,7 +453,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -475,7 +487,8 @@
         "end_line_hash": "889792ca5269732e125f6abb0d0245a7dcb83862e34d797a5ee890a4a7a5eae7",
         "code_hash": "d2c95171288a258009c5187392c5e2122e2640e0431af8b1cad77d5b403ed850",
         "pattern_hash": "d2c95171288a258009c5187392c5e2122e2640e0431af8b1cad77d5b403ed850"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -497,7 +510,8 @@
         "end_line_hash": "0f1b9301a089bbcbbb0dd563a4a01270919f60a5bfd3d738788a8bbb1f7e0a59",
         "code_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613",
         "pattern_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -519,7 +533,8 @@
         "end_line_hash": "c772c5c0ca842b8e194eca4ed7bf1333c1e67bab038e9ac76c788d0e819c51ba",
         "code_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f",
         "pattern_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -541,7 +556,8 @@
         "end_line_hash": "e89b663d624741879a65668fed6c6dce5c9823fa17962ff69ae19b369b09e77c",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "token": null,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket/findings_and_ignores.json
@@ -91,7 +91,8 @@
             "sink(d2)"
           ]
         ]
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "supply-chain1",
@@ -171,7 +172,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -206,7 +208,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -239,7 +242,8 @@
         "end_line_hash": "27937fb6c73e88412e7e39647557d4c03fda0ea04b91cecb3852355f387d03c8",
         "code_hash": "2005925cbb09029b2f5c8700dcae5c9a8b9a4324a15643853626afd0bf65c052",
         "pattern_hash": "2005925cbb09029b2f5c8700dcae5c9a8b9a4324a15643853626afd0bf65c052"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -261,7 +265,8 @@
         "end_line_hash": "510108a9aab34209e18dc5b9bba20dee69d9981b536ac1c927db223d8b0cb5bf",
         "code_hash": "bbe58d6d77d6bcf2aba1a2ea780990cc922fab514445048b3bf5b50a7a7c0250",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -283,7 +288,8 @@
         "end_line_hash": "60f5f1fb9303e4f18ddcada8deb88cb2ac20c7d95cfcd424b65934545481a1a9",
         "code_hash": "97c1aa56d43d22e7ec10a8ca99ceab7e02749262a4be0c51683dd353b3b1a868",
         "pattern_hash": "06b2540894e5b13085b613a69a474505628594986504f246b7a521b99ce10bf2"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -305,7 +311,8 @@
         "end_line_hash": "1ca20045d4e8968c3774538d54b138132fa83b7b18e0137435f3108f40ae163e",
         "code_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241",
         "pattern_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -327,7 +334,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -349,7 +357,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -371,7 +380,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "ignores": [
@@ -407,7 +417,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -442,7 +453,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -475,7 +487,8 @@
         "end_line_hash": "889792ca5269732e125f6abb0d0245a7dcb83862e34d797a5ee890a4a7a5eae7",
         "code_hash": "d2c95171288a258009c5187392c5e2122e2640e0431af8b1cad77d5b403ed850",
         "pattern_hash": "d2c95171288a258009c5187392c5e2122e2640e0431af8b1cad77d5b403ed850"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -497,7 +510,8 @@
         "end_line_hash": "0f1b9301a089bbcbbb0dd563a4a01270919f60a5bfd3d738788a8bbb1f7e0a59",
         "code_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613",
         "pattern_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -519,7 +533,8 @@
         "end_line_hash": "c772c5c0ca842b8e194eca4ed7bf1333c1e67bab038e9ac76c788d0e819c51ba",
         "code_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f",
         "pattern_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -541,7 +556,8 @@
         "end_line_hash": "e89b663d624741879a65668fed6c6dce5c9823fa17962ff69ae19b369b09e77c",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "token": null,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite-overwrite-autodetected-variables/findings_and_ignores.json
@@ -91,7 +91,8 @@
             "sink(d2)"
           ]
         ]
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "supply-chain1",
@@ -171,7 +172,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -206,7 +208,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -239,7 +242,8 @@
         "end_line_hash": "27937fb6c73e88412e7e39647557d4c03fda0ea04b91cecb3852355f387d03c8",
         "code_hash": "2005925cbb09029b2f5c8700dcae5c9a8b9a4324a15643853626afd0bf65c052",
         "pattern_hash": "2005925cbb09029b2f5c8700dcae5c9a8b9a4324a15643853626afd0bf65c052"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -261,7 +265,8 @@
         "end_line_hash": "510108a9aab34209e18dc5b9bba20dee69d9981b536ac1c927db223d8b0cb5bf",
         "code_hash": "bbe58d6d77d6bcf2aba1a2ea780990cc922fab514445048b3bf5b50a7a7c0250",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -283,7 +288,8 @@
         "end_line_hash": "60f5f1fb9303e4f18ddcada8deb88cb2ac20c7d95cfcd424b65934545481a1a9",
         "code_hash": "97c1aa56d43d22e7ec10a8ca99ceab7e02749262a4be0c51683dd353b3b1a868",
         "pattern_hash": "06b2540894e5b13085b613a69a474505628594986504f246b7a521b99ce10bf2"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -305,7 +311,8 @@
         "end_line_hash": "1ca20045d4e8968c3774538d54b138132fa83b7b18e0137435f3108f40ae163e",
         "code_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241",
         "pattern_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -327,7 +334,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -349,7 +357,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -371,7 +380,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "ignores": [
@@ -407,7 +417,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -442,7 +453,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -475,7 +487,8 @@
         "end_line_hash": "889792ca5269732e125f6abb0d0245a7dcb83862e34d797a5ee890a4a7a5eae7",
         "code_hash": "d2c95171288a258009c5187392c5e2122e2640e0431af8b1cad77d5b403ed850",
         "pattern_hash": "d2c95171288a258009c5187392c5e2122e2640e0431af8b1cad77d5b403ed850"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -497,7 +510,8 @@
         "end_line_hash": "0f1b9301a089bbcbbb0dd563a4a01270919f60a5bfd3d738788a8bbb1f7e0a59",
         "code_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613",
         "pattern_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -519,7 +533,8 @@
         "end_line_hash": "c772c5c0ca842b8e194eca4ed7bf1333c1e67bab038e9ac76c788d0e819c51ba",
         "code_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f",
         "pattern_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -541,7 +556,8 @@
         "end_line_hash": "e89b663d624741879a65668fed6c6dce5c9823fa17962ff69ae19b369b09e77c",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "token": null,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite/findings_and_ignores.json
@@ -91,7 +91,8 @@
             "sink(d2)"
           ]
         ]
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "supply-chain1",
@@ -171,7 +172,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -206,7 +208,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -239,7 +242,8 @@
         "end_line_hash": "27937fb6c73e88412e7e39647557d4c03fda0ea04b91cecb3852355f387d03c8",
         "code_hash": "2005925cbb09029b2f5c8700dcae5c9a8b9a4324a15643853626afd0bf65c052",
         "pattern_hash": "2005925cbb09029b2f5c8700dcae5c9a8b9a4324a15643853626afd0bf65c052"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -261,7 +265,8 @@
         "end_line_hash": "510108a9aab34209e18dc5b9bba20dee69d9981b536ac1c927db223d8b0cb5bf",
         "code_hash": "bbe58d6d77d6bcf2aba1a2ea780990cc922fab514445048b3bf5b50a7a7c0250",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -283,7 +288,8 @@
         "end_line_hash": "60f5f1fb9303e4f18ddcada8deb88cb2ac20c7d95cfcd424b65934545481a1a9",
         "code_hash": "97c1aa56d43d22e7ec10a8ca99ceab7e02749262a4be0c51683dd353b3b1a868",
         "pattern_hash": "06b2540894e5b13085b613a69a474505628594986504f246b7a521b99ce10bf2"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -305,7 +311,8 @@
         "end_line_hash": "1ca20045d4e8968c3774538d54b138132fa83b7b18e0137435f3108f40ae163e",
         "code_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241",
         "pattern_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -327,7 +334,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -349,7 +357,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -371,7 +380,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "ignores": [
@@ -407,7 +417,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -442,7 +453,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -475,7 +487,8 @@
         "end_line_hash": "889792ca5269732e125f6abb0d0245a7dcb83862e34d797a5ee890a4a7a5eae7",
         "code_hash": "d2c95171288a258009c5187392c5e2122e2640e0431af8b1cad77d5b403ed850",
         "pattern_hash": "d2c95171288a258009c5187392c5e2122e2640e0431af8b1cad77d5b403ed850"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -497,7 +510,8 @@
         "end_line_hash": "0f1b9301a089bbcbbb0dd563a4a01270919f60a5bfd3d738788a8bbb1f7e0a59",
         "code_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613",
         "pattern_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -519,7 +533,8 @@
         "end_line_hash": "c772c5c0ca842b8e194eca4ed7bf1333c1e67bab038e9ac76c788d0e819c51ba",
         "code_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f",
         "pattern_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -541,7 +556,8 @@
         "end_line_hash": "e89b663d624741879a65668fed6c6dce5c9823fa17962ff69ae19b369b09e77c",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "token": null,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci-overwrite-autodetected-variables/findings_and_ignores.json
@@ -91,7 +91,8 @@
             "sink(d2)"
           ]
         ]
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "supply-chain1",
@@ -171,7 +172,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -206,7 +208,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -239,7 +242,8 @@
         "end_line_hash": "27937fb6c73e88412e7e39647557d4c03fda0ea04b91cecb3852355f387d03c8",
         "code_hash": "2005925cbb09029b2f5c8700dcae5c9a8b9a4324a15643853626afd0bf65c052",
         "pattern_hash": "2005925cbb09029b2f5c8700dcae5c9a8b9a4324a15643853626afd0bf65c052"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -261,7 +265,8 @@
         "end_line_hash": "510108a9aab34209e18dc5b9bba20dee69d9981b536ac1c927db223d8b0cb5bf",
         "code_hash": "bbe58d6d77d6bcf2aba1a2ea780990cc922fab514445048b3bf5b50a7a7c0250",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -283,7 +288,8 @@
         "end_line_hash": "60f5f1fb9303e4f18ddcada8deb88cb2ac20c7d95cfcd424b65934545481a1a9",
         "code_hash": "97c1aa56d43d22e7ec10a8ca99ceab7e02749262a4be0c51683dd353b3b1a868",
         "pattern_hash": "06b2540894e5b13085b613a69a474505628594986504f246b7a521b99ce10bf2"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -305,7 +311,8 @@
         "end_line_hash": "1ca20045d4e8968c3774538d54b138132fa83b7b18e0137435f3108f40ae163e",
         "code_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241",
         "pattern_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -327,7 +334,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -349,7 +357,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -371,7 +380,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "ignores": [
@@ -407,7 +417,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -442,7 +453,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -475,7 +487,8 @@
         "end_line_hash": "889792ca5269732e125f6abb0d0245a7dcb83862e34d797a5ee890a4a7a5eae7",
         "code_hash": "d2c95171288a258009c5187392c5e2122e2640e0431af8b1cad77d5b403ed850",
         "pattern_hash": "d2c95171288a258009c5187392c5e2122e2640e0431af8b1cad77d5b403ed850"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -497,7 +510,8 @@
         "end_line_hash": "0f1b9301a089bbcbbb0dd563a4a01270919f60a5bfd3d738788a8bbb1f7e0a59",
         "code_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613",
         "pattern_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -519,7 +533,8 @@
         "end_line_hash": "c772c5c0ca842b8e194eca4ed7bf1333c1e67bab038e9ac76c788d0e819c51ba",
         "code_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f",
         "pattern_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -541,7 +556,8 @@
         "end_line_hash": "e89b663d624741879a65668fed6c6dce5c9823fa17962ff69ae19b369b09e77c",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "token": null,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci/findings_and_ignores.json
@@ -91,7 +91,8 @@
             "sink(d2)"
           ]
         ]
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "supply-chain1",
@@ -171,7 +172,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -206,7 +208,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -239,7 +242,8 @@
         "end_line_hash": "27937fb6c73e88412e7e39647557d4c03fda0ea04b91cecb3852355f387d03c8",
         "code_hash": "2005925cbb09029b2f5c8700dcae5c9a8b9a4324a15643853626afd0bf65c052",
         "pattern_hash": "2005925cbb09029b2f5c8700dcae5c9a8b9a4324a15643853626afd0bf65c052"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -261,7 +265,8 @@
         "end_line_hash": "510108a9aab34209e18dc5b9bba20dee69d9981b536ac1c927db223d8b0cb5bf",
         "code_hash": "bbe58d6d77d6bcf2aba1a2ea780990cc922fab514445048b3bf5b50a7a7c0250",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -283,7 +288,8 @@
         "end_line_hash": "60f5f1fb9303e4f18ddcada8deb88cb2ac20c7d95cfcd424b65934545481a1a9",
         "code_hash": "97c1aa56d43d22e7ec10a8ca99ceab7e02749262a4be0c51683dd353b3b1a868",
         "pattern_hash": "06b2540894e5b13085b613a69a474505628594986504f246b7a521b99ce10bf2"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -305,7 +311,8 @@
         "end_line_hash": "1ca20045d4e8968c3774538d54b138132fa83b7b18e0137435f3108f40ae163e",
         "code_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241",
         "pattern_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -327,7 +334,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -349,7 +357,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -371,7 +380,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "ignores": [
@@ -407,7 +417,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -442,7 +453,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -475,7 +487,8 @@
         "end_line_hash": "889792ca5269732e125f6abb0d0245a7dcb83862e34d797a5ee890a4a7a5eae7",
         "code_hash": "d2c95171288a258009c5187392c5e2122e2640e0431af8b1cad77d5b403ed850",
         "pattern_hash": "d2c95171288a258009c5187392c5e2122e2640e0431af8b1cad77d5b403ed850"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -497,7 +510,8 @@
         "end_line_hash": "0f1b9301a089bbcbbb0dd563a4a01270919f60a5bfd3d738788a8bbb1f7e0a59",
         "code_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613",
         "pattern_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -519,7 +533,8 @@
         "end_line_hash": "c772c5c0ca842b8e194eca4ed7bf1333c1e67bab038e9ac76c788d0e819c51ba",
         "code_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f",
         "pattern_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -541,7 +556,8 @@
         "end_line_hash": "e89b663d624741879a65668fed6c6dce5c9823fa17962ff69ae19b369b09e77c",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "token": null,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/findings_and_ignores.json
@@ -91,7 +91,8 @@
             "sink(d2)"
           ]
         ]
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "supply-chain1",
@@ -171,7 +172,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -206,7 +208,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -239,7 +242,8 @@
         "end_line_hash": "27937fb6c73e88412e7e39647557d4c03fda0ea04b91cecb3852355f387d03c8",
         "code_hash": "2005925cbb09029b2f5c8700dcae5c9a8b9a4324a15643853626afd0bf65c052",
         "pattern_hash": "2005925cbb09029b2f5c8700dcae5c9a8b9a4324a15643853626afd0bf65c052"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -261,7 +265,8 @@
         "end_line_hash": "510108a9aab34209e18dc5b9bba20dee69d9981b536ac1c927db223d8b0cb5bf",
         "code_hash": "bbe58d6d77d6bcf2aba1a2ea780990cc922fab514445048b3bf5b50a7a7c0250",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -283,7 +288,8 @@
         "end_line_hash": "60f5f1fb9303e4f18ddcada8deb88cb2ac20c7d95cfcd424b65934545481a1a9",
         "code_hash": "97c1aa56d43d22e7ec10a8ca99ceab7e02749262a4be0c51683dd353b3b1a868",
         "pattern_hash": "06b2540894e5b13085b613a69a474505628594986504f246b7a521b99ce10bf2"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -305,7 +311,8 @@
         "end_line_hash": "1ca20045d4e8968c3774538d54b138132fa83b7b18e0137435f3108f40ae163e",
         "code_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241",
         "pattern_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -327,7 +334,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -349,7 +357,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -371,7 +380,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "ignores": [
@@ -407,7 +417,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -442,7 +453,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -475,7 +487,8 @@
         "end_line_hash": "889792ca5269732e125f6abb0d0245a7dcb83862e34d797a5ee890a4a7a5eae7",
         "code_hash": "d2c95171288a258009c5187392c5e2122e2640e0431af8b1cad77d5b403ed850",
         "pattern_hash": "d2c95171288a258009c5187392c5e2122e2640e0431af8b1cad77d5b403ed850"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -497,7 +510,8 @@
         "end_line_hash": "0f1b9301a089bbcbbb0dd563a4a01270919f60a5bfd3d738788a8bbb1f7e0a59",
         "code_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613",
         "pattern_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -519,7 +533,8 @@
         "end_line_hash": "c772c5c0ca842b8e194eca4ed7bf1333c1e67bab038e9ac76c788d0e819c51ba",
         "code_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f",
         "pattern_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -541,7 +556,8 @@
         "end_line_hash": "e89b663d624741879a65668fed6c6dce5c9823fa17962ff69ae19b369b09e77c",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "token": null,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr-semgrepconfig/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr-semgrepconfig/findings_and_ignores.json
@@ -91,7 +91,8 @@
             "sink(d2)"
           ]
         ]
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "abceversion1",
@@ -125,7 +126,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -160,7 +162,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -193,7 +196,8 @@
         "end_line_hash": "27937fb6c73e88412e7e39647557d4c03fda0ea04b91cecb3852355f387d03c8",
         "code_hash": "2005925cbb09029b2f5c8700dcae5c9a8b9a4324a15643853626afd0bf65c052",
         "pattern_hash": "2005925cbb09029b2f5c8700dcae5c9a8b9a4324a15643853626afd0bf65c052"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -215,7 +219,8 @@
         "end_line_hash": "510108a9aab34209e18dc5b9bba20dee69d9981b536ac1c927db223d8b0cb5bf",
         "code_hash": "bbe58d6d77d6bcf2aba1a2ea780990cc922fab514445048b3bf5b50a7a7c0250",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -237,7 +242,8 @@
         "end_line_hash": "60f5f1fb9303e4f18ddcada8deb88cb2ac20c7d95cfcd424b65934545481a1a9",
         "code_hash": "97c1aa56d43d22e7ec10a8ca99ceab7e02749262a4be0c51683dd353b3b1a868",
         "pattern_hash": "06b2540894e5b13085b613a69a474505628594986504f246b7a521b99ce10bf2"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -259,7 +265,8 @@
         "end_line_hash": "1ca20045d4e8968c3774538d54b138132fa83b7b18e0137435f3108f40ae163e",
         "code_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241",
         "pattern_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -281,7 +288,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -303,7 +311,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -325,7 +334,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "ignores": [
@@ -361,7 +371,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -396,7 +407,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -429,7 +441,8 @@
         "end_line_hash": "889792ca5269732e125f6abb0d0245a7dcb83862e34d797a5ee890a4a7a5eae7",
         "code_hash": "d2c95171288a258009c5187392c5e2122e2640e0431af8b1cad77d5b403ed850",
         "pattern_hash": "d2c95171288a258009c5187392c5e2122e2640e0431af8b1cad77d5b403ed850"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -451,7 +464,8 @@
         "end_line_hash": "0f1b9301a089bbcbbb0dd563a4a01270919f60a5bfd3d738788a8bbb1f7e0a59",
         "code_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613",
         "pattern_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -473,7 +487,8 @@
         "end_line_hash": "c772c5c0ca842b8e194eca4ed7bf1333c1e67bab038e9ac76c788d0e819c51ba",
         "code_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f",
         "pattern_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -495,7 +510,8 @@
         "end_line_hash": "e89b663d624741879a65668fed6c6dce5c9823fa17962ff69ae19b369b09e77c",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "token": null,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr/findings_and_ignores.json
@@ -91,7 +91,8 @@
             "sink(d2)"
           ]
         ]
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "abceversion1",
@@ -125,7 +126,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -160,7 +162,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -193,7 +196,8 @@
         "end_line_hash": "27937fb6c73e88412e7e39647557d4c03fda0ea04b91cecb3852355f387d03c8",
         "code_hash": "2005925cbb09029b2f5c8700dcae5c9a8b9a4324a15643853626afd0bf65c052",
         "pattern_hash": "2005925cbb09029b2f5c8700dcae5c9a8b9a4324a15643853626afd0bf65c052"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -215,7 +219,8 @@
         "end_line_hash": "510108a9aab34209e18dc5b9bba20dee69d9981b536ac1c927db223d8b0cb5bf",
         "code_hash": "bbe58d6d77d6bcf2aba1a2ea780990cc922fab514445048b3bf5b50a7a7c0250",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -237,7 +242,8 @@
         "end_line_hash": "60f5f1fb9303e4f18ddcada8deb88cb2ac20c7d95cfcd424b65934545481a1a9",
         "code_hash": "97c1aa56d43d22e7ec10a8ca99ceab7e02749262a4be0c51683dd353b3b1a868",
         "pattern_hash": "06b2540894e5b13085b613a69a474505628594986504f246b7a521b99ce10bf2"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -259,7 +265,8 @@
         "end_line_hash": "1ca20045d4e8968c3774538d54b138132fa83b7b18e0137435f3108f40ae163e",
         "code_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241",
         "pattern_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -281,7 +288,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -303,7 +311,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -325,7 +334,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "ignores": [
@@ -361,7 +371,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -396,7 +407,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -429,7 +441,8 @@
         "end_line_hash": "889792ca5269732e125f6abb0d0245a7dcb83862e34d797a5ee890a4a7a5eae7",
         "code_hash": "d2c95171288a258009c5187392c5e2122e2640e0431af8b1cad77d5b403ed850",
         "pattern_hash": "d2c95171288a258009c5187392c5e2122e2640e0431af8b1cad77d5b403ed850"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -451,7 +464,8 @@
         "end_line_hash": "0f1b9301a089bbcbbb0dd563a4a01270919f60a5bfd3d738788a8bbb1f7e0a59",
         "code_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613",
         "pattern_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -473,7 +487,8 @@
         "end_line_hash": "c772c5c0ca842b8e194eca4ed7bf1333c1e67bab038e9ac76c788d0e819c51ba",
         "code_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f",
         "pattern_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -495,7 +510,8 @@
         "end_line_hash": "e89b663d624741879a65668fed6c6dce5c9823fa17962ff69ae19b369b09e77c",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "token": null,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push-special-env-vars/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push-special-env-vars/findings_and_ignores.json
@@ -91,7 +91,8 @@
             "sink(d2)"
           ]
         ]
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "supply-chain1",
@@ -171,7 +172,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -206,7 +208,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -239,7 +242,8 @@
         "end_line_hash": "27937fb6c73e88412e7e39647557d4c03fda0ea04b91cecb3852355f387d03c8",
         "code_hash": "2005925cbb09029b2f5c8700dcae5c9a8b9a4324a15643853626afd0bf65c052",
         "pattern_hash": "2005925cbb09029b2f5c8700dcae5c9a8b9a4324a15643853626afd0bf65c052"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -261,7 +265,8 @@
         "end_line_hash": "510108a9aab34209e18dc5b9bba20dee69d9981b536ac1c927db223d8b0cb5bf",
         "code_hash": "bbe58d6d77d6bcf2aba1a2ea780990cc922fab514445048b3bf5b50a7a7c0250",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -283,7 +288,8 @@
         "end_line_hash": "60f5f1fb9303e4f18ddcada8deb88cb2ac20c7d95cfcd424b65934545481a1a9",
         "code_hash": "97c1aa56d43d22e7ec10a8ca99ceab7e02749262a4be0c51683dd353b3b1a868",
         "pattern_hash": "06b2540894e5b13085b613a69a474505628594986504f246b7a521b99ce10bf2"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -305,7 +311,8 @@
         "end_line_hash": "1ca20045d4e8968c3774538d54b138132fa83b7b18e0137435f3108f40ae163e",
         "code_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241",
         "pattern_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -327,7 +334,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -349,7 +357,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -371,7 +380,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "ignores": [
@@ -407,7 +417,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -442,7 +453,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -475,7 +487,8 @@
         "end_line_hash": "889792ca5269732e125f6abb0d0245a7dcb83862e34d797a5ee890a4a7a5eae7",
         "code_hash": "d2c95171288a258009c5187392c5e2122e2640e0431af8b1cad77d5b403ed850",
         "pattern_hash": "d2c95171288a258009c5187392c5e2122e2640e0431af8b1cad77d5b403ed850"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -497,7 +510,8 @@
         "end_line_hash": "0f1b9301a089bbcbbb0dd563a4a01270919f60a5bfd3d738788a8bbb1f7e0a59",
         "code_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613",
         "pattern_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -519,7 +533,8 @@
         "end_line_hash": "c772c5c0ca842b8e194eca4ed7bf1333c1e67bab038e9ac76c788d0e819c51ba",
         "code_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f",
         "pattern_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -541,7 +556,8 @@
         "end_line_hash": "e89b663d624741879a65668fed6c6dce5c9823fa17962ff69ae19b369b09e77c",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "token": null,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/findings_and_ignores.json
@@ -91,7 +91,8 @@
             "sink(d2)"
           ]
         ]
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "supply-chain1",
@@ -171,7 +172,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -206,7 +208,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -239,7 +242,8 @@
         "end_line_hash": "27937fb6c73e88412e7e39647557d4c03fda0ea04b91cecb3852355f387d03c8",
         "code_hash": "2005925cbb09029b2f5c8700dcae5c9a8b9a4324a15643853626afd0bf65c052",
         "pattern_hash": "2005925cbb09029b2f5c8700dcae5c9a8b9a4324a15643853626afd0bf65c052"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -261,7 +265,8 @@
         "end_line_hash": "510108a9aab34209e18dc5b9bba20dee69d9981b536ac1c927db223d8b0cb5bf",
         "code_hash": "bbe58d6d77d6bcf2aba1a2ea780990cc922fab514445048b3bf5b50a7a7c0250",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -283,7 +288,8 @@
         "end_line_hash": "60f5f1fb9303e4f18ddcada8deb88cb2ac20c7d95cfcd424b65934545481a1a9",
         "code_hash": "97c1aa56d43d22e7ec10a8ca99ceab7e02749262a4be0c51683dd353b3b1a868",
         "pattern_hash": "06b2540894e5b13085b613a69a474505628594986504f246b7a521b99ce10bf2"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -305,7 +311,8 @@
         "end_line_hash": "1ca20045d4e8968c3774538d54b138132fa83b7b18e0137435f3108f40ae163e",
         "code_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241",
         "pattern_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -327,7 +334,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -349,7 +357,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -371,7 +380,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "ignores": [
@@ -407,7 +417,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -442,7 +453,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -475,7 +487,8 @@
         "end_line_hash": "889792ca5269732e125f6abb0d0245a7dcb83862e34d797a5ee890a4a7a5eae7",
         "code_hash": "d2c95171288a258009c5187392c5e2122e2640e0431af8b1cad77d5b403ed850",
         "pattern_hash": "d2c95171288a258009c5187392c5e2122e2640e0431af8b1cad77d5b403ed850"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -497,7 +510,8 @@
         "end_line_hash": "0f1b9301a089bbcbbb0dd563a4a01270919f60a5bfd3d738788a8bbb1f7e0a59",
         "code_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613",
         "pattern_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -519,7 +533,8 @@
         "end_line_hash": "c772c5c0ca842b8e194eca4ed7bf1333c1e67bab038e9ac76c788d0e819c51ba",
         "code_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f",
         "pattern_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -541,7 +556,8 @@
         "end_line_hash": "e89b663d624741879a65668fed6c6dce5c9823fa17962ff69ae19b369b09e77c",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "token": null,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-push/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-push/findings_and_ignores.json
@@ -91,7 +91,8 @@
             "sink(d2)"
           ]
         ]
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "supply-chain1",
@@ -171,7 +172,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -206,7 +208,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -239,7 +242,8 @@
         "end_line_hash": "27937fb6c73e88412e7e39647557d4c03fda0ea04b91cecb3852355f387d03c8",
         "code_hash": "2005925cbb09029b2f5c8700dcae5c9a8b9a4324a15643853626afd0bf65c052",
         "pattern_hash": "2005925cbb09029b2f5c8700dcae5c9a8b9a4324a15643853626afd0bf65c052"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -261,7 +265,8 @@
         "end_line_hash": "510108a9aab34209e18dc5b9bba20dee69d9981b536ac1c927db223d8b0cb5bf",
         "code_hash": "bbe58d6d77d6bcf2aba1a2ea780990cc922fab514445048b3bf5b50a7a7c0250",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -283,7 +288,8 @@
         "end_line_hash": "60f5f1fb9303e4f18ddcada8deb88cb2ac20c7d95cfcd424b65934545481a1a9",
         "code_hash": "97c1aa56d43d22e7ec10a8ca99ceab7e02749262a4be0c51683dd353b3b1a868",
         "pattern_hash": "06b2540894e5b13085b613a69a474505628594986504f246b7a521b99ce10bf2"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -305,7 +311,8 @@
         "end_line_hash": "1ca20045d4e8968c3774538d54b138132fa83b7b18e0137435f3108f40ae163e",
         "code_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241",
         "pattern_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -327,7 +334,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -349,7 +357,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -371,7 +380,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "ignores": [
@@ -407,7 +417,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -442,7 +453,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -475,7 +487,8 @@
         "end_line_hash": "889792ca5269732e125f6abb0d0245a7dcb83862e34d797a5ee890a4a7a5eae7",
         "code_hash": "d2c95171288a258009c5187392c5e2122e2640e0431af8b1cad77d5b403ed850",
         "pattern_hash": "d2c95171288a258009c5187392c5e2122e2640e0431af8b1cad77d5b403ed850"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -497,7 +510,8 @@
         "end_line_hash": "0f1b9301a089bbcbbb0dd563a4a01270919f60a5bfd3d738788a8bbb1f7e0a59",
         "code_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613",
         "pattern_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -519,7 +533,8 @@
         "end_line_hash": "c772c5c0ca842b8e194eca4ed7bf1333c1e67bab038e9ac76c788d0e819c51ba",
         "code_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f",
         "pattern_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -541,7 +556,8 @@
         "end_line_hash": "e89b663d624741879a65668fed6c6dce5c9823fa17962ff69ae19b369b09e77c",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "token": null,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-special-env-vars/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-special-env-vars/findings_and_ignores.json
@@ -91,7 +91,8 @@
             "sink(d2)"
           ]
         ]
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "abceversion1",
@@ -125,7 +126,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -160,7 +162,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -193,7 +196,8 @@
         "end_line_hash": "27937fb6c73e88412e7e39647557d4c03fda0ea04b91cecb3852355f387d03c8",
         "code_hash": "2005925cbb09029b2f5c8700dcae5c9a8b9a4324a15643853626afd0bf65c052",
         "pattern_hash": "2005925cbb09029b2f5c8700dcae5c9a8b9a4324a15643853626afd0bf65c052"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -215,7 +219,8 @@
         "end_line_hash": "510108a9aab34209e18dc5b9bba20dee69d9981b536ac1c927db223d8b0cb5bf",
         "code_hash": "bbe58d6d77d6bcf2aba1a2ea780990cc922fab514445048b3bf5b50a7a7c0250",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -237,7 +242,8 @@
         "end_line_hash": "60f5f1fb9303e4f18ddcada8deb88cb2ac20c7d95cfcd424b65934545481a1a9",
         "code_hash": "97c1aa56d43d22e7ec10a8ca99ceab7e02749262a4be0c51683dd353b3b1a868",
         "pattern_hash": "06b2540894e5b13085b613a69a474505628594986504f246b7a521b99ce10bf2"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -259,7 +265,8 @@
         "end_line_hash": "1ca20045d4e8968c3774538d54b138132fa83b7b18e0137435f3108f40ae163e",
         "code_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241",
         "pattern_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -281,7 +288,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -303,7 +311,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -325,7 +334,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "ignores": [
@@ -361,7 +371,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -396,7 +407,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -429,7 +441,8 @@
         "end_line_hash": "889792ca5269732e125f6abb0d0245a7dcb83862e34d797a5ee890a4a7a5eae7",
         "code_hash": "d2c95171288a258009c5187392c5e2122e2640e0431af8b1cad77d5b403ed850",
         "pattern_hash": "d2c95171288a258009c5187392c5e2122e2640e0431af8b1cad77d5b403ed850"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -451,7 +464,8 @@
         "end_line_hash": "0f1b9301a089bbcbbb0dd563a4a01270919f60a5bfd3d738788a8bbb1f7e0a59",
         "code_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613",
         "pattern_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -473,7 +487,8 @@
         "end_line_hash": "c772c5c0ca842b8e194eca4ed7bf1333c1e67bab038e9ac76c788d0e819c51ba",
         "code_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f",
         "pattern_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -495,7 +510,8 @@
         "end_line_hash": "e89b663d624741879a65668fed6c6dce5c9823fa17962ff69ae19b369b09e77c",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "token": null,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab/findings_and_ignores.json
@@ -91,7 +91,8 @@
             "sink(d2)"
           ]
         ]
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "abceversion1",
@@ -125,7 +126,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -160,7 +162,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -193,7 +196,8 @@
         "end_line_hash": "27937fb6c73e88412e7e39647557d4c03fda0ea04b91cecb3852355f387d03c8",
         "code_hash": "2005925cbb09029b2f5c8700dcae5c9a8b9a4324a15643853626afd0bf65c052",
         "pattern_hash": "2005925cbb09029b2f5c8700dcae5c9a8b9a4324a15643853626afd0bf65c052"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -215,7 +219,8 @@
         "end_line_hash": "510108a9aab34209e18dc5b9bba20dee69d9981b536ac1c927db223d8b0cb5bf",
         "code_hash": "bbe58d6d77d6bcf2aba1a2ea780990cc922fab514445048b3bf5b50a7a7c0250",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -237,7 +242,8 @@
         "end_line_hash": "60f5f1fb9303e4f18ddcada8deb88cb2ac20c7d95cfcd424b65934545481a1a9",
         "code_hash": "97c1aa56d43d22e7ec10a8ca99ceab7e02749262a4be0c51683dd353b3b1a868",
         "pattern_hash": "06b2540894e5b13085b613a69a474505628594986504f246b7a521b99ce10bf2"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -259,7 +265,8 @@
         "end_line_hash": "1ca20045d4e8968c3774538d54b138132fa83b7b18e0137435f3108f40ae163e",
         "code_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241",
         "pattern_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -281,7 +288,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -303,7 +311,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -325,7 +334,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "ignores": [
@@ -361,7 +371,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -396,7 +407,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -429,7 +441,8 @@
         "end_line_hash": "889792ca5269732e125f6abb0d0245a7dcb83862e34d797a5ee890a4a7a5eae7",
         "code_hash": "d2c95171288a258009c5187392c5e2122e2640e0431af8b1cad77d5b403ed850",
         "pattern_hash": "d2c95171288a258009c5187392c5e2122e2640e0431af8b1cad77d5b403ed850"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -451,7 +464,8 @@
         "end_line_hash": "0f1b9301a089bbcbbb0dd563a4a01270919f60a5bfd3d738788a8bbb1f7e0a59",
         "code_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613",
         "pattern_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -473,7 +487,8 @@
         "end_line_hash": "c772c5c0ca842b8e194eca4ed7bf1333c1e67bab038e9ac76c788d0e819c51ba",
         "code_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f",
         "pattern_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -495,7 +510,8 @@
         "end_line_hash": "e89b663d624741879a65668fed6c6dce5c9823fa17962ff69ae19b369b09e77c",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "token": null,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/findings_and_ignores.json
@@ -91,7 +91,8 @@
             "sink(d2)"
           ]
         ]
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "supply-chain1",
@@ -171,7 +172,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -206,7 +208,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -239,7 +242,8 @@
         "end_line_hash": "27937fb6c73e88412e7e39647557d4c03fda0ea04b91cecb3852355f387d03c8",
         "code_hash": "2005925cbb09029b2f5c8700dcae5c9a8b9a4324a15643853626afd0bf65c052",
         "pattern_hash": "2005925cbb09029b2f5c8700dcae5c9a8b9a4324a15643853626afd0bf65c052"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -261,7 +265,8 @@
         "end_line_hash": "510108a9aab34209e18dc5b9bba20dee69d9981b536ac1c927db223d8b0cb5bf",
         "code_hash": "bbe58d6d77d6bcf2aba1a2ea780990cc922fab514445048b3bf5b50a7a7c0250",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -283,7 +288,8 @@
         "end_line_hash": "60f5f1fb9303e4f18ddcada8deb88cb2ac20c7d95cfcd424b65934545481a1a9",
         "code_hash": "97c1aa56d43d22e7ec10a8ca99ceab7e02749262a4be0c51683dd353b3b1a868",
         "pattern_hash": "06b2540894e5b13085b613a69a474505628594986504f246b7a521b99ce10bf2"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -305,7 +311,8 @@
         "end_line_hash": "1ca20045d4e8968c3774538d54b138132fa83b7b18e0137435f3108f40ae163e",
         "code_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241",
         "pattern_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -327,7 +334,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -349,7 +357,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -371,7 +380,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "ignores": [
@@ -407,7 +417,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -442,7 +453,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -475,7 +487,8 @@
         "end_line_hash": "889792ca5269732e125f6abb0d0245a7dcb83862e34d797a5ee890a4a7a5eae7",
         "code_hash": "d2c95171288a258009c5187392c5e2122e2640e0431af8b1cad77d5b403ed850",
         "pattern_hash": "d2c95171288a258009c5187392c5e2122e2640e0431af8b1cad77d5b403ed850"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -497,7 +510,8 @@
         "end_line_hash": "0f1b9301a089bbcbbb0dd563a4a01270919f60a5bfd3d738788a8bbb1f7e0a59",
         "code_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613",
         "pattern_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -519,7 +533,8 @@
         "end_line_hash": "c772c5c0ca842b8e194eca4ed7bf1333c1e67bab038e9ac76c788d0e819c51ba",
         "code_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f",
         "pattern_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -541,7 +556,8 @@
         "end_line_hash": "e89b663d624741879a65668fed6c6dce5c9823fa17962ff69ae19b369b09e77c",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "token": null,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-overwrite-autodetected-variables/findings_and_ignores.json
@@ -91,7 +91,8 @@
             "sink(d2)"
           ]
         ]
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "supply-chain1",
@@ -171,7 +172,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -206,7 +208,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -239,7 +242,8 @@
         "end_line_hash": "27937fb6c73e88412e7e39647557d4c03fda0ea04b91cecb3852355f387d03c8",
         "code_hash": "2005925cbb09029b2f5c8700dcae5c9a8b9a4324a15643853626afd0bf65c052",
         "pattern_hash": "2005925cbb09029b2f5c8700dcae5c9a8b9a4324a15643853626afd0bf65c052"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -261,7 +265,8 @@
         "end_line_hash": "510108a9aab34209e18dc5b9bba20dee69d9981b536ac1c927db223d8b0cb5bf",
         "code_hash": "bbe58d6d77d6bcf2aba1a2ea780990cc922fab514445048b3bf5b50a7a7c0250",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -283,7 +288,8 @@
         "end_line_hash": "60f5f1fb9303e4f18ddcada8deb88cb2ac20c7d95cfcd424b65934545481a1a9",
         "code_hash": "97c1aa56d43d22e7ec10a8ca99ceab7e02749262a4be0c51683dd353b3b1a868",
         "pattern_hash": "06b2540894e5b13085b613a69a474505628594986504f246b7a521b99ce10bf2"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -305,7 +311,8 @@
         "end_line_hash": "1ca20045d4e8968c3774538d54b138132fa83b7b18e0137435f3108f40ae163e",
         "code_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241",
         "pattern_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -327,7 +334,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -349,7 +357,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -371,7 +380,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "ignores": [
@@ -407,7 +417,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -442,7 +453,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -475,7 +487,8 @@
         "end_line_hash": "889792ca5269732e125f6abb0d0245a7dcb83862e34d797a5ee890a4a7a5eae7",
         "code_hash": "d2c95171288a258009c5187392c5e2122e2640e0431af8b1cad77d5b403ed850",
         "pattern_hash": "d2c95171288a258009c5187392c5e2122e2640e0431af8b1cad77d5b403ed850"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -497,7 +510,8 @@
         "end_line_hash": "0f1b9301a089bbcbbb0dd563a4a01270919f60a5bfd3d738788a8bbb1f7e0a59",
         "code_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613",
         "pattern_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -519,7 +533,8 @@
         "end_line_hash": "c772c5c0ca842b8e194eca4ed7bf1333c1e67bab038e9ac76c788d0e819c51ba",
         "code_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f",
         "pattern_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -541,7 +556,8 @@
         "end_line_hash": "e89b663d624741879a65668fed6c6dce5c9823fa17962ff69ae19b369b09e77c",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "token": null,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins/findings_and_ignores.json
@@ -91,7 +91,8 @@
             "sink(d2)"
           ]
         ]
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "supply-chain1",
@@ -171,7 +172,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -206,7 +208,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -239,7 +242,8 @@
         "end_line_hash": "27937fb6c73e88412e7e39647557d4c03fda0ea04b91cecb3852355f387d03c8",
         "code_hash": "2005925cbb09029b2f5c8700dcae5c9a8b9a4324a15643853626afd0bf65c052",
         "pattern_hash": "2005925cbb09029b2f5c8700dcae5c9a8b9a4324a15643853626afd0bf65c052"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -261,7 +265,8 @@
         "end_line_hash": "510108a9aab34209e18dc5b9bba20dee69d9981b536ac1c927db223d8b0cb5bf",
         "code_hash": "bbe58d6d77d6bcf2aba1a2ea780990cc922fab514445048b3bf5b50a7a7c0250",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -283,7 +288,8 @@
         "end_line_hash": "60f5f1fb9303e4f18ddcada8deb88cb2ac20c7d95cfcd424b65934545481a1a9",
         "code_hash": "97c1aa56d43d22e7ec10a8ca99ceab7e02749262a4be0c51683dd353b3b1a868",
         "pattern_hash": "06b2540894e5b13085b613a69a474505628594986504f246b7a521b99ce10bf2"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -305,7 +311,8 @@
         "end_line_hash": "1ca20045d4e8968c3774538d54b138132fa83b7b18e0137435f3108f40ae163e",
         "code_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241",
         "pattern_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -327,7 +334,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -349,7 +357,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -371,7 +380,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "ignores": [
@@ -407,7 +417,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -442,7 +453,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -475,7 +487,8 @@
         "end_line_hash": "889792ca5269732e125f6abb0d0245a7dcb83862e34d797a5ee890a4a7a5eae7",
         "code_hash": "d2c95171288a258009c5187392c5e2122e2640e0431af8b1cad77d5b403ed850",
         "pattern_hash": "d2c95171288a258009c5187392c5e2122e2640e0431af8b1cad77d5b403ed850"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -497,7 +510,8 @@
         "end_line_hash": "0f1b9301a089bbcbbb0dd563a4a01270919f60a5bfd3d738788a8bbb1f7e0a59",
         "code_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613",
         "pattern_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -519,7 +533,8 @@
         "end_line_hash": "c772c5c0ca842b8e194eca4ed7bf1333c1e67bab038e9ac76c788d0e819c51ba",
         "code_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f",
         "pattern_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -541,7 +556,8 @@
         "end_line_hash": "e89b663d624741879a65668fed6c6dce5c9823fa17962ff69ae19b369b09e77c",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "token": null,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/findings_and_ignores.json
@@ -91,7 +91,8 @@
             "sink(d2)"
           ]
         ]
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "supply-chain1",
@@ -171,7 +172,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -206,7 +208,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -239,7 +242,8 @@
         "end_line_hash": "27937fb6c73e88412e7e39647557d4c03fda0ea04b91cecb3852355f387d03c8",
         "code_hash": "2005925cbb09029b2f5c8700dcae5c9a8b9a4324a15643853626afd0bf65c052",
         "pattern_hash": "2005925cbb09029b2f5c8700dcae5c9a8b9a4324a15643853626afd0bf65c052"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -261,7 +265,8 @@
         "end_line_hash": "510108a9aab34209e18dc5b9bba20dee69d9981b536ac1c927db223d8b0cb5bf",
         "code_hash": "bbe58d6d77d6bcf2aba1a2ea780990cc922fab514445048b3bf5b50a7a7c0250",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -283,7 +288,8 @@
         "end_line_hash": "60f5f1fb9303e4f18ddcada8deb88cb2ac20c7d95cfcd424b65934545481a1a9",
         "code_hash": "97c1aa56d43d22e7ec10a8ca99ceab7e02749262a4be0c51683dd353b3b1a868",
         "pattern_hash": "06b2540894e5b13085b613a69a474505628594986504f246b7a521b99ce10bf2"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -305,7 +311,8 @@
         "end_line_hash": "1ca20045d4e8968c3774538d54b138132fa83b7b18e0137435f3108f40ae163e",
         "code_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241",
         "pattern_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -327,7 +334,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -349,7 +357,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -371,7 +380,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "ignores": [
@@ -407,7 +417,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -442,7 +453,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -475,7 +487,8 @@
         "end_line_hash": "889792ca5269732e125f6abb0d0245a7dcb83862e34d797a5ee890a4a7a5eae7",
         "code_hash": "d2c95171288a258009c5187392c5e2122e2640e0431af8b1cad77d5b403ed850",
         "pattern_hash": "d2c95171288a258009c5187392c5e2122e2640e0431af8b1cad77d5b403ed850"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -497,7 +510,8 @@
         "end_line_hash": "0f1b9301a089bbcbbb0dd563a4a01270919f60a5bfd3d738788a8bbb1f7e0a59",
         "code_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613",
         "pattern_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -519,7 +533,8 @@
         "end_line_hash": "c772c5c0ca842b8e194eca4ed7bf1333c1e67bab038e9ac76c788d0e819c51ba",
         "code_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f",
         "pattern_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -541,7 +556,8 @@
         "end_line_hash": "e89b663d624741879a65668fed6c6dce5c9823fa17962ff69ae19b369b09e77c",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "token": null,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-self-hosted/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-self-hosted/findings_and_ignores.json
@@ -91,7 +91,8 @@
             "sink(d2)"
           ]
         ]
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "supply-chain1",
@@ -171,7 +172,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -206,7 +208,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -239,7 +242,8 @@
         "end_line_hash": "27937fb6c73e88412e7e39647557d4c03fda0ea04b91cecb3852355f387d03c8",
         "code_hash": "2005925cbb09029b2f5c8700dcae5c9a8b9a4324a15643853626afd0bf65c052",
         "pattern_hash": "2005925cbb09029b2f5c8700dcae5c9a8b9a4324a15643853626afd0bf65c052"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -261,7 +265,8 @@
         "end_line_hash": "510108a9aab34209e18dc5b9bba20dee69d9981b536ac1c927db223d8b0cb5bf",
         "code_hash": "bbe58d6d77d6bcf2aba1a2ea780990cc922fab514445048b3bf5b50a7a7c0250",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -283,7 +288,8 @@
         "end_line_hash": "60f5f1fb9303e4f18ddcada8deb88cb2ac20c7d95cfcd424b65934545481a1a9",
         "code_hash": "97c1aa56d43d22e7ec10a8ca99ceab7e02749262a4be0c51683dd353b3b1a868",
         "pattern_hash": "06b2540894e5b13085b613a69a474505628594986504f246b7a521b99ce10bf2"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -305,7 +311,8 @@
         "end_line_hash": "1ca20045d4e8968c3774538d54b138132fa83b7b18e0137435f3108f40ae163e",
         "code_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241",
         "pattern_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -327,7 +334,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -349,7 +357,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -371,7 +380,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "ignores": [
@@ -407,7 +417,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -442,7 +453,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -475,7 +487,8 @@
         "end_line_hash": "889792ca5269732e125f6abb0d0245a7dcb83862e34d797a5ee890a4a7a5eae7",
         "code_hash": "d2c95171288a258009c5187392c5e2122e2640e0431af8b1cad77d5b403ed850",
         "pattern_hash": "d2c95171288a258009c5187392c5e2122e2640e0431af8b1cad77d5b403ed850"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -497,7 +510,8 @@
         "end_line_hash": "0f1b9301a089bbcbbb0dd563a4a01270919f60a5bfd3d738788a8bbb1f7e0a59",
         "code_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613",
         "pattern_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -519,7 +533,8 @@
         "end_line_hash": "c772c5c0ca842b8e194eca4ed7bf1333c1e67bab038e9ac76c788d0e819c51ba",
         "code_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f",
         "pattern_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -541,7 +556,8 @@
         "end_line_hash": "e89b663d624741879a65668fed6c6dce5c9823fa17962ff69ae19b369b09e77c",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "token": null,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis-overwrite-autodetected-variables/findings_and_ignores.json
@@ -91,7 +91,8 @@
             "sink(d2)"
           ]
         ]
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "supply-chain1",
@@ -171,7 +172,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -206,7 +208,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -239,7 +242,8 @@
         "end_line_hash": "27937fb6c73e88412e7e39647557d4c03fda0ea04b91cecb3852355f387d03c8",
         "code_hash": "2005925cbb09029b2f5c8700dcae5c9a8b9a4324a15643853626afd0bf65c052",
         "pattern_hash": "2005925cbb09029b2f5c8700dcae5c9a8b9a4324a15643853626afd0bf65c052"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -261,7 +265,8 @@
         "end_line_hash": "510108a9aab34209e18dc5b9bba20dee69d9981b536ac1c927db223d8b0cb5bf",
         "code_hash": "bbe58d6d77d6bcf2aba1a2ea780990cc922fab514445048b3bf5b50a7a7c0250",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -283,7 +288,8 @@
         "end_line_hash": "60f5f1fb9303e4f18ddcada8deb88cb2ac20c7d95cfcd424b65934545481a1a9",
         "code_hash": "97c1aa56d43d22e7ec10a8ca99ceab7e02749262a4be0c51683dd353b3b1a868",
         "pattern_hash": "06b2540894e5b13085b613a69a474505628594986504f246b7a521b99ce10bf2"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -305,7 +311,8 @@
         "end_line_hash": "1ca20045d4e8968c3774538d54b138132fa83b7b18e0137435f3108f40ae163e",
         "code_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241",
         "pattern_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -327,7 +334,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -349,7 +357,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -371,7 +380,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "ignores": [
@@ -407,7 +417,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -442,7 +453,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -475,7 +487,8 @@
         "end_line_hash": "889792ca5269732e125f6abb0d0245a7dcb83862e34d797a5ee890a4a7a5eae7",
         "code_hash": "d2c95171288a258009c5187392c5e2122e2640e0431af8b1cad77d5b403ed850",
         "pattern_hash": "d2c95171288a258009c5187392c5e2122e2640e0431af8b1cad77d5b403ed850"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -497,7 +510,8 @@
         "end_line_hash": "0f1b9301a089bbcbbb0dd563a4a01270919f60a5bfd3d738788a8bbb1f7e0a59",
         "code_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613",
         "pattern_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -519,7 +533,8 @@
         "end_line_hash": "c772c5c0ca842b8e194eca4ed7bf1333c1e67bab038e9ac76c788d0e819c51ba",
         "code_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f",
         "pattern_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -541,7 +556,8 @@
         "end_line_hash": "e89b663d624741879a65668fed6c6dce5c9823fa17962ff69ae19b369b09e77c",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "token": null,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis/findings_and_ignores.json
@@ -91,7 +91,8 @@
             "sink(d2)"
           ]
         ]
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "supply-chain1",
@@ -171,7 +172,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -206,7 +208,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -239,7 +242,8 @@
         "end_line_hash": "27937fb6c73e88412e7e39647557d4c03fda0ea04b91cecb3852355f387d03c8",
         "code_hash": "2005925cbb09029b2f5c8700dcae5c9a8b9a4324a15643853626afd0bf65c052",
         "pattern_hash": "2005925cbb09029b2f5c8700dcae5c9a8b9a4324a15643853626afd0bf65c052"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -261,7 +265,8 @@
         "end_line_hash": "510108a9aab34209e18dc5b9bba20dee69d9981b536ac1c927db223d8b0cb5bf",
         "code_hash": "bbe58d6d77d6bcf2aba1a2ea780990cc922fab514445048b3bf5b50a7a7c0250",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -283,7 +288,8 @@
         "end_line_hash": "60f5f1fb9303e4f18ddcada8deb88cb2ac20c7d95cfcd424b65934545481a1a9",
         "code_hash": "97c1aa56d43d22e7ec10a8ca99ceab7e02749262a4be0c51683dd353b3b1a868",
         "pattern_hash": "06b2540894e5b13085b613a69a474505628594986504f246b7a521b99ce10bf2"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -305,7 +311,8 @@
         "end_line_hash": "1ca20045d4e8968c3774538d54b138132fa83b7b18e0137435f3108f40ae163e",
         "code_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241",
         "pattern_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -327,7 +334,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -349,7 +357,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -371,7 +380,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "ignores": [
@@ -407,7 +417,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -442,7 +453,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -475,7 +487,8 @@
         "end_line_hash": "889792ca5269732e125f6abb0d0245a7dcb83862e34d797a5ee890a4a7a5eae7",
         "code_hash": "d2c95171288a258009c5187392c5e2122e2640e0431af8b1cad77d5b403ed850",
         "pattern_hash": "d2c95171288a258009c5187392c5e2122e2640e0431af8b1cad77d5b403ed850"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -497,7 +510,8 @@
         "end_line_hash": "0f1b9301a089bbcbbb0dd563a4a01270919f60a5bfd3d738788a8bbb1f7e0a59",
         "code_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613",
         "pattern_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -519,7 +533,8 @@
         "end_line_hash": "c772c5c0ca842b8e194eca4ed7bf1333c1e67bab038e9ac76c788d0e819c51ba",
         "code_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f",
         "pattern_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -541,7 +556,8 @@
         "end_line_hash": "e89b663d624741879a65668fed6c6dce5c9823fa17962ff69ae19b369b09e77c",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "token": null,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-unparsable_url/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-unparsable_url/findings_and_ignores.json
@@ -91,7 +91,8 @@
             "sink(d2)"
           ]
         ]
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "supply-chain1",
@@ -171,7 +172,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -206,7 +208,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -239,7 +242,8 @@
         "end_line_hash": "27937fb6c73e88412e7e39647557d4c03fda0ea04b91cecb3852355f387d03c8",
         "code_hash": "2005925cbb09029b2f5c8700dcae5c9a8b9a4324a15643853626afd0bf65c052",
         "pattern_hash": "2005925cbb09029b2f5c8700dcae5c9a8b9a4324a15643853626afd0bf65c052"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -261,7 +265,8 @@
         "end_line_hash": "510108a9aab34209e18dc5b9bba20dee69d9981b536ac1c927db223d8b0cb5bf",
         "code_hash": "bbe58d6d77d6bcf2aba1a2ea780990cc922fab514445048b3bf5b50a7a7c0250",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -283,7 +288,8 @@
         "end_line_hash": "60f5f1fb9303e4f18ddcada8deb88cb2ac20c7d95cfcd424b65934545481a1a9",
         "code_hash": "97c1aa56d43d22e7ec10a8ca99ceab7e02749262a4be0c51683dd353b3b1a868",
         "pattern_hash": "06b2540894e5b13085b613a69a474505628594986504f246b7a521b99ce10bf2"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -305,7 +311,8 @@
         "end_line_hash": "1ca20045d4e8968c3774538d54b138132fa83b7b18e0137435f3108f40ae163e",
         "code_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241",
         "pattern_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -327,7 +334,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -349,7 +357,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -371,7 +380,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "ignores": [
@@ -407,7 +417,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -442,7 +453,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -475,7 +487,8 @@
         "end_line_hash": "889792ca5269732e125f6abb0d0245a7dcb83862e34d797a5ee890a4a7a5eae7",
         "code_hash": "d2c95171288a258009c5187392c5e2122e2640e0431af8b1cad77d5b403ed850",
         "pattern_hash": "d2c95171288a258009c5187392c5e2122e2640e0431af8b1cad77d5b403ed850"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -497,7 +510,8 @@
         "end_line_hash": "0f1b9301a089bbcbbb0dd563a4a01270919f60a5bfd3d738788a8bbb1f7e0a59",
         "code_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613",
         "pattern_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -519,7 +533,8 @@
         "end_line_hash": "c772c5c0ca842b8e194eca4ed7bf1333c1e67bab038e9ac76c788d0e819c51ba",
         "code_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f",
         "pattern_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -541,7 +556,8 @@
         "end_line_hash": "e89b663d624741879a65668fed6c6dce5c9823fa17962ff69ae19b369b09e77c",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "token": null,

--- a/cli/tests/e2e/snapshots/test_ci/test_lockfile_parse_failure_reporting/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_lockfile_parse_failure_reporting/findings_and_ignores.json
@@ -91,7 +91,8 @@
             "sink(d2)"
           ]
         ]
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "supply-chain1",
@@ -171,7 +172,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -206,7 +208,8 @@
         "end_line_hash": "767b54a8959ab1bae471d88d9351ab3dc8c417471a5ed2dc874b67e012102baa",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -239,7 +242,8 @@
         "end_line_hash": "27937fb6c73e88412e7e39647557d4c03fda0ea04b91cecb3852355f387d03c8",
         "code_hash": "2005925cbb09029b2f5c8700dcae5c9a8b9a4324a15643853626afd0bf65c052",
         "pattern_hash": "2005925cbb09029b2f5c8700dcae5c9a8b9a4324a15643853626afd0bf65c052"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -261,7 +265,8 @@
         "end_line_hash": "510108a9aab34209e18dc5b9bba20dee69d9981b536ac1c927db223d8b0cb5bf",
         "code_hash": "bbe58d6d77d6bcf2aba1a2ea780990cc922fab514445048b3bf5b50a7a7c0250",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -283,7 +288,8 @@
         "end_line_hash": "60f5f1fb9303e4f18ddcada8deb88cb2ac20c7d95cfcd424b65934545481a1a9",
         "code_hash": "97c1aa56d43d22e7ec10a8ca99ceab7e02749262a4be0c51683dd353b3b1a868",
         "pattern_hash": "06b2540894e5b13085b613a69a474505628594986504f246b7a521b99ce10bf2"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -305,7 +311,8 @@
         "end_line_hash": "1ca20045d4e8968c3774538d54b138132fa83b7b18e0137435f3108f40ae163e",
         "code_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241",
         "pattern_hash": "8ad0935f9eb4c01f858bd5ed1e9c28aa60f8d49625bc26ecfe2b1ee90c26a241"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -327,7 +334,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -349,7 +357,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -371,7 +380,8 @@
         "end_line_hash": "bf62385c9376655f85afc789e40f1e16e7cc0f90d87288a13ccb62802be1f601",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "ignores": [
@@ -407,7 +417,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-four",
@@ -442,7 +453,8 @@
         "end_line_hash": "705071b3cc1398dc0eeaa7e759a7c4d39d33162c54ea7111cdc796790378e4c0",
         "code_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488",
         "pattern_hash": "027befcac4cbd8f5faffbcbee0e4cca5cd373af76c7e3d64574daa4b0f70a488"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-five",
@@ -475,7 +487,8 @@
         "end_line_hash": "889792ca5269732e125f6abb0d0245a7dcb83862e34d797a5ee890a4a7a5eae7",
         "code_hash": "d2c95171288a258009c5187392c5e2122e2640e0431af8b1cad77d5b403ed850",
         "pattern_hash": "d2c95171288a258009c5187392c5e2122e2640e0431af8b1cad77d5b403ed850"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -497,7 +510,8 @@
         "end_line_hash": "0f1b9301a089bbcbbb0dd563a4a01270919f60a5bfd3d738788a8bbb1f7e0a59",
         "code_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613",
         "pattern_hash": "0dbe5dc16d13b428b405ee54035df43ce62eccd8aebeb050e90047f09a24a613"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -519,7 +533,8 @@
         "end_line_hash": "c772c5c0ca842b8e194eca4ed7bf1333c1e67bab038e9ac76c788d0e819c51ba",
         "code_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f",
         "pattern_hash": "949d78287cab758a6d6f6cf8baf2cafb80399ce489cc94b58765da6c51c1c92f"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     },
     {
       "check_id": "eqeq-bad",
@@ -541,7 +556,8 @@
         "end_line_hash": "e89b663d624741879a65668fed6c6dce5c9823fa17962ff69ae19b369b09e77c",
         "code_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345",
         "pattern_hash": "e3eeff2fec82bf5b2a4b1837922798992b793f1d13ef91c3f81e39117fc24345"
-      }
+      },
+      "validation_state": "NO_VALIDATOR"
     }
   ],
   "token": null,


### PR DESCRIPTION
## What
Updates `Finding`  type to include validation_state to further communicate with the backend if secrets findings are valid or invalid.

[semgrep-interfaces PR](https://github.com/returntocorp/semgrep-interfaces/pull/119)

## Test
`make test` 
Currently a bunch of snapshots will need to be updated. (these have been updated and seem sensible.)
 
PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
