### PR TITLE
delete output_from_core.py

### DIFF
--- a/cli/src/semgrep/core_runner.py
+++ b/cli/src/semgrep/core_runner.py
@@ -42,7 +42,7 @@ from rich.progress import TimeElapsedColumn
 from rich.table import Table
 from ruamel.yaml import YAML
 
-import semgrep.output_from_core as core
+import semgrep.semgrep_interfaces.semgrep_output_v1 as out
 from semgrep.app import auth
 from semgrep.config_resolver import Config
 from semgrep.console import console
@@ -153,7 +153,7 @@ def dedup_errors(errors: List[SemgrepCoreError]) -> List[SemgrepCoreError]:
 
 def uniq_error_id(
     error: SemgrepCoreError,
-) -> Tuple[int, Path, core.Position, core.Position, str]:
+) -> Tuple[int, Path, out.Position, out.Position, str]:
     return (
         error.code,
         Path(error.core.location.path.value),
@@ -912,7 +912,7 @@ class CoreRunner:
     def _add_match_times(
         self,
         profiling_data: ProfilingData,
-        timing: core.CoreTiming,
+        timing: out.CoreTiming,
     ) -> None:
         if timing.rules_parse_time:
             profiling_data.set_rules_parse_time(timing.rules_parse_time)
@@ -1151,7 +1151,7 @@ class CoreRunner:
             outputs = core_matches_to_rule_matches(rules, core_output)
             parsed_errors = [core_error_to_semgrep_error(e) for e in core_output.errors]
             for err in core_output.errors:
-                if isinstance(err.error_type.value, core.Timeout):
+                if isinstance(err.error_type.value, out.Timeout):
                     assert err.location.path is not None
 
                     file_timeouts[Path(err.location.path.value)] += 1
@@ -1164,11 +1164,11 @@ class CoreRunner:
                 if isinstance(
                     err.error_type.value,
                     (
-                        core.LexicalError,
-                        core.ParseError,
-                        core.PartialParsing,
-                        core.SpecifiedParseError,
-                        core.AstBuilderError,
+                        out.LexicalError,
+                        out.ParseError,
+                        out.PartialParsing,
+                        out.SpecifiedParseError,
+                        out.AstBuilderError,
                     ),
                 ):
                     parsing_data.add_error(err)

--- a/cli/src/semgrep/dependency_aware_rule.py
+++ b/cli/src/semgrep/dependency_aware_rule.py
@@ -6,7 +6,7 @@ from typing import Iterator
 from typing import List
 from typing import Tuple
 
-import semgrep.output_from_core as core
+import semgrep.semgrep_interfaces.semgrep_output_v1 as out
 from semdep.external.packaging.specifiers import InvalidSpecifier  # type: ignore
 from semdep.external.packaging.specifiers import SpecifierSet  # type: ignore
 from semdep.package_restrictions import dependencies_range_match_any
@@ -95,20 +95,20 @@ def generate_unreachable_sca_findings(
                     severity=rule.severity,
                     fix=None,
                     fix_regex=None,
-                    match=core.CoreMatch(
-                        check_id=core.RuleId(rule.id),
-                        path=core.Fpath(str(lockfile_path)),
-                        start=core.Position(found_dep.line_number or 0, 0, 0),
-                        end=core.Position(
+                    match=out.CoreMatch(
+                        check_id=out.RuleId(rule.id),
+                        path=out.Fpath(str(lockfile_path)),
+                        start=out.Position(found_dep.line_number or 0, 0, 0),
+                        end=out.Position(
                             (found_dep.line_number + 1 if found_dep.line_number else 0),
                             0,
                             0,
                         ),
                         # TODO: we need to define the fields below in
-                        # Output_from_core.atd so we can reuse core.MatchExtra
-                        extra=core.CoreMatchExtra(
-                            metavars=core.Metavars({}),
-                            engine_kind=core.EngineKind(core.OSS()),
+                        # Output_from_core.atd so we can reuse out.MatchExtra
+                        extra=out.CoreMatchExtra(
+                            metavars=out.Metavars({}),
+                            engine_kind=out.EngineKind(out.OSS()),
                         ),
                     ),
                     extra={

--- a/cli/src/semgrep/join_rule.py
+++ b/cli/src/semgrep/join_rule.py
@@ -21,8 +21,8 @@ from peewee import CTE
 from peewee import ModelSelect
 from ruamel.yaml import YAML
 
-import semgrep.output_from_core as core
 import semgrep.run_scan
+import semgrep.semgrep_interfaces.semgrep_output_v1 as out
 from semgrep.config_resolver import Config
 from semgrep.config_resolver import ConfigPath
 from semgrep.constants import RuleSeverity
@@ -367,8 +367,8 @@ def generate_recursive_cte(model: Type[BaseModel], column1: str, column2: str) -
 # RuleMatches from that. Ideally something would be refactored so that we don't
 # need to move backwards in the pipeline like this.
 def json_to_rule_match(join_rule: Dict[str, Any], match: Dict[str, Any]) -> RuleMatch:
-    cli_match_extra = core.CliMatchExtra.from_json(match.get("extra", {}))
-    extra = core.CoreMatchExtra(
+    cli_match_extra = out.CliMatchExtra.from_json(match.get("extra", {}))
+    extra = out.CoreMatchExtra(
         message=cli_match_extra.message,
         # cli_match_extra.metavars is optional, but core_match_extra.metavars is
         # not. This is unsafe, but before it was just implicitly unsafe.
@@ -376,7 +376,7 @@ def json_to_rule_match(join_rule: Dict[str, Any], match: Dict[str, Any]) -> Rule
         dataflow_trace=cli_match_extra.dataflow_trace,
         engine_kind=cli_match_extra.engine_kind
         if cli_match_extra.engine_kind
-        else core.EngineKind(core.OSS()),
+        else out.EngineKind(out.OSS()),
     )
     return RuleMatch(
         message=join_rule.get(
@@ -386,11 +386,11 @@ def json_to_rule_match(join_rule: Dict[str, Any], match: Dict[str, Any]) -> Rule
         severity=RuleSeverity(
             join_rule.get("severity", match.get("severity", RuleSeverity.INFO.value))
         ),
-        match=core.CoreMatch(
-            check_id=core.RuleId(join_rule.get("id", match.get("check_id", "[empty]"))),
-            path=core.Fpath(match.get("path", "[empty]")),
-            start=core.Position.from_json(match["start"]),
-            end=core.Position.from_json(match["end"]),
+        match=out.CoreMatch(
+            check_id=out.RuleId(join_rule.get("id", match.get("check_id", "[empty]"))),
+            path=out.Fpath(match.get("path", "[empty]")),
+            start=out.Position.from_json(match["start"]),
+            end=out.Position.from_json(match["end"]),
             extra=extra,
         ),
         # still needed?

--- a/cli/src/semgrep/output_extra.py
+++ b/cli/src/semgrep/output_extra.py
@@ -5,7 +5,7 @@ from typing import Set
 
 from attrs import frozen
 
-import semgrep.output_from_core as core
+import semgrep.semgrep_interfaces.semgrep_output_v1 as out
 from semgrep.parsing_data import ParsingData
 from semgrep.profiling import ProfilingData
 
@@ -18,5 +18,5 @@ class OutputExtra:
     all_targets: Set[Path]
     profiling_data: ProfilingData
     parsing_data: ParsingData
-    explanations: Optional[List[core.MatchingExplanation]]
-    rules_by_engine: List[core.RuleIdAndEngineKind]
+    explanations: Optional[List[out.MatchingExplanation]]
+    rules_by_engine: List[out.RuleIdAndEngineKind]

--- a/cli/src/semgrep/output_from_core.py
+++ b/cli/src/semgrep/output_from_core.py
@@ -1,2 +1,0 @@
-# TODO: when ATD gets its module system, we would not need to this anymore
-from .semgrep_interfaces.semgrep_output_v1 import *  # noqa

--- a/cli/src/semgrep/parsing_data.py
+++ b/cli/src/semgrep/parsing_data.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from semgrep.core_runner import Plan
 
-import semgrep.output_from_core as core
+import semgrep.semgrep_interfaces.semgrep_output_v1 as out
 from semgrep.semgrep_types import Language
 
 
@@ -45,7 +45,7 @@ class ParsingData:
                 pass
             self._parse_errors_by_lang[task.language] = entry
 
-    def add_error(self, err: core.CoreError) -> None:
+    def add_error(self, err: out.CoreError) -> None:
         """
         Records the targets/bytes which were not parsed as a result of the
         given error. The file the error originated from should have been
@@ -73,10 +73,10 @@ class ParsingData:
         if isinstance(
             err.error_type.value,
             (
-                core.LexicalError,
-                core.ParseError,
-                core.SpecifiedParseError,
-                core.AstBuilderError,
+                out.LexicalError,
+                out.ParseError,
+                out.SpecifiedParseError,
+                out.AstBuilderError,
             ),
         ):
             try:
@@ -87,7 +87,7 @@ class ParsingData:
                 # purposes.
                 pass
         # Partial errors for a subsection of the file
-        elif isinstance(err.error_type.value, core.PartialParsing):
+        elif isinstance(err.error_type.value, out.PartialParsing):
             for loc in err.error_type.value.value:
                 lang_parse_data.error_bytes += loc.end.offset - loc.start.offset
         else:

--- a/cli/src/semgrep/profiling.py
+++ b/cli/src/semgrep/profiling.py
@@ -4,12 +4,12 @@ from typing import Dict
 from typing import NamedTuple
 from typing import Optional
 
-import semgrep.output_from_core as core
+import semgrep.semgrep_interfaces.semgrep_output_v1 as out
 from semgrep.rule import Rule
 
 
 class Semgrep_run(NamedTuple):
-    rule: core.RuleId
+    rule: out.RuleId
     target: Path
 
 
@@ -25,8 +25,8 @@ class ProfilingData:
         self._file_run_time: Dict[Path, float] = defaultdict(float)
         self._match_time_matrix: Dict[Semgrep_run, Times] = defaultdict(Times)
 
-        self._rule_match_times: Dict[core.RuleId, float] = defaultdict(float)
-        self._rule_bytes_scanned: Dict[core.RuleId, int] = defaultdict(int)
+        self._rule_match_times: Dict[out.RuleId, float] = defaultdict(float)
+        self._rule_bytes_scanned: Dict[out.RuleId, int] = defaultdict(int)
         self._file_match_times: Dict[Path, float] = defaultdict(float)
         self._file_num_times_scanned: Dict[Path, int] = defaultdict(int)
 
@@ -94,7 +94,7 @@ class ProfilingData:
         return self._max_memory_bytes
 
     def set_file_times(
-        self, target: Path, times: Dict[core.RuleId, Times], run_time: float
+        self, target: Path, times: Dict[out.RuleId, Times], run_time: float
     ) -> None:
         num_bytes = target.stat().st_size
 

--- a/cli/src/semgrep/rule.py
+++ b/cli/src/semgrep/rule.py
@@ -12,7 +12,7 @@ from typing import Sequence
 from typing import Set
 from typing import Union
 
-import semgrep.output_from_core as core
+import semgrep.semgrep_interfaces.semgrep_output_v1 as out
 from semgrep.constants import RuleScanSource
 from semgrep.constants import RuleSeverity
 from semgrep.error import InvalidRuleSchemaError
@@ -136,12 +136,12 @@ class Rule:
         return self._excludes
 
     @property
-    def id(self) -> str:  # TODO: return a core.RuleId
+    def id(self) -> str:  # TODO: return a out.RuleId
         return self._id
 
     @property
-    def id2(self) -> core.RuleId:  # TODO: merge with id
-        return core.RuleId(self._id)
+    def id2(self) -> out.RuleId:  # TODO: merge with id
+        return out.RuleId(self._id)
 
     @property
     def message(self) -> str:

--- a/cli/src/semgrep/rule_match.py
+++ b/cli/src/semgrep/rule_match.py
@@ -20,7 +20,6 @@ from attrs import evolve
 from attrs import field
 from attrs import frozen
 
-import semgrep.output_from_core as core
 import semgrep.semgrep_interfaces.semgrep_output_v1 as out
 from semgrep.constants import NOSEM_INLINE_COMMENT_RE
 from semgrep.constants import RuleScanSource
@@ -51,7 +50,7 @@ class RuleMatch:
     TODO: Rename this class to Finding?
     """
 
-    match: core.CoreMatch
+    match: out.CoreMatch
 
     # fields from the rule
     message: str = field(repr=False)
@@ -118,11 +117,11 @@ class RuleMatch:
         return Path(self.match.path.value)
 
     @property
-    def start(self) -> core.Position:
+    def start(self) -> out.Position:
         return self.match.start
 
     @property
-    def end(self) -> core.Position:
+    def end(self) -> out.Position:
         return self.match.end
 
     @property
@@ -447,7 +446,7 @@ class RuleMatch:
             return blocking
 
     @property
-    def dataflow_trace(self) -> Optional[core.MatchDataflowTrace]:
+    def dataflow_trace(self) -> Optional[out.MatchDataflowTrace]:
         return self.match.extra.dataflow_trace
 
     @property

--- a/cli/src/semgrep/target_manager.py
+++ b/cli/src/semgrep/target_manager.py
@@ -22,7 +22,7 @@ from typing import Set
 from typing import Tuple
 from typing import Union
 
-import semgrep.output_from_core as core
+import semgrep.semgrep_interfaces.semgrep_output_v1 as out
 from semgrep.git import BaselineHandler
 
 # usually this would be a try...except ImportError
@@ -138,7 +138,7 @@ class FileTargetingLog:
 
     # "None" indicates that all lines were skipped
     core_failure_lines_by_file: Mapping[
-        Path, Tuple[Optional[int], List[core.RuleId]]
+        Path, Tuple[Optional[int], List[out.RuleId]]
     ] = Factory(dict)
 
     # Indicates which files were NOT scanned by each language

--- a/cli/tests/unit/test_formatters.py
+++ b/cli/tests/unit/test_formatters.py
@@ -6,7 +6,7 @@ from textwrap import dedent
 import pytest
 from ruamel.yaml import YAML
 
-import semgrep.output_from_core as core
+import semgrep.semgrep_interfaces.semgrep_output_v1 as out
 from semgrep.constants import RuleSeverity
 from semgrep.formatter.sarif import SarifFormatter
 from semgrep.rule import Rule
@@ -21,50 +21,50 @@ def create_taint_rule_match():
     match = RuleMatch(
         message="message",
         severity=RuleSeverity.ERROR,
-        match=core.CoreMatch(
-            check_id=core.RuleId("rule.id"),
-            path=core.Fpath("foo.py"),
-            start=core.Position(3, 4, 6),
-            end=core.Position(3, 5, 7),
-            extra=core.CoreMatchExtra(
-                metavars=core.Metavars({}),
-                dataflow_trace=core.MatchDataflowTrace(
-                    taint_source=core.MatchCallTrace(
-                        core.CliLoc(
+        match=out.CoreMatch(
+            check_id=out.RuleId("rule.id"),
+            path=out.Fpath("foo.py"),
+            start=out.Position(3, 4, 6),
+            end=out.Position(3, 5, 7),
+            extra=out.CoreMatchExtra(
+                metavars=out.Metavars({}),
+                dataflow_trace=out.MatchDataflowTrace(
+                    taint_source=out.MatchCallTrace(
+                        out.CliLoc(
                             (
-                                core.Location(
-                                    path=core.Fpath("foo.py"),
-                                    start=core.Position(8, 9, 11),
-                                    end=core.Position(8, 10, 12),
+                                out.Location(
+                                    path=out.Fpath("foo.py"),
+                                    start=out.Position(8, 9, 11),
+                                    end=out.Position(8, 10, 12),
                                 ),
                                 "??",
                             )
                         )
                     ),
                     intermediate_vars=[
-                        core.MatchIntermediateVar(
-                            location=core.Location(
-                                path=core.Fpath("foo.py"),
-                                start=core.Position(13, 14, 16),
-                                end=core.Position(13, 15, 17),
+                        out.MatchIntermediateVar(
+                            location=out.Location(
+                                path=out.Fpath("foo.py"),
+                                start=out.Position(13, 14, 16),
+                                end=out.Position(13, 15, 17),
                             ),
                             content="??",
                         )
                     ],
-                    taint_sink=core.MatchCallTrace(
-                        core.CliLoc(
+                    taint_sink=out.MatchCallTrace(
+                        out.CliLoc(
                             (
-                                core.Location(
-                                    path=core.Fpath("foo.py"),
-                                    start=core.Position(15, 16, 20),
-                                    end=core.Position(15, 17, 21),
+                                out.Location(
+                                    path=out.Fpath("foo.py"),
+                                    start=out.Position(15, 16, 20),
+                                    end=out.Position(15, 17, 21),
                                 ),
                                 "??",
                             )
                         )
                     ),
                 ),
-                engine_kind=core.EngineKind(core.OSS()),
+                engine_kind=out.EngineKind(out.OSS()),
             ),
         ),
     )

--- a/cli/tests/unit/test_match_hashes.py
+++ b/cli/tests/unit/test_match_hashes.py
@@ -3,7 +3,7 @@ from textwrap import dedent
 
 import pytest
 
-import semgrep.output_from_core as core
+import semgrep.semgrep_interfaces.semgrep_output_v1 as out
 from semgrep.config_resolver import parse_config_string
 from semgrep.constants import RuleSeverity
 from semgrep.rule import Rule
@@ -76,14 +76,14 @@ def get_rule_match(
     return RuleMatch(
         message="message",
         severity=RuleSeverity.ERROR,
-        match=core.CoreMatch(
-            check_id=core.RuleId(rule_id),
-            path=core.Fpath(filepath),
-            start=core.Position(start_line, 0, start_line * 5),
-            end=core.Position(end_line, 5, end_line * 5 + 5),
-            extra=core.CoreMatchExtra(
-                metavars=core.Metavars(metavars if metavars else {}),
-                engine_kind=core.EngineKind(core.OSS()),
+        match=out.CoreMatch(
+            check_id=out.RuleId(rule_id),
+            path=out.Fpath(filepath),
+            start=out.Position(start_line, 0, start_line * 5),
+            end=out.Position(end_line, 5, end_line * 5 + 5),
+            extra=out.CoreMatchExtra(
+                metavars=out.Metavars(metavars if metavars else {}),
+                engine_kind=out.EngineKind(out.OSS()),
             ),
         ),
         extra={"metavars": metavars if metavars else {}},

--- a/cli/tests/unit/test_rule_match.py
+++ b/cli/tests/unit/test_rule_match.py
@@ -4,7 +4,6 @@ from textwrap import dedent
 
 import pytest
 
-import semgrep.output_from_core as core
 import semgrep.semgrep_interfaces.semgrep_output_v1 as out
 from semgrep.config_resolver import parse_config_string
 from semgrep.constants import RuleSeverity
@@ -45,13 +44,13 @@ def test_rule_match_attributes(mocker):
     match = RuleMatch(
         message="message",
         severity=RuleSeverity.ERROR,
-        match=core.CoreMatch(
-            check_id=core.RuleId("long.rule.id"),
-            path=core.Fpath("relative/path/to/foo.py"),
-            start=core.Position(3, 1, 24),
-            end=core.Position(3, 15, 38),
-            extra=core.CoreMatchExtra(
-                metavars=core.Metavars({}), engine_kind=core.EngineKind(core.OSS())
+        match=out.CoreMatch(
+            check_id=out.RuleId("long.rule.id"),
+            path=out.Fpath("relative/path/to/foo.py"),
+            start=out.Position(3, 1, 24),
+            end=out.Position(3, 15, 38),
+            extra=out.CoreMatchExtra(
+                metavars=out.Metavars({}), engine_kind=out.EngineKind(out.OSS())
             ),
         ),
     )
@@ -81,26 +80,26 @@ def test_rule_match_sorting(mocker):
     line3 = RuleMatch(
         message="message",
         severity=RuleSeverity.ERROR,
-        match=core.CoreMatch(
-            check_id=core.RuleId("rule_id"),
-            path=core.Fpath("foo.py"),
-            start=core.Position(3, 1, 24),
-            end=core.Position(3, 15, 38),
-            extra=core.CoreMatchExtra(
-                metavars=core.Metavars({}), engine_kind=core.EngineKind(core.OSS())
+        match=out.CoreMatch(
+            check_id=out.RuleId("rule_id"),
+            path=out.Fpath("foo.py"),
+            start=out.Position(3, 1, 24),
+            end=out.Position(3, 15, 38),
+            extra=out.CoreMatchExtra(
+                metavars=out.Metavars({}), engine_kind=out.EngineKind(out.OSS())
             ),
         ),
     )
     line4 = RuleMatch(
         message="message",
         severity=RuleSeverity.ERROR,
-        match=core.CoreMatch(
-            check_id=core.RuleId("rule_id"),
-            path=core.Fpath("foo.py"),
-            start=core.Position(4, 1, 36),
-            end=core.Position(4, 15, 50),
-            extra=core.CoreMatchExtra(
-                metavars=core.Metavars({}), engine_kind=core.EngineKind(core.OSS())
+        match=out.CoreMatch(
+            check_id=out.RuleId("rule_id"),
+            path=out.Fpath("foo.py"),
+            start=out.Position(4, 1, 36),
+            end=out.Position(4, 15, 50),
+            extra=out.CoreMatchExtra(
+                metavars=out.Metavars({}), engine_kind=out.EngineKind(out.OSS())
             ),
         ),
     )
@@ -124,13 +123,13 @@ def test_rule_match_hashing(mocker):
     match = RuleMatch(
         message="message",
         severity=RuleSeverity.ERROR,
-        match=core.CoreMatch(
-            check_id=core.RuleId("rule_id"),
-            path=core.Fpath("foo.py"),
-            start=core.Position(3, 1, 24),
-            end=core.Position(3, 15, 38),
-            extra=core.CoreMatchExtra(
-                metavars=core.Metavars({}), engine_kind=core.EngineKind(core.OSS())
+        match=out.CoreMatch(
+            check_id=out.RuleId("rule_id"),
+            path=out.Fpath("foo.py"),
+            start=out.Position(3, 1, 24),
+            end=out.Position(3, 15, 38),
+            extra=out.CoreMatchExtra(
+                metavars=out.Metavars({}), engine_kind=out.EngineKind(out.OSS())
             ),
         ),
     )
@@ -152,13 +151,13 @@ def test_rule_match_is_nosemgrep_agnostic(mocker):
     match_1 = RuleMatch(
         message="message",
         severity=RuleSeverity.ERROR,
-        match=core.CoreMatch(
-            check_id=core.RuleId("rule_id"),
-            path=core.Fpath("foo.py"),
-            start=core.Position(3, 1, 28),
-            end=core.Position(5, 2, 48),
-            extra=core.CoreMatchExtra(
-                metavars=core.Metavars({}), engine_kind=core.EngineKind(core.OSS())
+        match=out.CoreMatch(
+            check_id=out.RuleId("rule_id"),
+            path=out.Fpath("foo.py"),
+            start=out.Position(3, 1, 28),
+            end=out.Position(5, 2, 48),
+            extra=out.CoreMatchExtra(
+                metavars=out.Metavars({}), engine_kind=out.EngineKind(out.OSS())
             ),
         ),
     )
@@ -175,13 +174,13 @@ def test_rule_match_is_nosemgrep_agnostic(mocker):
     match_2 = RuleMatch(
         message="message",
         severity=RuleSeverity.ERROR,
-        match=core.CoreMatch(
-            check_id=core.RuleId("rule_id"),
-            path=core.Fpath("foo.py"),
-            start=core.Position(3, 1, 28),
-            end=core.Position(5, 2, 72),
-            extra=core.CoreMatchExtra(
-                metavars=core.Metavars({}), engine_kind=core.EngineKind(core.OSS())
+        match=out.CoreMatch(
+            check_id=out.RuleId("rule_id"),
+            path=out.Fpath("foo.py"),
+            start=out.Position(3, 1, 28),
+            end=out.Position(5, 2, 72),
+            extra=out.CoreMatchExtra(
+                metavars=out.Metavars({}), engine_kind=out.EngineKind(out.OSS())
             ),
         ),
     )
@@ -199,13 +198,13 @@ def test_rule_match_is_nosemgrep_agnostic(mocker):
     match_3 = RuleMatch(
         message="message",
         severity=RuleSeverity.ERROR,
-        match=core.CoreMatch(
-            check_id=core.RuleId("rule_id"),
-            path=core.Fpath("foo.py"),
-            start=core.Position(4, 1, 55),
-            end=core.Position(6, 2, 75),
-            extra=core.CoreMatchExtra(
-                metavars=core.Metavars({}), engine_kind=core.EngineKind(core.OSS())
+        match=out.CoreMatch(
+            check_id=out.RuleId("rule_id"),
+            path=out.Fpath("foo.py"),
+            start=out.Position(4, 1, 55),
+            end=out.Position(6, 2, 75),
+            extra=out.CoreMatchExtra(
+                metavars=out.Metavars({}), engine_kind=out.EngineKind(out.OSS())
             ),
         ),
     )
@@ -234,52 +233,52 @@ def test_rule_match_set_indexes(mocker):
     line3 = RuleMatch(
         message="message",
         severity=RuleSeverity.ERROR,
-        match=core.CoreMatch(
-            check_id=core.RuleId("rule_id"),
-            path=core.Fpath("foo.py"),
-            start=core.Position(3, 1, 24),
-            end=core.Position(3, 15, 38),
-            extra=core.CoreMatchExtra(
-                metavars=core.Metavars({}), engine_kind=core.EngineKind(core.OSS())
+        match=out.CoreMatch(
+            check_id=out.RuleId("rule_id"),
+            path=out.Fpath("foo.py"),
+            start=out.Position(3, 1, 24),
+            end=out.Position(3, 15, 38),
+            extra=out.CoreMatchExtra(
+                metavars=out.Metavars({}), engine_kind=out.EngineKind(out.OSS())
             ),
         ),
     )
     line4 = RuleMatch(
         message="message",
         severity=RuleSeverity.ERROR,
-        match=core.CoreMatch(
-            check_id=core.RuleId("rule_id"),
-            path=core.Fpath("foo.py"),
-            start=core.Position(4, 1, 36),
-            end=core.Position(4, 15, 50),
-            extra=core.CoreMatchExtra(
-                metavars=core.Metavars({}), engine_kind=core.EngineKind(core.OSS())
+        match=out.CoreMatch(
+            check_id=out.RuleId("rule_id"),
+            path=out.Fpath("foo.py"),
+            start=out.Position(4, 1, 36),
+            end=out.Position(4, 15, 50),
+            extra=out.CoreMatchExtra(
+                metavars=out.Metavars({}), engine_kind=out.EngineKind(out.OSS())
             ),
         ),
     )
     line5 = RuleMatch(
         message="message",
         severity=RuleSeverity.ERROR,
-        match=core.CoreMatch(
-            check_id=core.RuleId("rule_id"),
-            path=core.Fpath("foo.py"),
-            start=core.Position(5, 1, 48),
-            end=core.Position(5, 15, 62),
-            extra=core.CoreMatchExtra(
-                metavars=core.Metavars({}), engine_kind=core.EngineKind(core.OSS())
+        match=out.CoreMatch(
+            check_id=out.RuleId("rule_id"),
+            path=out.Fpath("foo.py"),
+            start=out.Position(5, 1, 48),
+            end=out.Position(5, 15, 62),
+            extra=out.CoreMatchExtra(
+                metavars=out.Metavars({}), engine_kind=out.EngineKind(out.OSS())
             ),
         ),
     )
     line6 = RuleMatch(
         message="message",
         severity=RuleSeverity.ERROR,
-        match=core.CoreMatch(
-            check_id=core.RuleId("rule_id"),
-            path=core.Fpath("foo.py"),
-            start=core.Position(6, 1, 60),
-            end=core.Position(6, 15, 74),
-            extra=core.CoreMatchExtra(
-                metavars=core.Metavars({}), engine_kind=core.EngineKind(core.OSS())
+        match=out.CoreMatch(
+            check_id=out.RuleId("rule_id"),
+            path=out.Fpath("foo.py"),
+            start=out.Position(6, 1, 60),
+            end=out.Position(6, 15, 74),
+            extra=out.CoreMatchExtra(
+                metavars=out.Metavars({}), engine_kind=out.EngineKind(out.OSS())
             ),
         ),
     )
@@ -287,13 +286,13 @@ def test_rule_match_set_indexes(mocker):
     line7 = RuleMatch(
         message="message",
         severity=RuleSeverity.ERROR,
-        match=core.CoreMatch(
-            check_id=core.RuleId("rule_id_wrong_one"),
-            path=core.Fpath("foo.py"),
-            start=core.Position(7, 1, 60),
-            end=core.Position(7, 15, 74),
-            extra=core.CoreMatchExtra(
-                metavars=core.Metavars({}), engine_kind=core.EngineKind(core.OSS())
+        match=out.CoreMatch(
+            check_id=out.RuleId("rule_id_wrong_one"),
+            path=out.Fpath("foo.py"),
+            start=out.Position(7, 1, 60),
+            end=out.Position(7, 15, 74),
+            extra=out.CoreMatchExtra(
+                metavars=out.Metavars({}), engine_kind=out.EngineKind(out.OSS())
             ),
         ),
     )
@@ -341,13 +340,13 @@ def test_rule_match_to_app_finding(snapshot, mocker):
     match = RuleMatch(
         message="message",
         severity=RuleSeverity.ERROR,
-        match=core.CoreMatch(
-            check_id=core.RuleId("rule.id"),
-            path=core.Fpath("foo.py"),
-            start=core.Position(0, 0, 0),
-            end=core.Position(0, 0, 0),
-            extra=core.CoreMatchExtra(
-                metavars=core.Metavars({}), engine_kind=core.EngineKind(core.OSS())
+        match=out.CoreMatch(
+            check_id=out.RuleId("rule.id"),
+            path=out.Fpath("foo.py"),
+            start=out.Position(0, 0, 0),
+            end=out.Position(0, 0, 0),
+            extra=out.CoreMatchExtra(
+                metavars=out.Metavars({}), engine_kind=out.EngineKind(out.OSS())
             ),
         ),
         extra={
@@ -393,13 +392,13 @@ def create_sca_rule_match(sca_kind, reachable_in_code, transitivity):
         message="message",
         metadata={"sca-kind": sca_kind, "dev.semgrep.actions": ["block"]},
         severity=RuleSeverity.ERROR,
-        match=core.CoreMatch(
-            check_id=core.RuleId("rule.id"),
-            path=core.Fpath("foo.py"),
-            start=core.Position(0, 0, 0),
-            end=core.Position(0, 0, 0),
-            extra=core.CoreMatchExtra(
-                metavars=core.Metavars({}), engine_kind=core.EngineKind(core.OSS())
+        match=out.CoreMatch(
+            check_id=out.RuleId("rule.id"),
+            path=out.Fpath("foo.py"),
+            start=out.Position(0, 0, 0),
+            end=out.Position(0, 0, 0),
+            extra=out.CoreMatchExtra(
+                metavars=out.Metavars({}), engine_kind=out.EngineKind(out.OSS())
             ),
         ),
         extra={


### PR DESCRIPTION
This was just an alias to semgrep_output_v1.py

There was a time where we wanted to use ATD module system
and maybe split semgrep_output_v1.atd in 2 with the spec
of the output from core separate from the spec of the output
of the CLI, but as we progress in osemgrep we want to merge
the 2 kinds of output, so this file is not useful anymore

test plan:
pre-commit run -a mypy
make quick-tests


PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)