### PR TITLE
build non-root docker image after standard image to maximize use of docker cache

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,7 +106,10 @@ jobs:
   build-test-docker-nonroot:
     uses: ./.github/workflows/build-test-docker.yaml
     secrets: inherit
-    needs: [inputs]
+    # We want to run build-test-docker-nonroot *after*
+    # build-test-docker so that it reuses the warmed-up
+    # docker cache.
+    needs: [inputs, build-test-docker]
     with:
       docker-flavor: |
         latest=auto

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -331,6 +331,10 @@ jobs:
       dry-run: false
 
   build-test-docker-nonroot:
+    # We want to run build-test-docker-nonroot *after*
+    # build-test-docker so that it reuses the warmed-up
+    # docker cache.
+    needs: [build-test-docker]
     uses: ./.github/workflows/build-test-docker.yaml
     secrets: inherit
     with:


### PR DESCRIPTION
Running the `build-test-docker` and `build-test-docker-nonroot` GHA jobs in parallel means that `build-test-docker-nonroot` never benefits from `build-test-docker` warming up the cache. I know it seems counter-intuitive, but running them serially means we ultimately spend _less_ time running `docker build` in total (which in turn means spending less money on GHA and depot.dev)

test plan:
- checks pass