### PR TITLE
Enable supply-chain product for logged-in scans by default

### DIFF
--- a/changelog.d/grow-51.changed
+++ b/changelog.d/grow-51.changed
@@ -1,0 +1,1 @@
+Add supply-chain feature for scan commands while logged in and no other config is provided

--- a/cli/src/semgrep/commands/scan.py
+++ b/cli/src/semgrep/commands/scan.py
@@ -20,6 +20,7 @@ import semgrep.run_scan
 import semgrep.test
 from semgrep import __VERSION__
 from semgrep import bytesize
+from semgrep.app.auth import get_token
 from semgrep.app.version import get_no_findings_msg
 from semgrep.commands.install import determine_semgrep_pro_path
 from semgrep.commands.wrapper import handle_command_errors
@@ -599,6 +600,9 @@ def scan(
                     output_handler.output({}, all_targets=set(), filtered_rules=[])
                     raise SemgrepError("Please fix the above errors and try again.")
         else:
+            # Check if we have an auth token to see if we apply the "supply-chain" flag
+            is_logged_in = get_token() is not None
+            configs = config or (["auto", "supply-chain"] if is_logged_in else ["auto"])
             try:
                 (
                     filtered_matches_by_rule,
@@ -622,7 +626,7 @@ def scan(
                     target=targets,
                     pattern=pattern,
                     lang=lang,
-                    configs=(config or ["auto"]),
+                    configs=configs,
                     no_rewrite_rule_ids=(not rewrite_rule_ids),
                     jobs=jobs,
                     include=include,

--- a/cli/src/semgrep/config_resolver.py
+++ b/cli/src/semgrep/config_resolver.py
@@ -329,35 +329,35 @@ def parse_config_files(
     return config
 
 
-class ConfigPath:
-    def __init__(self, config_str: str, project_url: Optional[str] = None) -> None:
-        self._config_str = config_str
-        self._project_url = project_url
+def resolve_config(
+    config_str: str, project_url: Optional[str] = None
+) -> Dict[str, YamlTree]:
+    """resolves if config arg is a registry entry, a url, or a file, folder, or loads from defaults if None"""
+    start_t = time.time()
+    config_loader = ConfigLoader(config_str, project_url)
+    config = parse_config_files(config_loader.load_config())
 
-    def resolve_config(self) -> Dict[str, YamlTree]:
-        """resolves if config arg is a registry entry, a url, or a file, folder, or loads from defaults if None"""
-        start_t = time.time()
-
-        config = parse_config_files(
-            ConfigLoader(self._config_str, self._project_url).load_config()
-        )
-
-        if config:
-            logger.debug(f"loaded {len(config)} configs in {time.time() - start_t}")
-        return config
-
-    def __str__(self) -> str:
-        # TODO return the resolved config_path
-        return self._config_str
+    if config:
+        logger.debug(f"loaded {len(config)} configs in {time.time() - start_t}")
+    return config
 
 
 class Config:
-    def __init__(self, valid_configs: Mapping[str, Sequence[Rule]]) -> None:
+    def __init__(
+        self,
+        valid_configs: Mapping[str, Sequence[Rule]],
+        *,
+        with_supply_chain: bool = False,
+        with_code_rules: bool = False,
+    ) -> None:
         """
         Handles parsing and validating of config files
         and exposes ability to get all rules in parsed config files
         """
         self.valid = valid_configs
+        self.with_supply_chain = with_supply_chain
+        self.with_code_rules = with_code_rules
+        #   bool(set(config) - {"supply-chain"})
 
     @classmethod
     def from_pattern_lang(
@@ -396,14 +396,19 @@ class Config:
         """
         config_dict: Dict[str, YamlTree] = {}
         errors: List[SemgrepError] = []
+        with_supply_chain = False
+        with_code_rules = False
 
         for i, config in enumerate(configs):
             try:
                 # Patch config_id to fix https://github.com/returntocorp/semgrep/issues/1912
-                resolved_config = ConfigPath(config, project_url).resolve_config()
+                resolved_config = resolve_config(config, project_url)
                 if not resolved_config:
                     logger.verbose(f"Could not resolve config for {config}. Skipping.")
                     continue
+
+                with_code_rules = with_code_rules or not is_supply_chain(config)
+                with_supply_chain = with_supply_chain or is_supply_chain(config)
 
                 for (
                     resolved_config_key,
@@ -420,7 +425,14 @@ class Config:
 
         valid, parse_errors = cls._validate(config_dict)
         errors.extend(parse_errors)
-        return cls(valid), errors
+        return (
+            cls(
+                valid,
+                with_supply_chain=with_supply_chain,
+                with_code_rules=with_code_rules,
+            ),
+            errors,
+        )
 
     def get_rules(self, no_rewrite_rule_ids: bool) -> List[Rule]:
         """

--- a/cli/src/semgrep/config_resolver.py
+++ b/cli/src/semgrep/config_resolver.py
@@ -347,17 +347,16 @@ class Config:
         self,
         valid_configs: Mapping[str, Sequence[Rule]],
         *,
-        with_supply_chain: bool = False,
         with_code_rules: bool = False,
+        with_supply_chain: bool = False,
     ) -> None:
         """
         Handles parsing and validating of config files
         and exposes ability to get all rules in parsed config files
         """
         self.valid = valid_configs
-        self.with_supply_chain = with_supply_chain
         self.with_code_rules = with_code_rules
-        #   bool(set(config) - {"supply-chain"})
+        self.with_supply_chain = with_supply_chain
 
     @classmethod
     def from_pattern_lang(
@@ -428,8 +427,8 @@ class Config:
         return (
             cls(
                 valid,
-                with_supply_chain=with_supply_chain,
                 with_code_rules=with_code_rules,
+                with_supply_chain=with_supply_chain,
             ),
             errors,
         )

--- a/cli/src/semgrep/join_rule.py
+++ b/cli/src/semgrep/join_rule.py
@@ -24,7 +24,7 @@ from ruamel.yaml import YAML
 import semgrep.run_scan
 import semgrep.semgrep_interfaces.semgrep_output_v1 as out
 from semgrep.config_resolver import Config
-from semgrep.config_resolver import ConfigPath
+from semgrep.config_resolver import resolve_config
 from semgrep.constants import RuleSeverity
 from semgrep.error import ERROR_MAP
 from semgrep.error import FATAL_EXIT_CODE
@@ -232,7 +232,7 @@ def create_config_map(semgrep_config_strings: List[str]) -> Dict[str, Rule]:
     """
     config = {}
     for config_string in semgrep_config_strings:
-        resolved = ConfigPath(config_string, get_project_url()).resolve_config()
+        resolved = resolve_config(config_string, get_project_url())
         # Some code-fu to get single rules
         config.update(
             {config_string: list(Config._validate(resolved)[0].values())[0][0]}

--- a/cli/src/semgrep/run_scan.py
+++ b/cli/src/semgrep/run_scan.py
@@ -291,7 +291,9 @@ def print_sca_table(sca_plan: Plan, rule_count: int) -> None:
     )
 
 
-def print_detailed_sca_table(sca_plan: Plan, rule_count: int) -> None:
+def print_detailed_sca_table(
+    sca_plan: Plan, rule_count: int, with_supply_chain: bool = False
+) -> None:
     """
     Pretty print the plan to stdout with the detailed CLI UX.
     """
@@ -309,7 +311,6 @@ def print_detailed_sca_table(sca_plan: Plan, rule_count: int) -> None:
     """
     # 1. Validate that the user is indeed running SCA (and not from semgrep scan).
     is_scan = get_state().is_scan_invocation()
-    is_supply_chain = get_state().is_supply_chain()
     # 2. Check if the user has metrics enabled.
     metrics = get_state().metrics
     metrics_enabled = metrics.is_enabled
@@ -330,7 +331,7 @@ def print_detailed_sca_table(sca_plan: Plan, rule_count: int) -> None:
                     width=70,
                 )
             )
-        elif not is_supply_chain:
+        elif not with_supply_chain:
             message = sep.join(
                 wrap(
                     f"💎 Run {ci_command} to find dependency vulnerabilities and advanced cross-file findings.",
@@ -347,7 +348,10 @@ def print_detailed_sca_table(sca_plan: Plan, rule_count: int) -> None:
 def print_scan_status(
     rules: Sequence[Rule],
     target_manager: TargetManager,
+    *,
     cli_ux: DesignTreatment = DesignTreatment.LEGACY,
+    with_code_rules: bool = True,
+    with_supply_chain: bool = False,
 ) -> int:
     """
     Print a section like:
@@ -408,8 +412,8 @@ def print_scan_status(
     if simple_ux:
         # Print the feature summary table instead of all tables with new simple CLI UX
         print_product_status(
-            sast_enabled=get_state().is_code(),
-            sca_enabled=get_state().is_supply_chain(),
+            sast_enabled=with_code_rules,
+            sca_enabled=with_supply_chain,
         )
         return sast_rule_count + sca_rule_count
 
@@ -451,7 +455,11 @@ def print_scan_status(
     else:
         # Show the table with a supply chain nudge or supply chain
         console.print(Title("Supply Chain Rules", order=2))
-        print_detailed_sca_table(sca_plan=sca_plan, rule_count=alt_sca_rule_count)
+        print_detailed_sca_table(
+            sca_plan=sca_plan,
+            rule_count=alt_sca_rule_count,
+            with_supply_chain=with_supply_chain,
+        )
 
     if detailed_ux:
         console.print(Title("Progress", order=2))
@@ -502,6 +510,8 @@ def run_rules(
     time_flag: bool,
     engine_type: EngineType,
     run_secrets: bool = False,
+    with_code_rules: bool = True,
+    with_supply_chain: bool = False,
 ) -> Tuple[
     RuleMatchMap,
     List[SemgrepError],
@@ -511,7 +521,13 @@ def run_rules(
     int,
 ]:
     cli_ux = get_state().get_cli_ux_flavor()
-    num_executed_rules = print_scan_status(filtered_rules, target_manager, cli_ux)
+    num_executed_rules = print_scan_status(
+        filtered_rules,
+        target_manager,
+        cli_ux=cli_ux,
+        with_code_rules=with_code_rules,
+        with_supply_chain=with_supply_chain,
+    )
 
     join_rules, rest_of_the_rules = partition(
         filtered_rules, lambda rule: rule.mode == JOIN_MODE
@@ -705,6 +721,10 @@ def run_scan(
     all_rules = configs_obj.get_rules(no_rewrite_rule_ids)
     profiler.save("config_time", rule_start_time)
 
+    # We determine if SAST / SCA is enabled based on the config str
+    with_code_rules = configs_obj.with_code_rules
+    with_supply_chain = configs_obj.with_supply_chain
+
     # Metrics send part 1: add environment information
     # Must happen after configs are resolved because it is determined
     # then whether metrics are sent or not
@@ -830,6 +850,8 @@ def run_scan(
         time_flag,
         engine_type,
         run_secrets,
+        with_code_rules,
+        with_supply_chain,
     )
     profiler.save("core_time", core_start_time)
     output_handler.handle_semgrep_errors(semgrep_errors)

--- a/cli/src/semgrep/state.py
+++ b/cli/src/semgrep/state.py
@@ -60,46 +60,6 @@ class SemgrepState:
         command_name = ctx.command.name if hasattr(ctx, "command") else "unset"
         return command_name == "scan"
 
-    @staticmethod
-    def is_supply_chain() -> bool:
-        """
-        Returns True iff the current CLI invocation is a supply chain (SCA) invocation.
-        """
-        ctx = get_context()
-        command_name = ctx.command.name if hasattr(ctx, "command") else "unset"
-        is_scan = command_name == "scan"
-        params = ctx.params if hasattr(ctx, "params") else {}
-        # NOTE: For `semgrep scan`, supply-chain is passed via --config
-        #   e.g. `semgrep scan --config supply-chain`
-        # whereas for `semgrep ci`, supply-chain is passed via --supply-chain
-        #   e.g. `semgrep ci --supply-chain`
-        _is_supply_chain = (
-            "supply-chain" in get_config()
-            if is_scan
-            else params.get("supply_chain")
-            or False  # NOTE: supply_chain no supply-chain for `ci`
-        )
-        return _is_supply_chain
-
-    @staticmethod
-    def is_code() -> bool:
-        """
-        Returns True iff the current CLI invocation includes a code (SAST) invocation.
-        """
-        ctx = get_context()
-        command_name = ctx.command.name if hasattr(ctx, "command") else "unset"
-        is_scan = command_name == "scan"
-        params = ctx.params if hasattr(ctx, "params") else {}
-        config = get_config()
-        # NOTE: For `semgrep scan`, code is passed via --config
-        # whereas for `semgrep ci`, code is passed via --code
-        _is_code = (
-            bool(set(config) - {"supply-chain"})
-            if is_scan
-            else params.get("code") or False
-        )
-        return _is_code
-
 
 def get_context() -> click.Context:
     """

--- a/cli/tests/e2e/snapshots/test_output/test_debug_experimental_rule/results.txt
+++ b/cli/tests/e2e/snapshots/test_output/test_debug_experimental_rule/results.txt
@@ -11,6 +11,7 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
 === end of stdout - plain
 
 === stderr - plain
+Getting API token from settings file
 semgrep version <MASKED>
 Failed to get project url from 'git ls-remote': Command failed with exit code: 128
 -----


### PR DESCRIPTION
## Description

This PR enables the supply-chain product for logged-in scans by default.

## Changes

Before this PR (e.g. #8807), we would need to pass the hidden `supply-chain` flag to enable this feature. Now, we will apply this flag by default for logged-in scans when no other config is specified.

<img width="1376" alt="Screenshot 2023-09-27 at 9 38 38 AM" src="https://github.com/returntocorp/semgrep/assets/5779832/670b4790-68a8-4a59-b608-8b3f51aa5e7b">

### Known Issues

Applying supply-chain by default may introduce additional latency. The operations for dependency vulnerability scanning can be time-intensive to complete, and may be perceived as a performance regression. If this behavior is undesirable, users may elect to specify `--config auto` when running a scan.

<hr/>

**Addresses**: https://linear.app/semgrep/issue/GROW-51