### PR TITLE
Introduce Core_result.result_and_exn alias type

### DIFF
--- a/cli/tests/e2e/test_rule_validation.py
+++ b/cli/tests/e2e/test_rule_validation.py
@@ -33,6 +33,7 @@ def test_validation_of_invalid_rules(run_semgrep_in_tmp: RunSemgrep, snapshot, r
     )
 
 
+@pytest.mark.kinda_slow
 @pytest.mark.parametrize(
     "rule",
     [

--- a/src/core/Core_result.ml
+++ b/src/core/Core_result.ml
@@ -59,6 +59,9 @@ type 'a match_result = {
 }
 [@@deriving show]
 
+(* TODO: change in result_or_exn *)
+type result_and_exn = Exception.t option * t
+
 (*****************************************************************************)
 (* Builders *)
 (*****************************************************************************)

--- a/src/core/Core_result.mli
+++ b/src/core/Core_result.mli
@@ -35,6 +35,9 @@ type t = {
 }
 [@@deriving show]
 
+(* TODO: change in result_or_exn *)
+type result_and_exn = Exception.t option * t
+
 val empty_match_result : Core_profiling.times match_result
 val empty_final_result : t
 

--- a/src/core_scan/Core_scan.mli
+++ b/src/core_scan/Core_scan.mli
@@ -93,8 +93,7 @@
 
 (* The type of the semgrep core scan. We define it here so that
    semgrep and semgrep-proprietary use the same definition *)
-type core_scan_func =
-  Core_scan_config.t -> (* Exn raised *) Exception.t option * Core_result.t
+type core_scan_func = Core_scan_config.t -> Core_result.result_and_exn
 
 (*****************************************************************************)
 (* Entry point *)
@@ -117,7 +116,7 @@ val semgrep_with_rules_and_formatted_output : Core_scan_config.t -> unit
 *)
 
 val output_semgrep_results :
-  Exception.t option * Core_result.t -> Core_scan_config.t -> unit
+  Core_result.result_and_exn -> Core_scan_config.t -> unit
 (** [output_semgrep_results] takes the results of a semgrep run and
     format the results on stdout either in a JSON or Textual format
     (depending on the value in config.output_format)
@@ -126,7 +125,7 @@ val output_semgrep_results :
 *)
 
 val semgrep_with_raw_results_and_exn_handler :
-  Core_scan_config.t -> Exception.t option * Core_result.t
+  Core_scan_config.t -> Core_result.result_and_exn
 (** [semgrep_with_raw_results_and_exn_handler config] runs the semgrep-core
     engine with a starting list of targets and returns
     (success, result).

--- a/src/osemgrep/cli_scan/Core_runner.mli
+++ b/src/osemgrep/cli_scan/Core_runner.mli
@@ -29,12 +29,9 @@ type semgrep_core_runner =
   Rule.rules ->
   Rule.invalid_rule_error list ->
   Fpath.t list ->
-  Exception.t option * Core_result.t * Fpath.t Set_.t
+  Core_result.result_and_exn
 
-val create_core_result :
-  Rule.rule list ->
-  Exception.t option * Core_result.t * Fpath.t Set_.t ->
-  result
+val create_core_result : Rule.rule list -> Core_result.result_and_exn -> result
 
 (*
    This calls the semgrep-core command like the Python implementation used


### PR DESCRIPTION
This is step1 towards an even better type,
Core_result.result_or_exn in a futur PR

test plan:
make core