### PR TITLE
Allow customizing the install location of the pro binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -239,4 +239,5 @@ LABEL maintainer="support@semgrep.com"
 # on the mounted volume when using instructions for running semgrep with docker:
 # `docker run -v "${PWD}:/src" -i returntocorp/semgrep semgrep`
 FROM semgrep-cli AS nonroot
+ENV SEMGREP_CORE_PROPRIETARY_PATH="/home/semgrep/bin/semgrep-core-proprietary"
 USER semgrep

--- a/Dockerfile
+++ b/Dockerfile
@@ -239,5 +239,5 @@ LABEL maintainer="support@semgrep.com"
 # on the mounted volume when using instructions for running semgrep with docker:
 # `docker run -v "${PWD}:/src" -i returntocorp/semgrep semgrep`
 FROM semgrep-cli AS nonroot
-ENV SEMGREP_CORE_PROPRIETARY_PATH="/home/semgrep/bin/semgrep-core-proprietary"
+ENV SEMGREP_CORE_PROPRIETARY_PATH="/home/semgrep/bin/semgrep-core-proprietary" PATH="$PATH:/home/semgrep/bin"
 USER semgrep

--- a/cli/src/semgrep/commands/install.py
+++ b/cli/src/semgrep/commands/install.py
@@ -27,8 +27,14 @@ from semgrep.verbose_logging import getLogger
 
 logger = getLogger(__name__)
 
+SEMGREP_CORE_PROPRIETARY_BINARY_NAME = "semgrep-core-proprietary"
+SEMGREP_CORE_PROPRIETARY_PATH = os.getenv("SEMGREP_CORE_PROPRIETARY_PATH")
+
 
 def determine_semgrep_pro_path() -> Path:
+    if SEMGREP_CORE_PROPRIETARY_PATH:
+        return Path(SEMGREP_CORE_PROPRIETARY_PATH)
+
     core_path = SemgrepCore.path()
     if core_path is None:
         logger.info(
@@ -37,7 +43,7 @@ def determine_semgrep_pro_path() -> Path:
         logger.info("There is something wrong with your semgrep installtation")
         sys.exit(FATAL_EXIT_CODE)
 
-    semgrep_pro_path = Path(core_path).parent / "semgrep-core-proprietary"
+    semgrep_pro_path = Path(core_path).parent / SEMGREP_CORE_PROPRIETARY_BINARY_NAME
     return semgrep_pro_path
 
 

--- a/cli/src/semgrep/commands/install.py
+++ b/cli/src/semgrep/commands/install.py
@@ -27,13 +27,14 @@ from semgrep.verbose_logging import getLogger
 
 logger = getLogger(__name__)
 
-SEMGREP_CORE_PROPRIETARY_BINARY_NAME = "semgrep-core-proprietary"
 SEMGREP_CORE_PROPRIETARY_PATH = os.getenv("SEMGREP_CORE_PROPRIETARY_PATH")
 
 
 def determine_semgrep_pro_path() -> Path:
     if SEMGREP_CORE_PROPRIETARY_PATH:
-        return Path(SEMGREP_CORE_PROPRIETARY_PATH)
+        path = Path(SEMGREP_CORE_PROPRIETARY_PATH)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        return path
 
     core_path = SemgrepCore.path()
     if core_path is None:
@@ -43,7 +44,7 @@ def determine_semgrep_pro_path() -> Path:
         logger.info("There is something wrong with your semgrep installtation")
         sys.exit(FATAL_EXIT_CODE)
 
-    semgrep_pro_path = Path(core_path).parent / SEMGREP_CORE_PROPRIETARY_BINARY_NAME
+    semgrep_pro_path = Path(core_path).parent / "semgrep-core-proprietary"
     return semgrep_pro_path
 
 


### PR DESCRIPTION
The pro binary is currently installed in the same directory as the core binary, /usr/local/bin. This is problematic for non root Docker containers since the non root `semgrep` user that performs the install at runtime does not have permissions to write to this directory. Allow the pro binary to be installed somewhere else the non root user does have permissions to (their home directory) by setting an environment variable. Additionally, set this environment variable in non root containers.

PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
