### PR TITLE
Generic-to-IL: Fix translation of C++ "foreach" loops

### DIFF
--- a/changelog.d/pa-3090.fixed
+++ b/changelog.d/pa-3090.fixed
@@ -1,0 +1,12 @@
+C++: Translate `for (T var : E)` loops into the Dataflow IL as for-each loops,
+so that Semgrep reports no finding in the following code:
+
+```
+  for (int *p : set) {
+    sink(p); // no finding
+    source(p);
+  }
+```
+
+Since each `p` is (in principle) a different object, even if `source(p)` taints
+the current `p`, that should not affect the next one.

--- a/src/analyzing/AST_to_IL.ml
+++ b/src/analyzing/AST_to_IL.ml
@@ -1339,6 +1339,19 @@ and stmt_aux env st =
       @ [ mk_s (Loop (tok, cond, st @ cont_label_s @ next @ ss2)) ]
       @ break_label_s
   | G.For (_, G.ForEllipsis _, _) -> sgrep_construct (G.S st)
+  | G.For
+      ( tok,
+        G.ForIn
+          ( [
+              G.ForInitVar
+                ({ name = G.EN (G.Id (id, ii)); _ }, { vinit = None; _ });
+            ],
+            [ e ] ),
+        stmts ) ->
+      (* e.g. C++: for (int *p : set)
+       * TODO: Should this be encoded as a ForEach already in Parse_cpp_tree_sitter ? *)
+      let pat = G.PatId (id, ii) in
+      for_each env tok (pat, snd id, e) stmts
   | G.For (tok, G.ForIn (xs, e), stmts) ->
       let orig_stmt = st in
       let cont_label_s, break_label_s, st_env =

--- a/tests/rules/taint_cpp_for_each.cpp
+++ b/tests/rules/taint_cpp_for_each.cpp
@@ -1,0 +1,10 @@
+void range_base_loop(std::set<int *> &set) {
+  for (int *p : set) {
+    // `p` is re-initialized on every iteration of the
+    // range-based loop. There is no path from source
+    // to sink with the same pointer
+    // ok: source-sink-range
+    sink(p);
+    source(p);
+  }
+}

--- a/tests/rules/taint_cpp_for_each.yaml
+++ b/tests/rules/taint_cpp_for_each.yaml
@@ -1,0 +1,16 @@
+rules:
+  - id: source-sink-range
+    languages:
+      - cpp
+    message: source-sink
+    mode: taint
+    pattern-sinks:
+      - pattern: |
+          sink(...)
+    pattern-sources:
+      - by-side-effect: true
+        patterns:
+          - pattern: source($X)
+          - focus-metavariable: $X
+    severity: WARNING
+


### PR DESCRIPTION
C++ loop `for (int *p : container) { ... }` is encoded as a Generic 'ForIn' node, using a 'ForInitVar' without an initial value. The IL translation of such Generic AST is flawed, and in fact that seems like it should be a 'ForEach' instead. So for now we just intercept this case and translate it as a for-each loop.

Helps PA-3090

test plan:
make test # new test

