### PR TITLE
test: Fail on empty set of parsing tests

### DIFF
--- a/src/parsing/Unit_parsing.ml
+++ b/src/parsing/Unit_parsing.ml
@@ -54,6 +54,8 @@ let lang_parsing_tests () =
     pack_tests slang
       (let dir = tests_path_parsing / dir in
        let files = Common2.glob (spf "%s/*%s" !!dir ext) in
+       if files =*= [] then
+         failwith (spf "Empty set of parsing tests for %s" slang);
        parsing_tests_for_lang files lang)
   in
   pack_suites "lang parsing testing"


### PR DESCRIPTION
https://github.com/returntocorp/semgrep/pull/8773 broke `Common2.glob` which this relies on. This change makes it so that if we find no parsing tests for a given language, we error out. This failsafe will make it more difficult to accidentally stop running the parsing tests in the future (via changes to `Common2.glob`, or moving the files and making a typo, or something else).

Test will be red on this until `Common2.glob` is fixed.

Test plan: `make core-test` -> observe a failure (as of October 3)

