### PR TITLE
Issue #6163 Fix - Using \n as the split character consistenly to retain CRLF \r\n line separators

### DIFF
--- a/cli/src/semgrep/autofix.py
+++ b/cli/src/semgrep/autofix.py
@@ -84,7 +84,7 @@ def _basic_fix(
     before_lines = lines[:start_line]
     before_on_start_line = lines[start_line][:start_col]
     after_on_end_line = lines[end_line][end_col:]  # next char after end of match
-    modified_lines = (before_on_start_line + fix + after_on_end_line).splitlines()
+    modified_lines = (before_on_start_line + fix + after_on_end_line).split(SPLIT_CHAR)
     after_lines = lines[end_line + 1 :]  # next line after end of match
     contents_after_fix = before_lines + modified_lines + after_lines
 
@@ -120,8 +120,8 @@ def _regex_replace(
 
     match_context = lines[start_line : end_line + 1]
 
-    fix = re.sub(from_str, to_str, "\n".join(match_context), count)
-    modified_context = fix.splitlines()
+    fix = re.sub(from_str, to_str, SPLIT_CHAR.join(match_context), count)
+    modified_context = fix.split(SPLIT_CHAR)
     modified_contents = before_lines + modified_context + after_lines
 
     # update offsets

--- a/cli/tests/e2e/rules/autofix/CRLF-line-endings.yaml
+++ b/cli/tests/e2e/rules/autofix/CRLF-line-endings.yaml
@@ -1,0 +1,16 @@
+rules:
+  - id: java.lang.security.audit.crypto.ssl.defaulthttpclient-is-deprecated.defaulthttpclient-is-deprecated
+    metadata:
+      cwe: "CWE-326: Inadequate Encryption Strength"
+      owasp: "A3: Sensitive Data Exposure"
+      source-rule-url: https://find-sec-bugs.github.io/bugs.htm#DEFAULT_HTTP_CLIENT
+    message: |
+      DefaultHttpClient is deprecated. Further, it does not support connections
+      using TLS1.2, which makes using DefaultHttpClient a security hazard.
+      Use SystemDefaultHttpClient instead, which supports TLS1.2.
+    severity: WARNING
+    languages: [java]
+    pattern: new DefaultHttpClient(...);
+    fix-regex:
+      regex: 'DefaultHttpClient\('
+      replacement: "SystemDefaultHttpClient("

--- a/cli/tests/e2e/targets/autofix/CRLF-line-endings.java
+++ b/cli/tests/e2e/targets/autofix/CRLF-line-endings.java
@@ -1,0 +1,20 @@
+// cf. https://mkyong.com/java/the-type-defaulthttpclient-is-deprecated/
+
+package com.exampleweb.controller;
+
+import org.apache.http.Header;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.DefaultHttpClient;
+
+public class WebCrawler {
+
+	public void crawl(String[] args) throws Exception {
+        // ruleid: defaulthttpclient-is-deprecated
+		HttpClient client = new DefaultHttpClient();
+		HttpGet request = new HttpGet("http://google.com");
+		HttpResponse response = client.execute(request);
+	}
+
+}


### PR DESCRIPTION
PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
