### PR TITLE
osemgrep: new 'semgrep show supported-languages' command

### DIFF
--- a/changelog.d/show.added
+++ b/changelog.d/show.added
@@ -1,0 +1,5 @@
+There is a new 'semgrep show' command to display information about
+semgrep, for example 'semgrep show supported-languages'. The goal is to
+cleanup 'semgrep scan' which is currently abused to not scan but
+also display semgrep information (e.g., 'semgrep scan --show-supported-languages).
+See 'semgrep show --help' for more information.

--- a/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -64,7 +64,6 @@ type conf = {
   common : CLI_common.conf;
   (* Ugly: should be in separate subcommands *)
   version : bool;
-  show_supported_languages : bool;
   show : Show_CLI.conf option;
   validate : Validate_subcommand.conf option;
   test : Test_subcommand.conf option;
@@ -143,7 +142,6 @@ let default : conf =
     version_check = true;
     (* ugly: should be separate subcommands *)
     version = false;
-    show_supported_languages = false;
     show = None;
     validate = None;
     test = None;
@@ -925,6 +923,8 @@ let cmdline_term ~allow_empty_config : conf Term.t =
           Some { Show.target = Show.EnginePath pro; json }
       | _ when dump_command_for_core ->
           Some { Show.target = Show.CommandForCore; json }
+      | _ when show_supported_languages ->
+          Some { Show.target = Show.SupportedLanguages; json }
       | _else_ -> None
     in
     (* ugly: validate should be a separate subcommand.
@@ -1026,7 +1026,6 @@ let cmdline_term ~allow_empty_config : conf Term.t =
       common;
       (* ugly: *)
       version;
-      show_supported_languages;
       show;
       validate;
       test;

--- a/src/osemgrep/cli_scan/Scan_CLI.mli
+++ b/src/osemgrep/cli_scan/Scan_CLI.mli
@@ -44,7 +44,6 @@ type conf = {
   common : CLI_common.conf;
   (* Ugly: should be in separate subcommands *)
   version : bool;
-  show_supported_languages : bool;
   show : Show_CLI.conf option;
   validate : Validate_subcommand.conf option;
   test : Test_subcommand.conf option;

--- a/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -608,9 +608,15 @@ let run_scan_conf (conf : Scan_CLI.conf) : Exit_code.t =
 let run_conf (conf : Scan_CLI.conf) : Exit_code.t =
   (match conf.common.maturity with
   | Maturity.Default -> (
-      match conf with
       (* TODO: handle more confs, or fallback to pysemgrep further down *)
-      | { show_supported_languages = true; _ } -> ()
+      match conf with
+      | {
+       show =
+         Some { target = Show_CLI.EnginePath _ | Show_CLI.CommandForCore; _ };
+       _;
+      } ->
+          raise Pysemgrep.Fallback
+      | { show = Some _; _ } -> ()
       | _else_ -> raise Pysemgrep.Fallback)
   (* this should never happen because --legacy is handled in cli/bin/semgrep *)
   | Maturity.Legacy -> raise Pysemgrep.Fallback
@@ -635,9 +641,6 @@ let run_conf (conf : Scan_CLI.conf) : Exit_code.t =
   | _ when conf.version ->
       Common.pr Version.version;
       (* TOPORT: if enable_version_check: version_check() *)
-      Exit_code.ok
-  | _ when conf.show_supported_languages ->
-      Common.pr (spf "supported languages are: %s" Xlang.supported_xlangs);
       Exit_code.ok
   | _ when conf.test <> None -> Test_subcommand.run (Common2.some conf.test)
   | _ when conf.validate <> None ->

--- a/src/osemgrep/cli_show/Show_CLI.ml
+++ b/src/osemgrep/cli_show/Show_CLI.ml
@@ -25,6 +25,9 @@ type conf = {
   json : bool;
 }
 
+(* coupling: if you add a command you probably need to modify [combine]
+ * below and also the doc in [man] further below
+ *)
 and target_kind =
   (* 'semgrep show ???'
    * accessible also as 'semgrep scan --dump-ast -e <pattern>'
@@ -44,6 +47,10 @@ and target_kind =
    * accessible also as 'semgrep scan --dump-command-for-core' (or just '-d')
    * LATER: get rid of it *)
   | CommandForCore
+  (* 'semgrep show supported-languages'
+   * accessible also as `semgrep scan --show-supported-languages
+   *)
+  | SupportedLanguages
 [@@deriving show]
 
 (*************************************************************************)
@@ -81,6 +88,7 @@ let cmdline_term : conf Term.t =
        *)
       match args with
       | [ "dump-config"; config_str ] -> Config config_str
+      | [ "supported-languages" ] -> SupportedLanguages
       | _ ->
           Error.abort
             (spf "show command not supported: %s" (String.concat " " args))
@@ -99,6 +107,9 @@ let man : Cmdliner.Manpage.block list =
     `P "Here are the different subcommands";
     `Pre "semgrep show dump-config <STRING>";
     `P "Dump the internal representation of the result of --config=<STRING>";
+    `Pre "semgrep show supported-languages";
+    (* coupling: Scan_CLI.o_show_supported_languages help *)
+    `P "Print a list of languages that are currently supported by Semgrep.";
   ]
   @ CLI_common.help_page_bottom
 

--- a/src/osemgrep/cli_show/Show_CLI.mli
+++ b/src/osemgrep/cli_show/Show_CLI.mli
@@ -20,6 +20,7 @@ and target_kind =
   | Config of Rules_config.config_string
   | EnginePath of bool (* pro = true *)
   | CommandForCore
+  | SupportedLanguages
 [@@deriving show]
 
 (*


### PR DESCRIPTION
test plan:
./bin/osemgrep show supported-languages
show the right thing
make e2e


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)