### PR TITLE
ci: configure permissions for the pr-checklist workflow

### DIFF
--- a/.github/workflows/pr-checklist.yaml
+++ b/.github/workflows/pr-checklist.yaml
@@ -28,6 +28,13 @@ on:
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+# This permission is needed to comment on a PR. Some GitHub bots
+# such as dependabot only have read permission by default.
+#
+# See:
+# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#changing-github_token-permissions
+#
+# Without this permission, this workflow will fail in those cases.
 permissions:
   pull-requests: write
 

--- a/.github/workflows/pr-checklist.yaml
+++ b/.github/workflows/pr-checklist.yaml
@@ -28,6 +28,9 @@ on:
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+permissions:
+  pull-requests: write
+
 jobs:
   add-checklist-comment:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The PR checklist workflow seems to be failing when dependabot creates a PR

According to dependabot's [documentation](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#changing-github_token-permissions), dependabot defaults to read-only permissions, so I'm configuring the workflow config to also add write permissions.

I'm not sure how to test this except wait until next week when dependabot is triggered again, but I think this is low risk and it seems to be what [others have tried](https://github.com/marocchino/sticky-pull-request-comment/issues/930) and succeeded.
