### PR TITLE
osemgrep: show skipped dotfiles when using --develop --verbose

### DIFF
--- a/changelog.d/dotfiles.added
+++ b/changelog.d/dotfiles.added
@@ -1,2 +1,2 @@
-Dotfiles (e.g., .emacs) are now displayed in the skip report when
+Dot files (e.g., .vscode) are now displayed in the skip report when
 using --verbose and --develop.

--- a/changelog.d/dotfiles.added
+++ b/changelog.d/dotfiles.added
@@ -1,0 +1,2 @@
+Dotfiles (e.g., .emacs) are now displayed in the skip report when
+using --verbose and --develop.

--- a/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -473,13 +473,13 @@ let run_scan_files (conf : Scan_CLI.conf) (profiler : Profiler.t)
 let run_scan_conf (conf : Scan_CLI.conf) : Exit_code.t =
   let profiler = Profiler.make () in
   Profiler.start profiler ~name:"total_time";
+  (* Metrics initialization (and finalization) is done in CLI.ml,
+   * but here we "configure" it (enable or disable it) based on CLI flags.
+   *)
+  Metrics_.configure conf.metrics;
   let settings =
     (fun () ->
       let settings = Semgrep_settings.load ~maturity:conf.common.maturity () in
-      (* Metrics initialization (and finalization) is done in CLI.ml,
-       * but here we "configure" it (enable or disable it) based on CLI flags.
-       *)
-      Metrics_.configure conf.metrics;
       Metrics_.add_token settings.api_token;
       (* TODO? why guard this one with is_enabled? because calling
        * git can take time (and generate errors on stderr)?

--- a/src/osemgrep/core/Metrics_.ml
+++ b/src/osemgrep/core/Metrics_.ml
@@ -71,6 +71,9 @@ open Semgrep_metrics_t
         where each row is a payload with the IP address as the Partition Key
       - The data is then stored in our S3 bucket ("semgrep-cli-metrics") and
         can be queried via Snowflake or Metabase
+
+    This file should be called simply Metrics.ml but this would conflict with
+    a module using the same name in one of the OCaml library we use.
 *)
 
 (*****************************************************************************)

--- a/src/osemgrep/reporting/Skipped_report.ml
+++ b/src/osemgrep/reporting/Skipped_report.ml
@@ -91,7 +91,7 @@ let group_skipped (skipped : Out.skipped_target list) : skipped_targets_grouped
 (*****************************************************************************)
 
 let pp_skipped ppf
-    (respect_git_ignore, maturity, max_target_bytes, skipped_groups) =
+    (respect_git_ignore, maturity, max_target_bytes, skipped_groups) : unit =
   let {
     ignored = semgrep_ignored;
     include_ = include_ignored;

--- a/src/osemgrep/reporting/Skipped_report.ml
+++ b/src/osemgrep/reporting/Skipped_report.ml
@@ -8,23 +8,99 @@ module Out = Semgrep_output_v1_t
 *)
 
 (*****************************************************************************)
+(* Types *)
+(*****************************************************************************)
+(* this is used both in this file and in Summary_report.ml *)
+type skipped_targets_grouped = {
+  (* targets skipped because of file targeting spec *)
+  ignored : Semgrep_output_v1_t.skipped_target list;
+  size : Semgrep_output_v1_t.skipped_target list;
+  include_ : Semgrep_output_v1_t.skipped_target list;
+  exclude : Semgrep_output_v1_t.skipped_target list;
+  other : Semgrep_output_v1_t.skipped_target list;
+  (* targets skipped because there was parsing/matching
+   * errors while running the engine on it.
+   *)
+  errors : Semgrep_output_v1_t.skipped_target list;
+}
+
+(*****************************************************************************)
 (* Helpers *)
 (*****************************************************************************)
+
+let errors_to_skipped (errors : Out.core_error list) : Out.skipped_target list =
+  errors
+  |> Common.map (fun Out.{ location; message; rule_id; _ } ->
+         Out.
+           {
+             path = location.path;
+             reason = Analysis_failed_parser_or_internal_error;
+             details = Some message;
+             rule_id;
+           })
+
+let group_skipped ~errors_skipped (skipped : Out.skipped_target list) :
+    skipped_targets_grouped =
+  let groups =
+    Common.group_by
+      (fun (Out.{ reason; _ } : Out.skipped_target) ->
+        match reason with
+        | Out.Gitignore_patterns_match
+        | Semgrepignore_patterns_match ->
+            `Semgrepignore
+        | Too_big
+        | Exceeded_size_limit ->
+            `Size
+        | Cli_include_flags_do_not_match -> `Include
+        | Cli_exclude_flags_match -> `Exclude
+        | Always_skipped
+        | Analysis_failed_parser_or_internal_error
+        | Excluded_by_config
+        | Wrong_language
+        | Minified
+        | Binary
+        | Dotfile
+        | Irrelevant_rule
+        | Too_many_matches ->
+            `Other)
+      skipped
+  in
+  {
+    ignored =
+      (try List.assoc `Semgrepignore groups with
+      | Not_found -> []);
+    include_ =
+      (try List.assoc `Include groups with
+      | Not_found -> []);
+    exclude =
+      (try List.assoc `Exclude groups with
+      | Not_found -> []);
+    size =
+      (try List.assoc `Size groups with
+      | Not_found -> []);
+    other =
+      (try List.assoc `Other groups with
+      | Not_found -> []);
+    errors = errors_skipped;
+  }
 
 (*****************************************************************************)
 (* Entry point *)
 (*****************************************************************************)
 
 let pp_skipped ppf
-    ( respect_git_ignore,
-      maturity,
-      max_target_bytes,
-      semgrep_ignored,
-      include_ignored,
-      exclude_ignored,
-      file_size_ignored,
-      other_ignored,
-      errors ) =
+    (respect_git_ignore, maturity, max_target_bytes, skipped_groups) =
+  let {
+    ignored = semgrep_ignored;
+    include_ = include_ignored;
+    exclude = exclude_ignored;
+    size = file_size_ignored;
+    other = other_ignored;
+    errors;
+  } =
+    skipped_groups
+  in
+
   (* not sure why but pysemgrep does not use the classic heading for skipped*)
   Fmt.pf ppf "%s@.Files skipped:@.%s@." (String.make 40 '=')
     (String.make 40 '=');

--- a/src/osemgrep/reporting/Skipped_report.mli
+++ b/src/osemgrep/reporting/Skipped_report.mli
@@ -1,13 +1,25 @@
-(* TODO: this is an ugly signature. Should define a record to hold the data *)
+(* this type is used both for Skipped_report.ml and Summary_report.ml *)
+type skipped_targets_grouped = {
+  (* targets skipped because of file targeting semantic *)
+  ignored : Semgrep_output_v1_t.skipped_target list;
+  size : Semgrep_output_v1_t.skipped_target list;
+  include_ : Semgrep_output_v1_t.skipped_target list;
+  exclude : Semgrep_output_v1_t.skipped_target list;
+  other : Semgrep_output_v1_t.skipped_target list;
+  (* targets skipped because there was parsing/matching
+   * errors while running the engine on it
+   * (see errors_skipped())
+   *)
+  errors : Semgrep_output_v1_t.skipped_target list;
+}
+
+val errors_to_skipped :
+  Semgrep_output_v1_t.core_error list -> Semgrep_output_v1_t.skipped_target list
+
+val group_skipped :
+  errors_skipped:Semgrep_output_v1_t.skipped_target list ->
+  Semgrep_output_v1_t.skipped_target list ->
+  skipped_targets_grouped
+
 val pp_skipped :
-  Format.formatter ->
-  bool
-  * Maturity.t
-  * int
-  * Semgrep_output_v1_t.skipped_target list
-  * Semgrep_output_v1_t.skipped_target list
-  * Semgrep_output_v1_t.skipped_target list
-  * Semgrep_output_v1_t.skipped_target list
-  * Semgrep_output_v1_t.skipped_target list
-  * Semgrep_output_v1_t.skipped_target list ->
-  unit
+  Format.formatter -> bool * Maturity.t * int * skipped_targets_grouped -> unit

--- a/src/osemgrep/reporting/Skipped_report.mli
+++ b/src/osemgrep/reporting/Skipped_report.mli
@@ -17,9 +17,7 @@ val errors_to_skipped :
   Semgrep_output_v1_t.core_error list -> Semgrep_output_v1_t.skipped_target list
 
 val group_skipped :
-  errors_skipped:Semgrep_output_v1_t.skipped_target list ->
-  Semgrep_output_v1_t.skipped_target list ->
-  skipped_targets_grouped
+  Semgrep_output_v1_t.skipped_target list -> skipped_targets_grouped
 
 val pp_skipped :
   Format.formatter -> bool * Maturity.t * int * skipped_targets_grouped -> unit

--- a/src/osemgrep/reporting/Summary_report.ml
+++ b/src/osemgrep/reporting/Summary_report.ml
@@ -16,24 +16,18 @@ module Out = Semgrep_output_v1_t
 (*****************************************************************************)
 
 let pp_summary ppf
-    (( respect_git_ignore,
-       maturity,
-       max_target_bytes,
-       semgrep_ignored,
-       include_ignored,
-       exclude_ignored,
-       file_size_ignored,
-       other_ignored,
-       errors ) :
-      bool
-      * Maturity.t
-      * int
-      * Out.skipped_target list
-      * Out.skipped_target list
-      * Out.skipped_target list
-      * Out.skipped_target list
-      * Out.skipped_target list
-      * Out.skipped_target list) =
+    (respect_git_ignore, maturity, max_target_bytes, skipped_groups) =
+  let {
+    Skipped_report.ignored = semgrep_ignored;
+    include_ = include_ignored;
+    exclude = exclude_ignored;
+    size = file_size_ignored;
+    other = other_ignored;
+    errors;
+  } =
+    skipped_groups
+  in
+
   Fmt_helpers.pp_heading ppf "Scan Summary";
   (* TODO
         if self.target_manager.baseline_handler:

--- a/src/osemgrep/reporting/Summary_report.ml
+++ b/src/osemgrep/reporting/Summary_report.ml
@@ -16,7 +16,7 @@ module Out = Semgrep_output_v1_t
 (*****************************************************************************)
 
 let pp_summary ppf
-    (respect_git_ignore, maturity, max_target_bytes, skipped_groups) =
+    (respect_git_ignore, maturity, max_target_bytes, skipped_groups) : unit =
   let {
     Skipped_report.ignored = semgrep_ignored;
     include_ = include_ignored;

--- a/src/osemgrep/reporting/Summary_report.mli
+++ b/src/osemgrep/reporting/Summary_report.mli
@@ -1,12 +1,4 @@
 val pp_summary :
   Format.formatter ->
-  bool
-  * Maturity.t
-  * int
-  * Semgrep_output_v1_t.skipped_target list
-  * Semgrep_output_v1_t.skipped_target list
-  * Semgrep_output_v1_t.skipped_target list
-  * Semgrep_output_v1_t.skipped_target list
-  * Semgrep_output_v1_t.skipped_target list
-  * Semgrep_output_v1_t.skipped_target list ->
+  bool * Maturity.t * int * Skipped_report.skipped_targets_grouped ->
   unit

--- a/src/targeting/Find_targets.ml
+++ b/src/targeting/Find_targets.ml
@@ -148,7 +148,16 @@ let walk_skip_and_collect (conf : conf) (ign : Semgrepignore.t)
             * TODO? maybe add a setting in conf?
             * TODO? add a skip reason for those?
             *)
-           if name =~ "^\\." then ignore ()
+           if name =~ "^\\." then
+             let skip =
+               {
+                 Out.path = !!fpath;
+                 reason = Out.Dotfile;
+                 details = None;
+                 rule_id = None;
+               }
+             in
+             Common.push skip skipped
            else
              let status, selection_events = Semgrepignore.select ign ppath in
              match status with


### PR DESCRIPTION
Also cleanup the old skip reporting code; use a record instead of those big tuples.

test plan:
./bin/osemgrep --develop -e 'foo($X);' . --verbose
see dotfiles in skip report


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)