### PR TITLE
add testcases for matching c, cpp array initializations

### DIFF
--- a/tests/rules/c_array_inits.c
+++ b/tests/rules/c_array_inits.c
@@ -1,0 +1,8 @@
+int foo() {
+    // ruleid: c-array-initialization
+    char buf[64];
+    // ruleid: c-array-initialization
+    char buf[64] = "foo bar baz...";
+    // ruleid: c-array-initialization
+    char buf[64] = {0};
+}

--- a/tests/rules/c_array_inits.yaml
+++ b/tests/rules/c_array_inits.yaml
@@ -1,0 +1,14 @@
+rules:
+  - id: c-array-initialization
+    message: Semgrep found a match
+    languages:
+      - c
+    severity: WARNING
+    pattern-either:
+      - pattern: |
+          $TY $BUF[$SIZE];
+      - pattern: |
+          $TY $BUF[$SIZE] = "...";
+      - pattern: |
+          $TY $BUF[$SIZE] = {...};
+

--- a/tests/rules/cpp_array_inits.cpp
+++ b/tests/rules/cpp_array_inits.cpp
@@ -1,0 +1,8 @@
+int foo() {
+    // ruleid: cpp-array-initialization
+    char buf[64];
+    // ruleid: cpp-array-initialization
+    char buf[64] = "foo bar baz...";
+    // ruleid: cpp-array-initialization
+    char buf[64] = {0};
+}

--- a/tests/rules/cpp_array_inits.yaml
+++ b/tests/rules/cpp_array_inits.yaml
@@ -1,0 +1,14 @@
+rules:
+  - id: cpp-array-initialization
+    message: Semgrep found a match
+    languages:
+      - cpp
+    severity: WARNING
+    pattern-either:
+      - pattern: |
+          $TY $BUF[$SIZE];
+      - pattern: |
+          $TY $BUF[$SIZE] = "...";
+      - pattern: |
+          $TY $BUF[$SIZE] = {...};
+


### PR DESCRIPTION
The ellipsis syntax was only implemented in the cpp tree-sitter parser, not in the c-menhir, cpp-menhir, or c-tree-sitter parsers. The use of the cpp tree-sitter parser as a secondary pattern parser for c (#8906) allowed us to execute this test.