### PR TITLE
fix: Check if intellij for messages

### DIFF
--- a/src/osemgrep/language_server/Diagnostics.ml
+++ b/src/osemgrep/language_server/Diagnostics.ml
@@ -23,6 +23,7 @@ let diagnostic_of_match is_intellij (m : Out.cli_match) =
   in
   let message =
     match shortlink with
+    (* IntelliJ doesn't display code descriptions:/ so we must insert them here *)
     | Some s when is_intellij ->
         message ^ Printf.sprintf "\nSemgrep(<a href=\"%s\">%s</a>)" s m.check_id
     | _ -> message
@@ -65,5 +66,5 @@ let diagnostics_of_file is_intellij matches file =
   in
   Server_notification.PublishDiagnostics params
 
-let diagnostics_of_results is_intellij results files =
+let diagnostics_of_results ~is_intellij results files =
   Common.map (diagnostics_of_file is_intellij results) files

--- a/src/osemgrep/language_server/Diagnostics.mli
+++ b/src/osemgrep/language_server/Diagnostics.mli
@@ -5,7 +5,8 @@ val diagnostics_of_results :
   Lsp.Server_notification.t list
 (** [diagnostics_of_results is_intellij results files] returns a list of LSP diagnostics
     for the given matches. A diagnostic is the little squiggly you see under
-    an error in your editor.
+    an error in your editor. [is_intellij] is true if the client is IntelliJ, and will
+    cause us to insert shortlinks directly into the diagnostic message.
 
     See:
     https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_publishDiagnostics

--- a/src/osemgrep/language_server/Diagnostics.mli
+++ b/src/osemgrep/language_server/Diagnostics.mli
@@ -1,5 +1,5 @@
 val diagnostics_of_results :
-  bool ->
+  is_intellij:bool ->
   Semgrep_output_v1_t.cli_match list ->
   Fpath.t list ->
   Lsp.Server_notification.t list

--- a/src/osemgrep/language_server/Diagnostics.mli
+++ b/src/osemgrep/language_server/Diagnostics.mli
@@ -1,8 +1,9 @@
 val diagnostics_of_results :
+  bool ->
   Semgrep_output_v1_t.cli_match list ->
   Fpath.t list ->
   Lsp.Server_notification.t list
-(** [diagnostics_of_results results files] returns a list of LSP diagnostics
+(** [diagnostics_of_results is_intellij results files] returns a list of LSP diagnostics
     for the given matches. A diagnostic is the little squiggly you see under
     an error in your editor.
 

--- a/src/osemgrep/language_server/LS.ml
+++ b/src/osemgrep/language_server/LS.ml
@@ -63,7 +63,10 @@ module MessageHandler = struct
     Session.record_results server.session results files;
     (* LSP expects empty diagnostics to clear problems *)
     let files = Session.scanned_files server.session in
-    let diagnostics = Diagnostics.diagnostics_of_results results files in
+    let diagnostics =
+      Diagnostics.diagnostics_of_results server.session.is_intellij results
+        files
+    in
     end_progress server token;
     batch_notify server diagnostics
 
@@ -93,7 +96,10 @@ module MessageHandler = struct
     in
     let files = [ file ] in
     Session.record_results server.session results files;
-    let diagnostics = Diagnostics.diagnostics_of_results results files in
+    let diagnostics =
+      Diagnostics.diagnostics_of_results server.session.is_intellij results
+        files
+    in
     batch_notify server diagnostics
 
   let refresh_rules server =
@@ -152,7 +158,10 @@ module MessageHandler = struct
                 Str.string_after uri (String.length "file://") |> Fpath.v)
               files
           in
-          let diagnostics = Diagnostics.diagnostics_of_results [] files in
+          let diagnostics =
+            Diagnostics.diagnostics_of_results server.session.is_intellij []
+              files
+          in
           batch_notify server diagnostics;
           server
       | CN.Exit ->
@@ -239,6 +248,15 @@ module MessageHandler = struct
             in
             { res with do_hover }
           in
+          let is_intellij =
+            match initializationOptions |> member "metrics" with
+            | `Assoc l when Option.is_some (List.assoc_opt "extensionType" l) ->
+                String.equal
+                  (Option.value ~default:""
+                     (to_string_option (List.assoc "extensionType" l)))
+                  "intellij"
+            | _ -> false
+          in
           let workspace_folders =
             match (workspaceFolders, rootUri) with
             | Some (Some folders), _ -> Conv.workspace_folders_to_paths folders
@@ -259,7 +277,13 @@ module MessageHandler = struct
           in
           let server =
             {
-              session = { server.session with workspace_folders; user_settings };
+              session =
+                {
+                  server.session with
+                  workspace_folders;
+                  user_settings;
+                  is_intellij;
+                };
               state = State.Running;
             }
           in

--- a/src/osemgrep/language_server/LS.ml
+++ b/src/osemgrep/language_server/LS.ml
@@ -64,8 +64,8 @@ module MessageHandler = struct
     (* LSP expects empty diagnostics to clear problems *)
     let files = Session.scanned_files server.session in
     let diagnostics =
-      Diagnostics.diagnostics_of_results server.session.is_intellij results
-        files
+      Diagnostics.diagnostics_of_results ~is_intellij:server.session.is_intellij
+        results files
     in
     end_progress server token;
     batch_notify server diagnostics
@@ -97,8 +97,8 @@ module MessageHandler = struct
     let files = [ file ] in
     Session.record_results server.session results files;
     let diagnostics =
-      Diagnostics.diagnostics_of_results server.session.is_intellij results
-        files
+      Diagnostics.diagnostics_of_results ~is_intellij:server.session.is_intellij
+        results files
     in
     batch_notify server diagnostics
 
@@ -159,8 +159,8 @@ module MessageHandler = struct
               files
           in
           let diagnostics =
-            Diagnostics.diagnostics_of_results server.session.is_intellij []
-              files
+            Diagnostics.diagnostics_of_results
+              ~is_intellij:server.session.is_intellij [] files
           in
           batch_notify server diagnostics;
           server

--- a/src/osemgrep/language_server/Session.ml
+++ b/src/osemgrep/language_server/Session.ml
@@ -23,6 +23,7 @@ type t = {
   cached_scans : (Fpath.t, Out.cli_match list) Hashtbl.t;
   cached_session : session_cache;
   user_settings : UserSettings.t;
+  is_intellij : bool;
 }
 
 (*****************************************************************************)
@@ -41,6 +42,7 @@ let create capabilities =
     cached_scans = Hashtbl.create 10;
     cached_session;
     user_settings = UserSettings.default;
+    is_intellij = false;
   }
 
 let dirty_files_of_folder folder =

--- a/src/osemgrep/language_server/Session.mli
+++ b/src/osemgrep/language_server/Session.mli
@@ -22,6 +22,7 @@ type t = {
   cached_scans : (Fpath.t, Semgrep_output_v1_t.cli_match list) Hashtbl.t;
   cached_session : session_cache;
   user_settings : UserSettings.t;
+  is_intellij : bool;
 }
 
 val create : ServerCapabilities.t -> t


### PR DESCRIPTION
IntelliJ is lame and won't display links as specified in the LSP spec. So we have to manually insert them.