### PR TITLE
update semgrep ci to let the backend know about its last attempt to /complete

### DIFF
--- a/cli/src/semgrep/app/scans.py
+++ b/cli/src/semgrep/app/scans.py
@@ -465,4 +465,3 @@ class ScanHandler:
 
             progress_bar.advance(complete_task)
             sleep(5 if datetime.utcnow() < slow_down_after else 30)
-            continue

--- a/cli/src/semgrep/commands/ci.py
+++ b/cli/src/semgrep/commands/ci.py
@@ -20,6 +20,7 @@ from rich.table import Table
 import semgrep.run_scan
 import semgrep.semgrep_interfaces.semgrep_output_v1 as out
 from semgrep.app import auth
+from semgrep.app.scans import ScanCompleteResult
 from semgrep.app.scans import ScanHandler
 from semgrep.commands.install import run_install_semgrep_pro
 from semgrep.commands.scan import scan_options
@@ -584,6 +585,7 @@ def ci(
         f"  Found {unit_str(num_blocking_findings + num_nonblocking_findings, 'finding')} ({num_blocking_findings} blocking) from {unit_str(num_executed_rules, 'rule')}."
     )
 
+    complete_result: ScanCompleteResult | None = None
     if scan_handler:
         with Progress(
             TextColumn("  {task.description}"),
@@ -636,7 +638,7 @@ def ci(
         logger.info("  No blocking findings so exiting with code 0")
         exit_code = 0
 
-    if complete_result.app_block_override and not audit_mode:
+    if complete_result and complete_result.app_block_override and not audit_mode:
         logger.info(
             f"  semgrep.dev is suggesting a non-zero exit code ({complete_result.app_block_reason})"
         )

--- a/cli/src/semgrep/commands/ci.py
+++ b/cli/src/semgrep/commands/ci.py
@@ -584,7 +584,6 @@ def ci(
         f"  Found {unit_str(num_blocking_findings + num_nonblocking_findings, 'finding')} ({num_blocking_findings} blocking) from {unit_str(num_executed_rules, 'rule')}."
     )
 
-    reason = ""
     if scan_handler:
         with Progress(
             TextColumn("  {task.description}"),
@@ -638,7 +637,9 @@ def ci(
         exit_code = 0
 
     if complete_result.app_block_override and not audit_mode:
-        logger.info(f"  semgrep.dev is suggesting a non-zero exit code ({reason})")
+        logger.info(
+            f"  semgrep.dev is suggesting a non-zero exit code ({complete_result.app_block_reason})"
+        )
         exit_code = 1
 
     if enable_version_check:

--- a/cli/tests/e2e/test_ci.py
+++ b/cli/tests/e2e/test_ci.py
@@ -25,6 +25,7 @@ from tests.e2e.test_baseline import _git_merge
 from tests.fixtures import RunSemgrep
 
 from semgrep import __VERSION__
+from semgrep.app.scans import ScanCompleteResult
 from semgrep.app.scans import ScanHandler
 from semgrep.app.session import AppSession
 from semgrep.config_resolver import ConfigFile
@@ -1562,7 +1563,9 @@ def test_backend_exit_code(run_semgrep: RunSemgrep, mocker, git_tmp_path_with_co
     Test backend sending non-zero exit code on complete causes exit 1
     """
     mocker.patch.object(
-        ScanHandler, "report_findings", return_value=(1, "some reason to fail")
+        ScanHandler,
+        "report_findings",
+        return_value=ScanCompleteResult(True, True, "some reason to fail"),
     )
     run_semgrep(
         options=["ci", "--no-suppress-errors"],


### PR DESCRIPTION
Currently the CLI will poll the backend for up to 20 minutes to check if the scan should block for the small set of features that are implemented in the backend rather than locally.

We'd like to start implementing graceful fallback features, and to do so the backend needs to know if the CLI will be retrying or not. This adds a flag to the request to communicate this.

This is an almost no-op change from the users perspective, the only tweak here is to change the "results available" message to indicate "results will be available soon" when the backend hasn't completed its work yet.

Test plan:
- Test against a local dev env with the processing completing quickly (working)
- Test against a local dev env with the processing taking longer than the timeout (working)
- Test against production (working)

Depends on: https://github.com/returntocorp/semgrep-interfaces/pull/145
