### PR TITLE
fix: metavariable-type correctly matches non-primitive types in php

### DIFF
--- a/changelog.d/gh-8781.fixed
+++ b/changelog.d/gh-8781.fixed
@@ -1,0 +1,1 @@
+fix: metavariable-type now correctly matches non-primitive types in php

--- a/tests/rules/metavar_type_non_prim_php.php
+++ b/tests/rules/metavar_type_non_prim_php.php
@@ -1,0 +1,9 @@
+<?php
+
+$foo1 = new BAR($x, $y, $z);
+# ruleid: test
+$foo1->exec($args);
+
+$foo2 = new ALICE($x, $y, $z);
+# ok
+$foo2->exec($args);

--- a/tests/rules/metavar_type_non_prim_php.yaml
+++ b/tests/rules/metavar_type_non_prim_php.yaml
@@ -1,0 +1,11 @@
+rules:
+  - id: test
+    patterns:
+      - pattern: $X->exec(...)
+      - metavariable-type:
+          metavariable: $X
+          type: BAR
+    message: foo bar
+    languages:
+      - php
+    severity: ERROR


### PR DESCRIPTION
close #8781 