### PR TITLE
Simplify masking of the variable part of test results

### DIFF
--- a/cli/tests/conftest.py
+++ b/cli/tests/conftest.py
@@ -119,7 +119,7 @@ def _clean_stdout(out):
     return json.dumps(json_output)
 
 
-def _clean_output_json(output_json: str, clean_fingerprint: bool) -> str:
+def _clean_output_if_json(output_json: str, clean_fingerprint: bool) -> str:
     """Make semgrep's output deterministic and nicer to read."""
     try:
         output = json.loads(output_json)
@@ -178,7 +178,7 @@ def _clean_output_json(output_json: str, clean_fingerprint: bool) -> str:
     return json.dumps(output, indent=2, sort_keys=True)
 
 
-def _clean_output_sarif(output_json: str) -> str:
+def _clean_output_if_sarif(output_json: str) -> str:
     try:
         output = json.loads(output_json)
     except json.decoder.JSONDecodeError:
@@ -221,7 +221,7 @@ def mask_capture_group(match: re.Match) -> str:
 # ProTip: make sure your regexps can't match JSON quotes so as to keep any
 # JSON parseable after a substitution!
 ALWAYS_MASK: Maskers = (
-    _clean_output_sarif,
+    _clean_output_if_sarif,
     __VERSION__,
     re.compile(r"python (\d+[.]\d+[.]\d+[ ]+)"),
     re.compile(r'SEMGREP_SETTINGS_FILE="(.+?)"'),
@@ -265,7 +265,7 @@ class SemgrepResult:
         text = re.sub(r"[ \t]+$", "", text, flags=re.M)
         # special code for JSON cleaning, used to be in ALWAYS_MASK
         # but sometimes we want fingerprint masking and sometimes not
-        text = _clean_output_json(text, self.clean_fingerprint)
+        text = _clean_output_if_json(text, self.clean_fingerprint)
         return text
 
     @property

--- a/cli/tests/e2e/snapshots/test_check/test_multi_subshell_input/results.json
+++ b/cli/tests/e2e/snapshots/test_check/test_multi_subshell_input/results.json
@@ -3,8 +3,8 @@
   "paths": {
     "_comment": "<add --verbose for a list of skipped paths>",
     "scanned": [
-      "/tmp/masked/path",
-      "/tmp/masked/path"
+      "<MASKED>",
+      "<MASKED>"
     ]
   },
   "results": [
@@ -26,7 +26,7 @@
         "severity": "ERROR",
         "validation_state": "NO_VALIDATOR"
       },
-      "path": "/tmp/masked/path",
+      "path": "<MASKED>",
       "start": {
         "col": 5,
         "line": 1,
@@ -51,7 +51,7 @@
         "severity": "ERROR",
         "validation_state": "NO_VALIDATOR"
       },
-      "path": "/tmp/masked/path",
+      "path": "<MASKED>",
       "start": {
         "col": 1,
         "line": 1,

--- a/cli/tests/e2e/snapshots/test_check/test_stdin_input/results.json
+++ b/cli/tests/e2e/snapshots/test_check/test_stdin_input/results.json
@@ -3,7 +3,7 @@
   "paths": {
     "_comment": "<add --verbose for a list of skipped paths>",
     "scanned": [
-      "/tmp/masked/path"
+      "<MASKED>"
     ]
   },
   "results": [
@@ -25,7 +25,7 @@
         "severity": "ERROR",
         "validation_state": "NO_VALIDATOR"
       },
-      "path": "/tmp/masked/path",
+      "path": "<MASKED>",
       "start": {
         "col": 1,
         "line": 1,

--- a/cli/tests/e2e/snapshots/test_check/test_subshell_input/results.json
+++ b/cli/tests/e2e/snapshots/test_check/test_subshell_input/results.json
@@ -3,7 +3,7 @@
   "paths": {
     "_comment": "<add --verbose for a list of skipped paths>",
     "scanned": [
-      "/tmp/masked/path"
+      "<MASKED>"
     ]
   },
   "results": [
@@ -25,7 +25,7 @@
         "severity": "ERROR",
         "validation_state": "NO_VALIDATOR"
       },
-      "path": "/tmp/masked/path",
+      "path": "<MASKED>",
       "start": {
         "col": 1,
         "line": 1,

--- a/cli/tests/e2e/snapshots/test_ignores/test_file_not_relative_to_base_path/results.txt
+++ b/cli/tests/e2e/snapshots/test_ignores/test_file_not_relative_to_base_path/results.txt
@@ -12,7 +12,7 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
   "paths": {
     "_comment": "<add --verbose for a list of skipped paths>",
     "scanned": [
-      "/tmp/masked/path"
+      "<MASKED>"
     ]
   },
   "results": [
@@ -34,7 +34,7 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
         "severity": "ERROR",
         "validation_state": "NO_VALIDATOR"
       },
-      "path": "/tmp/masked/path",
+      "path": "<MASKED>",
       "start": {
         "col": 1,
         "line": 1,

--- a/cli/tests/e2e/snapshots/test_pro_rule_skipping/test_pro_rule_skipping/results.json
+++ b/cli/tests/e2e/snapshots/test_pro_rule_skipping/test_pro_rule_skipping/results.json
@@ -4,7 +4,7 @@
       "code": 0,
       "level": "info",
       "message": "Missing plugin for rule rules.dummy-apex-rule:\n Missing Semgrep extension needed for parsing Apex target. Try adding `--pro` to your command.",
-      "path": "<MASKED>.json",
+      "path": "<MASKED>",
       "rule_id": "rules.dummy-apex-rule",
       "type": "Missing plugin"
     }

--- a/cli/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badpattern/error.json
+++ b/cli/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badpattern/error.json
@@ -29,7 +29,7 @@
             "line": 11,
             "offset": 222
           },
-          "file": "<MASKED>.json",
+          "file": "<MASKED>",
           "start": {
             "col": 22,
             "line": 11,

--- a/cli/tests/e2e/snapshots/test_rule_parser/test_rule_parser_cli_pattern/error.json
+++ b/cli/tests/e2e/snapshots/test_rule_parser/test_rule_parser_cli_pattern/error.json
@@ -27,7 +27,7 @@
             "line": 9,
             "offset": 166
           },
-          "file": "<MASKED>.json",
+          "file": "<MASKED>",
           "start": {
             "col": 18,
             "line": 9,

--- a/cli/tests/e2e/snapshots/test_semgrep_core_parse_error/test_rule_parser__failure__error_messages/settings0/out.json
+++ b/cli/tests/e2e/snapshots/test_semgrep_core_parse_error/test_rule_parser__failure__error_messages/settings0/out.json
@@ -29,7 +29,7 @@
             "line": 14,
             "offset": 292
           },
-          "file": "<MASKED>.json",
+          "file": "<MASKED>",
           "start": {
             "col": 26,
             "line": 14,
@@ -44,7 +44,7 @@
     "scanned": [],
     "skipped": [
       {
-        "path": "<MASKED>.json",
+        "path": "<MASKED>",
         "reason": "analysis_failed_parser_or_internal_error"
       }
     ]

--- a/cli/tests/e2e/snapshots/test_version_constraints/test_version_constraints/results.json
+++ b/cli/tests/e2e/snapshots/test_version_constraints/test_version_constraints/results.json
@@ -4,7 +4,7 @@
       "code": 0,
       "level": "info",
       "message": "Incompatible rule rules.need-to-upgrade1:\n This rule requires upgrading Semgrep from version <MASKED> to at least 1000.0.0",
-      "path": "<MASKED>.json",
+      "path": "<MASKED>",
       "rule_id": "rules.need-to-upgrade1",
       "type": "Incompatible rule"
     },
@@ -12,7 +12,7 @@
       "code": 0,
       "level": "info",
       "message": "Incompatible rule rules.need-to-upgrade2:\n This rule requires upgrading Semgrep from version <MASKED> to at least 1.1000.0",
-      "path": "<MASKED>.json",
+      "path": "<MASKED>",
       "rule_id": "rules.need-to-upgrade2",
       "type": "Incompatible rule"
     },
@@ -20,7 +20,7 @@
       "code": 0,
       "level": "info",
       "message": "Incompatible rule rules.retired-feature1:\n This rule is no longer supported by Semgrep. The last compatible version was 0.0.0. This version of Semgrep is <MASKED>",
-      "path": "<MASKED>.json",
+      "path": "<MASKED>",
       "rule_id": "rules.retired-feature1",
       "type": "Incompatible rule"
     },
@@ -28,7 +28,7 @@
       "code": 0,
       "level": "info",
       "message": "Incompatible rule rules.retired-feature2:\n This rule is no longer supported by Semgrep. The last compatible version was 0.0.1000. This version of Semgrep is <MASKED>",
-      "path": "<MASKED>.json",
+      "path": "<MASKED>",
       "rule_id": "rules.retired-feature2",
       "type": "Incompatible rule"
     },
@@ -36,7 +36,7 @@
       "code": 0,
       "level": "info",
       "message": "Incompatible rule rules.retired-feature3:\n This rule is no longer supported by Semgrep. The last compatible version was 0.1000.0. This version of Semgrep is <MASKED>",
-      "path": "<MASKED>.json",
+      "path": "<MASKED>",
       "rule_id": "rules.retired-feature3",
       "type": "Incompatible rule"
     },
@@ -44,7 +44,7 @@
       "code": 0,
       "level": "info",
       "message": "Incompatible rule rules.past-version-range:\n This rule is no longer supported by Semgrep. The last compatible version was 0.8.3. This version of Semgrep is <MASKED>",
-      "path": "<MASKED>.json",
+      "path": "<MASKED>",
       "rule_id": "rules.past-version-range",
       "type": "Incompatible rule"
     },
@@ -52,7 +52,7 @@
       "code": 0,
       "level": "info",
       "message": "Incompatible rule rules.future-version-range:\n This rule requires upgrading Semgrep from version <MASKED> to at least 49.1.7",
-      "path": "<MASKED>.json",
+      "path": "<MASKED>",
       "rule_id": "rules.future-version-range",
       "type": "Incompatible rule"
     },
@@ -60,7 +60,7 @@
       "code": 0,
       "level": "info",
       "message": "Incompatible rule rules.empty-version-range:\n This rule requires upgrading Semgrep from version <MASKED> to at least 2.0.0",
-      "path": "<MASKED>.json",
+      "path": "<MASKED>",
       "rule_id": "rules.empty-version-range",
       "type": "Incompatible rule"
     }

--- a/cli/tests/e2e/test_check.py
+++ b/cli/tests/e2e/test_check.py
@@ -5,7 +5,7 @@ import tempfile
 from pathlib import Path
 
 import pytest
-from tests.conftest import _clean_output_json
+from tests.conftest import _clean_output_if_json
 from tests.conftest import _clean_stdout
 from tests.fixtures import RunSemgrep
 from tests.semgrep_runner import SEMGREP_BASE_COMMAND
@@ -241,7 +241,7 @@ def test_stdin_input(snapshot):
         stdout=subprocess.PIPE,
     )
     stdout, _ = process.communicate("a")
-    snapshot.assert_match(_clean_output_json(stdout, True), "results.json")
+    snapshot.assert_match(_clean_output_if_json(stdout, True), "results.json")
 
 
 @pytest.mark.kinda_slow
@@ -268,7 +268,7 @@ def test_subshell_input(snapshot):
     )
     # Clean fingerprint from result since it's path dependent and that changes
     # everytime due to the way stdin works
-    snapshot.assert_match(_clean_output_json(stdout, True), "results.json")
+    snapshot.assert_match(_clean_output_if_json(stdout, True), "results.json")
 
 
 @pytest.mark.kinda_slow
@@ -293,7 +293,7 @@ def test_multi_subshell_input(snapshot):
             "SEMGREP_SEND_METRICS": "off",
         },
     )
-    snapshot.assert_match(_clean_output_json(stdout, True), "results.json")
+    snapshot.assert_match(_clean_output_if_json(stdout, True), "results.json")
 
 
 @pytest.mark.kinda_slow

--- a/cli/tests/e2e/test_check.py
+++ b/cli/tests/e2e/test_check.py
@@ -5,8 +5,8 @@ import tempfile
 from pathlib import Path
 
 import pytest
-from tests.conftest import _clean_output_if_json
 from tests.conftest import _clean_stdout
+from tests.conftest import mask_variable_text
 from tests.fixtures import RunSemgrep
 from tests.semgrep_runner import SEMGREP_BASE_COMMAND
 from tests.semgrep_runner import SEMGREP_BASE_COMMAND_STR
@@ -241,7 +241,7 @@ def test_stdin_input(snapshot):
         stdout=subprocess.PIPE,
     )
     stdout, _ = process.communicate("a")
-    snapshot.assert_match(_clean_output_if_json(stdout, True), "results.json")
+    snapshot.assert_match(mask_variable_text(stdout), "results.json")
 
 
 @pytest.mark.kinda_slow
@@ -268,7 +268,7 @@ def test_subshell_input(snapshot):
     )
     # Clean fingerprint from result since it's path dependent and that changes
     # everytime due to the way stdin works
-    snapshot.assert_match(_clean_output_if_json(stdout, True), "results.json")
+    snapshot.assert_match(mask_variable_text(stdout), "results.json")
 
 
 @pytest.mark.kinda_slow
@@ -293,7 +293,7 @@ def test_multi_subshell_input(snapshot):
             "SEMGREP_SEND_METRICS": "off",
         },
     )
-    snapshot.assert_match(_clean_output_if_json(stdout, True), "results.json")
+    snapshot.assert_match(mask_variable_text(stdout), "results.json")
 
 
 @pytest.mark.kinda_slow

--- a/cli/tests/e2e/test_ignores.py
+++ b/cli/tests/e2e/test_ignores.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 import pytest
-from tests.conftest import _clean_output_if_json
+from tests.conftest import mask_variable_text
 from tests.fixtures import RunSemgrep
 
 from ..conftest import TESTS_PATH
@@ -39,7 +39,7 @@ def test_file_not_relative_to_base_path(run_semgrep: RunSemgrep, snapshot):
         stdin="a",
         use_click_runner=True,  # TODO: probably because of stdin?
     )
-    results.raw_stdout = _clean_output_if_json(results.raw_stdout, True)
+    results.raw_stdout = mask_variable_text(results.raw_stdout)
     snapshot.assert_match(results.as_snapshot(), "results.txt")
 
 

--- a/cli/tests/e2e/test_ignores.py
+++ b/cli/tests/e2e/test_ignores.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 import pytest
-from tests.conftest import _clean_output_json
+from tests.conftest import _clean_output_if_json
 from tests.fixtures import RunSemgrep
 
 from ..conftest import TESTS_PATH
@@ -39,7 +39,7 @@ def test_file_not_relative_to_base_path(run_semgrep: RunSemgrep, snapshot):
         stdin="a",
         use_click_runner=True,  # TODO: probably because of stdin?
     )
-    results.raw_stdout = _clean_output_json(results.raw_stdout, True)
+    results.raw_stdout = _clean_output_if_json(results.raw_stdout, True)
     snapshot.assert_match(results.as_snapshot(), "results.txt")
 
 

--- a/cli/tests/e2e/test_pro_rule_skipping.py
+++ b/cli/tests/e2e/test_pro_rule_skipping.py
@@ -1,8 +1,9 @@
 import pytest
 from tests.fixtures import RunSemgrep
 
-
-@pytest.mark.osempass
+# TODO: print message containing the full dotted path to the rule in osemgrep
+# See https://github.com/returntocorp/semgrep/pull/8686#issuecomment-1716299070
+# @pytest.mark.osempass
 @pytest.mark.kinda_slow
 def test_pro_rule_skipping(run_semgrep_in_tmp: RunSemgrep, snapshot):
     snapshot.assert_match(

--- a/cli/tests/e2e/test_pro_rule_skipping.py
+++ b/cli/tests/e2e/test_pro_rule_skipping.py
@@ -1,8 +1,8 @@
 import pytest
 from tests.fixtures import RunSemgrep
 
-# TODO: osemgrep: implement '<MASKED>' for osemgrep output
-# @pytest.mark.osempass
+
+@pytest.mark.osempass
 @pytest.mark.kinda_slow
 def test_pro_rule_skipping(run_semgrep_in_tmp: RunSemgrep, snapshot):
     snapshot.assert_match(

--- a/cli/tests/e2e/test_version_constraints.py
+++ b/cli/tests/e2e/test_version_constraints.py
@@ -1,9 +1,8 @@
 import pytest
 from tests.fixtures import RunSemgrep
 
-# TODO: to pass with osemgrep, we need to mask the variable bits of output
-# with "<MASKED>" like it's done by SemgrepResult.as_snapshot in conftest.py.
-# @pytest.mark.osempass
+
+@pytest.mark.osempass
 @pytest.mark.kinda_slow
 def test_version_constraints(run_semgrep_in_tmp: RunSemgrep, snapshot):
     snapshot.assert_match(

--- a/src/core/Rule_ID.ml
+++ b/src/core/Rule_ID.ml
@@ -20,6 +20,8 @@
  *
  * History: this used to be defined in Rule.ml as a simple type alias,
  * but better to provide a precise API to manipulate Rule IDs.
+
+   TODO: distinguish the bare rule name 'foo' from the path 'path.to.foo'
  *)
 
 (*****************************************************************************)

--- a/src/osemgrep/reporting/Cli_json_output.ml
+++ b/src/osemgrep/reporting/Cli_json_output.ml
@@ -254,7 +254,22 @@ let cli_error_of_core_error (x : Out.core_error) : Out.cli_error =
         | LexicalError
         | PartialParsing _ ->
             None
-        | _else_ -> rule_id
+        | SpecifiedParseError
+        | AstBuilderError
+        | RuleParseError
+        | PatternParseError _
+        | InvalidYaml
+        | MatchingError
+        | SemgrepMatchFound
+        | TooManyMatches
+        | FatalError
+        | Timeout
+        | OutOfMemory
+        | TimeoutDuringInterfile
+        | OutOfMemoryDuringInterfile
+        | IncompatibleRule _
+        | MissingPlugin ->
+            rule_id
       in
       let path =
         (* # For rule errors path is a temp file so will just be confusing *)
@@ -262,7 +277,23 @@ let cli_error_of_core_error (x : Out.core_error) : Out.cli_error =
         | RuleParseError
         | PatternParseError _ ->
             None
-        | _else_ -> Some location.path
+        | ParseError
+        | LexicalError
+        | PartialParsing _
+        | SpecifiedParseError
+        | AstBuilderError
+        | InvalidYaml
+        | MatchingError
+        | SemgrepMatchFound
+        | TooManyMatches
+        | FatalError
+        | Timeout
+        | OutOfMemory
+        | TimeoutDuringInterfile
+        | OutOfMemoryDuringInterfile
+        | IncompatibleRule _
+        | MissingPlugin ->
+            Some location.path
       in
       let message =
         Some (error_message ~rule_id ~error_type ~location ~core_message)


### PR DESCRIPTION
* Some of the temporary path masking was done on specific JSON fields. I removed some of it to simplify things. This will make it easier to port this feature to OCaml. Some JSON-specific masking remains. We might want to get rid of it as well eventually.
* I also added a special case for masking paths that are temporary in pysemgrep but constant in osemgrep so as to pass tests (rule files being copied in one case but not the other). This technique could be used to mask other ignorable differences between pysemgrep and osemgrep.

This allowed me to enable two osempass tests.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
