### PR TITLE
move sort_cli_matches in renamed Semgrep_output_utils.ml

### DIFF
--- a/src/core/Matching_explanation.ml
+++ b/src/core/Matching_explanation.ml
@@ -44,7 +44,7 @@ type t = {
 (* less: could also display short info on metavar values *)
 let match_to_charpos_range (pm : Pattern_match.t) : string =
   let min_loc, max_loc = pm.range_loc in
-  let startp, endp = Output_utils.position_range min_loc max_loc in
+  let startp, endp = Semgrep_output_utils.position_range min_loc max_loc in
   spf "%d-%d" startp.Out.offset endp.Out.offset
 
 (* alt: use Format module *)

--- a/src/core/Semgrep_output_utils.ml
+++ b/src/core/Semgrep_output_utils.ml
@@ -188,7 +188,7 @@ let sort_core_matches (matches : core_match list) : core_match list =
    Order by:
      file path, start line, start column, end line, end column, rule name
 
-   This uses the same ordering as in pysemgrep.
+   This uses the same ordering as in pysemgrep in RuleMatch.get_ordering_key()
 *)
 let compare_cli_matches (a : cli_match) (b : cli_match) =
   let c = String.compare a.path b.path in

--- a/src/core/Semgrep_output_utils.mli
+++ b/src/core/Semgrep_output_utils.mli
@@ -32,5 +32,9 @@ val tokens_to_single_loc : Tok.t list -> Semgrep_output_v1_t.location option
    Sort results in the most natural way possible, typically preferring
    match location first.
 *)
-val sort_match_results :
-  Semgrep_output_v1_t.core_output -> Semgrep_output_v1_t.core_output
+val sort_core_matches :
+  Semgrep_output_v1_t.core_match list -> Semgrep_output_v1_t.core_match list
+
+(* Sort matches in an order suitable for displaying results. *)
+val sort_cli_matches :
+  Semgrep_output_v1_t.cli_match list -> Semgrep_output_v1_t.cli_match list

--- a/src/osemgrep/cli_scan/Output.ml
+++ b/src/osemgrep/cli_scan/Output.ml
@@ -118,7 +118,7 @@ let dispatch_output_format (output_format : Output_format.t)
                     * contains a string, not a string list.
                     *)
                    match
-                     Output_utils.lines_of_file_at_range (start, end_)
+                     Semgrep_output_utils.lines_of_file_at_range (start, end_)
                        (Fpath.v path)
                    with
                    | [] -> ""

--- a/src/osemgrep/reporting/Cli_json_output.ml
+++ b/src/osemgrep/reporting/Cli_json_output.ml
@@ -65,7 +65,7 @@ let interpolate_metavars (text : string) (metavars : metavars) (file : filename)
          let (v : Out.metavar_value) = mval in
          let content =
            lazy
-             (Output_utils.content_of_file_at_range (v.start, v.end_)
+             (Semgrep_output_utils.content_of_file_at_range (v.start, v.end_)
                 (Fpath.v file))
          in
          text
@@ -428,7 +428,7 @@ let cli_match_of_core_match (hrules : Rule.hrules) (m : Out.core_match) :
       (* TODO? at this point why not using content_of_file_at_range since
        * we concatenate the lines after? *)
       let lines =
-        Output_utils.lines_of_file_at_range (start, end_) (Fpath.v path)
+        Semgrep_output_utils.lines_of_file_at_range (start, end_) (Fpath.v path)
         |> String.concat "\n"
       in
       {
@@ -462,34 +462,6 @@ let cli_match_of_core_match (hrules : Rule.hrules) (m : Out.core_match) :
       }
 
 (*
-   Order by:
-     file path, start line, start column, end line, end column, rule name
-
-   This uses the same ordering as in pysemgrep.
-*)
-let compare_cli_matches (a : Out.cli_match) (b : Out.cli_match) =
-  let c = String.compare a.path b.path in
-  if c <> 0 then c
-  else
-    let a_start = a.start in
-    let b_start = b.start in
-    let c = Int.compare a_start.line b_start.line in
-    if c <> 0 then c
-    else
-      let c = Int.compare a_start.col b_start.col in
-      if c <> 0 then c
-      else
-        let a_end = a.end_ in
-        let b_end = b.end_ in
-        let c = Int.compare a_end.line b_end.line in
-        if c <> 0 then c
-        else
-          let c = Int.compare a_end.col b_end.col in
-          if c <> 0 then c else String.compare a.check_id b.check_id
-
-let sort_cli_matches xs = List.sort compare_cli_matches xs
-
-(*
  # Sort results so as to guarantee the same results across different
  # runs. Results may arrive in a different order due to parallelism
  # (-j option).
@@ -505,7 +477,7 @@ let dedup_and_sort (xs : Out.cli_match list) : Out.cli_match list =
            let key = x in
            Hashtbl.replace seen key true;
            true)
-  |> sort_cli_matches
+  |> Semgrep_output_utils.sort_cli_matches
 
 (* This is the same algorithm for indexing as in pysemgrep. We shouldn't need to update this *)
 (* match based ids have an index appended at the end which indicates what

--- a/src/osemgrep/reporting/Cli_json_output.mli
+++ b/src/osemgrep/reporting/Cli_json_output.mli
@@ -7,10 +7,6 @@ val cli_output_of_core_results :
   Fpath.t Set_.t ->
   Semgrep_output_v1_j.cli_output
 
-(* Sort matches in an order suitable for displaying results. *)
-val sort_cli_matches :
-  Semgrep_output_v1_t.cli_match list -> Semgrep_output_v1_t.cli_match list
-
 (* internals used in Scan_subcommant.ml *)
 val exit_code_of_error_type : Semgrep_output_v1_t.core_error_kind -> Exit_code.t
 

--- a/src/osemgrep/reporting/Matches_report.ml
+++ b/src/osemgrep/reporting/Matches_report.ml
@@ -283,7 +283,7 @@ let pp_text_outputs ~max_chars_per_line ~max_lines_per_finding ~color_output ppf
 let pp_cli_output ~max_chars_per_line ~max_lines_per_finding ~color_output ppf
     (cli_output : Out.cli_output) =
   let groups =
-    cli_output.results |> Cli_json_output.sort_cli_matches
+    cli_output.results |> Semgrep_output_utils.sort_cli_matches
     |> Common.group_by (fun (m : Out.cli_match) ->
            (* TODO: python (text.py):
               if match.product == RuleProduct.sast:

--- a/src/parsing/Parse_target.ml
+++ b/src/parsing/Parse_target.ml
@@ -45,7 +45,9 @@ let errors_from_skipped_tokens xs =
   | x :: _ ->
       let e = exn_of_loc x in
       let err = E.exn_to_error None x.Tok.pos.file e in
-      let locs = xs |> Common.map Output_utils.location_of_token_location in
+      let locs =
+        xs |> Common.map Semgrep_output_utils.location_of_token_location
+      in
       Core_error.ErrorSet.singleton { err with typ = Out.PartialParsing locs }
 
 let undefined_just_parse_with_lang _lang _file =

--- a/src/reporting/Core_json_output.ml
+++ b/src/reporting/Core_json_output.ml
@@ -24,6 +24,7 @@ module PM = Pattern_match
 open Pattern_match
 module SJ = Semgrep_output_v1_j (* JSON conversions *)
 module Out = Semgrep_output_v1_t (* atdgen definitions *)
+module OutUtils = Semgrep_output_utils
 
 (*****************************************************************************)
 (* Types *)
@@ -87,7 +88,7 @@ let range_of_any_opt startp_of_match_range any =
   | Lbli _
   | Anys _ ->
       let* min_loc, max_loc = AST_generic_helpers.range_of_any_opt any in
-      let startp, endp = Output_utils.position_range min_loc max_loc in
+      let startp, endp = OutUtils.position_range min_loc max_loc in
       Some (startp, endp)
 
 (*****************************************************************************)
@@ -171,10 +172,10 @@ let metavars startp_of_match_range (s, mval) =
  * pysemgrep).
  *)
 let content_of_loc (loc : Out.location) : string =
-  Output_utils.content_of_file_at_range (loc.start, loc.end_) (Fpath.v loc.path)
+  OutUtils.content_of_file_at_range (loc.start, loc.end_) (Fpath.v loc.path)
 
 let token_to_intermediate_var token : Out.match_intermediate_var option =
-  let* location = Output_utils.tokens_to_single_loc [ token ] in
+  let* location = OutUtils.tokens_to_single_loc [ token ] in
   Some
     ({ Out.location; content = content_of_loc location }
       : Out.match_intermediate_var)
@@ -186,10 +187,10 @@ let rec taint_call_trace (trace : PM.taint_call_trace) :
     Out.match_call_trace option =
   match trace with
   | Toks toks ->
-      let* loc = Output_utils.tokens_to_single_loc toks in
+      let* loc = OutUtils.tokens_to_single_loc toks in
       Some (Out.CliLoc (loc, content_of_loc loc))
   | Call { call_trace; intermediate_vars; call_toks } ->
-      let* loc = Output_utils.tokens_to_single_loc call_toks in
+      let* loc = OutUtils.tokens_to_single_loc call_toks in
       let intermediate_vars = tokens_to_intermediate_vars intermediate_vars in
       let* call_trace = taint_call_trace call_trace in
       Some
@@ -223,7 +224,7 @@ let taint_trace_to_dataflow_trace (traces : PM.taint_trace_item list) :
 let unsafe_match_to_match render_fix_opt (x : Pattern_match.t) : Out.core_match
     =
   let min_loc, max_loc = x.range_loc in
-  let startp, endp = Output_utils.position_range min_loc max_loc in
+  let startp, endp = OutUtils.position_range min_loc max_loc in
   let dataflow_trace =
     Option.map
       (function
@@ -289,7 +290,7 @@ let match_to_match render_fix (x : Pattern_match.t) :
  *)
 let error_to_error err =
   let file = err.E.loc.pos.file in
-  let startp, endp = Output_utils.position_range err.E.loc err.E.loc in
+  let startp, endp = OutUtils.position_range err.E.loc err.E.loc in
   let rule_id = Option.map Rule_ID.to_string err.E.rule_id in
   let error_type = err.E.typ in
   let severity = E.severity_of_error err.E.typ in
@@ -312,7 +313,7 @@ let rec explanation_to_explanation (exp : Matching_explanation.t) :
     Out.op;
     children = children |> Common.map explanation_to_explanation;
     matches = matches |> Common.map (unsafe_match_to_match None);
-    loc = Output_utils.location_of_token_location tloc;
+    loc = OutUtils.location_of_token_location tloc;
   }
 
 let profiling_to_profiling (profiling_data : Core_profiling.t) : Out.profile =
@@ -400,7 +401,7 @@ let core_output_of_matches_and_errors render_fix nfiles (res : Core_result.t) =
     | Core_profiling.No_info -> (None, None)
   in
   {
-    Out.results = matches;
+    Out.results = matches |> OutUtils.sort_core_matches;
     errors = errs |> Common.map error_to_error;
     skipped_targets;
     skipped_rules =
@@ -410,7 +411,7 @@ let core_output_of_matches_and_errors render_fix nfiles (res : Core_result.t) =
              {
                Out.rule_id = (rule_id :> string);
                details = Rule.string_of_invalid_rule_error_kind kind;
-               position = Output_utils.position_of_token_location loc;
+               position = OutUtils.position_of_token_location loc;
              });
     stats = { okfiles = count_ok; errorfiles = count_errors };
     time = profiling |> Option.map profiling_to_profiling;
@@ -420,7 +421,6 @@ let core_output_of_matches_and_errors render_fix nfiles (res : Core_result.t) =
     rules_by_engine = Common.map convert_rule res.rules_by_engine;
     engine_requested = `OSS;
   }
-  |> Output_utils.sort_match_results
   [@@profiling]
 
 (*****************************************************************************)


### PR DESCRIPTION
Just small followup on Martin's PR which introduced
sort_cli_matches. I think it's a better location for it.

test plan:
make core