### PR TITLE
fix GITHUB_xxx in test env

### DIFF
--- a/cli/tests/e2e/test_ci.py
+++ b/cli/tests/e2e/test_ci.py
@@ -68,7 +68,9 @@ FROZEN_ISOTIMESTAMP = "1970-01-01T00:00:00"
 _cli_src = (Path(__file__).parent.parent.parent / "src").resolve()
 USED_GITHUB_VARS = set(
     subprocess.run(
-        f"git grep -hPo 'GITHUB_[\\w_]*' {_cli_src}", shell=True, capture_output=True
+        f"git grep --recurse-submodules -hPo 'GITHUB_[\\w_]*' {_cli_src}",
+        shell=True,
+        capture_output=True,
     )
     .stdout.decode()
     .strip()
@@ -76,6 +78,7 @@ USED_GITHUB_VARS = set(
 ) - {
     "GITHUB_TOKEN",  # not used in the cli, just passed to the backend
     "GITHUB_EVENT_PATH",  # TODO: mock this for more than just PR events
+    "GITHUB_xxx",  # not used, just an example in comments
 }
 
 assert "GITHUB_ACTIONS" in USED_GITHUB_VARS  # ensure the parsing did something


### PR DESCRIPTION
@aryx [pointed out](https://github.com/returntocorp/semgrep/pull/8671#discussion_r1330229613) that in returntocorp/semgrep#8671 I introduced a quirk where if you had your git config set with `submodule.recurse = true` then `git grep` would behave differently than without.

To work around this, we can force `--recurse-submodules` so that the behavior is consistent regardless of local git config.
This also requires that we put the offending `GITHUB_xxx` from a comment in semgrep-interfaces into the exceptions list.