### PR TITLE
update release workflow to tag images with canary(-nonroot) instead of latest(-nonroot)

### DIFF
--- a/.github/workflows/build-test-docker.yaml
+++ b/.github/workflows/build-test-docker.yaml
@@ -8,11 +8,11 @@ on:
       docker-flavor:
         required: true
         type: string
-        description: A multi-line string in the format accepted by docker metadata tag action for the flavor of the image
+        description: A multi-line string in the format accepted by docker metadata tag action for the flavor of the image. See https://github.com/docker/metadata-action#flavor-input for more information
       docker-tags:
         required: true
         type: string
-        description: A multi-line string in the format accepted by docker metadata tag action for the tags to apply to the image
+        description: A multi-line string in the format accepted by docker metadata tag action for the tags to apply to the image. See https://github.com/docker/metadata-action#tags-input for more information
       artifact-name:
         required: true
         type: string
@@ -41,11 +41,11 @@ on:
       docker-flavor:
         required: true
         type: string
-        description: A multi-line string in the format accepted by docker metadata tag action for the flavor of the image
+        description: A multi-line string in the format accepted by docker metadata tag action for the flavor of the image. See https://github.com/docker/metadata-action#flavor-input for more information
       docker-tags:
         required: true
         type: string
-        description: A multi-line string in the format accepted by docker metadata tag action for the tags to apply to the image
+        description: A multi-line string in the format accepted by docker metadata tag action for the tags to apply to the image. See https://github.com/docker/metadata-action#tags-input for more information
       artifact-name:
         required: true
         type: string

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,7 +128,7 @@ jobs:
         latest=false
         suffix=-nonroot
       docker-tags: |
-        type=raw,value=canary-nonroot
+        type=raw,value=canary
         type=semver,pattern={{version}}
         type=semver,pattern={{major}}.{{minor}}
       repository-name: ${{ github.repository }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,9 +92,16 @@ jobs:
     secrets: inherit
     needs: [inputs]
     with:
+      # latest=false == don't set the latest tag
+      #
+      # We first push to canary and then promote to latest
+      # once we confirm that the release doesn't have any
+      # obvious bugs or issues
+      #
       docker-flavor: |
-        latest=auto
+        latest=false
       docker-tags: |
+        type=raw,value=canary
         type=semver,pattern={{version}}
         type=semver,pattern={{major}}.{{minor}}
       repository-name: ${{ github.repository }}
@@ -111,10 +118,17 @@ jobs:
     # docker cache.
     needs: [inputs, build-test-docker]
     with:
+      # latest=false == don't set the latest tag
+      #
+      # We first push to canary-nonroot and then promote to latest-nonroot
+      # once we confirm that the release doesn't have any
+      # obvious bugs or issues
+      #
       docker-flavor: |
-        latest=auto
-        suffix=-nonroot,onlatest=true
+        latest=false
+        suffix=-nonroot
       docker-tags: |
+        type=raw,value=canary-nonroot
         type=semver,pattern={{version}}
         type=semver,pattern={{major}}.{{minor}}
       repository-name: ${{ github.repository }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,17 +92,15 @@ jobs:
     secrets: inherit
     needs: [inputs]
     with:
-      # latest=false == don't set the latest tag
-      #
-      # We first push to canary and then promote to latest
-      # once we confirm that the release doesn't have any
-      # obvious bugs or issues
-      #
       docker-flavor: |
+        # don't add a "latest" tag (we'll promote "canary-nonroot" to "latest-nonroot" after testing)
         latest=false
       docker-tags: |
+        # tag image with "canary"
         type=raw,value=canary
+        # tag image with full version (ex. "1.2.3")
         type=semver,pattern={{version}}
+        # tag image with major.minor (ex. "1.2")
         type=semver,pattern={{major}}.{{minor}}
       repository-name: ${{ github.repository }}
       artifact-name: image-release
@@ -125,11 +123,16 @@ jobs:
       # obvious bugs or issues
       #
       docker-flavor: |
-        latest=false
+        # suffix all tags with "-nonroot"
         suffix=-nonroot
+        # don't add a "latest" tag (we'll promote "canary" to "latest" after testing)
+        latest=false
       docker-tags: |
+        # tag image with "canary-nonroot"
         type=raw,value=canary
+        # tag image with full version (ex. "1.2.3-nonroot")
         type=semver,pattern={{version}}
+        # tag image with major.minor version (ex. "1.2-nonroot")
         type=semver,pattern={{major}}.{{minor}}
       repository-name: ${{ github.repository }}
       artifact-name: image-release-nonroot


### PR DESCRIPTION
test plan
- checks pass
- release dry run looks good