### PR TITLE
fix: Fix contribution err log and change to warning

### DIFF
--- a/cli/src/semgrep/core_runner.py
+++ b/cli/src/semgrep/core_runner.py
@@ -1310,8 +1310,8 @@ Exception raised: `{e}`
                 [], returncode, " ".join(cmd), runner.stdout, runner.stderr
             )
             contributions = out.Contributions.from_json(output_json)
-        except SemgrepError as e:
-            logger.error(f"Failed to collect contributions: str{e}")
+        except SemgrepError:
+            logger.warning("Failed to collect contributions. Continuing with scan...")
             contributions = out.Contributions([])
 
         logger.debug(f"semgrep contributions ran in {datetime.now() - start}")


### PR DESCRIPTION
When the `dump_contributions` command fails, the error log is misleading (it shows the generic crash message even though the scan continues).

- Updating the error log to exclude the generic crash message
- Changing the error to a warning

PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
