### PR TITLE
pysemgrep: remove the --core-opts flag

### DIFF
--- a/changelog.d/core_opts.fixed
+++ b/changelog.d/core_opts.fixed
@@ -1,0 +1,1 @@
+The --core-opts flag has been removed.

--- a/cli/src/semgrep/commands/ci.py
+++ b/cli/src/semgrep/commands/ci.py
@@ -181,7 +181,6 @@ def ci(
     # redirect to `--secrets` aka run_secrets_flag.
     beta_testing_secrets: bool,
     code: bool,
-    core_opts: Optional[str],
     config: Optional[Tuple[str, ...]],
     debug: bool,
     dump_command_for_core: bool,
@@ -438,7 +437,6 @@ def ci(
             num_executed_rules,
             contributions,
         ) = semgrep.run_scan.run_scan(
-            core_opts_str=core_opts,
             engine_type=engine_type,
             run_secrets=run_secrets,
             output_handler=output_handler,

--- a/cli/src/semgrep/commands/scan.py
+++ b/cli/src/semgrep/commands/scan.py
@@ -276,12 +276,6 @@ _scan_options: List[Callable] = [
             to 3 hours.
         """,
     ),
-    optgroup.option(
-        "--core-opts",
-        hidden=True,
-        type=str,
-        help="Flags to pass semgrep-core when executing",
-    ),
     optgroup.group("Display options"),
     optgroup.option(
         "--enable-nosem/--disable-nosem",
@@ -578,7 +572,6 @@ def scan(
     autofix: bool,
     baseline_commit: Optional[str],
     config: Optional[Tuple[str, ...]],
-    core_opts: Optional[str],
     debug: bool,
     dump_engine_path: bool,
     requested_engine: Optional[EngineType],
@@ -764,7 +757,6 @@ def scan(
                             interfile_timeout=interfile_timeout,
                             optimizations=optimizations,
                             allow_untrusted_postprocessors=allow_untrusted_postprocessors,
-                            core_opts_str=core_opts,
                         ).validate_configs(config)
                     except SemgrepError as e:
                         metacheck_errors = [e]
@@ -796,7 +788,6 @@ def scan(
                     _num_executed_rules,
                     _,
                 ) = semgrep.run_scan.run_scan(
-                    core_opts_str=core_opts,
                     dump_command_for_core=dump_command_for_core,
                     time_flag=time_flag,
                     engine_type=engine_type,

--- a/cli/src/semgrep/core_runner.py
+++ b/cli/src/semgrep/core_runner.py
@@ -3,7 +3,6 @@ import collections
 import contextlib
 import json
 import resource
-import shlex
 import subprocess
 import sys
 import tempfile
@@ -733,7 +732,6 @@ class CoreRunner:
         interfile_timeout: int,
         optimizations: str,
         allow_untrusted_postprocessors: bool,
-        core_opts_str: Optional[str],
     ):
         self._binary_path = engine_type.get_binary_path()
         self._jobs = jobs or engine_type.default_jobs
@@ -745,7 +743,6 @@ class CoreRunner:
         self._interfile_timeout = interfile_timeout
         self._optimizations = optimizations
         self._allow_untrusted_postprocessors = allow_untrusted_postprocessors
-        self._core_opts = shlex.split(core_opts_str) if core_opts_str else []
 
     def _extract_core_output(
         self,
@@ -1010,12 +1007,6 @@ class CoreRunner:
 
             if time_flag:
                 cmd.append("-json_time")
-
-            if self._core_opts:
-                logger.info(
-                    f"Running with user defined core options: {self._core_opts}"
-                )
-                cmd.extend(self._core_opts)
 
             if self._optimizations != "none":
                 cmd.append("-fast")

--- a/cli/src/semgrep/run_scan.py
+++ b/cli/src/semgrep/run_scan.py
@@ -624,7 +624,6 @@ def run_rules(
 # old: this used to be called semgrep.semgrep_main.main
 def run_scan(
     *,
-    core_opts_str: Optional[str] = None,
     dump_command_for_core: bool = False,
     time_flag: bool = False,
     engine_type: EngineType = EngineType.OSS,
@@ -791,7 +790,6 @@ def run_scan(
         timeout_threshold=timeout_threshold,
         optimizations=optimizations,
         allow_untrusted_postprocessors=allow_untrusted_postprocessors,
-        core_opts_str=core_opts_str,
     )
 
     if dump_contributions:

--- a/cli/tests/e2e/snapshots/test_output/test_debug_experimental_rule/results.txt
+++ b/cli/tests/e2e/snapshots/test_output/test_debug_experimental_rule/results.txt
@@ -43,7 +43,7 @@ Experimental Rules:
   Scanning 1 file.
 Passing whole rules directly to semgrep_core
 Running Semgrep engine with command:
-/<MASKED>/semgrep-core -json -rules <MASKED>.json -j 2 -targets <MASKED> -timeout_threshold 3 -max_memory 0 -fast --debug
+/<MASKED>/semgrep-core -json -rules <MASKED>.json -j <MASKED> -targets <MASKED> -timeout_threshold 3 -max_memory 0 -fast --debug
 --- semgrep-core stderr ---
 <semgrep-core stderr not captured, should be printed above>
 --- end semgrep-core stderr ---

--- a/cli/tests/e2e/test_output.py
+++ b/cli/tests/e2e/test_output.py
@@ -248,6 +248,7 @@ def test_debug_experimental_rule(run_semgrep_in_tmp: RunSemgrep, snapshot):
                 re.compile(r"-targets (.*) -timeout"),
                 re.compile(r"-rules (.*).json"),
                 re.compile(r".*Main.Autofix.*"),
+                re.compile(r"-j ([0-9]+)"),
             ]
         ),
         "results.txt",


### PR DESCRIPTION
We want to move in the direction of not having a semgrep-core.
Moreover osemgrep was not even accepting this flag, and is
now the entry point, which means it could not even work,
so let's just remove it.

test plan:
git grep -- --core-opts
=> no relevant match