### PR TITLE
osemgrep: fix Metrics_.is_enabled

### DIFF
--- a/src/osemgrep/cli/CLI.ml
+++ b/src/osemgrep/cli/CLI.ml
@@ -61,9 +61,11 @@ let metrics_init () : unit =
   let api_token = settings.Semgrep_settings.api_token in
   let anonymous_user_id = settings.Semgrep_settings.anonymous_user_id in
   Metrics_.init ~anonymous_user_id ~ci:!Env.v.is_ci;
-  (* TODO: we always send is_authenticated metrics then? *)
-  Metrics_.add_token (Some api_token);
+  api_token
+  |> Option.iter (fun (_token : Auth.token) ->
+         Metrics_.g.payload.environment.isAuthenticated <- true);
   !Env.v.user_agent_append |> Option.iter Metrics_.add_user_agent_tag;
+  Metrics_.g.payload.environment.integrationName <- !Env.v.integration_name;
   ()
 
 (* For debugging customer issues, we append the CLI flags for each subcommand,

--- a/src/osemgrep/cli/CLI.ml
+++ b/src/osemgrep/cli/CLI.ml
@@ -28,7 +28,7 @@ open Common
    We don't use Cmdliner to dispatch subcommands because it's too
    complicated and anywant we want full control on main help message.
 
-   Translated from cli.py and commands/wrapper.py
+   Translated from cli.py and commands/wrapper.py and parts of metrics.py
 *)
 
 module Env = Semgrep_envvars
@@ -52,11 +52,16 @@ let default_subcommand = "scan"
    ()
 *)
 
+(*****************************************************************************)
+(* Metrics start and end *)
+(*****************************************************************************)
+
 let metrics_init () : unit =
   let settings = Semgrep_settings.load () in
   let api_token = settings.Semgrep_settings.api_token in
   let anonymous_user_id = settings.Semgrep_settings.anonymous_user_id in
   Metrics_.init ~anonymous_user_id ~ci:!Env.v.is_ci;
+  (* TODO: we always send is_authenticated metrics then? *)
   Metrics_.add_token (Some api_token);
   !Env.v.user_agent_append |> Option.iter Metrics_.add_user_agent_tag;
   ()
@@ -70,14 +75,13 @@ let log_cli_feature flag : unit =
     |> Base.String.chop_prefix_if_exists ~prefix:"-"
     |> Base.String.chop_prefix_if_exists ~prefix:"-")
 
-(* NOTE: We could implement send_metrics in Metrics_.ml,
+(* CLI subcmds need to call Metrics_.configure conf.metrics
+   otherwise metrics will not be send as Metrics.g.config default
+   to Off
+   alt: we could implement send_metrics() in Metrics_.ml,
    but we would need to add a dependency on Http_helpers.
 *)
 let send_metrics () : unit =
-  (* NOTE: CLI subcmd needs to call Metrics_.configure conf.metrics;
-     otherwise, metrics will not be enabled as our default state
-     for our metrics singleton is false.
-  *)
   if Metrics_.is_enabled () then (
     (* Populate the sent_at timestamp *)
     Metrics_.prepare_to_send ();
@@ -94,9 +98,7 @@ let send_metrics () : unit =
     | Error (status_code, err) ->
         Logs.warn (fun m -> m "Metrics Endpoint error: %d %s" status_code err);
         ())
-  else (
-    Logs.debug (fun m -> m "Metrics not enabled, skipping sending");
-    ())
+  else Logs.debug (fun m -> m "Metrics not enabled, skipping sending")
 
 (*****************************************************************************)
 (* Subcommands dispatch *)
@@ -166,17 +168,15 @@ let dispatch_subcommand argv =
         subcmd_argv0 :: subcmd_args |> Array.of_list
       in
       let experimental = Array.mem "--experimental" argv in
+      (* basic metrics on what was the command *)
+      Metrics_.add_feature "subcommand" subcmd;
+      Metrics_.add_user_agent_tag (spf "command/%s" subcmd);
+      subcmd_argv |> Array.to_list
+      |> exclude (fun x -> not (Base.String.is_prefix ~prefix:"-" x))
+      |> List.iter log_cli_feature;
       (* coupling: with known_subcommands if you add an entry below.
        * coupling: with Help.ml if you add an entry below.
        *)
-      Metrics_.add_feature "subcommand" subcmd;
-      Metrics_.add_user_agent_tag (spf "command/%s" subcmd);
-      let flags =
-        subcmd_argv |> Array.to_list
-        |> exclude (fun x -> not (Base.String.is_prefix ~prefix:"-" x))
-        |> uniq_by ( =*= )
-      in
-      List.iter log_cli_feature flags;
       try
         match subcmd with
         (* TODO: gradually remove those 'when experimental' guards as
@@ -301,21 +301,19 @@ let main argv : Exit_code.t =
    * alt: we could analyze [argv] and do it sooner for all subcommands here.
    *)
   Logs_helpers.enable_logging ();
+  (* TOADAPT: profile_start := Unix.gettimeofday (); *)
   (* pad poor's man profiler *)
   if profile then Profiling.profile := Profiling.ProfAll;
 
-  (* TOADAPT: profile_start := Unix.gettimeofday (); *)
   (* hacks for having a smaller engine.js file *)
   Parsing_init.init ();
   Data_init.init ();
+
   metrics_init ();
-
   (* TOPORT: maybe_set_git_safe_directories() *)
-
-  (*TOADAPT? adapt more of Common.boilerplate? *)
+  (* TOADAPT? adapt more of Common.boilerplate? *)
   let exit_code = safe_run ~debug (fun () -> dispatch_subcommand argv) in
   Metrics_.add_exit_code exit_code;
   send_metrics ();
-
   before_exit ~profile ();
   exit_code

--- a/src/osemgrep/cli_ci/Ci_subcommand.ml
+++ b/src/osemgrep/cli_ci/Ci_subcommand.ml
@@ -353,6 +353,7 @@ let prepare_for_report ~blocking_findings findings errors rules ~targets
 let run_conf (conf : Ci_CLI.conf) : Exit_code.t =
   CLI_common.setup_logging ~force_color:conf.force_color
     ~level:conf.common.logging_level;
+  (* TODO? we probably want to set the metrics to On by default in CI ctx? *)
   Metrics_.configure conf.metrics;
   let settings = Semgrep_settings.load ~maturity:conf.common.maturity () in
   let deployment =

--- a/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -136,6 +136,7 @@ let default : conf =
     max_chars_per_line = 160;
     max_lines_per_finding = 10;
     rewrite_rule_ids = true;
+    (* will send metrics only if the user uses the registry or the app *)
     metrics = Metrics_.Auto;
     (* like maturity, should maybe be set to false when we release osemgrep *)
     registry_caching = false;

--- a/src/osemgrep/core/Metrics_.ml
+++ b/src/osemgrep/core/Metrics_.ml
@@ -91,13 +91,13 @@ let metrics_url =
 (*
      Configures metrics upload.
 
-     On - Metrics always sent
-     Off - Metrics never sent
+     On   - Metrics always sent
+     Off  - Metrics never sent
      Auto - Metrics only sent if config is pulled from the registry
-          or if using the Semgrep App.
+            or if using the Semgrep App.
 
   What is the rational for Auto? I guess if the user is requesting rules
-  from our registry, we already can identify him (the request and his IP),
+  from our Registry or App, we already can identify him by his IP
   so we might as well get more data from him?
 
   python: was in an intermediate MetricsState before.
@@ -170,7 +170,11 @@ let default_payload =
 
 let default =
   {
+    (* default to Off, so don't forget to call Metrics_.configure()
+     * to change it in the different subcommands.
+     *)
     config = Off;
+    (* should be set in Rule_fetching.ml when using the Registry or App *)
     is_using_registry = false;
     is_using_app = false;
     user_agent = [ spf "Semgrep/%s" Version.version ];
@@ -319,7 +323,8 @@ let add_max_memory_bytes (profiling_data : Report.final_profiling option) =
       g.payload.performance.maxMemoryBytes <- Some max_memory_bytes)
     profiling_data
 
-let add_findings (filtered_matches : (Rule.t * int) list) =
+let add_rules_hashes_and_findings_count (filtered_matches : (Rule.t * int) list)
+    =
   let ruleHashesWithFindings_value =
     filtered_matches
     |> Common.map (fun (rule, rule_matches) ->
@@ -381,9 +386,6 @@ let add_errors errors =
 
 let add_profiling profiler =
   g.payload.performance.profilingTimes <- Some (Profiler.dump profiler)
-
-let add_token token =
-  g.payload.environment.isAuthenticated <- Option.is_some token
 
 let add_exit_code code =
   let code = Exit_code.to_int code in

--- a/src/osemgrep/core/Metrics_.ml
+++ b/src/osemgrep/core/Metrics_.ml
@@ -116,7 +116,7 @@ type t = {
   mutable config : config;
   (* works with Auto *)
   mutable is_using_registry : bool;
-  (* TODO: not set for now *)
+  (* TODO: not fully set for now; should set in CI and more contexts *)
   mutable is_using_app : bool;
   mutable user_agent : string list;
   mutable payload : Semgrep_metrics_t.payload;

--- a/src/osemgrep/core/Metrics_.mli
+++ b/src/osemgrep/core/Metrics_.mli
@@ -3,7 +3,8 @@
 
    On - Metrics always sent
    Off - Metrics never sent
-   Auto - Metrics only sent if config is pulled from the server
+   Auto - Metrics only sent if config is pulled from the registry
+          or if using the Semgrep App.
 *)
 type config = On | Off | Auto [@@deriving show]
 
@@ -15,7 +16,9 @@ val metrics_url : Uri.t
 
 type t = {
   mutable config : config;
+  (* this works with the Auto option *)
   mutable is_using_registry : bool;
+  mutable is_using_app : bool;
   (* The user agent used when sending data to https://metrics.semgrep.dev.
    * We override the default value (e.g. "ocaml-cohttp/5.3.0") with a
    * custom string built from:
@@ -49,7 +52,8 @@ val g : t
 (* set g.config *)
 val configure : config -> unit
 
-(* check whether g.config is On (or Auto) *)
+(* check whether g.config is On or
+ * set to Auto and (is_using_registry or is_using_app) *)
 val is_enabled : unit -> bool
 
 (* Add more tags to the user_agent string (e.g., "command/scan").
@@ -90,6 +94,8 @@ val add_rules_hashes_and_rules_profiling :
 val add_findings : (Rule.t * int) list -> unit
 val add_targets_stats : Fpath.t Set_.t -> Report.final_profiling option -> unit
 val add_engine_kind : Semgrep_output_v1_t.engine_kind -> unit
+
+(* just sent whether the user had a token and so was authenticated *)
 val add_token : 'a option -> unit
 val add_exit_code : Exit_code.t -> unit
 

--- a/src/osemgrep/core/Metrics_.mli
+++ b/src/osemgrep/core/Metrics_.mli
@@ -1,8 +1,8 @@
 (*
    Configures metrics upload.
 
-   On - Metrics always sent
-   Off - Metrics never sent
+   On   - Metrics always sent
+   Off  - Metrics never sent
    Auto - Metrics only sent if config is pulled from the registry
           or if using the Semgrep App.
 *)
@@ -66,6 +66,8 @@ val string_of_user_agent : unit -> string
 (* initialize the payload in g, which can then be modified by the
  * add_xxx functions below (or by accessing directly g.payload) and
  * finally accessed in string_of_metrics().
+ * You should not call this function though; only CLI.metrics_init()
+ * should call it.
  *)
 val init : anonymous_user_id:Uuidm.t -> ci:bool -> unit
 
@@ -91,12 +93,9 @@ val add_configs_hash : Rules_config.config_string list -> unit
 val add_rules_hashes_and_rules_profiling :
   ?profiling:Semgrep_output_v1_t.core_timing -> Rule.rules -> unit
 
-val add_findings : (Rule.t * int) list -> unit
+val add_rules_hashes_and_findings_count : (Rule.t * int) list -> unit
 val add_targets_stats : Fpath.t Set_.t -> Report.final_profiling option -> unit
 val add_engine_kind : Semgrep_output_v1_t.engine_kind -> unit
-
-(* just sent whether the user had a token and so was authenticated *)
-val add_token : 'a option -> unit
 val add_exit_code : Exit_code.t -> unit
 
 (* ex: "language/python" *)


### PR DESCRIPTION
We were just looking whether it was Off, but if it's Auto
we also need to make sure the user was using the registry (or the App)

test plan:
make e2e


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)