### PR TITLE
osemgrep: cosmetic changes to 'osemgrep install-ci' code

### DIFF
--- a/libs/commons/Logs_helpers.ml
+++ b/libs/commons/Logs_helpers.ml
@@ -105,17 +105,17 @@ let setup_logging ~force_color ~level =
          | "application" -> ()
          | s -> failwith ("Logs library not handled: " ^ s))
 
-let with_err_tag ?(tag = " ERROR ") () =
+let err_tag ?(tag = " ERROR ") () =
   ANSITerminal.sprintf
     [ ANSITerminal.white; ANSITerminal.Bold; ANSITerminal.on_red ]
     "%s" tag
 
-let with_warn_tag ?(tag = " WARN ") () =
+let warn_tag ?(tag = " WARN ") () =
   ANSITerminal.sprintf
     [ ANSITerminal.white; ANSITerminal.Bold; ANSITerminal.on_yellow ]
     "%s" tag
 
-let with_success_tag ?(tag = " SUCCESS ") () =
+let success_tag ?(tag = " SUCCESS ") () =
   ANSITerminal.sprintf
     [ ANSITerminal.white; ANSITerminal.Bold; ANSITerminal.on_green ]
     "%s" tag

--- a/libs/commons/Logs_helpers.mli
+++ b/libs/commons/Logs_helpers.mli
@@ -33,9 +33,10 @@ val enable_logging : unit -> unit
 val setup_logging : force_color:bool -> level:Logs.level option -> unit
 
 (* TODO:
-   Logs.Error, Logs.Warning, and friends should apply the appropriate color and tag prefix (e.g. ERROR)
-   to the message. For now, we prepend the tag manually before the log message.
+   Logs.Error, Logs.Warning, and friends should apply the appropriate color
+   and tag prefix (e.g. ERROR) to the message. For now, those functions can
+   be used to prepend the colored tag manually before the log message.
 *)
-val with_err_tag : ?tag:string -> unit -> string
-val with_warn_tag : ?tag:string -> unit -> string
-val with_success_tag : ?tag:string -> unit -> string
+val err_tag : ?tag:string -> unit -> string
+val warn_tag : ?tag:string -> unit -> string
+val success_tag : ?tag:string -> unit -> string

--- a/src/osemgrep/cli/CLI.ml
+++ b/src/osemgrep/cli/CLI.ml
@@ -55,7 +55,7 @@ let known_subcommands =
     "publish";
     "scan";
     (* osemgrep-only *)
-    "install";
+    "install-ci";
     "interactive";
     "show";
   ]
@@ -124,7 +124,7 @@ let dispatch_subcommand argv =
         (* partial support, still use Pysemgrep.Fallback in it *)
         | "scan" -> Scan_subcommand.main subcmd_argv
         (* osemgrep-only: and by default! no need experimental! *)
-        | "install" -> Install_subcommand.main subcmd_argv
+        | "install-ci" -> Install_subcommand.main subcmd_argv
         | "interactive" -> Interactive_subcommand.main subcmd_argv
         | "show" -> Show_subcommand.main subcmd_argv
         (* LATER: "test" *)

--- a/src/osemgrep/cli_install/Install_CLI.mli
+++ b/src/osemgrep/cli_install/Install_CLI.mli
@@ -1,25 +1,26 @@
 (*
-   'semgrep install' command-line parsing.
+   'semgrep install-ci ...' command-line parsing.
 *)
 
-(*
-   The result of parsing a 'semgrep install' command.
-*)
-
+(* we only support Github Actions (GHA) for now *)
 type ci_env_flavor = Github [@@deriving show]
 
 type repo_kind =
-  | Dir of Fpath.t (* local directory *)
+  | Dir of Fpath.t (* local directory, usually simply "." *)
   | Repository of string * string (* owner, repo *)
 [@@deriving show]
 
+(* The result of parsing a 'semgrep install-ci ...' command *)
 type conf = {
   ci_env : ci_env_flavor;
-  logging_level : Logs.level option;
   repo : repo_kind;
+  (* To update an existing workflow (default to false).
+   * Should only be required when previous attempts only partially succeeded.
+   *)
   update : bool;
+  commons : CLI_common.conf;
 }
 [@@deriving show]
 
-val get_repo : repo_kind -> string
+(* entry point *)
 val parse_argv : string array -> conf

--- a/src/osemgrep/cli_install/Install_subcommand.ml
+++ b/src/osemgrep/cli_install/Install_subcommand.ml
@@ -1,118 +1,36 @@
+open Common
+open File.Operators
+
 (*****************************************************************************)
 (* Prelude *)
 (*****************************************************************************)
-(* This is a command to install semgrep (in CI) for a given repository *)
+(* This is a command to install semgrep in CI for the current repo
+ * or for a given repository.
+ *)
 
 (*****************************************************************************)
 (* Helpers *)
 (*****************************************************************************)
 
-let install_gh_cli () =
-  (* NOTE: This only supports mac users and we would need to direct users to
-     their own platform-specific instructions at https://github.com/cli/cli#installation
-  *)
-  let cmd = Bos.Cmd.(v "brew" % "install" % "github") in
-  match Bos.OS.Cmd.run_out cmd |> Bos.OS.Cmd.to_string with
-  | Ok _ -> Logs.app (fun m -> m "Github cli installed successfully")
-  | _ ->
-      Logs.err (fun m ->
-          m "%s Github cli failed to install" (Logs_helpers.with_err_tag ()));
-      Error.abort
-        (Printf.sprintf
-           "Please install the Github CLI manually by following the \
-            instructions at %s"
-           "https://github.com/cli/cli#installation")
-
-let test_gh_cli () : bool =
-  let cmd = Bos.Cmd.(v "command" % "-v" % "gh") in
-  match Bos.OS.Cmd.run_out cmd |> Bos.OS.Cmd.to_string with
-  | Ok _ -> true
-  | _ -> false
-
-let install_gh_cli_if_needed () =
-  let installed = test_gh_cli () in
-  match installed with
-  | true ->
-      Logs.info (fun m ->
-          m "Github CLI already installed, skipping installation")
-  | false ->
-      Logs.info (fun m -> m "Github CLI not installed, installing now");
-      install_gh_cli ()
-
-let test_gh_authed () : bool =
-  let cmd = Bos.Cmd.(v "gh" % "auth" % "status") in
-  match Bos.OS.Cmd.run_out cmd |> Bos.OS.Cmd.to_string with
-  | Ok _ -> true
-  | _ -> false
-
-let prompt_gh_auth () =
-  let cmd = Bos.Cmd.(v "gh" % "auth" % "login" % "--web") in
-  match Bos.OS.Cmd.run_out cmd |> Bos.OS.Cmd.to_string with
-  | _ -> ()
-
-let prompt_gh_auth_if_needed () =
-  let authed = test_gh_authed () in
-  match authed with
-  | true ->
-      Logs.info (fun m ->
-          m "Github CLI already logged in, skipping authentication")
-  | false ->
-      Logs.info (fun m -> m "Prompting Github CLI authentication");
-      prompt_gh_auth ()
-
-(* TODO: handle GitHub Enterprise *)
-let set_ssh_as_default () =
-  let cmd =
-    Bos.Cmd.(
-      v "gh" % "config" % "set" % "git_protocol" % "ssh" % "--host"
-      % "github.com")
-  in
-  match Bos.OS.Cmd.run_out cmd |> Bos.OS.Cmd.to_string with
-  | Ok _ -> ()
-  | _ -> Error.abort "failed to set git_protocol as ssh"
-
-(* Checks whether the repo has a semgrep workflow file already.
-   NOTE: This only checks for the presence of the file, not the contents or version
-*)
-let test_semgrep_workflow_added ~repo : bool =
-  let dir, cmd =
-    match repo with
-    | _ when Common2.dir_exists repo ->
-        ( Fpath.to_dir_path Fpath.(v repo),
-          Bos.Cmd.(v "gh" % "workflow" % "view" % "semgrep.yml") )
-    | _ ->
-        ( Bos.OS.Dir.current () |> Rresult.R.get_ok,
-          Bos.Cmd.(
-            v "gh" % "workflow" % "view" % "semgrep.yml" % "--repo" % repo) )
-  in
-  Logs.debug (fun m ->
-      m "Checking for semgrep workflow from %s" (Fpath.to_string dir));
-  let res = ref false in
-  match
-    Bos.OS.Dir.with_current dir
-      (fun () ->
-        match Bos.OS.Cmd.run_out cmd |> Bos.OS.Cmd.to_string with
-        | Ok _ -> res := true
-        | _ -> res := false)
-      ()
-  with
-  | Ok _ -> !res
-  | _ -> false
-
-let chop_origin ~branch =
-  let open Base in
+let chop_origin_if_needed branch : string =
   match branch with
   | "main"
   | "master"
   | "develop" ->
+      (* NOTE: we use develop as the default branch for the workflow file as
+       * it is the default branch for the semgrep repo
+       *)
       "develop"
-      (* NOTE: we use develop as the default branch for the workflow file as it is the default branch for the semgrep repo *)
-  | _ when String.is_prefix ~prefix:"origin/" branch ->
-      String.chop_prefix_exn ~prefix:"origin/" branch
+  (* let's chop the origin *)
+  | _ when Base.String.is_prefix ~prefix:"origin/" branch ->
+      Base.String.chop_prefix_exn ~prefix:"origin/" branch
   | _ -> branch
 
-let sprint_workflow ~default_branch:branch =
-  let branch = chop_origin ~branch in
+(* coupling: this should be roughly the same config than the one in
+ * https://semgrep.dev/docs/semgrep-ci/sample-ci-configs/#github-actions
+ *)
+let gha_semgrep_ci_workflow ~default_branch : string =
+  let branch = chop_origin_if_needed default_branch in
   (* Actual branch name if not from main list *)
   Printf.sprintf
     {|
@@ -144,12 +62,102 @@ jobs:
 |}
     branch
 
+(* arbitrary name where we do our work *)
+let get_new_branch () : string =
+  let version = "v1" in
+  Printf.sprintf "semgrep/install-ci-%s" version
+
+let mkdir_if_needed path : unit =
+  if not (Sys.file_exists path) then Unix.mkdir path 0o777
+
+let get_repo (repo : Install_CLI.repo_kind) : string =
+  match repo with
+  | Dir v -> Fpath.to_dir_path v |> Fpath.rem_empty_seg |> Fpath.to_string
+  | Repository (owner, repo) -> spf "%s/%s" owner repo
+
+(*****************************************************************************)
+(* gh (github CLI) setup *)
+(*****************************************************************************)
+(* We're using gh to automatically create a PR for the user, to setup
+ * the SEMGREP_APP_TOKEN secret in github, and more.
+ *)
+
+let install_gh_cli () : unit =
+  (* NOTE: This only supports mac users and we would need to direct users to
+     their own platform-specific instructions at https://github.com/cli/cli#installation
+  *)
+  let cmd = Bos.Cmd.(v "brew" % "install" % "github") in
+  match Bos.OS.Cmd.run_out cmd |> Bos.OS.Cmd.to_string with
+  | Ok _ -> Logs.app (fun m -> m "Github cli installed successfully")
+  | _ ->
+      Logs.err (fun m ->
+          m "%s Github cli failed to install" (Logs_helpers.err_tag ()));
+      (* TODO? we could instead just remove the last step of 'install-ci'
+       * and let the user commit the workflow by himself?
+       *)
+      Error.abort
+        (Printf.sprintf
+           "Please install the Github CLI manually by following the \
+            instructions at %s"
+           "https://github.com/cli/cli#installation")
+
+let gh_cli_exists () : bool =
+  (* 'command' can be used to test the presence of another command
+   * see https://askubuntu.com/questions/512770/what-is-the-bash-command-command
+   * alt: run gh --version and check for exit code
+   *)
+  let cmd = Bos.Cmd.(v "command" % "-v" % "gh") in
+  match Bos.OS.Cmd.run_out cmd |> Bos.OS.Cmd.to_string with
+  | Ok _ -> true
+  | _ -> false
+
+let install_gh_cli_if_needed () : unit =
+  if gh_cli_exists () then
+    Logs.info (fun m -> m "Github CLI already installed, skipping installation")
+  else (
+    Logs.info (fun m -> m "Github CLI not installed, installing now");
+    install_gh_cli ())
+
+let gh_authed () : bool =
+  let cmd = Bos.Cmd.(v "gh" % "auth" % "status") in
+  match Bos.OS.Cmd.run_out cmd |> Bos.OS.Cmd.to_string with
+  | Ok _ -> true
+  | _ -> false
+
+let prompt_gh_auth () : unit =
+  let cmd = Bos.Cmd.(v "gh" % "auth" % "login" % "--web") in
+  match Bos.OS.Cmd.run_out cmd |> Bos.OS.Cmd.to_string with
+  | _ -> ()
+
+let prompt_gh_auth_if_needed () : unit =
+  if gh_authed () then
+    Logs.info (fun m ->
+        m "Github CLI already logged in, skipping authentication")
+  else (
+    Logs.info (fun m -> m "Prompting Github CLI authentication");
+    prompt_gh_auth ())
+
+(* TODO: handle GitHub Enterprise *)
+let set_ssh_as_default () : unit =
+  let cmd =
+    Bos.Cmd.(
+      v "gh" % "config" % "set" % "git_protocol" % "ssh" % "--host"
+      % "github.com")
+  in
+  match Bos.OS.Cmd.run_out cmd |> Bos.OS.Cmd.to_string with
+  | Ok _ -> ()
+  | _ -> Error.abort "failed to set git_protocol as ssh"
+
+(*****************************************************************************)
+(* gh use *)
+(*****************************************************************************)
+
 (* NOTE: we use the gh repo clone subcommand over
    the regular git clone as the subcommand allows for
    both OWNER/REPO and cannonical GitHub URLs as arguments
    to clone the repo.
 *)
-let clone_repo ~repo =
+let clone_repo ~repo : unit =
   let cmd =
     Bos.Cmd.(v "gh" % "repo" % "clone" % repo % "--" % "--depth" % "1")
   in
@@ -157,71 +165,13 @@ let clone_repo ~repo =
   | Ok _ -> ()
   | _ -> Error.abort (Printf.sprintf "failed to clone remote repo: %s" repo)
 
-let clone_repo_to ~repo ~dst =
+let clone_repo_to ~repo ~dst : unit =
   match Bos.OS.Dir.with_current dst (fun () -> clone_repo ~repo) () with
-  | Ok _ ->
-      Logs.info (fun m -> m "Cloned repo %s to %s." repo (Fpath.to_string dst))
-  | _ ->
-      Logs.warn (fun m ->
-          m "Failed to clone repo %s to %s." repo (Fpath.to_string dst))
+  | Ok _ -> Logs.info (fun m -> m "Cloned repo %s to %s." repo !!dst)
+  | _ -> Logs.warn (fun m -> m "Failed to clone repo %s to %s." repo !!dst)
 
-let get_default_branch () =
-  let cmd =
-    Bos.Cmd.(v "git" % "symbolic-ref" % "refs/remotes/origin/HEAD" % "--short")
-  in
-  match Bos.OS.Cmd.run_out cmd |> Bos.OS.Cmd.to_string with
-  | Ok s -> s
-  | _ ->
-      Logs.warn (fun m -> m "Failed to get default branch");
-      "origin/main"
-
-let get_default_branch_in ~dst =
-  let res = ref "origin/main" in
-  match
-    Bos.OS.Dir.with_current dst (fun () -> res := get_default_branch ()) ()
-  with
-  | Ok _ -> !res
-  | _ ->
-      Logs.warn (fun m ->
-          m "Failed to get default branch in %s, defaulting to %s"
-            (Fpath.to_string dst) !res);
-      !res
-
-let add_all_to_git () =
-  let cmd = Bos.Cmd.(v "git" % "add" % ".") in
-  match Bos.OS.Cmd.run_out cmd |> Bos.OS.Cmd.to_string with
-  | Ok _ -> ()
-  | _ -> Error.abort "Failed to add files to git"
-
-let get_new_branch () =
-  let version = "v1" in
-  Printf.sprintf "semgrep/install-ci-%s" version
-
-let git_push () =
-  let branch = get_new_branch () in
-  let cmd = Bos.Cmd.(v "git" % "push" % "--set-upstream" % "origin" % branch) in
-  match Bos.OS.Cmd.run_out cmd |> Bos.OS.Cmd.to_string with
-  | Ok _ -> ()
-  | _ ->
-      Logs.warn (fun m -> m "Failed to push to branch %s" branch);
-      Error.abort
-        (Printf.sprintf "Failed to push to branch %s. Please push manually"
-           branch)
-
-let git_commit () =
-  let cmd =
-    Bos.Cmd.(
-      v "git" % "commit" % "-m" % "Add semgrep workflow"
-      % "--author=\"Semgrep CI Installer <support@semgrep.com>\"")
-  in
-  match Bos.OS.Cmd.run_out cmd |> Bos.OS.Cmd.to_string with
-  | Ok _ -> ()
-  | _ ->
-      Logs.warn (fun m -> m "Failed to commit changes to current branch!");
-      Error.abort "Failed to commit changes. Please commit manually"
-
-let create_pr ~default_branch:branch =
-  let branch = chop_origin ~branch in
+let create_pr ~default_branch:branch : unit =
+  let branch = chop_origin_if_needed branch in
   let cmd =
     Bos.Cmd.(
       v "gh" % "pr" % "create" % "--title" % "Add Semgrep workflow" % "--body"
@@ -237,7 +187,7 @@ This PR enables Semgrep scans with your repository.
       Logs.warn (fun m -> m "Failed to create PR!");
       Error.abort "Failed to create PR. Please create manually"
 
-let merge_pr () =
+let merge_pr () : unit =
   let cmd =
     Bos.Cmd.(
       v "gh" % "pr" % "merge" % "--merge" % "--subject" % "Add Semgrep workflow"
@@ -249,38 +199,7 @@ let merge_pr () =
       Logs.warn (fun m -> m "Failed to merge PR!");
       Error.abort "Failed to merge PR. Please merge manually"
 
-let mkdir path = if not (Sys.file_exists path) then Unix.mkdir path 0o777
-
-(* NOTE: If the repo is not checked out locally,
-   we first clone the repo to a temporary directory,
-   and then return the path to the cloned repo.
-*)
-let prep_repo ~repo =
-  let dir =
-    match repo with
-    | _ when Common2.dir_exists repo -> Fpath.v repo
-    | _ ->
-        let tmp_dir =
-          Filename.concat
-            (Filename.get_temp_dir_name ())
-            (Printf.sprintf "semgrep_install_ci_%6X" (Random.int 0xFFFFFF))
-        in
-        mkdir tmp_dir;
-        clone_repo_to ~repo ~dst:(Fpath.v tmp_dir);
-        (* NOTE: when we clone we get a directory with the repo name.
-           we need to strip the owner from the repo name if it is present
-           and then join the tmp_dir with the repo name to get the full path
-        *)
-        let repo =
-          match String.split_on_char '/' repo with
-          | [ _; repo ] -> repo
-          | _ -> repo
-        in
-        Fpath.v (Filename.concat tmp_dir repo)
-  in
-  dir
-
-let test_semgrep_gh_secret ~git_dir:dir =
+let semgrep_app_token_secret_exists ~git_dir:dir : bool =
   let cmd = Bos.Cmd.(v "gh" % "secret" % "list" % "-a" % "actions") in
   match
     Bos.OS.Dir.with_current dir
@@ -291,67 +210,168 @@ let test_semgrep_gh_secret ~git_dir:dir =
               (fun line -> String.starts_with ~prefix:"SEMGREP_APP_TOKEN" line)
               lines
         | _ ->
-            Logs.warn (fun m ->
-                m "Failed to list secrets for %s" (Fpath.to_string dir));
+            Logs.warn (fun m -> m "Failed to list secrets for %s" !!dir);
             Error.abort
               "Failed to check for SEMGREP_APP_TOKEN. Please add it manually")
       ()
   with
-  | Ok _ -> true
+  (* bugfix: was Ok _ -> true, but we should return the boolean instead *)
+  | Ok b -> b
   | _ -> false
 
-let add_semgrep_gh_secret ~git_dir:dir ~token =
+let add_semgrep_gh_secret ~git_dir:dir ~token : unit =
   let cmd =
     Bos.Cmd.(
       v "gh" % "secret" % "set" % "SEMGREP_APP_TOKEN" % "-a" % "actions"
       % "--body" % token)
   in
-  match
-    Bos.OS.Dir.with_current dir
-      (fun () ->
-        match Bos.OS.Cmd.run_out cmd |> Bos.OS.Cmd.to_string with
-        | Ok _ -> Logs.debug (fun m -> m "Set SEMGREP_APP_TOKEN=%s" token)
-        | _ ->
-            Logs.warn (fun m ->
-                m "Failed to set SEMGREP_APP_TOKEN for %s" (Fpath.to_string dir));
-            Error.abort
-              "Failed to set SEMGREP_APP_TOKEN. Please add it manually")
-      ()
-  with
-  | Ok _ -> ()
-  | _ -> ()
+  Bos.OS.Dir.with_current dir
+    (fun () ->
+      match Bos.OS.Cmd.run_out cmd |> Bos.OS.Cmd.to_string with
+      | Ok _ -> Logs.debug (fun m -> m "Set SEMGREP_APP_TOKEN=%s" token)
+      | _ ->
+          Logs.warn (fun m -> m "Failed to set SEMGREP_APP_TOKEN for %s" !!dir);
+          Error.abort "Failed to set SEMGREP_APP_TOKEN. Please add it manually")
+    ()
+  |> ignore
 
-let write_workflow_file ~git_dir:dir =
+(*****************************************************************************)
+(* Git calls *)
+(*****************************************************************************)
+(* TODO? add in Git_wrapper.ml instead? *)
+
+let get_default_branch () : string =
+  let cmd =
+    Bos.Cmd.(v "git" % "symbolic-ref" % "refs/remotes/origin/HEAD" % "--short")
+  in
+  match Bos.OS.Cmd.run_out cmd |> Bos.OS.Cmd.to_string with
+  | Ok s -> s
+  | _ ->
+      Logs.warn (fun m -> m "Failed to get default branch");
+      "origin/main"
+
+let get_default_branch_in ~dst : string =
+  let default = "origin/main" in
+  let res = Bos.OS.Dir.with_current dst (fun () -> get_default_branch ()) () in
+  match res with
+  | Ok branch -> branch
+  | _ ->
+      Logs.warn (fun m ->
+          m "Failed to get default branch in %s, defaulting to %s" !!dst default);
+      default
+
+let add_all_to_git () : unit =
+  let cmd = Bos.Cmd.(v "git" % "add" % ".") in
+  match Bos.OS.Cmd.run_out cmd |> Bos.OS.Cmd.to_string with
+  | Ok _ -> ()
+  | _ -> Error.abort "Failed to add files to git"
+
+let git_push () : unit =
+  let branch = get_new_branch () in
+  let cmd = Bos.Cmd.(v "git" % "push" % "--set-upstream" % "origin" % branch) in
+  match Bos.OS.Cmd.run_out cmd |> Bos.OS.Cmd.to_string with
+  | Ok _ -> ()
+  | _ ->
+      Logs.warn (fun m -> m "Failed to push to branch %s" branch);
+      Error.abort
+        (Printf.sprintf "Failed to push to branch %s. Please push manually"
+           branch)
+
+let git_commit () : unit =
+  let cmd =
+    Bos.Cmd.(
+      v "git" % "commit" % "-m" % "Add semgrep workflow"
+      % "--author=\"Semgrep CI Installer <support@semgrep.com>\"")
+  in
+  match Bos.OS.Cmd.run_out cmd |> Bos.OS.Cmd.to_string with
+  | Ok _ -> ()
+  | _ ->
+      Logs.warn (fun m -> m "Failed to commit changes to current branch!");
+      Error.abort "Failed to commit changes. Please commit manually"
+
+(*****************************************************************************)
+(* GHA workflow helpers *)
+(*****************************************************************************)
+
+(* Checks whether the repo has a semgrep workflow file already.
+ * NOTE: This only checks for the presence of the file, not the contents
+ * or version
+ *)
+let semgrep_workflow_exists ~repo : bool =
+  let dir, cmd =
+    if Common2.dir_exists repo then
+      ( Fpath.to_dir_path Fpath.(v repo),
+        Bos.Cmd.(v "gh" % "workflow" % "view" % "semgrep.yml") )
+    else
+      ( Bos.OS.Dir.current () |> Rresult.R.get_ok,
+        Bos.Cmd.(v "gh" % "workflow" % "view" % "semgrep.yml" % "--repo" % repo)
+      )
+  in
+  Logs.debug (fun m -> m "Checking for semgrep workflow from %s" !!dir);
+  let res =
+    Bos.OS.Dir.with_current dir
+      (fun () -> Bos.OS.Cmd.run_out cmd |> Bos.OS.Cmd.to_string)
+      ()
+  in
+  match res with
+  | Ok (Ok _) -> true
+  | _else_ -> false
+
+(* NOTE: If the repo is not checked out locally,
+   we first clone the repo to a temporary directory,
+   and then return the path to the cloned repo.
+*)
+let prep_repo (repo : string) : Fpath.t =
+  if Common2.dir_exists repo then Fpath.v repo
+  else
+    let tmp_dir =
+      Filename.concat
+        (Filename.get_temp_dir_name ())
+        (Printf.sprintf "semgrep_install_ci_%6X" (Random.int 0xFFFFFF))
+    in
+    mkdir_if_needed tmp_dir;
+    clone_repo_to ~repo ~dst:(Fpath.v tmp_dir);
+    (* NOTE: when we clone we get a directory with the repo name.
+       we need to strip the owner from the repo name if it is present
+       and then join the tmp_dir with the repo name to get the full path
+    *)
+    let repo =
+      match String.split_on_char '/' repo with
+      | [ _; repo ] -> repo
+      | _ -> repo
+    in
+    Fpath.v (Filename.concat tmp_dir repo)
+
+let write_workflow_file ~git_dir:dir : unit =
   let commit = get_default_branch_in ~dst:dir in
   Logs.debug (fun m -> m "Using '%s' as default branch." commit);
-  match
+  let res =
     Bos.OS.Dir.with_current dir
       (fun () ->
         Git_wrapper.run_with_worktree ~commit
           ~branch:(Some (get_new_branch ()))
           (fun () ->
             let github_dir = ".github" in
-            mkdir github_dir;
+            mkdir_if_needed github_dir;
             let workflow_dir = Filename.concat github_dir "workflows" in
-            mkdir workflow_dir;
+            mkdir_if_needed workflow_dir;
             let file = Filename.concat workflow_dir "semgrep.yml" in
             let oc = open_out_bin file in
-            output_string oc (sprint_workflow ~default_branch:commit);
+            output_string oc (gha_semgrep_ci_workflow ~default_branch:commit);
             close_out oc;
             Logs.info (fun m -> m "Wrote semgrep workflow to %s" file);
-            let cwd =
-              Bos.OS.Dir.current () |> Rresult.R.get_ok |> Fpath.to_string
-            in
+            let cwd = Bos.OS.Dir.current () |> Rresult.R.get_ok in
             Logs.info (fun m ->
-                m "Preparing to run git operations in dir: %s" cwd);
+                m "Preparing to run git operations in dir: %s" !!cwd);
             add_all_to_git ();
             git_commit ();
             git_push ();
             create_pr ~default_branch:commit;
             merge_pr ()))
       ()
-  with
-  | Ok _ -> ()
+  in
+  match res with
+  | Ok () -> ()
   | _ -> Logs.err (fun m -> m "Failed to write workflow file")
 
 (* Basic Outline:
@@ -360,37 +380,25 @@ let write_workflow_file ~git_dir:dir =
    2. Commit and push changes to the repo
    3. Open a PR to the repo to merge the changes
 *)
-let add_semgrep_workflow ~repo ~token ~update =
-  let added = test_semgrep_workflow_added ~repo in
-  match (added, update) with
-  | true, false ->
-      Logs.info (fun m -> m "Semgrep workflow already present, skipping")
-  | _ ->
-      Logs.info (fun m -> m "Preparing Semgrep workflow for %s" repo);
-      let dir = prep_repo ~repo in
-      write_workflow_file ~git_dir:dir;
-      let added = test_semgrep_gh_secret ~git_dir:dir in
-      let () =
-        match (added, update) with
-        | true, false ->
-            Logs.info (fun m -> m "Semgrep secret already present, skipping")
-        | _ -> add_semgrep_gh_secret ~git_dir:dir ~token
-      in
-      Logs.info (fun m -> m "Semgrep workflow added to %s" repo);
-      ()
+let add_semgrep_workflow ~repo ~token ~update : unit =
+  if semgrep_workflow_exists ~repo && not update then
+    Logs.info (fun m -> m "Semgrep workflow already present, skipping")
+  else (
+    Logs.info (fun m -> m "Preparing Semgrep workflow for %s" repo);
+    let dir = prep_repo repo in
+    write_workflow_file ~git_dir:dir;
+    if semgrep_app_token_secret_exists ~git_dir:dir && not update then
+      Logs.info (fun m -> m "Semgrep secret already present, skipping")
+    else add_semgrep_gh_secret ~git_dir:dir ~token;
+    Logs.info (fun m -> m "Semgrep workflow added to %s" repo))
 
 (*****************************************************************************)
 (* Main logic *)
 (*****************************************************************************)
 
 let run (conf : Install_CLI.conf) : Exit_code.t =
-  CLI_common.setup_logging ~force_color:true ~level:conf.logging_level;
-  Logs.debug (fun m ->
-      m "Running install command with env %s"
-        (Install_CLI.show_ci_env_flavor conf.ci_env));
-  Logs.debug (fun m ->
-      m "Running with repo %s" (Install_CLI.get_repo conf.repo));
-  Logs.debug (fun m -> m "--update: %b" conf.update);
+  CLI_common.setup_logging ~force_color:true ~level:conf.commons.logging_level;
+  Logs.debug (fun m -> m "conf = %s" (Install_CLI.show_conf conf));
   let settings = Semgrep_settings.load () in
   let api_token = settings.Semgrep_settings.api_token in
   match api_token with
@@ -398,19 +406,19 @@ let run (conf : Install_CLI.conf) : Exit_code.t =
       Logs.err (fun m ->
           m
             "%s You are not logged in! Run `semgrep login` before using \
-             `semgrep install`"
-            (Logs_helpers.with_err_tag ()));
+             `semgrep install-ci`"
+            (Logs_helpers.err_tag ()));
       Exit_code.fatal
   | Some token ->
+      (* setup gh *)
+      install_gh_cli_if_needed ();
+      prompt_gh_auth_if_needed ();
+      set_ssh_as_default ();
+      (* let's go! *)
+      add_semgrep_workflow ~repo:(get_repo conf.repo) ~token ~update:conf.update;
       Logs.app (fun m ->
-          install_gh_cli_if_needed ();
-          prompt_gh_auth_if_needed ();
-          set_ssh_as_default ();
-          add_semgrep_workflow
-            ~repo:(Install_CLI.get_repo conf.repo)
-            ~token ~update:conf.update;
           m "%s Installed semgrep workflow for this repository"
-            (Logs_helpers.with_success_tag ()));
+            (Logs_helpers.success_tag ()));
       Exit_code.ok
 
 (*****************************************************************************)

--- a/src/osemgrep/cli_install/Install_subcommand.mli
+++ b/src/osemgrep/cli_install/Install_subcommand.mli
@@ -1,6 +1,15 @@
 (*
-   Install semgrep (in CI) for a given repository
+   Install semgrep in CI for a given repository.
 *)
 
+(*
+   Parse a semgrep-install-ci command, execute it and exit.
+
+   Usage: main [| "semgrep-install-ci"; ... |]
+
+   This function returns an exit code to be passed to the 'exit' function.
+*)
 val main : string array -> Exit_code.t
+
+(* internal *)
 val run : Install_CLI.conf -> Exit_code.t

--- a/src/osemgrep/cli_login/Login_subcommand.ml
+++ b/src/osemgrep/cli_login/Login_subcommand.ml
@@ -141,8 +141,7 @@ Plus, you can manage your rules and code findings with Semgrep Cloud Platform.
                        connect to Semgrep servers. Please check your internet \
                        connection and try again. If this issue persists, \
                        please reach out to Semgrep support at @{<cyan;ul>%s@}"
-                      (Logs_helpers.with_err_tag ())
-                      support_url
+                      (Logs_helpers.err_tag ()) support_url
                   in
                   Logs.err (fun m -> m "%s" msg);
                   Exit_code.fatal
@@ -172,7 +171,7 @@ Plus, you can manage your rules and code findings with Semgrep Cloud Platform.
                                   m
                                     "%s Successfully logged in as %s! You can \
                                      now run `semgrep ci` to start a scan."
-                                    (Logs_helpers.with_success_tag ())
+                                    (Logs_helpers.success_tag ())
                                     user_name);
                               Exit_code.ok)
                             else Exit_code.fatal
@@ -208,8 +207,8 @@ Plus, you can manage your rules and code findings with Semgrep Cloud Platform.
                              (status code %d).\n\
                              Please try again or reach out to Semgrep support \
                              at @{<cyan;ul>%s@}"
-                            (Logs_helpers.with_err_tag ())
-                            (Uri.to_string url) status_code support_url
+                            (Logs_helpers.err_tag ()) (Uri.to_string url)
+                            status_code support_url
                         in
                         Logs.err (fun m -> m "%s" msg);
                         Logs.info (fun m -> m "HTTP error: %s" err);
@@ -223,7 +222,7 @@ Plus, you can manage your rules and code findings with Semgrep Cloud Platform.
           m
             "%s You're already logged in. Use `semgrep logout` to log out \
              first, and then you can login with a new access token."
-            (Logs_helpers.with_err_tag ()));
+            (Logs_helpers.err_tag ()));
       Exit_code.fatal
 (*****************************************************************************)
 (* Entry point *)

--- a/src/osemgrep/cli_login/Logout_subcommand.ml
+++ b/src/osemgrep/cli_login/Logout_subcommand.ml
@@ -20,14 +20,14 @@ let run (conf : Login_CLI.conf) : Exit_code.t =
   | None ->
       Logs.app (fun m ->
           m "%s You are not logged in! This command had no effect."
-            (Logs_helpers.with_warn_tag ()));
+            (Logs_helpers.warn_tag ()));
       Exit_code.ok
   | Some _ ->
       let settings = Semgrep_settings.{ settings with api_token = None } in
       if Semgrep_settings.save settings then (
         Logs.app (fun m ->
             m "%s Logged out! Log back in with `semgrep login`"
-              (Logs_helpers.with_success_tag ()));
+              (Logs_helpers.success_tag ()));
         Exit_code.ok)
       else Exit_code.fatal
 


### PR DESCRIPTION
First rename it to 'semgrep install-ci' then did
lots of small cosmetic changes to make the code
looks more like idiomatic OCaml code.

test plan:
make core


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)