### PR TITLE
return total_bytes from semgrep-core

### DIFF
--- a/cli/src/semgrep/output.py
+++ b/cli/src/semgrep/output.py
@@ -129,7 +129,7 @@ def _build_time_json(
             _build_time_target_json(rules, target, num_bytes, profiling_data)
             for target, num_bytes in zip(targets, target_bytes)
         ],
-        total_bytes=sum(n for n in target_bytes),
+        total_bytes=profiling_data.profile.total_bytes,
         rules_parse_time=profiling_data.profile.rules_parse_time,
         max_memory_bytes=profiling_data.profile.max_memory_bytes,
     )

--- a/src/engine/Match_rules.ml
+++ b/src/engine/Match_rules.ml
@@ -211,7 +211,7 @@ let check ~match_hook ~timeout ~timeout_threshold (xconf : Match_env.xconfig)
                | `Steps _ -> raise Multistep_rules_not_available))
   in
   let res_total = res_taint_rules @ res_nontaint_rules in
-  let res = RP.collate_rule_results !!(xtarget.Xtarget.file) res_total in
+  let res = RP.collate_rule_results xtarget.Xtarget.file res_total in
   let extra =
     match res.extra with
     | RP.Debug { skipped_targets; profiling } ->

--- a/src/osemgrep/core/Metrics_.ml
+++ b/src/osemgrep/core/Metrics_.ml
@@ -341,7 +341,7 @@ let add_targets_stats (targets : Fpath.t Set_.t)
     | Some prof ->
         prof.file_times
         |> Common.map (fun ({ Report.file; _ } as file_prof) ->
-               (Fpath.v file, file_prof))
+               (file, file_prof))
         |> Common.hash_of_list
   in
   let file_stats =

--- a/src/reporting/Core_json_output.ml
+++ b/src/reporting/Core_json_output.ml
@@ -13,6 +13,7 @@
  * LICENSE for more details.
  *)
 open Common
+open File.Operators
 module StrSet = Common2.StringSet
 open AST_generic
 module E = Semgrep_error_code
@@ -331,7 +332,7 @@ let profiling_to_profiling (profiling_data : RP.final_profiling) :
       profiling_data.RP.file_times
       |> Common.map (fun { RP.file = target; rule_times; run_time } ->
              {
-               Out.path = target;
+               Out.path = !!target;
                rule_times = json_time_of_rule_times rule_times;
                run_time;
              });
@@ -346,8 +347,7 @@ let profiling_to_profiling (profiling_data : RP.final_profiling) :
      *)
     total_bytes =
       profiling_data.RP.file_times
-      |> Common.map (fun { RP.file = target; _ } ->
-             File.filesize (Fpath.v target))
+      |> Common.map (fun { RP.file = target; _ } -> File.filesize target)
       |> Common2.sum_int;
   }
 

--- a/src/reporting/Core_json_output.ml
+++ b/src/reporting/Core_json_output.ml
@@ -341,6 +341,14 @@ let profiling_to_profiling (profiling_data : RP.final_profiling) :
         profiling_data.RP.rules;
     rules_parse_time = profiling_data.rules_parse_time;
     max_memory_bytes = Some profiling_data.max_memory_bytes;
+    (* TODO: does it cover all targets or just the relevant target we actually
+     * parsed for matching?
+     *)
+    total_bytes =
+      profiling_data.RP.file_times
+      |> Common.map (fun { RP.file = target; _ } ->
+             File.filesize (Fpath.v target))
+      |> Common2.sum_int;
   }
 
 (*****************************************************************************)

--- a/src/reporting/Report.ml
+++ b/src/reporting/Report.ml
@@ -77,7 +77,7 @@ let debug_info_to_option = function
 let mode = ref MNo_info
 
 (*****************************************************************************)
-(* Different formats for profiling information as we have access to more data *)
+(* Different formats for profiling info as we have access to more data *)
 (*****************************************************************************)
 
 (* Save time information as we run each rule *)
@@ -94,6 +94,7 @@ type times = { parse_time : float; match_time : float }
 (* Save time information as we run each file *)
 
 type file_profiling = {
+  (* TODO: use Fpath.t *)
   file : Common.filename;
   rule_times : rule_profiling list;
   run_time : float;

--- a/src/reporting/Report.mli
+++ b/src/reporting/Report.mli
@@ -33,15 +33,11 @@ type rule_profiling = {
 
 (* Save time information as we run each file *)
 
-type partial_profiling = {
-  file : Common.filename;
-  rule_times : rule_profiling list;
-}
+type partial_profiling = { file : Fpath.t; rule_times : rule_profiling list }
 [@@deriving show]
 
 type file_profiling = {
-  (* TODO: Fpath.t *)
-  file : Common.filename;
+  file : Fpath.t;
   rule_times : rule_profiling list;
   run_time : float;
 }
@@ -83,7 +79,7 @@ type final_result = {
 [@@deriving show]
 
 val empty_extra : 'a -> 'a debug_info
-val empty_partial_profiling : Common.filename -> partial_profiling
+val empty_partial_profiling : Fpath.t -> partial_profiling
 val empty_rule_profiling : Rule.t -> rule_profiling
 val empty_semgrep_result : times match_result
 val empty_final_result : final_result
@@ -91,11 +87,11 @@ val empty_final_result : final_result
 val make_match_result :
   Pattern_match.t list -> ErrorSet.t -> 'a -> 'a match_result
 
-val add_run_time :
-  float -> partial_profiling match_result -> file_profiling match_result
-
 val modify_match_result_profiling :
   'a match_result -> ('a -> 'b) -> 'b match_result
+
+val add_run_time :
+  float -> partial_profiling match_result -> file_profiling match_result
 
 val add_rule : Rule.rule -> times match_result -> rule_profiling match_result
 val collate_pattern_results : times match_result list -> times match_result
@@ -107,4 +103,4 @@ val make_final_result :
   final_result
 
 val collate_rule_results :
-  string -> rule_profiling match_result list -> partial_profiling match_result
+  Fpath.t -> rule_profiling match_result list -> partial_profiling match_result

--- a/src/runner/Run_semgrep.mli
+++ b/src/runner/Run_semgrep.mli
@@ -176,6 +176,7 @@ val print_match :
 *)
 val update_cli_progress : Runner_config.t -> unit
 
+(* TODO: Fpath.t *)
 val exn_to_error : Common.filename -> Exception.t -> Semgrep_error_code.error
 (**
   Small wrapper over Semgrep_error_code.exn_to_error to handle also


### PR DESCRIPTION
One step closer to merge core_timing and cli_timing and having
pysemgrep just propagate the profiling info computed in semgrep-core
without doing any postprocessing on it.

test plan:
make e2e