### PR TITLE
Using the returntocorp/semgrep:canary docker image in CI!

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -21,8 +21,10 @@ jobs:
   semgrep:
     name: semgrep ci
     runs-on: ubuntu-20.04
+    # We're dogfooding the canary here!
+    # see https://www.notion.so/semgrep/returntocorp-semgrep-canary-docker-canary
     container:
-      image: returntocorp/semgrep
+      image: returntocorp/semgrep:canary
     env:
       SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
     if: (github.actor != 'dependabot[bot]')


### PR DESCRIPTION
See
https://www.notion.so/semgrep/returntocorp-semgrep-canary-docker-canary-45e4927fb1f847429f6064a96bf9dffd?d=3c69c79e4b76466db62647c86fd62a5a#e9fa3fc351274e59a3f9f6b938f5f7a3

test plan:
wait for CI, see if semgrep CI is working