### PR TITLE
feat: differential scan for Pro engine support in pysemgrep

### DIFF
--- a/cli/src/semgrep/commands/ci.py
+++ b/cli/src/semgrep/commands/ci.py
@@ -182,6 +182,7 @@ def ci(
     code: bool,
     config: Optional[Tuple[str, ...]],
     debug: bool,
+    diff_depth: int,
     dump_command_for_core: bool,
     dry_run: bool,
     enable_nosem: bool,
@@ -381,6 +382,7 @@ def ci(
         scan_handler=scan_handler,
         git_meta=metadata,
         run_secrets=run_secrets,
+        enable_pro_diff_scan=diff_depth >= 0,
     )
 
     # set default settings for selected engine type
@@ -465,6 +467,7 @@ def ci(
             optimizations=optimizations,
             baseline_commit=metadata.merge_base_ref,
             baseline_commit_is_mergebase=True,
+            diff_depth=diff_depth,
             dump_contributions=True,
         )
     except SemgrepError as e:

--- a/cli/src/semgrep/constants.py
+++ b/cli/src/semgrep/constants.py
@@ -15,6 +15,14 @@ DEFAULT_TIMEOUT = 30  # seconds
 DEFAULT_PRO_TIMEOUT_CI = 10800  # seconds
 DEFAULT_MAX_MEMORY_PRO_CI = 5000  # MiB
 
+# The default depth has been configured as -1 in order to prevent unexpected
+# behavior for current users of pro intra-file diff scanning. To enable pro
+# inter-file diff scanning, users are required to manually specify the
+# `-diff-depth` parameter with a value equal to or greater than 0.
+# TODO update the default depth to a non-negative value, such as 2, once this
+# new feature has reached a stable state.
+DEFAULT_DIFF_DEPTH = -1
+
 SETTINGS_FILENAME = "settings.yml"
 
 YML_EXTENSIONS = {".yml", ".yaml"}

--- a/cli/src/semgrep/engine.py
+++ b/cli/src/semgrep/engine.py
@@ -33,6 +33,7 @@ class EngineType(Enum):
         scan_handler: Optional[ScanHandler] = None,
         git_meta: Optional[GitMeta] = None,
         run_secrets: bool = False,
+        enable_pro_diff_scan: bool = False,
     ) -> "EngineType":
         """Select which Semgrep engine type to use if none is explicitly requested.
 
@@ -50,7 +51,11 @@ class EngineType(Enum):
             if scan_handler.deepsemgrep and requested_engine is None:
                 requested_engine = cls.PRO_INTERFILE
 
-            if requested_engine == cls.PRO_INTERFILE and not git_meta.is_full_scan:
+            if (
+                requested_engine == cls.PRO_INTERFILE
+                and not git_meta.is_full_scan
+                and not enable_pro_diff_scan
+            ):
                 requested_engine = cls.PRO_INTRAFILE
 
         return requested_engine or cls.OSS

--- a/cli/src/semgrep/run_scan.py
+++ b/cli/src/semgrep/run_scan.py
@@ -27,6 +27,7 @@ from typing import Set
 from typing import Tuple
 from typing import Union
 
+from attrs import evolve
 from boltons.iterutils import partition
 from rich.columns import Columns
 from rich.padding import Padding
@@ -42,6 +43,7 @@ from semgrep.config_resolver import get_config
 from semgrep.console import console
 from semgrep.console import Title
 from semgrep.constants import Colors
+from semgrep.constants import DEFAULT_DIFF_DEPTH
 from semgrep.constants import DEFAULT_TIMEOUT
 from semgrep.constants import OutputFormat
 from semgrep.constants import RuleSeverity
@@ -74,6 +76,7 @@ from semgrep.state import get_state
 from semgrep.target_manager import ECOSYSTEM_TO_LOCKFILES
 from semgrep.target_manager import FileTargetingLog
 from semgrep.target_manager import TargetManager
+from semgrep.target_mode import TargetModeConfig
 from semgrep.util import unit_str
 from semgrep.util import with_color
 from semgrep.util import with_feature_status
@@ -190,6 +193,7 @@ def print_scan_plan_header(
     target_manager: TargetManager,
     sast_plan: Plan,
     sca_plan: Plan,
+    target_mode_config: TargetModeConfig,
     cli_ux: DesignTreatment = DesignTreatment.LEGACY,
 ) -> None:
     """
@@ -200,7 +204,16 @@ def print_scan_plan_header(
     legacy_cli_ux = cli_ux == DesignTreatment.LEGACY
     simple_ux = cli_ux == DesignTreatment.SIMPLE
 
-    summary_line = f"Scanning {unit_str(file_count, 'file')}"
+    if target_mode_config.is_pro_diff_scan:
+        total_file_count = len(
+            evolve(target_manager, baseline_handler=None).get_all_files()
+        )
+        diff_file_count = len(target_mode_config.get_diff_targets())
+        summary_line = f"Pro Differential Scanning {diff_file_count}/{unit_str(total_file_count, 'file')}"
+    else:
+        file_count = len(target_manager.get_all_files())
+        summary_line = f"Scanning {unit_str(file_count, 'file')}"
+
     if target_manager.respect_git_ignore:
         summary_line += (
             f" {'tracked by git' if legacy_cli_ux else '(only git-tracked)'}"
@@ -347,6 +360,7 @@ def print_detailed_sca_table(sca_plan: Plan, rule_count: int) -> None:
 def print_scan_status(
     rules: Sequence[Rule],
     target_manager: TargetManager,
+    target_mode_config: TargetModeConfig,
     cli_ux: DesignTreatment = DesignTreatment.LEGACY,
 ) -> int:
     """
@@ -383,7 +397,11 @@ def print_scan_status(
                 and (not rule.from_transient_scan)
             )
         ],
-        target_manager,
+        target_manager
+        if not target_mode_config.is_pro_diff_scan
+        else evolve(
+            target_manager, target_strings=target_mode_config.get_diff_targets()
+        ),
     )
 
     sca_plan = CoreRunner.plan_core_run(
@@ -391,7 +409,9 @@ def print_scan_status(
         target_manager,
     )
 
-    print_scan_plan_header(target_manager, sast_plan, sca_plan, cli_ux)
+    print_scan_plan_header(
+        target_manager, sast_plan, sca_plan, target_mode_config, cli_ux
+    )
 
     sast_rule_count = len(sast_plan.rules)
     sca_rule_count = len(sca_plan.rules)
@@ -502,6 +522,7 @@ def run_rules(
     time_flag: bool,
     engine_type: EngineType,
     run_secrets: bool = False,
+    target_mode_config: Optional[TargetModeConfig] = None,
 ) -> Tuple[
     RuleMatchMap,
     List[SemgrepError],
@@ -510,8 +531,13 @@ def run_rules(
     List[DependencyParserError],
     int,
 ]:
+    if not target_mode_config:
+        target_mode_config = TargetModeConfig.whole_scan()
+
     cli_ux = get_state().get_cli_ux_flavor()
-    num_executed_rules = print_scan_status(filtered_rules, target_manager, cli_ux)
+    num_executed_rules = print_scan_status(
+        filtered_rules, target_manager, target_mode_config, cli_ux
+    )
 
     join_rules, rest_of_the_rules = partition(
         filtered_rules, lambda rule: rule.mode == JOIN_MODE
@@ -533,6 +559,7 @@ def run_rules(
         time_flag,
         engine_type,
         run_secrets,
+        target_mode_config,
     )
 
     if join_rules:
@@ -624,6 +651,7 @@ def run_rules(
 # old: this used to be called semgrep.semgrep_main.main
 def run_scan(
     *,
+    diff_depth: int = DEFAULT_DIFF_DEPTH,
     dump_command_for_core: bool = False,
     time_flag: bool = False,
     engine_type: EngineType = EngineType.OSS,
@@ -783,6 +811,18 @@ def run_scan(
     except FilesNotFoundError as e:
         raise SemgrepError(e)
 
+    target_mode_config = TargetModeConfig.whole_scan()
+    if baseline_handler is not None:
+        if engine_type.is_interfile:
+            target_mode_config = TargetModeConfig.pro_diff_scan(
+                # `target_manager.get_all_files()` will only return changed files
+                # (diff targets) when baseline_handler is set
+                target_manager.get_all_files(),
+                diff_depth,
+            )
+        else:
+            target_mode_config = TargetModeConfig.diff_scan()
+
     core_start_time = time.time()
     core_runner = CoreRunner(
         jobs=jobs,
@@ -830,6 +870,7 @@ def run_scan(
         time_flag,
         engine_type,
         run_secrets,
+        target_mode_config,
     )
     profiler.save("core_time", core_start_time)
     output_handler.handle_semgrep_errors(semgrep_errors)
@@ -866,16 +907,29 @@ def run_scan(
             logger.info("")
             try:
                 with baseline_handler.baseline_context():
+                    baseline_target_strings = target
+                    baseline_target_mode_config = target_mode_config
+                    if target_mode_config.is_pro_diff_scan:
+                        baseline_target_mode_config = TargetModeConfig.pro_diff_scan(
+                            frozenset(
+                                t
+                                for t in target_mode_config.get_diff_targets()
+                                if t.exists() and not t.is_symlink()
+                            ),
+                            target_mode_config.get_diff_depth(),
+                        )
+                    else:
+                        baseline_target_strings = [
+                            str(t)
+                            for t in baseline_targets
+                            if t.exists() and not t.is_symlink()
+                        ]
                     baseline_target_manager = TargetManager(
                         includes=include,
                         excludes=exclude,
                         max_target_bytes=max_target_bytes,
                         # only target the paths that had a match, ignoring symlinks and non-existent files
-                        target_strings=[
-                            str(t)
-                            for t in baseline_targets
-                            if t.exists() and not t.is_symlink()
-                        ],
+                        target_strings=baseline_target_strings,
                         respect_git_ignore=respect_git_ignore,
                         allow_unknown_extensions=not skip_unknown_extensions,
                         file_ignore=get_file_ignore(),
@@ -902,6 +956,7 @@ def run_scan(
                         time_flag,
                         engine_type,
                         run_secrets,
+                        baseline_target_mode_config,
                     )
                     rule_matches_by_rule = remove_matches_in_baseline(
                         rule_matches_by_rule,

--- a/cli/src/semgrep/target_mode.py
+++ b/cli/src/semgrep/target_mode.py
@@ -1,0 +1,87 @@
+"""
+Target mode configuration for Semgrep Scan
+
+It's important to note that the targeting schemes differ among three scanning
+modes: pro (interfile) differential scanning, open-source (per-file)
+differential scanning, and whole scan. Here's a breakdown of their respective
+targeting requirements:
+
+Pro Diff Scan: In this mode, all input files are designated as "targets", and
+specifically, the files that have changed between the head and baseline commits
+are considered "diff targets".
+
+OSS Diff Scan: For OSS differential scanning, the files that have changed
+between the head and baseline commits serve as the primary "targets".
+
+Whole Scan: In the case of the whole scan, all input files are categorized as
+"targets" without any distinction based on commit changes.
+"""
+from pathlib import Path
+from typing import FrozenSet
+from typing import Union
+
+from attr import field
+from attr import frozen
+
+
+@frozen
+class WholeScan:
+    ()
+
+
+@frozen
+class DiffScan:
+    ()
+
+
+@frozen
+class ProDiffScan:
+    diff_targets: FrozenSet[Path] = field()
+    diff_depth: int = field()
+
+
+@frozen
+class TargetModeConfig:
+    scan_type: Union[WholeScan, DiffScan, ProDiffScan] = field()
+
+    @classmethod
+    def pro_diff_scan(
+        cls, diff_targets: FrozenSet[Path], diff_depth: int
+    ) -> "TargetModeConfig":
+        return cls(ProDiffScan(diff_targets, diff_depth))
+
+    @classmethod
+    def whole_scan(cls) -> "TargetModeConfig":
+        return cls(WholeScan())
+
+    @classmethod
+    def diff_scan(cls) -> "TargetModeConfig":
+        return cls(DiffScan())
+
+    @property
+    def is_pro_diff_scan(self) -> bool:
+        return isinstance(self.scan_type, ProDiffScan)
+
+    @property
+    def is_diff_scan(self) -> bool:
+        return isinstance(self.scan_type, DiffScan)
+
+    def get_diff_targets(self) -> FrozenSet[Path]:
+        if isinstance(self.scan_type, WholeScan) or isinstance(
+            self.scan_type, DiffScan
+        ):
+            raise ValueError("not a pro diff scan")
+        elif isinstance(self.scan_type, ProDiffScan):
+            return self.scan_type.diff_targets
+        else:
+            raise ValueError("unknown scan type: " + str(self.scan_type))
+
+    def get_diff_depth(self) -> int:
+        if isinstance(self.scan_type, WholeScan) or isinstance(
+            self.scan_type, DiffScan
+        ):
+            raise ValueError("not a pro diff scan")
+        elif isinstance(self.scan_type, ProDiffScan):
+            return self.scan_type.diff_depth
+        else:
+            raise ValueError("unknown scan type: " + str(self.scan_type))

--- a/cli/tests/unit/test_engine_type.py
+++ b/cli/tests/unit/test_engine_type.py
@@ -7,42 +7,44 @@ from semgrep.meta import GitMeta
 
 @pytest.mark.quick
 @pytest.mark.parametrize(
-    ("is_cloud_flag_on", "is_ci_scan_full", "requested", "expected"),
+    ("is_cloud_flag_on", "is_ci_scan_full", "enable_pro_diff", "requested", "expected"),
     [
         # semgrep scan
-        (False, None, None, ET.OSS),
-        (False, None, ET.OSS, ET.OSS),
-        (False, None, ET.PRO_LANG, ET.PRO_LANG),
-        (False, None, ET.PRO_INTRAFILE, ET.PRO_INTRAFILE),
-        (False, None, ET.PRO_INTERFILE, ET.PRO_INTERFILE),
+        (False, None, False, None, ET.OSS),
+        (False, None, False, ET.OSS, ET.OSS),
+        (False, None, False, ET.PRO_LANG, ET.PRO_LANG),
+        (False, None, False, ET.PRO_INTRAFILE, ET.PRO_INTRAFILE),
+        (False, None, False, ET.PRO_INTERFILE, ET.PRO_INTERFILE),
         # semgrep ci with toggle on, full scan
-        (True, True, None, ET.PRO_INTERFILE),
-        (True, True, ET.OSS, ET.OSS),
-        (True, True, ET.PRO_LANG, ET.PRO_LANG),
-        (True, True, ET.PRO_INTRAFILE, ET.PRO_INTRAFILE),
-        (True, True, ET.PRO_INTERFILE, ET.PRO_INTERFILE),
+        (True, True, False, None, ET.PRO_INTERFILE),
+        (True, True, False, ET.OSS, ET.OSS),
+        (True, True, False, ET.PRO_LANG, ET.PRO_LANG),
+        (True, True, False, ET.PRO_INTRAFILE, ET.PRO_INTRAFILE),
+        (True, True, False, ET.PRO_INTERFILE, ET.PRO_INTERFILE),
         # semgrep ci with toggle on, diff scan
-        (True, False, None, ET.PRO_INTRAFILE),
-        (True, False, ET.OSS, ET.OSS),
-        (True, False, ET.PRO_LANG, ET.PRO_LANG),
-        (True, False, ET.PRO_INTRAFILE, ET.PRO_INTRAFILE),
-        (True, False, ET.PRO_INTERFILE, ET.PRO_INTRAFILE),
+        (True, False, False, None, ET.PRO_INTRAFILE),
+        (True, False, False, ET.OSS, ET.OSS),
+        (True, False, False, ET.PRO_LANG, ET.PRO_LANG),
+        (True, False, False, ET.PRO_INTRAFILE, ET.PRO_INTRAFILE),
+        (True, False, False, ET.PRO_INTERFILE, ET.PRO_INTRAFILE),
+        (True, False, True, ET.PRO_INTERFILE, ET.PRO_INTERFILE),
         # semgrep ci with toggle off, full scan
-        (False, True, None, ET.OSS),
-        (False, True, ET.OSS, ET.OSS),
-        (False, True, ET.PRO_LANG, ET.PRO_LANG),
-        (False, True, ET.PRO_INTRAFILE, ET.PRO_INTRAFILE),
-        (False, True, ET.PRO_INTERFILE, ET.PRO_INTERFILE),
-        # semgrep ci with toggle off, full scan
-        (False, False, None, ET.OSS),
-        (False, False, ET.OSS, ET.OSS),
-        (False, False, ET.PRO_LANG, ET.PRO_LANG),
-        (False, False, ET.PRO_INTRAFILE, ET.PRO_INTRAFILE),
-        (False, False, ET.PRO_INTERFILE, ET.PRO_INTRAFILE),
+        (False, True, False, None, ET.OSS),
+        (False, True, False, ET.OSS, ET.OSS),
+        (False, True, False, ET.PRO_LANG, ET.PRO_LANG),
+        (False, True, False, ET.PRO_INTRAFILE, ET.PRO_INTRAFILE),
+        (False, True, False, ET.PRO_INTERFILE, ET.PRO_INTERFILE),
+        # semgrep ci with toggle off, diff scan
+        (False, False, False, None, ET.OSS),
+        (False, False, False, ET.OSS, ET.OSS),
+        (False, False, False, ET.PRO_LANG, ET.PRO_LANG),
+        (False, False, False, ET.PRO_INTRAFILE, ET.PRO_INTRAFILE),
+        (False, False, False, ET.PRO_INTERFILE, ET.PRO_INTRAFILE),
+        (False, False, True, ET.PRO_INTERFILE, ET.PRO_INTERFILE),
     ],
 )
 def test_decide_engine_type(
-    mocker, is_cloud_flag_on, is_ci_scan_full, requested, expected
+    mocker, is_cloud_flag_on, is_ci_scan_full, enable_pro_diff, requested, expected
 ):
     scan_handler = None
     git_meta = None
@@ -54,4 +56,12 @@ def test_decide_engine_type(
         git_meta = mocker.Mock(spec=GitMeta)
         git_meta.is_full_scan = is_ci_scan_full
 
-    assert ET.decide_engine_type(requested, scan_handler, git_meta) == expected
+    assert (
+        ET.decide_engine_type(
+            requested_engine=requested,
+            scan_handler=scan_handler,
+            git_meta=git_meta,
+            enable_pro_diff_scan=enable_pro_diff,
+        )
+        == expected
+    )

--- a/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -92,6 +92,7 @@ let default : conf =
         exclude = [];
         include_ = None;
         baseline_commit = None;
+        diff_depth = 2;
         max_target_bytes = 1_000_000 (* 1 MB *);
         respect_git_ignore = true;
         scan_unknown_extensions = false;
@@ -282,6 +283,18 @@ given baseline hash doesn't exist.
              supports only one environment variable per option *)
   in
   Arg.value (Arg.opt Arg.(some string) None info)
+
+let o_diff_depth : int Term.t =
+  let info =
+    Arg.info [ "diff-depth" ]
+      ~doc:
+        {|The depth of the Pro (interfile) differential scan, the number of
+       steps (both in the caller and callee sides) from the targets in the
+       call graph tracked by the deep preprocessor. Only applied in differential
+       scan mode. Default to 2.
+       |}
+  in
+  Arg.value (Arg.opt Arg.int default.targeting_conf.diff_depth info)
 
 (* ------------------------------------------------------------------ *)
 (* Performance and memory options *)
@@ -791,16 +804,16 @@ let cmdline_term ~allow_empty_config : conf Term.t =
   (* !The parameters must be in alphabetic orders to match the order
    * of the corresponding '$ o_xx $' further below! *)
   let combine allow_untrusted_postprocessors ast_caching autofix baseline_commit
-      common config dataflow_traces dryrun dump_ast dump_command_for_core
-      dump_engine_path emacs error exclude exclude_rule_ids force_color
-      gitlab_sast gitlab_secrets include_ json junit_xml lang max_chars_per_line
-      max_lines_per_finding max_memory_mb max_target_bytes metrics num_jobs
-      nosem optimizations oss output pattern pro project_root pro_intrafile
-      pro_lang registry_caching replacement respect_git_ignore rewrite_rule_ids
-      sarif scan_unknown_extensions secrets severity show_supported_languages
-      strict target_roots test test_ignore_todo text time_flag timeout
-      _timeout_interfileTODO timeout_threshold validate version version_check
-      vim =
+      common config dataflow_traces diff_depth dryrun dump_ast
+      dump_command_for_core dump_engine_path emacs error exclude
+      exclude_rule_ids force_color gitlab_sast gitlab_secrets include_ json
+      junit_xml lang max_chars_per_line max_lines_per_finding max_memory_mb
+      max_target_bytes metrics num_jobs nosem optimizations oss output pattern
+      pro project_root pro_intrafile pro_lang registry_caching replacement
+      respect_git_ignore rewrite_rule_ids sarif scan_unknown_extensions secrets
+      severity show_supported_languages strict target_roots test
+      test_ignore_todo text time_flag timeout _timeout_interfileTODO
+      timeout_threshold validate version version_check vim =
     (* ugly: call setup_logging ASAP so the Logs.xxx below are displayed
      * correctly *)
     Logs_helpers.setup_logging ~force_color
@@ -935,6 +948,7 @@ let cmdline_term ~allow_empty_config : conf Term.t =
         exclude;
         include_;
         baseline_commit;
+        diff_depth;
         max_target_bytes;
         scan_unknown_extensions;
         respect_git_ignore;
@@ -1106,13 +1120,13 @@ let cmdline_term ~allow_empty_config : conf Term.t =
      * combine above! *)
     const combine $ o_allow_untrusted_postprocessors $ o_ast_caching $ o_autofix
     $ o_baseline_commit $ CLI_common.o_common $ o_config $ o_dataflow_traces
-    $ o_dryrun $ o_dump_ast $ o_dump_command_for_core $ o_dump_engine_path
-    $ o_emacs $ o_error $ o_exclude $ o_exclude_rule_ids $ o_force_color
-    $ o_gitlab_sast $ o_gitlab_secrets $ o_include $ o_json $ o_junit_xml
-    $ o_lang $ o_max_chars_per_line $ o_max_lines_per_finding $ o_max_memory_mb
-    $ o_max_target_bytes $ o_metrics $ o_num_jobs $ o_nosem $ o_optimizations
-    $ o_oss $ o_output $ o_pattern $ o_pro $ o_project_root $ o_pro_intrafile
-    $ o_pro_languages $ o_registry_caching $ o_replacement
+    $ o_diff_depth $ o_dryrun $ o_dump_ast $ o_dump_command_for_core
+    $ o_dump_engine_path $ o_emacs $ o_error $ o_exclude $ o_exclude_rule_ids
+    $ o_force_color $ o_gitlab_sast $ o_gitlab_secrets $ o_include $ o_json
+    $ o_junit_xml $ o_lang $ o_max_chars_per_line $ o_max_lines_per_finding
+    $ o_max_memory_mb $ o_max_target_bytes $ o_metrics $ o_num_jobs $ o_nosem
+    $ o_optimizations $ o_oss $ o_output $ o_pattern $ o_pro $ o_project_root
+    $ o_pro_intrafile $ o_pro_languages $ o_registry_caching $ o_replacement
     $ o_respect_git_ignore $ o_rewrite_rule_ids $ o_sarif
     $ o_scan_unknown_extensions $ o_secrets $ o_severity
     $ o_show_supported_languages $ o_strict $ o_target_roots $ o_test

--- a/src/osemgrep/language_server/UserSettings.ml
+++ b/src/osemgrep/language_server/UserSettings.ml
@@ -68,6 +68,7 @@ let find_targets_conf_of_t settings =
       max_target_bytes = settings.max_target_bytes;
       respect_git_ignore = true;
       baseline_commit = None;
+      diff_depth = 0;
       scan_unknown_extensions = true;
       project_root = None;
     }

--- a/src/targeting/Find_targets.ml
+++ b/src/targeting/Find_targets.ml
@@ -55,6 +55,7 @@ type conf = {
   respect_git_ignore : bool;
   (* TODO? use, and better parsing of the string? a Git.version type? *)
   baseline_commit : string option;
+  diff_depth : int;
   (* TODO: use *)
   scan_unknown_extensions : bool;
   (* osemgrep-only: option (see Git_project.ml and the force_root parameter) *)

--- a/src/targeting/Find_targets.mli
+++ b/src/targeting/Find_targets.mli
@@ -18,6 +18,8 @@ type conf = {
   (* TODO: not used for now *)
   baseline_commit : string option;
   (* TODO: not used for now *)
+  diff_depth : int;
+  (* TODO: not used for now *)
   scan_unknown_extensions : bool;
   (* osemgrep-only: option (see Git_project.ml and the force_root parameter) *)
   project_root : Fpath.t option;


### PR DESCRIPTION
This commit adds support for performing differential scans using the Pro engine within PySemgrep. Both the `scan` and `ci` commands have been updated to accommodate this functionality. PySemgrep will automatically switch to differential scan mode when both the `--baseline-commit` and `--pro` flags are specified in the command.

To further enhance flexibility, we have introduced an optional `--diff-depth` parameter. This parameter allows users to adjust the scanning speed, potentially sacrificing some accuracy in the process.

Test Plan:
  - Running diff scan validation script (modified binary path to pysemgrep and `--experimental` flag removed):
https://www.notion.so/semgrep/Differential-Scan-Support-for-Pro-Engine-4bdd04519e524aaeb616dc61b704e043?pvs=4#f02163357b5241c4a5704cee082c9d9b
  - Log:
```
Initialized empty Git repository in test_repos/go_diff_scan_test/tmp_test/.git/
[main (root-commit) 5e13806] commit deps
 3 files changed, 39 insertions(+)
 create mode 100644 test2.go
 create mode 100644 test3.go
 create mode 100644 test4.go
[main 861e69b] commit sink
 1 file changed, 13 insertions(+)
 create mode 100644 test.go
out of callee depth: OK
[main 20d4295] depth 2 callee
 1 file changed, 1 insertion(+), 1 deletion(-)
depth 2 callee: OK
HEAD is now at 861e69b commit sink
[main 6d48a25] depth 1 callee
 1 file changed, 1 insertion(+), 1 deletion(-)
depth 1 callee: OK
[main 2e5ad1c] remove pre-existing
 1 file changed, 9 insertions(+)
remove pre-existing: OK
[main 7ddb5ef] remove sources
 3 files changed, 3 insertions(+), 3 deletions(-)
no sources: OK
[main 4bb5d75] out of caller depth
 1 file changed, 1 insertion(+), 1 deletion(-)
out of caller depth: OK
[main 35a1425] depth 2 caller
 1 file changed, 1 insertion(+), 1 deletion(-)
depth 2 caller: OK
[main 58a0329] depth 1 caller
 1 file changed, 1 insertion(+), 1 deletion(-)
depth 1 caller: OK

```

  - actual command line per diff scan mode
```
> semgrep ci --baseline-commit HEAD~1 -d (per-file diff scan)

semgrep-core -json -rules /Users/heejong/.semgrep/semgrep_rules.json \
-targets /Users/heejong/.semgrep/semgrep_targets.txt -j 10 -timeout 30 -timeout_threshold 3 \
-max_memory 0 -json_time -fast

> semgrep ci --pro -d (inter-file whole scan)

semgrep-core-proprietary -json -rules /Users/heejong/.semgrep/semgrep_rules.json \
-targets /Users/heejong/.semgrep/semgrep_targets.txt -j 1 -timeout 30 -timeout_threshold 3 \
-max_memory 5000 -json_time -fast -deep_inter_file -timeout_for_interfile_analysis 10800 .

> semgrep ci --baseline-commit HEAD~1 --pro -d (intra-file diff scan)

semgrep-core-proprietary -json -rules /Users/heejong/.semgrep/semgrep_rules.json \
-targets /Users/heejong/.semgrep/semgrep_targets.txt -j 10 -timeout 30 -timeout_threshold 3 \
-max_memory 0 -json_time -fast -deep_intra_file

> semgrep ci --baseline-commit HEAD~1 --pro --diff-depth 2 -d (inter-file diff scan, depth 2)

semgrep-core-proprietary -json -rules /Users/heejong/.semgrep/semgrep_rules.json \
-diff_targets /Users/heejong/.semgrep/semgrep_diff_targets.txt -diff_depth 2 \
-targets /Users/heejong/.semgrep/semgrep_targets.txt -j 1 -timeout 30 -timeout_threshold 3 \
-max_memory 5000 -json_time -fast -deep_inter_file -timeout_for_interfile_analysis 10800 .

> semgrep ci --baseline-commit HEAD~1 --pro --diff-depth 0 -d (inter-file diff scan, depth 0)

semgrep-core-proprietary -json -rules /Users/heejong/.semgrep/semgrep_rules.json \
-diff_targets /Users/heejong/.semgrep/semgrep_diff_targets.txt -diff_depth 0 \
-targets /Users/heejong/.semgrep/semgrep_targets.txt -j 1 -timeout 30 -timeout_threshold 3 \
-max_memory 5000 -json_time -fast -deep_inter_file -timeout_for_interfile_analysis 10800 .
```