### PR TITLE
Add checks for `semgrep ci` nudge message

### DIFF
--- a/cli/src/semgrep/state.py
+++ b/cli/src/semgrep/state.py
@@ -26,9 +26,9 @@ class SemgrepState:
     terminal: Terminal = Factory(Terminal)
 
 
-def get_state() -> SemgrepState:
+def get_context() -> click.Context:
     """
-    Get the current CLI invocation's global state.
+    Get the current CLI invocation's click context.
     """
     ctx = click.get_current_context(silent=True)
     if ctx is None:
@@ -37,4 +37,12 @@ def get_state() -> SemgrepState:
 
         ctx = click.Context(command=cli).scope().__enter__()
 
+    return ctx
+
+
+def get_state() -> SemgrepState:
+    """
+    Get the current CLI invocation's global state.
+    """
+    ctx = get_context()
     return ctx.ensure_object(SemgrepState)


### PR DESCRIPTION
## Description
This PR adds some additional checks to skip printing the `semgrep ci` nudge message.

## Test Plan
- [x] Expect to see no nudge when `semgrep ci` is run on a repo w/o a lockfile
- [x] Expect to see no nudge when `semgrep --config supply-chain` is run on a repo w/o a lockfile

### PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
