### PR TITLE
osemgrep: fix regression in --registry-caching

### DIFF
--- a/changelog.d/gh-8828.fixed
+++ b/changelog.d/gh-8828.fixed
@@ -1,0 +1,2 @@
+fixed the regression in --registry-caching and add better error message
+to tell the user he needs also --experimental.

--- a/libs/networking/dune
+++ b/libs/networking/dune
@@ -7,7 +7,6 @@
     cohttp
     cohttp-lwt-unix
 
-
     profiling
   )
   (preprocess

--- a/libs/networking/http_helpers.ml
+++ b/libs/networking/http_helpers.ml
@@ -1,11 +1,19 @@
 open Cohttp
 
-(* Below we separate the methods out by async (returns Lwt promise),
-   and sync (runs async method in lwt runtime)
-*)
-(* This way we can use the async methods in the language server,
-   and other places too
-*)
+(*****************************************************************************)
+(* Prelude *)
+(*****************************************************************************)
+(* A few helpers to perform http GET and POST requests.
+ *
+ * Below we separate the methods out by async (returns Lwt promise),
+ * and sync (runs async method in lwt runtime)
+ * This way we can use the async methods in the language server,
+ * and other places too.
+ *
+ * Note that using [@@profiling] with xxx_async function is useless
+ * as the actual computation is done in the caller doing the
+ * Lwy_main.run
+ *)
 
 (*****************************************************************************)
 (* Client *)
@@ -36,7 +44,6 @@ let get_async ?(headers = []) url =
       let err = "HTTP GET unexpected response: " ^ code_str ^ ":\n" ^ body in
       Logs.debug (fun m -> m "%s" err);
       Lwt.return (Error err)
-  [@@profiling]
 
 let post_async ~body ?(headers = [ ("content-type", "application/json") ])
     ?(chunked = false) url =
@@ -59,7 +66,6 @@ let post_async ~body ?(headers = [ ("content-type", "application/json") ])
       let err = "HTTP POST unexpected response: " ^ code_str ^ ":\n" ^ body in
       Logs.debug (fun m -> m "%s" err);
       Lwt.return (Error (code, err))
-  [@@profiling]
 
 (*****************************************************************************)
 (* Sync *)

--- a/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -567,6 +567,13 @@ let run_scan_conf (conf : Scan_CLI.conf) : Exit_code.t =
    exit code. *)
 let run_conf (conf : Scan_CLI.conf) : Exit_code.t =
   (match conf.common.maturity with
+  (* those are osemgrep-only option not available in pysemgrep,
+   * so better print a good error message for it.
+   * coupling: see the 'NEW' section in Scan_CLI.ml for all those new flags
+   *)
+  | Maturity.Default
+    when conf.registry_caching || conf.core_runner_conf.ast_caching ->
+      Error.abort "--registry_caching or --ast_caching require --experimental"
   | Maturity.Default -> (
       (* TODO: handle more confs, or fallback to pysemgrep further down *)
       match conf with
@@ -580,6 +587,9 @@ let run_conf (conf : Scan_CLI.conf) : Exit_code.t =
       | _else_ -> raise Pysemgrep.Fallback)
   (* this should never happen because --legacy is handled in cli/bin/semgrep *)
   | Maturity.Legacy -> raise Pysemgrep.Fallback
+  (* ok the user explicitely requested --experimental (or --develop),
+   * let's keep going with osemgrep then
+   *)
   | Maturity.Experimental
   | Maturity.Develop ->
       ());


### PR DESCRIPTION
This closes #8828 and also #8829

test plan:
```
$ semgrep scan --config=p/ocaml src/semgrep --registry-caching --profile --metrics=off
--registry_caching or --ast_caching require --experimental
...
$ semgrep scan --experimental --config=p/ocaml src/semgrep --registry-caching --profile --metrics=off
...
---------------------
profiling result
---------------------
CLI.dispatch_subcommand                  :      0.058 sec          1 count
Find_targets.get_targets                 :      0.054 sec          1 count
Semgrepignore.select                     :      0.053 sec        172 count
Gitignore_filter.select                  :      0.053 sec        172 count
Glob.Match.run                           :      0.035 sec     215840 count
Rule_fetching.rules_from_rules_source    :      0.004 sec          1 count
```