### PR TITLE
fix: Try new type inference even when target is a name

### DIFF
--- a/changelog.d/type-inference.fixed
+++ b/changelog.d/type-inference.fixed
@@ -1,0 +1,1 @@
+fix: Improve typed metavariable matching against expressions consisting of names only.

--- a/src/matching/Generic_vs_generic.ml
+++ b/src/matching/Generic_vs_generic.ml
@@ -1478,13 +1478,17 @@ and m_compatible_type lang typed_mvar t e =
       m_type_ t
         (G.TyPointer (t1, G.TyN (G.Id (("char", tok), id_info)) |> G.t) |> G.t)
       >>= fun () -> envf typed_mvar (MV.E e)
-  (* for matching ids *)
-  (* this is covered by the basic type propagation done in Naming_AST.ml *)
-  | _ta, B.N (B.Id (idb, ({ B.id_type = tb; _ } as id_infob))) ->
-      (* NOTE: Name values must be represented with MV.Id! *)
-      m_type_option_with_hook idb (Some t) !tb >>= fun () ->
-      envf typed_mvar (MV.Id (idb, Some id_infob))
   | _ta, _eb -> (
+      (match (t.G.t, e.G.e) with
+      (* for matching ids *)
+      (* this is covered by the basic type propagation done in Naming_AST.ml *)
+      (* TODO Remove this case in favor of the newer type inference below. *)
+      | _ta, B.N (B.Id (idb, ({ B.id_type = tb; _ } as id_infob))) ->
+          (* NOTE: Name values must be represented with MV.Id! *)
+          m_type_option_with_hook idb (Some t) !tb >>= fun () ->
+          envf typed_mvar (MV.Id (idb, Some id_infob))
+      | _else_ -> fail ())
+      >||>
       let with_bound_metavar =
         match e.G.e with
         | B.N (B.Id (id, info)) ->

--- a/tests/patterns/java/boxing_equivalences_boolean.java
+++ b/tests/patterns/java/boxing_equivalences_boolean.java
@@ -5,9 +5,9 @@ public class boxing_equivalences_boolean {
     java.lang.Boolean b3 = true;
     // MATCH:
     System.out.println(b1);
-    // TODO:
+    // MATCH:
     System.out.println(b2);
-    // TODO:
+    // MATCH:
     System.out.println(b3);
     // MATCH:
     System.out.println(true);

--- a/tests/patterns/java/boxing_equivalences_boxed_boolean.java
+++ b/tests/patterns/java/boxing_equivalences_boxed_boolean.java
@@ -3,11 +3,11 @@ public class boxing_equivalences_boxed_boolean {
     boolean b1 = true;
     Boolean b2 = false;
     java.lang.Boolean b3 = true;
-    // TODO:
+    // MATCH:
     System.out.println(b1);
     // MATCH:
     System.out.println(b2);
-    // TODO:
+    // MATCH:
     System.out.println(b3);
     // MATCH:
     System.out.println(true);

--- a/tests/patterns/java/boxing_equivalences_int.java
+++ b/tests/patterns/java/boxing_equivalences_int.java
@@ -5,9 +5,9 @@ public class boxing_equivalences_int {
     java.lang.Integer i3 = 6;
     // MATCH:
     System.out.println(i1);
-    // TODO:
+    // MATCH:
     System.out.println(i2);
-    // TODO:
+    // MATCH:
     System.out.println(i3);
     // MATCH:
     System.out.println(7);

--- a/tests/patterns/java/boxing_equivalences_integer.java
+++ b/tests/patterns/java/boxing_equivalences_integer.java
@@ -3,11 +3,11 @@ public class boxing_equivalences_integer {
     int i1 = 4;
     Integer i2 = 5;
     java.lang.Integer i3 = 6;
-    // TODO:
+    // MATCH:
     System.out.println(i1);
     // MATCH:
     System.out.println(i2);
-    // TODO:
+    // MATCH:
     System.out.println(i3);
     // MATCH:
     System.out.println(7);

--- a/tests/patterns/java/boxing_equivalences_string.java
+++ b/tests/patterns/java/boxing_equivalences_string.java
@@ -8,7 +8,7 @@ public class boxing_equivalences_string {
     java.lang.String s2 = "asdf";
     // MATCH:
     System.out.println(s1);
-    // TODO:
+    // MATCH:
     System.out.println(s2);
     // MATCH:
     System.out.println("asdf");

--- a/tests/patterns/java/typed_metavar_class.java
+++ b/tests/patterns/java/typed_metavar_class.java
@@ -15,13 +15,13 @@ public class SemgrepTest
     // `Class<MessageDigest>`, not type `MessageDigest`. Maybe the pattern for
     // this shouldn't even involve a typed metavariable?
 
-    // TODO ?:
+    // MATCH:
     MessageDigest md1 = MessageDigest.getInstance("MD5");
 
-    // TODO ?:
+    // MATCH:
     MessageDigest md2 = MessageDigest.getInstance(MD5_1);
 
-    // TODO ?:
+    // MATCH:
     MessageDigest md3 = MessageDigest.getInstance(MD5_2);
 
     int stam1 = 0;


### PR DESCRIPTION
We have a special case for metavariable matching when the target is a name with a resolved type. I tried to remove this in #7929 and sadly had to revert it in #7999.

Ideally we would extend the new, more powerful type inference to be able to handle all of the cases that are handled here. In the meantime, I'd like to have matching try both the existing special case and the new, more general type inference.

I have some upcoming work to untangle boxed and primitive types, as well as Strings, in Java, to support better matching both in OSS and in the Pro Engine and to improve naming and typing in the Pro Engine. This will entail changing how typed metavariables are matched, and I do not want to have to make changes in two places.

This also changes the behavior of one test, which I have previously discussed. It probably shouldn't match, but we currently conflate `X` with `Class<X>` so it does.

Test plan: Automated tests

