### PR TITLE
fix(ci): semgrep ci --pro defaults to legacy

### DIFF
--- a/cli/bin/semgrep
+++ b/cli/bin/semgrep
@@ -48,6 +48,13 @@ warnings.filterwarnings("ignore", category=DeprecationWarning)
 # which seems more complicated).
 PATH = os.environ.get("PATH", "")
 os.environ["PATH"] = PATH + os.pathsep + os.path.dirname(os.path.abspath(__file__))
+
+class CoreNotFound(Exception):
+    def __init__(self, value):
+        self.value = value
+ 
+    def __str__(self):
+        return(self.value)
            
 # similar to cli/src/semgrep/semgrep_core.py compute_executable_path()
 def find_semgrep_core_path(core="semgrep-core", extra_message=""):
@@ -71,10 +78,11 @@ def find_semgrep_core_path(core="semgrep-core", extra_message=""):
     if path is not None:
         return path
  
-    print(f"Failed to find {core} in PATH or in the semgrep package.{extra_message}",
-          file=sys.stderr)
-    # fatal error, see src/osemgrep/core/Exit_code.ml
-    sys.exit(2)
+    raise CoreNotFound(f"Failed to find {core} in PATH or in the semgrep package.{extra_message}")
+
+def exec_legacy_semgrep():
+    import semgrep.main
+    sys.exit(semgrep.main.main())
 
 # We could have moved the code below in a separate 'osemgrep' file, like
 # for 'pysemgrep', but we don't want users to be exposed to another command,
@@ -86,13 +94,29 @@ def find_semgrep_core_path(core="semgrep-core", extra_message=""):
 # they'll get the old behavior.
 def exec_osemgrep():
     if "--pro" in sys.argv:
-        path = find_semgrep_core_path(core="semgrep-core-proprietary",
+        try:
+            path = find_semgrep_core_path(core="semgrep-core-proprietary",
                                       extra_message="\nYou may need to run `semgrep install-semgrep-pro`"    )
+        except CoreNotFound as e:
+            print(str(e), file=sys.stderr)
+            if "ci" in sys.argv:
+                # CI users usually want things to just work. In particular, if they
+                # are running `semgrep ci --pro` they don't want to have to add an
+                # extra step to install-semgrep-pro. This wrapper doesn't have a way
+                # to install semgrep-pro, however, so have them run legacy `semgrep`. 
+                print("Since `semgrep ci` was run, defaulting to legacy semgrep", file=sys.stderr)
+                exec_legacy_semgrep()
         # If you call semgrep-core-proprietary as osemgrep-pro, then we get
         # osemgrep-pro behavior, see semgrep-proprietary/src/main/Pro_main.ml
         sys.argv[0] = "osemgrep-pro"
     else:
-        path = find_semgrep_core_path()
+        try:
+            path = find_semgrep_core_path()
+        except CoreNotFound as e:
+            print(str(e), file=sys.stderr)
+            # fatal error, see src/osemgrep/core/Exit_code.ml
+            sys.exit(2)
+
         # If you call semgrep-core as osemgrep, then we get
         # osemgrep behavior, see src/main/Main.ml
         sys.argv[0] = "osemgrep"
@@ -112,8 +136,7 @@ if __name__ == "__main__":
        # thing not supported by osemgrep anyway),
        #TODO: we should fix --test instead.
        # The past investigation of Austin is available in #8360 PR comments
-       import semgrep.main
-       sys.exit(semgrep.main.main())
+       exec_legacy_semgrep()
     elif "--experimental" in sys.argv:
        exec_osemgrep()
     else:

--- a/cli/bin/semgrep
+++ b/cli/bin/semgrep
@@ -80,7 +80,14 @@ def find_semgrep_core_path(core="semgrep-core", extra_message=""):
  
     raise CoreNotFound(f"Failed to find {core} in PATH or in the semgrep package.{extra_message}")
 
-def exec_legacy_semgrep():
+#TODO: we should just do 'execvp("pysemgrep", sys.argv)'
+# but this causes some regressions with --test (see PA-2963)
+# and autocomplete (see #8359)
+#TODO: we should get rid of autocomplete anyway (it's a Python Click
+# thing not supported by osemgrep anyway),
+#TODO: we should fix --test instead.
+# The past investigation of Austin is available in #8360 PR comments
+def exec_pysemgrep():
     import semgrep.main
     sys.exit(semgrep.main.main())
 
@@ -99,13 +106,13 @@ def exec_osemgrep():
                                       extra_message="\nYou may need to run `semgrep install-semgrep-pro`"    )
         except CoreNotFound as e:
             print(str(e), file=sys.stderr)
-            if "ci" in sys.argv:
+            if sys.argv[1] == "ci":
                 # CI users usually want things to just work. In particular, if they
                 # are running `semgrep ci --pro` they don't want to have to add an
                 # extra step to install-semgrep-pro. This wrapper doesn't have a way
                 # to install semgrep-pro, however, so have them run legacy `semgrep`. 
                 print("Since `semgrep ci` was run, defaulting to legacy semgrep", file=sys.stderr)
-                exec_legacy_semgrep()
+                exec_pysemgrep()
         # If you call semgrep-core-proprietary as osemgrep-pro, then we get
         # osemgrep-pro behavior, see semgrep-proprietary/src/main/Pro_main.ml
         sys.argv[0] = "osemgrep-pro"
@@ -129,14 +136,7 @@ if __name__ == "__main__":
     # can also call directly 'pysemgrep').
     if "--legacy" in sys.argv:
        sys.argv.remove("--legacy")
-       #TODO: we should just do 'execvp("pysemgrep", sys.argv)'
-       # but this causes some regressions with --test (see PA-2963)
-       # and autocomplete (see #8359)
-       #TODO: we should get rid of autocomplete anyway (it's a Python Click
-       # thing not supported by osemgrep anyway),
-       #TODO: we should fix --test instead.
-       # The past investigation of Austin is available in #8360 PR comments
-       exec_legacy_semgrep()
+       exec_pysemgrep()
     elif "--experimental" in sys.argv:
        exec_osemgrep()
     else:


### PR DESCRIPTION
`semgrep` runs `osemgrep`, which for most things switches back to the python version. However, when `semgrep --pro` is passed, we try to run `osemgrep-pro`. If this isn't present, we fail.

This is fine for `semgrep scan` users but `semgrep ci` users cannot respond to the failure as easily. This is why legacy `semgrep ci` will install semgrep-pro for the user. To resolve this for the osemgrep entry point, `semgrep ci --pro` will default to legacy semgrep if `osemgrep-pro` is not already there.

Test plan: remove semgrep-pro such that `semgrep ci --pro` fails. Then install this version of semgrep and run it again. You should see:

```
➜  single_namespace git:(emma/make-same-namespace-tests-pass) ✗ semgrep ci --pro
Failed to find semgrep-core-proprietary in PATH or in the semgrep package.
You may need to run `semgrep install-semgrep-pro`
Since `semgrep ci` was run, defaulting to legacy semgrep

┌────────────────┐
│ Debugging Info │
└────────────────┘
...
```

The scan should succeed

PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
