### PR TITLE
js: only publish JS artifacts to S3 for develop branch, release branch, or if PR has a special label

### DIFF
--- a/.github/workflows/build-test-javascript.yaml
+++ b/.github/workflows/build-test-javascript.yaml
@@ -97,7 +97,8 @@ jobs:
 
   upload-javascript-artifacts:
     needs: [build-test-js-artifacts]
-    if: github.ref == 'refs/heads/develop' || github.event.pull_request.head.repo.full_name == github.repository
+    # in english: (this pull request is not from a fork) AND (branch is "develop" OR branch starts with "release-" OR pull request has a "publish-js" label applied to it)
+    if: github.event.pull_request.head.repo.full_name == github.repository && (github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/heads/release-') || contains(github.event.pull_request.labels.*.name, 'publish-js'))
     runs-on: ubuntu-latest
     permissions:
       id-token: write


### PR DESCRIPTION
We're currently uploading semgrep.js artifacts on push for _every_ PR, which is a bit excessive. This PR updates the `upload-javascript-artifacts` workflow to only run:
- on push to `develop` (so that we can test the latest-and-greatest)
- on push to a release branch (starts with `release-`)
- if the PR is labelled with `publish-js` (because there are still occasionally times where it's helpful for troubleshooting)

test plan:
- checks pass
