### PR TITLE
Add scanned targets in Core_result.t

### DIFF
--- a/js/engine/Main.ml
+++ b/js/engine/Main.ml
@@ -120,10 +120,10 @@ let _ =
            }
          in
          let timed_rules = (rules_and_errors, 0.) in
-         let res, files = Core_scan.semgrep_with_rules config timed_rules in
+         let res = Core_scan.semgrep_with_rules config timed_rules in
          let res =
            Core_json_output.core_output_of_matches_and_errors
-             (Some Autofix.render_fix) (List.length files) res
+             (Some Autofix.render_fix) (List.length res.scanned) res
          in
          Semgrep_output_v1_j.string_of_core_output res
     end)

--- a/src/core/Core_result.mli
+++ b/src/core/Core_result.mli
@@ -22,6 +22,16 @@ type t = {
   extra : Core_profiling.t Core_profiling.debug_info;
   explanations : Matching_explanation.t list;
   rules_by_engine : (Rule_ID.t * Pattern_match.engine_kind) list;
+  (* The targets are all the files that were considered valid targets for the
+   * semgrep scan. This excludes files that were filtered out on purpose
+   * due to being in the wrong language, too big, etc.
+   * It includes targets that couldn't be scanned, for instance due to
+   * a parsing error.
+   * TODO: are we actually doing that? this was a comment
+   * for semgrep_with_raw_results_and_exn_handler but I'm not sure
+   * we're doing it here.
+   *)
+  scanned : Fpath.t list;
 }
 [@@deriving show]
 
@@ -31,11 +41,14 @@ val empty_final_result : t
 val make_match_result :
   Pattern_match.t list -> Core_error.ErrorSet.t -> 'a -> 'a match_result
 
-(* take the match results for each file, all the rules, and build the final
- * result *)
+(* take the match results for each file, all the rules, all the targets,
+ * and build the final result
+ *)
 val make_final_result :
   Core_profiling.file_profiling match_result list ->
   (Rule.rule * Pattern_match.engine_kind) list ->
+  Rule.invalid_rule_error list ->
+  Fpath.t list ->
   rules_parse_time:float ->
   t
 

--- a/src/core_scan/Core_scan_config.ml
+++ b/src/core_scan/Core_scan_config.ml
@@ -76,17 +76,6 @@ type t = {
 }
 [@@deriving show]
 
-(* The type of the semgrep core runner. We define it here so that
-   semgrep and semgrep-proprietary use the same definition *)
-type semgrep_engine =
-  t ->
-  (* Exceptions raised *)
-  Exception.t option
-  * (* Result *)
-    Core_result.t
-  * (* The processed targets *)
-  Fpath.t list
-
 (*
    Default values for all the semgrep-core command-line arguments and options.
 

--- a/src/metachecking/Check_rule.ml
+++ b/src/metachecking/Check_rule.ml
@@ -219,7 +219,7 @@ let semgrep_check config metachecks rules =
       roots = rules;
     }
   in
-  let _success, res, _targets =
+  let _success, res =
     Core_scan.semgrep_with_raw_results_and_exn_handler config
   in
   res.matches |> Common.map match_to_semgrep_error

--- a/src/osemgrep/cli_scan/Core_runner.ml
+++ b/src/osemgrep/cli_scan/Core_runner.ml
@@ -261,7 +261,7 @@ let invoke_semgrep_core
   let config = prepare_config_for_semgrep_core config lang_jobs in
 
   (* !!!!Finally! this is where we branch to semgrep-core!!! *)
-  let exn, res, files = engine config in
+  let exn, res = engine config in
 
   (* Reinject rule errors *)
   let res =
@@ -272,7 +272,7 @@ let invoke_semgrep_core
     }
   in
 
-  let scanned = Set_.of_list files in
+  let scanned = Set_.of_list res.scanned in
 
   (* TODO(dinosaure): currently, we don't collect metrics when we invoke
      semgrep-core but we should. However, if we implement a way to collect

--- a/src/osemgrep/cli_scan/Core_runner.mli
+++ b/src/osemgrep/cli_scan/Core_runner.mli
@@ -44,7 +44,7 @@ val create_core_result :
    integrated into what's currently semgrep-core.
 *)
 val invoke_semgrep_core :
-  ?engine:Core_scan_config.semgrep_engine -> semgrep_core_runner
+  ?engine:Core_scan.core_scan_func -> semgrep_core_runner
 
 (* Helper used in Semgrep_scan.ml to setup logging *)
 val core_scan_config_of_conf : conf -> Core_scan_config.t


### PR DESCRIPTION
So we don't have each time to return a pair of Core_result.t * Fpath.t
list

test plan:
make core