### PR TITLE
move src/reporting/Semgrep_error_code.ml -> src/core/Core_error.ml

### DIFF
--- a/src/core/Core_error.mli
+++ b/src/core/Core_error.mli
@@ -6,7 +6,7 @@
 (* Main error type *)
 (*****************************************************************************)
 
-type error = {
+type t = {
   rule_id : Rule_ID.t option;
   typ : Semgrep_output_v1_t.core_error_kind;
   loc : Tok.location;
@@ -16,7 +16,9 @@ type error = {
 }
 [@@deriving show]
 
-val g_errors : error list ref
+val g_errors : t list ref
+
+module ErrorSet : Set.S with type elt = t
 
 (*****************************************************************************)
 (* Converter functions *)
@@ -27,7 +29,7 @@ val mk_error :
   Tok.location ->
   string ->
   Semgrep_output_v1_t.core_error_kind ->
-  error
+  t
 
 val error :
   Rule_ID.t ->
@@ -40,10 +42,10 @@ val error :
    TODO: return None for rules that are being skipped due to version
    mismatches.
 *)
-val error_of_invalid_rule_error : Rule.invalid_rule_error -> error
+val error_of_invalid_rule_error : Rule.invalid_rule_error -> t
 
 (* Convert a caught exception and its stack trace to a Semgrep error. *)
-val exn_to_error : Rule_ID.t option -> Common.filename -> Exception.t -> error
+val exn_to_error : Rule_ID.t option -> Common.filename -> Exception.t -> t
 
 (*****************************************************************************)
 (* Try with error *)
@@ -56,7 +58,7 @@ val try_with_print_exn_and_reraise : Common.filename -> (unit -> unit) -> unit
 (* Pretty printers *)
 (*****************************************************************************)
 
-val string_of_error : error -> string
+val string_of_error : t -> string
 
 val severity_of_error :
   Semgrep_output_v1_t.core_error_kind -> Semgrep_output_v1_t.core_severity
@@ -74,8 +76,8 @@ val expected_error_lines_of_files :
 
 (* Return the number of errors and an error message, if there's any error. *)
 val compare_actual_to_expected :
-  error list -> (Common.filename * int) list -> (unit, int * string) result
+  t list -> (Common.filename * int) list -> (unit, int * string) result
 
 (* Call Alcotest.fail in case of errors *)
 val compare_actual_to_expected_for_alcotest :
-  error list -> (Common.filename * int) list -> unit
+  t list -> (Common.filename * int) list -> unit

--- a/src/core_cli/Core_CLI.ml
+++ b/src/core_cli/Core_CLI.ml
@@ -10,7 +10,7 @@ open Common
 open File.Operators
 open Runner_config
 module Flag = Flag_semgrep
-module E = Semgrep_error_code
+module E = Core_error
 module J = JSON
 
 let logger = Logging.get_logger [ __MODULE__ ]

--- a/src/core_cli/Core_actions.ml
+++ b/src/core_cli/Core_actions.ml
@@ -1,7 +1,7 @@
 open Common
 open File.Operators
 module J = JSON
-module E = Semgrep_error_code
+module E = Core_error
 
 (*****************************************************************************)
 (* Prelude *)

--- a/src/engine/Match_env.ml
+++ b/src/engine/Match_env.ml
@@ -13,7 +13,7 @@
  * LICENSE for more details.
  *)
 open File.Operators
-module E = Semgrep_error_code
+module E = Core_error
 module Out = Semgrep_output_v1_t
 module PM = Pattern_match
 
@@ -60,7 +60,7 @@ type env = {
   rule : Rule.t;
   (* problems found during evaluation, one day these may be caught earlier by
    * the meta-checker *)
-  errors : Report.ErrorSet.t ref;
+  errors : Core_error.ErrorSet.t ref;
 }
 
 (*****************************************************************************)
@@ -78,7 +78,7 @@ let error env msg =
   let err =
     E.mk_error (Some (fst env.rule.Rule.id)) loc msg Out.MatchingError
   in
-  env.errors := Report.ErrorSet.add err !(env.errors)
+  env.errors := Core_error.ErrorSet.add err !(env.errors)
 
 (* this will be adjusted later in range_to_pattern_match_adjusted *)
 let fake_rule_id (id, str) =

--- a/src/engine/Match_extract_mode.ml
+++ b/src/engine/Match_extract_mode.ml
@@ -282,8 +282,8 @@ let map_res map_loc (tmpfile : Fpath.t) (file : Fpath.t)
       mr.matches
   in
   let errors =
-    Report.ErrorSet.map
-      (fun (e : Semgrep_error_code.error) -> { e with loc = map_loc e.loc })
+    Core_error.ErrorSet.map
+      (fun (e : Core_error.t) -> { e with loc = map_loc e.loc })
       mr.errors
   in
   let extra =

--- a/src/engine/Match_rules.ml
+++ b/src/engine/Match_rules.ml
@@ -17,7 +17,7 @@ open File.Operators
 module R = Rule
 module RP = Report
 module Resp = Semgrep_output_v1_t
-module E = Semgrep_error_code
+module E = Core_error
 module Out = Semgrep_output_v1_t
 
 let logger = Logging.get_logger [ __MODULE__ ]
@@ -153,7 +153,7 @@ let per_rule_boilerplate_fn ~timeout ~timeout_threshold =
         let loc = Tok.first_loc_of_file file in
         let error = E.mk_error (Some rule_id) loc "" Out.Timeout in
         RP.make_match_result []
-          (Report.ErrorSet.singleton error)
+          (Core_error.ErrorSet.singleton error)
           (RP.empty_rule_profiling rule)
 
 (*****************************************************************************)

--- a/src/engine/Test_engine.ml
+++ b/src/engine/Test_engine.ml
@@ -16,7 +16,7 @@ open Common
 open File.Operators
 module FT = File_type
 module R = Rule
-module E = Semgrep_error_code
+module E = Core_error
 module RP = Report
 
 let logger = Logging.get_logger [ __MODULE__ ]
@@ -278,11 +278,10 @@ let make_tests ?(unit_testing = false) ?(get_xlang = None) xs =
              res :: eres
              |> List.iter (fun (res : RP.partial_profiling RP.match_result) ->
                     res.matches |> List.iter Core_json_output.match_to_error);
-             (if not (Report.ErrorSet.is_empty res.errors) then
+             (if not (E.ErrorSet.is_empty res.errors) then
               let errors =
-                Report.ErrorSet.elements res.errors
-                |> Common.map Semgrep_error_code.show_error
-                |> String.concat "-----\n"
+                E.ErrorSet.elements res.errors
+                |> Common.map Core_error.show |> String.concat "-----\n"
               in
               failwith (spf "parsing error(s) on %s:\n%s" !!file errors));
              let actual_errors = !E.g_errors in

--- a/src/engine/Unit_engine.ml
+++ b/src/engine/Unit_engine.ml
@@ -4,7 +4,7 @@ open Testutil
 module R = Rule
 module MR = Mini_rule
 module P = Pattern_match
-module E = Semgrep_error_code
+module E = Core_error
 module Out = Semgrep_output_v1_t
 
 let logger = Logging.get_logger [ __MODULE__ ]

--- a/src/engine/Xpattern_matcher.ml
+++ b/src/engine/Xpattern_matcher.ml
@@ -87,7 +87,7 @@ let (matches_of_matcher :
                               validation_state = No_validator;
                             })))
         in
-        RP.make_match_result res Report.ErrorSet.empty
+        RP.make_match_result res Core_error.ErrorSet.empty
           { RP.parse_time; match_time }
 
 (* todo: same, we should not need that *)

--- a/src/experiments/misc/dune
+++ b/src/experiments/misc/dune
@@ -9,7 +9,6 @@
    pfff-lang_GENERIC-analyze
 
    semgrep.core
-   semgrep.reporting
    semgrep.parsing
  )
  (preprocess (pps

--- a/src/experiments/synthesizing/Unit_synthesizer_targets.ml
+++ b/src/experiments/synthesizing/Unit_synthesizer_targets.ml
@@ -1,7 +1,6 @@
-(*s: semgrep/matching/Unit_matcher.ml *)
 open Common
 module R = Rule
-module E = Semgrep_error_code
+module E = Core_error
 module Out = Semgrep_output_v1_t
 
 (* ran from the root of the semgrep repository *)

--- a/src/metachecking/Check_rule.ml
+++ b/src/metachecking/Check_rule.ml
@@ -17,7 +17,7 @@ open File.Operators
 module FT = File_type
 open Rule
 module R = Rule
-module E = Semgrep_error_code
+module E = Core_error
 module P = Pattern_match
 module RP = Report
 module SJ = Semgrep_output_v1_j
@@ -62,7 +62,7 @@ let logger = Logging.get_logger [ __MODULE__ ]
 (*****************************************************************************)
 exception No_metacheck_file of string
 
-type env = { r : Rule.t; errors : E.error list ref }
+type env = { r : Rule.t; errors : Core_error.t list ref }
 
 (*****************************************************************************)
 (* Helpers *)

--- a/src/metachecking/Check_rule.mli
+++ b/src/metachecking/Check_rule.mli
@@ -1,5 +1,5 @@
-(* will populate Semgrep_error_code.errors *)
-val check : Rule.t -> Semgrep_error_code.error list
+(* will populate Core_error.errors *)
+val check : Rule.t -> Core_error.t list
 
 (* to test -check_rules *)
 val run_checks :
@@ -7,7 +7,7 @@ val run_checks :
   (Fpath.t -> Rule.t list) ->
   Fpath.t (* metachecks *) ->
   Fpath.t list (* rules *) ->
-  Semgrep_error_code.error list
+  Core_error.t list
 
 (* -check_rules *)
 val check_files :

--- a/src/metachecking/Test_metachecking.ml
+++ b/src/metachecking/Test_metachecking.ml
@@ -16,7 +16,7 @@ open Common
 open File.Operators
 module FT = File_type
 module R = Rule
-module E = Semgrep_error_code
+module E = Core_error
 
 let logger = Logging.get_logger [ __MODULE__ ]
 

--- a/src/metachecking/Unit_metachecking.ml
+++ b/src/metachecking/Unit_metachecking.ml
@@ -1,7 +1,7 @@
 open Common
 open File.Operators
 open Testutil
-module E = Semgrep_error_code
+module E = Core_error
 
 (*****************************************************************************)
 (* Purpose *)

--- a/src/parsing/Parse_target.ml
+++ b/src/parsing/Parse_target.ml
@@ -18,7 +18,7 @@ open File.Operators
 open Pfff_or_tree_sitter
 open Parsing_result2
 module Flag = Flag_semgrep
-module E = Semgrep_error_code
+module E = Core_error
 module Out = Semgrep_output_v1_t
 
 let logger = Logging.get_logger [ __MODULE__ ]
@@ -41,12 +41,12 @@ let logger = Logging.get_logger [ __MODULE__ ]
 (* used by Match_search_mode and Match_tainting_mode *)
 let errors_from_skipped_tokens xs =
   match xs with
-  | [] -> Report.ErrorSet.empty
+  | [] -> Core_error.ErrorSet.empty
   | x :: _ ->
       let e = exn_of_loc x in
       let err = E.exn_to_error None x.Tok.pos.file e in
       let locs = xs |> Common.map Output_utils.location_of_token_location in
-      Report.ErrorSet.singleton { err with typ = Out.PartialParsing locs }
+      Core_error.ErrorSet.singleton { err with typ = Out.PartialParsing locs }
 
 let undefined_just_parse_with_lang _lang _file =
   failwith "just_parse_with_lang_ref unset"

--- a/src/parsing/Parse_target.mli
+++ b/src/parsing/Parse_target.mli
@@ -28,4 +28,4 @@ val just_parse_with_lang_ref :
   (Lang.t -> Common.filename -> Parsing_result2.t) ref
 
 (* returns a Output_from_core.PartialParsing error *)
-val errors_from_skipped_tokens : Tok.location list -> Report.ErrorSet.t
+val errors_from_skipped_tokens : Tok.location list -> Core_error.ErrorSet.t

--- a/src/parsing/Unit_parsing.ml
+++ b/src/parsing/Unit_parsing.ml
@@ -1,7 +1,7 @@
 open Common
 open Testutil
 open File.Operators
-module E = Semgrep_error_code
+module E = Core_error
 
 (*****************************************************************************)
 (* Purpose *)

--- a/src/parsing/dune
+++ b/src/parsing/dune
@@ -25,7 +25,7 @@
 
    semgrep_core
    semgrep_optimizing
-   semgrep_reporting ; TODO: for Report.ErrorSet.ml, should move to core/
+   semgrep_reporting ; TODO: for Report..ml, should move to core/
    semgrep.typing
  )
  (preprocess (pps ppx_profiling ppx_deriving.show))

--- a/src/reporting/Core_json_output.ml
+++ b/src/reporting/Core_json_output.ml
@@ -16,7 +16,7 @@ open Common
 open File.Operators
 module StrSet = Common2.StringSet
 open AST_generic
-module E = Semgrep_error_code
+module E = Core_error
 module J = JSON
 module MV = Metavariable
 module RP = Report
@@ -273,7 +273,7 @@ let unsafe_match_to_match render_fix_opt (x : Pattern_match.t) : Out.core_match
   }
 
 let match_to_match render_fix (x : Pattern_match.t) :
-    (Out.core_match, Semgrep_error_code.error) Common.either =
+    (Out.core_match, Core_error.t) Common.either =
   try
     Left (unsafe_match_to_match render_fix x)
     (* raised by min_max_ii_by_pos in range_of_any when the AST of the

--- a/src/reporting/Core_json_output.mli
+++ b/src/reporting/Core_json_output.mli
@@ -6,7 +6,7 @@ type render_fix = Pattern_match.t -> Textedit.t option
 val match_to_match :
   render_fix option ->
   Pattern_match.t ->
-  (Semgrep_output_v1_t.core_match, Semgrep_error_code.error) Common.either
+  (Semgrep_output_v1_t.core_match, Core_error.t) Common.either
 
 val core_output_of_matches_and_errors :
   render_fix option ->
@@ -20,7 +20,7 @@ val core_output_of_matches_and_errors :
 val metavar_string_of_any : AST_generic.any -> string
 
 (* now used also in osemgrep *)
-val error_to_error : Semgrep_error_code.error -> Semgrep_output_v1_t.core_error
+val error_to_error : Core_error.t -> Semgrep_output_v1_t.core_error
 
 (* This is used only in the testing code, to reuse the
  * Semgrep_error_code.compare_actual_to_expected

--- a/src/reporting/Report.mli
+++ b/src/reporting/Report.mli
@@ -48,11 +48,9 @@ type rule_id_and_engine_kind = Rule_ID.t * Pattern_match.engine_kind
 
 (* Substitute in the profiling type we have *)
 
-module ErrorSet : Set.S with type elt = Semgrep_error_code.error
-
 type 'a match_result = {
   matches : Pattern_match.t list;
-  errors : ErrorSet.t;
+  errors : Core_error.ErrorSet.t;
   extra : 'a debug_info;
   explanations : Matching_explanation.t list;
 }
@@ -70,7 +68,7 @@ type final_profiling = {
 
 type final_result = {
   matches : Pattern_match.t list;
-  errors : Semgrep_error_code.error list;
+  errors : Core_error.t list;
   skipped_rules : Rule.invalid_rule_error list;
   extra : final_profiling debug_info;
   explanations : Matching_explanation.t list;
@@ -85,7 +83,7 @@ val empty_semgrep_result : times match_result
 val empty_final_result : final_result
 
 val make_match_result :
-  Pattern_match.t list -> ErrorSet.t -> 'a -> 'a match_result
+  Pattern_match.t list -> Core_error.ErrorSet.t -> 'a -> 'a match_result
 
 val modify_match_result_profiling :
   'a match_result -> ('a -> 'b) -> 'b match_result

--- a/src/runner/Run_semgrep.ml
+++ b/src/runner/Run_semgrep.ml
@@ -16,7 +16,7 @@ open Common
 open Runner_config
 open File.Operators
 module PM = Pattern_match
-module E = Semgrep_error_code
+module E = Core_error
 module MR = Mini_rule
 module R = Rule
 module RP = Report
@@ -346,7 +346,7 @@ let errors_of_invalid_rule_errors (invalid_rules : Rule.invalid_rule_error list)
 let sanity_check_invalid_patterns (res : RP.final_result) files =
   match
     res.RP.errors
-    |> List.find_opt (fun (err : E.error) ->
+    |> List.find_opt (fun (err : Core_error.t) ->
            match err.typ with
            | Out.PatternParseError _ -> true
            | _else_ -> false)
@@ -453,7 +453,7 @@ let iter_targets_and_get_matches_and_exn_to_errors config f targets =
                        logger#info "full pattern is: %s" rule.MR.pattern_string);
                    let loc = Tok.first_loc_of_file !!file in
                    let errors =
-                     RP.ErrorSet.singleton
+                     Core_error.ErrorSet.singleton
                        (E.mk_error !Rule.last_matched_rule loc ""
                           (match exn with
                           | Match_rules.File_timeout ->
@@ -489,7 +489,9 @@ let iter_targets_and_get_matches_and_exn_to_errors config f targets =
                 *)
                | exn when not !Flag_semgrep.fail_fast ->
                    let e = Exception.catch exn in
-                   let errors = RP.ErrorSet.singleton (exn_to_error !!file e) in
+                   let errors =
+                     Core_error.ErrorSet.singleton (exn_to_error !!file e)
+                   in
                    RP.make_match_result [] errors
                      (RP.empty_partial_profiling file))
          in

--- a/src/runner/Run_semgrep.mli
+++ b/src/runner/Run_semgrep.mli
@@ -149,7 +149,7 @@ val semgrep_with_rules :
 
 (* used internally but also called by osemgrep *)
 val errors_of_invalid_rule_errors :
-  Rule.invalid_rule_error list -> Semgrep_error_code.error list
+  Rule.invalid_rule_error list -> Core_error.t list
 
 val replace_named_pipe_by_regular_file : Fpath.t -> Fpath.t
 (**
@@ -177,7 +177,7 @@ val print_match :
 val update_cli_progress : Runner_config.t -> unit
 
 (* TODO: Fpath.t *)
-val exn_to_error : Common.filename -> Exception.t -> Semgrep_error_code.error
+val exn_to_error : Common.filename -> Exception.t -> Core_error.t
 (**
   Small wrapper over Semgrep_error_code.exn_to_error to handle also
   semgrep-specific exns that have a position.
@@ -219,7 +219,7 @@ val filter_files_with_too_many_matches_and_transform_as_timeout :
   int ->
   Pattern_match.t list ->
   Pattern_match.t list
-  * Semgrep_error_code.error list
+  * Core_error.t list
   * Semgrep_output_v1_j.skipped_target list
 
 (* TODO: This is used by semgrep-pro and not by semgrep. What is it?

--- a/src/tests/dune
+++ b/src/tests/dune
@@ -17,7 +17,6 @@
     semgrep.parsing_languages
     semgrep.matching
     semgrep.synthesizing
-    semgrep.reporting
     semgrep.engine
     parser_python.menhir parser_python.ast_generic
     semgrep.data


### PR DESCRIPTION
Also added some comments explaining its relation to the
(too many) other error types in semgrep.

test plan:
make core