### PR TITLE
feat: Allowing multiple type fields in metavariable-type rule syntax

### DIFF
--- a/changelog.d/gh-8913.added
+++ b/changelog.d/gh-8913.added
@@ -1,0 +1,12 @@
+Allowing multiple type fields in metavariable-type rule syntax
+
+Users have the flexibility to utilize multiple type fields to match the type of
+metavariables. For instance:
+
+metavariable-type:
+  metavariable: $X
+  types:
+    - typeA
+    - typeB
+
+This approach is also supported in rule 2.0.

--- a/src/core/Rule.ml
+++ b/src/core/Rule.ml
@@ -109,8 +109,9 @@ and metavar_cond =
   | CondType of
       MV.mvar
       * Xlang.t option (* when the type expression is in different lang *)
-      * string (* raw input string saved for regenerating rule yaml *)
-      * AST_generic.type_ (* LATER: could parse lazily, like the patterns *)
+      * string list (* raw input string saved for regenerating rule yaml *)
+      * AST_generic.type_ list
+    (* LATER: could parse lazily, like the patterns *)
   | CondAnalysis of MV.mvar * metavar_analysis_kind
   | CondNestedFormula of MV.mvar * Xlang.t option * formula
 

--- a/src/engine/Match_search_mode.ml
+++ b/src/engine/Match_search_mode.ml
@@ -554,7 +554,7 @@ let rec filter_ranges (env : env) (xs : (RM.t * MV.bindings list) list)
              with
              | [] -> None
              | bindings -> Some (r, bindings @ new_bindings))
-         | R.CondType (mvar, opt_lang, _, t) -> (
+         | R.CondType (mvar, opt_lang, _, ts) -> (
              let mvalue_to_expr m =
                match Metavariable.mvalue_to_any m with
                | G.E e -> Some e
@@ -579,9 +579,14 @@ let rec filter_ranges (env : env) (xs : (RM.t * MV.bindings list) list)
                      ast
                  in
                  let matches =
-                   GG.m_compatible_type lang
-                     (mvar, Tok.unsafe_fake_tok "")
-                     t e env
+                   (* We check whether any of the types listed in the
+                      `type` field match. These types are treated as
+                      connected by "or" logical operators. *)
+                   ts
+                   |> List.concat_map (fun t ->
+                          GG.m_compatible_type lang
+                            (mvar, Tok.unsafe_fake_tok "")
+                            t e env)
                  in
 
                  (* the type can also contain metavariables, but we probably

--- a/src/metachecking/Translate_rule.ml
+++ b/src/metachecking/Translate_rule.ml
@@ -47,9 +47,12 @@ let rec range_to_string (range : (Tok.location * Tok.location) option) =
 and translate_metavar_cond cond : [> `O of (string * Yaml.value) list ] =
   match cond with
   | CondEval e -> `O [ ("comparison", `String (range_to_string e.e_range)) ]
-  | CondType (mv, lang, str, _) ->
+  | CondType (mv, lang, strs, _) ->
       `O
-        ([ ("metavariable", `String mv); ("type", `String str) ]
+        ([
+           ("metavariable", `String mv);
+           ("types", `A (Common.map (fun s -> `String s) strs));
+         ]
         @
         match lang with
         | None -> []

--- a/tests/rules/metavar_type_multi_types_cpp.cpp
+++ b/tests/rules/metavar_type_multi_types_cpp.cpp
@@ -1,0 +1,17 @@
+#include <fstream>
+
+using namespace std;
+
+void test_001() {
+    ifstream in;
+    // ruleid: match-multiple-metavar-type
+    in.get(str, 2);
+
+    mystream my;
+    // ruleid: match-multiple-metavar-type
+    my.get(str, 2);
+
+    yourstream your;
+    // ok: match-multiple-metavar-type
+    your.get(str, 2);
+}

--- a/tests/rules/metavar_type_multi_types_cpp.yaml
+++ b/tests/rules/metavar_type_multi_types_cpp.yaml
@@ -1,0 +1,13 @@
+rules:
+  - id: match-multiple-metavar-type
+    patterns:
+      - pattern: $X.get($SRC, ...)
+      - metavariable-type:
+          metavariable: $X
+          types:
+            - ifstream
+            - mystream
+    message: Semgrep found a match
+    languages:
+      - cpp
+    severity: WARNING

--- a/tests/rules/metavar_type_multi_types_rule20_cpp.cpp
+++ b/tests/rules/metavar_type_multi_types_rule20_cpp.cpp
@@ -1,0 +1,17 @@
+#include <fstream>
+
+using namespace std;
+
+void test_001() {
+    ifstream in;
+    // ruleid: match-multiple-metavar-type-rule20
+    in.get(str, 2);
+
+    mystream my;
+    // ruleid: match-multiple-metavar-type-rule20
+    my.get(str, 2);
+
+    yourstream your;
+    // ok: match-multiple-metavar-type-rule20
+    your.get(str, 2);
+}

--- a/tests/rules/metavar_type_multi_types_rule20_cpp.yaml
+++ b/tests/rules/metavar_type_multi_types_rule20_cpp.yaml
@@ -1,0 +1,14 @@
+rules:
+  - id: match-multiple-metavar-type-rule20
+    message: Semgrep found a match
+    severity: WARNING
+    languages:
+      - cpp
+    match:
+      all:
+        - $X.get($SRC, ...)
+      where:
+        - metavariable: $X
+          types:
+            - ifstream
+            - mystream


### PR DESCRIPTION
Allowing multiple type fields in metavariable-type rule syntax

Users have the flexibility to utilize multiple type fields to match the type of
metavariables. For instance:
```
metavariable-type:
  metavariable: $X
  types:
    - typeA
    - typeB
```
This approach is also supported in rule 2.0.