### PR TITLE
fix: support labeled let bindings within Swift case statements

### DIFF
--- a/changelog.d/pa-3120.fixed
+++ b/changelog.d/pa-3120.fixed
@@ -1,0 +1,15 @@
+Support labeled let bindings within Swift case statements
+
+Correctly parsing labeled let bindings within Swift case statements.
+For instance, the code snippet:
+```
+switch self {
+  case .bar(_, _, x: let y):
+    return y
+}
+```
+
+now successfully matches the pattern:
+```
+switch self {case .$X(..., $Y: $Z): ...}
+```

--- a/languages/swift/generic/Parse_swift_tree_sitter.ml
+++ b/languages/swift/generic/Parse_swift_tree_sitter.ml
@@ -2236,7 +2236,7 @@ and map_tuple_pattern_item (env : env) (x : CST.tuple_pattern_item) : G.pattern
       let v1 = map_bound_identifier env v1 in
       let v2 = (* ":" *) token env v2 in
       let v3 = map_switch_pattern env v3 in
-      todo env (v1, v2, v3)
+      G.OtherPat (("LabeledLet", v2), [ G.Lbli (LId v1); P v3 ])
   | `Bind_pat_with_expr x -> map_switch_pattern env x
 
 (* TODO? return a G.pattern instead which is a PatTuple? *)
@@ -2723,7 +2723,7 @@ and map_switch_entry (env : env) ((v1, v2, v3, v4, v5) : CST.switch_entry) =
   let _TODO = Option.map (* "fallthrough" *) (token env) v5 in
   G.CasesAndBody ([ case ], stmt |> G.s)
 
-and map_switch_pattern (env : env) (x : CST.switch_pattern) =
+and map_switch_pattern (env : env) (x : CST.switch_pattern) : G.pattern =
   map_binding_pattern_with_expr env x
 
 and map_switch_statement (env : env)

--- a/tests/patterns/swift/labeled_binding_in_case_stmt.sgrep
+++ b/tests/patterns/swift/labeled_binding_in_case_stmt.sgrep
@@ -1,0 +1,1 @@
+switch self {case .$X(..., $Y: $Z): ...}

--- a/tests/patterns/swift/labeled_binding_in_case_stmt.swift
+++ b/tests/patterns/swift/labeled_binding_in_case_stmt.swift
@@ -1,0 +1,13 @@
+public var foo: String {
+   // MATCH:
+    switch self {
+        case .bar(_, _, x: let y):
+            return y
+    }
+    // OK:
+    switch self {
+        case .baz(let a):
+            return a
+    }
+}
+


### PR DESCRIPTION
closes pa-3120