### PR TITLE
do not call semgrep-core with -json_time unless semgrep --time

### DIFF
--- a/cli/src/semgrep/commands/scan.py
+++ b/cli/src/semgrep/commands/scan.py
@@ -776,8 +776,6 @@ def scan(
     if not interfile_timeout:
         interfile_timeout = 0  # unlimited
 
-    output_time = time_flag
-
     # Note this must be after the call to `terminal.configure` so that verbosity is respected
     possibly_notify_user()
 
@@ -793,7 +791,7 @@ def scan(
         strict=strict,
         verbose_errors=verbose,
         timeout_threshold=timeout_threshold,
-        output_time=output_time,
+        output_time=time_flag,
         output_per_finding_max_lines_limit=max_lines_per_finding,
         output_per_line_max_chars_limit=max_chars_per_line,
         dataflow_traces=dataflow_traces,
@@ -887,6 +885,7 @@ def scan(
                 ) = semgrep.run_scan.run_scan(
                     core_opts_str=core_opts,
                     dump_command_for_core=dump_command_for_core,
+                    time_flag=time_flag,
                     engine_type=engine_type,
                     run_secrets=run_secrets_flag,
                     output_handler=output_handler,

--- a/cli/src/semgrep/core_runner.py
+++ b/cli/src/semgrep/core_runner.py
@@ -1072,6 +1072,7 @@ class CoreRunner:
         rules: List[Rule],
         target_manager: TargetManager,
         dump_command_for_core: bool,
+        time_flag: bool,
         engine: EngineType,
         run_secrets: bool,
     ) -> Tuple[RuleMatchMap, List[SemgrepError], OutputExtra,]:
@@ -1144,8 +1145,10 @@ class CoreRunner:
                 str(self._timeout_threshold),
                 "-max_memory",
                 str(self._max_memory),
-                "-json_time",
             ]
+
+            if time_flag:
+                cmd.append("-json_time")
 
             if self._core_opts:
                 logger.info(
@@ -1282,6 +1285,7 @@ class CoreRunner:
         rules: List[Rule],
         target_manager: TargetManager,
         dump_command_for_core: bool,
+        time_flag: bool,
         engine: EngineType,
         run_secrets: bool,
     ) -> Tuple[RuleMatchMap, List[SemgrepError], OutputExtra,]:
@@ -1298,6 +1302,7 @@ class CoreRunner:
                 rules,
                 target_manager,
                 dump_command_for_core,
+                time_flag,
                 engine,
                 run_secrets,
             )
@@ -1331,6 +1336,7 @@ Exception raised: `{e}`
         target_manager: TargetManager,
         rules: List[Rule],
         dump_command_for_core: bool,
+        time_flag: bool,
         engine: EngineType,
         run_secrets: bool,
     ) -> Tuple[RuleMatchMap, List[SemgrepError], OutputExtra,]:
@@ -1347,6 +1353,7 @@ Exception raised: `{e}`
             rules,
             target_manager,
             dump_command_for_core,
+            time_flag,
             engine,
             run_secrets,
         )

--- a/cli/src/semgrep/run_scan.py
+++ b/cli/src/semgrep/run_scan.py
@@ -253,6 +253,7 @@ def run_rules(
     core_runner: CoreRunner,
     output_handler: OutputHandler,
     dump_command_for_core: bool,
+    time_flag: bool,
     engine_type: EngineType,
     run_secrets: bool = False,
 ) -> Tuple[
@@ -282,6 +283,7 @@ def run_rules(
         target_manager,
         rest_of_the_rules,
         dump_command_for_core,
+        time_flag,
         engine_type,
         run_secrets,
     )
@@ -377,6 +379,7 @@ def run_scan(
     *,
     core_opts_str: Optional[str] = None,
     dump_command_for_core: bool = False,
+    time_flag: bool = False,
     engine_type: EngineType = EngineType.OSS,
     run_secrets: bool = False,
     output_handler: OutputHandler,
@@ -575,6 +578,7 @@ def run_scan(
         core_runner,
         output_handler,
         dump_command_for_core,
+        time_flag,
         engine_type,
         run_secrets,
     )
@@ -646,6 +650,7 @@ def run_scan(
                         core_runner,
                         output_handler,
                         dump_command_for_core,
+                        time_flag,
                         engine_type,
                         run_secrets,
                     )

--- a/cli/tests/e2e/snapshots/test_metrics/test_metrics_payload/pro_flag0/metrics-payload.json
+++ b/cli/tests/e2e/snapshots/test_metrics/test_metrics_payload/pro_flag0/metrics-payload.json
@@ -24,15 +24,6 @@
     }
   },
   "performance": {
-    "fileStats": [
-      {
-        "matchTime": 0.0,
-        "numTimesScanned": 0,
-        "parseTime": 0.0,
-        "runTime": 0.0,
-        "size": 6
-      }
-    ],
     "numRules": 4,
     "numTargets": 1,
     "profilingTimes": {
@@ -41,28 +32,6 @@
       "ignores_time": 0.0,
       "total_time": 0.0
     },
-    "ruleStats": [
-      {
-        "bytesScanned": 0,
-        "matchTime": 0.0,
-        "ruleHash": "0c9be123b69d289f1b0fa65faefade9c76479bae63006869f3ecacd8ffe8b0a8"
-      },
-      {
-        "bytesScanned": 0,
-        "matchTime": 0.0,
-        "ruleHash": "5c6d327ecdc0f6028e2d9a7e79c0ca03887a91189fbfd871286edad46e5d2516"
-      },
-      {
-        "bytesScanned": 0,
-        "matchTime": 0.0,
-        "ruleHash": "c3f79a06bc39dcd0d7ed1e1b676934d1d9fa628d5631ecd666fc204e3d811089"
-      },
-      {
-        "bytesScanned": 0,
-        "matchTime": 0.0,
-        "ruleHash": "f19cada0143903df62f6b421917d325fbbcc5ff6a7c423818030cdf64c828731"
-      }
-    ],
     "totalBytesScanned": 6
   },
   "sent_at": "2017-03-03T00:00:00+09:00",

--- a/cli/tests/e2e/snapshots/test_output/test_debug_experimental_rule/results.txt
+++ b/cli/tests/e2e/snapshots/test_output/test_debug_experimental_rule/results.txt
@@ -43,7 +43,7 @@ Experimental Rules:
   Scanning 1 file.
 Passing whole rules directly to semgrep_core
 Running Semgrep engine with command:
-/<MASKED>/semgrep-core -json -rules <MASKED>.json -j 16 -targets <MASKED> -timeout_threshold 3 -max_memory 0 -fast --debug
+/<MASKED>/semgrep-core -json -rules <MASKED>.json -j 2 -targets <MASKED> -timeout_threshold 3 -max_memory 0 -fast --debug
 --- semgrep-core stderr ---
 <semgrep-core stderr not captured, should be printed above>
 --- end semgrep-core stderr ---

--- a/cli/tests/e2e/snapshots/test_output/test_debug_experimental_rule/results.txt
+++ b/cli/tests/e2e/snapshots/test_output/test_debug_experimental_rule/results.txt
@@ -43,7 +43,7 @@ Experimental Rules:
   Scanning 1 file.
 Passing whole rules directly to semgrep_core
 Running Semgrep engine with command:
-/<MASKED>/semgrep-core -json -rules <MASKED>-json_time -fast --debug
+/<MASKED>/semgrep-core -json -rules <MASKED>.json -j 16 -targets <MASKED> -timeout_threshold 3 -max_memory 0 -fast --debug
 --- semgrep-core stderr ---
 <semgrep-core stderr not captured, should be printed above>
 --- end semgrep-core stderr ---

--- a/cli/tests/e2e/test_metrics.py
+++ b/cli/tests/e2e/test_metrics.py
@@ -215,8 +215,6 @@ def test_metrics_payload(tmp_path, snapshot, mocker, monkeypatch, pro_flag):
     payload = json.loads(mock_post.call_args.kwargs["data"])
     payload["environment"]["version"] = _mask_version(payload["environment"]["version"])
     payload["environment"]["isAuthenticated"] = False
-    # undeterministic
-    del payload["performance"]["maxMemoryBytes"]
 
     snapshot.assert_match(
         json.dumps(payload, indent=2, sort_keys=True), "metrics-payload.json"


### PR DESCRIPTION
Iago is trying to fix -filter-irrelevant-rules, which will
trigger less (but to be correct), which leads to segfault
in elasticsearch because the profiling dump seems too big.
However there is no reason to get this profiling dump
in the JSON since semgrep was not called with --time

test plan:
make e2e