### PR TITLE
update dogfood precommit to 1.39.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -179,7 +179,7 @@ repos:
   # Dogfood! running semgrep in pre-commit!
   # ----------------------------------------------------------
   - repo: https://github.com/returntocorp/semgrep
-    rev: v1.30.0
+    rev: v1.39.0
     hooks:
       - id: semgrep
         name: Semgrep Jsonnet


### PR DESCRIPTION
Tom reported some DNS issues during precommit or in CI, probably
because we were using the pre-move-to-cohttp semgrep
so let's use a more recent semgrep in precommit

test plan:
I was able to commit this, and during precommit I got
some
```
[INFO] Initializing environment for https://github.com/returntocorp/semgrep.
[INFO] Installing environment for https://github.com/returntocorp/semgrep.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
```
because precommit was locally fetching and building locally the new semgrep


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)