### PR TITLE
Use config auto by default for scan command

### DIFF
--- a/changelog.d/grow-50.changed
+++ b/changelog.d/grow-50.changed
@@ -1,0 +1,1 @@
+Use config=auto by default for the scan command when other options are not specified

--- a/cli/src/semgrep/commands/scan.py
+++ b/cli/src/semgrep/commands/scan.py
@@ -806,7 +806,7 @@ def scan(
                     target=targets,
                     pattern=pattern,
                     lang=lang,
-                    configs=(config or []),
+                    configs=(config or ["auto"]),
                     no_rewrite_rule_ids=(not rewrite_rule_ids),
                     jobs=jobs,
                     include=include,

--- a/cli/src/semgrep/config_resolver.py
+++ b/cli/src/semgrep/config_resolver.py
@@ -838,9 +838,4 @@ def get_config(
     else:
         config, errors = Config.from_config_list(config_strs, project_url)
 
-    if not config:
-        raise SemgrepError(
-            f"No config given. Try running with --help to debug or if you want to download a default config, try running with --config r2c"
-        )
-
     return config, errors

--- a/cli/src/semgrep/run_scan.py
+++ b/cli/src/semgrep/run_scan.py
@@ -629,7 +629,9 @@ def run_scan(
     target: Sequence[str],
     pattern: Optional[str],
     lang: Optional[str],
-    configs: Sequence[str],
+    configs: Sequence[
+        str
+    ],  # NOTE: Since the `ci` command reuses this function, we intentionally do not set a default at this level.
     no_rewrite_rule_ids: bool = False,
     jobs: Optional[int] = None,
     include: Optional[Sequence[str]] = None,
@@ -743,6 +745,8 @@ def run_scan(
                 f"invalid configuration file found ({len(config_errors)} configs were invalid)",
                 code=MISSING_CONFIG_EXIT_CODE,
             )
+        # NOTE: We should default to config auto if no config was passed in an earlier step,
+        #       but if we reach this step without a config, we emit the error below.
         if len(configs_obj.valid) == 0:
             raise SemgrepError(
                 """No config given. Run with `--config auto` or see https://semgrep.dev/docs/running-rules/ for instructions on running with a specific config


### PR DESCRIPTION
## Description
This PR applies `--config auto` for the scan command when no other options are specified.

## Changes

Previously, users would see the following error message when running `semgrep scan`:

```
No config given. Run with `--config auto` or see https://semgrep.dev/docs/running-rules/ for instructions on running with a specific config
exiting with error status 2: osemgrep scan
```

Now, scans will proceed with one fewer required argument.

<hr/>

Addresses: https://linear.app/semgrep/issue/grow-50