### PR TITLE
Gracefully exit if `semgrep scan --pro` is called before install

### DIFF
--- a/cli/bin/semgrep
+++ b/cli/bin/semgrep
@@ -113,6 +113,8 @@ def exec_osemgrep():
                 # to install semgrep-pro, however, so have them run legacy `semgrep`. 
                 print("Since `semgrep ci` was run, defaulting to legacy semgrep", file=sys.stderr)
                 exec_pysemgrep()
+            else:
+                sys.exit(2)
         # If you call semgrep-core-proprietary as osemgrep-pro, then we get
         # osemgrep-pro behavior, see semgrep-proprietary/src/main/Pro_main.ml
         sys.argv[0] = "osemgrep-pro"


### PR DESCRIPTION
Currently, if `semgrep scan --pro --config auto` is called before the Pro Engine binary is installed, semgrep crashes. This gracefully exits instead.

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure about any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)