### PR TITLE
tainting: Track taint via globals or class attributes

### DIFF
--- a/changelog.d/pa-1636.added
+++ b/changelog.d/pa-1636.added
@@ -1,0 +1,17 @@
+taint-mode: Semgrep will now track taint via globals or class attributes that are
+_effectively_ `final` (as in Java), e.g.:
+
+```java
+class Test {
+  private String x = source();
+
+  void test() {
+    sink(x); // finding here !
+  }
+}
+```
+
+Semgrep will recognize that `x` must be tainted because it is a private class
+attribute that is initialized to `source()`, and it is not re-defined anywhere
+else. This will also work if `x` is initialized in _the_ constructor (if there
+is only one constructor), or in a `static` block.

--- a/libs/ast_generic/AST_generic.ml
+++ b/libs/ast_generic/AST_generic.ml
@@ -587,11 +587,12 @@ and id_info = {
    * depending where it is used.
    *)
   id_svalue : svalue option ref; [@equal fun _a _b -> true]
-  (* THINK: Drop option? *)
-  (* See module 'IdFlags'. *)
-  id_flags : id_flags ref;
-      [@equal
-        AST_generic_equals.equal_id_info (fun f1 f2 -> IdFlags.equal !f1 !f2)]
+  (* ^^^ THINK: Drop option? *)
+  (* See module 'IdFlags'. Previously we compared 'id_flags' with 'IdFlags.equal'
+   * but, once we added the 'final' flag which is only set at definition site,
+   * the same identifier can now have different flags. In fact we did not really
+   * have to compare 'id_flags' anyways. *)
+  id_flags : id_flags ref; [@equal fun _a _b -> true]
   (* this is used by Naming_X in deep-semgrep *)
   id_info_id : id_info_id; [@equal fun _a _b -> true]
 }
@@ -2146,7 +2147,7 @@ let empty_id_info ?(hidden = false) ?(case_insensitive = false)
     id_resolved = ref None;
     id_type = ref None;
     id_svalue = ref None;
-    id_flags = ref (IdFlags.make ~hidden ~case_insensitive);
+    id_flags = ref (IdFlags.make ~hidden ~case_insensitive ~final:false);
     id_info_id = id;
   }
 

--- a/libs/ast_generic/AST_generic_helpers.ml
+++ b/libs/ast_generic/AST_generic_helpers.ml
@@ -335,6 +335,20 @@ let has_keyword_attr kwd attrs =
        | KeywordAttr (kwd2, _) -> kwd =*= kwd2
        | _ -> false)
 
+let name_is_global = function
+  | Global (* OSS *)
+  | GlobalName _ (* Pro *)
+  | EnclosedVar (* OSS / a class variable *) ->
+      true
+  | LocalVar
+  | Parameter
+  | ImportedEntity _
+  | ImportedModule _
+  | TypeName
+  | Macro
+  | EnumConstant ->
+      false
+
 (* just used in cpp_to_generic.ml for now, could be moved there *)
 let parameter_to_catch_exn_opt p =
   match p with

--- a/libs/ast_generic/AST_generic_helpers.mli
+++ b/libs/ast_generic/AST_generic_helpers.mli
@@ -76,6 +76,8 @@ val dotted_ident_of_name : AST_generic.name -> AST_generic.dotted_ident
 
 (* misc *)
 
+val name_is_global : AST_generic.resolved_name_kind -> bool
+
 val parameter_to_catch_exn_opt :
   AST_generic.parameter -> AST_generic.catch_exn option
 

--- a/libs/ast_generic/IdFlags.ml
+++ b/libs/ast_generic/IdFlags.ml
@@ -15,18 +15,25 @@ open Ppx_hash_lib.Std.Hash.Builtin
 
 let bitmask_HIDDEN = 0x01
 let bitmask_CASE_INSENSITIVE = 0x02
+let bitmask_FINAL = 0x04
 
 type t = int [@@deriving show, eq, ord, hash]
 
 let empty = 0
-let is_hidden flags = Int.logand flags bitmask_HIDDEN <> 0
-let set_hidden flags = Int.logor flags bitmask_HIDDEN
-let is_case_insensitive flags = Int.logand flags bitmask_CASE_INSENSITIVE <> 0
-let set_case_insensitive flags = Int.logor flags bitmask_CASE_INSENSITIVE
+let get_flag bitmask flags = Int.logand flags bitmask <> 0
+let set_flag bitmask flags = Int.logor flags bitmask
+let make_flag bitmask = (get_flag bitmask, set_flag bitmask)
+let is_hidden, set_hidden = make_flag bitmask_HIDDEN
+
+let is_case_insensitive, set_case_insensitive =
+  make_flag bitmask_CASE_INSENSITIVE
+
+let is_final, set_final = make_flag bitmask_FINAL
 let to_int x = x
 
-let make ~hidden ~case_insensitive =
+let make ~hidden ~case_insensitive ~final =
   let flags = empty in
   let flags = if hidden then set_hidden flags else flags in
   let flags = if case_insensitive then set_case_insensitive flags else flags in
+  let flags = if final then set_final flags else flags in
   flags

--- a/libs/ast_generic/IdFlags.mli
+++ b/libs/ast_generic/IdFlags.mli
@@ -4,7 +4,7 @@ type t [@@deriving show, eq, ord, hash]
 val empty : t
 (** No flags set *)
 
-val make : hidden:bool -> case_insensitive:bool -> t
+val make : hidden:bool -> case_insensitive:bool -> final:bool -> t
 
 val is_hidden : t -> bool
 (**
@@ -39,4 +39,12 @@ val is_case_insensitive : t -> bool
 *)
 
 val set_case_insensitive : t -> t
+
+val is_final : t -> bool
+(** Flag 'is_final' is used within variable definitions/assignments to record
+ * whether the variable being defined is "effectively final" (as in Java).
+ * This is used by e.g. taint analysis to propagate taint via globals and
+ * private class attributes. *)
+
+val set_final : t -> t
 val to_int : t -> int

--- a/src/analyzing/AST_to_IL.ml
+++ b/src/analyzing/AST_to_IL.ml
@@ -1727,3 +1727,7 @@ let function_definition lang ?ctx def =
 let stmt lang st =
   let env = empty_env lang in
   stmt env st
+
+let expr lang e =
+  let env = empty_env lang in
+  expr env e

--- a/src/analyzing/AST_to_IL.mli
+++ b/src/analyzing/AST_to_IL.mli
@@ -10,6 +10,7 @@ val function_definition :
   IL.name list * IL.stmt list
 
 val stmt : Lang.t -> AST_generic.stmt -> IL.stmt list
+val expr : Lang.t -> AST_generic.expr -> IL.exp
 val name_of_entity : AST_generic.entity -> IL.name option
 val var_of_name : AST_generic.name -> IL.name
 val var_of_id_info : AST_generic.ident -> AST_generic.id_info -> IL.name

--- a/src/engine/Match_tainting_mode.ml
+++ b/src/engine/Match_tainting_mode.ml
@@ -638,31 +638,54 @@ let pm_of_finding finding =
         let taint_trace = Some (lazy traces) in
         Some { sink_pm with env = merged_env; taint_trace }
 
-let mk_params_env lang options taint_config fdef =
-  let add_to_env env id ii pdefault =
-    let var = AST_to_IL.var_of_id_info id ii in
-    let var_type = Typing.resolved_type_of_id_info lang var.id_info in
-    let source_pms =
-      taint_config.D.is_source (G.Tk (snd id))
-      @
-      match pdefault with
-      | Some e -> taint_config.D.is_source (G.E e)
-      | None -> []
-    in
-    let taints =
-      source_pms
-      |> Common.map (fun (x : _ D.tmatch) -> (x.spec_pm, x.spec))
-      (* These sources come from the parameters to a function,
-         which are not within the normal control flow of a code.
-         We can safely say there's no incoming taints to these sources.
-      *)
-      |> T.taints_of_pms ~incoming:T.Taint_set.empty
-    in
-    let taints =
-      Dataflow_tainting.drop_taints_if_bool_or_number options taints var_type
-    in
-    Lval_env.add env (IL_helpers.lval_of_var var) taints
+let check_var_def lang options taint_config env id ii expr =
+  let name = AST_to_IL.var_of_id_info id ii in
+  let assign =
+    G.Assign (G.N (G.Id (id, ii)) |> G.e, Tok.fake_tok (snd id) "=", expr)
+    |> G.e |> G.exprstmt
   in
+  let xs = AST_to_IL.stmt lang assign in
+  let flow = CFG_build.cfg_of_stmts xs in
+  let end_mapping =
+    let java_props_cache = D.mk_empty_java_props_cache () in
+    Dataflow_tainting.fixpoint ~in_env:env lang options taint_config
+      java_props_cache flow
+  in
+  let out_env = end_mapping.(flow.exit).Dataflow_core.out_env in
+  let lval : IL.lval = { base = Var name; rev_offset = [] } in
+  Lval_env.dumb_find out_env lval
+
+let add_to_env lang options taint_config env id ii opt_expr =
+  let var = AST_to_IL.var_of_id_info id ii in
+  let var_type = Typing.resolved_type_of_id_info lang var.id_info in
+  let id_taints =
+    taint_config.D.is_source (G.Tk (snd id))
+    |> Common.map (fun (x : _ D.tmatch) -> (x.spec_pm, x.spec))
+    (* These sources come from the parameters to a function,
+        which are not within the normal control flow of a code.
+        We can safely say there's no incoming taints to these sources.
+    *)
+    |> T.taints_of_pms ~incoming:T.Taint_set.empty
+  in
+  let expr_taints =
+    match opt_expr with
+    | Some e -> (
+        match check_var_def lang options taint_config env id ii e with
+        | `None
+        | `Clean ->
+            T.Taint_set.empty
+        | `Tainted taints -> taints)
+    | None -> T.Taint_set.empty
+  in
+  let taints = id_taints |> T.Taint_set.union expr_taints in
+  let taints =
+    Dataflow_tainting.drop_taints_if_bool_or_number options taints var_type
+  in
+  Lval_env.add env (IL_helpers.lval_of_var var) taints
+
+let mk_fun_input_env lang options taint_config ?(glob_env = Lval_env.empty) fdef
+    =
+  let add_to_env = add_to_env lang options taint_config in
   let in_env =
     (* For each argument, check if it's a source and, if so, add it to the input
      * environment. *)
@@ -718,12 +741,52 @@ let mk_params_env lang options taint_config fdef =
         | G.ParamReceiver _
         | G.OtherParam (_, _) ->
             env)
-      Lval_env.empty
+      glob_env
       (Tok.unbracket fdef.G.fparams)
   in
   in_env
 
-let check_fundef lang options taint_config opt_ent ctx java_props_cache fdef =
+let is_global (id_info : G.id_info) =
+  let* kind, _sid = !(id_info.id_resolved) in
+  Some (H.name_is_global kind)
+
+let mk_file_env lang options taint_config ast =
+  let add_to_env = add_to_env lang options taint_config in
+  let env = ref Lval_env.empty in
+  let visitor =
+    object (_self : 'self)
+      inherit [_] G.iter_no_id_info as super
+
+      method! visit_definition env (entity, def_kind) =
+        match (entity, def_kind) with
+        | { name = EN (Id (id, id_info)); _ }, VarDef { vinit; _ }
+          when IdFlags.is_final !(id_info.id_flags)
+               && is_global id_info =*= Some true ->
+            env := add_to_env !env id id_info vinit
+        | __else__ -> super#visit_definition env (entity, def_kind)
+
+      method! visit_Assign env lhs tok expr =
+        match lhs with
+        | {
+         e =
+           ( N (Id (id, id_info))
+           | DotAccess
+               ( { e = IdSpecial ((This | Self), _); _ },
+                 _,
+                 FN (Id (id, id_info)) ) );
+         _;
+        }
+          when IdFlags.is_final !(id_info.id_flags)
+               && is_global id_info =*= Some true ->
+            env := add_to_env !env id id_info (Some expr)
+        | __else__ -> super#visit_Assign env lhs tok expr
+    end
+  in
+  visitor#visit_program env ast;
+  !env
+
+let check_fundef lang options taint_config opt_ent ctx ?glob_env
+    java_props_cache fdef =
   let name =
     let* ent = opt_ent in
     let* name = AST_to_IL.name_of_entity ent in
@@ -731,7 +794,7 @@ let check_fundef lang options taint_config opt_ent ctx java_props_cache fdef =
   in
   let _, xs = AST_to_IL.function_definition lang ~ctx fdef in
   let flow = CFG_build.cfg_of_stmts xs in
-  let in_env = mk_params_env lang options taint_config fdef in
+  let in_env = mk_fun_input_env lang options taint_config ?glob_env fdef in
   let mapping =
     Dataflow_tainting.fixpoint ~in_env ?name lang options taint_config
       java_props_cache flow
@@ -784,11 +847,13 @@ let check_rule per_file_formula_cache (rule : R.taint_rule) match_hook
 
   let java_props_cache = Dataflow_tainting.mk_empty_java_props_cache () in
 
+  let glob_env = mk_file_env lang xconf.config taint_config ast in
+
   (* Check each function definition. *)
   Visit_function_defs.visit
     (fun opt_ent fdef ->
-      check_fundef lang xconf.config taint_config opt_ent !ctx java_props_cache
-        fdef
+      check_fundef lang xconf.config taint_config opt_ent !ctx ~glob_env
+        java_props_cache fdef
       |> ignore)
     ast;
 

--- a/src/engine/Match_tainting_mode.mli
+++ b/src/engine/Match_tainting_mode.mli
@@ -58,10 +58,11 @@ val taint_config_of_rule :
   unit) ->
   Dataflow_tainting.config * debug_taint * Matching_explanation.t list
 
-val mk_params_env :
+val mk_fun_input_env :
   Language.t ->
   Rule_options_t.t ->
   Dataflow_tainting.config ->
+  ?glob_env:Taint_lval_env.t ->
   AST_generic.function_definition ->
   Taint_lval_env.t
 (** Constructs the initial taint environment for a given function definition.
@@ -75,6 +76,7 @@ val check_fundef :
   Dataflow_tainting.config ->
   AST_generic.entity option (** entity being analyzed *) ->
   AST_to_IL.ctx ->
+  ?glob_env:Taint_lval_env.t ->
   Dataflow_tainting.java_props_cache ->
   AST_generic.function_definition ->
   IL.cfg * Dataflow_tainting.mapping

--- a/tests/rules/taint_final_globals.java
+++ b/tests/rules/taint_final_globals.java
@@ -1,0 +1,10 @@
+class Test {
+
+  private String x = source();
+
+  void test() {
+    //ruleid: test
+    sink(x);
+  }
+
+}

--- a/tests/rules/taint_final_globals.yaml
+++ b/tests/rules/taint_final_globals.yaml
@@ -1,0 +1,11 @@
+rules:
+  - id: tainting
+    mode: taint
+    languages:
+      - java
+    message: Test
+    pattern-sinks:
+      - pattern: sink(...)
+    pattern-sources:
+      - pattern: source(...)
+    severity: ERROR

--- a/tests/rules/taint_final_globals1.js
+++ b/tests/rules/taint_final_globals1.js
@@ -1,0 +1,29 @@
+let hashvalue = window.location.hash.substring(1);
+let msg = `Hash value: ${hashvalue}`;
+
+if(hashvalue){
+    async function postData(url = '', data = {}) {
+        const response = await fetch(url, {
+            method: 'POST',
+            mode: 'cors',
+            cache: 'no-cache',
+            credentials: 'same-origin',
+            headers: {
+                'Content-Type': 'application/json',
+                //ruleid: test
+                'Custom': hashvalue,
+            },
+            redirect: 'follow',
+            referrerPolicy: 'no-referrer',
+            body: JSON.stringify(data)
+        });
+        return "";
+    }
+
+    postData('example', { key: 0 })
+    .then(data => {
+        console.log(data);
+  });
+}
+
+document.getElementById("output").innerText = msg;

--- a/tests/rules/taint_final_globals1.yaml
+++ b/tests/rules/taint_final_globals1.yaml
@@ -1,0 +1,21 @@
+rules:
+  - id: test
+    mode: taint
+    pattern-sources:
+      - pattern: window.location.hash
+    pattern-sinks:
+      - patterns:
+          - pattern-inside: |
+              fetch(..., {
+                  ...
+              })
+          - pattern: |
+              headers: {
+                '$KEY': $H
+              }
+          - focus-metavariable: $H
+    message: "Semgrep found a match: $KEY $H"
+    languages:
+      - javascript
+      - typescript
+    severity: WARNING

--- a/tests/rules/taint_final_globals2.java
+++ b/tests/rules/taint_final_globals2.java
@@ -1,0 +1,26 @@
+package parsers.DocumentBuilderFactory;
+
+import org.xml.sax.EntityResolver;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.*;
+
+class Foobar {
+
+    private static DocumentBuilderFactory dbFactory;
+
+    static {
+        dbFactory = DocumentBuilderFactory.newInstance();
+    }
+
+    public void todoExample(File input) {
+        //ruleid: test
+        DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+        dBuilder.parse(input);
+    }
+}

--- a/tests/rules/taint_final_globals2.yaml
+++ b/tests/rules/taint_final_globals2.yaml
@@ -1,0 +1,11 @@
+rules:
+  - id: test
+    message: Test
+    severity: ERROR
+    languages:
+      - java
+    mode: taint
+    pattern-sources:
+      - pattern: javax.xml.parsers.DocumentBuilderFactory.newInstance()
+    pattern-sinks:
+      - pattern: $FACTORY.newDocumentBuilder()


### PR DESCRIPTION
Provided that they are _effectively_ `final` (as in Java).

Closes PA-1636

test plan:
make test # three new tests

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
