### PR TITLE
const-prop: Handle implicit number-to-string conversions

### DIFF
--- a/changelog.d/pro-169.fixed
+++ b/changelog.d/pro-169.fixed
@@ -1,0 +1,3 @@
+Constant propagation now handles implicit number-to-string conversions in Java
+and JS/TS. A Java expression such as `"foo" + 123` will now match the string
+pattern "foo123".

--- a/src/analyzing/Constant_propagation.ml
+++ b/src/analyzing/Constant_propagation.ml
@@ -286,10 +286,18 @@ let binop_bool_cst op b1 b2 =
       Some (Cst Cbool)
   | _b1, _b2 -> None
 
-let concat_string_cst s1 s2 =
+let concat_string_cst env s1 s2 =
   match (s1, s2) with
   | Some (Lit (String (l, (s1, t1), r))), Some (Lit (String (_, (s2, _), _))) ->
       Some (Lit (String (l, (s1 ^ s2, t1), r)))
+  | Some (Lit (String (l, (s1, t1), r))), Some (Lit (Int (Some m, _)))
+    when is_lang env Lang.Java || is_js env ->
+      (* implicit int-to-string conversion *)
+      Some (Lit (String (l, (s1 ^ string_of_int m, t1), r)))
+  | Some (Lit (String (l, (s1, t1), r))), Some (Lit (Float (Some m, _)))
+    when Float.is_integer m && is_js env ->
+      (* implicit float-to-string conversion *)
+      Some (Lit (String (l, (s1 ^ string_of_int (int_of_float m), t1), r)))
   | Some (Lit (String _)), Some (Cst Cstr)
   | Some (Cst Cstr), Some (Lit (String _))
   | Some (Cst Cstr), Some (Cst Cstr) ->
@@ -372,7 +380,7 @@ and eval_special env (special, _) args =
   (* strings *)
   | (Op (Plus | Concat) | ConcatString _), args
     when find_type_args args = Some Cstr ->
-      fold_args1 concat_string_cst args
+      fold_args1 (concat_string_cst env) args
   | __else__ -> None
 
 and eval_call env name args =
@@ -653,7 +661,6 @@ let propagate_basic lang prog =
                     ( id,
                       {
                         id_resolved = { contents = Some (_kind, sid) };
-                        id_svalue;
                         id_flags;
                         _;
                       } ));
@@ -674,7 +681,7 @@ let propagate_basic lang prog =
                  && List.exists is_private attrs
             then (
               id_flags := IdFlags.set_final !id_flags;
-              match (!id_svalue, e.e) with
+              match (eval env e, e.e) with
               (* When the name already has an svalue computed, just use
                * that. DeepSemgrep assigns svalues sometimes in its naming
                * phase. *)

--- a/src/analyzing/Constant_propagation.ml
+++ b/src/analyzing/Constant_propagation.ml
@@ -295,9 +295,14 @@ let concat_string_cst env s1 s2 =
       (* implicit int-to-string conversion *)
       Some (Lit (String (l, (s1 ^ string_of_int m, t1), r)))
   | Some (Lit (String (l, (s1, t1), r))), Some (Lit (Float (Some m, _)))
-    when Float.is_integer m && is_js env ->
+    when is_js env ->
       (* implicit float-to-string conversion *)
-      Some (Lit (String (l, (s1 ^ string_of_int (int_of_float m), t1), r)))
+      let m_str =
+        (* JS: we parse all numbers as floats, and 1.0 is printed as "1" *)
+        if Float.is_integer m then string_of_int (int_of_float m)
+        else string_of_float m
+      in
+      Some (Lit (String (l, (s1 ^ m_str, t1), r)))
   | Some (Lit (String _)), Some (Cst Cstr)
   | Some (Cst Cstr), Some (Lit (String _))
   | Some (Cst Cstr), Some (Cst Cstr) ->

--- a/tests/patterns/js/cp_implicit_conversion.js
+++ b/tests/patterns/js/cp_implicit_conversion.js
@@ -1,0 +1,5 @@
+function secret () {
+  const password = 'tJbQjCM=' + 9 + 'SnCq' + 6 + 'LBU=' + 2 + 'h5GD' + 7
+  //ERROR:
+  return password
+}

--- a/tests/patterns/js/cp_implicit_conversion.sgrep
+++ b/tests/patterns/js/cp_implicit_conversion.sgrep
@@ -1,0 +1,1 @@
+return 'tJbQjCM=9SnCq6LBU=2h5GD7'


### PR DESCRIPTION
In languages like Java or JS/TS numbers are implicitly converted into strings when used in a string-concatenation expression.

Closes PRO-169

test plan:
make test # new test

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
