### PR TITLE
Create --code flag for users who want to run code-only scans

### DIFF
--- a/changelog.d/gh-8679
+++ b/changelog.d/gh-8679
@@ -1,1 +1,1 @@
-Allow Semgrep CI users to specify Code product using `--code` command-line option. This works the same as `--supply-chain` now and fleshes out the product suite. 
+Allow Semgrep CI users to specify Code product using `--code` command-line option. This works the same as `--supply-chain` now and fleshes out the product suite.

--- a/changelog.d/gh-8679
+++ b/changelog.d/gh-8679
@@ -1,0 +1,1 @@
+Allow Semgrep CI users to specify Code product using `--code` command-line option. This works the same as `--supply-chain` now and fleshes out the product suite. 

--- a/cli/src/semgrep/commands/ci.py
+++ b/cli/src/semgrep/commands/ci.py
@@ -155,6 +155,7 @@ def fix_head_if_github_action(metadata: GitMeta) -> None:
     is_flag=True,
     hidden=True,
 )
+@click.option("--code", is_flag=True, hidden=True)
 @click.option("--beta-testing-secrets", is_flag=True, hidden=True)
 @click.option(
     "--suppress-errors/--no-suppress-errors",
@@ -175,6 +176,7 @@ def ci(
     autofix: bool,
     baseline_commit: Optional[str],
     beta_testing_secrets: bool,
+    code: bool,
     core_opts: Optional[str],
     config: Optional[Tuple[str, ...]],
     debug: bool,
@@ -309,6 +311,7 @@ def ci(
             console.print(Title("Connection", order=2))
             metadata_dict = metadata.to_dict()
             metadata_dict["is_sca_scan"] = supply_chain
+            metadata_dict["is_code_scan"] = code
             metadata_dict["is_secrets_scan"] = beta_testing_secrets
             proj_config = ProjectConfig.load_all()
             metadata_dict = {**metadata_dict, **proj_config.to_dict()}

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines-overwrite-autodetected-variables/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines-overwrite-autodetected-variables/meta.json
@@ -20,6 +20,7 @@
     "scan_environment": "azure-pipelines",
     "is_full_scan": true,
     "is_sca_scan": false,
+    "is_code_scan": false,
     "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines/meta.json
@@ -20,6 +20,7 @@
     "scan_environment": "azure-pipelines",
     "is_full_scan": true,
     "is_sca_scan": false,
+    "is_code_scan": false,
     "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket-overwrite-autodetected-variables/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket-overwrite-autodetected-variables/meta.json
@@ -20,6 +20,7 @@
     "scan_environment": "bitbucket",
     "is_full_scan": true,
     "is_sca_scan": false,
+    "is_code_scan": false,
     "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket/meta.json
@@ -20,6 +20,7 @@
     "scan_environment": "bitbucket",
     "is_full_scan": true,
     "is_sca_scan": false,
+    "is_code_scan": false,
     "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite-overwrite-autodetected-variables/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite-overwrite-autodetected-variables/meta.json
@@ -20,6 +20,7 @@
     "scan_environment": "buildkite",
     "is_full_scan": true,
     "is_sca_scan": false,
+    "is_code_scan": false,
     "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite/meta.json
@@ -20,6 +20,7 @@
     "scan_environment": "buildkite",
     "is_full_scan": true,
     "is_sca_scan": false,
+    "is_code_scan": false,
     "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci-overwrite-autodetected-variables/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci-overwrite-autodetected-variables/meta.json
@@ -20,6 +20,7 @@
     "scan_environment": "circleci",
     "is_full_scan": true,
     "is_sca_scan": false,
+    "is_code_scan": false,
     "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci/meta.json
@@ -20,6 +20,7 @@
     "scan_environment": "circleci",
     "is_full_scan": true,
     "is_sca_scan": false,
+    "is_code_scan": false,
     "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/meta.json
@@ -20,6 +20,7 @@
     "scan_environment": "github-actions",
     "is_full_scan": true,
     "is_sca_scan": false,
+    "is_code_scan": false,
     "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr-semgrepconfig/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr-semgrepconfig/meta.json
@@ -20,6 +20,7 @@
     "scan_environment": "github-actions",
     "is_full_scan": false,
     "is_sca_scan": false,
+    "is_code_scan": false,
     "is_secrets_scan": false,
     "tags": [
       "tag1",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr/meta.json
@@ -20,6 +20,7 @@
     "scan_environment": "github-actions",
     "is_full_scan": false,
     "is_sca_scan": false,
+    "is_code_scan": false,
     "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push-special-env-vars/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push-special-env-vars/meta.json
@@ -20,6 +20,7 @@
     "scan_environment": "github-actions",
     "is_full_scan": true,
     "is_sca_scan": false,
+    "is_code_scan": false,
     "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/meta.json
@@ -20,6 +20,7 @@
     "scan_environment": "github-actions",
     "is_full_scan": true,
     "is_sca_scan": false,
+    "is_code_scan": false,
     "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-push/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-push/meta.json
@@ -22,6 +22,7 @@
     "base_sha": "sanitized",
     "start_sha": null,
     "is_sca_scan": false,
+    "is_code_scan": false,
     "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-special-env-vars/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-special-env-vars/meta.json
@@ -22,6 +22,7 @@
     "base_sha": "sanitized",
     "start_sha": "unused-commit-test-placeholder",
     "is_sca_scan": false,
+    "is_code_scan": false,
     "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab/meta.json
@@ -22,6 +22,7 @@
     "base_sha": "sanitized",
     "start_sha": "unused-commit-test-placeholder",
     "is_sca_scan": false,
+    "is_code_scan": false,
     "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/meta.json
@@ -20,6 +20,7 @@
     "scan_environment": "jenkins",
     "is_full_scan": true,
     "is_sca_scan": false,
+    "is_code_scan": false,
     "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-overwrite-autodetected-variables/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-overwrite-autodetected-variables/meta.json
@@ -20,6 +20,7 @@
     "scan_environment": "jenkins",
     "is_full_scan": true,
     "is_sca_scan": false,
+    "is_code_scan": false,
     "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins/meta.json
@@ -20,6 +20,7 @@
     "scan_environment": "jenkins",
     "is_full_scan": true,
     "is_sca_scan": false,
+    "is_code_scan": false,
     "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/meta.json
@@ -20,6 +20,7 @@
     "scan_environment": "git",
     "is_full_scan": true,
     "is_sca_scan": false,
+    "is_code_scan": false,
     "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-self-hosted/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-self-hosted/meta.json
@@ -20,6 +20,7 @@
     "scan_environment": "git",
     "is_full_scan": true,
     "is_sca_scan": false,
+    "is_code_scan": false,
     "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis-overwrite-autodetected-variables/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis-overwrite-autodetected-variables/meta.json
@@ -20,6 +20,7 @@
     "scan_environment": "travis-ci",
     "is_full_scan": true,
     "is_sca_scan": false,
+    "is_code_scan": false,
     "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis/meta.json
@@ -20,6 +20,7 @@
     "scan_environment": "travis-ci",
     "is_full_scan": true,
     "is_sca_scan": false,
+    "is_code_scan": false,
     "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-unparsable_url/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-unparsable_url/meta.json
@@ -20,6 +20,7 @@
     "scan_environment": "git",
     "is_full_scan": true,
     "is_sca_scan": false,
+    "is_code_scan": false,
     "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines-overwrite-autodetected-variables/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines-overwrite-autodetected-variables/meta.json
@@ -20,6 +20,7 @@
     "scan_environment": "azure-pipelines",
     "is_full_scan": true,
     "is_sca_scan": false,
+    "is_code_scan": false,
     "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines/meta.json
@@ -20,6 +20,7 @@
     "scan_environment": "azure-pipelines",
     "is_full_scan": true,
     "is_sca_scan": false,
+    "is_code_scan": false,
     "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket-overwrite-autodetected-variables/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket-overwrite-autodetected-variables/meta.json
@@ -20,6 +20,7 @@
     "scan_environment": "bitbucket",
     "is_full_scan": true,
     "is_sca_scan": false,
+    "is_code_scan": false,
     "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket/meta.json
@@ -20,6 +20,7 @@
     "scan_environment": "bitbucket",
     "is_full_scan": true,
     "is_sca_scan": false,
+    "is_code_scan": false,
     "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite-overwrite-autodetected-variables/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite-overwrite-autodetected-variables/meta.json
@@ -20,6 +20,7 @@
     "scan_environment": "buildkite",
     "is_full_scan": true,
     "is_sca_scan": false,
+    "is_code_scan": false,
     "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite/meta.json
@@ -20,6 +20,7 @@
     "scan_environment": "buildkite",
     "is_full_scan": true,
     "is_sca_scan": false,
+    "is_code_scan": false,
     "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci-overwrite-autodetected-variables/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci-overwrite-autodetected-variables/meta.json
@@ -20,6 +20,7 @@
     "scan_environment": "circleci",
     "is_full_scan": true,
     "is_sca_scan": false,
+    "is_code_scan": false,
     "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci/meta.json
@@ -20,6 +20,7 @@
     "scan_environment": "circleci",
     "is_full_scan": true,
     "is_sca_scan": false,
+    "is_code_scan": false,
     "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/meta.json
@@ -20,6 +20,7 @@
     "scan_environment": "github-actions",
     "is_full_scan": true,
     "is_sca_scan": false,
+    "is_code_scan": false,
     "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr-semgrepconfig/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr-semgrepconfig/meta.json
@@ -20,6 +20,7 @@
     "scan_environment": "github-actions",
     "is_full_scan": false,
     "is_sca_scan": false,
+    "is_code_scan": false,
     "is_secrets_scan": false,
     "tags": [
       "tag1",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr/meta.json
@@ -20,6 +20,7 @@
     "scan_environment": "github-actions",
     "is_full_scan": false,
     "is_sca_scan": false,
+    "is_code_scan": false,
     "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push-special-env-vars/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push-special-env-vars/meta.json
@@ -20,6 +20,7 @@
     "scan_environment": "github-actions",
     "is_full_scan": true,
     "is_sca_scan": false,
+    "is_code_scan": false,
     "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/meta.json
@@ -20,6 +20,7 @@
     "scan_environment": "github-actions",
     "is_full_scan": true,
     "is_sca_scan": false,
+    "is_code_scan": false,
     "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-push/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-push/meta.json
@@ -22,6 +22,7 @@
     "base_sha": "sanitized",
     "start_sha": null,
     "is_sca_scan": false,
+    "is_code_scan": false,
     "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-special-env-vars/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-special-env-vars/meta.json
@@ -22,6 +22,7 @@
     "base_sha": "sanitized",
     "start_sha": "unused-commit-test-placeholder",
     "is_sca_scan": false,
+    "is_code_scan": false,
     "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab/meta.json
@@ -22,6 +22,7 @@
     "base_sha": "sanitized",
     "start_sha": "unused-commit-test-placeholder",
     "is_sca_scan": false,
+    "is_code_scan": false,
     "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/meta.json
@@ -20,6 +20,7 @@
     "scan_environment": "jenkins",
     "is_full_scan": true,
     "is_sca_scan": false,
+    "is_code_scan": false,
     "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-overwrite-autodetected-variables/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-overwrite-autodetected-variables/meta.json
@@ -20,6 +20,7 @@
     "scan_environment": "jenkins",
     "is_full_scan": true,
     "is_sca_scan": false,
+    "is_code_scan": false,
     "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins/meta.json
@@ -20,6 +20,7 @@
     "scan_environment": "jenkins",
     "is_full_scan": true,
     "is_sca_scan": false,
+    "is_code_scan": false,
     "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/meta.json
@@ -20,6 +20,7 @@
     "scan_environment": "git",
     "is_full_scan": true,
     "is_sca_scan": false,
+    "is_code_scan": false,
     "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-self-hosted/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-self-hosted/meta.json
@@ -20,6 +20,7 @@
     "scan_environment": "git",
     "is_full_scan": true,
     "is_sca_scan": false,
+    "is_code_scan": false,
     "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis-overwrite-autodetected-variables/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis-overwrite-autodetected-variables/meta.json
@@ -20,6 +20,7 @@
     "scan_environment": "travis-ci",
     "is_full_scan": true,
     "is_sca_scan": false,
+    "is_code_scan": false,
     "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis/meta.json
@@ -20,6 +20,7 @@
     "scan_environment": "travis-ci",
     "is_full_scan": true,
     "is_sca_scan": false,
+    "is_code_scan": false,
     "is_secrets_scan": false
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-unparsable_url/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-unparsable_url/meta.json
@@ -20,6 +20,7 @@
     "scan_environment": "git",
     "is_full_scan": true,
     "is_sca_scan": false,
+    "is_code_scan": false,
     "is_secrets_scan": false
   }
 }


### PR DESCRIPTION
PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
