### PR TITLE
osemgrep: handle --matching-explanations

### DIFF
--- a/cli/tests/e2e/test_output.py
+++ b/cli/tests/e2e/test_output.py
@@ -523,6 +523,10 @@ def test_cli_test_secret_rule(run_semgrep_in_tmp: RunSemgrep, snapshot):
 
 
 # TODO! @pytest.mark.osempass
+# This is currently not passing because the loc field in the explanation
+# differs between pysemgrep and osemgrep because it's a location in the rule
+# (not in the target), and pysemgrep passes a preprocessed rule file to
+# semgrep-core hence the mistmatch.
 @pytest.mark.quick
 def test_output_matching_explanations(run_semgrep_in_tmp: RunSemgrep, snapshot):
     stdout, _ = run_semgrep_in_tmp(

--- a/src/core/Core_result.ml
+++ b/src/core/Core_result.ml
@@ -1,3 +1,7 @@
+open Common
+module E = Core_error
+open Core_profiling
+
 (*****************************************************************************)
 (* Prelude *)
 (*****************************************************************************)
@@ -21,8 +25,6 @@
  *  -> Semgrep_output_v1.findings
  * LATER: it would be good to remove some intermediate types.
  *)
-module E = Core_error
-open Core_profiling
 
 let logger = Logging.get_logger [ __MODULE__ ]
 
@@ -52,7 +54,7 @@ type t = {
   skipped_rules : Rule.invalid_rule_error list;
   (* may contain also skipped_target information *)
   extra : Core_profiling.t Core_profiling.debug_info;
-  explanations : Matching_explanation.t list;
+  explanations : Matching_explanation.t list option;
   rules_by_engine : (Rule_ID.t * Engine_kind.t) list;
   scanned : Fpath.t list;
 }
@@ -89,7 +91,7 @@ let mk_final_result_with_just_errors (errors : Core_error.t list) : t =
     matches = [];
     skipped_rules = [];
     extra = No_info;
-    explanations = [];
+    explanations = None;
     rules_by_engine = [];
     scanned = [];
   }
@@ -315,7 +317,7 @@ let make_final_result
     errors;
     extra;
     skipped_rules;
-    explanations;
+    explanations = (if explanations =*= [] then None else Some explanations);
     rules_by_engine =
       rules_with_engine |> Common.map (fun (r, ek) -> (fst r.Rule.id, ek));
     scanned;

--- a/src/core/Core_result.mli
+++ b/src/core/Core_result.mli
@@ -17,7 +17,7 @@ type t = {
   skipped_rules : Rule.invalid_rule_error list;
   (* may contain skipped_target info *)
   extra : Core_profiling.t Core_profiling.debug_info;
-  explanations : Matching_explanation.t list;
+  explanations : Matching_explanation.t list option;
   rules_by_engine : (Rule_ID.t * Engine_kind.t) list;
   (* The targets are all the files that were considered valid targets for the
    * semgrep scan. This excludes files that were filtered out on purpose

--- a/src/core_cli/Core_command.ml
+++ b/src/core_cli/Core_command.ml
@@ -100,7 +100,7 @@ let output_core_results (result_or_exn : Core_result.result_or_exn)
       | Ok res ->
           if config.matching_explanations then
             res.explanations
-            |> List.iter (fun explain -> Matching_explanation.print explain);
+            |> Option.iter (List.iter Matching_explanation.print);
           (* the match has already been printed above. We just print errors here *)
           if not (null res.errors) then (
             pr "WARNING: some files were skipped or only partially analyzed:";

--- a/src/osemgrep/reporting/Cli_json_output.ml
+++ b/src/osemgrep/reporting/Cli_json_output.ml
@@ -548,8 +548,8 @@ let cli_output_of_core_results ~logging_level (core : Out.core_output)
        scanned = _;
      };
    skipped_rules;
+   explanations;
    (* LATER *)
-   explanations = _;
    time = _;
    rules_by_engine = _;
    engine_requested = _;
@@ -608,8 +608,8 @@ let cli_output_of_core_results ~logging_level (core : Out.core_output)
         errors = errors |> Common.map cli_error_of_core_error;
         paths;
         skipped_rules;
+        explanations;
         (* LATER *)
-        explanations = None;
         time = None;
         rules_by_engine = None;
         engine_requested = None;

--- a/src/reporting/Core_json_output.ml
+++ b/src/reporting/Core_json_output.ml
@@ -403,9 +403,9 @@ let profiling_to_profiling (profiling_data : Core_profiling.t) : Out.profile =
 let core_output_of_matches_and_errors render_fix (res : Core_result.t) :
     Out.core_output =
   let matches, new_errs =
-    Common.partition_either (match_to_match render_fix) res.RP.matches
+    Common.partition_either (match_to_match render_fix) res.matches
   in
-  let errs = !E.g_errors @ new_errs @ res.RP.errors in
+  let errs = !E.g_errors @ new_errs @ res.errors in
   let skipped_targets, profiling =
     match res.extra with
     | Core_profiling.Debug { skipped_targets; profiling } ->
@@ -425,7 +425,7 @@ let core_output_of_matches_and_errors render_fix (res : Core_result.t) :
         scanned = [];
       };
     skipped_rules =
-      res.RP.skipped_rules
+      res.skipped_rules
       |> Common.map (fun ((kind, rule_id, tk) : Rule.invalid_rule_error) ->
              let loc = Tok.unsafe_loc_of_tok tk in
              {
@@ -435,8 +435,7 @@ let core_output_of_matches_and_errors render_fix (res : Core_result.t) :
              });
     time = profiling |> Option.map profiling_to_profiling;
     explanations =
-      ( res.RP.explanations |> Common.map explanation_to_explanation |> fun x ->
-        Some x );
+      res.explanations |> Option.map (Common.map explanation_to_explanation);
     rules_by_engine = Some (Common.map convert_rule res.rules_by_engine);
     engine_requested = Some `OSS;
     version = Some Version.version;


### PR DESCRIPTION
test plan:
PYTEST_USE_OSEMGREP=true pipenv run pytest tests/e2e/test_output.py::test_output_matching_explanations -vv

is failing, but the only difference is about the 'loc' field
because pysemgrep pass a preprocessed rule to semgrep-core,
but osemgrep processes the original rule instead.