### PR TITLE
feat(java): update for java 21

### DIFF
--- a/changelog.d/pa-3148.added
+++ b/changelog.d/pa-3148.added
@@ -1,0 +1,1 @@
+Java: Semgrep now supports all language features introduced in Java 21.

--- a/languages/java/menhir/parser_java.mly
+++ b/languages/java/menhir/parser_java.mly
@@ -550,7 +550,7 @@ literal:
  | TInt    { Literal (Int ($1)) }
  | TFloat  { Literal (Float ($1)) }
  | TChar   { Literal (Char ($1)) }
- | TString { Literal (String ($1)) }
+ | TString { Literal (String (Tok.unsafe_fake_bracket [StrLit $1])) }
  | NULL    { Literal (Null $1) }
 
 class_literal:
@@ -728,7 +728,7 @@ relational_expression:
  | relational_expression GT shift_expression  { Infix ($1, (Gt,$2), $3) }
  | relational_expression LE shift_expression  { Infix ($1, (LtE,$2), $3) }
  | relational_expression GE shift_expression  { Infix ($1, (GtE,$2), $3) }
- | relational_expression INSTANCEOF reference_type  { InstanceOf ($1, $3) }
+ | relational_expression INSTANCEOF reference_type  { InstanceOf ($1, Left $3) }
 
 equality_expression:
  | relational_expression  { $1 }
@@ -952,7 +952,7 @@ switch_block_statement_group: switch_label+ block_statement+
   {$1, $2}
 
 switch_label:
- | CASE constant_expression ":"        { Case ($1, $2) }
+ | CASE constant_expression ":"        { CaseExprs ($1, [$2], None) }
  | DEFAULT_COLON ":"                   { Default $1 }
 
 

--- a/libs/ast_generic/AST_generic.ml
+++ b/libs/ast_generic/AST_generic.ml
@@ -2221,7 +2221,30 @@ let string_ (lquote, xs, rquote) : string wrap bracket =
  * instead of abusing special?
  *)
 let interpolated (lquote, xs, rquote) =
-  match xs with
+  (* Certain languages allow string components to be not just interpolated
+     expression and string literals, but make a distinction between
+     string literals and escape sequences.
+     There's no reason why both of these can't be combined into a single
+     string component, however.
+  *)
+  let xs_with_fused_literals =
+    List.fold_right
+      (fun x acc ->
+        match (x, acc) with
+        | Common.Left3 (s, t), Common.Left3 (s', t') :: acc ->
+            Left3 (s ^ s', Tok.combine_toks t [ t' ]) :: acc
+        | _ -> x :: acc)
+      xs []
+  in
+  match xs_with_fused_literals with
+  | [] ->
+      let begin_pos =
+        match Tok.loc_of_tok rquote with
+        | Ok loc -> loc.pos
+        | Error _ -> Pos.fake_pos
+      in
+      let empty_tok = Tok.OriginTok { str = ""; pos = begin_pos } in
+      L (String (lquote, ("", empty_tok), rquote)) |> e
   | [ Common.Left3 (str, tstr) ] ->
       L (String (lquote, (str, tstr), rquote)) |> e
   | __else__ ->

--- a/libs/ast_generic/AST_generic.ml
+++ b/libs/ast_generic/AST_generic.ml
@@ -2238,6 +2238,12 @@ let interpolated (lquote, xs, rquote) =
   in
   match xs_with_fused_literals with
   | [] ->
+      (* For the empty interpolated string, we would like to produce an empty
+         literal string.
+         For that, we need a token, however, and we preferably would like one
+         with real location data. We will just produce a length-0 token with
+         the position of the right quote, since we know the string is empty.
+      *)
       let begin_pos =
         match Tok.loc_of_tok rquote with
         | Ok loc -> loc.pos

--- a/tests/patterns/java/template_expr.java
+++ b/tests/patterns/java/template_expr.java
@@ -1,0 +1,14 @@
+public class A {
+  int main() {
+    String s = "semgrep";
+
+    // ERROR: match
+    int it = STR."i love semgrep!";
+    // ERROR: match
+    int it = STR."i love \{s}!";
+
+    int not_it = STR."i hate \{s}";
+    int not_it2 = STR."love \{s}!";
+    int not_it3 = STR."i love \{s}";
+  }
+}

--- a/tests/patterns/java/template_expr.sgrep
+++ b/tests/patterns/java/template_expr.sgrep
@@ -1,0 +1,1 @@
+"i love semgrep!"

--- a/tests/patterns/kotlin/string_metavar.kt
+++ b/tests/patterns/kotlin/string_metavar.kt
@@ -2,11 +2,11 @@
 // not this because it has no part of it thats not the interpolation
 val x = "$X"
 
-// ERROR: match 
+// ERROR: match
 val x = "but $X is good"
 
 // ERROR: match
 val x = "anything"
 
-// not this cause its empty 
+// ERROR: can match the empty literal string too
 val x = ""

--- a/tests/rules/empty_literal_metavar.kt
+++ b/tests/rules/empty_literal_metavar.kt
@@ -1,0 +1,8 @@
+
+// ruleid: empty-literal-metavar
+var x = foo("");
+
+var x = foo("h");
+
+// ruleid: empty-literal-metavar
+var x = foo("hi");

--- a/tests/rules/empty_literal_metavar.yaml
+++ b/tests/rules/empty_literal_metavar.yaml
@@ -1,0 +1,16 @@
+rules:
+  - id: empty-literal-metavar
+    patterns:
+    - pattern: |
+        foo("$X")
+    - focus-metavariable: $X
+    - metavariable-regex:
+        metavariable: $X
+        regex: ^$|hi
+    message: |
+      This test is demonstrating that literal metavariables can match
+      empty ranges, without crashing the engine upon a `focus`. They also
+      will faithfully match the empty string and "hi", respectively.
+    languages:
+      - kotlin
+    severity: WARNING


### PR DESCRIPTION
## What:
This PR incorporates the `ocaml-tree-sitter-semgrep` changes for Java 21.

## Why:
Java 21 is a largely anticipated release of Java. It would be nice to support it within Semgrep.

## How:
Did the translation.

More generally, I decided to incorporate some extra logic into the generic `AST_generic.interpolated` function. Certain programming languages have interpolated strings, which usually separates the contents of the string into different things (such as the raw string literals, interpolated exprs, etc). Sometimes, this makes a separation for the escape sequences too, meaning that such string literals are chopped into a million `G.Left3` pieces, which could be folded together.

This PR makes it such that we now combine literals that are next to each other. In addition, we handle the empty interpolated string, by producing the empty literal string.

## Test plan:
`make test`

Closes PA-3148
