### PR TITLE
feat(ls): port login to osemgrep

### DIFF
--- a/src/osemgrep/cli/CLI.ml
+++ b/src/osemgrep/cli/CLI.ml
@@ -190,8 +190,7 @@ let dispatch_subcommand argv =
         | "login" when experimental -> Login_subcommand.main subcmd_argv
         | "logout" when experimental -> Logout_subcommand.main subcmd_argv
         | "publish" when experimental -> missing_subcommand ()
-        (* TODO: next target for not requiring the 'when experimental' guard!*)
-        | "lsp" when experimental -> Lsp_subcommand.main subcmd_argv
+        | "lsp" -> Lsp_subcommand.main subcmd_argv
         (* partial support, still use Pysemgrep.Fallback in it *)
         | "scan" -> Scan_subcommand.main subcmd_argv
         (* osemgrep-only: and by default! no need experimental! *)

--- a/src/osemgrep/language_server/custom_requests/Login.ml
+++ b/src/osemgrep/language_server/custom_requests/Login.ml
@@ -9,14 +9,8 @@ let on_request (server : RPC_server.t) params : Yojson.Safe.t option =
   match params with
   | None ->
       if Semgrep_login.is_logged_in () then (
-        let notifs =
-          SN.ShowMessage
-            {
-              ShowMessageParams.message = "Already logged in to Semgrep Code";
-              type_ = MessageType.Info;
-            }
-        in
-        RPC_server.batch_notify server [ notifs ];
+        RPC_server.notify_show_message server ~kind:MessageType.Info
+          "Already logged in to Semgrep Code";
         None)
       else
         let id, uri = Semgrep_login.make_login_url () in

--- a/src/osemgrep/language_server/custom_requests/Login.ml
+++ b/src/osemgrep/language_server/custom_requests/Login.ml
@@ -1,0 +1,32 @@
+open Lsp.Types
+module SN = Lsp.Server_notification
+module Conv = Convert_utils
+module Out = Semgrep_output_v1_t
+
+let logger = Logging.get_logger [ __MODULE__ ]
+let meth = "semgrep/login"
+
+let on_request (server : RPC_server.t) params : Yojson.Safe.t option =
+  match params with
+  | None ->
+      if Semgrep_login.is_logged_in () then (
+        let notifs =
+          SN.ShowMessage
+            {
+              ShowMessageParams.message = "Already logged in to Semgrep Code";
+              type_ = MessageType.Info;
+            }
+        in
+        RPC_server.batch_notify server [ notifs ];
+        None)
+      else
+        let id, uri = Semgrep_login.make_login_url () in
+        Some
+          (`Assoc
+            [
+              ("url", `String (Uri.to_string uri));
+              ("sessionId", `String (Uuidm.to_string id));
+            ])
+  | Some _ ->
+      logger#error "semgrep/login got params but expected none";
+      None

--- a/src/osemgrep/language_server/custom_requests/Login.ml
+++ b/src/osemgrep/language_server/custom_requests/Login.ml
@@ -3,7 +3,6 @@ module SN = Lsp.Server_notification
 module Conv = Convert_utils
 module Out = Semgrep_output_v1_t
 
-let logger = Logging.get_logger [ __MODULE__ ]
 let meth = "semgrep/login"
 
 let on_request (server : RPC_server.t) params : Yojson.Safe.t option =
@@ -28,5 +27,5 @@ let on_request (server : RPC_server.t) params : Yojson.Safe.t option =
               ("sessionId", `String (Uuidm.to_string id));
             ])
   | Some _ ->
-      logger#error "semgrep/login got params but expected none";
+      Logs.warn (fun m -> m "semgrep/login got params but expected none");
       None

--- a/src/osemgrep/language_server/custom_requests/Login.mli
+++ b/src/osemgrep/language_server/custom_requests/Login.mli
@@ -1,0 +1,7 @@
+val meth : string
+(** method to match on: semgrep/login *)
+
+val on_request :
+  RPC_server.t -> Jsonrpc.Structured.t option -> Yojson.Safe.t option
+(** Called by client to login to Semgrep App, returning the [id] of the
+      login session and the [uri] to log in to. Returns None if already logged in **)

--- a/src/osemgrep/language_server/custom_requests/LoginStatus.ml
+++ b/src/osemgrep/language_server/custom_requests/LoginStatus.ml
@@ -1,0 +1,8 @@
+module SN = Lsp.Server_notification
+module Conv = Convert_utils
+module Out = Semgrep_output_v1_t
+
+let meth = "semgrep/loginStatus"
+
+let on_request (_server : RPC_server.t) _params : Yojson.Safe.t option =
+  Some (`Bool (Semgrep_login.is_logged_in ()))

--- a/src/osemgrep/language_server/custom_requests/LoginStatus.ml
+++ b/src/osemgrep/language_server/custom_requests/LoginStatus.ml
@@ -5,4 +5,4 @@ module Out = Semgrep_output_v1_t
 let meth = "semgrep/loginStatus"
 
 let on_request (_server : RPC_server.t) _params : Yojson.Safe.t option =
-  Some (`Bool (Semgrep_login.is_logged_in ()))
+  Some (`Assoc [ ("loggedIn", `Bool (Semgrep_login.is_logged_in ())) ])

--- a/src/osemgrep/language_server/custom_requests/LoginStatus.mli
+++ b/src/osemgrep/language_server/custom_requests/LoginStatus.mli
@@ -1,4 +1,5 @@
 val meth : string
+(** method to match on: semgrep/loginStatus *)
 
 val on_request :
   RPC_server.t -> Jsonrpc.Structured.t option -> Yojson.Safe.t option

--- a/src/osemgrep/language_server/custom_requests/ShowAst.ml
+++ b/src/osemgrep/language_server/custom_requests/ShowAst.ml
@@ -57,7 +57,7 @@ end
 
 let meth = "semgrep/showAst"
 
-let on_request (params : Jsonrpc.Structured.t option) =
+let on_request _server (params : Jsonrpc.Structured.t option) =
   let { Request_params.document_uri; named } =
     Request_params.of_jsonrpc_params_exn params
   in

--- a/src/osemgrep/language_server/custom_requests/dune
+++ b/src/osemgrep/language_server/custom_requests/dune
@@ -5,5 +5,6 @@
  (libraries
    osemgrep_cli_scan
    semgrep.language_server.util
+   osemgrep_language_server_server
  )
 )

--- a/src/osemgrep/language_server/notifications/LoginFinish.ml
+++ b/src/osemgrep/language_server/notifications/LoginFinish.ml
@@ -1,0 +1,98 @@
+open Lsp.Types
+module Conv = Convert_utils
+module Out = Semgrep_output_v1_t
+
+let logger = Logging.get_logger [ __MODULE__ ]
+let meth = "semgrep/loginFinish"
+
+(*
+
+let wait_before_retry_in_sec = 6
+let max_retries = 30
+
+def m_semgrep__login_finish(self, url: str, sessionId: str) -> None:
+  """Called by client to finish login to Semgrep App and save token"""
+  self.notify_show_message(3, f"Waiting for login to Semgrep Code at {url}...")
+
+  state = get_state()
+  for _ in range(MAX_RETRIES):
+      r = state.app_session.post(
+          f"{state.env.semgrep_url}/api/agent/tokens/requests",
+          json={"token_request_key": sessionId},
+      )
+      if r.status_code == 200:
+          as_json = r.json()
+          login_token = as_json.get("token")
+          state = get_state()
+          if login_token is not None and auth.get_deployment_from_token(
+              login_token
+          ):
+              auth.set_token(login_token)
+              state = get_state()
+              state.app_session.authenticate()
+              self.notify_show_message(
+                  3, f"Successfully logged in to Semgrep Code"
+              )
+          else:
+              self.notify_show_message(1, f"Failed to log in to Semgrep Code")
+          return
+      elif r.status_code != 404:
+          self.notify_show_message(
+              1,
+              f"Unexpected failure from {state.env.semgrep_url}: status code {r.status_code}; please contact support@semgrep.com if this persists",
+          )
+
+      time.sleep(WAIT_BETWEEN_RETRY_IN_SEC)
+*)
+
+(*****************************************************************************)
+(* Request parameters *)
+(*****************************************************************************)
+
+type t = { url : string; sessionId : string } [@@deriving yojson]
+
+let of_jsonrpc_params params : t option =
+  match params with
+  | Some params ->
+      of_yojson (Jsonrpc.Structured.yojson_of_t params) |> Result.to_option
+  | __else__ -> None
+
+(*****************************************************************************)
+(* Entry point *)
+(*****************************************************************************)
+
+let on_notification server params : RPC_server.t option =
+  let ( let^ ) x f =
+    match x with
+    | Error s ->
+        RPC_server.notify_show_message server ~kind:MessageType.Error
+          ("semgrep/loginFinish failed: " ^ s);
+        None
+    | Ok y -> f y
+  in
+  match params with
+  | None ->
+      logger#error "semgrep/loginFinish got no params but expected some";
+      None
+  | Some _ ->
+      let^ { url; sessionId } =
+        of_jsonrpc_params params |> Option.to_result ~none:"got invalid params"
+      in
+      let url = Uuidm.of_string url |> Option.get in
+      let sessionId = sessionId |> Uri.of_string in
+      let^ token, _ = Semgrep_login.fetch_token (url, sessionId) in
+      let^ _deployment =
+        Semgrep_App.get_deployment_from_token token
+        |> Option.to_result ~none:"failed to get deployment"
+      in
+      let notifs =
+        Lsp.Server_notification.ShowMessage
+          {
+            ShowMessageParams.message = "Successfully logged in to Semgrep Code";
+            type_ = MessageType.Info;
+          }
+      in
+      RPC_server.batch_notify server [ notifs ];
+      let^ () = Semgrep_login.save_token token in
+      (* TODO: state.app_session.authenticate() *)
+      Some server

--- a/src/osemgrep/language_server/notifications/LoginFinish.ml
+++ b/src/osemgrep/language_server/notifications/LoginFinish.ml
@@ -2,7 +2,6 @@ open Lsp.Types
 module Conv = Convert_utils
 module Out = Semgrep_output_v1_t
 
-let logger = Logging.get_logger [ __MODULE__ ]
 let meth = "semgrep/loginFinish"
 let wait_before_retry_in_ms = 6 * 1000
 let max_retries = 30
@@ -38,7 +37,9 @@ let on_notification server params : unit =
     | Ok y -> f y
   in
   match params with
-  | None -> logger#error "semgrep/loginFinish got no params but expected some"
+  | None ->
+      Logs.warn (fun m ->
+          m "semgrep/loginFinish got no params but expected some")
   | Some _ ->
       (* All of this is side-effecting, so we can run it asynchronously, and
          return to the main event loop.

--- a/src/osemgrep/language_server/notifications/LoginFinish.ml
+++ b/src/osemgrep/language_server/notifications/LoginFinish.ml
@@ -4,46 +4,8 @@ module Out = Semgrep_output_v1_t
 
 let logger = Logging.get_logger [ __MODULE__ ]
 let meth = "semgrep/loginFinish"
-
-(*
-
-let wait_before_retry_in_sec = 6
+let wait_before_retry_in_ms = 6 * 1000
 let max_retries = 30
-
-def m_semgrep__login_finish(self, url: str, sessionId: str) -> None:
-  """Called by client to finish login to Semgrep App and save token"""
-  self.notify_show_message(3, f"Waiting for login to Semgrep Code at {url}...")
-
-  state = get_state()
-  for _ in range(MAX_RETRIES):
-      r = state.app_session.post(
-          f"{state.env.semgrep_url}/api/agent/tokens/requests",
-          json={"token_request_key": sessionId},
-      )
-      if r.status_code == 200:
-          as_json = r.json()
-          login_token = as_json.get("token")
-          state = get_state()
-          if login_token is not None and auth.get_deployment_from_token(
-              login_token
-          ):
-              auth.set_token(login_token)
-              state = get_state()
-              state.app_session.authenticate()
-              self.notify_show_message(
-                  3, f"Successfully logged in to Semgrep Code"
-              )
-          else:
-              self.notify_show_message(1, f"Failed to log in to Semgrep Code")
-          return
-      elif r.status_code != 404:
-          self.notify_show_message(
-              1,
-              f"Unexpected failure from {state.env.semgrep_url}: status code {r.status_code}; please contact support@semgrep.com if this persists",
-          )
-
-      time.sleep(WAIT_BETWEEN_RETRY_IN_SEC)
-*)
 
 (*****************************************************************************)
 (* Request parameters *)
@@ -51,10 +13,13 @@ def m_semgrep__login_finish(self, url: str, sessionId: str) -> None:
 
 type t = { url : string; sessionId : string } [@@deriving yojson]
 
-let of_jsonrpc_params params : t option =
+let of_jsonrpc_params params : (Uri.t * Uuidm.t) option =
   match params with
-  | Some params ->
-      of_yojson (Jsonrpc.Structured.yojson_of_t params) |> Result.to_option
+  | Some params -> (
+      match of_yojson (Jsonrpc.Structured.yojson_of_t params) with
+      | Error _ -> None
+      | Ok { url; sessionId } ->
+          Some (Uri.of_string url, Uuidm.of_string sessionId |> Option.get))
   | __else__ -> None
 
 (*****************************************************************************)
@@ -62,9 +27,10 @@ let of_jsonrpc_params params : t option =
 (*****************************************************************************)
 
 let on_notification server params : unit =
-  (* Emulating a poor man's writer's monad *)
-  let ( let^ ) x f =
-    match x with
+  (* Emulating a poor man's writer's monad, mixed with some LWT goodness. *)
+  let ( let^ ) (x : (_, string) Result.t Lwt.t) f : unit Lwt.t =
+    let%lwt result = x in
+    match result with
     | Error s ->
         RPC_server.notify_show_message server ~kind:MessageType.Error
           ("Failed to complete login process: " ^ s);
@@ -78,20 +44,23 @@ let on_notification server params : unit =
          return to the main event loop.
       *)
       Lwt.async (fun () ->
-          let^ { url; sessionId } =
+          let^ url, sessionId =
             of_jsonrpc_params params
-            |> Option.to_result ~none:"got invalid parameterss"
+            |> Option.to_result ~none:"got invalid parameters"
+            |> Lwt.return
           in
-          let sessionId = Uuidm.of_string sessionId |> Option.get in
-          let url = url |> Uri.of_string in
-          let%lwt result = Semgrep_login.fetch_token_async (sessionId, url) in
-          let^ token, _ = result in
+          let^ token, _ =
+            Semgrep_login.fetch_token_async ~min_wait_ms:wait_before_retry_in_ms
+              ~max_retries (sessionId, url)
+          in
           let^ _deployment =
-            Semgrep_App.get_deployment_from_token token
-            |> Option.to_result ~none:"failed to get deployment"
+            Semgrep_App.get_deployment_from_token_async token
+            |> Lwt.map (Option.to_result ~none:"failed to get deployment")
           in
+          (* TODO: state.app_session.authenticate()
+             basically, just add the token to the metrics once that exists
+          *)
           RPC_server.notify_show_message server ~kind:MessageType.Info
             "Successfully logged into Semgrep Code";
-          let^ () = Semgrep_login.save_token token in
+          let^ () = Semgrep_login.save_token_async token in
           Lwt.return ())
-(* TODO: state.app_session.authenticate() *)

--- a/src/osemgrep/language_server/notifications/LoginFinish.mli
+++ b/src/osemgrep/language_server/notifications/LoginFinish.mli
@@ -1,0 +1,5 @@
+val meth : string
+(** method to match on: semgrep/loginFinish *)
+
+val on_notification :
+  RPC_server.t -> Jsonrpc.Structured.t option -> RPC_server.t option

--- a/src/osemgrep/language_server/notifications/LoginFinish.mli
+++ b/src/osemgrep/language_server/notifications/LoginFinish.mli
@@ -1,5 +1,7 @@
 val meth : string
 (** method to match on: semgrep/loginFinish *)
 
-val on_notification :
-  RPC_server.t -> Jsonrpc.Structured.t option -> RPC_server.t option
+val on_notification : RPC_server.t -> Jsonrpc.Structured.t option -> unit
+(** [on_notification] will start an asynchronous job to process the
+      session information and complete the authentication process for login
+    *)

--- a/src/osemgrep/language_server/notifications/Notification_handler.ml
+++ b/src/osemgrep/language_server/notifications/Notification_handler.ml
@@ -30,6 +30,19 @@ module Conv = Convert_utils
 (* Code *)
 (*****************************************************************************)
 
+(* Dispatch to the various custom request handlers. *)
+let handle_custom_notification server (meth : string)
+    (params : Jsonrpc.Structured.t option) : RPC_server.t =
+  match
+    [ (LoginFinish.meth, LoginFinish.on_notification) ] |> List.assoc_opt meth
+  with
+  | None ->
+      Logs.warn (fun m -> m "Unhandled custom notification %s" meth);
+      server
+  | Some handler ->
+      handler server params;
+      server
+
 let on_notification notification (server : RPC_server.t) =
   let server =
     match notification with
@@ -86,15 +99,17 @@ let on_notification notification (server : RPC_server.t) =
     | CN.Exit ->
         Logs.app (fun m -> m "Server exiting");
         { server with state = RPC_server.State.Stopped }
-    | CN.UnknownNotification { method_ = "semgrep/refreshRules"; _ }
-    | CN.UnknownNotification { method_ = "semgrep/loginFinish"; _ } ->
+    | CN.UnknownNotification { method_ = "semgrep/refreshRules"; _ } ->
         Scan_helpers.refresh_rules server;
         server
     | CN.UnknownNotification { method_ = "semgrep/logout"; _ } ->
         if
           Semgrep_settings.save
             { (Semgrep_settings.load ()) with api_token = None }
-        then server
+        then (
+          RPC_server.notify_show_message server ~kind:MessageType.Info
+            "Logged out of Semgrep Code";
+          server)
         else (
           RPC_server.notify_show_message server ~kind:MessageType.Error
             "Failed to log out";
@@ -120,6 +135,8 @@ let on_notification notification (server : RPC_server.t) =
         Scan_helpers.scan_workspace scan_server;
         Logs.app (fun m -> m "Scanning workspace complete");
         server
+    | CN.UnknownNotification { method_; params } ->
+        handle_custom_notification server method_ params
     | _ ->
         Logs.warn (fun m ->
             m "Unhandled notification %s"

--- a/src/osemgrep/language_server/notifications/dune
+++ b/src/osemgrep/language_server/notifications/dune
@@ -4,5 +4,11 @@
  (wrapped false)
  (libraries
    semgrep.language_server.scan_helpers
+   osemgrep_language_server_server
+ )
+  (preprocess
+   (pps
+     ppx_deriving_yojson
+   )
  )
 )

--- a/src/osemgrep/language_server/notifications/dune
+++ b/src/osemgrep/language_server/notifications/dune
@@ -9,6 +9,7 @@
   (preprocess
    (pps
      ppx_deriving_yojson
+     lwt_ppx
    )
  )
 )

--- a/src/osemgrep/language_server/requests/Request_handler.ml
+++ b/src/osemgrep/language_server/requests/Request_handler.ml
@@ -50,13 +50,18 @@ let handle_custom_request server (meth : string)
     (params : Jsonrpc.Structured.t option) : Yojson.Safe.t option * RPC_server.t
     =
   match
-    [ (Search.meth, search_handler server); (ShowAst.meth, ShowAst.on_request) ]
+    [
+      (Search.meth, search_handler);
+      (ShowAst.meth, ShowAst.on_request);
+      (Login.meth, Login.on_request);
+      (LoginStatus.meth, LoginStatus.on_request);
+    ]
     |> List.assoc_opt meth
   with
   | None ->
       Logs.warn (fun m -> m "Unhandled custom request %s" meth);
       (None, server)
-  | Some handler -> (handler params, server)
+  | Some handler -> (handler server params, server)
 
 let on_request (type r) (request : r CR.t) server =
   let process_result (r, server) =

--- a/src/osemgrep/language_server/server/RPC_server.ml
+++ b/src/osemgrep/language_server/server/RPC_server.ml
@@ -136,6 +136,13 @@ let batch_notify server notifications =
   Logs.app (fun m -> m "Sending notifications");
   Lwt.async (fun () -> Lwt_list.iter_s (notify server) notifications)
 
+let notify_show_message server ~kind s =
+  let notif =
+    Server_notification.ShowMessage
+      { ShowMessageParams.message = s; type_ = kind }
+  in
+  batch_notify server [ notif ]
+
 (** Show a little progress circle while doing thing. Returns a token needed to end progress*)
 let create_progress server title message =
   let id = Uuidm.v `V4 |> Uuidm.to_string in

--- a/src/osemgrep/language_server/server/RPC_server.mli
+++ b/src/osemgrep/language_server/server/RPC_server.mli
@@ -17,6 +17,9 @@ val batch_notify : t -> Lsp.Server_notification.t list -> unit
 (** [batch_notify t notifs] sends a batch of notifications to the client. *)
 
 val notify_show_message : t -> kind:Lsp.Types.MessageType.t -> string -> unit
+(** [notify_show_message] server ~kind s sends the string [s] as a message with
+    type [kind] as a window to the extension
+  *)
 
 val create_progress : t -> string -> string -> Lsp.Types.ProgressToken.t
 (** [create_progress t title message] creates a progress token. *)

--- a/src/osemgrep/language_server/server/RPC_server.mli
+++ b/src/osemgrep/language_server/server/RPC_server.mli
@@ -16,6 +16,8 @@ type t = { session : Session.t; state : State.t }
 val batch_notify : t -> Lsp.Server_notification.t list -> unit
 (** [batch_notify t notifs] sends a batch of notifications to the client. *)
 
+val notify_show_message : t -> kind:Lsp.Types.MessageType.t -> string -> unit
+
 val create_progress : t -> string -> string -> Lsp.Types.ProgressToken.t
 (** [create_progress t title message] creates a progress token. *)
 

--- a/src/osemgrep/language_server/server/User_settings.ml
+++ b/src/osemgrep/language_server/server/User_settings.ml
@@ -36,6 +36,7 @@ type t = {
   only_git_dirty : bool; [@key "onlyGitDirty"] [@default true]
   ci : bool; [@default true]
   do_hover : bool; [@default false]
+  auth_token : string option; [@default None]
 }
 [@@deriving yojson]
 
@@ -52,6 +53,7 @@ let default =
     only_git_dirty = true;
     ci = true (* Secret setting for testing purposes *);
     do_hover = false;
+    auth_token = None;
   }
 
 let t_of_yojson json = of_yojson json

--- a/src/osemgrep/language_server/server/User_settings.ml
+++ b/src/osemgrep/language_server/server/User_settings.ml
@@ -36,7 +36,6 @@ type t = {
   only_git_dirty : bool; [@key "onlyGitDirty"] [@default true]
   ci : bool; [@default true]
   do_hover : bool; [@default false]
-  auth_token : string option; [@default None]
 }
 [@@deriving yojson]
 
@@ -53,7 +52,6 @@ let default =
     only_git_dirty = true;
     ci = true (* Secret setting for testing purposes *);
     do_hover = false;
-    auth_token = None;
   }
 
 let t_of_yojson json = of_yojson json

--- a/src/osemgrep/language_server/server/User_settings.mli
+++ b/src/osemgrep/language_server/server/User_settings.mli
@@ -10,7 +10,6 @@ type t = {
   only_git_dirty : bool;
   ci : bool;
   do_hover : bool;
-  auth_token : string option; [@default None]
 }
 
 val default : t

--- a/src/osemgrep/language_server/server/User_settings.mli
+++ b/src/osemgrep/language_server/server/User_settings.mli
@@ -10,6 +10,7 @@ type t = {
   only_git_dirty : bool;
   ci : bool;
   do_hover : bool;
+  auth_token : string option; [@default None]
 }
 
 val default : t

--- a/src/osemgrep/networking/Semgrep_login.ml
+++ b/src/osemgrep/networking/Semgrep_login.ml
@@ -37,25 +37,33 @@ let make_login_url () =
           ("gha", if !Semgrep_envvars.v.in_gh_action then "True" else "False");
         ]) )
 
-let save_token ?(ident = None) token =
+let save_token_async ?(ident = None) token =
   Option.iter
     (fun v -> Logs.debug (fun m -> m "saving token for user %s" v))
     ident;
   let settings = Semgrep_settings.load () in
-  match Semgrep_App.get_deployment_from_token token with
-  | None -> Error "Login token is not valid. Please try again."
-  | Some _deployment_config
-    when Semgrep_settings.save
-           Semgrep_settings.{ settings with api_token = Some token } ->
-      Ok ()
-  | _ -> Error "Failed to save token. Please try again."
+  Semgrep_App.get_deployment_from_token_async token
+  |> Lwt.map (function
+       | None -> Error "Login token is not valid. Please try again."
+       | Some _deployment_config
+         when Semgrep_settings.save
+                Semgrep_settings.{ settings with api_token = Some token } ->
+           Ok ()
+       | _ -> Error "Failed to save token. Please try again.")
+
+let save_token ?(ident = None) token =
+  Lwt_main.run (save_token_async ~ident token)
 
 let is_logged_in () =
   let settings = Semgrep_settings.load () in
   Option.is_some settings.api_token
 
+let default_wait_hook delay_ms =
+  (* Note: sleep is measured in seconds *)
+  Unix.sleepf (Float.of_int delay_ms /. Float.of_int (1000 * 100))
+
 let fetch_token_async ?(min_wait_ms = 2000) ?(next_wait_ms = 1000)
-    ?(max_retries = 12) ?(wait_hook = fun _delay_ms -> ()) login_session =
+    ?(max_retries = 12) ?(wait_hook = default_wait_hook) login_session =
   let apply_backoff current_wait_ms =
     Float.to_int (Float.ceil (Float.of_int current_wait_ms *. 1.3))
   in
@@ -100,9 +108,8 @@ let fetch_token_async ?(min_wait_ms = 2000) ?(next_wait_ms = 1000)
               | `String token ->
                   (* NOTE: We should probably use user_id over user_name for uniqueness constraints *)
                   let ident = json |> member "user_name" |> to_string in
-                  Result.bind (save_token ~ident:(Some ident) token) (fun () ->
-                      Ok (token, ident))
-                  |> Lwt.return
+                  let%lwt result = save_token_async ~ident:(Some ident) token in
+                  Result.bind result (fun () -> Ok (token, ident)) |> Lwt.return
               | `Null
               | _ ->
                   let message = Printf.sprintf "Failed to get token: %s" body in

--- a/src/osemgrep/networking/Semgrep_login.mli
+++ b/src/osemgrep/networking/Semgrep_login.mli
@@ -36,3 +36,18 @@ val fetch_token :
   * error message. These will give users ~2 minutes to login
   * [wait_hook] is a function that will be called before each retry
   *)
+
+val fetch_token_async :
+  ?min_wait_ms:int ->
+  ?next_wait_ms:int ->
+  ?max_retries:int ->
+  ?wait_hook:(int -> unit) ->
+  login_session ->
+  (string * string, string) result Lwt.t
+(** [fetch_token_async ?min_wait_ms ?next_wait_ms ?max_retries wait_hook login_session] will
+  * fetch the token using the request token and url the login session. It will retry up to [max_retries]
+  * times, waiting [min_wait_ms] ms between each retry, and increasing the
+  * wait time by [next_wait_ms] ms each time, returning a promise if successful. If it
+  * fails, it will return an error message. These will give users ~2 minutes to login
+  * [wait_hook] is a function that will be called before each retry
+  *)

--- a/src/osemgrep/networking/Semgrep_login.mli
+++ b/src/osemgrep/networking/Semgrep_login.mli
@@ -10,6 +10,9 @@ val make_login_url : unit -> login_session
   * environment (gha, cli etc.)
   *)
 
+val save_token_async :
+  ?ident:string option -> string -> (unit, string) result Lwt.t
+
 val save_token : ?ident:string option -> string -> (unit, string) result
 (** [save_token ?ident token] will save the token to the user's settings file.
   * If it fails, it will return an error message.


### PR DESCRIPTION
## What:
This PR ports `semgrep login` functionality to `osemgrep`, and retires `pysemgrep`'s LSP code as the entry point for `semgrep lsp`.

## Why:
We would like to officially make `osemgrep` the entry point for LSP!

## How:
Ported code, changed the entry point. There's a lot of `Lwt` wrangling to be done, because we have to use asynchronous helpers.

## Test plan:
Manually tested that logging in, logging out, and then logging back in functioned as expected.