### PR TITLE
commons: Add a 'protect' that does not raise 'Finally_raised'

### DIFF
--- a/languages/regexp/Parse.ml
+++ b/languages/regexp/Parse.ml
@@ -13,7 +13,9 @@ let channel conf ic = Lexing.from_channel ic |> from_lexbuf conf
 
 let file ?(conf = Dialect.default_conf) path =
   let ic = open_in_bin !!path in
-  Fun.protect ~finally:(fun () -> close_in_noerr ic) (fun () -> channel conf ic)
+  Common.protect
+    ~finally:(fun () -> close_in_noerr ic)
+    (fun () -> channel conf ic)
 
 let string ?(conf = Dialect.default_conf) s =
   Lexing.from_string s |> from_lexbuf conf

--- a/libs/ast_generic/AST_generic_equals.ml
+++ b/libs/ast_generic/AST_generic_equals.ml
@@ -77,7 +77,7 @@ let with_syntactic_equal equal a b =
   match !busy_with_equal with
   | Not_busy ->
       busy_with_equal := Syntactic_equal;
-      Fun.protect
+      Common.protect
         ~finally:(fun () -> busy_with_equal := Not_busy)
         (fun () -> equal a b)
   | Syntactic_equal
@@ -92,7 +92,7 @@ let with_structural_equal equal a b =
   match !busy_with_equal with
   | Not_busy ->
       busy_with_equal := Structural_equal;
-      Fun.protect
+      Common.protect
         ~finally:(fun () -> busy_with_equal := Not_busy)
         (fun () -> equal a b)
   | Syntactic_equal

--- a/libs/commons/Common.ml
+++ b/libs/commons/Common.ml
@@ -103,30 +103,13 @@ let before_return f v =
 (* Composition/Control *)
 (*****************************************************************************)
 
-(* alt: We could simply handle the 'Timeout' exception, record in a 'ref' that
- * it was raised, and re-raise it after 'finally' completes. Problem is that
- * the 'finally' block may have been interrupted. *)
 let protect ~finally work =
-  let prev_blocked = ref None in
-  let finally () =
-    (try
-       prev_blocked := Some (Unix.sigprocmask Unix.SIG_BLOCK [ Sys.sigalrm ])
-     with
-    | Invalid_argument _ -> (* TODO: on Windows ? *) ());
-    finally ()
-    (* If we unblock here, we could get a Timeout exception inside 'finally' ... *)
-  in
   (* nosemgrep: no-fun-protect *)
-  let x = Fun.protect ~finally work in
-  (* If 'prev_blocked' is 'None' then nothing was blocked... if it's 'Some _' then
-   * we are not on Windows so calling 'Unix.sigprocmask' should not raise any
-   * exception.
-   * NOTE: If SIGALRM was raised while it was blocked, it will not be lost,
-   *       it will trigger soon after we unblock it. *)
-  !prev_blocked
-  |> Option.iter (fun prev_blocked ->
-         Unix.sigprocmask Unix.SIG_SETMASK prev_blocked |> ignore);
-  x
+  try Fun.protect ~finally work with
+  | Fun.Finally_raised exn1 as exn ->
+      (* Just re-raise whatever exception was raised during a 'finally', drop 'Finally_raised'. *)
+      logger#error "protect: %s" (exn |> Exception.catch |> Exception.to_string);
+      Exception.catch_and_reraise exn1
 
 (*****************************************************************************)
 (* Profiling *)

--- a/libs/commons/Common.ml
+++ b/libs/commons/Common.ml
@@ -100,6 +100,29 @@ let before_return f v =
   v
 
 (*****************************************************************************)
+(* Composition/Control *)
+(*****************************************************************************)
+
+let protect ~finally work =
+  let prev_blocked = ref None in
+  let finally () =
+    (try
+       prev_blocked := Some (Unix.sigprocmask Unix.SIG_BLOCK [ Sys.sigalrm ])
+     with
+    | Invalid_argument _ -> (* TODO: on Windows ? *) ());
+    finally ()
+    (* If we unblock here, we could get a Timeout exception inside 'finally' ... *)
+  in
+  (* nosemgrep: no-fun-protect *)
+  let x = Fun.protect ~finally work in
+  (* If 'prev_blocked' is 'None' then nothing was blocked... if it's 'Some _' then
+   * we are not on Windows so future calls should not raise any exception. *)
+  !prev_blocked
+  |> Option.iter (fun prev_blocked ->
+         Unix.sigprocmask Unix.SIG_SETMASK prev_blocked |> ignore);
+  x
+
+(*****************************************************************************)
 (* Profiling *)
 (*****************************************************************************)
 (* see also profiling/Profiling.ml now *)
@@ -113,13 +136,13 @@ let with_time f =
 
 let pr_time name f =
   let t1 = Unix.gettimeofday () in
-  Fun.protect f ~finally:(fun () ->
+  protect f ~finally:(fun () ->
       let t2 = Unix.gettimeofday () in
       pr (spf "%s: %.6f s" name (t2 -. t1)))
 
 let pr2_time name f =
   let t1 = Unix.gettimeofday () in
-  Fun.protect f ~finally:(fun () ->
+  protect f ~finally:(fun () ->
       let t2 = Unix.gettimeofday () in
       pr2 (spf "%s: %.6f s" name (t2 -. t1)))
 
@@ -468,7 +491,7 @@ let unwind_protect f cleanup =
         cleanup e;
         Exception.reraise e
 
-(* TODO: remove and use Fun.protect instead? but then it will not have the
+(* TODO: remove and use 'protect' instead? but then it will not have the
  * !debugger goodies *)
 let finalize f cleanup =
   (* Does this debugger mode changes the semantic of the program too much?
@@ -481,7 +504,7 @@ let finalize f cleanup =
     let res = f () in
     cleanup ();
     res)
-  else Fun.protect f ~finally:cleanup
+  else protect f ~finally:cleanup
 
 let save_excursion reference newv f =
   let old = !reference in
@@ -930,7 +953,7 @@ let read_file ?(max_len = max_int) path =
           else loop fd
     in
     let fd = Unix.openfile path [ Unix.O_RDONLY ] 0 in
-    Fun.protect ~finally:(fun () -> Unix.close fd) (fun () -> loop fd)
+    protect ~finally:(fun () -> Unix.close fd) (fun () -> loop fd)
 
 let write_file ~file s =
   let chan = open_out_bin file in

--- a/libs/commons/Common.mli
+++ b/libs/commons/Common.mli
@@ -448,9 +448,10 @@ val memoized : ?use_cache:bool -> ('a, 'b) Hashtbl.t -> 'a -> (unit -> 'b) -> 'b
 val protect : finally:(unit -> unit) -> (unit -> 'a) -> 'a
 (** Same as 'Fun.protect' but we block SIGALRM while executing `finally()`, this
  * prevents that a timeout set via 'Time_limit' accidentally raises 'Timeout'
- * in the middle of 'finally's code, which would crash Semgrep. After 'finally'
- * completes, we restore SIGALRM and, if the timeout alarm triggered while it was
- * being blocked, 'Timeout' will still be raised.
+ * in the middle of 'finally's code, which is considered a programming error and
+ * it will raise 'Finally_raised'. After 'finally' completes, we restore SIGALRM
+ * and, if the timeout alarm triggered while it was being blocked, 'Timeout' will
+ * still be raised.
  *
  * It is safe to nest a 'protect' inside the 'finally' of another 'protect. *)
 

--- a/libs/commons/Common.mli
+++ b/libs/commons/Common.mli
@@ -442,6 +442,19 @@ val partition_result :
 val memoized : ?use_cache:bool -> ('a, 'b) Hashtbl.t -> 'a -> (unit -> 'b) -> 'b
 
 (*****************************************************************************)
+(* Composition/Control *)
+(*****************************************************************************)
+
+val protect : finally:(unit -> unit) -> (unit -> 'a) -> 'a
+(** Same as 'Fun.protect' but we block SIGALRM while executing `finally()`, this
+ * prevents that a timeout set via 'Time_limit' accidentally raises 'Timeout'
+ * in the middle of 'finally's code, which would crash Semgrep. After 'finally'
+ * completes, we restore SIGALRM and, if the timeout alarm triggered while it was
+ * being blocked, 'Timeout' will still be raised.
+ *
+ * It is safe to nest a 'protect' inside the 'finally' of another 'protect. *)
+
+(*****************************************************************************)
 (* Profiling *)
 (*****************************************************************************)
 (* See also the profiling library and profiling.ppx [@@profiling] annot *)

--- a/libs/commons/Testutil.ml
+++ b/libs/commons/Testutil.ml
@@ -125,7 +125,7 @@ let filter ?substring ?pcre tests =
 
 let run what f =
   printf "running %s...\n%!" what;
-  Fun.protect ~finally:(fun () -> printf "done with %s.\n%!" what) f
+  Common.protect ~finally:(fun () -> printf "done with %s.\n%!" what) f
 
 let registered_tests : test list ref = ref []
 

--- a/libs/commons/Testutil_files.ml
+++ b/libs/commons/Testutil_files.ml
@@ -77,7 +77,7 @@ and write_one root file =
 
 let get_dir_entries path =
   let dir = Unix.opendir (Fpath.to_string path) in
-  Fun.protect
+  Common.protect
     ~finally:(fun () -> Unix.closedir dir)
     (fun () ->
       let acc = ref [] in
@@ -153,7 +153,7 @@ let mkdir ?(root = Sys.getcwd () |> Fpath.v) path =
 let with_chdir dir f =
   let dir_s = Fpath.to_string dir in
   let orig = Unix.getcwd () in
-  Fun.protect
+  Common.protect
     ~finally:(fun () -> Unix.chdir orig)
     (fun () ->
       Unix.chdir dir_s;
@@ -189,7 +189,7 @@ let remove path =
 
 let with_tempdir ?(persist = false) ?(chdir = false) func =
   let dir = create_tempdir () in
-  Fun.protect
+  Common.protect
     ~finally:(fun () -> if not persist then remove dir)
     (fun () -> if chdir then with_chdir dir (fun () -> func dir) else func dir)
 

--- a/libs/commons/tests/Unit_commons.ml
+++ b/libs/commons/tests/Unit_commons.ml
@@ -102,7 +102,7 @@ let test_readable () =
 
 let with_file contents f =
   let file, oc = Filename.open_temp_file "test_pfff_read_file_" ".dat" in
-  Fun.protect
+  Common.protect
     ~finally:(fun () ->
       close_out_noerr oc;
       Sys.remove file)

--- a/libs/concurrency/Concurrency.ml
+++ b/libs/concurrency/Concurrency.ml
@@ -31,4 +31,4 @@
 (* See also Lock_protected.ml *)
 let with_lock f lock =
   Mutex.lock lock;
-  Fun.protect ~finally:(fun () -> Mutex.unlock lock) f
+  Common.protect ~finally:(fun () -> Mutex.unlock lock) f

--- a/libs/concurrency/dune
+++ b/libs/concurrency/dune
@@ -3,6 +3,8 @@
  (wrapped false)
  (libraries
    threads
+
+   commons
  )
  (preprocess
    (pps

--- a/libs/git_wrapper/Git_wrapper.ml
+++ b/libs/git_wrapper/Git_wrapper.ml
@@ -206,7 +206,7 @@ let run_with_worktree ~commit ?(branch = None) f =
         | Ok _ -> raise (Error ("Could not remove git worktree at " ^ temp_dir))
         | Error (`Msg e) -> raise (Error e)
       in
-      Fun.protect ~finally:cleanup work
+      Common.protect ~finally:cleanup work
   | Ok _ -> raise (Error ("Could not create git worktree for " ^ commit))
   | Error (`Msg e) -> raise (Error e)
 

--- a/libs/ograph/ograph_extended.ml
+++ b/libs/ograph/ograph_extended.ml
@@ -264,7 +264,7 @@ let get_os =
   let os =
     lazy
       (let ic = Unix.open_process_in "uname" in
-       Fun.protect
+       Common.protect
          (fun () ->
            let uname = input_line ic in
            match uname with

--- a/libs/paths/List_files.ml
+++ b/libs/paths/List_files.ml
@@ -18,7 +18,7 @@ let logger = Logging.get_logger [ __MODULE__ ]
 
 let with_dir_handle path func =
   let dir = Unix.opendir !!path in
-  Fun.protect ~finally:(fun () -> Unix.closedir dir) (fun () -> func dir)
+  Common.protect ~finally:(fun () -> Unix.closedir dir) (fun () -> func dir)
 
 (* Read the names found in a directory, excluding "." and "..". *)
 let read_dir_entries path =

--- a/libs/paths/Unit_Rpath.ml
+++ b/libs/paths/Unit_Rpath.ml
@@ -1,7 +1,7 @@
 (* TODO: copy paste of Unit_commons.with_file, but should be in Common.ml *)
 let with_file contents f =
   let file, oc = Filename.open_temp_file "test_pfff_read_file_" ".dat" in
-  Fun.protect
+  Common.protect
     ~finally:(fun () ->
       close_out_noerr oc;
       Sys.remove file)

--- a/libs/paths/Unit_list_files.ml
+++ b/libs/paths/Unit_list_files.ml
@@ -50,13 +50,13 @@ let with_file_tree tree func =
     / sprintf "test-list_files-%i" (Random.bits ())
   in
   Unix.mkdir !!workspace 0o777;
-  Fun.protect
+  Common.protect
     ~finally:(fun () ->
       try Sys.rmdir !!workspace with
       | _ -> ())
     (fun () ->
       create_files workspace tree;
-      Fun.protect
+      Common.protect
         ~finally:(fun () -> delete_files workspace tree)
         (fun () -> func workspace))
 

--- a/libs/process_limits/Memory_limit.ml
+++ b/libs/process_limits/Memory_limit.ml
@@ -115,7 +115,7 @@ let run_with_memory_limit ?get_context
       stack_already_warned := true)
   in
   let alarm = Gc.create_alarm limit_memory in
-  try Fun.protect f ~finally:(fun () -> Gc.delete_alarm alarm) with
+  try Common.protect f ~finally:(fun () -> Gc.delete_alarm alarm) with
   | Out_of_memory as exn ->
       (*
          Is it bad to collect a full stack backtrace when we're out of memory?

--- a/libs/process_limits/Unit_memory_limit.ml
+++ b/libs/process_limits/Unit_memory_limit.ml
@@ -18,7 +18,7 @@ let get_heap_size_in_bytes () =
 *)
 let with_debug_alarm f =
   let alarm = Gc.create_alarm (fun () -> printf "Running GC alarm.\n%!") in
-  Fun.protect f ~finally:(fun () -> Gc.delete_alarm alarm)
+  Common.protect f ~finally:(fun () -> Gc.delete_alarm alarm)
 
 (*
    Grow the stack until some limit expressed in bytes.

--- a/libs/profiling/Profiling.ml
+++ b/libs/profiling/Profiling.ml
@@ -112,7 +112,7 @@ let profile_code_exclusif category f =
         failwith (spf "profile_code_exclusif: %s but already in %s " category s)
     | None ->
         _is_in_exclusif := Some category;
-        Fun.protect
+        protect
           (fun () -> profile_code category f)
           ~finally:(fun () -> _is_in_exclusif := None)
 

--- a/libs/spacegrep/src/lib/Print.ml
+++ b/libs/spacegrep/src/lib/Print.ml
@@ -45,7 +45,7 @@ let to_stdout nodes = to_channel stdout nodes
 
 let to_file file nodes =
   let oc = open_out_bin file in
-  Fun.protect
+  Common.protect
     ~finally:(fun () -> close_out_noerr oc)
     (fun () -> to_channel oc nodes)
 
@@ -90,7 +90,7 @@ module Debug = struct
 
   let to_file file nodes =
     let oc = open_out_bin file in
-    Fun.protect
+    Common.protect
       ~finally:(fun () -> close_out_noerr oc)
       (fun () -> to_channel oc nodes)
 end

--- a/semgrep.yml
+++ b/semgrep.yml
@@ -397,27 +397,13 @@ rules:
     severity: WARNING
 
   - id: no-logger-flash
-    patterns:
-      # FIXME: This doesn't work as expected
-      # - pattern-inside: |
-      #     let $LOGGER = Logging.get_logger ...
-      #     ...
-      - pattern: $LOGGER#flash ...
+    pattern-either:
+      - pattern-regex: "logger#flash"
+      - pattern-regex: "_logger#flash"
     message: >-
-      $LOGGER#flash is just for debuggging purposes.
+      logger#flash is just for debuggging purposes.
     fix: ""
     languages: [ocaml]
-    severity: WARNING
-
-  - id: no-logger-flash-in-comments
-    patterns:
-      - pattern: (* ... $LOGGER#flash ... *)
-    message: >-
-      $LOGGER#flash is just for debuggging purposes.
-    fix: ""
-    languages: [generic]
-    paths:
-      include: ["*.ml"]
     severity: WARNING
 
   - id: no-match-x-x-with
@@ -427,3 +413,17 @@ rules:
       You probably meant ($X, something-else) and this is due to a typo.
     languages: [ocaml]
     severity: WARNING
+
+  - id: no-fun-protect
+    pattern: Fun.protect
+    message: >-
+      `Fun.protect` does not block SIGALRM, which we use to implement timeouts (see
+      module 'Time_limit'). The alarm could trigger while we are executing a 'finally'
+      ths causing Semgrep to crash. Use `Common.protect` instead.
+    fix: Common.protect
+    languages: [ocaml]
+    severity: ERROR
+    paths:
+      include:
+        - src/*
+        - libs/*

--- a/src/core_scan/Core_scan.ml
+++ b/src/core_scan/Core_scan.ml
@@ -167,7 +167,7 @@ let replace_named_pipe_by_regular_file path =
         let remove () = if Sys.file_exists tmp_path then Sys.remove tmp_path in
         (* Try to remove temporary file when program exits. *)
         at_exit remove;
-        Fun.protect
+        Common.protect
           ~finally:(fun () -> close_out_noerr oc)
           (fun () -> output_string oc data);
         Fpath.v tmp_path
@@ -587,6 +587,9 @@ let iter_targets_and_get_matches_and_exn_to_errors config
                        (Core_profiling.empty_partial_profiling file),
                      Scanned )
                (* those were converted in Main_timeout in timeout_function()*)
+               (* FIXME:
+                  Actually, I managed to get this assert to trigger by running
+                  semgrep -c p/default-v2 on elasticsearch with -timeout 0.01 ! *)
                | Time_limit.Timeout _ -> assert false
                (* It would be nice to detect 'R.Err (R.InvalidRule _)' here
                 * for errors while parsing patterns. This exn used to be raised earlier

--- a/src/engine/Xpattern_matcher.ml
+++ b/src/engine/Xpattern_matcher.ml
@@ -107,7 +107,7 @@ let line_col_of_charpos file charpos =
  * https://github.com/returntocorp/semgrep/issues/5277 *)
 let with_tmp_file ~str ~ext f =
   Common2.with_tmp_file ~str ~ext (fun file ->
-      Fun.protect
+      Common.protect
         ~finally:(fun () -> Hashtbl.remove hmemo file)
         (fun () -> f file))
 

--- a/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -133,7 +133,7 @@ let file_match_results_hook (conf : Scan_CLI.conf) (rules : Rule.rules)
   in
   if cli_matches <> [] then (
     Unix.lockf Unix.stdout Unix.F_LOCK 0;
-    Fun.protect
+    Common.protect
       (fun () ->
         (* coupling: similar to Output.dispatch_output_format for Text *)
         Matches_report.pp_text_outputs

--- a/src/osemgrep/core/Profiler.ml
+++ b/src/osemgrep/core/Profiler.ml
@@ -30,7 +30,7 @@ let record profiler ~name fn =
     let t1 = Unix.gettimeofday () in
     Hashtbl.add profiler name (Recorded (t1 -. t0))
   in
-  Fun.protect ~finally fn
+  Common.protect ~finally fn
 
 let dump profiler =
   Hashtbl.fold

--- a/src/targeting/Unit_guess_lang.ml
+++ b/src/targeting/Unit_guess_lang.ml
@@ -76,7 +76,7 @@ let with_file name contents exec f =
   (match exec with
   | Exec -> Unix.chmod !!path 0o755
   | Nonexec -> ());
-  Fun.protect
+  Common.protect
     ~finally:(fun () -> close_out oc)
     (fun () ->
       output_string oc contents;


### PR DESCRIPTION
With `Fun.protect ~finally work`, if a timeout happens in the middle of `finally()`, it will raise a `Finally_raised` exception rather than a `Timeout` exception, so it will be handled as a fatal error rather than as a timeout. This does not happen much (ever?) right now because timeouts are rare, but we want to have finer-grained timeouts during inter-file tainting, particularly during taint-signature inference. When there are more timeouts, it becomes more likely than one coincides in the middle of a `finally`. (I have experience this running on _elasticsearch_ with fine-grained timeouts.)

For now, we just drop `Finally_raised` exceptions and instead re-raise whatever exception was raised during `finally`.

Eventually we may want to write a more robust `protect` function that blocks `SIGALRM`, but it seems that first we may need to review every single use of `protect`. (We tried blocking `SIGALRM` and ran into some weird problems, see code comments.)

test plan:
Add fine-grained timeouts to inter-proc tainting and run with --pro on elasticsearch