### PR TITLE
Tweak `semgrep ci` timeouts and logging

### DIFF
--- a/changelog.d/gh-8656.changed
+++ b/changelog.d/gh-8656.changed
@@ -1,0 +1,1 @@
+Further improvements to timeouts and logging for `semgrep ci`

--- a/cli/src/semgrep/app/scans.py
+++ b/cli/src/semgrep/app/scans.py
@@ -203,7 +203,7 @@ class ScanHandler:
             logger.info(f"Would have sent POST request to create scan")
             return
 
-        logger.debug("Starting scan")
+        logger.debug(f"Starting scan: {json.dumps({'meta': meta}, indent=4)}")
         response = state.app_session.post(
             f"{state.env.semgrep_url}/api/agent/deployments/scans",
             json={"meta": meta},
@@ -399,7 +399,7 @@ class ScanHandler:
         except requests.RequestException as exc:
             raise Exception(f"API server returned this error: {response.text}") from exc
 
-        try_until = datetime.now() + timedelta(minutes=10)
+        try_until = datetime.now() + timedelta(minutes=20)
         complete_task = progress_bar.add_task("Finalizing scan")
         while datetime.now() < try_until:
             logger.debug("Sending /complete")

--- a/cli/src/semgrep/app/session.py
+++ b/cli/src/semgrep/app/session.py
@@ -173,7 +173,9 @@ class AppSession(requests.Session):
         return self.token is not None
 
     def request(self, *args: Any, **kwargs: Any) -> requests.Response:
-        kwargs.setdefault("timeout", 60)
+        kwargs.setdefault(
+            "timeout", 70
+        )  # most backend endpoints are 60s, ideally we have the backend time out before the client
         kwargs.setdefault("headers", {})
         kwargs["headers"].setdefault("User-Agent", str(self.user_agent))
         if self.token:

--- a/cli/src/semgrep/commands/ci.py
+++ b/cli/src/semgrep/commands/ci.py
@@ -323,11 +323,14 @@ def ci(
                     else ""
                 )
 
-                start_scan_task = progress_bar.add_task(
-                    f"Reporting start of scan for [bold]{scan_handler.deployment_name}[/bold]"
-                )
+                start_scan_desc = f"Reporting start of scan for [bold]{scan_handler.deployment_name}[/bold]"
+                start_scan_task = progress_bar.add_task(start_scan_desc)
                 scan_handler.start_scan(metadata_dict)
-                progress_bar.update(start_scan_task, completed=100)
+                progress_bar.update(
+                    start_scan_task,
+                    completed=100,
+                    description=f"{start_scan_desc} (scan_id={scan_handler.scan_id})",
+                )
 
                 connection_task = progress_bar.add_task(
                     f"Fetching configuration from Semgrep Cloud Platform{at_url_maybe}"


### PR DESCRIPTION
As we work to make `semgrep ci` more reliable we're finding that a few things show up in our debugging:
- We're missing debug info for the start scan step, so lets add the scan id to the output and add the meta payload to the debug logs.
- Under high load, jobs can occasionally take 15 minutes to process, for now lets raise the limit to 30min while we work on optimisations there. 
- Sometimes the client times out and never gets the response from the backend, which is awkward because the timeouts are the same at both ends. Ideally the client's timeouts are slightly higher than the backends so that the errors propagate appropriately.

Tested locally.

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
