### PR TITLE
semgrep.js: set cache-control headers for JS releases + clean up upload conditional

### DIFF
--- a/.github/workflows/build-test-javascript.yaml
+++ b/.github/workflows/build-test-javascript.yaml
@@ -99,7 +99,7 @@ jobs:
     needs: [build-test-js-artifacts]
     # in english: (branch name is "develop") OR (branch name starts with "release-")
     # we restrict this so that we don't fill up the S3 bucket with tons of semgrep.js builds
-    if: (github.ref == 'refs/heads/develop') || startsWith(github.ref, 'refs/heads/release-')
+    if: ${{ (github.ref == 'refs/heads/develop') || startsWith(github.ref, 'refs/heads/release-') }}
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -122,4 +122,14 @@ jobs:
           tar xvzf semgrep-js-artifacts.tar.gz
           branch_name=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
           urlencoded_branch_name=$(printf %s $branch_name | jq -sRr @uri)
-          aws s3 sync /tmp/semgrep/js/ "s3://semgrep-app-static-assets/static/turbo/${urlencoded_branch_name}/"
+
+          cache_control_arg=""
+          if [[ "${branch_name}" =~ "^release-[0-9.]+$" ]]; then
+            # Set the cache-control header if this bundle is a release:
+            # - public: The response can be stored in a shared cache
+            # - max-age=31536000: Cache for up to 1 year
+            # - immutable: The response will not be updated while fresh
+            cache_control_arg="--cache-control public,max-age=31536000,immutable"
+          fi
+
+          aws s3 cp --recursive "${cache_control_arg}" /tmp/semgrep/js/ "s3://semgrep-app-static-assets/static/turbo/${urlencoded_branch_name}/"

--- a/.github/workflows/build-test-javascript.yaml
+++ b/.github/workflows/build-test-javascript.yaml
@@ -4,7 +4,19 @@ name: build-test-javascript
 
 on:
   workflow_dispatch:
+    inputs:
+      upload-artifacts:
+        required: true
+        type: boolean
+        default: false
+        description: Whether or not to upload JS artifacts to S3
   workflow_call:
+    inputs:
+      upload-artifacts:
+        required: true
+        type: boolean
+        default: false
+        description: Whether or not to upload JS artifacts to S3
 
 jobs:
   build-semgrep-js-ocaml:
@@ -97,9 +109,7 @@ jobs:
 
   upload-javascript-artifacts:
     needs: [build-test-js-artifacts]
-    # in english: (branch name is "develop") OR (branch name starts with "release-")
-    # we restrict this so that we don't fill up the S3 bucket with tons of semgrep.js builds
-    if: ${{ (github.ref == 'refs/heads/develop') || startsWith(github.ref, 'refs/heads/release-') }}
+    if: ${{ inputs.upload-artifacts }}
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/.github/workflows/build-test-javascript.yaml
+++ b/.github/workflows/build-test-javascript.yaml
@@ -6,14 +6,12 @@ on:
   workflow_dispatch:
     inputs:
       upload-artifacts:
-        required: true
         type: boolean
         default: false
         description: Whether or not to upload JS artifacts to S3
   workflow_call:
     inputs:
       upload-artifacts:
-        required: true
         type: boolean
         default: false
         description: Whether or not to upload JS artifacts to S3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -398,3 +398,10 @@ jobs:
   build-test-javascript:
     uses: ./.github/workflows/build-test-javascript.yaml
     secrets: inherit
+    with:
+      # we limit artifact uploads to avoid filling the S3 bucket with tons of semgrep.js builds.
+      # we will upload if one of these are true:
+      # - the branch name is "develop" (so that we can test the bleeding edge)
+      # - the branch name starts with "release-" (TODO: move this to release.yml instead)
+      # - the PR is not a fork and has a "publish-js" label
+      upload-artifacts: ${{ (github.ref == 'refs/heads/develop') || startsWith(github.ref, 'refs/heads/release-') || (!github.event.pull_request.head.repo.fork && contains(github.event.pull_request.labels.*.name, 'publish-js')) }}


### PR DESCRIPTION
1. Explicitly set `Cache-Control` header on objects uploaded to S3 if this is part of a release. This will cause browsers to cache the static assets which will improve the playground load time
2. I forgot to wrap `upload-javascript-artifacts`' conditional in `${{ }}`, so lets fix that too 😞 
3. (bonus) while I'm at it, let's factor out the upload logic and bring back the ability to opt-in PRs to upload artifacts via label