### PR TITLE
js: fix logic for when to run upload-javascript-artifacts workflow

### DIFF
--- a/.github/workflows/build-test-javascript.yaml
+++ b/.github/workflows/build-test-javascript.yaml
@@ -97,8 +97,8 @@ jobs:
 
   upload-javascript-artifacts:
     needs: [build-test-js-artifacts]
-    # in english: (this pull request is not from a fork) AND (branch is "develop" OR branch starts with "release-" OR pull request has a "publish-js" label applied to it)
-    if: github.event.pull_request.head.repo.full_name == github.repository && (github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/heads/release-') || contains(github.event.pull_request.labels.*.name, 'publish-js'))
+    # in english: (this pull request is not from a fork AND the pull request has a "publish-js" label applied to it) OR (branch name is "develop") OR (branch name starts with "release-")
+    if: ((github.event.pull_request.head.repo.full_name == github.repository) && contains(github.event.pull_request.labels.*.name, 'publish-js')) || (github.ref == 'refs/heads/develop') || startsWith(github.ref, 'refs/heads/release-')
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/.github/workflows/build-test-javascript.yaml
+++ b/.github/workflows/build-test-javascript.yaml
@@ -97,8 +97,9 @@ jobs:
 
   upload-javascript-artifacts:
     needs: [build-test-js-artifacts]
-    # in english: (this pull request is not from a fork AND the pull request has a "publish-js" label applied to it) OR (branch name is "develop") OR (branch name starts with "release-")
-    if: ((github.event.pull_request.head.repo.full_name == github.repository) && contains(github.event.pull_request.labels.*.name, 'publish-js')) || (github.ref == 'refs/heads/develop') || startsWith(github.ref, 'refs/heads/release-')
+    # in english: (branch name is "develop") OR (branch name starts with "release-")
+    # we restrict this so that we don't fill up the S3 bucket with tons of semgrep.js builds
+    if: (github.ref == 'refs/heads/develop') || startsWith(github.ref, 'refs/heads/release-')
     runs-on: ubuntu-latest
     permissions:
       id-token: write


### PR DESCRIPTION
I originally opened https://github.com/returntocorp/semgrep/pull/8642 to limit uploading semgrep.js artifacts to S3 to:
- pushes to develop branch
- releases (pushes to `release-X.Y.Z` branch)
- if a PR has a `publish-js` label

I screwed up the logic, though: `github.event.pull_request.head.repo.full_name == github.repository` is only true when the `pull_request` event is triggered, which only happens when a pull request is **opened for the first time**.

This PR removes the special PR label logic -- I'll add that back once I have a better sense of how to accomplish this (if its needed at all)

test plan:
- checks pass