### PR TITLE
Fix: dev-setup

### DIFF
--- a/dev/dev.opam
+++ b/dev/dev.opam
@@ -16,7 +16,6 @@ depends: [
   "ocamlformat" {= "0.23.0" }  # used by the pre-commit hook
   "ppx_deriving_cmdliner" # used by hello_script.ml
   "feather" # used by hello_script.ml
-  #TODO: those 2 packages generate conflict when running 'make dev-setup'
-  #"ocaml-lsp-server" {= "1.16.2"} # used by the VSCode extension
-  #"ocamlearlybird" {= "1.2.1"} # used by the VSCode extension
+  "ocaml-lsp-server" {= "1.15.1-4.14"} # used by the VSCode extension
+  "earlybird" {= "1.2.1"} # used by the VSCode extension
 ]


### PR DESCRIPTION
Fixed the versions of lsp-server and the name of earlybird so dev-setup now works

## Test Plan

```bash
opam switch create new 4.14.0
opam install dune
make dev-setup
```