### PR TITLE
Allow customizing the install location of the pro binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -247,5 +247,4 @@ LABEL maintainer="support@semgrep.com"
 # `docker run -v "${PWD}:/src" -i returntocorp/semgrep semgrep`
 FROM semgrep-cli AS nonroot
 ENV SEMGREP_PRO_PATH="/home/semgrep/bin"
-ENV PATH="$PATH:$SEMGREP_PRO_PATH"
 USER semgrep

--- a/Dockerfile
+++ b/Dockerfile
@@ -247,5 +247,5 @@ LABEL maintainer="support@semgrep.com"
 # `docker run -v "${PWD}:/src" -i returntocorp/semgrep semgrep`
 FROM semgrep-cli AS nonroot
 ENV SEMGREP_PRO_PATH="/home/semgrep/bin" \
-	PATH="$PATH:/home/semgrep/bin"
+    PATH="$PATH:/home/semgrep/bin"
 USER semgrep

--- a/Dockerfile
+++ b/Dockerfile
@@ -247,5 +247,5 @@ LABEL maintainer="support@semgrep.com"
 # `docker run -v "${PWD}:/src" -i returntocorp/semgrep semgrep`
 FROM semgrep-cli AS nonroot
 ENV SEMGREP_PRO_PATH="/home/semgrep/bin" \
-    PATH="$PATH:/home/semgrep/bin"
+    PATH="$PATH:$SEMGREP_PRO_PATH"
 USER semgrep

--- a/Dockerfile
+++ b/Dockerfile
@@ -246,4 +246,6 @@ LABEL maintainer="support@semgrep.com"
 # on the mounted volume when using instructions for running semgrep with docker:
 # `docker run -v "${PWD}:/src" -i returntocorp/semgrep semgrep`
 FROM semgrep-cli AS nonroot
+ENV SEMGREP_PRO_PATH="/home/semgrep/bin" \
+	PATH="$PATH:/home/semgrep/bin"
 USER semgrep

--- a/Dockerfile
+++ b/Dockerfile
@@ -246,6 +246,6 @@ LABEL maintainer="support@semgrep.com"
 # on the mounted volume when using instructions for running semgrep with docker:
 # `docker run -v "${PWD}:/src" -i returntocorp/semgrep semgrep`
 FROM semgrep-cli AS nonroot
-ENV SEMGREP_PRO_PATH="/home/semgrep/bin" \
-    PATH="$PATH:$SEMGREP_PRO_PATH"
+ENV SEMGREP_PRO_PATH="/home/semgrep/bin"
+ENV PATH="$PATH:$SEMGREP_PRO_PATH"
 USER semgrep

--- a/changelog.d/pa-3026.fixed
+++ b/changelog.d/pa-3026.fixed
@@ -1,0 +1,3 @@
+Allowed the Pro Engine binary to be installed where a non-root user has 
+permissions to (their home directory) by setting an environment variable. 
+Additionally, set this environment variable for non-root containers.

--- a/changelog.d/pa-3026.fixed
+++ b/changelog.d/pa-3026.fixed
@@ -1,3 +1,3 @@
-Allowed the Pro Engine binary to be installed where a non-root user has 
-permissions to (their home directory) by setting an environment variable. 
+Allowed the Pro Engine binary to be installed where a non-root user has
+permissions to (their home directory) by setting an environment variable.
 Additionally, set this environment variable for non-root containers.

--- a/cli/bin/semgrep
+++ b/cli/bin/semgrep
@@ -33,6 +33,7 @@ import os
 import sys
 import importlib.resources
 import shutil
+from pathlib import Path
 #alt: you can also add '-W ignore::DeprecationWarning' after the python3 above,
 # but setuptools and pip adjust this line when installing semgrep so we need
 # to do this instead.
@@ -100,19 +101,38 @@ def exec_pysemgrep():
 # we can always tell users to run pysemgrep instead of semgrep and be sure
 # they'll get the old behavior.
 def exec_osemgrep():
+    path = None
     if "--pro" in sys.argv:
-        try:
-            path = find_semgrep_core_path(core="semgrep-core-proprietary",
-                                      extra_message="\nYou may need to run `semgrep install-semgrep-pro`"    )
-        except CoreNotFound as e:
-            print(str(e), file=sys.stderr)
-            if sys.argv[1] == "ci":
-                # CI users usually want things to just work. In particular, if they
-                # are running `semgrep ci --pro` they don't want to have to add an
-                # extra step to install-semgrep-pro. This wrapper doesn't have a way
-                # to install semgrep-pro, however, so have them run legacy `semgrep`. 
-                print("Since `semgrep ci` was run, defaulting to legacy semgrep", file=sys.stderr)
-                exec_pysemgrep()
+        # The SEMGREP_PRO_PATH env var is set for the non-root Docker image to install
+        # the Pro Engine binary in the semgrep user's $HOME/bin directory where it has
+        # the proper permissions to do so.
+        SEMGREP_PRO_PATH = os.getenv("SEMGREP_PRO_PATH")
+
+        if SEMGREP_PRO_PATH:
+            # Set pro binary path to that designated by SEMGREP_PRO_PATH and verify it exists
+            path = Path(SEMGREP_PRO_PATH) / "semgrep-core-proprietary"
+            if path.is_file():
+                os.environ["PATH"] = os.getenv("PATH") + os.pathsep + os.getenv("SEMGREP_PRO_PATH")
+            else:
+                # Reset path due to invalid SEMGREP_PRO_PATH
+                path = None
+                print("Failed to find semgrep-core-proprietary in designated SEMGREP_PRO_PATH.", file=sys.stderr)
+        # If SEMGREP_PRO_PATH was not set or is invalid, continue looking for pro binary
+        if path is None:
+            try:
+                path = find_semgrep_core_path(core="semgrep-core-proprietary",
+                                        extra_message="\nYou may need to run `semgrep install-semgrep-pro`"    )
+            except CoreNotFound as e:
+                print(str(e), file=sys.stderr)
+                if sys.argv[1] == "ci":
+                    # CI users usually want things to just work. In particular, if they
+                    # are running `semgrep ci --pro` they don't want to have to add an
+                    # extra step to install-semgrep-pro. This wrapper doesn't have a way
+                    # to install semgrep-pro, however, so have them run legacy `semgrep`. 
+                    print("Since `semgrep ci` was run, defaulting to legacy semgrep", file=sys.stderr)
+                    exec_pysemgrep()
+                else:
+                    sys.exit(2)
         # If you call semgrep-core-proprietary as osemgrep-pro, then we get
         # osemgrep-pro behavior, see semgrep-proprietary/src/main/Pro_main.ml
         sys.argv[0] = "osemgrep-pro"

--- a/cli/bin/semgrep
+++ b/cli/bin/semgrep
@@ -112,7 +112,7 @@ def exec_osemgrep():
             # Set pro binary path to that designated by SEMGREP_PRO_PATH and verify it exists
             path = Path(SEMGREP_PRO_PATH) / "semgrep-core-proprietary"
             if path.is_file():
-                os.environ["PATH"] = os.getenv("PATH") + os.pathsep + os.getenv("SEMGREP_PRO_PATH")
+                os.environ["PATH"] = os.getenv("PATH", "") + os.pathsep + os.getenv("SEMGREP_PRO_PATH", "")
             else:
                 # Reset path due to invalid SEMGREP_PRO_PATH
                 path = None

--- a/cli/src/semgrep/commands/install.py
+++ b/cli/src/semgrep/commands/install.py
@@ -49,9 +49,7 @@ def determine_semgrep_pro_path() -> Path:
         if os.access(semgrep_pro_path.parent, os.W_OK):
             return semgrep_pro_path
         else:
-            logger.info(
-                "Invalid path, designated SEMGREP_PRO_PATH is not writeable."
-            )
+            logger.info("Invalid path, designated SEMGREP_PRO_PATH is not writeable.")
             sys.exit(FATAL_EXIT_CODE)
 
     core_path = SemgrepCore.path()

--- a/cli/src/semgrep/commands/install.py
+++ b/cli/src/semgrep/commands/install.py
@@ -27,8 +27,14 @@ from semgrep.verbose_logging import getLogger
 
 logger = getLogger(__name__)
 
+SEMGREP_PRO_PATH = os.getenv("SEMGREP_PRO_PATH")
 
 def determine_semgrep_pro_path() -> Path:
+    if SEMGREP_PRO_PATH:
+	    path = Path(SEMGREP_PRO_PATH) / "semgrep-core-proprietary"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        return path
+        
     core_path = SemgrepCore.path()
     if core_path is None:
         logger.info(

--- a/cli/src/semgrep/commands/install.py
+++ b/cli/src/semgrep/commands/install.py
@@ -31,7 +31,7 @@ SEMGREP_PRO_PATH = os.getenv("SEMGREP_PRO_PATH")
 
 def determine_semgrep_pro_path() -> Path:
     if SEMGREP_PRO_PATH:
-	path = Path(SEMGREP_PRO_PATH) / "semgrep-core-proprietary"
+        path = Path(SEMGREP_PRO_PATH) / "semgrep-core-proprietary"
         path.parent.mkdir(parents=True, exist_ok=True)
         return path
         

--- a/cli/src/semgrep/commands/install.py
+++ b/cli/src/semgrep/commands/install.py
@@ -152,7 +152,7 @@ def run_install_semgrep_pro() -> None:
     if semgrep_pro_path.exists():
         semgrep_pro_path.unlink()
     semgrep_pro_path_tmp.rename(semgrep_pro_path)
-    logger.info(f"Successfully installed Semgrep Pro Engine (version {version})!")
+    logger.info(f"\nSuccessfully installed Semgrep Pro Engine (version {version})!")
 
 
 @click.command()

--- a/cli/src/semgrep/commands/install.py
+++ b/cli/src/semgrep/commands/install.py
@@ -40,7 +40,9 @@ def determine_semgrep_pro_path() -> Path:
             semgrep_pro_path.parent.mkdir(parents=True, exist_ok=True)
             return semgrep_pro_path
         else:
-            logger.info("Invalid path, please set a valid path with proper permissions for SEMGREP_PRO_PATH")
+            logger.info(
+                "Invalid path, please set a valid path with proper permissions for SEMGREP_PRO_PATH"
+            )
             sys.exit(FATAL_EXIT_CODE)
 
     core_path = SemgrepCore.path()

--- a/cli/src/semgrep/commands/install.py
+++ b/cli/src/semgrep/commands/install.py
@@ -27,10 +27,13 @@ from semgrep.verbose_logging import getLogger
 
 logger = getLogger(__name__)
 
-SEMGREP_PRO_PATH = os.getenv("SEMGREP_PRO_PATH")
-
 
 def determine_semgrep_pro_path() -> Path:
+    # The SEMGREP_PRO_PATH env var is set for the non-root Docker image to install
+    # the Pro Engine binary in the semgrep user's $HOME/bin directory where it has
+    # the proper permissions to do so.
+    SEMGREP_PRO_PATH = os.getenv("SEMGREP_PRO_PATH")
+    
     if SEMGREP_PRO_PATH:
         path = Path(SEMGREP_PRO_PATH) / "semgrep-core-proprietary"
         path.parent.mkdir(parents=True, exist_ok=True)

--- a/cli/src/semgrep/commands/install.py
+++ b/cli/src/semgrep/commands/install.py
@@ -35,16 +35,20 @@ def determine_semgrep_pro_path() -> Path:
     SEMGREP_PRO_PATH = os.getenv("SEMGREP_PRO_PATH")
 
     if SEMGREP_PRO_PATH:
-        path = Path(SEMGREP_PRO_PATH) / "semgrep-core-proprietary"
-        path.parent.mkdir(parents=True, exist_ok=True)
-        return path
+        semgrep_pro_path = Path(SEMGREP_PRO_PATH) / "semgrep-core-proprietary"
+        if os.access(semgrep_pro_path.parent, os.W_OK):
+            semgrep_pro_path.parent.mkdir(parents=True, exist_ok=True)
+            return semgrep_pro_path
+        else:
+            logger.info("Invalid path, please set a valid path with proper permissions for SEMGREP_PRO_PATH")
+            sys.exit(FATAL_EXIT_CODE)
 
     core_path = SemgrepCore.path()
     if core_path is None:
         logger.info(
             "Could not find `semgrep-core` executable so not sure where to install DeepSemgrep"
         )
-        logger.info("There is something wrong with your semgrep installtation")
+        logger.info("There is something wrong with your semgrep installation")
         sys.exit(FATAL_EXIT_CODE)
 
     semgrep_pro_path = Path(core_path).parent / "semgrep-core-proprietary"

--- a/cli/src/semgrep/commands/install.py
+++ b/cli/src/semgrep/commands/install.py
@@ -47,7 +47,9 @@ def determine_semgrep_pro_path() -> Path:
 
         # Make sure SEMGREP_PRO_PATH is writeable
         if os.access(semgrep_pro_path.parent, os.W_OK):
-            os.environ["PATH"] = os.getenv("PATH") + os.pathsep + os.getenv("SEMGREP_PRO_PATH")
+            os.environ["PATH"] = (
+                os.getenv("PATH") + os.pathsep + os.getenv("SEMGREP_PRO_PATH")
+            )
             return semgrep_pro_path
         else:
             logger.info("Invalid path, designated SEMGREP_PRO_PATH is not writeable.")

--- a/cli/src/semgrep/commands/install.py
+++ b/cli/src/semgrep/commands/install.py
@@ -47,6 +47,7 @@ def determine_semgrep_pro_path() -> Path:
 
         # Make sure SEMGREP_PRO_PATH is writeable
         if os.access(semgrep_pro_path.parent, os.W_OK):
+            os.environ["PATH"] = os.getenv("PATH") + os.pathsep + os.getenv("SEMGREP_PRO_PATH")
             return semgrep_pro_path
         else:
             logger.info("Invalid path, designated SEMGREP_PRO_PATH is not writeable.")

--- a/cli/src/semgrep/commands/install.py
+++ b/cli/src/semgrep/commands/install.py
@@ -33,7 +33,7 @@ def determine_semgrep_pro_path() -> Path:
     # the Pro Engine binary in the semgrep user's $HOME/bin directory where it has
     # the proper permissions to do so.
     SEMGREP_PRO_PATH = os.getenv("SEMGREP_PRO_PATH")
-    
+
     if SEMGREP_PRO_PATH:
         path = Path(SEMGREP_PRO_PATH) / "semgrep-core-proprietary"
         path.parent.mkdir(parents=True, exist_ok=True)

--- a/cli/src/semgrep/commands/install.py
+++ b/cli/src/semgrep/commands/install.py
@@ -48,7 +48,7 @@ def determine_semgrep_pro_path() -> Path:
         # Make sure SEMGREP_PRO_PATH is writeable
         if os.access(semgrep_pro_path.parent, os.W_OK):
             os.environ["PATH"] = (
-                os.getenv("PATH") + os.pathsep + os.getenv("SEMGREP_PRO_PATH")
+                os.getenv("PATH", "") + os.pathsep + os.getenv("SEMGREP_PRO_PATH", "")
             )
             return semgrep_pro_path
         else:

--- a/cli/src/semgrep/commands/install.py
+++ b/cli/src/semgrep/commands/install.py
@@ -36,12 +36,21 @@ def determine_semgrep_pro_path() -> Path:
 
     if SEMGREP_PRO_PATH:
         semgrep_pro_path = Path(SEMGREP_PRO_PATH) / "semgrep-core-proprietary"
-        if os.access(semgrep_pro_path.parent, os.W_OK):
+        # Try creating the path set by SEMGREP_PRO_PATH
+        try:
             semgrep_pro_path.parent.mkdir(parents=True, exist_ok=True)
+        except PermissionError:
+            logger.info(
+                "Invalid path, could not create directory at designated SEMGREP_PRO_PATH."
+            )
+            sys.exit(FATAL_EXIT_CODE)
+
+        # Make sure SEMGREP_PRO_PATH is writeable
+        if os.access(semgrep_pro_path.parent, os.W_OK):
             return semgrep_pro_path
         else:
             logger.info(
-                "Invalid path, please set a valid path with proper permissions for SEMGREP_PRO_PATH"
+                "Invalid path, designated SEMGREP_PRO_PATH is not writeable."
             )
             sys.exit(FATAL_EXIT_CODE)
 

--- a/cli/src/semgrep/commands/install.py
+++ b/cli/src/semgrep/commands/install.py
@@ -31,7 +31,7 @@ SEMGREP_PRO_PATH = os.getenv("SEMGREP_PRO_PATH")
 
 def determine_semgrep_pro_path() -> Path:
     if SEMGREP_PRO_PATH:
-	    path = Path(SEMGREP_PRO_PATH) / "semgrep-core-proprietary"
+	path = Path(SEMGREP_PRO_PATH) / "semgrep-core-proprietary"
         path.parent.mkdir(parents=True, exist_ok=True)
         return path
         

--- a/cli/src/semgrep/commands/install.py
+++ b/cli/src/semgrep/commands/install.py
@@ -29,12 +29,13 @@ logger = getLogger(__name__)
 
 SEMGREP_PRO_PATH = os.getenv("SEMGREP_PRO_PATH")
 
+
 def determine_semgrep_pro_path() -> Path:
     if SEMGREP_PRO_PATH:
         path = Path(SEMGREP_PRO_PATH) / "semgrep-core-proprietary"
         path.parent.mkdir(parents=True, exist_ok=True)
         return path
-        
+
     core_path = SemgrepCore.path()
     if core_path is None:
         logger.info(


### PR DESCRIPTION
The pro binary is currently installed in the same directory as the core binary, `/usr/local/bin`. This is problematic for non-root Docker containers since the non-root `semgrep` user that performs the install at runtime does not have permissions to write to this directory. Allow the pro binary to be installed somewhere else the non-root user does have permissions to (their home directory) by setting an environment variable. Additionally, set this environment variable in non-root containers.

Credit goes to @cgdolan for the original PR:
https://github.com/returntocorp/semgrep/pull/8695

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
