### PR TITLE
fix: The prefilter table no longer applies between runs

### DIFF
--- a/src/optimizing/Analyze_rule.ml
+++ b/src/optimizing/Analyze_rule.ml
@@ -587,7 +587,7 @@ let regexp_prefilter_of_taint_rule (_rule_id, rule_tok) taint_spec =
   in
   regexp_prefilter_of_formula f
 
-let hmemo = Hashtbl.create 101
+let hmemo = ref (Hashtbl.create 101)
 
 let regexp_prefilter_of_rule (r : R.rule) =
   let rule_id, _t = r.R.id in
@@ -598,7 +598,7 @@ let regexp_prefilter_of_rule (r : R.rule) =
    * which was triggering a FakeInfoStr exn
    *)
   let key = rule_id in
-  Common.memoized hmemo key (fun () ->
+  Common.memoized !hmemo key (fun () ->
       try
         match r.mode with
         | `Search f

--- a/src/optimizing/Analyze_rule.mli
+++ b/src/optimizing/Analyze_rule.mli
@@ -34,3 +34,5 @@ val regexp_prefilter_of_formula : Rule.formula -> prefilter option
  * also prune certain rules/files.
  *)
 val prefilter_formula_of_prefilter : prefilter -> Semgrep_prefilter_t.formula
+
+val hmemo : (Rule_ID.t, prefilter option) Hashtbl.t ref


### PR DESCRIPTION
This is for tests.

See corresponding semgrep-proprietary PR

