### PR TITLE
feat(cfg): add support for try-catch-else-finally 

### DIFF
--- a/languages/cpp/generic/cpp_to_generic.ml
+++ b/languages/cpp/generic/cpp_to_generic.ml
@@ -759,7 +759,7 @@ and map_stmt env x : G.stmt =
       let v1 = map_tok env v1
       and v2 = map_compound env v2
       and v3 = map_of_list (map_handler env) v3 in
-      G.Try (v1, G.Block v2 |> G.s, v3, None) |> G.s
+      G.Try (v1, G.Block v2 |> G.s, v3, None, None) |> G.s
   | StmtTodo (v1, v2) ->
       let v1 = map_todo_category env v1
       and v2 = map_of_list (map_stmt env) v2 in

--- a/languages/csharp/generic/Parse_csharp_tree_sitter.ml
+++ b/languages/csharp/generic/Parse_csharp_tree_sitter.ml
@@ -1947,7 +1947,7 @@ and statement (env : env) (x : CST.statement) =
       let v2 = block env v2 in
       let v3 = Common.map (catch_clause env) v3 in
       let v4 = Option.map (finally_clause env) v4 in
-      Try (v1, v2, v3, v4) |> G.s
+      Try (v1, v2, v3, None, v4) |> G.s
   | `Unsafe_stmt (v1, v2) ->
       let tunsafe = token env v1 (* "unsafe" *) in
       let v2 = block env v2 in

--- a/languages/java/generic/java_to_generic.ml
+++ b/languages/java/generic/java_to_generic.ml
@@ -488,7 +488,7 @@ and stmt_aux st =
       [ G.OtherStmtWithStmt (G.OSWS_Block ("Sync", v0), [ G.E v1 ], v2) |> G.s ]
   | Try (t, v0, v1, v2, v3) -> (
       let v1 = stmt v1 and v2 = catches v2 and v3 = option tok_and_stmt v3 in
-      let try_stmt = G.Try (t, v1, v2, v3) |> G.s in
+      let try_stmt = G.Try (t, v1, v2, None, v3) |> G.s in
       match v0 with
       | None -> [ try_stmt ]
       | Some r -> [ G.WithUsingResource (t, resources r, try_stmt) |> G.s ])

--- a/languages/javascript/generic/js_to_generic.ml
+++ b/languages/javascript/generic/js_to_generic.ml
@@ -395,7 +395,7 @@ and stmt x =
       let v1 = stmt v1
       and v2 = option catch_block v2
       and v3 = option tok_and_stmt v3 in
-      G.Try (t, v1, Option.to_list v2, v3) |> G.s
+      G.Try (t, v1, Option.to_list v2, None, v3) |> G.s
   | With (_v1, v2, v3) ->
       let e = expr v2 in
       let v3 = stmt v3 in

--- a/languages/julia/generic/Parse_julia_tree_sitter.ml
+++ b/languages/julia/generic/Parse_julia_tree_sitter.ml
@@ -2077,16 +2077,8 @@ and map_statement (env : env) (x : CST.statement) : stmt list =
           | `Catch_clause_opt_else_clause_opt_fina_clause
               (clause, elsee, finally) ->
               let v4 = [ map_catch_clause env clause ] in
-              let v5 =
-                match elsee with
-                | Some x -> Some (map_try_else_clause env x)
-                | None -> None
-              in
-              let v6 =
-                match finally with
-                | Some x -> Some (map_finally_clause env x)
-                | None -> None
-              in
+              let v5 = Option.map (map_try_else_clause env) elsee in
+              let v6 = Option.map (map_finally_clause env) finally in
               [ Try (v1, v3, v4, v5, v6) |> G.s ]
           | `Fina_clause_opt_catch_clause (finally, catch) ->
               let v4 =

--- a/languages/julia/generic/Parse_julia_tree_sitter.ml
+++ b/languages/julia/generic/Parse_julia_tree_sitter.ml
@@ -1395,6 +1395,12 @@ and map_field_expression (env : env) ((v1, v2, v3) : CST.field_expression) =
   in
   DotAccess (v1, v2, field) |> G.e
 
+and map_try_else_clause (env : env) ((v1, v2, v3) : CST.else_clause) =
+  let v1 = (* "else" *) token env v1 in
+  let _v2 = map_terminator_opt env v2 in
+  let v3 = map_source_file env v3 in
+  (v1, Block (fb v3) |> G.s)
+
 and map_finally_clause (env : env) ((v1, v2, v3) : CST.finally_clause) =
   let v1 = (* "finally" *) token env v1 in
   let _v2 = map_terminator_opt env v2 in
@@ -2071,33 +2077,25 @@ and map_statement (env : env) (x : CST.statement) : stmt list =
           | `Catch_clause_opt_else_clause_opt_fina_clause
               (clause, elsee, finally) ->
               let v4 = [ map_catch_clause env clause ] in
-              let _v2 =
+              let v5 =
                 match elsee with
-                | Some _x ->
-                    (* map_else_clause env x *)
-                    (* TODO: We can't actually accommodate this within the Generic AST.
-                       "else" is something kind of weird where it's something you enter
-                       if you do not enter the "catch", but it's not the same as a
-                        "finally", which always runs in either case.
-                       https://docs.julialang.org/en/v1/manual/control-flow/#else-Clauses
-                    *)
-                    None
+                | Some x -> Some (map_try_else_clause env x)
                 | None -> None
               in
-              let v5 =
+              let v6 =
                 match finally with
                 | Some x -> Some (map_finally_clause env x)
                 | None -> None
               in
-              [ Try (v1, v3, v4, v5) |> G.s ]
+              [ Try (v1, v3, v4, v5, v6) |> G.s ]
           | `Fina_clause_opt_catch_clause (finally, catch) ->
               let v4 =
                 match catch with
                 | Some x -> [ map_catch_clause env x ]
                 | None -> []
               in
-              let v5 = map_finally_clause env finally in
-              [ Try (v1, v3, v4, Some v5) |> G.s ])
+              let v5 = Some (map_finally_clause env finally) in
+              [ Try (v1, v3, v4, None, v5) |> G.s ])
       | `For_stmt (v1, v2, v3, v4, v5, v6) ->
           let v1 = (* "for" *) token env v1 in
           let header =

--- a/languages/kotlin/generic/Parse_kotlin_tree_sitter.ml
+++ b/languages/kotlin/generic/Parse_kotlin_tree_sitter.ml
@@ -1802,7 +1802,7 @@ and primary_expression (env : env) (x : CST.primary_expression) : expr =
             let finally = finally_block env x in
             ([], Some finally)
       in
-      let try_stmt = Try (v1, v2, catch, finally) |> G.s in
+      let try_stmt = Try (v1, v2, catch, None, finally) |> G.s in
       stmt_to_expr try_stmt
   | `Jump_exp x ->
       let v1 = jump_expression env x in

--- a/languages/ocaml/generic/ml_to_generic.ml
+++ b/languages/ocaml/generic/ml_to_generic.ml
@@ -167,7 +167,7 @@ and stmt e : G.stmt =
         |> Common.map (fun (pat, e) ->
                (fake "catch", G.CatchPattern pat, G.exprstmt e))
       in
-      G.Try (t, v1, catches, None) |> G.s
+      G.Try (t, v1, catches, None, None) |> G.s
   | While (t, v1, v2) ->
       let v1 = expr v1 and v2 = stmt v2 in
       G.While (t, G.Cond v1, v2) |> G.s

--- a/languages/php/generic/php_to_generic.ml
+++ b/languages/php/generic/php_to_generic.ml
@@ -147,7 +147,7 @@ let rec stmt_aux = function
   | Goto (t, id) -> [ G.Goto (t, ident id, G.sc) |> G.s ]
   | Try (t, v1, v2, v3) ->
       let v1 = stmt v1 and v2 = list catch v2 and v3 = finally v3 in
-      [ G.Try (t, v1, v2, v3) |> G.s ]
+      [ G.Try (t, v1, v2, None, v3) |> G.s ]
   | ClassDef v1 ->
       let ent, def = class_def v1 in
       [ G.DefStmt (ent, G.ClassDef def) |> G.s ]

--- a/languages/python/ast/AST_python.ml
+++ b/languages/python/ast/AST_python.ml
@@ -358,8 +358,8 @@ type stmt =
       tok
       * stmt list (* body *)
       * excepthandler list (* handlers *)
-      * stmt list (* orelse *)
-  | TryFinally of tok * stmt list (* body *) * tok * stmt list (* finalbody *)
+      * (tok * stmt list) option (* orelse *)
+      * (tok * stmt list) option (* finally *)
   (* TODO: tree-sitter-python say expr list *)
   | Assert of tok * expr (* test *) * expr option (* msg *)
   (* 'Global' is needed because Python does not have a VarDef and abuse Assign

--- a/languages/python/menhir/Parser_python.mly
+++ b/languages/python/menhir/Parser_python.mly
@@ -604,15 +604,15 @@ for_stmt:
 
 try_stmt:
   | TRY ":" suite excepthandler+
-      { TryExcept ($1, $3, $4, []) }
+      { TryExcept ($1, $3, $4, None, None) }
   | TRY ":" suite excepthandler+ ELSE ":" suite
-      { TryExcept ($1, $3, $4, $7) }
+      { TryExcept ($1, $3, $4, Some ($5, $7), None) }
   | TRY ":" suite excepthandler+ ELSE ":" suite FINALLY ":" suite
-      { TryFinally ($1, [TryExcept ($1, $3, $4, $7)], $8, $10) }
+      { TryExcept ($1, $3, $4, Some ($5, $7), Some ($8, $10)) }
   | TRY ":" suite excepthandler+ FINALLY ":" suite
-      { TryFinally ($1, [TryExcept ($1, $3, $4, [])], $5, $7) }
+      { TryExcept ($1, $3, $4, None, Some ($5, $7)) }
   | TRY ":" suite FINALLY ":" suite
-      { TryFinally ($1, $3, $4, $6) }
+      { TryExcept ($1, $3, [], None, Some ($4, $6)) }
 
 excepthandler:
   | EXCEPT              ":" suite { ExceptHandler ($1, None, None, $3) }

--- a/languages/python/menhir/Visitor_python.ml
+++ b/languages/python/menhir/Visitor_python.ml
@@ -445,16 +445,23 @@ let (mk_visitor : visitor_in -> visitor_out) =
           and v2 = v_option v_expr v2
           and v3 = v_option v_expr v3 in
           ()
-      | TryExcept (t, v1, v2, v3) ->
-          let t = v_info t in
-          let v1 = v_list v_stmt v1
+      | TryExcept (t, v1, v2, v3, v4) ->
+          let t = v_info t
+          and v1 = v_list v_stmt v1
           and v2 = v_list v_excepthandler v2
-          and v3 = v_list v_stmt v3 in
-          ()
-      | TryFinally (t, v1, t2, v2) ->
-          let t = v_info t in
-          let t2 = v_info t2 in
-          let v1 = v_list v_stmt v1 and v2 = v_list v_stmt v2 in
+          and v3 =
+            v_option
+              (fun (t, v1) ->
+                let t = v_info t and v1 = v_list v_stmt v1 in
+                ())
+              v3
+          and v4 =
+            v_option
+              (fun (t, v1) ->
+                let t = v_info t and v1 = v_list v_stmt v1 in
+                ())
+              v4
+          in
           ()
       | Assert (t, v1, v2) ->
           let t = v_info t in

--- a/languages/python/tree-sitter/Parse_python_tree_sitter.ml
+++ b/languages/python/tree-sitter/Parse_python_tree_sitter.ml
@@ -1510,8 +1510,8 @@ and map_compound_statement (env : env) (x : CST.compound_statement) : stmt =
             let finally_opt = Option.map (map_finally_clause env) v3 in
             TryExcept (ttry, body, excepts, else_opt, finally_opt)
         | `Fina_clause x ->
-            let tfinal, finalbody = map_finally_clause env x in
-            TryExcept (ttry, body, [], None, Some (tfinal, finalbody))
+            let finally_opt = Some (map_finally_clause env x) in
+            TryExcept (ttry, body, [], None, finally_opt)
       in
       res
   | `With_stmt (v1, v2, v3, v4, v5) ->

--- a/languages/ruby/generic/ruby_to_generic.ml
+++ b/languages/ruby/generic/ruby_to_generic.ml
@@ -881,9 +881,11 @@ and body_exn x =
           G.Block (fb [ try_ ]) |> G.s
       | Some (t, sts) ->
           let st = list_stmt1 sts in
-          let try_ = G.Try (fake t "try", body, catches, finally_opt) |> G.s in
+          let try_ =
+            G.Try (unsafe_fake "try", body, catches, finally_opt) |> G.s
+          in
           let st = G.Block (fb [ try_; st ]) |> G.s in
-          G.OtherStmtWithStmt (G.OSWS_Else_in_try, [], st) |> G.s)
+          G.OtherStmtWithStmt (G.OSWS_Else_in_try, [ G.Tk t ], st) |> G.s)
 
 and rescue_clause (t, exns, exnvaropt, sts) : G.catch =
   let st = list_stmt1 sts in

--- a/languages/ruby/generic/ruby_to_generic.ml
+++ b/languages/ruby/generic/ruby_to_generic.ml
@@ -177,6 +177,7 @@ let rec expr e =
           ( t,
             G.exprstmt e1,
             [ (t, CatchPattern (PatUnderscore t), G.exprstmt e2) ],
+            None,
             None )
         |> G.s
       in
@@ -863,29 +864,15 @@ and body_exn x =
    rescue_exprs = catches;
    ensure_expr = finally_opt;
    else_expr = elseopt;
-  } -> (
+  } ->
       let body = list_stmt1 xs in
       let catches = list rescue_clause catches in
-      let finally_opt =
-        match finally_opt with
-        | None -> None
-        | Some (t, sts) ->
-            let st = list_stmt1 sts in
-            Some (t, st)
-      in
-      match elseopt with
-      | None ->
-          let try_ =
-            G.Try (unsafe_fake "try", body, catches, finally_opt) |> G.s
-          in
-          G.Block (fb [ try_ ]) |> G.s
-      | Some (t, sts) ->
-          let st = list_stmt1 sts in
-          let try_ =
-            G.Try (unsafe_fake "try", body, catches, finally_opt) |> G.s
-          in
-          let st = G.Block (fb [ try_; st ]) |> G.s in
-          G.OtherStmtWithStmt (G.OSWS_Else_in_try, [ G.Tk t ], st) |> G.s)
+      let finally_opt = option finally_clause finally_opt in
+      let elseopt = option else_clause elseopt in
+      G.Try (unsafe_fake "try", body, catches, elseopt, finally_opt) |> G.s
+
+and else_clause (t, sts) = (t, list_stmt1 sts)
+and finally_clause (t, sts) = (t, list_stmt1 sts)
 
 and rescue_clause (t, exns, exnvaropt, sts) : G.catch =
   let st = list_stmt1 sts in

--- a/languages/scala/generic/scala_to_generic.ml
+++ b/languages/scala/generic/scala_to_generic.ml
@@ -707,7 +707,7 @@ and v_stmt = function
         | None -> []
         | Some xs -> xs
       in
-      G.Try (v1, v2, catches, v4) |> G.s
+      G.Try (v1, v2, catches, None, v4) |> G.s
   | Throw (v1, v2) ->
       let v1 = v_tok v1 and v2 = v_expr v2 in
       G.Throw (v1, v2, G.sc) |> G.s

--- a/languages/solidity/generic/Parse_solidity_tree_sitter.ml
+++ b/languages/solidity/generic/Parse_solidity_tree_sitter.ml
@@ -2089,7 +2089,7 @@ and map_statement (env : env) (x : CST.statement) : stmt =
       let call = Call (lambda, fb [ Arg e ]) |> G.e in
       let try_stmt = G.exprstmt call in
       let catches = Common.map (map_catch_clause env) v5 in
-      Try (ttry, try_stmt, catches, None) |> G.s
+      Try (ttry, try_stmt, catches, None, None) |> G.s
   | `Ret_stmt (v1, v2, v3) ->
       let tret = (* "return" *) token env v1 in
       let eopt =

--- a/languages/swift/generic/Parse_swift_tree_sitter.ml
+++ b/languages/swift/generic/Parse_swift_tree_sitter.ml
@@ -1350,7 +1350,7 @@ and map_do_statement (env : env) ((v1, v2, v3) : CST.do_statement) =
   (* TODO? A do statement is not quite the same as a `try`... but it's close
      enough?
   *)
-  G.Try (do_tok, v2, v3, None) |> G.s
+  G.Try (do_tok, v2, v3, None, None) |> G.s
 
 and map_else_options (env : env) (x : CST.else_options) =
   match x with

--- a/languages/tree-sitter-to-generic/Parse_hack_tree_sitter.ml
+++ b/languages/tree-sitter-to-generic/Parse_hack_tree_sitter.ml
@@ -2343,10 +2343,10 @@ and statement (env : env) (x : CST.statement) =
         match v4 with
         | `Catch_clause x ->
             let catch = [ catch_clause env x ] in
-            G.Try (v1, v2, v3 @ catch, None) |> G.s
+            G.Try (v1, v2, v3 @ catch, None, None) |> G.s
         | `Fina_clause x ->
             let finally = Some (finally_clause env x) in
-            G.Try (v1, v2, v3, finally) |> G.s
+            G.Try (v1, v2, v3, None, finally) |> G.s
       in
       v4
   | `Conc_stmt (v1, v2) ->

--- a/libs/ast_generic/AST_generic.ml
+++ b/libs/ast_generic/AST_generic.ml
@@ -1183,7 +1183,14 @@ and stmt_kind =
   | Goto of tok * label * sc (* less: use label_ident for computed goto in C*)
   (* TODO? move in expr! in C++ the expr can be an option *)
   | Throw of tok (* 'raise' in OCaml, 'throw' in Java/PHP *) * expr * sc
-  | Try of tok * stmt * catch list * try_else option * finally option
+  | Try of
+      tok (* 'try' *)
+      * stmt (* body of the try clause *)
+      * catch list (* list of exception handlers *)
+      * try_else option
+      (* optional else block that executes when no exception is thrown *)
+      * finally option
+    (* optional finally block that executes at the end no matter what *)
   | WithUsingResource of
       tok (* 'with' in Python, 'using' in C# *)
       * stmt list (* resource acquisition *)

--- a/libs/ast_generic/AST_generic.ml
+++ b/libs/ast_generic/AST_generic.ml
@@ -1183,7 +1183,7 @@ and stmt_kind =
   | Goto of tok * label * sc (* less: use label_ident for computed goto in C*)
   (* TODO? move in expr! in C++ the expr can be an option *)
   | Throw of tok (* 'raise' in OCaml, 'throw' in Java/PHP *) * expr * sc
-  | Try of tok * stmt * catch list * finally option
+  | Try of tok * stmt * catch list * try_else option * finally option
   | WithUsingResource of
       tok (* 'with' in Python, 'using' in C# *)
       * stmt list (* resource acquisition *)
@@ -1256,6 +1256,8 @@ and catch_exn =
   | CatchParam of parameter_classic
   (* e.g., CatchEmpty/CatchParams in Solidity *)
   | OtherCatch of todo_kind * any list
+
+and try_else = tok * stmt
 
 (* ptype should never be None *)
 

--- a/libs/ast_generic/AST_generic_to_v1.ml
+++ b/libs/ast_generic/AST_generic_to_v1.ml
@@ -766,12 +766,16 @@ and map_stmt x : B.stmt =
         let v1 = map_expr v1 in
         let sc = map_tok sc in
         `Throw (t, v1, sc)
-    | Try (t, v1, v2, v3) ->
+    | Try (t, v1, v2, v3, v4) ->
         let t = map_tok t in
         let v1 = map_stmt v1
         and v2 = map_of_list map_catch v2
-        and v3 = map_of_option map_finally v3 in
-        `Try (t, v1, v2, v3)
+        and _v3 = map_of_option map_try_else v3
+        and v4 = map_of_option map_finally v4 in
+        (* TODO: some languages such as ruby have try-catch-else-finally
+         * statements. Support the else block in the atd.
+         *)
+        `Try (t, v1, v2, v4)
     | WithUsingResource (t, v1, v2) ->
         let t = map_tok t in
         let v1 = map_of_list map_stmt v1 in
@@ -882,6 +886,7 @@ and map_catch_exn = function
       let v2 = map_of_list map_any v2 in
       `OtherCatch (v1, v2)
 
+and map_try_else v = map_tok_and_stmt v
 and map_finally v = map_tok_and_stmt v
 
 and map_tok_and_stmt (t, v) =

--- a/libs/ast_generic/Meta_AST.ml
+++ b/libs/ast_generic/Meta_AST.ml
@@ -857,12 +857,13 @@ and vof_stmt st =
       let v1 = vof_expr v1 in
       let sc = vof_tok sc in
       OCaml.VSum ("Throw", [ t; v1; sc ])
-  | Try (t, v1, v2, v3) ->
+  | Try (t, v1, v2, v3, v4) ->
       let t = vof_tok t in
       let v1 = vof_stmt v1
       and v2 = OCaml.vof_list vof_catch v2
-      and v3 = OCaml.vof_option vof_finally v3 in
-      OCaml.VSum ("Try", [ t; v1; v2; v3 ])
+      and v3 = OCaml.vof_option vof_try_else v3
+      and v4 = OCaml.vof_option vof_finally v4 in
+      OCaml.VSum ("Try", [ t; v1; v2; v3; v4 ])
   | WithUsingResource (t, v1, v2) ->
       let t = vof_tok t in
       let v1 = OCaml.vof_list vof_stmt v1 in
@@ -953,6 +954,7 @@ and vof_catch_exn = function
       let v1 = vof_parameter_classic v1 in
       OCaml.VSum ("CatchParam", [ v1 ])
 
+and vof_try_else v = vof_tok_and_stmt v
 and vof_finally v = vof_tok_and_stmt v
 
 and vof_tok_and_stmt (t, v) =

--- a/src/analyzing/AST_to_IL.ml
+++ b/src/analyzing/AST_to_IL.ml
@@ -378,24 +378,17 @@ and try_catch_else_finally env ~try_st ~catches ~opt_else ~opt_finally =
         (name, todo_pattern @ catch_stmt) :: acc)
       [] catches
   in
-  let all_handlers_rev =
+  let else_stmt =
     match opt_else with
-    | None -> catches_stmt_rev
-    | Some (tok, else_st) ->
-        let name = fresh_var env tok in
-        let todo_pattern =
-          fixme_stmt ToDo (G.Ce (G.OtherCatch (("else_catch", tok), [])))
-        in
-        let else_stmt = stmt env else_st in
-        let else_handler = (name, todo_pattern @ else_stmt) in
-        else_handler :: catches_stmt_rev
+    | None -> []
+    | Some (_tok, else_st) -> stmt env else_st
   in
   let finally_stmt =
     match opt_finally with
     | None -> []
     | Some (_tok, finally_st) -> stmt env finally_st
   in
-  [ mk_s (Try (try_stmt, List.rev all_handlers_rev, finally_stmt)) ]
+  [ mk_s (Try (try_stmt, List.rev catches_stmt_rev, else_stmt, finally_stmt)) ]
 
 (*****************************************************************************)
 (* Assign *)
@@ -1451,8 +1444,8 @@ and stmt_aux env st =
       (* Python's `raise E1 from E2` *)
       let todo_stmt = fixme_stmt ToDo (G.E from) in
       todo_stmt @ stmt_aux env throw_stmt
-  | G.Try (_tok, try_st, catches, opt_finally) ->
-      try_catch_else_finally env ~try_st ~catches ~opt_else:None ~opt_finally
+  | G.Try (_tok, try_st, catches, opt_else, opt_finally) ->
+      try_catch_else_finally env ~try_st ~catches ~opt_else ~opt_finally
   | G.WithUsingResource (_, stmt1, stmt2) ->
       let stmt1 = List.concat_map (stmt env) stmt1 in
       let stmt2 = stmt env stmt2 in
@@ -1472,21 +1465,6 @@ and stmt_aux env st =
   | G.OtherStmtWithStmt (G.OSWS_Block _, [ G.E objorig ], stmt1) ->
       let ss, _TODO_obj = expr_with_pre_stmts env objorig in
       ss @ stmt env stmt1
-  (* Ruby: begin ... rescue ... else ... ensure ... *)
-  | G.OtherStmtWithStmt
-      ( G.OSWS_Else_in_try,
-        [ G.Tk else_tok ],
-        {
-          s =
-            G.Block
-              ( _,
-                [ { s = G.Try (_, try_st, catches, opt_finally); _ }; else_st ],
-                _ );
-          _;
-        } ) ->
-      try_catch_else_finally env ~try_st ~catches
-        ~opt_else:(Some (else_tok, else_st))
-        ~opt_finally
   | G.OtherStmt _
   | G.OtherStmtWithStmt _ ->
       todo (G.S st)
@@ -1734,11 +1712,12 @@ and python_with_stmt env manager opt_pat body =
     ss_def_pat @ stmt env body
   in
   let try_catches = [] in
+  let try_else = [] in
   let try_finally =
     let ss_exit, _ = call_mgr_method "__exit___" in
     ss_exit
   in
-  pre_try_stmts @ [ mk_s (Try (try_body, try_catches, try_finally)) ]
+  pre_try_stmts @ [ mk_s (Try (try_body, try_catches, try_else, try_finally)) ]
 
 (*****************************************************************************)
 (* Defs *)

--- a/src/analyzing/CFG_build.ml
+++ b/src/analyzing/CFG_build.ml
@@ -60,7 +60,7 @@ type state = {
    * or not after executing a finally clause in exception handling.
    *)
   may_return : bool ref;
-  (* Destination node that a return node should go to. *)
+  (* Destination node that a throw node should go to. *)
   throw_destination : F.nodei;
   (* True when a throw may occur in any of the nodes being visited.
    * Initialized as false, and once set to true, remains true forever.

--- a/src/il/IL.ml
+++ b/src/il/IL.ml
@@ -338,6 +338,7 @@ and stmt_kind =
   | Try of
       stmt list
       * (name * stmt list) list (* catches *)
+      * stmt list (* else *)
       * stmt list (* finally *)
   | Throw of tok * exp (* less: enforce lval here? *)
   | MiscStmt of other_stmt

--- a/src/matching/Generic_vs_generic.ml
+++ b/src/matching/Generic_vs_generic.ml
@@ -2551,11 +2551,12 @@ and m_stmt a b =
       let* () = m_tok a0 b0 in
       let* () = m_expr a1 b1 in
       m_tok asc bsc
-  | G.Try (a0, a1, a2, a3), B.Try (b0, b1, b2, b3) ->
+  | G.Try (a0, a1, a2, a3, a4), B.Try (b0, b1, b2, b3, b4) ->
       let* () = m_tok a0 b0 in
       let* () = m_stmt a1 b1 in
       let* () = (m_list m_catch) a2 b2 in
-      (m_option m_finally) a3 b3
+      let* () = (m_option m_try_else) a3 b3 in
+      (m_option m_finally) a4 b4
   | G.Assert (a0, aargs, asc), B.Assert (b0, bargs, bsc) ->
       let* () = m_tok a0 b0 in
       let* () = m_arguments aargs bargs in
@@ -2696,6 +2697,10 @@ and m_catch_exn a b =
   | G.OtherCatch _, _
   | G.CatchParam _, _ ->
       fail ()
+
+and m_try_else a b =
+  match (a, b) with
+  | (at, a), (bt, b) -> m_tok at bt >>= fun () -> m_stmt a b
 
 and m_finally a b =
   match (a, b) with
@@ -2970,7 +2975,7 @@ and m_function_definition a b =
 
 and m_function_body a b =
   match (a, b) with
-  | G.FBStmt a1, B.FBStmt b1 -> m_stmt a1 b1
+  | G.FBStmt a1, B.FBStmt b1 -> m_block a1 b1
   (* TODO: equivalence: do magic conversion to FStmt? *)
   | G.FBExpr a1, B.FBExpr b1 -> m_expr a1 b1
   | G.FBDecl a1, B.FBDecl b1 -> m_tok a1 b1

--- a/src/matching/Matching_visitor.ml
+++ b/src/matching/Matching_visitor.ml
@@ -232,7 +232,7 @@ class ['self] matching_visitor =
           self#v_partial ~recurse:false env (PartialIf (t, v1))
       | Switch (v0, Some (G.Cond v1), _v2) ->
           self#v_partial ~recurse:false env (PartialMatch (v0, v1))
-      | Try (t, v1, _v2, _v3) ->
+      | Try (t, v1, _v2, _v3, _v4) ->
           self#v_partial ~recurse:false env (PartialTry (t, v1))
       | _else -> ());
       (* todo? visit the s_id too? *)

--- a/src/matching/SubAST_generic.ml
+++ b/src/matching/SubAST_generic.ml
@@ -302,13 +302,18 @@ let substmts_of_stmt st =
       |> List.concat_map (function
            | CasesAndBody (_, st) -> [ st ]
            | CaseEllipsis _ -> [])
-  | Try (_, st, xs, opt) -> (
+  | Try (_, st, xs, opt1, opt2) -> (
       [ st ]
       @ (xs |> Common.map Common2.thd3)
       @
-      match opt with
+      match opt1 with
       | None -> []
-      | Some (_, st) -> [ st ])
+      | Some (_, st) -> (
+          [ st ]
+          @
+          match opt2 with
+          | None -> []
+          | Some (_, st) -> [ st ]))
   | DisjStmt _ -> raise Common.Impossible
   (* this may slow down things quite a bit *)
   | DefStmt (_ent, def) -> (

--- a/src/matching/Trace_matching.ml
+++ b/src/matching/Trace_matching.ml
@@ -13,7 +13,7 @@ open Printf
 let on = false
 
 (* max_depth: Print the nodes just deep enough to see something useful. *)
-let max_depth = 3
+let max_depth = 30
 
 let print_pair name vof a b =
   printf "----- m_%s -----\n%s pattern:\n%s\n~~~~~\n%s target:\n%s\n\n" name

--- a/src/matching/Trace_matching.ml
+++ b/src/matching/Trace_matching.ml
@@ -13,7 +13,7 @@ open Printf
 let on = false
 
 (* max_depth: Print the nodes just deep enough to see something useful. *)
-let max_depth = 30
+let max_depth = 3
 
 let print_pair name vof a b =
   printf "----- m_%s -----\n%s pattern:\n%s\n~~~~~\n%s target:\n%s\n\n" name

--- a/src/printing/Pretty_print_AST.ml
+++ b/src/printing/Pretty_print_AST.ml
@@ -159,7 +159,7 @@ let rec stmt env st =
   | Label (_, _)
   | Goto (_, _, _)
   | Throw (_, _, _)
-  | Try (_, _, _, _)
+  | Try (_, _, _, _, _)
   | WithUsingResource (_, _, _)
   | Assert (_, _, _)
   | DirectiveStmt _

--- a/tests/rules/taint_exception.py
+++ b/tests/rules/taint_exception.py
@@ -1,0 +1,242 @@
+# This test aims to exercise various exception paths.
+
+def throw_exits(input):
+  clean = None
+  raise RuntimeError()
+
+  # ok:
+  sink = clean
+
+def throw_in_catch_exits(input):
+  clean = None
+  try:
+    raise RuntimeError()
+  except Exception as e:
+    raise RuntimeError()
+
+  #ok: unreachable, because throw inside the catch clause exits
+  sink = clean
+
+def throw_in_else_exits(input):
+  clean = None
+  try:
+    pass
+  except Exception as e:
+    clean = input
+    #ok: unreachable, because exception was not thrown
+    sink = clean
+  else:
+    raise RuntimeError()
+
+  #ok: unreachable, because throw inside the else clause exits
+  sink = clean
+
+def throw_in_finally_exits(input):
+  clean = None
+  try:
+    pass
+  finally:
+    raise RuntimeError()
+
+  #ok: unreachable, because throw inside the finally clause exits
+  sink = clean
+
+def return_exits(input):
+  clean = None
+  return
+
+  # ok:
+  sink = clean
+
+def return_in_catch_exits(input):
+  clean = None
+  try:
+    raise RuntimeError()
+  except Exception as e:
+    return
+
+  #ok: unreachable, because return inside the catch clause exits
+  sink = clean
+
+def return_in_else_exits(input):
+  clean = None
+  try:
+    pass
+  except Exception as e:
+    clean = input
+    #ok: unreachable, because exception was not thrown
+    sink = clean
+  else:
+    return
+
+  #ok: unreachable, because return inside the else clause exits
+  sink = clean
+
+def throw_in_finally_exits(input):
+  clean = None
+  try:
+    pass
+  finally:
+    return
+
+  #ok: unreachable, because return inside the finally clause exits
+  sink = clean
+
+def throw_must_not_go_through_else(input):
+  clean = None
+  dirty = None
+  try:
+    raise RuntimeError()
+  except Exception as e:
+    # assume this path may be taken
+    dirty = input
+  else:
+    # no flow through here because an exception was thrown
+    clean = input
+
+  #ok:
+  sink = clean
+  #ruleid: python-exception
+  sink = dirty
+
+def no_throw_goes_through_else(input):
+  clean = None
+  dirty = None
+  try:
+    pass
+  except Exception as e:
+    # no flow through here because no exception was thrown
+    clean = input
+  else:
+    dirty = input
+
+  #ok:
+  sink = clean
+  #ruleid: python-exception
+  sink = dirty
+
+def may_throw_goes_through_catch_and_else(input):
+  dirty1 = None
+  dirty2 = None
+  try:
+    any_function_call_may_raise()
+  except Exception as e:
+    # exception may be thrown
+    dirty1 = input
+  else:
+    # exception may not be thrown either
+    dirty2 = input
+
+  #ruleid: python-exception
+  sink = dirty1
+  #ruleid: python-exception
+  sink = dirty2
+
+def exception_or_not_goes_through_finally(input):
+  clean1 = None
+  clean2 = None
+  try:
+    any_function_call_may_raise()
+  except Exception as e:
+    clean1 = input
+  else:
+    clean2 = input
+  finally:
+    clean1 = sanitize
+    clean2 = sanitize
+
+  #ok:
+  sink = clean1
+  #ok:
+  sink = clean2
+
+def exception_or_not_goes_through_finally(input):
+  clean1 = None
+  clean2 = None
+  try:
+    any_function_call_may_raise()
+  except Exception as e:
+    clean1 = input
+  else:
+    clean2 = input
+  finally:
+    clean1 = sanitize
+    clean2 = sanitize
+
+  #ok:
+  sink = clean1
+  #ok:
+  sink = dirty2
+
+def return_goes_through_finally_and_propagates(input):
+  clean1 = None
+  clean2 = None
+  clean3 = None
+  clean4 = None
+  dirty1 = None
+  dirty2 = None
+  try:
+    try:
+      return
+    except Exception as e:
+      clean1 = input
+      #ok: unreachable because the try clause returns
+      sink = clean1
+    else:
+      clean2 = input
+      #ok: unreachable because the try clause returns
+      sink = clean2
+    finally:
+      # Finally clauses are always reachable when present
+      dirty1 = input
+
+    clean3 = input
+    #ok: unreachable because the inner try is returning
+    sink = clean3
+  except Exception as e:
+    clean4 = input
+    #ok: unreachable because the inner try didn't throw an exception
+    sink = clean4
+  finally:
+    dirty2 = input
+
+  #ruleid: python-exception
+  sink = dirty1
+  #ruleid: python-exception
+  sink = dirty2
+
+def throw_may_go_through_catch_and_propagates(input):
+  clean1 = None
+  clean2 = None
+  clean3 = None
+  dirty1 = None
+  dirty2 = None
+  dirty3 = None
+  try:
+    try:
+      raise RuntimeError()
+    except Exception as e:
+      clean1 = input
+      #ruleid: python-exception
+      sink = clean1
+    else:
+      clean2 = input
+      #ok: unreachable because the try clause returns
+      sink = clean2
+    finally:
+      # Finally clauses are always reachable when present.
+      dirty1 = input
+    # This is reachable when the exception isn't handled.
+    clean3 = input
+  except Exception as e:
+    # The inner exception may be propagated here.
+    dirty2 = input
+  finally:
+    dirty3 = input
+
+    #ruleid: python-exception
+    sink = dirty1
+    #ruleid: python-exception
+    sink = dirty2
+    #ruleid: python-exception
+    sink = dirty3

--- a/tests/rules/taint_exception.yaml
+++ b/tests/rules/taint_exception.yaml
@@ -1,0 +1,13 @@
+rules:
+- id: python-exception
+  mode: taint
+  pattern-sources:
+    - pattern: input
+  pattern-sanitizers:
+    - pattern: $X = sanitize
+  pattern-sinks:
+    - pattern: sink = $X
+  message: Match found
+  languages:
+    - python
+  severity: ERROR


### PR DESCRIPTION
In Ruby, the try-catch-else (as well as try-catch-else-finally) statement is captured as an [OtherStmtWithStmt](https://github.com/returntocorp/semgrep/blob/965c454931a1c2f3939b16761b801ab3fdd4ed86/libs/ast_generic/AST_generic.ml#L1204) in the generic ast and looks something like

```
OtherStmtWithStmt (
    OSWS_Else_in_try,
    a_list_of_any,
    Block(..., [ try_catch_finally_stmt; else_stmt], ...)
)
```

Previously this statement isn't handled in AST_to_IL.ml. This PR adds support for it.

This PR extends the original `Try` statement to include the else clause. Python and Julia benefit from this change as well.

Additionally this PR also updates how the CFG is built for `Try` statements.

Test plan: no regressions in `make core-test` (new tests added). The tests are written in Python because Ruby has its own set of problems with the generic AST. Namely, `raise "error"` is a function call in Ruby, while it should be a throw statement. I'll tackle that separately, but I want the tests to cover more cases, so I went with Python.

Closes [PA-3054](https://linear.app/semgrep/issue/PA-3054).