### PR TITLE
chore: Show conflicts when running `make dev-setup`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -361,7 +361,12 @@ setup: semgrep.opam
 .PHONY: dev-setup
 dev-setup:
 	$(MAKE) setup
-	opam install -y --deps-only ./dev
+	# This is partly redundant with `make setup`, called above. We include `./`
+	# and `./libs/ocaml-tree-sitter-core` so that if the dependencies specified in
+	# `./dev` conflict with any of the other dependencies, we get a conflict
+	# message here rather than having this command silently install the versions
+	# that `./dev` requires, potentially breaking the build.
+	opam install -y --deps-only ./dev ./ ./libs/ocaml-tree-sitter-core
 
 # Update and rebuild everything within the project.
 .PHONY: rebuild


### PR DESCRIPTION
We recently encountered an issue where a dependency in `./dev` needed an old version of `ppxlib`. However, the current version of `ppx_sexp_conv` needs a newer version of `ppxlib`. Thus, running `make dev-setup` silently downgraded the version of `ppx_sexp_conv` that was already installed. The older version of `ppx_sexp_conv` has a bug that leads to build failures.

With this change, if we ever add a dependency that conflicts, we'll find out about it when installing dev dependencies rather than having weird things happen later.

Test plan: I ran `make setup` before we addressed the conflict and it failed, with opam reporting the conflict.

