### PR TITLE
rename invoke_semgrep_core_proprietary to hook_pro_scan_func

### DIFF
--- a/src/osemgrep/cli_scan/Core_runner.ml
+++ b/src/osemgrep/cli_scan/Core_runner.ml
@@ -51,10 +51,10 @@ type result = {
   *)
 }
 
-(* Type for the core scan function, which can either be invoked by
-   invoke_core_scan or invoke_semgrep_core_proprietary *)
+(* Type for the scan function, which can either be build by
+   mk_scan_func_for_osemgrep or set in Scan_subcommand.hook_pro_scan_func *)
 
-type core_scan_func_for_osemgrep =
+type scan_func_for_osemgrep =
   ?respect_git_ignore:bool ->
   ?file_match_results_hook:
     (Fpath.t ->
@@ -225,63 +225,71 @@ let create_core_result all_rules (_exns, (res : Core_result.t)) =
 (*
    Take in rules and targets and return object with findings.
 *)
-let invoke_core_scan ?(engine = Core_scan.scan_with_exn_handler)
-    ?(respect_git_ignore = true) ?(file_match_results_hook = None) (conf : conf)
-    (all_rules : Rule.t list) (invalid_rules : Rule.invalid_rule_error list)
-    (all_targets : Fpath.t list) : Core_result.result_and_exn =
-  let rule_errors = Core_scan.errors_of_invalid_rule_errors invalid_rules in
-  let config : Core_scan_config.t = core_scan_config_of_conf conf in
-  let config = { config with file_match_results_hook } in
-  (* TODO: we should not need to use Common.map below, because
-     Run_semgrep.semgrep_with_raw_results_and_exn_handler can accept
-     a list of targets with different languages! We just
-     need to pass the right target object (and not a lang_job)
-     TODO: Martin said the issue was that Run_semgrep.targets_of_config
-     requires the xlang object to contain a single language.
-     TODO: Martin says there's no fundamental reason to split
-     a scanning job by programming language. Several optimizations
-     are possible based on target project structure, number and diversity
-     of rules, presence of rule-specific include/exclude patterns etc.
-     Right now we're constrained by the pysemgrep/semgrep-core interface
-     that requires a split by "language". While this interface is still
-     in use, bypassing it without removing it seems complicated.
-     See https://www.notion.so/r2cdev/Osemgrep-scanning-algorithm-5962232bfd74433ba50f97c86bd1a0f3
-  *)
-  let lang_jobs = split_jobs_by_language all_rules all_targets in
-  Logs.app (fun m ->
-      m "%a"
-        (fun ppf () ->
-          Status_report.pp_status ~num_rules:(List.length all_rules)
-            ~num_targets:(List.length all_targets) ~respect_git_ignore lang_jobs
-            ppf)
-        ());
-  List.iter
-    (fun { Lang_job.xlang; _ } ->
-      Metrics_.add_feature "language" (Xlang.to_string xlang))
-    lang_jobs;
-  let config = prepare_config_for_core_scan config lang_jobs in
+let mk_scan_func_for_osemgrep (core_scan_func : Core_scan.core_scan_func) :
+    scan_func_for_osemgrep =
+  (* this is just to prevent ocamlformat to remove the fun below,
+   * but I want to be explicit that the usecase for this function
+   * is to return a function
+   *)
+  let _ = ignore () in
+  fun ?(respect_git_ignore = true) ?(file_match_results_hook = None)
+      (conf : conf) (all_rules : Rule.t list)
+      (invalid_rules : Rule.invalid_rule_error list)
+      (all_targets : Fpath.t list) : Core_result.result_and_exn ->
+    let rule_errors = Core_scan.errors_of_invalid_rule_errors invalid_rules in
+    let config : Core_scan_config.t = core_scan_config_of_conf conf in
+    let config = { config with file_match_results_hook } in
+    (* TODO: we should not need to use Common.map below, because
+       Run_semgrep.semgrep_with_raw_results_and_exn_handler can accept
+       a list of targets with different languages! We just
+       need to pass the right target object (and not a lang_job)
+       TODO: Martin said the issue was that Run_semgrep.targets_of_config
+       requires the xlang object to contain a single language.
+       TODO: Martin says there's no fundamental reason to split
+       a scanning job by programming language. Several optimizations
+       are possible based on target project structure, number and diversity
+       of rules, presence of rule-specific include/exclude patterns etc.
+       Right now we're constrained by the pysemgrep/semgrep-core interface
+       that requires a split by "language". While this interface is still
+       in use, bypassing it without removing it seems complicated.
+       See https://www.notion.so/r2cdev/Osemgrep-scanning-algorithm-5962232bfd74433ba50f97c86bd1a0f3
+    *)
+    let lang_jobs = split_jobs_by_language all_rules all_targets in
+    Logs.app (fun m ->
+        m "%a"
+          (fun ppf () ->
+            Status_report.pp_status ~num_rules:(List.length all_rules)
+              ~num_targets:(List.length all_targets) ~respect_git_ignore
+              lang_jobs ppf)
+          ());
+    List.iter
+      (fun { Lang_job.xlang; _ } ->
+        Metrics_.add_feature "language" (Xlang.to_string xlang))
+      lang_jobs;
+    let config = prepare_config_for_core_scan config lang_jobs in
 
-  (* !!!!Finally! this is where we branch to semgrep-core!!! *)
-  let exn, res = engine config in
+    (* !!!!Finally! this is where we branch to semgrep-core core scan fun!!! *)
+    let exn, res = core_scan_func config in
 
-  (* Reinject rule errors *)
-  let res =
-    {
-      res with
-      errors = rule_errors @ res.errors;
-      skipped_rules = invalid_rules @ res.skipped_rules;
-    }
-  in
+    (* Reinject rule errors *)
+    let res =
+      {
+        res with
+        errors = rule_errors @ res.errors;
+        skipped_rules = invalid_rules @ res.skipped_rules;
+      }
+    in
 
-  let scanned = Set_.of_list res.scanned in
+    let scanned = Set_.of_list res.scanned in
 
-  (* TODO(dinosaure): currently, we don't collect metrics when we invoke
-     semgrep-core but we should. However, if we implement a way to collect
-     metrics, we will just need to set [final_result.extra] to
-     [Core_result.Debug]/[Core_result.Time] and this line of code will not change. *)
-  Metrics_.add_max_memory_bytes (Core_profiling.debug_info_to_option res.extra);
-  Metrics_.add_targets_stats scanned
-    (Core_profiling.debug_info_to_option res.extra);
+    (* TODO(dinosaure): currently, we don't collect metrics when we invoke
+       semgrep-core but we should. However, if we implement a way to collect
+       metrics, we will just need to set [final_result.extra] to
+       [Core_result.Debug]/[Core_result.Time] and this line of code will not change. *)
+    Metrics_.add_max_memory_bytes
+      (Core_profiling.debug_info_to_option res.extra);
+    Metrics_.add_targets_stats scanned
+      (Core_profiling.debug_info_to_option res.extra);
 
-  (exn, res)
+    (exn, res)
   [@@profiling]

--- a/src/osemgrep/cli_scan/Core_runner.mli
+++ b/src/osemgrep/cli_scan/Core_runner.mli
@@ -34,11 +34,15 @@ type scan_func_for_osemgrep =
   Fpath.t list ->
   Core_result.result_and_exn
 
-(*
+(* Core_scan_func adapter to be used in osemgrep.
+
    This will eventually call a core scan like pysemgrep but without
    creating a subprocess.
+
    The first argument is usually Core_scan.scan_with_exn_handler,
-   but it can also be ???
+   but it can also be Run.deep_with_raw_results_and_exn_handler
+   when running in Pro Interfile mode and when called from
+   the Steps_runner in Semgrep Pro.
 
    LATER: This function should go away.
 *)

--- a/src/osemgrep/cli_scan/Core_runner.mli
+++ b/src/osemgrep/cli_scan/Core_runner.mli
@@ -17,8 +17,10 @@ type result = {
   scanned : Fpath.t Set_.t;
 }
 
+val create_core_result : Rule.rule list -> Core_result.result_and_exn -> result
+
 (* similar to Core_scan.core_scan_func *)
-type core_scan_func_for_osemgrep =
+type scan_func_for_osemgrep =
   ?respect_git_ignore:bool ->
   ?file_match_results_hook:
     (Fpath.t ->
@@ -32,16 +34,16 @@ type core_scan_func_for_osemgrep =
   Fpath.t list ->
   Core_result.result_and_exn
 
-val create_core_result : Rule.rule list -> Core_result.result_and_exn -> result
-
 (*
-   This calls a core scan like pysemgrep but without creating a subprocess.
+   This will eventually call a core scan like pysemgrep but without
+   creating a subprocess.
+   The first argument is usually Core_scan.scan_with_exn_handler,
+   but it can also be ???
 
-   LATER: This function should go away, eventually, with some parts being
-   integrated into what's currently semgrep-core.
+   LATER: This function should go away.
 *)
-val invoke_core_scan :
-  ?engine:Core_scan.core_scan_func -> core_scan_func_for_osemgrep
+val mk_scan_func_for_osemgrep :
+  Core_scan.core_scan_func -> scan_func_for_osemgrep
 
 (* Helper used in Semgrep_scan.ml to setup logging *)
 val core_scan_config_of_conf : conf -> Core_scan_config.t

--- a/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -30,14 +30,25 @@ module RP = Core_result
 module SS = Set.Make (String)
 
 (*****************************************************************************)
-(* To run the pro engine, including multistep rules *)
+(* To run a Pro scan, including multistep rules *)
 (*****************************************************************************)
 
-let (invoke_semgrep_core_proprietary :
+(* Semgrep Pro hook. Note that this is useful only for osemgrep. Indeed,
+ * for pysemgrep the code path is instead to fork the
+ * semgrep-core-proprietary program, which executes Pro_CLI_main.ml
+ * which then calls Run.ml code which is mostly a copy-paste Core_scan.ml
+ * with the Pro_scan specifities hard-coded (no need for hooks).
+ * We could do the same for osemgrep, but that would require to copy-paste
+ * lots of code, so simpler to use a hook instead.
+ *
+ * Note that Scan_subcommand.ml itself is linked in (o)semgrep-pro,
+ * and executed by osemgrep-pro.
+ *)
+let (hook_pro_scan_func_for_osemgrep :
       (Fpath.t list ->
       ?diff_config:Differential_scan_config.t ->
       Engine_type.t ->
-      Core_runner.core_scan_func_for_osemgrep)
+      Core_runner.scan_func_for_osemgrep)
       option
       ref) =
   ref None
@@ -159,27 +170,30 @@ let rules_and_counted_matches (res : Core_runner.result) : (Rule.t * int) list =
       | None -> acc)
     map []
 
-(* Select and execute the Semgrep core engine based on the configured
-   engine settings. *)
-let core (conf : Scan_CLI.conf) file_match_results_hook errors targets
+(* Select and execute the scan func based on the configured engine settings.
+ * Yet another mk_scan_func adapter. TODO: can we simplify?
+ *)
+let mk_scan_func (conf : Scan_CLI.conf) file_match_results_hook errors targets
     ?(diff_config = Differential_scan_config.WholeScan) rules () =
-  let invoke_semgrep_core =
+  let scan_func_for_osemgrep : Core_runner.scan_func_for_osemgrep =
     match conf.engine_type with
     | OSS ->
-        Core_runner.invoke_core_scan ~engine:Core_scan.scan_with_exn_handler
+        Core_runner.mk_scan_func_for_osemgrep Core_scan.scan_with_exn_handler
     | PRO _ -> (
-        match !invoke_semgrep_core_proprietary with
+        match !hook_pro_scan_func_for_osemgrep with
         | None ->
-            (* TODO: improve this error message depending on what the instructions should be *)
+            (* TODO: improve this error message depending on what the
+             * instructions should be *)
             failwith
               "You have requested running semgrep with a setting that requires \
                the pro engine, but do not have the pro engine. You may need to \
                acquire a different binary."
-        | Some invoke_semgrep_core_proprietary ->
+        | Some pro_scan_func ->
             let roots = conf.target_roots in
-            invoke_semgrep_core_proprietary roots ~diff_config conf.engine_type)
+            pro_scan_func roots ~diff_config conf.engine_type)
   in
-  invoke_semgrep_core ~respect_git_ignore:conf.targeting_conf.respect_git_ignore
+  scan_func_for_osemgrep
+    ~respect_git_ignore:conf.targeting_conf.respect_git_ignore
     ~file_match_results_hook conf.core_runner_conf rules errors targets
 
 (*****************************************************************************)
@@ -369,12 +383,12 @@ let run_scan_files (conf : Scan_CLI.conf) (profiler : Profiler.t)
             Some (file_match_results_hook conf filtered_rules) )
       | { output_format; _ } -> (output_format, None)
     in
-    let core = core conf file_match_results_hook errors in
+    let scan_func = mk_scan_func conf file_match_results_hook errors in
     let exn_and_matches =
       match conf.targeting_conf.baseline_commit with
       | None ->
           Profiler.record profiler ~name:"core_time"
-            (core targets filtered_rules)
+            (scan_func targets filtered_rules)
       | Some baseline_commit ->
           (* diff scan mode *)
           let commit = Git_wrapper.get_merge_base baseline_commit in
@@ -389,14 +403,14 @@ let run_scan_files (conf : Scan_CLI.conf) (profiler : Profiler.t)
           in
           let head_scan_result =
             Profiler.record profiler ~name:"head_core_time"
-              (core targets
+              (scan_func targets
                  ~diff_config:
                    (Differential_scan_config.Depth
                       (diff_targets, Differential_scan_config.default_depth))
                  filtered_rules)
           in
           scan_baseline_and_remove_duplicates conf profiler head_scan_result
-            filtered_rules commit status core
+            filtered_rules commit status scan_func
     in
     (* step 3': call the engine! *)
     let (res : Core_runner.result) =

--- a/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -30,19 +30,20 @@ module RP = Core_result
 module SS = Set.Make (String)
 
 (*****************************************************************************)
-(* To run a Pro scan, including multistep rules *)
+(* To run a Pro scan (Deep scan and multistep scan) *)
 (*****************************************************************************)
 
 (* Semgrep Pro hook. Note that this is useful only for osemgrep. Indeed,
  * for pysemgrep the code path is instead to fork the
  * semgrep-core-proprietary program, which executes Pro_CLI_main.ml
- * which then calls Run.ml code which is mostly a copy-paste Core_scan.ml
- * with the Pro_scan specifities hard-coded (no need for hooks).
+ * which then calls Run.ml code which is mostly a copy-paste of Core_scan.ml
+ * with the Pro scan specifities hard-coded (no need for hooks).
  * We could do the same for osemgrep, but that would require to copy-paste
  * lots of code, so simpler to use a hook instead.
  *
  * Note that Scan_subcommand.ml itself is linked in (o)semgrep-pro,
- * and executed by osemgrep-pro.
+ * and executed by osemgrep-pro. When linked from osemgrep-pro, this
+ * hook below will be set.
  *)
 let (hook_pro_scan_func_for_osemgrep :
       (Fpath.t list ->

--- a/src/osemgrep/cli_scan/Scan_subcommand.mli
+++ b/src/osemgrep/cli_scan/Scan_subcommand.mli
@@ -11,14 +11,12 @@ val main : string array -> Exit_code.t
 val run_conf : Scan_CLI.conf -> Exit_code.t
 val run_scan_conf : Scan_CLI.conf -> Exit_code.t
 
-(* Semgrep Pro hook *)
-(* TODO it might be better to pass this through and avoid the hook,
-   but it was fairly annoying to *)
-val invoke_semgrep_core_proprietary :
+(* Semgrep Pro hook for osemgrep *)
+val hook_pro_scan_func_for_osemgrep :
   (Fpath.t list ->
   ?diff_config:Differential_scan_config.t ->
   Engine_type.t ->
-  Core_runner.core_scan_func_for_osemgrep)
+  Core_runner.scan_func_for_osemgrep)
   option
   ref
 

--- a/src/osemgrep/cli_scan/Validate_subcommand.ml
+++ b/src/osemgrep/cli_scan/Validate_subcommand.ml
@@ -105,11 +105,13 @@ let run (conf : conf) : Exit_code.t =
         if metaerrors <> [] then
           Error.abort (spf "error in metachecks! please fix %s" metarules_pack);
 
-        let exn_and_matches =
-          Core_runner.invoke_core_scan conf.core_runner_conf metarules []
-            targets
+        let scan_func =
+          Core_runner.mk_scan_func_for_osemgrep Core_scan.scan_with_exn_handler
         in
-        let res = Core_runner.create_core_result metarules exn_and_matches in
+        let result_and_exn =
+          scan_func conf.core_runner_conf metarules [] targets
+        in
+        let res = Core_runner.create_core_result metarules result_and_exn in
 
         (* TODO? sanity check errors below too? *)
         let { Out.results; errors = _; _ } =

--- a/src/osemgrep/language_server/LS.ml
+++ b/src/osemgrep/language_server/LS.ml
@@ -12,13 +12,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
  * LICENSE for more details.
  *)
-
-(* Commentary *)
-(* This contains all networking/rpc related functionality of the language server *)
-
-(*****************************************************************************)
-(* Prelude *)
-(*****************************************************************************)
 open Jsonrpc
 open Lsp
 open Types
@@ -28,6 +21,13 @@ module CN = Client_notification
 module CR = Client_request
 module Conv = Convert_utils
 module Out = Semgrep_output_v1_t
+
+(*****************************************************************************)
+(* Prelude *)
+(*****************************************************************************)
+(* This module contains all networking/rpc related functionality of the
+ * language server.
+ *)
 
 module MessageHandler = struct
   (* Relevant here means any matches we actually care about showing the user.
@@ -42,9 +42,12 @@ module MessageHandler = struct
     let targets = Option.value ~default:(Session.targets session) targets in
     Logs.app (fun m -> m "Running Semgrep with %d rules" (List.length rules));
     let runner_conf = Session.runner_conf session in
+    let scan_func =
+      Core_runner.mk_scan_func_for_osemgrep Core_scan.scan_with_exn_handler
+    in
     let run =
-      Core_runner.invoke_core_scan ~respect_git_ignore:true
-        ~file_match_results_hook:None runner_conf rules [] targets
+      scan_func ~respect_git_ignore:true ~file_match_results_hook:None
+        runner_conf rules [] targets
     in
     let res = Core_runner.create_core_result rules run in
     let scanned = res.scanned |> Set_.elements in


### PR DESCRIPTION
Those invoke were actually misleading because they were
hook, not functions.
Moreover I've removed a few invoke_semgrep_xxx because they
are ambiguous and make you think you fork and call semgrep.

test plan:
make core