### PR TITLE
add comments and change default for Git_wrapper_get_git_lots()

### DIFF
--- a/libs/git_wrapper/Git_wrapper.mli
+++ b/libs/git_wrapper/Git_wrapper.mli
@@ -65,12 +65,15 @@ val commit : Fpath.t -> string -> unit
 val get_project_url : unit -> string option
 (** [get_project_url ()] tries to get the URL of the project from
     [git ls-remote] or from the [.git/config] file. It returns [None] if it
-    found nothing relevant. *)
+    found nothing relevant.
+    TODO: should maybe raise an exn instead if not run from a git repo.
+*)
 
 val get_git_logs : ?since:Common2.float_time option -> unit -> string list
-(** [get_git_logs since] tries to get the git logs of the project from
-    [git log] commits made after "since" timestamp (defaults to 30 days).
+(** [get_git_logs()] will run 'git log' in the current directory
+    and returns for each log a JSON string that fits the schema
+    defined in semgrep_output_v1.atd contribution type.
     It returns an empty list if it found nothing relevant.
-    The strings returned contain each JSON data that
-    fit the schema defined in semgrep_output_v1.atd contribution type.
+    You can use the [since] parameter to restrict the logs to
+    the commits since the specified time.
  *)

--- a/src/parsing/Parse_contribution.ml
+++ b/src/parsing/Parse_contribution.ml
@@ -3,8 +3,10 @@
 let get_contributions () : Semgrep_output_v1_j.contribution list =
   (* ugly: this works because get_git_logs() uses a special format string
    * to output the git log in a JSON format that matches
-   * the definition in semgrep_output_v1.atd contribution type
+   * the definition in semgrep_output_v1.atd contribution type.
+   * We use ~since:"last 30 days" because of our usage policy.
+   * See https://semgrep.dev/docs/usage-limits
    *)
-  let since = Some (Common2.month_before (Common2.yesterday ())) in
-  Git_wrapper.get_git_logs ~since ()
+  let last_30_days = Common2.today () |> Common2.month_before in
+  Git_wrapper.get_git_logs ~since:(Some last_30_days) ()
   |> Common.map Semgrep_output_v1_j.contribution_of_string


### PR DESCRIPTION
Feels better that by default we just get all the logs.
The 30 days in Git_wrapper seems very arbitrary.

test plan:
make core-test