### PR TITLE
docs: add additional context for HTTP mocking from a file

### DIFF
--- a/libs/networking/Http_mock_client.mli
+++ b/libs/networking/Http_mock_client.mli
@@ -132,4 +132,27 @@ val client_from_file :
   * ```
   * NOTE: currently, blank lines should still have "> " or "< ", i.e., there
   * should be a space after the indicator.
+  *
+  * The easiest way to create a file in this format is to make a request using
+  * curl, with the -v flag. For example, `curl -v google.com` would give
+  * *   Trying 142.251.46.206:80...
+  * * Connected to google.com (142.251.46.206) port 80 (#0)
+  * > GET / HTTP/1.1
+  * > Host: google.com
+  * > User-Agent: curl/8.1.2
+  * > Accept: */*
+  * >
+  * < HTTP/1.1 301 Moved Permanently
+  * < [snipped, more headers]
+  * <
+  * <HTML><HEAD><meta content="text/html;charset=utf-8">
+  * <TITLE>301 Moved</TITLE></HEAD><BODY>
+  * <H1>301 Moved</H1>
+  * The document has moved
+  * <A HREF="http://www.google.com/">here</A>.
+  * </BODY></HTML>
+  * * Connection #0 to host google.com left intact
+  * This can be used almost directly: the only change required is to prefix the
+  * response body (bzw. request body, if it were non-empty) with "< "
+  * (bzw. "> ").
   *)


### PR DESCRIPTION
Addresses some comments from @akuhlens on https://github.com/returntocorp/semgrep-proprietary/pull/958

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
