### PR TITLE
cleanup Version_info.mli

### DIFF
--- a/src/core/Version_info.ml
+++ b/src/core/Version_info.ml
@@ -6,14 +6,18 @@
 
 type t = Semver.t
 
+(* we don't have access to Semver code so can't add the deriving there
+ * so we need to roll our own boilerplate imitating what
+ * a simple [@@deriving show, ord] would do above.
+ *)
 let pp fmt x = Format.pp_print_string fmt (Semver.to_string x)
 let compare = Semver.compare
-let of_string = Semver.of_string
+let show = Semver.to_string
 let to_string = Semver.to_string
-let string = Version.version
+let of_string = Semver.of_string
 
 let version =
-  match Semver.of_string string with
+  match Semver.of_string Version.version with
   | Some x -> x
   | None ->
       failwith

--- a/src/core/Version_info.mli
+++ b/src/core/Version_info.mli
@@ -5,17 +5,18 @@
    Use the Semver library to parse, print, and compare versions.
 *)
 
-type t = Semver.t
+type t [@@deriving show, ord]
 
-(* For ppx dumper. *)
-val pp : Format.formatter -> t -> unit
-val compare : t -> t -> int
+(* useful to parse the version stored in the semgrep rules in the
+ * min_version and max_version fields
+ *)
 val of_string : string -> t option
+
+(* useful for reporting errors related to versioning *)
 val to_string : t -> string
 
-(* The current Semgrep version *)
-val version : Semver.t
+(* The current Semgrep version (the parsed form of Version.version) *)
+val version : t
 val major : int
 val minor : int
 val patch : int
-val string : string


### PR DESCRIPTION
As I was preparing to do a some important file reorg of src/core/,
I though the interface of Version_info.mli was a bit complicated
and redundant, so I've cleaned it a bit

test plan:
make core