### PR TITLE
fix: persist full scan diagnostics until change

### DIFF
--- a/changelog.d/pa-3046.fixed
+++ b/changelog.d/pa-3046.fixed
@@ -1,0 +1,1 @@
+Diagnostics from a full scan through Semgrep LS no longer disappear when file is opened

--- a/cli/src/semgrep/lsp/config.py
+++ b/cli/src/semgrep/lsp/config.py
@@ -23,7 +23,7 @@ class LSPConfig:
     # =====================
     @property
     def extension_metrics(self) -> Dict[str, Any]:
-        extension_metrics = self._settings.get("extensionMetrics", {})
+        extension_metrics = self._settings.get("metrics", {})
         if isinstance(extension_metrics, dict):
             return extension_metrics
         elif isinstance(extension_metrics, str):

--- a/cli/src/semgrep/lsp/server.py
+++ b/cli/src/semgrep/lsp/server.py
@@ -181,6 +181,17 @@ class SemgrepCoreLSServer:
             auth.delete_token()
             self.notify_show_message(3, "Logged out of Semgrep Code")
 
+        log.info(f"Received message: {msg}")
+        if (
+            method == "semgrep/scanWorkspace"
+            and params.get("full", False)
+            and self.config.extension_metrics.get("isNewAppInstall", False)
+        ):
+            self.notify_show_message(
+                3,
+                "Scanning all files regardless of git status. These diagnostics will persist until a file is edited. To default to always scanning regardless of git status, please disable 'Only Git Dirty' in settings",
+            )
+
         self.core_writer.write(msg)
 
     def on_core_message(self, msg: JsonObject) -> None:

--- a/src/osemgrep/language_server/Session.mli
+++ b/src/osemgrep/language_server/Session.mli
@@ -10,7 +10,7 @@ type t = {
   incoming : Lwt_io.input_channel;
   outgoing : Lwt_io.output_channel;
   workspace_folders : Fpath.t list;
-  documents : (Fpath.t, Semgrep_output_v1_t.cli_match list) Hashtbl.t;
+  cached_scans : (Fpath.t, Semgrep_output_v1_t.cli_match list) Hashtbl.t;
   cached_rules : rule_cache;
   user_settings : UserSettings.t;
   token : string option; (* Mostly for testing *)
@@ -35,6 +35,10 @@ val runner_conf : t -> Core_runner.conf
 
 val scanned_files : t -> Fpath.t list
 (** [scanned_files t] returns the list of files that have been scanned in the session *)
+
+val previous_scan_of_file :
+  t -> Fpath.t -> Semgrep_output_v1_t.cli_match list option
+(** [previous_scan_of_file session path] returns the last results of a scan on a file if it exists *)
 
 val record_results :
   t -> Semgrep_output_v1_t.cli_match list -> Fpath.t list -> unit


### PR DESCRIPTION
Previously, we would rescan a file whenever it was opened. This is not performant, and also would clear diagnostics from a full scan. Now we do not scan a file when opened unless it has never been scanned before in the session. 
 

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
