### PR TITLE
Rename Run_semgrep.semgrep_with_rules() to Core_scan.scan()

### DIFF
--- a/js/engine/Main.ml
+++ b/js/engine/Main.ml
@@ -120,7 +120,7 @@ let _ =
            }
          in
          let timed_rules = (rules_and_errors, 0.) in
-         let res = Core_scan.semgrep_with_rules config timed_rules in
+         let res = Core_scan.scan config timed_rules in
          let res =
            Core_json_output.core_output_of_matches_and_errors
              (Some Autofix.render_fix) (List.length res.scanned) res

--- a/src/core_cli/Core_CLI.ml
+++ b/src/core_cli/Core_CLI.ml
@@ -732,7 +732,7 @@ let main_no_exn_handler (sys_argv : string array) : unit =
              for now just turn it off *)
           (* if !Flag.gc_tuning && config.max_memory_mb = 0 then set_gc (); *)
           let config = { config with roots = File.Path.of_strings roots } in
-          Core_scan.semgrep_dispatch config)
+          Core_scan.semgrep_core_dispatch config)
 
 let with_exception_trace f =
   Printexc.record_backtrace true;

--- a/src/metachecking/Check_rule.ml
+++ b/src/metachecking/Check_rule.ml
@@ -219,9 +219,7 @@ let semgrep_check config metachecks rules =
       roots = rules;
     }
   in
-  let _success, res =
-    Core_scan.semgrep_with_raw_results_and_exn_handler config
-  in
+  let _success, res = Core_scan.scan_with_exn_handler config in
   res.matches |> Common.map match_to_semgrep_error
 
 (* TODO *)

--- a/src/osemgrep/cli_scan/Core_runner.mli
+++ b/src/osemgrep/cli_scan/Core_runner.mli
@@ -17,7 +17,8 @@ type result = {
   scanned : Fpath.t Set_.t;
 }
 
-type semgrep_core_runner =
+(* similar to Core_scan.core_scan_func *)
+type core_scan_func_for_osemgrep =
   ?respect_git_ignore:bool ->
   ?file_match_results_hook:
     (Fpath.t ->
@@ -34,14 +35,13 @@ type semgrep_core_runner =
 val create_core_result : Rule.rule list -> Core_result.result_and_exn -> result
 
 (*
-   This calls the semgrep-core command like the Python implementation used
-   to, but without creating a subprocess.
+   This calls a core scan like pysemgrep but without creating a subprocess.
 
    LATER: This function should go away, eventually, with some parts being
    integrated into what's currently semgrep-core.
 *)
-val invoke_semgrep_core :
-  ?engine:Core_scan.core_scan_func -> semgrep_core_runner
+val invoke_core_scan :
+  ?engine:Core_scan.core_scan_func -> core_scan_func_for_osemgrep
 
 (* Helper used in Semgrep_scan.ml to setup logging *)
 val core_scan_config_of_conf : conf -> Core_scan_config.t

--- a/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -37,7 +37,7 @@ let (invoke_semgrep_core_proprietary :
       (Fpath.t list ->
       ?diff_config:Differential_scan_config.t ->
       Engine_type.t ->
-      Core_runner.semgrep_core_runner)
+      Core_runner.core_scan_func_for_osemgrep)
       option
       ref) =
   ref None
@@ -166,8 +166,7 @@ let core (conf : Scan_CLI.conf) file_match_results_hook errors targets
   let invoke_semgrep_core =
     match conf.engine_type with
     | OSS ->
-        Core_runner.invoke_semgrep_core
-          ~engine:Core_scan.semgrep_with_raw_results_and_exn_handler
+        Core_runner.invoke_core_scan ~engine:Core_scan.scan_with_exn_handler
     | PRO _ -> (
         match !invoke_semgrep_core_proprietary with
         | None ->

--- a/src/osemgrep/cli_scan/Scan_subcommand.mli
+++ b/src/osemgrep/cli_scan/Scan_subcommand.mli
@@ -18,7 +18,7 @@ val invoke_semgrep_core_proprietary :
   (Fpath.t list ->
   ?diff_config:Differential_scan_config.t ->
   Engine_type.t ->
-  Core_runner.semgrep_core_runner)
+  Core_runner.core_scan_func_for_osemgrep)
   option
   ref
 

--- a/src/osemgrep/cli_scan/Validate_subcommand.ml
+++ b/src/osemgrep/cli_scan/Validate_subcommand.ml
@@ -106,7 +106,7 @@ let run (conf : conf) : Exit_code.t =
           Error.abort (spf "error in metachecks! please fix %s" metarules_pack);
 
         let exn_and_matches =
-          Core_runner.invoke_semgrep_core conf.core_runner_conf metarules []
+          Core_runner.invoke_core_scan conf.core_runner_conf metarules []
             targets
         in
         let res = Core_runner.create_core_result metarules exn_and_matches in

--- a/src/osemgrep/language_server/LS.ml
+++ b/src/osemgrep/language_server/LS.ml
@@ -43,7 +43,7 @@ module MessageHandler = struct
     Logs.app (fun m -> m "Running Semgrep with %d rules" (List.length rules));
     let runner_conf = Session.runner_conf session in
     let run =
-      Core_runner.invoke_semgrep_core ~respect_git_ignore:true
+      Core_runner.invoke_core_scan ~respect_git_ignore:true
         ~file_match_results_hook:None runner_conf rules [] targets
     in
     let res = Core_runner.create_core_result rules run in


### PR DESCRIPTION
The run_semgrep was confusing because it was actually not running
semgrep ...

test plan:
make core