### PR TITLE
fix(pro): change type signature for semgrep_core_proprietary hook

### DIFF
--- a/src/core/Differential_scan_config.ml
+++ b/src/core/Differential_scan_config.ml
@@ -1,0 +1,46 @@
+(*
+ * Copyright (C) 2023 Semgrep Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * version 2.1 as published by the Free Software Foundation, with the
+ * special exception on linking described in file LICENSE.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
+ * LICENSE for more details.
+ *)
+
+let default_depth = 2
+
+(* This option is designed for the differential scan within the Pro
+   engine. It involves two distinct configuration options: one to
+   specify the set of changed files and the other to determine the
+   depth of dependencies to be jointly analyzed. When operating in
+   differential scan mode, the deep preprocessors, which include
+   constant propagation and taint signature extraction, exclusively
+   process the files contained within the changed input set, as
+   configured by the `targets` parameter, along with their associated
+   dependencies. This targeted approach substantially reduces the
+   overall analysis time while maintaining a high level of
+   accuracy. The dependencies are identified through a file-level
+   dependency graph with a maximum distance of k edges, as configured
+   by the `depth` parameter. Note that, when the --baseline-commit
+   option is used, `targets` are automatically calculated based on the
+   output from the `git diff` command between the baseline commit and
+   the head commit. *)
+type t =
+  | BaseLine of Fpath.t list (* implies depth 0 *)
+  | Depth of Fpath.t list (* starting point *) * int (* depth *)
+  | WholeScan
+
+let map_targets f = function
+  | BaseLine targets -> BaseLine (f targets)
+  | Depth (targets, depth) -> Depth (f targets, depth)
+  | WholeScan -> WholeScan
+
+let apply_targets f = function
+  | BaseLine targets -> Some (f targets)
+  | Depth (targets, _) -> Some (f targets)
+  | WholeScan -> None

--- a/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -33,13 +33,9 @@ module SS = Set.Make (String)
 (* To run the pro engine, including multistep rules *)
 (*****************************************************************************)
 
-type diff_config = { diff_targets : Fpath.t list; diff_depth : int option }
-
-let default_diff_config = { diff_targets = []; diff_depth = None }
-
 let (invoke_semgrep_core_proprietary :
       (Fpath.t list ->
-      ?diff_config:diff_config ->
+      ?diff_config:Differential_scan_config.t ->
       Engine_type.t ->
       Core_runner.semgrep_core_runner)
       option
@@ -163,7 +159,7 @@ let rules_and_counted_matches (res : Core_runner.result) : (Rule.t * int) list =
 (* Select and execute the Semgrep core engine based on the configured
    engine settings. *)
 let core (conf : Scan_CLI.conf) file_match_results_hook errors targets
-    ?(diff_config = default_diff_config) rules () =
+    ?(diff_config = Differential_scan_config.WholeScan) rules () =
   let invoke_semgrep_core =
     match conf.engine_type with
     | OSS ->
@@ -258,7 +254,7 @@ let scan_baseline_and_remove_duplicates (conf : Scan_CLI.conf)
     (status : Git_wrapper.status)
     (core :
       Fpath.t list ->
-      ?diff_config:diff_config ->
+      ?diff_config:Differential_scan_config.t ->
       Rule.rules ->
       unit ->
       Exception.t option * RP.final_result * Fpath.t Set_.t) =
@@ -317,7 +313,7 @@ let scan_baseline_and_remove_duplicates (conf : Scan_CLI.conf)
               in
               core baseline_targets
                 ~diff_config:
-                  { diff_targets = baseline_diff_targets; diff_depth = Some 0 }
+                  (Differential_scan_config.BaseLine baseline_diff_targets)
                 baseline_rules ()))
     in
     (exn, remove_matches_in_baseline commit baseline_r r status.renamed, scanned)
@@ -394,7 +390,9 @@ let run_scan_files (conf : Scan_CLI.conf) (profiler : Profiler.t)
           let head_scan_result =
             Profiler.record profiler ~name:"head_core_time"
               (core targets
-                 ~diff_config:{ diff_targets; diff_depth = None }
+                 ~diff_config:
+                   (Differential_scan_config.Depth
+                      (diff_targets, Differential_scan_config.default_depth))
                  filtered_rules)
           in
           scan_baseline_and_remove_duplicates conf profiler head_scan_result

--- a/src/osemgrep/cli_scan/Scan_subcommand.mli
+++ b/src/osemgrep/cli_scan/Scan_subcommand.mli
@@ -11,31 +11,12 @@ val main : string array -> Exit_code.t
 val run_conf : Scan_CLI.conf -> Exit_code.t
 val run_scan_conf : Scan_CLI.conf -> Exit_code.t
 
-(* This option is designed for the differential scan within the Pro
-   engine. It involves two distinct sets of input files: one for the
-   entire input set and the other for the differential input set,
-   which is defined using the `diff_targets` parameter. In this
-   context, the deep preprocessors, including constant propagation and
-   taint signature extraction, exclusively process the files found in
-   the differential input set and their related dependencies. This
-   targeted approach substantially cuts down the overall analysis time
-   while upholding a high level of accuracy. The dependencies are
-   identified through a file-level dependency graph with a maximum
-   distance of k edges, as determined by the `diff_depth`
-   parameter. Note that, when the `--baseline-commit` option is given,
-   `diff_targets` are automatically calculated based on the output
-   from the `git diff` command between the baseline commit and the
-   head commit. *)
-type diff_config = { diff_targets : Fpath.t list; diff_depth : int option }
-
-val default_diff_config : diff_config
-
 (* Semgrep Pro hook *)
 (* TODO it might be better to pass this through and avoid the hook,
    but it was fairly annoying to *)
 val invoke_semgrep_core_proprietary :
   (Fpath.t list ->
-  ?diff_config:diff_config ->
+  ?diff_config:Differential_scan_config.t ->
   Engine_type.t ->
   Core_runner.semgrep_core_runner)
   option


### PR DESCRIPTION
Modify the data type of `diff_targets` from `Fpath.t list` to `Fpath.t list option` to accommodate three distinct scenarios: diff mode with non-empty diff targets, diff mode with empty diff targets, and whole scan mode.

PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
