### PR TITLE
feat: allow mocking network requests based on environment variable

### DIFF
--- a/src/core_scan/Core_scan.ml
+++ b/src/core_scan/Core_scan.ml
@@ -968,6 +968,15 @@ let scan_with_exn_handler (config : Core_scan_config.t) :
     let timed_rules =
       Common.with_time (fun () -> rules_from_rule_source config)
     in
+    (* Configure HTTP mocking based on network file provided by environment
+       variable. An environment variable is used to (1) avoid needing to thread
+       a command line flag throughout and (2) for ease of testing, given there
+       isn't a reason to use this option in a production environment *)
+    Sys.getenv_opt "SEMGREP_MOCK_NETWORK"
+    |> Option.map (fun network_file ->
+           Http_helpers.client_ref :=
+             fst @@ Http_mock_client.client_from_file network_file)
+    |> ignore;
     (* The pre and post processors hook here is currently just used
        for the secrets post processor, but it should now be trivial to
        hook any post processing step that needs to look at rules and

--- a/src/core_scan/dune
+++ b/src/core_scan/dune
@@ -6,6 +6,7 @@
     parmap
 
     commons
+    networking
 
     semgrep_core
     semgrep_parsing


### PR DESCRIPTION
This adds an environment variable `SEMGREP_MOCK_NETWORK`, which if set, gives a file path for a "network file" (see, e.g., https://github.com/returntocorp/semgrep/pull/8667) which is used to create an HTTP mock at the scan entry point.

Test plan: equivalent PR in pro.