### PR TITLE
fix(sca): fixed the node lockfile parser to identify direct dependencies correctly

### DIFF
--- a/changelog.d/sc-1057.fixed
+++ b/changelog.d/sc-1057.fixed
@@ -1,0 +1,3 @@
+Fixes how semgrep identifies the transitivity of dependencies in node v9 (lockfile version 3) and above.
+Specifically, dependencies that should have been identified as "direct" were being miscategorized as "transitive",
+which should no longer be the case.

--- a/cli/src/semdep/parsers/package_lock.py
+++ b/cli/src/semdep/parsers/package_lock.py
@@ -60,9 +60,11 @@ def parse_packages_field(deps: Dict[str, JSON]) -> List[FoundDependency]:
                 if integrity
                 else {},
                 resolved_url=resolved_url,
-                transitivity=Transitivity(Transitive())
-                if nested
-                else transitivity(manifest_deps, [package]),
+                transitivity=Transitivity(Transitive()) if nested
+                # The manifest stores the pure package names but the deps names are all relative paths (prefix'd with 'node_modules'),
+                # so check to see if `package_name` (without the 'node_modules' prefix) is present in the manifest.
+                # https://docs.npmjs.com/cli/v10/configuring-npm/package-lock-json#packages
+                else transitivity(manifest_deps, [package_name]),
                 line_number=dep_json.line_number,
             )
         )

--- a/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awarejs-yarn2-sca.yaml-dependency_awarepackage-lock-v3/results.txt
+++ b/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awarejs-yarn2-sca.yaml-dependency_awarepackage-lock-v3/results.txt
@@ -20,7 +20,7 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
       "check_id": "rules.dependency_aware.js-yarn2-sca",
       "end": {
         "col": 0,
-        "line": 57,
+        "line": 59,
         "offset": 0
       },
       "extra": {
@@ -45,10 +45,10 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
                 ]
               },
               "ecosystem": "npm",
-              "line_number": 56,
+              "line_number": 58,
               "package": "@babel/core",
               "resolved_url": "https://registry.npmjs.org/@babel/core/-/core-7.21.3.tgz",
-              "transitivity": "transitive",
+              "transitivity": "direct",
               "version": "7.21.3"
             },
             "lockfile": "targets/dependency_aware/package-lock-v3/package-lock.json"
@@ -62,7 +62,7 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
       "path": "targets/dependency_aware/package-lock-v3/package-lock.json",
       "start": {
         "col": 0,
-        "line": 56,
+        "line": 58,
         "offset": 0
       }
     },
@@ -70,7 +70,7 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
       "check_id": "rules.dependency_aware.js-yarn2-sca",
       "end": {
         "col": 0,
-        "line": 111,
+        "line": 113,
         "offset": 0
       },
       "extra": {
@@ -95,7 +95,7 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
                 ]
               },
               "ecosystem": "npm",
-              "line_number": 110,
+              "line_number": 112,
               "package": "@babel/core",
               "resolved_url": "https://registry.npmjs.org/@babel/core/-/core-7.21.3.tgz",
               "transitivity": "transitive",
@@ -112,7 +112,7 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
       "path": "targets/dependency_aware/package-lock-v3/package-lock.json",
       "start": {
         "col": 0,
-        "line": 110,
+        "line": 112,
         "offset": 0
       }
     }

--- a/cli/tests/e2e/targets/dependency_aware/package-lock-v3/package-lock.json
+++ b/cli/tests/e2e/targets/dependency_aware/package-lock-v3/package-lock.json
@@ -8,6 +8,8 @@
             "name":"money-manager",
             "version":"0.1.0",
             "dependencies":{
+                "@adobe/css-tools":"4.2.0",
+                "@babel/core":"7.21.3",
                 "@testing-library/jest-dom":"^5.16.5",
                 "@testing-library/react":"^13.4.0",
                 "@testing-library/user-event":"^13.5.0",


### PR DESCRIPTION
## Context
A client found a bug when performing a full scan: all of their dependencies were being marked as "transitive". This is obviously a bug. The project in question used node/npm with lockfile version 3 (used with node v9), and it's unclear whether this affects other clients or projects with similar setups. [See the original linear ticket for reference](https://linear.app/semgrep/issue/SC-1057/javascript-project-showing-all-libraries-as-transitive).

## Solution

The node lockfile parser correctly identified that lockfiles with version number 3 list their dependencies differently from versions 1 and 2, but it contained one seemingly innocuous oversight: it assumed that the manifest (list of direct dependencies) lists the package names in the same format as the lockfile's exhaustive dependencies map. In reality, the lockfile's exhaustive map lists their full relative paths while the manifest only lists their name. This change corrects that oversight.

## To test

Either:
- run `semgrep` on an npm project using `lockfileversion: 3` and note the presence of direct dependencies in the result
- run the lockfile parser in isolation (e.g. with `pipenv shell` + `python -i cli/src/semdep/parsers/package_lock.py`) 
    - call `parse_package_lock` with the first argument containing a `Path` to a version 3 node lockfile (I used the lockfile in the linear ticket)

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
