### PR TITLE
osemgrep: finish unify core_match_trace with cli_match_trace

### DIFF
--- a/cli/src/semgrep/rule_match.py
+++ b/cli/src/semgrep/rule_match.py
@@ -22,7 +22,6 @@ from attrs import frozen
 
 import semgrep.output_from_core as core
 import semgrep.semgrep_interfaces.semgrep_output_v1 as out
-import semgrep.util as util
 from semgrep.constants import NOSEM_INLINE_COMMENT_RE
 from semgrep.constants import RuleScanSource
 from semgrep.constants import RuleSeverity
@@ -449,80 +448,7 @@ class RuleMatch:
 
     @property
     def dataflow_trace(self) -> Optional[core.CliMatchDataflowTrace]:
-        # TODO: once semgrep-core generates directly the right content, we can
-        # just remove all those functions below as loc[1] will contain the right thing instead
-        # of "??" currently,
-        # and just return self.match.extra.dataflow_trace
-
-        # We need this to quickly get augment a Location with the contents of the location
-        # Convenient to just have it as a separate function
-        def translate_loc(loc: Tuple[core.Location, str]) -> Tuple[core.Location, str]:
-            location = loc[0]
-            with open(location.path.value, errors="replace") as fd:
-                content = util.read_range(
-                    fd, location.start.offset, location.end.offset
-                )
-            return (location, content)
-
-        def translate_core_match_call_trace(
-            call_trace: core.CliMatchCallTrace,
-        ) -> core.CliMatchCallTrace:
-            if isinstance(call_trace.value, core.CliLoc):
-                return core.CliMatchCallTrace(
-                    core.CliLoc(translate_loc(call_trace.value.value))
-                )
-            elif isinstance(call_trace.value, core.CliCall):
-                intermediate_vars = [
-                    core.CliMatchIntermediateVar(
-                        *translate_loc((var.location, var.content))
-                    )
-                    for var in call_trace.value.value[1]
-                ]
-
-                return core.CliMatchCallTrace(
-                    core.CliCall(
-                        (
-                            translate_loc(call_trace.value.value[0]),
-                            intermediate_vars,
-                            translate_core_match_call_trace(call_trace.value.value[2]),
-                        )
-                    )
-                )
-
-        dataflow_trace = self.match.extra.dataflow_trace
-        if dataflow_trace:
-            taint_source = None
-            intermediate_vars = None
-            taint_sink = None
-            if dataflow_trace.taint_source:
-                taint_source = translate_core_match_call_trace(
-                    dataflow_trace.taint_source
-                )
-            if dataflow_trace.intermediate_vars:
-                intermediate_vars = []
-                for var in dataflow_trace.intermediate_vars:
-                    location = var.location
-                    # TODO avoid repeated opens in the common case (i.e. not
-                    # DeepSemgrep) where all of these locations are in the same
-                    # file?
-                    with open(location.path.value, errors="replace") as fd:
-                        content = util.read_range(
-                            fd, location.start.offset, location.end.offset
-                        )
-                    intermediate_vars.append(
-                        core.CliMatchIntermediateVar(
-                            location=location,
-                            content=content,
-                        )
-                    )
-            if dataflow_trace.taint_sink:
-                taint_sink = translate_core_match_call_trace(dataflow_trace.taint_sink)
-            return core.CliMatchDataflowTrace(
-                taint_source=taint_source,
-                intermediate_vars=intermediate_vars,
-                taint_sink=taint_sink,
-            )
-        return None
+        return self.match.extra.dataflow_trace
 
     @property
     def exposure_type(self) -> Optional[str]:

--- a/src/osemgrep/cli_scan/Output.ml
+++ b/src/osemgrep/cli_scan/Output.ml
@@ -118,7 +118,8 @@ let dispatch_output_format (output_format : Output_format.t)
                     * contains a string, not a string list.
                     *)
                    match
-                     Output_utils.lines_of_file (start, end_) (Fpath.v path)
+                     Output_utils.lines_of_file_at_range (start, end_)
+                       (Fpath.v path)
                    with
                    | [] -> ""
                    | x :: _ -> x (* TOPORT rstrip? *)

--- a/src/osemgrep/reporting/Cli_json_output.ml
+++ b/src/osemgrep/reporting/Cli_json_output.ml
@@ -64,7 +64,7 @@ let interpolate_metavars (text : string) (metavars : metavars) (file : filename)
           * name in semgrep_output_v1.atd *)
          let (v : Out.metavar_value) = mval in
          let content =
-           lazy (Output_utils.contents_of_file (v.start, v.end_) file)
+           lazy (Output_utils.contents_of_file (v.start, v.end_) (Fpath.v file))
          in
          text
          (* first value($X), and then $X *)

--- a/src/osemgrep/reporting/Cli_json_output.ml
+++ b/src/osemgrep/reporting/Cli_json_output.ml
@@ -64,7 +64,9 @@ let interpolate_metavars (text : string) (metavars : metavars) (file : filename)
           * name in semgrep_output_v1.atd *)
          let (v : Out.metavar_value) = mval in
          let content =
-           lazy (Output_utils.contents_of_file (v.start, v.end_) (Fpath.v file))
+           lazy
+             (Output_utils.content_of_file_at_range (v.start, v.end_)
+                (Fpath.v file))
          in
          text
          (* first value($X), and then $X *)
@@ -329,8 +331,10 @@ let cli_match_of_core_match (hrules : Rule.hrules) (m : Out.core_match) :
         | None -> `Assoc []
         | Some json -> JSON.to_yojson json
       in
+      (* TODO? at this point why not using content_of_file_at_range since
+       * we concatenate the lines after? *)
       let lines =
-        Output_utils.lines_of_file (start, end_) (Fpath.v path)
+        Output_utils.lines_of_file_at_range (start, end_) (Fpath.v path)
         |> String.concat "\n"
       in
       {

--- a/src/reporting/Core_json_output.ml
+++ b/src/reporting/Core_json_output.ml
@@ -175,7 +175,7 @@ let metavars startp_of_match_range (s, mval) =
  * pysemgrep).
  *)
 let content_of_loc (loc : Out.location) : string =
-  Output_utils.contents_of_file (loc.start, loc.end_) (Fpath.v loc.path)
+  Output_utils.content_of_file_at_range (loc.start, loc.end_) (Fpath.v loc.path)
 
 let token_to_intermediate_var token : Out.cli_match_intermediate_var option =
   let* location = Output_utils.tokens_to_single_loc [ token ] in

--- a/src/reporting/Core_json_output.ml
+++ b/src/reporting/Core_json_output.ml
@@ -174,12 +174,13 @@ let metavars startp_of_match_range (s, mval) =
  * directly from semgrep-core (to avoid some boilerplate code in
  * pysemgrep).
  *)
-let todo_content_for_location = "??"
+let content_of_loc (loc : Out.location) : string =
+  Output_utils.contents_of_file (loc.start, loc.end_) (Fpath.v loc.path)
 
 let token_to_intermediate_var token : Out.cli_match_intermediate_var option =
   let* location = Output_utils.tokens_to_single_loc [ token ] in
   Some
-    ({ Out.location; content = todo_content_for_location }
+    ({ Out.location; content = content_of_loc location }
       : Out.cli_match_intermediate_var)
 
 let tokens_to_intermediate_vars tokens =
@@ -190,14 +191,13 @@ let rec taint_call_trace (trace : PM.taint_call_trace) :
   match trace with
   | Toks toks ->
       let* loc = Output_utils.tokens_to_single_loc toks in
-      Some (Out.CliLoc (loc, todo_content_for_location))
+      Some (Out.CliLoc (loc, content_of_loc loc))
   | Call { call_trace; intermediate_vars; call_toks } ->
-      let* location = Output_utils.tokens_to_single_loc call_toks in
+      let* loc = Output_utils.tokens_to_single_loc call_toks in
       let intermediate_vars = tokens_to_intermediate_vars intermediate_vars in
       let* call_trace = taint_call_trace call_trace in
       Some
-        (Out.CliCall
-           ((location, todo_content_for_location), intermediate_vars, call_trace))
+        (Out.CliCall ((loc, content_of_loc loc), intermediate_vars, call_trace))
 
 let taint_trace_to_dataflow_trace (traces : PM.taint_trace_item list) :
     Out.cli_match_dataflow_trace =

--- a/src/reporting/Output_utils.ml
+++ b/src/reporting/Output_utils.ml
@@ -33,8 +33,9 @@ let first_and_last = function
  * TODO: could be moved to another helper module.
  *
  * Should we use a faster implementation, using a cache
- * to avoid rereading the same file again and again? probably fast
- * enough like this thanks to OS buffer cache.
+ * to avoid rereading the same file again and again?
+ * Use weak hashtable or LRU cache?
+ * Or maybe fast enough like this thanks to OS buffer cache?
  *
  * python: # 'lines' already contains '\n' at the end of each line
  *   lines="".join(rule_match.lines).rstrip(),
@@ -50,10 +51,9 @@ let lines_of_file (range : position * position) (file : Fpath.t) : string list =
  * to ignore non-utf8 bytes.
  * See https://stackoverflow.com/a/56441652.
  *)
-let contents_of_file (range : position * position) (file : Common.filename) :
-    string =
+let contents_of_file (range : position * position) (file : Fpath.t) : string =
   let start, end_ = range in
-  let str = Common.read_file file in
+  let str = File.read_file file in
   String.sub str start.offset (end_.offset - start.offset)
   [@@profiling]
 

--- a/src/reporting/Output_utils.ml
+++ b/src/reporting/Output_utils.ml
@@ -40,7 +40,8 @@ let first_and_last = function
  * python: # 'lines' already contains '\n' at the end of each line
  *   lines="".join(rule_match.lines).rstrip(),
  *)
-let lines_of_file (range : position * position) (file : Fpath.t) : string list =
+let lines_of_file_at_range (range : position * position) (file : Fpath.t) :
+    string list =
   let start, end_ = range in
   File.lines_of_file (start.line, end_.line) file
   [@@profiling]
@@ -51,7 +52,8 @@ let lines_of_file (range : position * position) (file : Fpath.t) : string list =
  * to ignore non-utf8 bytes.
  * See https://stackoverflow.com/a/56441652.
  *)
-let contents_of_file (range : position * position) (file : Fpath.t) : string =
+let content_of_file_at_range (range : position * position) (file : Fpath.t) :
+    string =
   let start, end_ = range in
   let str = File.read_file file in
   String.sub str start.offset (end_.offset - start.offset)

--- a/src/reporting/Output_utils.mli
+++ b/src/reporting/Output_utils.mli
@@ -5,13 +5,15 @@
 (* internal function used for the 'lines:' field in the JSON output
  * but also now in Output.ml for the Emacs output.
  *)
-val lines_of_file :
+val lines_of_file_at_range :
   Semgrep_output_v1_t.position * Semgrep_output_v1_t.position ->
   Fpath.t ->
   string list
 
-(* for now used only to interpolate metavars in the 'message:' field *)
-val contents_of_file :
+(* used to interpolate metavars in the 'message:' field and
+ * for the dataflow call traces.
+ *)
+val content_of_file_at_range :
   Semgrep_output_v1_t.position * Semgrep_output_v1_t.position ->
   Fpath.t ->
   string

--- a/src/reporting/Output_utils.mli
+++ b/src/reporting/Output_utils.mli
@@ -13,7 +13,7 @@ val lines_of_file :
 (* for now used only to interpolate metavars in the 'message:' field *)
 val contents_of_file :
   Semgrep_output_v1_t.position * Semgrep_output_v1_t.position ->
-  Common.filename ->
+  Fpath.t ->
   string
 
 val position_of_token_location : Tok.location -> Semgrep_output_v1_t.position


### PR DESCRIPTION
This finishes #8596 and removes more python code.

test plan:
make e2e


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)