### PR TITLE
fix: disable capture group unification

### DIFF
--- a/changelog.d/pa-3050.fixed
+++ b/changelog.d/pa-3050.fixed
@@ -1,0 +1,6 @@
+Matching: Numeric capture group metavariables of the form $1, $2, etc that are
+introduced by unnamed capture groups, now no longer will cause matches to fail
+if they do not unify. They are still referenceable, however.
+
+This is so that capture group metavariables (which are introduced rather implicitly)
+do not cause rules to "invisibly" fail to match.

--- a/src/engine/Range_with_metavars.ml
+++ b/src/engine/Range_with_metavars.ml
@@ -65,6 +65,7 @@ let included_in config rv1 rv2 =
      |> List.for_all (fun (mvar, mval1) ->
             match List.assoc_opt mvar rv2.mvars with
             | None -> true
+            | _ when Metavariable.is_metavar_for_capture_group mvar -> true
             | Some mval2 ->
                 Matching_generic.equal_ast_bound_code config mval1 mval2)
 

--- a/src/engine/Range_with_metavars.ml
+++ b/src/engine/Range_with_metavars.ml
@@ -65,6 +65,14 @@ let included_in config rv1 rv2 =
      |> List.for_all (fun (mvar, mval1) ->
             match List.assoc_opt mvar rv2.mvars with
             | None -> true
+            (* Capture group metavariables (of the form $1, $2, etc) may
+               be introduced implicitly via regular expressions that have
+               capture groups in them.
+               The unification of these metavariables can be dangerous, as
+               it will prevent matches, when users may not even know these
+               metavariables exist.
+               To be safe, let's assume they always unify.
+            *)
             | _ when Metavariable.is_metavar_for_capture_group mvar -> true
             | Some mval2 ->
                 Matching_generic.equal_ast_bound_code config mval1 mval2)

--- a/src/engine/Range_with_metavars.ml
+++ b/src/engine/Range_with_metavars.ml
@@ -65,13 +65,15 @@ let included_in config rv1 rv2 =
      |> List.for_all (fun (mvar, mval1) ->
             match List.assoc_opt mvar rv2.mvars with
             | None -> true
-            (* Capture group metavariables (of the form $1, $2, etc) may
+            (* Numeric capture group metavariables (of the form $1, $2, etc) may
                be introduced implicitly via regular expressions that have
-               capture groups in them.
-               The unification of these metavariables can be dangerous, as
-               it will prevent matches, when users may not even know these
-               metavariables exist.
-               To be safe, let's assume they always unify.
+               capture groups in them. The unification of these metavariables
+               can be dangerous, as it will prevent matches, when users may not
+               even know these metavariables exist. To be safe, let's assume
+               they always unify.
+
+               note: this does not affect named capture group metavariables
+               from <?xxx>, which will still be unified as normal
             *)
             | _ when Metavariable.is_metavar_for_capture_group mvar -> true
             | Some mval2 ->

--- a/tests/rules/capture_group_unification.py
+++ b/tests/rules/capture_group_unification.py
@@ -1,6 +1,6 @@
 
-# ERROR:
+# ruleid: capture-group-unification
 x = 'foo1bar2qux'
 
-# ERROR:
+# ruleid: capture-group-unification
 y = 'foo1bar1qux'

--- a/tests/rules/capture_group_unification.py
+++ b/tests/rules/capture_group_unification.py
@@ -1,0 +1,6 @@
+
+# ERROR:
+x = 'foo1bar2qux'
+
+# ERROR:
+y = 'foo1bar1qux'

--- a/tests/rules/capture_group_unification.yaml
+++ b/tests/rules/capture_group_unification.yaml
@@ -1,0 +1,9 @@
+rules:
+  - id: capture-group-unification
+    patterns:
+      - pattern-regex: "'foo(.*)bar.*qux'"
+      - pattern-regex: "'foo.*bar(.*)qux'"
+    message: Demo $X. This also demonstrates Julia singleton parens.
+    languages:
+      - python
+    severity: WARNING

--- a/tests/rules/capture_group_unification.yaml
+++ b/tests/rules/capture_group_unification.yaml
@@ -3,7 +3,7 @@ rules:
     patterns:
       - pattern-regex: "'foo(.*)bar.*qux'"
       - pattern-regex: "'foo.*bar(.*)qux'"
-    message: Demo $X. This also demonstrates Julia singleton parens.
+    message: These should not unify and kill the match!
     languages:
       - python
     severity: WARNING


### PR DESCRIPTION
## What:
This PR prevents numeric capture group metavariables from invisibly unifying.

## Why:
Numeric capture group metavariables (like `$1`, `$2`, etc) are introduced implicitly by regular expressions using capture groups, which are essentially parentheses around certain regular expressions.

This is done "implicitly" because these metavariables are never named, and simply happen whenever parentheses do. This can lead to unpredictable results, however, because a rule-writer might accidentally introduce these metavariables, and then fail to get matches because the first such metavariable (`$1`) fails to match.

## How:
Just prevented it when ranges are being combined. We don't need to touch `Matching_generic` because `Generic_vs_generic` guards all `envf` calls with `is_metavar_name`.

## Test plan:
`make test`

Closes PA-3050

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
