### PR TITLE
Extract Core_profiling.ml from Core_Resul.ml (which was Report.ml)

### DIFF
--- a/src/core/Core_profiling.ml
+++ b/src/core/Core_profiling.ml
@@ -1,0 +1,146 @@
+(*****************************************************************************)
+(* Prelude *)
+(*****************************************************************************)
+(* Profiling info on rule matching and target parsing
+ * Many of the types below are created to collect profiling information in as
+ * well-typed a manner as possible. Creating a type for practically every
+ * stage that reports matches is annoying, but prevents us from relying on
+ * dummy values or unlabeled tuples.
+ *
+ * Another challenge we face is that the extra information can take a lot
+ * of memory, which scales with both the number of rules and files. On
+ * large repos, this is the most significant factor driving semgrep's
+ * memory consumption. Therefore, if the skipped targets (for example) are
+ * not being used, we don't want to save them. On the other hand, we want
+ * to feel confident in the correctness of the code and make it easy to
+ * know what is or isn't being saved. And we want our code to be relatively
+ * readable.
+ *
+ * The debug_info type attempts to solve this. It has a variant for each
+ * verbosity mode semgrep-core may be invoked with, which contains all
+ * the fields semgrep requests from semgrep-core in that mode. Each result
+ * contains debug_info in addition to the always-reported fields. The
+ * variant of debug_info used in the results is always determined either
+ * by the mode, which is a global set in Main.ml after the arguments are
+ * read, or by a previous result. In this way we ensure that the fields
+ * stored in the result are determined by the arguments passed by the user.
+ *
+ * Alternatives considered to the extra field:
+ * - storing the information but just ommitting it in the final result (I
+ *   tried this but it still uses too much memory)
+ * - using option types within the result types for field and a global
+ *   config to decide which fields are in use
+ *
+ * I considered the latter, but I'm not a fan of mix-and-match option types.
+ * Maybe I just think it makes it tempting to use map_option, where here
+ * the assumption that is being made feels more obvious. It also makes it
+ * extra clear what information is being used for each mode and encourages
+ * us to do the work of deciding what should be included instead of giving
+ * the user choice that they probably don't know how to make intelligently.
+ * That being said, if we wanted users to be able to "mix-and-match" request
+ * fields, we should move to the option-types paradigm. Also, the collate
+ * functions are quite ugly. I'm open to argument.
+ *
+ * Like for Core_error.ml and Core_result.ml, this "core" profiling
+ * is eventually converted in semgrep_output_v1.core_timing and
+ * which is then transformed in ProfilingData in profiling.py and
+ * finally transformed in a semgrep_output_v1.profile type.
+ * There's also Profiler.ml in osemgrep, and poor man profiler
+ * stuff in libs/profiling/profiling.ml accessed via --profile
+ * LATER: remove some intermediate types.
+ *)
+
+(*****************************************************************************)
+(* Debug/Profile choice *)
+(*****************************************************************************)
+(* Options for what extra debugging information to output.
+ * These are generally memory intensive fields that aren't strictly needed
+ *)
+
+(* coupling: the debug_info variant of each result record should always
+ *  be the same as the mode's variant *)
+type debug_mode = MDebug | MTime | MNo_info [@@deriving show]
+
+type 'a debug_info =
+  (* -debug: save all the information that could be useful *)
+  | Debug of {
+      skipped_targets : Semgrep_output_v1_t.skipped_target list;
+      profiling : 'a;
+    }
+  (* -json_time: save just profiling info; currently our metrics record this *)
+  | Time of { profiling : 'a }
+  (* save nothing else *)
+  | No_info
+[@@deriving show]
+
+let debug_info_to_option = function
+  | Debug { profiling; _ } -> Some profiling
+  | Time { profiling } -> Some profiling
+  | No_info -> None
+
+let mode = ref MNo_info
+
+(*****************************************************************************)
+(* Different formats for profiling info as we have access to more data *)
+(*****************************************************************************)
+
+(* general type *)
+type times = { parse_time : float; match_time : float }
+
+(* Save time information as we run each rule *)
+
+type rule_profiling = {
+  rule_id : Rule_ID.t;
+  parse_time : float;
+  match_time : float;
+}
+[@@deriving show]
+
+(* Save time information as we run each file *)
+
+type file_profiling = {
+  file : Fpath.t;
+  rule_times : rule_profiling list;
+  run_time : float;
+}
+[@@deriving show]
+
+type partial_profiling = { file : Fpath.t; rule_times : rule_profiling list }
+[@@deriving show]
+
+(* Result object for the entire rule *)
+
+(* old: was called Report.final_profiling before *)
+type t = {
+  rules : Rule.rule list;
+  rules_parse_time : float;
+  file_times : file_profiling list;
+  (* This is meant to represent the maximum amount of memory used by
+     Semgrep during the course of its execution.
+
+     This is useful to emit with the other profiling data for telemetry
+     purposes, particuarly as it relates to measuring memory management
+     with DeepSemgrep.
+
+     It's not important that this number be incredibly precise, but
+     measuring general trends is useful for ascertaining our memory
+     usage.
+  *)
+  max_memory_bytes : int;
+}
+[@@deriving show]
+
+(*****************************************************************************)
+(* Create empty versions of profiling objects *)
+(*****************************************************************************)
+
+let empty_partial_profiling file = { file; rule_times = [] }
+
+let empty_rule_profiling rule =
+  { rule_id = fst rule.Rule.id; parse_time = 0.0; match_time = 0.0 }
+
+let empty_extra profiling =
+  match !mode with
+  | MDebug -> Debug { skipped_targets = []; profiling }
+  | MTime -> Time { profiling }
+  | MNo_info -> No_info

--- a/src/core/Core_profiling.mli
+++ b/src/core/Core_profiling.mli
@@ -1,0 +1,56 @@
+(* Options for what extra debugging information to output*)
+
+type debug_mode = MDebug | MTime | MNo_info [@@deriving show]
+
+type 'a debug_info =
+  | Debug of {
+      skipped_targets : Semgrep_output_v1_t.skipped_target list;
+      profiling : 'a;
+    }
+  | Time of { profiling : 'a }
+  | No_info
+[@@deriving show]
+
+val debug_info_to_option : 'a debug_info -> 'a option
+(** [debug_info_to_option debug] returns [Some profiling] if we collected
+    metrics. Otherwise, it returns [None]. *)
+
+(* Global to set the debug mode. Should be set
+   exactly once after the arguments are read *)
+
+val mode : debug_mode ref
+
+(* Save time information as we run each rule *)
+
+type times = { parse_time : float; match_time : float }
+
+type rule_profiling = {
+  rule_id : Rule_ID.t;
+  parse_time : float;
+  match_time : float;
+}
+[@@deriving show]
+
+(* Save time information as we run each file *)
+
+type partial_profiling = { file : Fpath.t; rule_times : rule_profiling list }
+[@@deriving show]
+
+type file_profiling = {
+  file : Fpath.t;
+  rule_times : rule_profiling list;
+  run_time : float;
+}
+[@@deriving show]
+
+type t = {
+  rules : Rule.rule list;
+  rules_parse_time : float;
+  file_times : file_profiling list;
+  max_memory_bytes : int;
+}
+[@@deriving show]
+
+val empty_extra : 'a -> 'a debug_info
+val empty_partial_profiling : Fpath.t -> partial_profiling
+val empty_rule_profiling : Rule.t -> rule_profiling

--- a/src/core/Core_result.ml
+++ b/src/core/Core_result.ml
@@ -13,146 +13,31 @@
  * There's also Core_runner.result in osemgrep.
  *
  * From the simplest matches to the most complex we have:
- * Pattern_match.t -> Rule_match.t
- * -> Core_result.xxx
+ * Pattern_match.t (and its alias Rule_match.t)
+ * -> Core_result.xxx (this file)
  * -> Semgrep_output_v1.core_output
  *  -> Core_runner.result
  *  -> Semgrep_output_v1.cli_output
  *  -> Semgrep_output_v1.findings
  * LATER: it would be good to remove some intermediate types.
- *
- * On profiling:
- * -------------
- * Many of the types below are created to collect profiling information in as
- * well-typed a manner as possible. Creating a type for practically every
- * stage that reports matches is annoying, but prevents us from relying on
- * dummy values or unlabeled tuples.
- *
- * Another challenge we face is that the extra information can take a lot
- * of memory, which scales with both the number of rules and files. On
- * large repos, this is the most significant factor driving semgrep's
- * memory consumption. Therefore, if the skipped targets (for example) are
- * not being used, we don't want to save them. On the other hand, we want
- * to feel confident in the correctness of the code and make it easy to
- * know what is or isn't being saved. And we want our code to be relatively
- * readable.
- *
- * The debug_info type attempts to solve this. It has a variant for each
- * verbosity mode semgrep-core may be invoked with, which contains all
- * the fields semgrep requests from semgrep-core in that mode. Each result
- * contains debug_info in addition to the always-reported fields. The
- * variant of debug_info used in the results is always determined either
- * by the mode, which is a global set in Main.ml after the arguments are
- * read, or by a previous result. In this way we ensure that the fields
- * stored in the result are determined by the arguments passed by the user.
- *
- * Alternatives considered to the extra field:
- * - storing the information but just ommitting it in the final result (I
- *   tried this but it still uses too much memory)
- * - using option types within the result types for field and a global
- *   config to decide which fields are in use
- *
- * I considered the latter, but I'm not a fan of mix-and-match option types.
- * Maybe I just think it makes it tempting to use map_option, where here
- * the assumption that is being made feels more obvious. It also makes it
- * extra clear what information is being used for each mode and encourages
- * us to do the work of deciding what should be included instead of giving
- * the user choice that they probably don't know how to make intelligently.
- * That being said, if we wanted users to be able to "mix-and-match" request
- * fields, we should move to the option-types paradigm. Also, the collate
- * functions are quite ugly. I'm open to argument.
  *)
-
 module E = Core_error
+open Core_profiling
 
 let logger = Logging.get_logger [ __MODULE__ ]
 
 (*****************************************************************************)
-(* Debug/Profile choice *)
+(* Types *)
 (*****************************************************************************)
-(* Options for what extra debugging information to output.
- *  These are generally memory intensive fields that aren't strictly needed
- *)
-
-(* coupling: the debug_info variant of each result record should always
-   be the same as the mode's variant *)
-type debug_mode = MDebug | MTime | MNo_info [@@deriving show]
-
-type 'a debug_info =
-  (* -debug: save all the information that could be useful *)
-  | Debug of {
-      skipped_targets : Semgrep_output_v1_t.skipped_target list;
-      profiling : 'a;
-    }
-  (* -json_time: save just profiling info; currently our metrics record this *)
-  | Time of { profiling : 'a }
-  (* save nothing else *)
-  | No_info
-[@@deriving show]
-
-let debug_info_to_option = function
-  | Debug { profiling; _ } -> Some profiling
-  | Time { profiling } -> Some profiling
-  | No_info -> None
-
-let mode = ref MNo_info
-
-(*****************************************************************************)
-(* Different formats for profiling info as we have access to more data *)
-(*****************************************************************************)
-
-(* Save time information as we run each rule *)
-
-type rule_profiling = {
-  rule_id : Rule_ID.t;
-  parse_time : float;
-  match_time : float;
-}
-[@@deriving show]
-
-type times = { parse_time : float; match_time : float }
-
-(* Save time information as we run each file *)
-
-type file_profiling = {
-  file : Fpath.t;
-  rule_times : rule_profiling list;
-  run_time : float;
-}
-[@@deriving show]
-
-type partial_profiling = { file : Fpath.t; rule_times : rule_profiling list }
-[@@deriving show]
-
-(* Result object for the entire rule *)
-
-type final_profiling = {
-  rules : Rule.rule list;
-  rules_parse_time : float;
-  file_times : file_profiling list;
-  (* This is meant to represent the maximum amount of memory used by
-     Semgrep during the course of its execution.
-
-     This is useful to emit with the other profiling data for telemetry
-     purposes, particuarly as it relates to measuring memory management
-     with DeepSemgrep.
-
-     It's not important that this number be incredibly precise, but
-     measuring general trends is useful for ascertaining our memory
-     usage.
-  *)
-  max_memory_bytes : int;
-}
-[@@deriving show]
 
 type rule_id_and_engine_kind = Rule_ID.t * Pattern_match.engine_kind
 [@@deriving show]
 
-type final_result = {
+type t = {
   matches : Pattern_match.t list;
   errors : Core_error.t list;
   skipped_rules : Rule.invalid_rule_error list;
-  extra : final_profiling debug_info;
+  extra : Core_profiling.t Core_profiling.debug_info;
   explanations : Matching_explanation.t list;
   rules_by_engine : rule_id_and_engine_kind list;
 }
@@ -170,33 +55,22 @@ type 'a match_result = {
             (fun error -> fprintf fmt "%s, " (Core_error.show error))
             errors;
           fprintf fmt "}"]
-  extra : 'a debug_info;
+  extra : 'a Core_profiling.debug_info;
   explanations : Matching_explanation.t list;
 }
 [@@deriving show]
 
 (*****************************************************************************)
-(* Create empty versions of profiling/results objects *)
+(* Create empty versions of results objects *)
 (*****************************************************************************)
 
-let empty_partial_profiling file = { file; rule_times = [] }
+let empty_times_profiling = { parse_time = 0.0; match_time = 0.0 }
 
 (* TODO: should get rid of that *)
 let empty_file_profiling =
   { file = Fpath.v "TODO.fake_file"; rule_times = []; run_time = 0.0 }
 
-let empty_rule_profiling rule =
-  { rule_id = fst rule.Rule.id; parse_time = 0.0; match_time = 0.0 }
-
-let empty_times_profiling = { parse_time = 0.0; match_time = 0.0 }
-
-let empty_extra profiling =
-  match !mode with
-  | MDebug -> Debug { skipped_targets = []; profiling }
-  | MTime -> Time { profiling }
-  | MNo_info -> No_info
-
-let empty_semgrep_result =
+let empty_match_result : Core_profiling.times match_result =
   {
     matches = [];
     errors = E.ErrorSet.empty;
@@ -204,7 +78,7 @@ let empty_semgrep_result =
     explanations = [];
   }
 
-let empty_final_result =
+let empty_final_result : t =
   {
     matches = [];
     errors = [];
@@ -288,11 +162,16 @@ let collate_results init_extra unzip_extra base_case_extra final_extra results =
   }
 
 (* Aggregate a list of pattern results into one result *)
-let collate_pattern_results results =
+let collate_pattern_results (results : Core_profiling.times match_result list) :
+    Core_profiling.times match_result =
   let init_extra = ([], { parse_time = 0.0; match_time = 0.0 }) in
 
-  let unzip_profiling { match_time; parse_time }
-      { match_time = all_match_time; parse_time = all_parse_time } =
+  let unzip_profiling (a : Core_profiling.times) (b : Core_profiling.times) =
+    let ({ match_time; parse_time } : Core_profiling.times) = a in
+    let ({ match_time = all_match_time; parse_time = all_parse_time }
+          : Core_profiling.times) =
+      b
+    in
     {
       match_time = match_time +. all_match_time;
       parse_time = parse_time +. all_parse_time;
@@ -302,12 +181,12 @@ let collate_pattern_results results =
   let unzip_extra extra all_skipped_targets all_profiling =
     (* should match mode *)
     match extra with
-    | Debug { skipped_targets; profiling } ->
+    | Core_profiling.Debug { skipped_targets; profiling } ->
         ( skipped_targets :: all_skipped_targets,
           unzip_profiling profiling all_profiling )
-    | Time { profiling } ->
+    | Core_profiling.Time { profiling } ->
         (all_skipped_targets, unzip_profiling profiling all_profiling)
-    | No_info -> (all_skipped_targets, all_profiling)
+    | Core_profiling.No_info -> (all_skipped_targets, all_profiling)
   in
 
   let base_case_extra all_skipped_targets all_profiling =
@@ -316,10 +195,11 @@ let collate_pattern_results results =
 
   let final_extra skipped_targets profiling =
     match !mode with
-    | MDebug ->
-        Debug { skipped_targets = List.flatten skipped_targets; profiling }
-    | MTime -> Time { profiling }
-    | MNo_info -> No_info
+    | Core_profiling.MDebug ->
+        Core_profiling.Debug
+          { skipped_targets = List.flatten skipped_targets; profiling }
+    | Core_profiling.MTime -> Core_profiling.Time { profiling }
+    | Core_profiling.MNo_info -> Core_profiling.No_info
   in
 
   collate_results init_extra unzip_extra base_case_extra final_extra results

--- a/src/core/Core_result.mli
+++ b/src/core/Core_result.mli
@@ -1,104 +1,63 @@
-(* Options for what extra debugging information to output*)
-
-type debug_mode = MDebug | MTime | MNo_info [@@deriving show]
-
-type 'a debug_info =
-  | Debug of {
-      skipped_targets : Semgrep_output_v1_t.skipped_target list;
-      profiling : 'a;
-    }
-  | Time of { profiling : 'a }
-  | No_info
-[@@deriving show]
-
-val debug_info_to_option : 'a debug_info -> 'a option
-(** [debug_info_to_option debug] returns [Some profiling] if we collected
-    metrics. Otherwise, it returns [None]. *)
-
-(* Global to set the debug mode. Should be set
-   exactly once after the arguments are read *)
-
-val mode : debug_mode ref
-
-(* Save time information as we run each rule *)
-
-type times = { parse_time : float; match_time : float }
-
-type rule_profiling = {
-  rule_id : Rule_ID.t;
-  parse_time : float;
-  match_time : float;
-}
-[@@deriving show]
-
-(* Save time information as we run each file *)
-
-type partial_profiling = { file : Fpath.t; rule_times : rule_profiling list }
-[@@deriving show]
-
-type file_profiling = {
-  file : Fpath.t;
-  rule_times : rule_profiling list;
-  run_time : float;
-}
-[@@deriving show]
-
-type rule_id_and_engine_kind = Rule_ID.t * Pattern_match.engine_kind
-[@@deriving show]
-
-(* Substitute in the profiling type we have *)
+(* The 'a below can be substituted with different profiling types
+ * in Core_profiling.ml.
+ * This usually represent the match results for one target file
+ * (possibly using more than one rule).
+ *)
 
 type 'a match_result = {
   matches : Pattern_match.t list;
   errors : Core_error.ErrorSet.t;
-  extra : 'a debug_info;
+  extra : 'a Core_profiling.debug_info;
   explanations : Matching_explanation.t list;
 }
 [@@deriving show]
 
-(* Result object for the entire rule *)
+(* Result object for all the files, all the rules *)
 
-type final_profiling = {
-  rules : Rule.rule list;
-  rules_parse_time : float;
-  file_times : file_profiling list;
-  max_memory_bytes : int;
-}
-[@@deriving show]
-
-type final_result = {
+type t = {
   matches : Pattern_match.t list;
   errors : Core_error.t list;
   skipped_rules : Rule.invalid_rule_error list;
-  extra : final_profiling debug_info;
+  extra : Core_profiling.t Core_profiling.debug_info;
   explanations : Matching_explanation.t list;
   rules_by_engine : rule_id_and_engine_kind list;
 }
+
+and rule_id_and_engine_kind = Rule_ID.t * Pattern_match.engine_kind
 [@@deriving show]
 
-val empty_extra : 'a -> 'a debug_info
-val empty_partial_profiling : Fpath.t -> partial_profiling
-val empty_rule_profiling : Rule.t -> rule_profiling
-val empty_semgrep_result : times match_result
-val empty_final_result : final_result
+val empty_match_result : Core_profiling.times match_result
+val empty_final_result : t
 
 val make_match_result :
   Pattern_match.t list -> Core_error.ErrorSet.t -> 'a -> 'a match_result
 
+(* take the match results for each file, all the rules, and build the final
+ * result *)
+val make_final_result :
+  Core_profiling.file_profiling match_result list ->
+  (Rule.rule * Pattern_match.engine_kind) list ->
+  rules_parse_time:float ->
+  t
+
+(* match results profiling adjustment helpers *)
 val modify_match_result_profiling :
   'a match_result -> ('a -> 'b) -> 'b match_result
 
 val add_run_time :
-  float -> partial_profiling match_result -> file_profiling match_result
+  float ->
+  Core_profiling.partial_profiling match_result ->
+  Core_profiling.file_profiling match_result
 
-val add_rule : Rule.rule -> times match_result -> rule_profiling match_result
-val collate_pattern_results : times match_result list -> times match_result
+val add_rule :
+  Rule.rule ->
+  Core_profiling.times match_result ->
+  Core_profiling.rule_profiling match_result
 
-val make_final_result :
-  file_profiling match_result list ->
-  (Rule.rule * Pattern_match.engine_kind) list ->
-  rules_parse_time:float ->
-  final_result
+val collate_pattern_results :
+  Core_profiling.times match_result list -> Core_profiling.times match_result
 
 val collate_rule_results :
-  Fpath.t -> rule_profiling match_result list -> partial_profiling match_result
+  Fpath.t ->
+  Core_profiling.rule_profiling match_result list ->
+  Core_profiling.partial_profiling match_result

--- a/src/core_cli/Core_CLI.ml
+++ b/src/core_cli/Core_CLI.ml
@@ -685,9 +685,9 @@ let main_no_exn_handler (sys_argv : string array) : unit =
 
   let config = mk_config () in
 
-  if config.debug then Core_result.mode := MDebug
-  else if config.report_time then Core_result.mode := MTime
-  else Core_result.mode := MNo_info;
+  if config.debug then Core_profiling.mode := MDebug
+  else if config.report_time then Core_profiling.mode := MTime
+  else Core_profiling.mode := MNo_info;
 
   Logging_helpers.setup ~debug:config.debug
     ~log_config_file:config.log_config_file ~log_to_file:config.log_to_file;

--- a/src/core_scan/Core_scan.mli
+++ b/src/core_scan/Core_scan.mli
@@ -112,7 +112,7 @@ val semgrep_with_rules_and_formatted_output : Core_scan_config.t -> unit
 *)
 
 val output_semgrep_results :
-  Exception.t option * Core_result.final_result * Fpath.t list ->
+  Exception.t option * Core_result.t * Fpath.t list ->
   Core_scan_config.t ->
   unit
 (** [output_semgrep_results] takes the results of a semgrep run and
@@ -123,8 +123,7 @@ val output_semgrep_results :
 *)
 
 val semgrep_with_raw_results_and_exn_handler :
-  Core_scan_config.t ->
-  Exception.t option * Core_result.final_result * Fpath.t list
+  Core_scan_config.t -> Exception.t option * Core_result.t * Fpath.t list
 (** [semgrep_with_raw_results_and_exn_handler config] runs the semgrep-core
     engine with a starting list of targets and returns
     (success, result, targets).
@@ -142,7 +141,7 @@ val semgrep_with_rules :
   ?match_hook:(string -> Pattern_match.t -> unit) ->
   Core_scan_config.t ->
   (Rule.t list * Rule.invalid_rule_error list) * float ->
-  Core_result.final_result * Fpath.t list
+  Core_result.t * Fpath.t list
 
 (*****************************************************************************)
 (* Utilities functions used in tests or semgrep-core variants *)

--- a/src/core_scan/Core_scan_config.ml
+++ b/src/core_scan/Core_scan_config.ml
@@ -63,7 +63,9 @@ type t = {
    * in Run_semgrep, so the hook should not rely on shared memory!
    *)
   file_match_results_hook :
-    (Fpath.t -> Core_result.partial_profiling Core_result.match_result -> unit)
+    (Fpath.t ->
+    Core_profiling.partial_profiling Core_result.match_result ->
+    unit)
     option;
   (* Flag used by pysemgrep *)
   target_source : target_source option;
@@ -81,7 +83,7 @@ type semgrep_engine =
   (* Exceptions raised *)
   Exception.t option
   * (* Result *)
-    Core_result.final_result
+    Core_result.t
   * (* The processed targets *)
   Fpath.t list
 

--- a/src/engine/Match_extract_mode.ml
+++ b/src/engine/Match_extract_mode.ml
@@ -48,8 +48,8 @@ let logger = Logging.get_logger [ __MODULE__ ]
  * although this is a bit less ergonomic for the caller.
  *)
 type match_result_location_adjuster =
-  Core_result.partial_profiling Core_result.match_result ->
-  Core_result.partial_profiling Core_result.match_result
+  Core_profiling.partial_profiling Core_result.match_result ->
+  Core_profiling.partial_profiling Core_result.match_result
 
 (*****************************************************************************)
 (* Helpers *)
@@ -265,7 +265,7 @@ let map_bindings map_loc bindings =
   Common.map map_binding bindings
 
 let map_res map_loc (tmpfile : Fpath.t) (file : Fpath.t)
-    (mr : Core_result.partial_profiling Core_result.match_result) =
+    (mr : Core_profiling.partial_profiling Core_result.match_result) =
   let matches =
     Common.map
       (fun (m : Pattern_match.t) ->
@@ -288,7 +288,7 @@ let map_res map_loc (tmpfile : Fpath.t) (file : Fpath.t)
   in
   let extra =
     match mr.extra with
-    | Debug { skipped_targets; profiling } ->
+    | Core_profiling.Debug { skipped_targets; profiling } ->
         let skipped_targets =
           Common.map
             (fun (st : Semgrep_output_v1_t.skipped_target) ->
@@ -298,11 +298,11 @@ let map_res map_loc (tmpfile : Fpath.t) (file : Fpath.t)
               })
             skipped_targets
         in
-        Core_result.Debug
-          { skipped_targets; profiling = { profiling with Core_result.file } }
-    | Time { profiling } ->
-        Time { profiling = { profiling with Core_result.file } }
-    | No_info -> No_info
+        Core_profiling.Debug
+          { skipped_targets; profiling = { profiling with file } }
+    | Core_profiling.Time { profiling } ->
+        Core_profiling.Time { profiling = { profiling with file } }
+    | Core_profiling.No_info -> Core_profiling.No_info
   in
   { Core_result.matches; errors; extra; explanations = [] }
 

--- a/src/engine/Match_extract_mode.mli
+++ b/src/engine/Match_extract_mode.mli
@@ -4,8 +4,8 @@
  *)
 
 type match_result_location_adjuster =
-  Core_result.partial_profiling Core_result.match_result ->
-  Core_result.partial_profiling Core_result.match_result
+  Core_profiling.partial_profiling Core_result.match_result ->
+  Core_profiling.partial_profiling Core_result.match_result
 
 (*
    Generates a list of targets corresponding to extract mode rule matches in

--- a/src/engine/Match_rules.ml
+++ b/src/engine/Match_rules.ml
@@ -154,7 +154,7 @@ let per_rule_boilerplate_fn ~timeout ~timeout_threshold =
         let error = E.mk_error (Some rule_id) loc "" Out.Timeout in
         RP.make_match_result []
           (Core_error.ErrorSet.singleton error)
-          (RP.empty_rule_profiling rule)
+          (Core_profiling.empty_rule_profiling rule)
 
 (*****************************************************************************)
 (* Entry point *)
@@ -214,12 +214,13 @@ let check ~match_hook ~timeout ~timeout_threshold (xconf : Match_env.xconfig)
   let res = RP.collate_rule_results xtarget.Xtarget.file res_total in
   let extra =
     match res.extra with
-    | RP.Debug { skipped_targets; profiling } ->
+    | Core_profiling.Debug { skipped_targets; profiling } ->
         let skipped =
           Common.map (skipped_target_of_rule xtarget) skipped_rules
         in
-        RP.Debug { skipped_targets = skipped @ skipped_targets; profiling }
-    | Time profiling -> Time profiling
-    | No_info -> No_info
+        Core_profiling.Debug
+          { skipped_targets = skipped @ skipped_targets; profiling }
+    | Core_profiling.Time profiling -> Core_profiling.Time profiling
+    | Core_profiling.No_info -> Core_profiling.No_info
   in
   { res with extra }

--- a/src/engine/Match_rules.mli
+++ b/src/engine/Match_rules.mli
@@ -14,7 +14,7 @@ val check :
   Match_env.xconfig ->
   Rule.rules ->
   Xtarget.t ->
-  Core_result.partial_profiling Core_result.match_result
+  Core_profiling.partial_profiling Core_result.match_result
 
 (* for osemgrep interactive *)
 val is_relevant_rule_for_xtarget :

--- a/src/engine/Match_search_mode.mli
+++ b/src/engine/Match_search_mode.mli
@@ -4,7 +4,7 @@ val check_rule :
   (string -> Pattern_match.t -> unit) ->
   Match_env.xconfig ->
   Xtarget.t ->
-  Core_result.rule_profiling Core_result.match_result
+  Core_profiling.rule_profiling Core_result.match_result
 
 (* called from check_rule above and from Match_tainting_mode *)
 val matches_of_formula :
@@ -13,5 +13,5 @@ val matches_of_formula :
   Xtarget.t ->
   Rule.formula ->
   Range_with_metavars.t option ->
-  Core_result.rule_profiling Core_result.match_result
+  Core_profiling.rule_profiling Core_result.match_result
   * Range_with_metavars.ranges

--- a/src/engine/Match_tainting_mode.ml
+++ b/src/engine/Match_tainting_mode.ml
@@ -902,7 +902,7 @@ let check_rule per_file_formula_cache (rule : R.taint_rule) match_hook
   let errors = Parse_target.errors_from_skipped_tokens skipped_tokens in
   let report =
     RP.make_match_result matches errors
-      { RP.rule_id = fst rule.Rule.id; parse_time; match_time }
+      { Core_profiling.rule_id = fst rule.Rule.id; parse_time; match_time }
   in
   let explanations =
     if xconf.matching_explanations then
@@ -922,10 +922,11 @@ let check_rule per_file_formula_cache (rule : R.taint_rule) match_hook
 let check_rules ~match_hook
     ~(per_rule_boilerplate_fn :
        R.rule ->
-       (unit -> RP.rule_profiling RP.match_result) ->
-       RP.rule_profiling RP.match_result) (rules : R.taint_rule list)
-    (xconf : Match_env.xconfig) (xtarget : Xtarget.t) :
-    RP.rule_profiling RP.match_result list =
+       (unit -> Core_profiling.rule_profiling Core_result.match_result) ->
+       Core_profiling.rule_profiling Core_result.match_result)
+    (rules : R.taint_rule list) (xconf : Match_env.xconfig)
+    (xtarget : Xtarget.t) :
+    Core_profiling.rule_profiling Core_result.match_result list =
   (* We create a "formula cache" here, before dealing with individual rules, to
      permit sharing of matches for sources, sanitizers, propagators, and sinks
      between rules.

--- a/src/engine/Match_tainting_mode.mli
+++ b/src/engine/Match_tainting_mode.mli
@@ -91,13 +91,14 @@ val check_rules :
   match_hook:(string -> Pattern_match.t -> unit) ->
   per_rule_boilerplate_fn:
     (Rule.rule ->
-    (unit -> Core_result.rule_profiling Core_result.match_result) ->
-    Core_result.rule_profiling Core_result.match_result) ->
+    (unit -> Core_profiling.rule_profiling Core_result.match_result) ->
+    Core_profiling.rule_profiling Core_result.match_result) ->
   Rule.taint_rule list ->
   Match_env.xconfig ->
   Xtarget.t ->
   (* timeout function *)
-  Core_result.rule_profiling Core_result.match_result list
-(** Runs the engine on a group of taint rules, which should be for the same language.
-  * Running on multiple rules at once enables inter-rule optimizations.
+  Core_profiling.rule_profiling Core_result.match_result list
+(** Runs the engine on a group of taint rules, which should be for the
+  * same language. Running on multiple rules at once enables inter-rule
+  * optimizations.
   *)

--- a/src/engine/Test_engine.ml
+++ b/src/engine/Test_engine.ml
@@ -165,7 +165,7 @@ let make_tests ?(unit_testing = false) ?(get_xlang = None) xs =
                }
              in
              E.g_errors := [];
-             Core_result.mode := MTime;
+             Core_profiling.mode := MTime;
              let rules, extract_rules =
                Common.partition_either
                  (fun r ->
@@ -249,7 +249,11 @@ let make_tests ?(unit_testing = false) ?(get_xlang = None) xs =
                      (spf "exn on %s (exn = %s)" !!file (Common.exn_to_s exn))
              in
              res :: eres
-             |> List.iter (fun (res : RP.partial_profiling RP.match_result) ->
+             |> List.iter
+                  (fun
+                    (res :
+                      Core_profiling.partial_profiling Core_result.match_result)
+                  ->
                     match res.extra with
                     | Debug _
                     | No_info ->
@@ -258,26 +262,30 @@ let make_tests ?(unit_testing = false) ?(get_xlang = None) xs =
                            which we force to be MTime"
                     | Time { profiling } ->
                         profiling.rule_times
-                        |> List.iter (fun rule_time ->
-                               if not (rule_time.RP.match_time >= 0.) then
+                        |> List.iter
+                             (fun (rule_time : Core_profiling.rule_profiling) ->
+                               if not (rule_time.match_time >= 0.) then
                                  (* match_time could be 0.0 if the rule contains no pattern or if the
                                     rules are skipped. Otherwise it's positive. *)
                                  failwith
                                    (spf
                                       "invalid value for match time: %g (rule: \
                                        %s, target: %s)"
-                                      rule_time.RP.match_time !!file !!target);
-                               if not (rule_time.RP.parse_time >= 0.) then
+                                      rule_time.match_time !!file !!target);
+                               if not (rule_time.parse_time >= 0.) then
                                  (* same for parse time *)
                                  failwith
                                    (spf
                                       "invalid value for parse time: %g (rule: \
                                        %s, target: %s)"
-                                      rule_time.RP.parse_time !!file !!target)));
+                                      rule_time.parse_time !!file !!target)));
 
              res :: eres
-             |> List.iter (fun (res : RP.partial_profiling RP.match_result) ->
-                    res.matches |> List.iter Core_json_output.match_to_error);
+             |> List.iter
+                  (fun
+                    (res :
+                      Core_profiling.partial_profiling Core_result.match_result)
+                  -> res.matches |> List.iter Core_json_output.match_to_error);
              (if not (E.ErrorSet.is_empty res.errors) then
               let errors =
                 E.ErrorSet.elements res.errors

--- a/src/engine/Xpattern_match_aliengrep.mli
+++ b/src/engine/Xpattern_match_aliengrep.mli
@@ -5,4 +5,4 @@ val matches_of_aliengrep :
   (Aliengrep.Pat_compile.t * Xpattern.pattern_id * string) list ->
   string Lazy.t ->
   Common.filename ->
-  Core_result.times Core_result.match_result
+  Core_profiling.times Core_result.match_result

--- a/src/engine/Xpattern_match_regexp.mli
+++ b/src/engine/Xpattern_match_regexp.mli
@@ -2,4 +2,4 @@ val matches_of_regexs :
   (Regexp_engine.t * Xpattern.pattern_id * string) list ->
   string Lazy.t ->
   Common.filename ->
-  Core_result.times Core_result.match_result
+  Core_profiling.times Core_result.match_result

--- a/src/engine/Xpattern_match_spacegrep.mli
+++ b/src/engine/Xpattern_match_spacegrep.mli
@@ -2,4 +2,4 @@ val matches_of_spacegrep :
   Match_env.xconfig ->
   (Spacegrep.Pattern_AST.t * Xpattern.pattern_id * string) list ->
   Common.filename ->
-  Core_result.times Core_result.match_result
+  Core_profiling.times Core_result.match_result

--- a/src/engine/Xpattern_matcher.ml
+++ b/src/engine/Xpattern_matcher.ml
@@ -57,15 +57,16 @@ let (matches_of_matcher :
       ('xpattern * Xpattern.pattern_id * string) list ->
       ('target_content, 'xpattern) t ->
       filename ->
-      RP.times RP.match_result) =
+      Core_profiling.times Core_result.match_result) =
  fun xpatterns matcher file ->
-  if xpatterns =*= [] then RP.empty_semgrep_result
+  if xpatterns =*= [] then Core_result.empty_match_result
   else
     let target_content_opt, parse_time =
       Common.with_time (fun () -> matcher.init file)
     in
     match target_content_opt with
-    | None -> RP.empty_semgrep_result (* less: could include parse_time *)
+    | None ->
+        Core_result.empty_match_result (* less: could include parse_time *)
     | Some target_content ->
         let res, match_time =
           Common.with_time (fun () ->
@@ -88,7 +89,7 @@ let (matches_of_matcher :
                             })))
         in
         RP.make_match_result res Core_error.ErrorSet.empty
-          { RP.parse_time; match_time }
+          { Core_profiling.parse_time; match_time }
 
 (* todo: same, we should not need that *)
 let hmemo = Hashtbl.create 101

--- a/src/osemgrep/cli_scan/Core_runner.mli
+++ b/src/osemgrep/cli_scan/Core_runner.mli
@@ -20,18 +20,20 @@ type result = {
 type semgrep_core_runner =
   ?respect_git_ignore:bool ->
   ?file_match_results_hook:
-    (Fpath.t -> Core_result.partial_profiling Core_result.match_result -> unit)
+    (Fpath.t ->
+    Core_profiling.partial_profiling Core_result.match_result ->
+    unit)
     option ->
   conf ->
   (* LATER? use Config_resolve.rules_and_origin instead? *)
   Rule.rules ->
   Rule.invalid_rule_error list ->
   Fpath.t list ->
-  Exception.t option * Core_result.final_result * Fpath.t Set_.t
+  Exception.t option * Core_result.t * Fpath.t Set_.t
 
 val create_core_result :
   Rule.rule list ->
-  Exception.t option * Core_result.final_result * Fpath.t Set_.t ->
+  Exception.t option * Core_result.t * Fpath.t Set_.t ->
   result
 
 (*

--- a/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -96,8 +96,9 @@ let exit_code_of_errors ~strict (errors : Out.core_error list) : Exit_code.t =
  * the use of Unix.lockf below.
  *)
 let file_match_results_hook (conf : Scan_CLI.conf) (rules : Rule.rules)
-    (_file : Fpath.t) (match_results : RP.partial_profiling RP.match_result) :
-    unit =
+    (_file : Fpath.t)
+    (match_results : Core_profiling.partial_profiling Core_result.match_result)
+    : unit =
   let (cli_matches : Out.cli_match list) =
     (* need to go through a series of transformation so that we can
      * get something that Matches_report.pp_text_outputs can operate on
@@ -191,8 +192,8 @@ let core (conf : Scan_CLI.conf) file_match_results_hook errors targets
    baseline commit scan. Matches are considered identical if the
    tuples containing the rule ID, file path, and matched code snippet
    are equal. *)
-let remove_matches_in_baseline (commit : string) (baseline : RP.final_result)
-    (head : RP.final_result) (renamed : (filename * filename) stack) =
+let remove_matches_in_baseline (commit : string) (baseline : Core_result.t)
+    (head : Core_result.t) (renamed : (filename * filename) stack) =
   let extract_sig renamed m =
     let rule_id = m.Pattern_match.rule_id in
     let path =
@@ -250,16 +251,14 @@ let remove_matches_in_baseline (commit : string) (baseline : RP.final_result)
    from the results of the head checkout scan. *)
 let scan_baseline_and_remove_duplicates (conf : Scan_CLI.conf)
     (profiler : Profiler.t)
-    ( (exn : Exception.t option),
-      (r : RP.final_result),
-      (scanned : Fpath.t Set_.t) ) (rules : Rule.rules) (commit : string)
-    (status : Git_wrapper.status)
+    ((exn : Exception.t option), (r : Core_result.t), (scanned : Fpath.t Set_.t))
+    (rules : Rule.rules) (commit : string) (status : Git_wrapper.status)
     (core :
       Fpath.t list ->
       ?diff_config:Differential_scan_config.t ->
       Rule.rules ->
       unit ->
-      Exception.t option * RP.final_result * Fpath.t Set_.t) =
+      Exception.t option * Core_result.t * Fpath.t Set_.t) =
   if r.matches <> [] then
     let add_renamed paths =
       List.fold_left (fun x (y, _) -> SS.add y x) paths status.renamed

--- a/src/osemgrep/core/Metrics_.ml
+++ b/src/osemgrep/core/Metrics_.ml
@@ -317,9 +317,9 @@ let add_rules_hashes_and_rules_profiling ?profiling:_TODO rules =
   in
   g.payload.performance.ruleStats <- Some ruleStats_value
 
-let add_max_memory_bytes (profiling_data : Core_result.final_profiling option) =
+let add_max_memory_bytes (profiling_data : Core_profiling.t option) =
   Option.iter
-    (fun { Core_result.max_memory_bytes; _ } ->
+    (fun { Core_profiling.max_memory_bytes; _ } ->
       g.payload.performance.maxMemoryBytes <- Some max_memory_bytes)
     profiling_data
 
@@ -333,14 +333,14 @@ let add_rules_hashes_and_findings_count (filtered_matches : (Rule.t * int) list)
   g.payload.value.ruleHashesWithFindings <- Some ruleHashesWithFindings_value
 
 let add_targets_stats (targets : Fpath.t Set_.t)
-    (prof_opt : Core_result.final_profiling option) =
+    (prof_opt : Core_profiling.t option) =
   let targets = Set_.elements targets in
-  let (hprof : (Fpath.t, Core_result.file_profiling) Hashtbl.t) =
+  let (hprof : (Fpath.t, Core_profiling.file_profiling) Hashtbl.t) =
     match prof_opt with
     | None -> Hashtbl.create 0
     | Some prof ->
         prof.file_times
-        |> Common.map (fun ({ Core_result.file; _ } as file_prof) ->
+        |> Common.map (fun ({ Core_profiling.file; _ } as file_prof) ->
                (file, file_prof))
         |> Common.hash_of_list
   in
@@ -353,11 +353,11 @@ let add_targets_stats (targets : Fpath.t Set_.t)
                  ( Some fprof.run_time,
                    Some
                      (fprof.rule_times
-                     |> Common.map (fun rt -> rt.Core_result.parse_time)
+                     |> Common.map (fun rt -> rt.Core_profiling.parse_time)
                      |> Common2.sum_float),
                    Some
                      (fprof.rule_times
-                     |> Common.map (fun rt -> rt.Core_result.match_time)
+                     |> Common.map (fun rt -> rt.Core_profiling.match_time)
                      |> Common2.sum_float) )
              | None -> (None, None, None)
            in

--- a/src/osemgrep/core/Metrics_.mli
+++ b/src/osemgrep/core/Metrics_.mli
@@ -94,10 +94,7 @@ val add_rules_hashes_and_rules_profiling :
   ?profiling:Semgrep_output_v1_t.core_timing -> Rule.rules -> unit
 
 val add_rules_hashes_and_findings_count : (Rule.t * int) list -> unit
-
-val add_targets_stats :
-  Fpath.t Set_.t -> Core_result.final_profiling option -> unit
-
+val add_targets_stats : Fpath.t Set_.t -> Core_profiling.t option -> unit
 val add_engine_kind : Semgrep_output_v1_t.engine_kind -> unit
 val add_exit_code : Exit_code.t -> unit
 
@@ -106,7 +103,7 @@ val add_feature : category:string -> name:string -> unit
 
 (* profiling data (TODO: should merge the 2 types and 2 calls) *)
 val add_profiling : Profiler.t -> unit
-val add_max_memory_bytes : Core_result.final_profiling option -> unit
+val add_max_memory_bytes : Core_profiling.t option -> unit
 
 (* useful for us to improve semgrep *)
 val add_errors : Semgrep_output_v1_t.cli_error list -> unit

--- a/src/reporting/Core_json_output.mli
+++ b/src/reporting/Core_json_output.mli
@@ -11,7 +11,7 @@ val match_to_match :
 val core_output_of_matches_and_errors :
   render_fix option ->
   int (* number of files processed, for the stats.okfiles *) ->
-  Core_result.final_result ->
+  Core_result.t ->
   Semgrep_output_v1_t.core_output
 
 (* for abstract_content and subpatterns matching-explanations


### PR DESCRIPTION
Separate of concerns. It's arguably cleaner that way and
mimic more what is in semgrep_output_v1.atd where
the core_output and profiling info are in separate sections.

test plan:
make core