### PR TITLE
Add workflow to trigger docs update upon release

### DIFF
--- a/.github/workflows/trigger-doc-update.yml
+++ b/.github/workflows/trigger-doc-update.yml
@@ -17,6 +17,6 @@ jobs:
           curl --location \
           --request POST \
           --header "Accept: application/vnd.github+json" \
-          --header "Authorization: Bearer ${{ secrets.DISPATCH_SECRET }}" \
+          --header "Authorization: Bearer ${{ secrets.DOCS_DISPATCH_SECRET }}" \
           https://api.github.com/repos/returntocorp/semgrep-docs/dispatches \
           --data '{"event_type":"new_release"}'

--- a/.github/workflows/trigger-doc-update.yml
+++ b/.github/workflows/trigger-doc-update.yml
@@ -12,11 +12,16 @@ jobs:
     name: Trigger Doc Update
     runs-on: ubuntu-latest
     steps:
+      - name: Generate a token
+        id: generate_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app_id: ${{ secrets.SEMGREP_DOCS_RELEASE_APP_ID }}
+          private_key: ${{ secrets.SEMGREP_DOCS_RELEASE_PRIVATE_KEY }}
+          repositories: "semgrep-docs"
       - name: Trigger doc update workflow
+        env:
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
         run: |
-          curl --location \
-          --request POST \
-          --header "Accept: application/vnd.github+json" \
-          --header "Authorization: Bearer ${{ secrets.DOCS_DISPATCH_SECRET }}" \
-          https://api.github.com/repos/returntocorp/semgrep-docs/dispatches \
-          --data '{"event_type":"new_release"}'
+          gh api repos/returntocorp/semgrep-docs/dispatches -f event_type=new_release --verbose
+          

--- a/.github/workflows/trigger-doc-update.yml
+++ b/.github/workflows/trigger-doc-update.yml
@@ -14,9 +14,9 @@ jobs:
     steps:
       - name: Trigger doc update workflow
         run: |
-            curl --location \
-            --request POST \
-            --header "Accept: application/vnd.github+json" \
-            --header "Authorization: Bearer ${{ secrets.DISPATCH_SECRET }}" \
-            https://api.github.com/repos/returntocorp/semgrep-docs/dispatches \
-            --data '{"event_type":"new_release"}'
+          curl --location \
+          --request POST \
+          --header "Accept: application/vnd.github+json" \
+          --header "Authorization: Bearer ${{ secrets.DISPATCH_SECRET }}" \
+          https://api.github.com/repos/returntocorp/semgrep-docs/dispatches \
+          --data '{"event_type":"new_release"}'

--- a/.github/workflows/trigger-doc-update.yml
+++ b/.github/workflows/trigger-doc-update.yml
@@ -1,0 +1,22 @@
+# Name of this GitHub Actions workflow.
+name: Trigger Doc Update
+
+# Only trigger when the release workflow has succeeded
+on:
+  workflow_run:
+    workflows: ["release"]
+    types: [completed]
+
+jobs:
+  trigger-doc-update:
+    name: Trigger Doc Update
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger doc update workflow
+        run: |
+            curl --location \
+            --request POST \
+            --header "Accept: application/vnd.github+json" \
+            --header "Authorization: Bearer ${{ secrets.DISPATCH_SECRET }}" \
+            https://api.github.com/repos/returntocorp/semgrep-docs/dispatches \
+            --data '{"event_type":"new_release"}'

--- a/.github/workflows/trigger-doc-update.yml
+++ b/.github/workflows/trigger-doc-update.yml
@@ -24,4 +24,3 @@ jobs:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
         run: |
           gh api repos/returntocorp/semgrep-docs/dispatches -f event_type=new_release --verbose
-          


### PR DESCRIPTION
A workflow in the main returntocorp/semgrep repo (the one in this PR) would trigger a workflow in the `semgrep-docs` repo (the one in [this PR](https://github.com/returntocorp/semgrep-docs/blob/cdfd885a05999b5083b3b1487cf722c23df6a342/.github/workflows/update-help-command.yml)) whenever there is a new release, and that would in turn update the reference files with the latest command output, thereby keeping our CLI command reference in the docs always up to date.