### PR TITLE
chore: [SCP-965] Limit contributions commits to 30 days

### DIFF
--- a/changelog.d/scp-965.changed
+++ b/changelog.d/scp-965.changed
@@ -1,0 +1,1 @@
+Limit collection of the contributions from git log to the last 30 days of commits.

--- a/libs/git_wrapper/Git_wrapper.ml
+++ b/libs/git_wrapper/Git_wrapper.ml
@@ -349,19 +349,20 @@ let git_log_json_format =
    \"contributor\": {\"commit_author_name\": \"%an\", \"commit_author_email\": \
    \"%ae\"}}"
 
-let get_month_ago_date () =
-  let yesterday = Common2.yesterday () in
-  let month_ago = Common2.month_before yesterday in
-  let after_date = Unix.gmtime month_ago in
-  let year = after_date.tm_year + 1900 in
-  let month = after_date.tm_mon + 1 in
-  let day = after_date.tm_mday in
+let date_to_year_str (timestamp : Common2.float_time) : string =
+  let date = Unix.gmtime timestamp in
+  let year = date.tm_year + 1900 in
+  let month = date.tm_mon + 1 in
+  let day = date.tm_mday in
   Printf.sprintf "%04d-%02d-%02d" year month day
 
-let get_git_logs () : string list =
-  (* TODO Allow this to be configurable past 30 days? *)
-  let month_ago_date = get_month_ago_date () in
-  let after_arg = Printf.sprintf "--after=\"%s\"" month_ago_date in
+let get_git_logs ?(since = None) () : string list =
+  let since_year =
+    match since with
+    | None -> date_to_year_str (Common2.month_before (Common2.yesterday ()))
+    | Some since_timestamp -> date_to_year_str since_timestamp
+  in
+  let after_arg = Printf.sprintf "--after=\"%s\"" since_year in
   let cmd = Bos.Cmd.(v "git" % "log" % after_arg % git_log_json_format) in
   let lines_r = Bos.OS.Cmd.run_out cmd in
   let lines = Bos.OS.Cmd.out_lines ~trim:true lines_r in

--- a/libs/git_wrapper/Git_wrapper.ml
+++ b/libs/git_wrapper/Git_wrapper.ml
@@ -349,8 +349,20 @@ let git_log_json_format =
    \"contributor\": {\"commit_author_name\": \"%an\", \"commit_author_email\": \
    \"%ae\"}}"
 
+let get_month_ago_date () =
+  let yesterday = Common2.yesterday () in
+  let month_ago = Common2.month_before yesterday in
+  let after_date = Unix.gmtime month_ago in
+  let year = after_date.tm_year + 1900 in
+  let month = after_date.tm_mon + 1 in
+  let day = after_date.tm_mday in
+  Printf.sprintf "%04d-%02d-%02d" year month day
+
 let get_git_logs () : string list =
-  let cmd = Bos.Cmd.(v "git" % "log" % git_log_json_format) in
+  (* TODO Allow this to be configurable past 30 days? *)
+  let month_ago_date = get_month_ago_date () in
+  let after_arg = Printf.sprintf "--after=\"%s\"" month_ago_date in
+  let cmd = Bos.Cmd.(v "git" % "log" % after_arg % git_log_json_format) in
   let lines_r = Bos.OS.Cmd.run_out cmd in
   let lines = Bos.OS.Cmd.out_lines ~trim:true lines_r in
   let lines =

--- a/libs/git_wrapper/Git_wrapper.mli
+++ b/libs/git_wrapper/Git_wrapper.mli
@@ -67,7 +67,7 @@ val get_project_url : unit -> string option
     [git ls-remote] or from the [.git/config] file. It returns [None] if it
     found nothing relevant. *)
 
-val get_git_logs : unit -> string list
+val get_git_logs : ?since:Common2.float_time option -> unit -> string list
 (** [get_git_logs ()] tries to get the git logs of the project from
     [git log]. It returns an empty list if it found nothing relevant.
     The strings returned contain each JSON data that

--- a/libs/git_wrapper/Git_wrapper.mli
+++ b/libs/git_wrapper/Git_wrapper.mli
@@ -68,8 +68,9 @@ val get_project_url : unit -> string option
     found nothing relevant. *)
 
 val get_git_logs : ?since:Common2.float_time option -> unit -> string list
-(** [get_git_logs ()] tries to get the git logs of the project from
-    [git log]. It returns an empty list if it found nothing relevant.
+(** [get_git_logs since] tries to get the git logs of the project from
+    [git log] commits made after "since" timestamp (defaults to 30 days).
+    It returns an empty list if it found nothing relevant.
     The strings returned contain each JSON data that
     fit the schema defined in semgrep_output_v1.atd contribution type.
  *)

--- a/src/parsing/Parse_contribution.ml
+++ b/src/parsing/Parse_contribution.ml
@@ -5,5 +5,6 @@ let get_contributions () : Semgrep_output_v1_j.contribution list =
    * to output the git log in a JSON format that matches
    * the definition in semgrep_output_v1.atd contribution type
    *)
-  Git_wrapper.get_git_logs ()
+  let since = Some (Common2.month_before (Common2.yesterday ())) in
+  Git_wrapper.get_git_logs ~since ()
   |> Common.map Semgrep_output_v1_j.contribution_of_string


### PR DESCRIPTION
The new `dump_contributions` command collects the contribution from ALL commits in the history.

- Limit the contributions to the commits created in the last 30 days

## Testing
Tested on a few high-traffic public repos (e.g. cpython). 

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
