### PR TITLE
Fix the error message for IncompatibleRule

### DIFF
--- a/changelog.d/gh-8634.fixed
+++ b/changelog.d/gh-8634.fixed
@@ -1,0 +1,2 @@
+The error message for skipped rules due to incompatible `min-version` or
+`max-version` constraints now makes sense.

--- a/cli/src/semgrep/error.py
+++ b/cli/src/semgrep/error.py
@@ -168,12 +168,16 @@ class SemgrepCoreError(SemgrepError):
         Generate error message exposed to user
         """
         if self.core.rule_id:
-            # For rule errors path is a temp file so for now will just be confusing to add
+            # For rule errors, the path is a temporary JSON file containing
+            # the rule(s).
             if isinstance(
                 self.core.error_type.value, core.RuleParseError
             ) or isinstance(self.core.error_type.value, core.PatternParseError):
                 error_context = f"in rule {self.core.rule_id.value}"
+            elif isinstance(self.core.error_type.value, core.IncompatibleRule_):
+                error_context = self.core.rule_id.value
             else:
+                # This message is suitable only if the error is in a target file:
                 error_context = f"when running {self.core.rule_id.value} on {self.core.location.path.value}"
         else:
             error_context = f"at line {self.core.location.path.value}:{self.core.location.start.line}"

--- a/cli/tests/e2e/snapshots/test_version_constraints/test_version_constraints/results.json
+++ b/cli/tests/e2e/snapshots/test_version_constraints/test_version_constraints/results.json
@@ -3,7 +3,7 @@
     {
       "code": 0,
       "level": "info",
-      "message": "Incompatible rule when running rules.need-to-upgrade1 on <MASKED>.json:\n This rule requires upgrading Semgrep from version <MASKED> to at least 1000.0.0",
+      "message": "Incompatible rule rules.need-to-upgrade1:\n This rule requires upgrading Semgrep from version <MASKED> to at least 1000.0.0",
       "path": "<MASKED>.json",
       "rule_id": "rules.need-to-upgrade1",
       "type": "Incompatible rule"
@@ -11,7 +11,7 @@
     {
       "code": 0,
       "level": "info",
-      "message": "Incompatible rule when running rules.need-to-upgrade2 on <MASKED>.json:\n This rule requires upgrading Semgrep from version <MASKED> to at least 1.1000.0",
+      "message": "Incompatible rule rules.need-to-upgrade2:\n This rule requires upgrading Semgrep from version <MASKED> to at least 1.1000.0",
       "path": "<MASKED>.json",
       "rule_id": "rules.need-to-upgrade2",
       "type": "Incompatible rule"
@@ -19,7 +19,7 @@
     {
       "code": 0,
       "level": "info",
-      "message": "Incompatible rule when running rules.retired-feature1 on <MASKED>.json:\n This rule is no longer supported by Semgrep. The last compatible version was 0.0.0. This version of Semgrep is <MASKED>",
+      "message": "Incompatible rule rules.retired-feature1:\n This rule is no longer supported by Semgrep. The last compatible version was 0.0.0. This version of Semgrep is <MASKED>",
       "path": "<MASKED>.json",
       "rule_id": "rules.retired-feature1",
       "type": "Incompatible rule"
@@ -27,7 +27,7 @@
     {
       "code": 0,
       "level": "info",
-      "message": "Incompatible rule when running rules.retired-feature2 on <MASKED>.json:\n This rule is no longer supported by Semgrep. The last compatible version was 0.0.1000. This version of Semgrep is <MASKED>",
+      "message": "Incompatible rule rules.retired-feature2:\n This rule is no longer supported by Semgrep. The last compatible version was 0.0.1000. This version of Semgrep is <MASKED>",
       "path": "<MASKED>.json",
       "rule_id": "rules.retired-feature2",
       "type": "Incompatible rule"
@@ -35,7 +35,7 @@
     {
       "code": 0,
       "level": "info",
-      "message": "Incompatible rule when running rules.retired-feature3 on <MASKED>.json:\n This rule is no longer supported by Semgrep. The last compatible version was 0.1000.0. This version of Semgrep is <MASKED>",
+      "message": "Incompatible rule rules.retired-feature3:\n This rule is no longer supported by Semgrep. The last compatible version was 0.1000.0. This version of Semgrep is <MASKED>",
       "path": "<MASKED>.json",
       "rule_id": "rules.retired-feature3",
       "type": "Incompatible rule"
@@ -43,7 +43,7 @@
     {
       "code": 0,
       "level": "info",
-      "message": "Incompatible rule when running rules.past-version-range on <MASKED>.json:\n This rule is no longer supported by Semgrep. The last compatible version was 0.8.3. This version of Semgrep is <MASKED>",
+      "message": "Incompatible rule rules.past-version-range:\n This rule is no longer supported by Semgrep. The last compatible version was 0.8.3. This version of Semgrep is <MASKED>",
       "path": "<MASKED>.json",
       "rule_id": "rules.past-version-range",
       "type": "Incompatible rule"
@@ -51,7 +51,7 @@
     {
       "code": 0,
       "level": "info",
-      "message": "Incompatible rule when running rules.future-version-range on <MASKED>.json:\n This rule requires upgrading Semgrep from version <MASKED> to at least 49.1.7",
+      "message": "Incompatible rule rules.future-version-range:\n This rule requires upgrading Semgrep from version <MASKED> to at least 49.1.7",
       "path": "<MASKED>.json",
       "rule_id": "rules.future-version-range",
       "type": "Incompatible rule"
@@ -59,7 +59,7 @@
     {
       "code": 0,
       "level": "info",
-      "message": "Incompatible rule when running rules.empty-version-range on <MASKED>.json:\n This rule requires upgrading Semgrep from version <MASKED> to at least 2.0.0",
+      "message": "Incompatible rule rules.empty-version-range:\n This rule requires upgrading Semgrep from version <MASKED> to at least 2.0.0",
       "path": "<MASKED>.json",
       "rule_id": "rules.empty-version-range",
       "type": "Incompatible rule"


### PR DESCRIPTION
The old message was confusing/wrong:
```
[INFO] Incompatible rule when running deprecated-shiftifly-operator on /var/folders/x1/ch8hs9bd4w90jdhn4j2_hkjc0000gn/T/tmpn4u0dx43.json:
 This rule requires upgrading Semgrep from version 1.38.3 to at least 23.57.0
```

New message:
```
[INFO] Incompatible rule deprecated-shiftifly-operator:
 This rule requires upgrading Semgrep from version 1.38.3 to at least 23.57.0
```

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
