### PR TITLE
Update the base image used in the Docker build of semgrep (3-month jump)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -88,7 +88,14 @@ COPY cli/src/semgrep/semgrep_interfaces cli/src/semgrep/semgrep_interfaces
 # coupling: if you modify the FROM below, you probably need to modify also
 # a few .github/workflows/ files. grep for returntocorp/ocaml there.
 
-FROM returntocorp/ocaml:alpine-2023-06-16 as semgrep-core-container
+# This base image should be updated regularly to maximize the caching
+# of opam packages. We don't use a rolling ':latest' tag to ensure
+# reproducible builds and fix problems more easily.
+#
+# Visit https://hub.docker.com/r/returntocorp/ocaml/tags to see the latest
+# images available.
+#
+FROM returntocorp/ocaml:alpine-2023-09-13 as semgrep-core-container
 
 WORKDIR /src/semgrep
 COPY --from=semgrep-core-files /src/semgrep .


### PR DESCRIPTION
The issue I was running into was that a bunch of opam packages were being reinstalled at the time of my pull request (https://github.com/returntocorp/semgrep/actions/runs/6177936022/job/16773443873?pr=8707) and the job got stuck because we're over our resource limit or something (according to @tpetr who was in a rush).

This updates the base image built by [ocaml-layer](https://github.com/returntocorp/ocaml-layer), which should make the steps run by Depot shorter and hopefully works around our resource limit (if we're still having it - Tom says he lifted it but my job is still stuck). If/when we are completely relying on Depot to cache the `opam install` step(s), we should start from a vanilla base image for ocaml and drop ocaml-layer. Ping me on Slack for details as needed.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
