### PR TITLE
fix(cfg): case statement in ruby does not fallthrough

### DIFF
--- a/changelog.d/pa-3055.fixed
+++ b/changelog.d/pa-3055.fixed
@@ -1,0 +1,1 @@
+The CFG now supports case statements in Ruby, which does not fall through.

--- a/src/analyzing/AST_to_IL.ml
+++ b/src/analyzing/AST_to_IL.ml
@@ -1167,7 +1167,9 @@ and type_ env (ty : G.type_) : type_ =
 
 (* TODO: What other languages have no fallthrough? *)
 and no_switch_fallthrough : Lang.t -> bool = function
-  | Go -> true
+  | Go
+  | Ruby ->
+      true
   | _ -> false
 
 and mk_break_continue_labels env tok =

--- a/src/engine/Unit_engine.ml
+++ b/src/engine/Unit_engine.ml
@@ -680,6 +680,13 @@ let lang_tainting_tests () =
          in
          let lang = Lang.Js in
          tainting_tests_for_lang files lang);
+      pack_tests "tainting Ruby"
+        (let dir = taint_tests_path / "ruby" in
+         let files =
+           Common2.glob (spf "%s/*.rb" !!dir) |> File.Path.of_strings
+         in
+         let lang = Lang.Ruby in
+         tainting_tests_for_lang files lang);
       pack_tests "tainting Typescript"
         (let dir = taint_tests_path / "ts" in
          let files =

--- a/tests/tainting_rules/ruby/switch.rb
+++ b/tests/tainting_rules/ruby/switch.rb
@@ -1,0 +1,19 @@
+def f()
+  i = source()
+  #ERROR:
+  sink(i)
+  case x
+  when 0
+    i = sanitize(i)
+    #OK:
+    sink(i)
+  when 1
+    unrelated_call()
+    #ERROR:
+    sink(i)
+  else
+    unrelated_call()
+    #ERROR:
+    sink(i)
+  end
+end

--- a/tests/tainting_rules/ruby/switch.yaml
+++ b/tests/tainting_rules/ruby/switch.yaml
@@ -1,0 +1,14 @@
+rules:
+  - id: test-switch
+    languages:
+      - ruby
+    message: Match Found!
+    mode: taint
+    pattern-sinks:
+      - pattern: sink(...)
+    pattern-sources:
+      - pattern: source(...)
+    pattern-sanitizers:
+      - pattern: sanitize(...)
+    severity: WARNING
+


### PR DESCRIPTION
There's already support for switch statements that don't fallthrough, but it's only enabled in Go.

This PR enables this for Ruby and includes a tainting test.

Test plan: added a new test and tested with `make core-test`.

Closes [PA-3055](https://linear.app/semgrep/issue/PA-3055)
