### PR TITLE
fix(cli): clarify that the user should run semgrep install-semgrep-pro and not semgrep install

### DIFF
--- a/cli/src/semgrep/commands/install.py
+++ b/cli/src/semgrep/commands/install.py
@@ -54,7 +54,7 @@ def run_install_semgrep_pro() -> None:
         logger.info(f"Overwriting Semgrep Pro Engine already installed!")
 
     if state.app_session.token is None:
-        logger.info("run `semgrep login` before using `semgrep install`")
+        logger.info("run `semgrep login` before running `semgrep install-semgrep-pro`")
         sys.exit(INVALID_API_KEY_EXIT_CODE)
 
     if sys.platform.startswith("darwin"):


### PR DESCRIPTION
If a user tries to run `semgrep install-semgrep-pro` without being logged in, they get an error message instructing them to login and then use `semgrep install`, which is not a command. This PR makes the instructions crystal clear.