### PR TITLE
Remove stdcompat + bump minimum ocaml version to 4.13.0

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -68,7 +68,7 @@ the other programming languages supported by atdgen."
   (authors "Yoann Padioleau <pad@semgrep.com>")
   (license "LGPL-2.1-only")
   (depends
-    (ocaml (>= 4.12.0))
+    (ocaml (>= 4.13.0))
     (dune (>= 3.2.0))
     (commons (>= 1.8.0))
     (lib_parsing (>= 1.5.5))
@@ -92,7 +92,7 @@ a few other projects developed at r2c.
   (license "LGPL-2.1-only")
 
   (depends
-    (ocaml (>= "4.12.0"))
+    (ocaml (>= "4.13.0"))
     (dune (>= "3.2.0" ))
     (ANSITerminal (>= "0.8.4"))
     (alcotest (>= "1.5.0"))
@@ -153,7 +153,7 @@ parsers, especially ocamlyacc/menhir based parsers.
   (license "LGPL-2.1-only")
 
   (depends
-    (ocaml (>= "4.12.0"))
+    (ocaml (>= "4.13.0"))
     (dune (>= "3.2.0" ))
     (commons (>= "1.5.5"))
     (profiling (>= "1.5.5"))
@@ -338,7 +338,7 @@ time and memory used by Semgrep.
   (license "LGPL-2.1-only")
 
   (depends
-    (ocaml (>= "4.12.0"))
+    (ocaml (>= "4.13.0"))
     (dune (>= "3.2.0" ))
     (commons (>= "1.5.5"))
   )
@@ -359,7 +359,7 @@ functions.
   (license "LGPL-2.1-only")
 
   (depends
-    (ocaml (>= "4.12.0"))
+    (ocaml (>= "4.13.0"))
     (dune (>= "3.2.0" ))
     (commons (>= "1.5.5"))
     (process_limits (>= "1.5.5"))
@@ -394,7 +394,7 @@ For more information see https://semgrep.dev
 ;TODO: restore  "bisect_ppx" {>= "2.5.0"} once can use ppxlib 0.22.0
   (depends
     ; core deps
-    (ocaml (>= 4.12.0))
+    (ocaml (>= 4.13.0))
     (dune (>= 2.7.0 ))
     ; parser generators
     (menhir (= 20211128)) ; Newer versions cause massive build slowdowns

--- a/libs/glob/Pattern.ml
+++ b/libs/glob/Pattern.ml
@@ -105,8 +105,6 @@ let append (a : t) (b : t) : t =
 let of_path_segments (segments : string list) : t =
   Common.map
     (fun s ->
-      let chars =
-        Stdcompat.String.fold_right (fun c acc -> Char c :: acc) s []
-      in
+      let chars = String.fold_right (fun c acc -> Char c :: acc) s [] in
       Segment chars)
     segments

--- a/libs/lib_parsing/Tok.ml
+++ b/libs/lib_parsing/Tok.ml
@@ -235,7 +235,7 @@ let content_of_tok ii =
 *)
 let end_pos_of_loc loc =
   let line, col =
-    Stdcompat.String.fold_left
+    String.fold_left
       (fun (line, col) c ->
         match c with
         | '\n' -> (line + 1, 0)

--- a/libs/lib_parsing/dune
+++ b/libs/lib_parsing/dune
@@ -4,7 +4,6 @@
  (wrapped false)
  (libraries
    fpath
-   stdcompat
    sexplib
 
    commons

--- a/semgrep.opam
+++ b/semgrep.opam
@@ -17,7 +17,6 @@ depends: [
   "ocaml" {>= "4.13.0"}
   "dune" {>= "3.7" & >= "2.7.0"}
   "menhir" {= "20211128"}
-  "stdcompat"
   "base" {>= "v0.15.1"}
   "fpath"
   "bos"

--- a/semgrep.opam
+++ b/semgrep.opam
@@ -14,7 +14,7 @@ license: "LGPL-2.1"
 homepage: "https://semgrep.dev"
 bug-reports: "https://github.com/returntocorp/semgrep/issues"
 depends: [
-  "ocaml" {>= "4.12.0"}
+  "ocaml" {>= "4.13.0"}
   "dune" {>= "3.7" & >= "2.7.0"}
   "menhir" {= "20211128"}
   "stdcompat"

--- a/src/core/dune
+++ b/src/core/dune
@@ -13,7 +13,6 @@
  (wrapped false)
  (libraries
    ; standard libraries
-   stdcompat
    str
    uri
    semver

--- a/src/engine/Match_extract_mode.ml
+++ b/src/engine/Match_extract_mode.ml
@@ -79,7 +79,7 @@ type extract_range = {
 }
 
 let count_lines_and_trailing =
-  Stdcompat.String.fold_left
+  String.fold_left
     (fun (n, c) b ->
       match b with
       | '\n' -> (n + 1, 0)
@@ -274,9 +274,7 @@ let map_res map_loc (tmpfile : Fpath.t) (file : Fpath.t)
           file = !!file;
           range_loc = Common2.pair map_loc m.range_loc;
           taint_trace =
-            Option.map
-              (Stdcompat.Lazy.map_val (map_taint_trace map_loc))
-              m.taint_trace;
+            Option.map (Lazy.map_val (map_taint_trace map_loc)) m.taint_trace;
           env = map_bindings map_loc m.env;
         })
       mr.matches

--- a/src/osemgrep/cli_interactive/Interactive_subcommand.ml
+++ b/src/osemgrep/cli_interactive/Interactive_subcommand.ml
@@ -661,7 +661,7 @@ let split_line (t1 : Tok.location) (t2 : Tok.location) (row, line) =
     let lb = if row = t1.pos.line then Some t1.pos.column else None in
     let rb = if row = end_line then Some end_col else None in
     let l_rev, m_rev, r_rev, _ =
-      Stdcompat.String.fold_left
+      String.fold_left
         (fun (l, m, r, i) c ->
           match placement_wrt_bound (lb, rb) i with
           | Common.Left3 _ -> (c :: l, m, r, i + 1)

--- a/src/targeting/dune
+++ b/src/targeting/dune
@@ -8,7 +8,6 @@
  (name semgrep_targeting)
  (wrapped false)
  (libraries
-   stdcompat
    commons
 
    fpath

--- a/tests/parsing/dockerfile/semgrep.dockerfile
+++ b/tests/parsing/dockerfile/semgrep.dockerfile
@@ -6,7 +6,7 @@
 # of the 'semgrep-python' wrapping.
 #
 
-# The docker base image below in the FROM currently uses OCaml 4.12.0
+# The docker base image below in the FROM currently uses OCaml 4.14.0
 # See https://github.com/returntocorp/ocaml-layer/blob/master/configs/alpine.sh
 #
 # coupling: if you modify the OCaml version there, you probably also need


### PR DESCRIPTION
The `stdcompat` functions we're using are all part of the standard library as of OCaml 4.13 (and we're [currently using 4.14](https://github.com/returntocorp/ocaml-layer/blob/master/configs/alpine.sh#L34) in our base docker image). This PR:
- removes the dep
- updates the functions
- bumps our minimum version of ocaml from 4.12.0 to 4.13.0

It wasn't 100% clear to me if we explicitly want to support 4.12 -- if that's the case we can close this PR.

test plan:
- [ ] `make test` passes locally
- [x] checks pass