### PR TITLE
fix js snapshot tests to mask semgrep version

### DIFF
--- a/js/engine/tests/__snapshots__/index.test.js.snap
+++ b/js/engine/tests/__snapshots__/index.test.js.snap
@@ -80,7 +80,7 @@ exports[`yaml parser parses a pattern with pattern-regex 1`] = `
     ],
   ],
   "skipped_rules": [],
-  "version": "1.41.0",
+  "version": "<MASKED>",
 }
 `;
 
@@ -192,6 +192,6 @@ exports[`yaml parser parses a simple pattern 1`] = `
     ],
   ],
   "skipped_rules": [],
-  "version": "1.41.0",
+  "version": "<MASKED>",
 }
 `;

--- a/js/engine/tests/index.test.js
+++ b/js/engine/tests/index.test.js
@@ -44,6 +44,7 @@ describe("yaml parser", () => {
         .replaceAll(targetPath, "test.yaml")
         .replaceAll("PRO", "OSS")
     );
+    result["version"] = "<MASKED>";
     expect(result).toMatchSnapshot();
   });
   test("parses a pattern with pattern-regex", async () => {
@@ -58,7 +59,7 @@ describe("yaml parser", () => {
         .replaceAll(targetPath, "test.yaml")
         .replaceAll("PRO", "OSS")
     );
-
+    result["version"] = "<MASKED>";
     expect(result).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
I'm sure there is a more elegant way to do it, but
I'll let javascript experts fix it the right way.
For now let's unblock the release.

test plan:
make
cd js/tests/engine
make test