### PR TITLE
GHA workflow to promote returntocorp/semgrep:canary to :latest

### DIFF
--- a/.github/workflows/promote-canary-to-latest.yml
+++ b/.github/workflows/promote-canary-to-latest.yml
@@ -1,0 +1,29 @@
+# Workflow to manually promote the returntocorp/semgrep:canary docker image
+# to returntocorp/semgrep:latest that most customers are using
+
+name: Promote returntocorp/semgrep:canary to :latest
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirmed:
+        description: "Are you sure you want to do this? This is a sensitive operation"
+        type: boolean
+        required: true
+        default: false
+
+jobs:
+  promote:
+    name: promote :canary to :latest
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - run: |
+          if [[ "${{ inputs.confirmeed }}" == "true" ]]; then
+             docker pull returntocorp/semgrep:canary
+             docker tag  returntocorp/semgrep:canary returntocorp/semgrep:latest
+             docker push returntocorp/semgrep:latest
+          fi

--- a/.github/workflows/promote-canary-to-latest.yml
+++ b/.github/workflows/promote-canary-to-latest.yml
@@ -22,8 +22,10 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - run: |
-          if [[ "${{ inputs.confirmeed }}" == "true" ]]; then
-             docker pull returntocorp/semgrep:canary
-             docker tag  returntocorp/semgrep:canary returntocorp/semgrep:latest
+          docker pull returntocorp/semgrep:canary
+          docker tag  returntocorp/semgrep:canary returntocorp/semgrep:latest
+          if [[ "${{ inputs.confirmed }}" == "true" ]]; then
              docker push returntocorp/semgrep:latest
+          else
+             echo "dry-run: not pushing tag upstream
           fi


### PR DESCRIPTION
test plan:
trigger manually from GHA dashboard
hope nothing breaks