### PR TITLE
fix(swift): Address all remaining "not implemented" errors

### DIFF
--- a/changelog.d/swift-parsing.fixed
+++ b/changelog.d/swift-parsing.fixed
@@ -1,0 +1,1 @@
+Add parsing support for various rare Swift constructs

--- a/libs/lib_parsing/Tok.ml
+++ b/libs/lib_parsing/Tok.ml
@@ -227,6 +227,14 @@ let content_of_tok ii =
   | Ab ->
       raise (NoTokenLocation "content_of_tok: Expanded or Ab")
 
+let content_of_tok_opt ii =
+  match ii with
+  | OriginTok x -> Some x.str
+  | FakeTok (s, _) -> Some s
+  | ExpandedTok _
+  | Ab ->
+      None
+
 (* Token locations are supposed to denote the beginning of a token.
    Suppose we are interested in instead having line, column, and bytepos of
    the end of a token instead.

--- a/libs/lib_parsing/Tok.mli
+++ b/libs/lib_parsing/Tok.mli
@@ -157,8 +157,11 @@ val stringpos_of_tok : t -> string
 (* @raise NoTokenLocation if given an unsafe fake token (without location) *)
 val unsafe_loc_of_tok : t -> location
 
-(* Extract the token (really lexeme) content *)
+(* Unsafe: Extract the token (really lexeme) content *)
 val content_of_tok : t -> string
+
+(* Extract the token (really lexeme) content *)
+val content_of_tok_opt : t -> string option
 
 (* Extract position information *)
 val line_of_tok : t -> int


### PR DESCRIPTION
There were just a handful of Swift constructs that still could lead to exceptions during the translation from the tree sitter CST to the generic AST.

This PR addresses these cases, mostly with the new `Raw_tree` functionality which will at least allow us to perform matching on these constructs.

Test plan: Automated tests

