### PR TITLE
fix(elixir): make sequential tainting work

### DIFF
--- a/changelog.d/pa-3130.fixed
+++ b/changelog.d/pa-3130.fixed
@@ -1,0 +1,11 @@
+Sequential tainting is now supported in Elixir.
+
+```elixir
+def f() do
+  x = "tainted"
+  y = x
+
+  # This now matches.
+  sink(y)
+end
+```

--- a/libs/ast_generic/AST_generic.ml
+++ b/libs/ast_generic/AST_generic.ml
@@ -1360,7 +1360,7 @@ and other_stmt_operator =
 (* Pattern *)
 (*****************************************************************************)
 (* This is quite similar to expr. A few constructs in expr have
-* equivalent here prefixed with Pat (e.g., PaLiteral, PatId). We could
+ * equivalent here prefixed with Pat (e.g., PaLiteral, PatId). We could
  * maybe factorize with expr, and this may help semgrep, but I think it's
  * cleaner to have a separate type because the scoping rules for a pattern and
  * an expr are quite different and not any expr is allowed here.

--- a/libs/commons/File_type.ml
+++ b/libs/commons/File_type.ml
@@ -77,6 +77,7 @@ and pl_type =
   | Web of webpl_type
   | IDL of idl_type
   | MiscPL of string
+  | Elixir
 
 and config_type =
   | Makefile
@@ -374,6 +375,7 @@ let file_type_of_file file =
   | "r"
   | "R" ->
       PL R
+  | "ex" -> PL Elixir
   | _ when File.is_executable file -> Binary e
   | _ when b = "Makefile" || b = "mkfile" || b = "Imakefile" -> Config Makefile
   | _ when b = "Dockerfile" -> Config Dockerfile

--- a/libs/commons/File_type.mli
+++ b/libs/commons/File_type.mli
@@ -43,6 +43,7 @@ and pl_type =
   | Web of webpl_type
   | IDL of idl_type
   | MiscPL of string
+  | Elixir
 
 and config_type =
   | Makefile

--- a/src/analyzing/AST_to_IL.ml
+++ b/src/analyzing/AST_to_IL.ml
@@ -326,6 +326,7 @@ and pattern env pat =
   | G.PatId (id, id_info) ->
       let lval = lval_of_id_info env id id_info in
       (lval, [])
+  | G.PatList (tok1, pats, tok2)
   | G.PatTuple (tok1, pats, tok2) ->
       (* P1, ..., Pn *)
       let tmp = fresh_var env tok2 in

--- a/src/core/Lang.ml
+++ b/src/core/Lang.ml
@@ -151,6 +151,7 @@ let langs_of_filename filename =
   | FT.PL FT.Scala -> [ Scala ]
   | FT.PL FT.Swift -> [ Swift ]
   | FT.PL (FT.Web FT.Html) -> [ Html ]
+  | FT.PL FT.Elixir -> [ Elixir ]
   | _ -> []
 
 let lang_of_filename_exn filename =

--- a/tests/taint_maturity/elixir/taint_seq.ex
+++ b/tests/taint_maturity/elixir/taint_seq.ex
@@ -1,0 +1,34 @@
+defmodule Test do
+
+  def test1() do
+    #ruleid: taint-maturity
+    sink("tainted")
+  end
+
+  def test2() do
+    x = "safe"
+    a = x
+    {x, dont_care} = {"tainted", "safe"}
+    [y, dont_care] = [x, "safe"]
+    z = y
+    #ruleid: taint-maturity
+    sink(z)
+    #OK: taint-maturity
+    sink(a)
+    #OK: taint-maturity
+    safe(z)
+  end
+
+  def test3() do
+    #OK: taint-maturity
+    sink(sanitize("tainted"))
+  end
+
+  def test4() do
+    x = "tainted"
+    x = sanitize(x)
+    #OK: taint-maturity
+    sink(x)
+  end
+
+end

--- a/tests/taint_maturity/elixir/taint_seq.yaml
+++ b/tests/taint_maturity/elixir/taint_seq.yaml
@@ -1,0 +1,15 @@
+rules:
+  - id: taint-maturity
+    mode: taint
+    languages:
+      - elixir
+    message: |
+      This confirms taint mode works.
+    pattern-sinks:
+      - pattern: sink(...)
+    pattern-sources:
+      - pattern: |
+          "tainted"
+    pattern-sanitizers:
+      - pattern: sanitize(...)
+    severity: ERROR


### PR DESCRIPTION
Before this PR, the statement
```
  x = y
```
is treated as a binary op, and the taint analysis won't properly analyze the dataflow.

In this PR
```
  x = y
```
is treated as VarDef, and for cases with more involved LHSs, such as
```
  {x1, x2} = {y1, y2}
  [x1, x2] = [y1, y2]
```
are treated as LetPatterns.

In the process, added support to PatList in AST_to_generic, so lists such as in the example above can be included.

Also added the .ex file type to default to Elixir. This is needed for looking at the generated IL, and I thought it's useful to keep it.

Tested with `make test-core`.

