### PR TITLE
Get rid of Rule.languages

### DIFF
--- a/src/core/Mini_rule.ml
+++ b/src/core/Mini_rule.ml
@@ -38,7 +38,7 @@ type rule = {
   (* originates from pattern-inside or pattern-not-inside *)
   message : string;
   severity : Rule.severity;
-  languages : Lang.t list;
+  langs : Lang.t list;
   (* at least one element *)
   (* Useful for debugging, to report bad rules. We could rule.id to
    * report those bad rules, but semgrep-python uses a weird encoding

--- a/src/core/Pattern_match.ml
+++ b/src/core/Pattern_match.ml
@@ -125,7 +125,7 @@ type t = {
  *
  * We could derive information in the other fields from the id, but that
  * would require to pass around the list of rules to get back the
- * information. Instead by embedding the information in the pattern match,
+ * information. Instead, by embedding the information in the pattern match,
  * some functions are simpler (we use the same trick with Parse_info.t
  * where for example we embed the filename in it, not just a position).
  * alt: reuse Mini_rule.t
@@ -144,7 +144,8 @@ and rule_id = {
    * mini_rule? *)
   message : string;
   fix : string option;
-  languages : Lang.t list;
+  (* ?? why we need that? *)
+  langs : Lang.t list;
   (* used for debugging (could be removed at some point) *)
   pattern_string : string;
 }

--- a/src/core/Rule.ml
+++ b/src/core/Rule.ml
@@ -368,54 +368,6 @@ type secrets = {
 [@@deriving show]
 
 (*****************************************************************************)
-(* Languages definition *)
-(*****************************************************************************)
-
-(* See the toplevel comment in Target_selector.ml for more information
- * on the selector vs analyzer terminology used below.
- *
- * TODO: instead of always deriving those fields automatically from
- * the 'languages:' field of the rule in Parse_rule.ml, we should add
- * support for an optional new 'target-selectors:' field in the rule syntax.
- *)
-type languages = {
-  (* How to *select* target files e.g. "files that look like C files".
-     If unspecified, the selector selects all the files that are not
-     ignored by generic mechanisms such as semgrepignore.
-     In a Semgrep rule where a string is expected, the standard way
-     is to use "generic" but "regex" and "none" have the same effect.
-     They all translate into 'None'.
-
-     Example:
-
-       target_selector = Some [Javascript; Typescript];
-
-     ... selects all the files that can be parsed and analyzed
-     as TypeScript ( *.js, *.ts, *.tsx) since TypeScript is an extension of
-     JavaScript.
-  *)
-  target_selector : Target_selector.t option;
-  (* How to *analyze* target files. The accompanying patterns are specified
-     elsewhere in the rule.
-     Examples:
-     - "pattern for the C parser using the generic AST" (regular programming
-       language using a classic Semgrep pattern)
-     - "pattern for Fortran77 or for Fortran90" (two possible parsers)
-     - "spacegrep pattern"
-     - "high-entropy detection" (doesn't use a pattern)
-     - "extract JavaScript snippets from a PDF file" (doesn't use a pattern)
-     This information may have to be extracted from another part of the
-     YAML rule.
-
-     Example:
-
-       target_analyzer = L (Typescript, []);
-  *)
-  target_analyzer : Xlang.t;
-}
-[@@deriving show]
-
-(*****************************************************************************)
 (* Paths *)
 (*****************************************************************************)
 
@@ -464,7 +416,8 @@ type steps_mode = [ `Steps of step list ] [@@deriving show]
 (*****************************************************************************)
 and step = {
   step_mode : mode_for_step;
-  step_languages : languages;
+  step_selector : Target_selector.t option;
+  step_analyzer : Xlang.t;
   step_paths : paths option;
 }
 
@@ -487,10 +440,8 @@ type 'mode rule_info = {
   message : string;
   (* Currently a dummy value for extract mode rules *)
   severity : severity;
-  (* This is the list of languages in which the root pattern makes sense.
-   *
-   * The two fields in the 'languages' type above used to be a single
-   * 'languages: Xlang.t' field.
+  (* Note: The two fields target_seletor and target_analyzer below used to
+   * be a single 'languages: Xlang.t' field.
    * Indeed, for historical reasons, the 'languages:' field in the
    * YAML file is a list of strings. There is no distinction between
    * target *selection* and target *analysis*. This led to oddities for
@@ -503,8 +454,45 @@ type 'mode rule_info = {
    * but analyze them using a regexp instead of a regular Semgrep pattern.
    *
    * see also https://www.notion.so/semgrep/What-s-a-language-3f4e75546edd4a0389fa29a24eedb6c0
+   *
+   * TODO: instead of always deriving those two fields automatically from
+   * the 'languages:' field of the rule in Parse_rule.ml, we should add
+   * support for an optional new 'target-selectors:' field in the rule syntax.
+   *
+   * target_selector: How to *select* target files e.g. "files that look
+   * like C files". If None, the selector selects all the files that are not
+   * ignored by generic mechanisms such as semgrepignore.
+   * In a Semgrep rule where a string is expected, the standard way
+   * is to use "generic" but "regex" and "none" have the same effect.
+   * They all translate into 'None'.
+   *
+   * Example:
+   *
+   *   target_selector = Some [Javascript; Typescript];
+   *
+   * ... selects all the files that can be parsed and analyzed
+   * as TypeScript ( *.js, *.ts, *.tsx) since TypeScript is an extension of
+   * JavaScript.
    *)
-  languages : languages;
+  target_selector : Target_selector.t option;
+  (* target_analyzer: How to *analyze* target files. The accompanying
+   * patterns are specified elsewhere in the rule.
+   *
+   * Examples:
+   * - "pattern for the C parser using the generic AST" (regular programming
+   *   language using a classic Semgrep pattern)
+   * - "pattern for Fortran77 or for Fortran90" (two possible parsers)
+   * - "spacegrep pattern"
+   * - "high-entropy detection" (doesn't use a pattern)
+   * - "extract JavaScript snippets from a PDF file" (doesn't use a pattern)
+   * This information may have to be extracted from another part of the
+   * YAML rule.
+   *
+   * Example:
+   *
+   *   target_analyzer = L (Typescript, []);
+   *)
+  target_analyzer : Xlang.t;
   (* OPTIONAL fields *)
   options : Rule_options.t option;
   (* deprecated? or should we resurrect the feature?
@@ -797,17 +785,14 @@ let xpatterns_of_rule rule =
 (* Converters *)
 (*****************************************************************************)
 
-let languages_of_lang (lang : Lang.t) : languages =
-  { target_selector = Some [ lang ]; target_analyzer = L (lang, []) }
-
-let languages_of_xlang (xlang : Xlang.t) : languages =
+let selector_and_analyzer_of_xlang (xlang : Xlang.t) :
+    Target_selector.t option * Xlang.t =
   match xlang with
   | LRegex
   | LAliengrep
   | LSpacegrep ->
-      { target_selector = None; target_analyzer = xlang }
-  | L (lang, other_langs) ->
-      { target_selector = Some (lang :: other_langs); target_analyzer = xlang }
+      (None, xlang)
+  | L (lang, other_langs) -> (Some (lang :: other_langs), xlang)
 
 (* return list of "positive" x list of Not *)
 let split_and (xs : formula list) : formula list * (tok * formula) list =
@@ -828,6 +813,7 @@ let split_and (xs : formula list) : formula list * (tok * formula) list =
  *)
 let rule_of_xpattern (xlang : Xlang.t) (xpat : Xpattern.t) : rule =
   let fk = Tok.unsafe_fake_tok "" in
+  let target_selector, target_analyzer = selector_and_analyzer_of_xlang xlang in
   {
     id = (Rule_ID.of_string "-e", fk);
     mode = `Search (P xpat);
@@ -836,7 +822,8 @@ let rule_of_xpattern (xlang : Xlang.t) (xpat : Xpattern.t) : rule =
     (* alt: could put xpat.pstr for the message *)
     message = "";
     severity = Error;
-    languages = languages_of_xlang xlang;
+    target_selector;
+    target_analyzer;
     options = None;
     equivalences = None;
     fix = None;

--- a/src/core_cli/Core_command.ml
+++ b/src/core_cli/Core_command.ml
@@ -128,7 +128,7 @@ let minirule_of_pattern lang pattern_string pattern =
     inside = false;
     message = "";
     severity = Rule.Error;
-    languages = [ lang ];
+    langs = [ lang ];
     fix = None;
   }
 

--- a/src/core_scan/Core_scan.ml
+++ b/src/core_scan/Core_scan.ml
@@ -581,7 +581,7 @@ let iter_targets_and_get_matches_and_exn_to_errors config f targets =
 let rules_for_xlang (xlang : Xlang.t) (rules : Rule.t list) : Rule.t list =
   rules
   |> List.filter (fun r ->
-         match (xlang, r.R.languages.target_analyzer) with
+         match (xlang, r.R.target_analyzer) with
          | LRegex, LRegex
          | LSpacegrep, LSpacegrep
          | LAliengrep, LAliengrep ->

--- a/src/engine/Match_env.ml
+++ b/src/engine/Match_env.ml
@@ -87,7 +87,7 @@ let fake_rule_id (id, str) =
     pattern_string = str;
     message = "";
     fix = None;
-    languages = [];
+    langs = [];
   }
 
 let adjust_xconfig_with_rule_options xconf options =

--- a/src/engine/Match_extract_mode.ml
+++ b/src/engine/Match_extract_mode.ml
@@ -142,7 +142,7 @@ let rules_for_extracted_lang ~(all_rules : Rule.t list) extract_rule_ids =
           all_rules
           |> Common.mapi (fun i r -> (i, r))
           |> List.filter (fun (_i, r) ->
-                 let r_lang = r.Rule.languages.target_analyzer in
+                 let r_lang = r.Rule.target_analyzer in
                  match (xlang, r_lang) with
                  | Xlang.L (l, _), Xlang.L (rl, rls) ->
                      List.exists (fun x -> Lang.equal l x) (rl :: rls)

--- a/src/engine/Match_rules.ml
+++ b/src/engine/Match_rules.ml
@@ -133,7 +133,7 @@ let group_rules xconf rules xtarget =
   *)
   let relevant_taint_rules_groups =
     relevant_taint_rules
-    |> Common.map (fun r -> (r.R.languages, r))
+    |> Common.map (fun r -> (r.R.target_analyzer, r))
     |> Common.group_assoc_bykey_eff |> Common.map snd
   in
   (relevant_taint_rules_groups, relevant_nontaint_rules, skipped_rules)

--- a/src/engine/Match_search_mode.ml
+++ b/src/engine/Match_search_mode.ml
@@ -172,7 +172,7 @@ let (mini_rule_of_pattern :
      *)
     message = "";
     severity = R.Error;
-    languages =
+    langs =
       (match xlang with
       | L (x, xs) -> x :: xs
       | LRegex

--- a/src/engine/Match_tainting_mode.ml
+++ b/src/engine/Match_tainting_mode.ml
@@ -110,7 +110,7 @@ let convert_rule_id (id, _tok) =
     message = "";
     pattern_string = Rule_ID.to_string id;
     fix = None;
-    languages = [];
+    langs = [];
   }
 
 let option_bind_list opt f =
@@ -449,7 +449,7 @@ let taint_config_of_rule ~per_file_formula_cache xconf file ast_and_errors
   let xtarget =
     {
       Xtarget.file;
-      xlang = rule.languages.target_analyzer;
+      xlang = rule.target_analyzer;
       lazy_content = lazy (File.read_file file);
       lazy_ast_and_errors;
     }

--- a/src/engine/Range_with_metavars.ml
+++ b/src/engine/Range_with_metavars.ml
@@ -37,14 +37,14 @@ let (range_to_pattern_match_adjusted : Rule.t -> t -> Pattern_match.t) =
  fun r range ->
   let m = range.origin in
   let rule_id = m.rule_id in
-  let languages = Xlang.to_langs r.Rule.languages.target_analyzer in
+  let langs = Xlang.to_langs r.Rule.target_analyzer in
   (* adjust the rule id *)
   let rule_id : Pattern_match.rule_id =
     {
       rule_id with
       id = fst r.Rule.id;
       fix = r.Rule.fix;
-      languages;
+      langs;
       message =
         r.Rule.message (* keep pattern_str which can be useful to debug *);
     }

--- a/src/engine/Test_dataflow_tainting.ml
+++ b/src/engine/Test_dataflow_tainting.ml
@@ -67,7 +67,7 @@ let test_dfg_tainting rules_file file =
   let rules =
     rules
     |> List.filter (fun r ->
-           match r.Rule.languages.target_analyzer with
+           match r.Rule.target_analyzer with
            | Xlang.L (x, xs) -> List.mem lang (x :: xs)
            | _ -> false)
   in

--- a/src/engine/Test_engine.ml
+++ b/src/engine/Test_engine.ml
@@ -43,14 +43,12 @@ let logger = Logging.get_logger [ __MODULE__ ]
 
 let (xlangs_of_rules : Rule.t list -> Xlang.t list) =
  fun rs ->
-  rs
-  |> Common.map (fun r -> r.R.languages.target_analyzer)
-  |> List.sort_uniq compare
+  rs |> Common.map (fun r -> r.R.target_analyzer) |> List.sort_uniq compare
 
-let first_xlang_of_rules rs =
+let first_xlang_of_rules (rs : Rule.t list) : Xlang.t =
   match rs with
   | [] -> failwith "no rules"
-  | { R.languages = x; _ } :: _ -> x.target_analyzer
+  | { R.target_analyzer = x; _ } :: _ -> x
 
 let single_xlang_from_rules file rules =
   let xlangs = xlangs_of_rules rules in

--- a/src/engine/Unit_engine.ml
+++ b/src/engine/Unit_engine.ml
@@ -288,7 +288,7 @@ let match_pattern ~lang ~hook ~file ~pattern ~fix_pattern =
       inside = false;
       message = "";
       severity = R.Error;
-      languages = [ lang ];
+      langs = [ lang ];
       pattern_string = "test: no need for pattern string";
       fix = fix_pattern;
     }
@@ -530,13 +530,14 @@ let filter_irrelevant_rules_tests () =
 let get_extract_source_lang file rules =
   let _, _, erules, _, _ = R.partition_rules rules in
   let erule_langs =
-    erules |> Common.map (fun r -> r.R.languages) |> List.sort_uniq compare
+    erules
+    |> Common.map (fun r -> r.R.target_analyzer)
+    |> List.sort_uniq compare
   in
   match erule_langs with
   | [] -> failwith (spf "no language for extract rule found in %s" !!file)
-  | [ x ] -> x.target_analyzer
-  | x :: _ ->
-      let xlang = x.target_analyzer in
+  | [ x ] -> x
+  | xlang :: _ ->
       pr2
         (spf
            "too many languages from extract rules found in %s, picking the \
@@ -574,7 +575,7 @@ let tainting_test lang rules_file file =
   let rules =
     rules
     |> List.filter (fun r ->
-           match r.Rule.languages.target_analyzer with
+           match r.Rule.target_analyzer with
            | Xlang.L (x, xs) -> List.mem lang (x :: xs)
            | _ -> false)
   in

--- a/src/experiments/synthesizing/Unit_synthesizer_targets.ml
+++ b/src/experiments/synthesizing/Unit_synthesizer_targets.ml
@@ -63,7 +63,7 @@ let ranges_matched lang file pattern : Range.t list =
       inside = false;
       message = "";
       severity = R.Error;
-      languages = [ lang ];
+      langs = [ lang ];
       pattern_string = "test: no need for pattern string";
       fix = None;
     }

--- a/src/fixing/Autofix.ml
+++ b/src/fixing/Autofix.ml
@@ -126,7 +126,7 @@ let validate_fix lang target_contents edit =
  * *)
 let render_fix pm =
   let* fix_pattern = pm.Pattern_match.rule_id.fix in
-  let* lang = List.nth_opt pm.Pattern_match.rule_id.languages 0 in
+  let* lang = List.nth_opt pm.Pattern_match.rule_id.langs 0 in
   let metavars = pm.Pattern_match.env in
   let start, end_ =
     let start, end_ = pm.Pattern_match.range_loc in

--- a/src/matching/Match_patterns.ml
+++ b/src/matching/Match_patterns.ml
@@ -138,7 +138,7 @@ let (rule_id_of_mini_rule : Mini_rule.t -> Pattern_match.rule_id) =
     message = mr.message;
     pattern_string = mr.pattern_string;
     fix = mr.fix;
-    languages = mr.languages;
+    langs = mr.langs;
   }
 
 let match_rules_and_recurse m_env (file, hook, matches) rules matcher k any x =

--- a/src/metachecking/Check_rule.ml
+++ b/src/metachecking/Check_rule.ml
@@ -195,7 +195,7 @@ let check r =
   match r.mode with
   | `Search f
   | `Extract { formula = f; _ } ->
-      check_formula { r; errors = ref [] } r.languages.target_analyzer f
+      check_formula { r; errors = ref [] } r.target_analyzer f
   | `Secrets _ -> (* TODO *) []
   | `Taint _ -> (* TODO *) []
   | `Steps _ -> (* TODO *) []

--- a/src/osemgrep/cli_interactive/Interactive_subcommand.ml
+++ b/src/osemgrep/cli_interactive/Interactive_subcommand.ml
@@ -490,7 +490,7 @@ let translate_formula iformula =
   | None -> failwith "should not happen"
   | Some iformula -> iformula
 
-let mk_fake_rule lang formula =
+let mk_fake_rule xlang formula =
   {
     Rule.id = (Rule_ID.of_string "-i", fk);
     mode = `Search formula;
@@ -499,7 +499,8 @@ let mk_fake_rule lang formula =
     (* alt: could put xpat.pstr for the message *)
     message = "";
     severity = Error;
-    languages = lang;
+    target_analyzer = xlang;
+    target_selector = None;
     options = None;
     equivalences = None;
     fix = None;
@@ -592,9 +593,7 @@ let buffer_matches_of_new_iformula (new_iform : iformula_zipper) (state : state)
   *)
   reset_file_zipper state;
   let rule_formula = translate_formula new_iform in
-  let fake_rule =
-    mk_fake_rule (Rule.languages_of_xlang state.xlang) rule_formula
-  in
+  let fake_rule = mk_fake_rule state.xlang rule_formula in
   let xconf =
     {
       Match_env.config = Rule_options.default_config;

--- a/src/osemgrep/cli_scan/Core_runner.ml
+++ b/src/osemgrep/cli_scan/Core_runner.ml
@@ -81,7 +81,7 @@ let group_rules_by_target_language rules : (Xlang.t * Rule.t list) list =
   let tbl = Hashtbl.create 100 in
   rules
   |> List.iter (fun (rule : Rule.t) ->
-         let pattern_lang = rule.languages.target_analyzer in
+         let pattern_lang = rule.target_analyzer in
          let target_langs = Xlang.flatten pattern_lang in
          target_langs
          |> List.iter (fun lang ->

--- a/src/parsing/Parse_rule.ml
+++ b/src/parsing/Parse_rule.ml
@@ -57,8 +57,8 @@ type key = string R.wrap
 type env = {
   (* id of the current rule (needed by some exns) *)
   id : Rule_ID.t;
-  (* languages of the current rule (needed by parse_pattern) *)
-  languages : Rule.languages;
+  (* analyzer of the current rule (needed by parse_pattern) *)
+  target_analyzer : Xlang.t;
   (* whether we are underneath a `metavariable-pattern` *)
   in_metavariable_pattern : bool;
   (* emma: save the path within the yaml file for each pattern
@@ -137,7 +137,7 @@ let try_and_raise_invalid_pattern_if_error (env : env) (s, t) f =
         | Parsing_plugin.Missing_plugin msg -> MissingPlugin msg
         | exn ->
             InvalidPattern
-              (s, env.languages.target_analyzer, Common.exn_to_s exn, env.path)
+              (s, env.target_analyzer, Common.exn_to_s exn, env.path)
       in
       Rule.raise_error (Some env.id) (InvalidRule (error_kind, env.id, t))
 
@@ -420,28 +420,26 @@ let parse_language ~id ((s, t) as _lang) : Lang.t =
    Xlang.of_string which allows "spacegrep" and "aliengrep" so
    this might lead to inconsistencies as here we allow just "generic".
 *)
-let parse_languages ~id (options : Rule_options_t.t) langs : Rule.languages =
-  let opt_target_selector, (target_analyzer : Xlang.t) =
-    match langs with
-    | [ (("none" | "regex"), _t) ] -> (None, LRegex)
-    | [ ("generic", _t) ] -> (
-        (* The generic mode now uses one of two possible engines.
-           For now, we keep the name "generic" for both and use an option
-           to choose one engine or the other. *)
-        match options.generic_engine with
-        | `Spacegrep -> (None, LSpacegrep)
-        | `Aliengrep -> (None, LAliengrep))
-    | xs -> (
-        let rule_id, _ = id in
-        let langs = xs |> Common.map (parse_language ~id:rule_id) in
-        match langs with
-        | [] ->
-            Rule.raise_error (Some rule_id)
-              (InvalidRule
-                 (InvalidOther "we need at least one language", fst id, snd id))
-        | x :: xs -> (Some langs, L (x, xs)))
-  in
-  { target_selector = opt_target_selector; target_analyzer }
+let parse_languages ~id (options : Rule_options_t.t) langs :
+    Target_selector.t option * Xlang.t =
+  match langs with
+  | [ (("none" | "regex"), _t) ] -> (None, LRegex)
+  | [ ("generic", _t) ] -> (
+      (* The generic mode now uses one of two possible engines.
+         For now, we keep the name "generic" for both and use an option
+         to choose one engine or the other. *)
+      match options.generic_engine with
+      | `Spacegrep -> (None, LSpacegrep)
+      | `Aliengrep -> (None, LAliengrep))
+  | xs -> (
+      let rule_id, _ = id in
+      let langs = xs |> Common.map (parse_language ~id:rule_id) in
+      match langs with
+      | [] ->
+          Rule.raise_error (Some rule_id)
+            (InvalidRule
+               (InvalidOther "we need at least one language", fst id, snd id))
+      | x :: xs -> (Some langs, L (x, xs)))
 
 let parse_severity ~id (s, t) : Rule.severity =
   match s with
@@ -476,7 +474,7 @@ let parse_python_expression env key s =
 let parse_metavar_cond env key s = parse_python_expression env key s
 
 let rec parse_type env key (str, tok) =
-  match env.languages.target_analyzer with
+  match env.target_analyzer with
   | Xlang.L (lang, _) ->
       let str = wrap_type_expr env key lang str in
       try_and_raise_invalid_pattern_if_error env (str, tok) (fun () ->
@@ -670,7 +668,7 @@ let parse_options rule_id (key : key) value =
 
 (* less: could move in a separate Parse_xpattern.ml *)
 let parse_rule_xpattern env (str, tok) =
-  match env.languages.target_analyzer with
+  match env.target_analyzer with
   | Xlang.L (lang, _) ->
       (* opti: parsing Semgrep patterns lazily improves speed significantly.
        * Parsing p/default goes from 13s to just 0.2s, mostly because
@@ -1006,7 +1004,7 @@ and parse_extra (env : env) (key : key) (value : G.expr) : extra =
             let env' =
               {
                 id = env.id;
-                languages = Rule.languages_of_xlang xlang;
+                target_analyzer = xlang;
                 in_metavariable_pattern = env.in_metavariable_pattern;
                 path = "metavariable-type" :: "metavariable" :: env.path;
                 options_key = None;
@@ -1028,7 +1026,7 @@ and parse_extra (env : env) (key : key) (value : G.expr) : extra =
             let env' =
               {
                 id = env.id;
-                languages = Rule.languages_of_xlang xlang;
+                target_analyzer = xlang;
                 in_metavariable_pattern = env.in_metavariable_pattern;
                 path = "metavariable-pattern" :: "metavariable" :: env.path;
                 options_key = None;
@@ -1126,10 +1124,7 @@ and parse_formula env (value : G.expr) : R.formula =
             Rule.raise_error (Some env.id)
               (InvalidRule
                  ( InvalidPattern
-                     ( s,
-                       env.languages.target_analyzer,
-                       Common.exn_to_s exn,
-                       env.path ),
+                     (s, env.target_analyzer, Common.exn_to_s exn, env.path),
                    env.id,
                    t )))
   (* If that doesn't work, it should be a key-value pairing.
@@ -1211,7 +1206,7 @@ and produce_constraint env dict tok indicator =
             let env' =
               {
                 env with
-                languages = Rule.languages_of_xlang xlang;
+                target_analyzer = xlang;
                 path = "metavariable-pattern" :: "metavariable" :: env.path;
               }
             in
@@ -1617,8 +1612,10 @@ let parse_step_fields env key (value : G.expr) : R.step =
   let id =
     (Rule_ID.of_string (* TODO: is this really a rule ID? *) step_id_str, tok)
   in
-  let step_languages = parse_languages ~id rule_options languages in
-  let env = { env with languages = step_languages } in
+  let step_selector, step_analyzer =
+    parse_languages ~id rule_options languages
+  in
+  let env = { env with target_analyzer = step_analyzer } in
   let step_paths = take_opt rd env parse_paths "paths" in
   let mode_opt = take_opt rd env parse_string_wrap "mode" in
   let has_taint_key = Option.is_some (Hashtbl.find_opt rd.h "taint") in
@@ -1640,7 +1637,7 @@ let parse_step_fields env key (value : G.expr) : R.step =
              "Unexpected value for mode, should be 'search' or 'taint', not %s"
              (fst key))
   in
-  { step_languages; step_paths; step_mode }
+  { step_selector; step_analyzer; step_paths; step_mode }
 
 let parse_steps env key (value : G.expr) : R.step list =
   let parse_step step = parse_step_fields env key step in
@@ -1804,11 +1801,13 @@ let parse_one_rule ~rewrite_rule_ids (t : G.tok) (i : int) (rule : G.expr) :
     | Some (options, options_key) -> (Some options, options_key)
   in
   let options = Option.value options_opt ~default:Rule_options.default_config in
-  let languages = parse_languages ~id options languages in
+  let target_selector, target_analyzer =
+    parse_languages ~id options languages
+  in
   let env =
     {
       id = rule_id;
-      languages;
+      target_analyzer;
       in_metavariable_pattern = false;
       path = [ string_of_int i; "rules" ];
       options_key;
@@ -1835,7 +1834,8 @@ let parse_one_rule ~rewrite_rule_ids (t : G.tok) (i : int) (rule : G.expr) :
     min_version = Option.map fst min_version;
     max_version = Option.map fst max_version;
     message;
-    languages;
+    target_selector;
+    target_analyzer;
     severity = parse_severity ~id:env.id severity;
     mode;
     (* optional fields *)
@@ -1986,7 +1986,7 @@ let parse_xpattern xlang (str, tok) =
   let env =
     {
       id = Rule_ID.of_string "anon-pattern";
-      languages = Rule.languages_of_xlang xlang;
+      target_analyzer = xlang;
       in_metavariable_pattern = false;
       path = [];
       options_key = None;


### PR DESCRIPTION
Like martin said it many times, "languages" is overloaded
so let's remove the Rule.languages type and field.

test plan:
make core