### PR TITLE
factorize Engine_kind

### DIFF
--- a/src/core/Core_result.ml
+++ b/src/core/Core_result.ml
@@ -37,7 +37,7 @@ type t = {
   (* may contain also skipped_target information *)
   extra : Core_profiling.t Core_profiling.debug_info;
   explanations : Matching_explanation.t list;
-  rules_by_engine : (Rule_ID.t * Pattern_match.engine_kind) list;
+  rules_by_engine : (Rule_ID.t * Engine_kind.t) list;
   scanned : Fpath.t list;
 }
 [@@deriving show]
@@ -248,7 +248,7 @@ let collate_rule_results (file : Fpath.t)
 (* Aggregate a list of target results into one final result *)
 let make_final_result
     (results : Core_profiling.file_profiling match_result list)
-    (rules_with_engine : (Rule.t * Pattern_match.engine_kind) list)
+    (rules_with_engine : (Rule.t * Engine_kind.t) list)
     (skipped_rules : Rule.invalid_rule_error list) (scanned : Fpath.t list)
     ~rules_parse_time =
   (* contenating information from the match_result list *)

--- a/src/core/Core_result.mli
+++ b/src/core/Core_result.mli
@@ -21,7 +21,7 @@ type t = {
   (* may contain skipped_target info *)
   extra : Core_profiling.t Core_profiling.debug_info;
   explanations : Matching_explanation.t list;
-  rules_by_engine : (Rule_ID.t * Pattern_match.engine_kind) list;
+  rules_by_engine : (Rule_ID.t * Engine_kind.t) list;
   (* The targets are all the files that were considered valid targets for the
    * semgrep scan. This excludes files that were filtered out on purpose
    * due to being in the wrong language, too big, etc.
@@ -49,7 +49,7 @@ val make_match_result :
  *)
 val make_final_result :
   Core_profiling.file_profiling match_result list ->
-  (Rule.rule * Pattern_match.engine_kind) list ->
+  (Rule.rule * Engine_kind.t) list ->
   Rule.invalid_rule_error list ->
   Fpath.t list ->
   rules_parse_time:float ->

--- a/src/core/Engine_kind.ml
+++ b/src/core/Engine_kind.ml
@@ -1,0 +1,1 @@
+type t = Semgrep_output_v1_t.engine_kind [@@deriving show]

--- a/src/core/Pattern_match.ml
+++ b/src/core/Pattern_match.ml
@@ -1,6 +1,6 @@
 (* Yoann Padioleau
  *
- * Copyright (C) 2019-2021 r2c
+ * Copyright (C) 2019-2023 Semgrep Inc.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
@@ -77,9 +77,6 @@ type taint_trace_item = {
 
 type taint_trace = taint_trace_item list [@@deriving show, eq]
 
-(* TODO: reuse semgrep_output_v1.atd engine kind enum *)
-type engine_kind = OSS | Pro [@@deriving show, eq]
-
 (* This type is used by postprocessors to report back the validity
    of a finding. No_validator is currently also used when no
    validation has yet occurred, which if that becomes confusing we
@@ -113,12 +110,14 @@ type t = {
      We now rely on equality of taint traces, which in turn relies on equality of `Parse_info.t`.
   *)
   taint_trace : taint_trace Lazy.t option;
-  (* This is a flag indicating whether this match was produced during a run of Semgrep PRO.
-     This will be overrided later by the Pro engine, on any matches which are produced
-     from a Pro run.
-  *)
-  engine_kind : engine_kind;
-  (* This flag indicates whether a postprocessor ran and validated this result. *)
+  (* Indicates whether this match was produced during a run
+   * of Semgrep PRO. This will be overrided later by the Pro engine, on any
+   * matches which are produced from a Pro run.
+   * TODO? do we want to consider the same match but with different engine
+   * as separate matches? or better make them equal for dedup purpose?
+   *)
+  engine_kind : Engine_kind.t; [@equal fun _a _b -> true]
+  (* Indicates whether a postprocessor ran and validated this result. *)
   validation_state : validation_state;
 }
 
@@ -194,12 +193,12 @@ let no_submatches pms =
   tbl |> Hashtbl.to_seq_values |> Seq.flat_map List.to_seq |> List.of_seq
   [@@profiling]
 
-let to_proprietary pm = { pm with engine_kind = Pro }
+let to_proprietary pm = { pm with engine_kind = `PRO }
 
 (* This special Set is used in the dataflow tainting code,
    which manipulates sets of matches associated to each variables.
-   We only care about the metavariable environment carried by the pattern matches
-   at the moment.
+   We only care about the metavariable environment carried by the pattern
+   matches at the moment.
 *)
 module Set = Set.Make (struct
   type previous_t = t
@@ -207,10 +206,13 @@ module Set = Set.Make (struct
   (* alt: use type nonrec t = t, but this causes pad's codegraph to blowup *)
   type t = previous_t
 
-  (* If the pattern matches are obviously different (have different ranges), this is enough to compare them.
-     If their ranges are the same, compare their metavariable environments. This is not robust to reordering
-     metavariable environments. [("$A",e1);("$B",e2)] is not equal to [("$B",e2);("$A",e1)]. This should be ok
-     but is potentially a source of duplicate findings in taint mode, where these sets are used.
+  (* If the pattern matches are obviously different (have different ranges),
+     this is enough to compare them.
+     If their ranges are the same, compare their metavariable environments.
+     This is not robust to reordering metavariable environments.
+     [("$A",e1);("$B",e2)] is not equal to [("$B",e2);("$A",e1)]. This should
+     be ok but is potentially a source of duplicate findings in taint mode,
+     where these sets are used.
   *)
   let compare pm1 pm2 =
     match compare pm1.range_loc pm2.range_loc with

--- a/src/core/dune
+++ b/src/core/dune
@@ -5,29 +5,32 @@
 ; This file used to be in reporting/ because it was concerned mostly with JSON
 ; reporting of a scan result, but it now contains core data definitions
 ; (e.g., engine_kind, core_error_kind, skip_reason, matching_operation) reused
-; in the OCaml core code.
+; in the OCaml core code, which is why it was moved here.
 
 (library
  (public_name semgrep.core)
  (name semgrep_core)
  (wrapped false)
  (libraries
-   semver
+   ; standard libraries
    stdcompat
    str
    uri
+   semver
    yaml
    atdgen-runtime
    sexplib
 
+   ; in libs/
    commons
    glob
    lib_parsing ; Parse_info.ml
    ast_generic
-   parser_javascript.ast ; TODO remove this, ugly dependency to Ast_js.default_entity in Pattern.ml
-   ;note: we should not depend on pfff-lang_GENERIC-analyze in core
-   ;note: we should also not depend on any other semgrep libs
-   ; (except the 1 below)
+
+   ; TODO ugly dependency to Ast_js.default_entity in Pattern.ml
+   parser_javascript.ast
+   ; We should not depend on pfff-lang_GENERIC-analyze in core.
+   ; We should also not depend on any other semgrep libs (except the 1 below).
    semgrep_configuring
 
    spacegrep ; Rule.ml references Spacegrep.Pattern_AST.t
@@ -46,7 +49,7 @@
  )
 )
 
-; '-j-defaults' is for matching the behavior of atdpy so that we can get the
+; '-j-defaults' below is for matching the behavior of atdpy so that we can get the
 ; same JSON output from pysemgrep and osemgrep. This is useful only for
 ; passing end-to-end tests where osemgrep is expected to produce the same
 ; output as pysemgrep. This allows us to use '~field: ... list' which is more

--- a/src/core_scan/Core_scan.ml
+++ b/src/core_scan/Core_scan.ml
@@ -859,7 +859,7 @@ let scan ?match_hook config ((rules, invalid_rules), rules_parse_time) :
   in
   let res =
     RP.make_final_result file_results
-      (Common.map (fun r -> (r, Pattern_match.OSS)) rules)
+      (Common.map (fun r -> (r, `OSS)) rules)
       invalid_rules scanned ~rules_parse_time
   in
   logger#info "found %d matches, %d errors" (List.length res.matches)

--- a/src/engine/Match_search_mode.ml
+++ b/src/engine/Match_search_mode.ml
@@ -381,7 +381,7 @@ let apply_focus_on_ranges env (focus_mvars_list : R.focus_mv_list list)
                PM.tokens = lazy (MV.ii_of_mval mval);
                PM.env = range.mvars;
                PM.taint_trace = None;
-               PM.engine_kind = PM.OSS;
+               PM.engine_kind = `OSS;
                PM.validation_state = PM.No_validator;
              })
     in

--- a/src/engine/Xpattern_matcher.ml
+++ b/src/engine/Xpattern_matcher.ml
@@ -84,7 +84,7 @@ let (matches_of_matcher :
                               env;
                               taint_trace = None;
                               tokens = lazy [ info_of_token_location loc1 ];
-                              engine_kind = OSS;
+                              engine_kind = `OSS;
                               validation_state = No_validator;
                             })))
         in

--- a/src/matching/Match_patterns.ml
+++ b/src/matching/Match_patterns.ml
@@ -173,7 +173,7 @@ let match_rules_and_recurse m_env (file, hook, matches) rules matcher k any x =
                           (* This will be overrided later on by the Pro engine, if this is
                              from a Pro run.
                           *)
-                          engine_kind = OSS;
+                          engine_kind = `OSS;
                           validation_state = No_validator;
                         }
                       in
@@ -337,7 +337,7 @@ let check2 ~hook mvar_context range_filter (config, equivs) rules
                                   range_loc;
                                   tokens;
                                   taint_trace = None;
-                                  engine_kind = OSS;
+                                  engine_kind = `OSS;
                                   validation_state = No_validator;
                                 }
                               in
@@ -396,7 +396,7 @@ let check2 ~hook mvar_context range_filter (config, equivs) rules
                                     range_loc;
                                     tokens;
                                     taint_trace = None;
-                                    engine_kind = OSS;
+                                    engine_kind = `OSS;
                                     validation_state = No_validator;
                                   }
                                 in
@@ -443,7 +443,7 @@ let check2 ~hook mvar_context range_filter (config, equivs) rules
                                       range_loc;
                                       tokens;
                                       taint_trace = None;
-                                      engine_kind = OSS;
+                                      engine_kind = `OSS;
                                       validation_state = No_validator;
                                     }
                                   in
@@ -536,7 +536,7 @@ let check2 ~hook mvar_context range_filter (config, equivs) rules
                                       range_loc;
                                       tokens;
                                       taint_trace = None;
-                                      engine_kind = OSS;
+                                      engine_kind = `OSS;
                                       validation_state = No_validator;
                                     }
                                   in

--- a/src/osemgrep/configuring/Engine_type.ml
+++ b/src/osemgrep/configuring/Engine_type.ml
@@ -1,5 +1,3 @@
-module Out = Semgrep_output_v1_t
-
-(* TODO it would be better for this also to be in the atd *)
+(* TODO merge with src/core/Engine_kind.ml *)
 type pro_flavor = Language_only | Intrafile | Interfile [@@deriving show]
 type t = OSS | PRO of pro_flavor [@@deriving show]

--- a/src/reporting/Core_json_output.ml
+++ b/src/reporting/Core_json_output.ml
@@ -94,14 +94,6 @@ let range_of_any_opt startp_of_match_range any =
 (* Converters *)
 (*****************************************************************************)
 
-(* TODO: should not be needed if we were using semgrep_output_v1.engine_kind
- * directly in Pattern_match.engine_kind
- *)
-let convert_engine_kind ek =
-  match ek with
-  | OSS -> `OSS
-  | Pro -> `PRO
-
 (* TODO: same, should reuse directly semgrep_output_v1 *)
 let convert_validation_state = function
   | Confirmed_valid -> `CONFIRMED_VALID
@@ -109,8 +101,7 @@ let convert_validation_state = function
   | Validation_error -> `VALIDATION_ERROR
   | No_validator -> `NO_VALIDATOR
 
-let convert_rule ((id, ek) : Rule_ID.t * Pattern_match.engine_kind) =
-  ((id :> string), convert_engine_kind ek)
+let convert_rule ((id, ek) : Rule_ID.t * Engine_kind.t) = ((id :> string), ek)
 
 let metavar_string_of_any any =
   (* TODO: metavar_string_of_any is used in get_propagated_value
@@ -270,7 +261,7 @@ let unsafe_match_to_match render_fix_opt (x : Pattern_match.t) : Out.core_match
         metavars = x.env |> Common.map (metavars startp);
         dataflow_trace;
         rendered_fix;
-        engine_kind = convert_engine_kind x.engine_kind;
+        engine_kind = x.engine_kind;
         validation_state = Some (convert_validation_state x.validation_state);
         extra_extra = None;
       };


### PR DESCRIPTION
Now that semgrep_output_v1.atd is in src/core/, we
can just reuse the types defined in it instead of
defining yet another engine_kind type.

test plan:
make core