### PR TITLE
chore: Get contributions using subprocess

### DIFF
--- a/changelog.d/os-967.changed
+++ b/changelog.d/os-967.changed
@@ -1,0 +1,1 @@
+Use subprocess.run to get contributions instead of StreamingSemgrepCore so crashes don't affect the actual scan.

--- a/cli/src/semgrep/core_runner.py
+++ b/cli/src/semgrep/core_runner.py
@@ -85,6 +85,36 @@ INPUT_BUFFER_LIMIT: int = 1024 * 1024 * 1024
 LARGE_READ_SIZE: int = 1024 * 1024 * 512
 
 
+def get_contributions(engine_type: EngineType) -> out.Contributions:
+    binary_path = engine_type.get_binary_path()
+    start = datetime.now()
+    if binary_path is None:  # should never happen, doing this for mypy
+        raise SemgrepError("semgrep engine not found.")
+    cmd = [
+        str(binary_path),
+        "-json",
+        "-dump_contributions",
+    ]
+    env = get_state().env
+
+    try:
+        # nosemgrep: python.lang.security.audit.dangerous-subprocess-use.dangerous-subprocess-use
+        raw_output = subprocess.run(
+            cmd,
+            timeout=env.git_command_timeout,
+            capture_output=True,
+            encoding="utf-8",
+            check=True,
+        ).stdout
+        contributions = out.Contributions.from_json_string(raw_output)
+    except subprocess.CalledProcessError:
+        logger.warning("Failed to collect contributions. Continuing with scan...")
+        contributions = out.Contributions([])
+
+    logger.debug(f"semgrep contributions ran in {datetime.now() - start}")
+    return contributions
+
+
 def setrlimits_preexec_fn() -> None:
     """
     Sets stack limit of current running process to the maximum possible
@@ -1300,32 +1330,6 @@ Exception raised: `{e}`
             raise e
 
     # end _run_rules_direct_to_semgrep_core
-
-    def invoke_semgrep_dump_contributions(self) -> out.Contributions:
-        start = datetime.now()
-        if self._binary_path is None:  # should never happen, doing this for mypy
-            raise SemgrepError("semgrep engine not found.")
-        cmd = [
-            str(self._binary_path),
-            "-json",
-            "-dump_contributions",
-        ]
-        try:
-            # only scanning combined rules
-            runner = StreamingSemgrepCore(cmd, 1, self._engine_type)
-            returncode = runner.execute()
-
-            # Process output
-            output_json = self._extract_core_output(
-                [], returncode, " ".join(cmd), runner.stdout, runner.stderr
-            )
-            contributions = out.Contributions.from_json(output_json)
-        except SemgrepError:
-            logger.warning("Failed to collect contributions. Continuing with scan...")
-            contributions = out.Contributions([])
-
-        logger.debug(f"semgrep contributions ran in {datetime.now() - start}")
-        return contributions
 
     def invoke_semgrep_core(
         self,

--- a/cli/src/semgrep/run_scan.py
+++ b/cli/src/semgrep/run_scan.py
@@ -41,6 +41,7 @@ from semgrep.constants import DEFAULT_TIMEOUT
 from semgrep.constants import OutputFormat
 from semgrep.constants import RuleSeverity
 from semgrep.core_runner import CoreRunner
+from semgrep.core_runner import get_contributions
 from semgrep.core_runner import Plan
 from semgrep.engine import EngineType
 from semgrep.error import FilesNotFoundError
@@ -544,7 +545,7 @@ def run_scan(
     )
 
     if dump_contributions:
-        contributions = core_runner.invoke_semgrep_dump_contributions()
+        contributions = get_contributions(engine_type)
     else:
         contributions = out.Contributions([])
 

--- a/cli/tests/unit/test_dump_contributions.py
+++ b/cli/tests/unit/test_dump_contributions.py
@@ -1,6 +1,5 @@
 import json
 import subprocess
-from unittest.mock import MagicMock
 
 import pytest
 
@@ -36,8 +35,8 @@ def mock_subprocess_run(mocker):
 
 @pytest.mark.quick
 @pytest.mark.no_semgrep_cli
-def test_dump_contributions_nominal(mock_state, mock_subprocess_run):
-    proc_result = MagicMock()
+def test_dump_contributions_nominal(mocker, mock_state, mock_subprocess_run):
+    proc_result = mocker.MagicMock()
     proc_result.stdout.return_value = json.dumps([CONTRIBUTION])
     mock_subprocess_run.return_value = proc_result
 

--- a/cli/tests/unit/test_dump_contributions.py
+++ b/cli/tests/unit/test_dump_contributions.py
@@ -1,11 +1,11 @@
 import json
+import subprocess
+from unittest.mock import MagicMock
 
 import pytest
 
-from semgrep.core_runner import CoreRunner
-from semgrep.core_runner import StreamingSemgrepCore
+from semgrep.core_runner import get_contributions
 from semgrep.engine import EngineType
-from semgrep.error import SemgrepError
 
 COMMIT_HASH = "abcd123"
 COMMIT_TIMESTAMP = "2023-09-13T00:00:00"
@@ -23,56 +23,32 @@ CONTRIBUTION = {
 
 
 @pytest.fixture()
-def streaming_semgrep_core(mocker):
-    mocked = mocker.patch.object(StreamingSemgrepCore, "execute")
-    yield mocked
+def mock_state(mocker):
+    mocked = mocker.patch("semgrep.core_runner.get_state")
+    yield mocked.return_value
 
 
 @pytest.fixture()
-def core_runner_output(mocker, streaming_semgrep_core):
-    mocked = mocker.patch.object(CoreRunner, "_extract_core_output")
+def mock_subprocess_run(mocker):
+    mocked = mocker.patch("semgrep.core_runner.subprocess.run")
     yield mocked
 
 
 @pytest.mark.quick
 @pytest.mark.no_semgrep_cli
-def test_dump_contributions_nominal(core_runner_output):
-    core_runner_output.return_value = [CONTRIBUTION]
+def test_dump_contributions_nominal(mock_state, mock_subprocess_run):
+    proc_result = MagicMock()
+    proc_result.stdout.return_value = json.dumps([CONTRIBUTION])
+    mock_subprocess_run.return_value = proc_result
 
-    core_runner = CoreRunner(
-        jobs=1,
-        engine_type=EngineType.OSS,
-        run_secrets=False,
-        timeout=1,
-        max_memory=0,
-        interfile_timeout=0,
-        timeout_threshold=0,
-        optimizations="none",
-        allow_untrusted_postprocessors=False,
-        core_opts_str=None,
-    )
-
-    contributions = core_runner.invoke_semgrep_dump_contributions()
+    contributions = get_contributions(EngineType.OSS)
     assert contributions.to_json_string() == json.dumps([CONTRIBUTION])
 
 
 @pytest.mark.quick
 @pytest.mark.no_semgrep_cli
-def test_dump_contributions_failed(core_runner_output):
-    core_runner_output.side_effect = SemgrepError()
+def test_dump_contributions_failed(mock_state, mock_subprocess_run):
+    mock_subprocess_run.side_effect = subprocess.CalledProcessError(1, "/bin/semgrep")
 
-    core_runner = CoreRunner(
-        jobs=1,
-        engine_type=EngineType.OSS,
-        run_secrets=False,
-        timeout=1,
-        max_memory=0,
-        interfile_timeout=0,
-        timeout_threshold=0,
-        optimizations="none",
-        allow_untrusted_postprocessors=False,
-        core_opts_str=None,
-    )
-
-    contributions = core_runner.invoke_semgrep_dump_contributions()
+    contributions = get_contributions(EngineType.OSS)
     assert contributions.value == []

--- a/cli/tests/unit/test_dump_contributions.py
+++ b/cli/tests/unit/test_dump_contributions.py
@@ -37,7 +37,7 @@ def mock_subprocess_run(mocker):
 @pytest.mark.no_semgrep_cli
 def test_dump_contributions_nominal(mocker, mock_state, mock_subprocess_run):
     proc_result = mocker.MagicMock()
-    proc_result.stdout.return_value = json.dumps([CONTRIBUTION])
+    proc_result.stdout = json.dumps([CONTRIBUTION])
     mock_subprocess_run.return_value = proc_result
 
     contributions = get_contributions(EngineType.OSS)


### PR DESCRIPTION
There are still some cases where dumping the contributions causes scans to fail because the event-loop crashes and cannot recover. 

Let's move the `dump_contributions` call to `subprocess.run` so that if it crashes, it doesn't affect the StreamingSemgrepCore or CoreRunner used for the actual scan.
