### PR TITLE
chore: repin benchmarks

### DIFF
--- a/scripts/run-benchmarks.sh
+++ b/scripts/run-benchmarks.sh
@@ -10,7 +10,7 @@ set -e
 cd cli || return
 
 # Run timing benchmark
-pipenv install semgrep==1.36.0
+pipenv install semgrep==1.40.0
 pipenv run semgrep --version
 export PATH=/github/home/.local/bin:$PATH
 


### PR DESCRIPTION
Benchmarks have been getting slower. This seems to be normal, caused by osemgrep porting (though I haven't investigated closely, just checked the graph). I'm going to repin under that assumption.

Test plan: make test

