### PR TITLE
osemgrep: update to latest interface with simpler skipped_target

### DIFF
--- a/cli/src/semgrep/output.py
+++ b/cli/src/semgrep/output.py
@@ -440,7 +440,7 @@ class OutputHandler:
 
     def _build_output(self) -> str:
         # CliOutputExtra members
-        cli_paths = out.CliPaths(
+        cli_paths = out.ScannedAndSkipped(
             scanned=[str(path) for path in sorted(self.all_targets)],
             _comment=None,
             skipped=None,
@@ -463,14 +463,14 @@ class OutputHandler:
                 self.profiler,
             )
         if self.settings.verbose_errors:
-            # TODO: use CliSkippedTarget directly in ignore_log or in yield_json_objects at least
+            # TODO: use SkippedTarget directly in ignore_log or in yield_json_objects at least
             skipped = sorted(
                 self.ignore_log.yield_json_objects(), key=lambda x: Path(x["path"])
             )
             cli_paths = dataclasses.replace(
                 cli_paths,
                 skipped=[
-                    out.CliSkippedTarget(
+                    out.SkippedTarget(
                         path=out.Fpath(x["path"]),
                         reason=out.SkipReason.from_json(x["reason"]),
                     )

--- a/cli/src/semgrep/target_manager.py
+++ b/cli/src/semgrep/target_manager.py
@@ -340,7 +340,7 @@ class FileTargetingLog:
 
         return output
 
-    # TODO: return directly a out.CliSkippedTarget
+    # TODO: return directly a out.SkippedTarget
     def yield_json_objects(self) -> Iterable[Dict[str, Any]]:
         # coupling: if you add a reason here,
         # add it also to semgrep_output_v1.atd.

--- a/src/engine/Match_rules.ml
+++ b/src/engine/Match_rules.ml
@@ -61,10 +61,11 @@ let skipped_target_of_rule (file_and_more : Xtarget.t) (rule : R.rule) :
     Resp.skipped_target =
   let rule_id, _ = rule.id in
   let details =
-    spf
-      "No need to perform deeper matching because target does not contain some \
-       elements necessary for the rule to match '%s'"
-      (rule_id :> string)
+    Some
+      (spf
+         "No need to perform deeper matching because target does not contain \
+          some elements necessary for the rule to match '%s'"
+         (rule_id :> string))
   in
   {
     path = !!(file_and_more.file);

--- a/src/osemgrep/cli_ci/Ci_subcommand.ml
+++ b/src/osemgrep/cli_ci/Ci_subcommand.ml
@@ -211,7 +211,7 @@ let finding_of_cli_match _commit_date index (m : Out.cli_match) : Out.finding =
 
 (* from scans.py *)
 let prepare_for_report ~blocking_findings findings errors rules ~targets
-    ~(ignored_targets : Out.cli_skipped_target list option) ~commit_date
+    ~(ignored_targets : Out.skipped_target list option) ~commit_date
     ~engine_requested =
   let rule_ids =
     Common.map (fun r -> Rule_ID.to_string (fst r.Rule.id)) rules
@@ -283,7 +283,7 @@ let prepare_for_report ~blocking_findings findings errors rules ~targets
 
   let ignored_ext_freqs =
     Option.value ~default:[] ignored_targets
-    |> Common.group_by (fun (skipped_target : Out.cli_skipped_target) ->
+    |> Common.group_by (fun (skipped_target : Out.skipped_target) ->
            Fpath.get_ext (Fpath.v skipped_target.Out.path))
     |> List.filter (fun (ext, _) -> not (String.equal ext ""))
     (* don't count files with no extension *)

--- a/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -12,7 +12,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
  * LICENSE for more details.
  *)
-
 open Common
 
 (*****************************************************************************)
@@ -149,7 +148,7 @@ let errors_to_skipped (errors : Out.core_error list) : Out.skipped_target list =
            {
              path = location.path;
              reason = Analysis_failed_parser_or_internal_error;
-             details = message;
+             details = Some message;
              rule_id;
            })
 
@@ -409,7 +408,7 @@ let run_scan_files (conf : Scan_CLI.conf) (profiler : Profiler.t)
                m "Ignoring %s due to %s (%s)" x.Semgrep_output_v1_t.path
                  (Semgrep_output_v1_t.show_skip_reason
                     x.Semgrep_output_v1_t.reason)
-                 x.Semgrep_output_v1_t.details));
+                 (x.Semgrep_output_v1_t.details ||| "")));
 
     (* step 3: choose the right engine and right hooks *)
     let output_format, file_match_results_hook =

--- a/src/osemgrep/reporting/Cli_json_output.ml
+++ b/src/osemgrep/reporting/Cli_json_output.ml
@@ -390,27 +390,22 @@ let dedup_and_sort (xs : Out.cli_match list) : Out.cli_match list =
 (* Skipped target *)
 (*****************************************************************************)
 
-let cli_skipped_target_of_skipped_target (x : Out.skipped_target) :
-    Out.cli_skipped_target =
-  { path = x.path; reason = x.reason }
-
-(* skipping the python intermediate FileTargetingLog for now *)
+(* Skipping the python intermediate FileTargetingLog for now.
+ * We used to have a cli_skipped_target and core_skipped_target type,
+ * but now they are merged so this function is the identity.
+ * In theory we could remove the details: and rule_id: from it
+ * because they used to not be included in the final JSON output
+ * (but the info was used in the text output to display skipping information).
+ *)
 let cli_skipped_targets ~(skipped_targets : Out.skipped_target list option) :
-    Out.cli_skipped_target list option =
-  let* skipped_targets_list = skipped_targets in
-
-  (* TODO: skipped targets are coming from the FileIgnoreLog which is
+    Out.skipped_target list option =
+  (* Still? skipped targets are coming from the FileIgnoreLog which is
    * populated from many places in the code.
-   *)
-
-  (* TODO: see _make_failed_to_analyze() in output.py,
+   * Still? see _make_failed_to_analyze() in output.py,
    * core_failure_lines_by_file in target_manager.py
+   * Still? need to sort
    *)
-  let core_skipped =
-    skipped_targets_list |> Common.map cli_skipped_target_of_skipped_target
-  in
-  (* TODO: need to sort *)
-  Some core_skipped
+  skipped_targets
 
 (*****************************************************************************)
 (* Entry point *)
@@ -446,7 +441,7 @@ let cli_output_of_core_results ~logging_level (core : Out.core_output)
        * python: scanned=[str(path) for path in sorted(self.all_targets)]
        *)
       let scanned = scanned |> Set_.elements |> File.Path.to_strings in
-      let (paths : Out.cli_paths) =
+      let (paths : Out.scanned_and_skipped) =
         match logging_level with
         | Some (Logs.Info | Logs.Debug) ->
             let skipped = cli_skipped_targets ~skipped_targets in

--- a/src/runner/Run_semgrep.ml
+++ b/src/runner/Run_semgrep.ml
@@ -292,12 +292,13 @@ let filter_files_with_too_many_matches_and_transform_as_timeout
              sorted_offending_rules
              |> Common.map (fun (((rule_id : Rule_ID.t), _pat), n) ->
                     let details =
-                      spf
-                        "found %i matches for rule %s, which exceeds the \
-                         maximum of %i matches."
-                        n
-                        (rule_id :> string)
-                        max_match_per_file
+                      Some
+                        (spf
+                           "found %i matches for rule %s, which exceeds the \
+                            maximum of %i matches."
+                           n
+                           (rule_id :> string)
+                           max_match_per_file)
                     in
                     {
                       Semgrep_output_v1_t.path = file;

--- a/src/targeting/Find_targets.ml
+++ b/src/targeting/Find_targets.ml
@@ -162,8 +162,9 @@ let walk_skip_and_collect (conf : conf) (ign : Semgrepignore.t)
                      Out.path = !!fpath;
                      reason;
                      details =
-                       "excluded by --include/--exclude, gitignore, or \
-                        semgrepignore";
+                       Some
+                         "excluded by --include/--exclude, gitignore, or \
+                          semgrepignore";
                      rule_id = None;
                    }
                  in

--- a/src/targeting/Find_targets_old.ml
+++ b/src/targeting/Find_targets_old.ml
@@ -283,8 +283,9 @@ let get_targets conf scanning_roots =
                           Resp.path = !!path;
                           reason;
                           details =
-                            "excluded by --include/--exclude, gitignore, or \
-                             semgrepignore";
+                            Some
+                              "excluded by --include/--exclude, gitignore, or \
+                               semgrepignore";
                           rule_id = None;
                         }
                       in
@@ -310,8 +311,9 @@ let get_targets conf scanning_roots =
                         Resp.path = !!path;
                         reason = Too_big;
                         details =
-                          spf "target file size exceeds %i bytes at %i bytes"
-                            conf.max_target_bytes size;
+                          Some
+                            (spf "target file size exceeds %i bytes at %i bytes"
+                               conf.max_target_bytes size);
                         rule_id = None;
                       }
                   else Ok path)

--- a/src/targeting/Guess_lang.ml
+++ b/src/targeting/Guess_lang.ml
@@ -290,8 +290,9 @@ let wrap_with_error_message lang path bool_res :
           path = !!path;
           reason = Wrong_language;
           details =
-            spf "target file doesn't look like language %s"
-              (Lang.to_string lang);
+            Some
+              (spf "target file doesn't look like language %s"
+                 (Lang.to_string lang));
           rule_id = None;
         }
 

--- a/src/targeting/Skip_target.ml
+++ b/src/targeting/Skip_target.ml
@@ -91,9 +91,11 @@ let is_minified (path : Fpath.t) =
             Resp.path = !!path;
             reason = Minified;
             details =
-              spf "file contains too little whitespace: %.3f%% (min = %.1f%%)"
-                (100. *. stat.ws_freq)
-                (100. *. min_whitespace_frequency);
+              Some
+                (spf
+                   "file contains too little whitespace: %.3f%% (min = %.1f%%)"
+                   (100. *. stat.ws_freq)
+                   (100. *. min_whitespace_frequency));
             rule_id = None;
           }
       else if stat.line_freq < min_line_frequency then
@@ -102,11 +104,12 @@ let is_minified (path : Fpath.t) =
             Resp.path = !!path;
             reason = Minified;
             details =
-              spf
-                "file contains too few lines for its size: %.4f%% (min = \
-                 %.2f%%)"
-                (100. *. stat.line_freq)
-                (100. *. min_line_frequency);
+              Some
+                (spf
+                   "file contains too few lines for its size: %.4f%% (min = \
+                    %.2f%%)"
+                   (100. *. stat.line_freq)
+                   (100. *. min_line_frequency));
             rule_id = None;
           }
       else Ok path
@@ -137,8 +140,9 @@ let exclude_big_files paths =
                Resp.path = !!path;
                reason = Too_big;
                details =
-                 spf "target file size exceeds %i bytes at %i bytes" max_bytes
-                   size;
+                 Some
+                   (spf "target file size exceeds %i bytes at %i bytes"
+                      max_bytes size);
                rule_id = None;
              }
          else Ok path)


### PR DESCRIPTION
cli_skipped_target and skipped_target are now merged into
a single type skipped_target.
This is similar to what I did previously for cli_call_datafalow_trace
and core_call_dataflow_trace

test plan:
make e2e


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)