### PR TITLE
debug: update formatter and introduce bc test

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -85,7 +85,7 @@ jobs:
           HOME: /root
         run: |
           # coupling: must be the same than in dev/dev.opam
-          opam install -y ocamlformat.0.26.0
+          opam install -y ocamlformat.0.23.0
           # Without this 'git config' command below, we would get this error in CI:
           #   fatal: detected dubious ownership in repository at '/__w/semgrep/semgrep'
           #   To add an exception for this directory, call:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -85,7 +85,7 @@ jobs:
           HOME: /root
         run: |
           # coupling: must be the same than in dev/dev.opam
-          opam install -y ocamlformat.0.21.0
+          opam install -y ocamlformat.0.26.0
           # Without this 'git config' command below, we would get this error in CI:
           #   fatal: detected dubious ownership in repository at '/__w/semgrep/semgrep'
           #   To add an exception for this directory, call:

--- a/dev/dev.opam
+++ b/dev/dev.opam
@@ -13,7 +13,9 @@ depends: [
   # - https://github.com/returntocorp/ocaml-layer/blob/master/common-config.sh
   # - scripts/lint-ocaml
   # - .github/workflows/lint.yml and its pre-commit-ocaml job
-  "ocamlformat" {= "0.21.0" }  # used by the pre-commit hook
+  "ocamlformat" {= "0.26.0" }  # used by the pre-commit hook
   "ppx_deriving_cmdliner" # used by hello_script.ml
   "feather" # used by hello_script.ml
+  "ocaml-lsp-server" {= "1.16.2"} # used by the VSCode extension
+  "ocamlearlybird" {= "1.2.1"} # used by the VSCode extension
 ]

--- a/dev/dev.opam
+++ b/dev/dev.opam
@@ -13,7 +13,7 @@ depends: [
   # - https://github.com/returntocorp/ocaml-layer/blob/master/common-config.sh
   # - scripts/lint-ocaml
   # - .github/workflows/lint.yml and its pre-commit-ocaml job
-  "ocamlformat" {= "0.26.0" }  # used by the pre-commit hook
+  "ocamlformat" {= "0.23.0" }  # used by the pre-commit hook
   "ppx_deriving_cmdliner" # used by hello_script.ml
   "feather" # used by hello_script.ml
   "ocaml-lsp-server" {= "1.16.2"} # used by the VSCode extension

--- a/scripts/lint-ocaml
+++ b/scripts/lint-ocaml
@@ -21,7 +21,7 @@ set -eu
 eval $(opam env)
 
 #coupling: must be the same than in dev/dev.opam
-required_version=0.21
+required_version=0.26
 
 if version=$(ocamlformat --version); then
   if [[ "$version" =~ ^"$required_version."[0-9]+$ ]]; then

--- a/scripts/lint-ocaml
+++ b/scripts/lint-ocaml
@@ -21,7 +21,7 @@ set -eu
 eval $(opam env)
 
 #coupling: must be the same than in dev/dev.opam
-required_version=0.26
+required_version=0.23
 
 if version=$(ocamlformat --version); then
   if [[ "$version" =~ ^"$required_version."[0-9]+$ ]]; then

--- a/src/tests/dune
+++ b/src/tests/dune
@@ -23,7 +23,7 @@
 
     osemgrep_language_server
   )
- (modes native) ; bytecode here for debugging
+ (modes native byte) ; bytecode here for debugging
  (preprocess
    (pps
       ppx_deriving.show

--- a/src/tests/dune
+++ b/src/tests/dune
@@ -1,5 +1,6 @@
 (test
  (name test)
+ (action (run %{exe:test.exe})); Ensure we're running the native binary
  (libraries
     commons
     process_limits

--- a/tools/oncall_email/oncall.ml
+++ b/tools/oncall_email/oncall.ml
@@ -57,15 +57,10 @@ let ( >> ) o fld =
       o
   | _ -> failwith (spf "could not find %s" fld)
 
-let jstring j =
-  match j with
-  | J.String s -> s
-  | _ -> error j "not a string"
+let jstring j = match j with J.String s -> s | _ -> error j "not a string"
 
 let array f j =
-  match j with
-  | J.Array xs -> xs |> List.map f
-  | _ -> error j "not an array"
+  match j with J.Array xs -> xs |> List.map f | _ -> error j "not an array"
 
 (*****************************************************************************)
 (* Helpers *)
@@ -74,9 +69,7 @@ let filter_some xs = xs |> Common.map_filter (fun x -> x)
 let find_issue_opt x xs = xs |> List.find_opt (fun y -> y.url = x.url)
 
 let has_issue x xs =
-  match find_issue_opt x xs with
-  | None -> false
-  | Some _ -> true
+  match find_issue_opt x xs with None -> false | Some _ -> true
 
 (*****************************************************************************)
 (* Parsing columns, cards, issues *)


### PR DESCRIPTION
This PR bumps the ocamlformat version so we can use the built in rpc server w/ocaml lsp (see[ here](https://github.com/ocaml-ppx/ocamlformat/releases/tag/0.22.3)). This provides things like showing the mli signatures in the .ml file and more.

This PR also adds earlybird + ocaml lsp to the dev dependencies

Finally we re-enable byte mode compilation so we can debug tests 