### PR TITLE
remove the cli_x prefix to call_dataflow_trace

### DIFF
--- a/cli/src/semgrep/formatter/text.py
+++ b/cli/src/semgrep/formatter/text.py
@@ -239,7 +239,7 @@ def match_to_lines(
 
 def call_trace_to_lines(
     ref_path: Path,
-    call_trace: out.CliMatchCallTrace,
+    call_trace: out.MatchCallTrace,
     color_output: bool,
     per_finding_max_lines_limit: Optional[int],
     per_line_max_chars_limit: Optional[int],
@@ -309,7 +309,7 @@ def call_trace_to_lines(
 
 def dataflow_trace_to_lines(
     rule_match_path: Path,
-    dataflow_trace: Optional[out.CliMatchDataflowTrace],
+    dataflow_trace: Optional[out.MatchDataflowTrace],
     color_output: bool,
     per_finding_max_lines_limit: Optional[int],
     per_line_max_chars_limit: Optional[int],

--- a/cli/src/semgrep/rule_match.py
+++ b/cli/src/semgrep/rule_match.py
@@ -447,7 +447,7 @@ class RuleMatch:
             return blocking
 
     @property
-    def dataflow_trace(self) -> Optional[core.CliMatchDataflowTrace]:
+    def dataflow_trace(self) -> Optional[core.MatchDataflowTrace]:
         return self.match.extra.dataflow_trace
 
     @property

--- a/cli/tests/unit/test_formatters.py
+++ b/cli/tests/unit/test_formatters.py
@@ -28,8 +28,8 @@ def create_taint_rule_match():
             end=core.Position(3, 5, 7),
             extra=core.CoreMatchExtra(
                 metavars=core.Metavars({}),
-                dataflow_trace=core.CliMatchDataflowTrace(
-                    taint_source=core.CliMatchCallTrace(
+                dataflow_trace=core.MatchDataflowTrace(
+                    taint_source=core.MatchCallTrace(
                         core.CliLoc(
                             (
                                 core.Location(
@@ -42,7 +42,7 @@ def create_taint_rule_match():
                         )
                     ),
                     intermediate_vars=[
-                        core.CliMatchIntermediateVar(
+                        core.MatchIntermediateVar(
                             location=core.Location(
                                 path=core.Fpath("foo.py"),
                                 start=core.Position(13, 14, 16),
@@ -51,7 +51,7 @@ def create_taint_rule_match():
                             content="??",
                         )
                     ],
-                    taint_sink=core.CliMatchCallTrace(
+                    taint_sink=core.MatchCallTrace(
                         core.CliLoc(
                             (
                                 core.Location(

--- a/src/reporting/Core_json_output.ml
+++ b/src/reporting/Core_json_output.ml
@@ -177,17 +177,17 @@ let metavars startp_of_match_range (s, mval) =
 let content_of_loc (loc : Out.location) : string =
   Output_utils.content_of_file_at_range (loc.start, loc.end_) (Fpath.v loc.path)
 
-let token_to_intermediate_var token : Out.cli_match_intermediate_var option =
+let token_to_intermediate_var token : Out.match_intermediate_var option =
   let* location = Output_utils.tokens_to_single_loc [ token ] in
   Some
     ({ Out.location; content = content_of_loc location }
-      : Out.cli_match_intermediate_var)
+      : Out.match_intermediate_var)
 
 let tokens_to_intermediate_vars tokens =
   Common.map_filter token_to_intermediate_var tokens
 
 let rec taint_call_trace (trace : PM.taint_call_trace) :
-    Out.cli_match_call_trace option =
+    Out.match_call_trace option =
   match trace with
   | Toks toks ->
       let* loc = Output_utils.tokens_to_single_loc toks in
@@ -200,7 +200,7 @@ let rec taint_call_trace (trace : PM.taint_call_trace) :
         (Out.CliCall ((loc, content_of_loc loc), intermediate_vars, call_trace))
 
 let taint_trace_to_dataflow_trace (traces : PM.taint_trace_item list) :
-    Out.cli_match_dataflow_trace =
+    Out.match_dataflow_trace =
   (* Here, we ignore all but the first taint trace, for source or sink.
      This is because we added support for multiple sources/sinks in a single
      trace, but only internally to semgrep-core. Externally, our CLI dataflow


### PR DESCRIPTION
The prefix is not needed anymore now that we've merged
the core_xxx and cli_xxx in a single dataflow trace type.

test plan:
make core
make copy-for-cli
make e2e


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)