### PR TITLE
refactor: kill `ForIn`

### DIFF
--- a/languages/cpp/ast/ast_cpp.ml
+++ b/languages/cpp/ast/ast_cpp.ml
@@ -512,7 +512,7 @@ and for_header =
   | ForRange of
       (* since c++20 *)
       condition_initializer option
-      * var_decl (* vinit = None *)
+      * (type_ * entity)
       * tok (*':'*)
       * initialiser
   (* sgrep-ext: *)

--- a/languages/cpp/generic/cpp_to_generic.ml
+++ b/languages/cpp/generic/cpp_to_generic.ml
@@ -1132,16 +1132,23 @@ and map_for_header env = function
       and v2 = map_of_option (map_expr env) v2
       and v3 = map_of_option (map_expr env) v3 in
       G.ForClassic (v1, v2, v3)
-  | ForRange (v1, v2, v3, v4) ->
+  | ForRange (v1, (ty, ent), v3, v4) ->
       (* TODO: We cannot accommodate this in the Generic AST at the present. *)
       let _initialiser_TODO =
         map_of_option (map_condition_initializer env) v1
       in
-      let ent, vardef = map_var_decl env v2
-      and _v2 = map_tok env v3
+      let ent = map_entity env ent
+      and ty = map_type_ env ty
+      and v2 = map_tok env v3
       and v4 = map_initialiser env v4 in
+      (* TODO: use the other stuff in the entity? *)
+      let pat =
+        match ent.name with
+        | EN (Id (id, idinfo)) -> G.PatId (id, idinfo) |> G.p
+        | _ -> G.OtherPat (("PatEnt", G.fake "PatEnt"), [ G.En ent ]) |> G.p
+      in
       (* less: or ForEach? *)
-      G.ForIn ([ G.ForInitVar (ent, vardef) ], [ v4 ])
+      G.ForEach (G.PatTyped (pat, ty) |> G.p, v2, v4)
 
 and map_a_expr_or_vars env v =
   match v with

--- a/languages/cpp/menhir/parser_cpp.mly
+++ b/languages/cpp/menhir/parser_cpp.mly
@@ -926,7 +926,7 @@ for_range_decl: type_spec_seq2 declarator
   { let (t_ret, _sto, mods) = type_and_storage_from_decl $1 in
     let (name, ftyp) = $2 in
     let ent = { name; specs = mods |> List.map (fun x -> M x) } in
-    ent, { v_type = ftyp t_ret; v_init = None } }
+    ftyp t_ret, ent }
 
 for_range_init: expr { InitExpr $1 }
 

--- a/languages/cpp/tree-sitter/Parse_cpp_tree_sitter.ml
+++ b/languages/cpp/tree-sitter/Parse_cpp_tree_sitter.ml
@@ -3111,8 +3111,7 @@ and map_for_range_loop_body (env : env)
   let v5 = map_anon_choice_exp_3078596 env v5 in
   let n = name_of_dname_for_var env v3.dn in
   let ent = { name = n; specs } in
-  let var = { v_type = v3.dt t; v_init = None } in
-  ForRange (v1, (ent, var), v4, v5)
+  ForRange (v1, (v3.dt t, ent), v4, v5)
 
 and map_for_statement (env : env) ((v1, v2, v3, v4, v5) : CST.for_statement) =
   let v1 = token env v1 (* "for" *) in

--- a/libs/ast_generic/AST_generic.ml
+++ b/libs/ast_generic/AST_generic.ml
@@ -1290,9 +1290,6 @@ and for_header =
   | ForEach of for_each
   (* Scala *)
   | MultiForEach of multi_for_each list
-  (* Lua. todo: merge with ForEach? *)
-  (* pattern 'in' expr *)
-  | ForIn of for_var_or_expr list (* init *) * expr list
   (* sgrep: *)
   | ForEllipsis of (* ... *) tok
 

--- a/libs/ast_generic/AST_generic_to_v1.ml
+++ b/libs/ast_generic/AST_generic_to_v1.ml
@@ -909,10 +909,6 @@ and map_for_header = function
       let v1 = map_of_list map_multi_for_each v1 in
       `MultiForEach v1
   | ForEllipsis t -> raise (SemgrepConstruct t)
-  | ForIn (v1, v2) ->
-      let v1 = map_of_list map_for_var_or_expr v1
-      and v2 = map_of_list map_expr v2 in
-      `ForIn (v1, v2)
 
 and map_for_each (v1, t, v2) =
   let t = map_tok t in

--- a/libs/ast_generic/Meta_AST.ml
+++ b/libs/ast_generic/Meta_AST.ml
@@ -979,10 +979,6 @@ and vof_for_header = function
   | ForEllipsis t ->
       let t = vof_tok t in
       OCaml.VSum ("ForEllipsis", [ t ])
-  | ForIn (v1, v2) ->
-      let v1 = OCaml.vof_list vof_for_var_or_expr v1
-      and v2 = OCaml.vof_list vof_expr v2 in
-      OCaml.VSum ("ForIn", [ v1; v2 ])
 
 and vof_for_each (v1, t, v2) =
   let t = vof_tok t in

--- a/src/analyzing/AST_to_IL.ml
+++ b/src/analyzing/AST_to_IL.ml
@@ -1418,39 +1418,6 @@ and stmt_aux env st =
       @ [ mk_s (Loop (tok, cond, st @ cont_label_s @ next @ ss2)) ]
       @ break_label_s
   | G.For (_, G.ForEllipsis _, _) -> sgrep_construct (G.S st)
-  | G.For
-      ( tok,
-        G.ForIn
-          ( [
-              G.ForInitVar
-                ({ name = G.EN (G.Id (id, ii)); _ }, { vinit = None; _ });
-            ],
-            [ e ] ),
-        stmts ) ->
-      (* e.g. C++: for (int *p : set)
-       * TODO: Should this be encoded as a ForEach already in Parse_cpp_tree_sitter ? *)
-      let pat = G.PatId (id, ii) in
-      for_each env tok (pat, snd id, e) stmts
-  | G.For (tok, G.ForIn (xs, e), stmts) ->
-      let orig_stmt = st in
-      let cont_label_s, break_label_s, st_env =
-        mk_break_continue_labels env tok
-      in
-      let ss1 = for_var_or_expr_list env xs in
-      let stmts = stmt st_env stmts in
-      let ss2, cond =
-        match e with
-        | first :: _TODO ->
-            (* TODO list *)
-            expr_with_pre_stmts env first
-        | [] ->
-            (* TODO: empty list of elements to iterate over
-               bash: for x do ... done *)
-            ([], fixme_exp ToDo (G.S orig_stmt) (related_tok tok))
-      in
-      ss1 @ ss2
-      @ [ mk_s (Loop (tok, cond, stmts @ cont_label_s @ ss2)) ]
-      @ break_label_s
   (* TODO: repeat env work of controlflow_build.ml *)
   | G.Continue (tok, lbl_ident, _) -> (
       match lbl_ident with

--- a/src/matching/Generic_vs_generic.ml
+++ b/src/matching/Generic_vs_generic.ml
@@ -2631,17 +2631,9 @@ and m_for_header a b =
           | G.FEllipsis _ -> true
           | _ -> false)
         a1 b1
-  | G.ForIn (a1, a2), B.ForIn (b1, b2) ->
-      (m_list m_for_var_or_expr) a1 b1 >>= fun () ->
-      m_list_with_dots m_expr
-        (function
-          | { e = G.Ellipsis _; _ } -> true
-          | _ -> false)
-        ~less_is_ok:false a2 b2
   | G.ForClassic _, _
   | G.ForEach _, _
-  | G.MultiForEach _, _
-  | G.ForIn _, _ ->
+  | G.MultiForEach _, _ ->
       fail ()
 
 and m_for_each (a1, at, a2) (b1, bt, b2) =

--- a/src/matching/SubAST_generic.ml
+++ b/src/matching/SubAST_generic.ml
@@ -77,7 +77,6 @@ let subexprs_of_stmt_kind = function
       |> Common.map_filter (function
            | Arg e -> Some e
            | _ -> None)
-  | For (_, ForIn (_, es), _) -> es
   | OtherStmt (_op, xs) -> subexprs_of_any_list xs
   | OtherStmtWithStmt (_, xs, _) -> subexprs_of_any_list xs
   (* 0 *)

--- a/src/printing/Pretty_print_AST.ml
+++ b/src/printing/Pretty_print_AST.ml
@@ -457,9 +457,6 @@ and for_stmt env (for_tok, hdr, s) =
     | ForEach (pat, tok, e) -> for_each (pat, tok, e)
     | MultiForEach fors -> String.concat ";" (Common.map multi_for_each fors)
     | ForEllipsis tok -> token ~d:"..." tok
-    | ForIn (init, exprs) ->
-        F.sprintf "%s %s %s" (show_init_list init) "in"
-          (String.concat "," (Common.map (fun e -> expr env e) exprs))
   in
   let body_str = stmt { env with level = env.level + 1 } s in
   for_format (token ~d:"for" for_tok) hdr_str body_str


### PR DESCRIPTION
## What:
This PR kills the `ForIn` construct for `for_header`, preferring instead the closely related `ForEach`.

## Why:
Both of these constructs have different types, but closely resemble each other in intention. This was causing us a bug, as a mistranslation to `ForIn` in C++ caused an inability to do taint tracking properly, which would not have happened had it been translated to the proper `ForEach`. See https://linear.app/semgrep/issue/PA-3090/incorrect-taint-tracking-in-c-range-based-loops

## How:
This PR just modifies the type, and embeds such range-based for loops into `ForEach` instead. This only takes a little more contorting, which is particularly noticeable in the case where we need to translate an entity into a pattern. This was handled relatively broadly, but I didn't feel like it was worth creating a brand new `pattern_of_entity` function, as I felt like it was impossible to write truly generally.

## Test plan:
`make test` (notably, the test added in https://github.com/returntocorp/semgrep/pull/8749 succeeds)

Closes PA-3090 (not just another birthday, it's 30/90...)