### PR TITLE
Make the `semgrep ci` tests for github envs more accurate

### DIFF
--- a/cli/src/semgrep/commands/ci.py
+++ b/cli/src/semgrep/commands/ci.py
@@ -110,7 +110,7 @@ def fix_head_if_github_action(metadata: GitMeta) -> None:
     logger.info(f"Not on head ref: {metadata.head_branch_hash}; checking that out now.")
     git_check_output(["git", "checkout", metadata.head_branch_hash])
 
-    atexit.register(git_check_output, ["git", "checkout", stashed_rev])
+    atexit.register(git_check_output, ["git", "checkout", stashed_rev], os.getcwd())
 
 
 @click.command(context_settings=CONTEXT_SETTINGS)

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/meta.json
@@ -3,7 +3,7 @@
     "semgrep_version": "<sanitized version>",
     "repository": "project_name/project_name",
     "repo_url": "https://some.enterprise.url.com/project_name/project_name",
-    "branch": "some/branch-name",
+    "branch": "refs/heads/some/branch-name",
     "ci_job_url": "https://some.enterprise.url.com/project_name/project_name/actions/runs/35",
     "commit": "sanitized",
     "commit_author_email": "test_environment@test.r2c.dev",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/results.txt
@@ -1,5 +1,5 @@
 === command
-CI="true" GITHUB_ACTIONS="true" GITHUB_EVENT_NAME="push" GITHUB_REPOSITORY="project_name/project_name" GITHUB_RUN_ID="35" GITHUB_ACTOR="some_test_username" GITHUB_REF="some/branch-name" GITHUB_SERVER_URL="https://some.enterprise.url.com" GITHUB_SHA="<MASKED>" SEMGREP_APP_TOKEN="fake-key-from-tests" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERSION_CACHE_PATH="<MASKED>" SEMGREP_ENABLE_VERSION_CHECK="0" SEMGREP_SEND_METRICS="off" semgrep ci --no-suppress-errors
+CI="true" GITHUB_ACTIONS="true" GITHUB_ACTOR="some_test_username" GITHUB_API_URL="https://api.github.com" GITHUB_REPOSITORY="project_name/project_name" GITHUB_RUN_ID="35" GITHUB_SERVER_URL="https://some.enterprise.url.com" GITHUB_WORKSPACE="/home/runner/work/actions-test/actions-test" GITHUB_EVENT_NAME="push" GITHUB_REF="refs/heads/some/branch-name" GITHUB_BASE_REF="" GITHUB_HEAD_REF="" GITHUB_SHA="<MASKED>" SEMGREP_APP_TOKEN="fake-key-from-tests" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERSION_CACHE_PATH="<MASKED>" SEMGREP_ENABLE_VERSION_CHECK="0" SEMGREP_SEND_METRICS="off" semgrep ci --no-suppress-errors
 === end of command
 
 === exit code

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr-semgrepconfig/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr-semgrepconfig/meta.json
@@ -3,7 +3,7 @@
     "semgrep_version": "<sanitized version>",
     "repository": "project_name/project_name",
     "repo_url": "https://github.com/project_name/project_name",
-    "branch": "some/branch-name",
+    "branch": "refs/pull/123/merge",
     "ci_job_url": "https://github.com/project_name/project_name/actions/runs/35",
     "commit": "sanitized",
     "commit_author_email": "test_environment@test.r2c.dev",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr-semgrepconfig/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr-semgrepconfig/results.txt
@@ -1,5 +1,5 @@
 === command
-CI="true" GITHUB_ACTIONS="true" GITHUB_EVENT_NAME="pull_request" GITHUB_REPOSITORY="project_name/project_name" GITHUB_RUN_ID="35" GITHUB_ACTOR="some_test_username" GITHUB_REF="some/branch-name" SEMGREP_PROJECT_CONFIG="tags:
+CI="true" GITHUB_ACTIONS="true" GITHUB_ACTOR="some_test_username" GITHUB_API_URL="https://api.github.com" GITHUB_REPOSITORY="project_name/project_name" GITHUB_RUN_ID="35" GITHUB_SERVER_URL="https://github.com" GITHUB_WORKSPACE="/home/runner/work/actions-test/actions-test" GITHUB_EVENT_NAME="pull_request" GITHUB_REF="refs/pull/123/merge" GITHUB_BASE_REF="main" GITHUB_HEAD_REF="some/branch-name" SEMGREP_PROJECT_CONFIG="tags:
 - tag1
 - tag_key:tag_val
 " GITHUB_SHA="<MASKED>" GITHUB_EVENT_PATH="<MASKED>" SEMGREP_APP_TOKEN="fake-key-from-tests" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERSION_CACHE_PATH="<MASKED>" SEMGREP_ENABLE_VERSION_CHECK="0" SEMGREP_SEND_METRICS="off" semgrep ci --no-suppress-errors

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr/meta.json
@@ -3,7 +3,7 @@
     "semgrep_version": "<sanitized version>",
     "repository": "project_name/project_name",
     "repo_url": "https://github.com/project_name/project_name",
-    "branch": "some/branch-name",
+    "branch": "refs/pull/123/merge",
     "ci_job_url": "https://github.com/project_name/project_name/actions/runs/35",
     "commit": "sanitized",
     "commit_author_email": "test_environment@test.r2c.dev",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr/results.txt
@@ -1,5 +1,5 @@
 === command
-CI="true" GITHUB_ACTIONS="true" GITHUB_EVENT_NAME="pull_request" GITHUB_REPOSITORY="project_name/project_name" GITHUB_RUN_ID="35" GITHUB_ACTOR="some_test_username" GITHUB_REF="some/branch-name" GITHUB_SHA="<MASKED>" GITHUB_EVENT_PATH="<MASKED>" SEMGREP_APP_TOKEN="fake-key-from-tests" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERSION_CACHE_PATH="<MASKED>" SEMGREP_ENABLE_VERSION_CHECK="0" SEMGREP_SEND_METRICS="off" semgrep ci --no-suppress-errors
+CI="true" GITHUB_ACTIONS="true" GITHUB_ACTOR="some_test_username" GITHUB_API_URL="https://api.github.com" GITHUB_REPOSITORY="project_name/project_name" GITHUB_RUN_ID="35" GITHUB_SERVER_URL="https://github.com" GITHUB_WORKSPACE="/home/runner/work/actions-test/actions-test" GITHUB_EVENT_NAME="pull_request" GITHUB_REF="refs/pull/123/merge" GITHUB_BASE_REF="main" GITHUB_HEAD_REF="some/branch-name" GITHUB_SHA="<MASKED>" GITHUB_EVENT_PATH="<MASKED>" SEMGREP_APP_TOKEN="fake-key-from-tests" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERSION_CACHE_PATH="<MASKED>" SEMGREP_ENABLE_VERSION_CHECK="0" SEMGREP_SEND_METRICS="off" semgrep ci --no-suppress-errors
 === end of command
 
 === exit code

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push-special-env-vars/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push-special-env-vars/results.txt
@@ -1,5 +1,5 @@
 === command
-CI="true" GITHUB_ACTIONS="true" GITHUB_EVENT_NAME="push" SEMGREP_REPO_NAME="project_name/project_name" SEMGREP_JOB_URL="customjoburl.com" GITHUB_ACTOR="some_test_username" SEMGREP_PR_ID="312" SEMGREP_PR_TITLE="PR_TITLE" SEMGREP_BRANCH="some/branch-name" GITHUB_SHA="<MASKED>" SEMGREP_APP_TOKEN="fake-key-from-tests" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERSION_CACHE_PATH="<MASKED>" SEMGREP_ENABLE_VERSION_CHECK="0" SEMGREP_SEND_METRICS="off" semgrep ci --no-suppress-errors
+CI="true" GITHUB_ACTIONS="true" GITHUB_ACTOR="some_test_username" GITHUB_API_URL="https://api.github.com" GITHUB_REPOSITORY="project_name/project_name" GITHUB_RUN_ID="35" GITHUB_SERVER_URL="https://github.com" GITHUB_WORKSPACE="/home/runner/work/actions-test/actions-test" GITHUB_EVENT_NAME="push" GITHUB_REF="refs/heads/some/branch-name" GITHUB_BASE_REF="" GITHUB_HEAD_REF="" SEMGREP_REPO_NAME="project_name/project_name" SEMGREP_JOB_URL="customjoburl.com" SEMGREP_PR_ID="312" SEMGREP_PR_TITLE="PR_TITLE" SEMGREP_BRANCH="some/branch-name" GITHUB_SHA="<MASKED>" SEMGREP_APP_TOKEN="fake-key-from-tests" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERSION_CACHE_PATH="<MASKED>" SEMGREP_ENABLE_VERSION_CHECK="0" SEMGREP_SEND_METRICS="off" semgrep ci --no-suppress-errors
 === end of command
 
 === exit code

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/meta.json
@@ -3,7 +3,7 @@
     "semgrep_version": "<sanitized version>",
     "repository": "project_name/project_name",
     "repo_url": "https://github.com/project_name/project_name",
-    "branch": "some/branch-name",
+    "branch": "refs/heads/some/branch-name",
     "ci_job_url": "https://github.com/project_name/project_name/actions/runs/35",
     "commit": "sanitized",
     "commit_author_email": "test_environment@test.r2c.dev",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/results.txt
@@ -1,5 +1,5 @@
 === command
-CI="true" GITHUB_ACTIONS="true" GITHUB_EVENT_NAME="push" GITHUB_REPOSITORY="project_name/project_name" GITHUB_RUN_ID="35" GITHUB_ACTOR="some_test_username" GITHUB_REF="some/branch-name" GITHUB_SERVER_URL="https://github.com" GITHUB_SHA="<MASKED>" SEMGREP_APP_TOKEN="fake-key-from-tests" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERSION_CACHE_PATH="<MASKED>" SEMGREP_ENABLE_VERSION_CHECK="0" SEMGREP_SEND_METRICS="off" semgrep ci --no-suppress-errors
+CI="true" GITHUB_ACTIONS="true" GITHUB_ACTOR="some_test_username" GITHUB_API_URL="https://api.github.com" GITHUB_REPOSITORY="project_name/project_name" GITHUB_RUN_ID="35" GITHUB_SERVER_URL="https://github.com" GITHUB_WORKSPACE="/home/runner/work/actions-test/actions-test" GITHUB_EVENT_NAME="push" GITHUB_REF="refs/heads/some/branch-name" GITHUB_BASE_REF="" GITHUB_HEAD_REF="" GITHUB_SHA="<MASKED>" SEMGREP_APP_TOKEN="fake-key-from-tests" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERSION_CACHE_PATH="<MASKED>" SEMGREP_ENABLE_VERSION_CHECK="0" SEMGREP_SEND_METRICS="off" semgrep ci --no-suppress-errors
 === end of command
 
 === exit code

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/meta.json
@@ -3,7 +3,7 @@
     "semgrep_version": "<sanitized version>",
     "repository": "project_name/project_name",
     "repo_url": "https://some.enterprise.url.com/project_name/project_name",
-    "branch": "some/branch-name",
+    "branch": "refs/heads/some/branch-name",
     "ci_job_url": "https://some.enterprise.url.com/project_name/project_name/actions/runs/35",
     "commit": "sanitized",
     "commit_author_email": "test_environment@test.r2c.dev",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/results.txt
@@ -1,5 +1,5 @@
 === command
-CI="true" GITHUB_ACTIONS="true" GITHUB_EVENT_NAME="push" GITHUB_REPOSITORY="project_name/project_name" GITHUB_RUN_ID="35" GITHUB_ACTOR="some_test_username" GITHUB_REF="some/branch-name" GITHUB_SERVER_URL="https://some.enterprise.url.com" GITHUB_SHA="<MASKED>" SEMGREP_APP_TOKEN="fake-key-from-tests" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERSION_CACHE_PATH="<MASKED>" SEMGREP_ENABLE_VERSION_CHECK="0" SEMGREP_SEND_METRICS="off" semgrep ci --no-suppress-errors
+CI="true" GITHUB_ACTIONS="true" GITHUB_ACTOR="some_test_username" GITHUB_API_URL="https://api.github.com" GITHUB_REPOSITORY="project_name/project_name" GITHUB_RUN_ID="35" GITHUB_SERVER_URL="https://some.enterprise.url.com" GITHUB_WORKSPACE="/home/runner/work/actions-test/actions-test" GITHUB_EVENT_NAME="push" GITHUB_REF="refs/heads/some/branch-name" GITHUB_BASE_REF="" GITHUB_HEAD_REF="" GITHUB_SHA="<MASKED>" SEMGREP_APP_TOKEN="fake-key-from-tests" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERSION_CACHE_PATH="<MASKED>" SEMGREP_ENABLE_VERSION_CHECK="0" SEMGREP_SEND_METRICS="off" semgrep ci --no-suppress-errors
 === end of command
 
 === exit code

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr-semgrepconfig/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr-semgrepconfig/meta.json
@@ -3,7 +3,7 @@
     "semgrep_version": "<sanitized version>",
     "repository": "project_name/project_name",
     "repo_url": "https://github.com/project_name/project_name",
-    "branch": "some/branch-name",
+    "branch": "refs/pull/123/merge",
     "ci_job_url": "https://github.com/project_name/project_name/actions/runs/35",
     "commit": "sanitized",
     "commit_author_email": "test_environment@test.r2c.dev",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr-semgrepconfig/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr-semgrepconfig/results.txt
@@ -1,5 +1,5 @@
 === command
-CI="true" GITHUB_ACTIONS="true" GITHUB_EVENT_NAME="pull_request" GITHUB_REPOSITORY="project_name/project_name" GITHUB_RUN_ID="35" GITHUB_ACTOR="some_test_username" GITHUB_REF="some/branch-name" SEMGREP_PROJECT_CONFIG="tags:
+CI="true" GITHUB_ACTIONS="true" GITHUB_ACTOR="some_test_username" GITHUB_API_URL="https://api.github.com" GITHUB_REPOSITORY="project_name/project_name" GITHUB_RUN_ID="35" GITHUB_SERVER_URL="https://github.com" GITHUB_WORKSPACE="/home/runner/work/actions-test/actions-test" GITHUB_EVENT_NAME="pull_request" GITHUB_REF="refs/pull/123/merge" GITHUB_BASE_REF="main" GITHUB_HEAD_REF="some/branch-name" SEMGREP_PROJECT_CONFIG="tags:
 - tag1
 - tag_key:tag_val
 " GITHUB_SHA="<MASKED>" GITHUB_EVENT_PATH="<MASKED>" SEMGREP_APP_TOKEN="fake-key-from-tests" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERSION_CACHE_PATH="<MASKED>" SEMGREP_ENABLE_VERSION_CHECK="0" SEMGREP_SEND_METRICS="off" semgrep ci --no-suppress-errors

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr/meta.json
@@ -3,7 +3,7 @@
     "semgrep_version": "<sanitized version>",
     "repository": "project_name/project_name",
     "repo_url": "https://github.com/project_name/project_name",
-    "branch": "some/branch-name",
+    "branch": "refs/pull/123/merge",
     "ci_job_url": "https://github.com/project_name/project_name/actions/runs/35",
     "commit": "sanitized",
     "commit_author_email": "test_environment@test.r2c.dev",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr/results.txt
@@ -1,5 +1,5 @@
 === command
-CI="true" GITHUB_ACTIONS="true" GITHUB_EVENT_NAME="pull_request" GITHUB_REPOSITORY="project_name/project_name" GITHUB_RUN_ID="35" GITHUB_ACTOR="some_test_username" GITHUB_REF="some/branch-name" GITHUB_SHA="<MASKED>" GITHUB_EVENT_PATH="<MASKED>" SEMGREP_APP_TOKEN="fake-key-from-tests" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERSION_CACHE_PATH="<MASKED>" SEMGREP_ENABLE_VERSION_CHECK="0" SEMGREP_SEND_METRICS="off" semgrep ci --no-suppress-errors
+CI="true" GITHUB_ACTIONS="true" GITHUB_ACTOR="some_test_username" GITHUB_API_URL="https://api.github.com" GITHUB_REPOSITORY="project_name/project_name" GITHUB_RUN_ID="35" GITHUB_SERVER_URL="https://github.com" GITHUB_WORKSPACE="/home/runner/work/actions-test/actions-test" GITHUB_EVENT_NAME="pull_request" GITHUB_REF="refs/pull/123/merge" GITHUB_BASE_REF="main" GITHUB_HEAD_REF="some/branch-name" GITHUB_SHA="<MASKED>" GITHUB_EVENT_PATH="<MASKED>" SEMGREP_APP_TOKEN="fake-key-from-tests" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERSION_CACHE_PATH="<MASKED>" SEMGREP_ENABLE_VERSION_CHECK="0" SEMGREP_SEND_METRICS="off" semgrep ci --no-suppress-errors
 === end of command
 
 === exit code

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push-special-env-vars/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push-special-env-vars/results.txt
@@ -1,5 +1,5 @@
 === command
-CI="true" GITHUB_ACTIONS="true" GITHUB_EVENT_NAME="push" SEMGREP_REPO_NAME="project_name/project_name" SEMGREP_JOB_URL="customjoburl.com" GITHUB_ACTOR="some_test_username" SEMGREP_PR_ID="312" SEMGREP_PR_TITLE="PR_TITLE" SEMGREP_BRANCH="some/branch-name" GITHUB_SHA="<MASKED>" SEMGREP_APP_TOKEN="fake-key-from-tests" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERSION_CACHE_PATH="<MASKED>" SEMGREP_ENABLE_VERSION_CHECK="0" SEMGREP_SEND_METRICS="off" semgrep ci --no-suppress-errors
+CI="true" GITHUB_ACTIONS="true" GITHUB_ACTOR="some_test_username" GITHUB_API_URL="https://api.github.com" GITHUB_REPOSITORY="project_name/project_name" GITHUB_RUN_ID="35" GITHUB_SERVER_URL="https://github.com" GITHUB_WORKSPACE="/home/runner/work/actions-test/actions-test" GITHUB_EVENT_NAME="push" GITHUB_REF="refs/heads/some/branch-name" GITHUB_BASE_REF="" GITHUB_HEAD_REF="" SEMGREP_REPO_NAME="project_name/project_name" SEMGREP_JOB_URL="customjoburl.com" SEMGREP_PR_ID="312" SEMGREP_PR_TITLE="PR_TITLE" SEMGREP_BRANCH="some/branch-name" GITHUB_SHA="<MASKED>" SEMGREP_APP_TOKEN="fake-key-from-tests" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERSION_CACHE_PATH="<MASKED>" SEMGREP_ENABLE_VERSION_CHECK="0" SEMGREP_SEND_METRICS="off" semgrep ci --no-suppress-errors
 === end of command
 
 === exit code

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/meta.json
@@ -3,7 +3,7 @@
     "semgrep_version": "<sanitized version>",
     "repository": "project_name/project_name",
     "repo_url": "https://github.com/project_name/project_name",
-    "branch": "some/branch-name",
+    "branch": "refs/heads/some/branch-name",
     "ci_job_url": "https://github.com/project_name/project_name/actions/runs/35",
     "commit": "sanitized",
     "commit_author_email": "test_environment@test.r2c.dev",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/results.txt
@@ -1,5 +1,5 @@
 === command
-CI="true" GITHUB_ACTIONS="true" GITHUB_EVENT_NAME="push" GITHUB_REPOSITORY="project_name/project_name" GITHUB_RUN_ID="35" GITHUB_ACTOR="some_test_username" GITHUB_REF="some/branch-name" GITHUB_SERVER_URL="https://github.com" GITHUB_SHA="<MASKED>" SEMGREP_APP_TOKEN="fake-key-from-tests" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERSION_CACHE_PATH="<MASKED>" SEMGREP_ENABLE_VERSION_CHECK="0" SEMGREP_SEND_METRICS="off" semgrep ci --no-suppress-errors
+CI="true" GITHUB_ACTIONS="true" GITHUB_ACTOR="some_test_username" GITHUB_API_URL="https://api.github.com" GITHUB_REPOSITORY="project_name/project_name" GITHUB_RUN_ID="35" GITHUB_SERVER_URL="https://github.com" GITHUB_WORKSPACE="/home/runner/work/actions-test/actions-test" GITHUB_EVENT_NAME="push" GITHUB_REF="refs/heads/some/branch-name" GITHUB_BASE_REF="" GITHUB_HEAD_REF="" GITHUB_SHA="<MASKED>" SEMGREP_APP_TOKEN="fake-key-from-tests" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERSION_CACHE_PATH="<MASKED>" SEMGREP_ENABLE_VERSION_CHECK="0" SEMGREP_SEND_METRICS="off" semgrep ci --no-suppress-errors
 === end of command
 
 === exit code

--- a/cli/tests/e2e/test_ci.py
+++ b/cli/tests/e2e/test_ci.py
@@ -404,6 +404,7 @@ def mock_autofix(request, mocker):
 # The tests
 ##############################################################################
 
+
 @pytest.mark.parametrize(
     "env",
     [

--- a/cli/tests/e2e/test_ci.py
+++ b/cli/tests/e2e/test_ci.py
@@ -404,12 +404,6 @@ def mock_autofix(request, mocker):
 # The tests
 ##############################################################################
 
-# "GITHUB_EVENT_NAME": "",
-#     "GITHUB_EVENT_PATH": "",
-#     "GITHUB_HEAD_REF": "", #
-#     "GITHUB_REF": "",
-
-
 @pytest.mark.parametrize(
     "env",
     [


### PR DESCRIPTION
The mocked env didn't accurately reflect the behavior of github actions which meant that the snapshots weren't accurately reflecting what we send to semgrep.dev in a scan. Before I make changes to the behavior I thought it appropriate to update these tests so that the diffs in future PRs are easier to review/understand.

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
