### PR TITLE
osemgrep: parse 'semgrep ci' CLI flags in osemgrep

### DIFF
--- a/cli/src/semgrep/commands/ci.py
+++ b/cli/src/semgrep/commands/ci.py
@@ -130,27 +130,11 @@ def fix_head_if_github_action(metadata: GitMeta) -> None:
     "-c",
     "-f",
     multiple=True,
-    help="""
-        YAML configuration file, directory of YAML files ending in
-        .yml|.yaml, URL of a configuration file, or Semgrep registry entry name.
-        \n\n
-        Use --config auto to automatically obtain rules tailored to this project; your project URL will be used to log in
-         to the Semgrep registry.
-        \n\n
-        To run multiple rule files simultaneously, use --config before every YAML, URL, or Semgrep registry entry name.
-         For example `semgrep --config p/python --config myrules/myrule.yaml`
-        \n\n
-        See https://semgrep.dev/docs/writing-rules/rule-syntax for information on configuration file format.
-    """,
     envvar="SEMGREP_RULES",
 )
 @click.option(
     "--dry-run",
     is_flag=True,
-    help="""
-        When set, will not start a scan on semgrep.dev and will not report findings.
-        Instead will print out json objects it would have sent.
-    """,
 )
 @click.option(
     "--supply-chain",
@@ -164,17 +148,11 @@ def fix_head_if_github_action(metadata: GitMeta) -> None:
     "run_secrets_flag",
     is_flag=True,
     hidden=True,
-    help="Enable support for secret validation. Requires Semgrep Secrets, contact support@semgrep.com for more information this.",
 )
 @click.option(
     "--suppress-errors/--no-suppress-errors",
     "suppress_errors",
     default=True,
-    help="""
-        Configures how the CI command reacts when an error occurs.
-        If true, encountered errors are suppressed and the exit code is zero (success).
-        If false, encountered errors are not suppressed and the exit code is non-zero (success).
-    """,
     envvar="SEMGREP_SUPPRESS_ERRORS",
 )
 @handle_command_errors
@@ -226,17 +204,6 @@ def ci(
     use_git_ignore: bool,
     verbose: bool,
 ) -> None:
-    """
-    The recommended way to run semgrep in CI
-
-    In pull_request/merge_request (PR/MR) contexts, `semgrep ci` will only report findings
-    that were introduced by the PR/MR.
-
-    When logged in, `semgrep ci` runs rules configured on Semgrep App and sends findings
-    to your findings dashboard.
-
-    Only displays findings that were marked as blocking.
-    """
     state = get_state()
     state.terminal.configure(
         verbose=verbose,

--- a/cli/src/semgrep/commands/scan.py
+++ b/cli/src/semgrep/commands/scan.py
@@ -325,11 +325,6 @@ _scan_options: List[Callable] = [
         "--diff-depth",
         type=int,
         default=DEFAULT_DIFF_DEPTH,
-        help="""
-            The depth of the Pro (interfile) differential scan, the number of steps
-            (both in the caller and callee sides) from the targets in the call graph
-            tracked by the deep preprocessor. Only applied in differential scan mode.
-        """,
     ),
     optgroup.option("--dump-command-for-core", "-d", is_flag=True, hidden=True),
     optgroup.option("--allow-untrusted-postprocessors", is_flag=True, hidden=True),

--- a/src/osemgrep/cli/CLI.ml
+++ b/src/osemgrep/cli/CLI.ml
@@ -185,14 +185,14 @@ let dispatch_subcommand argv =
          * we progress in osemgrep port (or use Pysemgrep.Fallback further
          * down when we know we don't handle certain kind of arguments).
          *)
-        | "ci" when experimental -> Ci_subcommand.main subcmd_argv
         | "install-semgrep-pro" when experimental -> missing_subcommand ()
+        | "publish" when experimental -> missing_subcommand ()
         | "login" when experimental -> Login_subcommand.main subcmd_argv
         | "logout" when experimental -> Logout_subcommand.main subcmd_argv
-        | "publish" when experimental -> missing_subcommand ()
         | "lsp" -> Lsp_subcommand.main subcmd_argv
         (* partial support, still use Pysemgrep.Fallback in it *)
         | "scan" -> Scan_subcommand.main subcmd_argv
+        | "ci" -> Ci_subcommand.main subcmd_argv
         (* osemgrep-only: and by default! no need experimental! *)
         | "install-ci" -> Install_subcommand.main subcmd_argv
         | "interactive" -> Interactive_subcommand.main subcmd_argv

--- a/src/osemgrep/cli_ci/Ci_CLI.ml
+++ b/src/osemgrep/cli_ci/Ci_CLI.ml
@@ -1,4 +1,8 @@
+module Out = Semgrep_output_v1_t
+module Arg = Cmdliner.Arg
 module Cmd = Cmdliner.Cmd
+module Term = Cmdliner.Term
+module H = Cmdliner_helpers
 
 (*****************************************************************************)
 (* Prelude *)
@@ -13,12 +17,92 @@ module Cmd = Cmdliner.Cmd
 (* Types and constants *)
 (*****************************************************************************)
 
-(* 'semgrep ci' shares most of its flags with 'semgrep scan' *)
-type conf = Scan_CLI.conf [@@deriving show]
+(* TODO: we should redesign the CLI flags of semgrep ci and reduce
+ * them to the minimum; if you want flexibility, use semgrep scan,
+ * otherwise semgrep ci should be minimalist and take no
+ * args at all in most cases.
+ *)
+type conf = {
+  (* TODO? is this still used? *)
+  audit_on : string list;
+  dry_run : bool;
+  suppress_errors : bool;
+  (* --code/--sca/--secrets/ *)
+  products : Out.product list;
+  (* 'semgrep ci' shares most of its flags with 'semgrep scan' *)
+  scan_conf : Scan_CLI.conf;
+}
+[@@deriving show]
 
 (*************************************************************************)
-(* Command-line parsing: turn argv into conf *)
+(* Command-line flags *)
 (*************************************************************************)
+
+let o_audit_on : string list Term.t =
+  let info = Arg.info [ "audit-on" ] ~env:(Cmd.Env.info "SEMGREP_AUDIT_ON") in
+  Arg.value (Arg.opt_all Arg.string [] info)
+
+(* ugly: we also have a --dryrun in semgrep scan *)
+let o_dry_run : bool Term.t =
+  let info =
+    Arg.info [ "dry-run" ]
+      ~doc:
+        {|When set, will not start a scan on semgrep.dev and will not report
+findings. Instead will print out json objects it would have sent.|}
+  in
+  Arg.value (Arg.flag info)
+
+let o_supply_chain : bool Term.t =
+  let info = Arg.info [ "supply-chain" ] in
+  Arg.value (Arg.flag info)
+
+let o_code : bool Term.t =
+  let info = Arg.info [ "code" ] in
+  Arg.value (Arg.flag info)
+
+let o_beta_testing_secrets : bool Term.t =
+  let info = Arg.info [ "beta-testing-secrets" ] in
+  Arg.value (Arg.flag info)
+
+let o_secrets : bool Term.t =
+  let info =
+    Arg.info [ "secrets" ]
+      ~doc:
+        {|Support for secret validation. Requires Semgrep Secrets,
+contact support@semgrep.com for more information this.|}
+  in
+  Arg.value (Arg.flag info)
+
+let o_suppress_errors : bool Term.t =
+  H.negatable_flag_with_env [ "suppress-errors" ]
+    ~neg_options:[ "no-suppress-errors" ]
+    ~env:(Cmd.Env.info "SEMGREP_SUPPRESS_ERRORS")
+    ~default:true
+    ~doc:
+      {|Configures how the CI command reacts when an error occurs.
+If true, encountered errors are suppressed and the exit code is zero (success).
+If false, encountered errors are not suppressed and the exit code is non-zero
+(success).|}
+
+(*************************************************************************)
+(* Turn argv into conf *)
+(*************************************************************************)
+
+let cmdline_term : conf Term.t =
+  let combine scan_conf audit_on beta_testing_secrets code dry_run secrets
+      supply_chain suppress_errors =
+    let products =
+      (if beta_testing_secrets || secrets then [ `Secrets ] else [])
+      @ (if code then [ `SAST ] else [])
+      @ if supply_chain then [ `SCA ] else []
+    in
+    { scan_conf; audit_on; dry_run; suppress_errors; products }
+  in
+  Term.(
+    const combine
+    $ Scan_CLI.cmdline_term ~allow_empty_config:true
+    $ o_audit_on $ o_beta_testing_secrets $ o_code $ o_dry_run $ o_secrets
+    $ o_supply_chain $ o_suppress_errors)
 
 let doc = "the recommended way to run semgrep in CI"
 
@@ -43,7 +127,5 @@ let cmdline_info : Cmd.info = Cmd.info "semgrep ci" ~doc ~man
 
 let parse_argv (argv : string array) : conf =
   (* mostly a copy of Scan_CLI.parse_argv with different doc and man *)
-  let cmd : conf Cmd.t =
-    Cmd.v cmdline_info (Scan_CLI.cmdline_term ~allow_empty_config:true)
-  in
+  let cmd : conf Cmd.t = Cmd.v cmdline_info cmdline_term in
   CLI_common.eval_value ~argv cmd

--- a/src/osemgrep/cli_ci/Ci_CLI.ml
+++ b/src/osemgrep/cli_ci/Ci_CLI.ml
@@ -21,6 +21,14 @@ module H = Cmdliner_helpers
  * them to the minimum; if you want flexibility, use semgrep scan,
  * otherwise semgrep ci should be minimalist and take no
  * args at all in most cases.
+ * We probably still want though conf_runner flags like:
+ *  - --max-memory, -j, --timeout (even though iago want to remove it)
+ *  - the pro-engine flags --pro, --oss-only, etc (even though again
+ *    we're going towards remove --pro for more precise --interfile,
+ *    --secrets, etc)
+ *  - --include, --exclude
+ *  - maybe also --output? (even though I don't understand why people
+ *    just don't simply use shell redirection)
  *)
 type conf = {
   (* TODO? is this still used? *)

--- a/src/osemgrep/cli_ci/Ci_CLI.mli
+++ b/src/osemgrep/cli_ci/Ci_CLI.mli
@@ -6,7 +6,15 @@
    The result of parsing a 'semgrep ci' command.
 *)
 
-type conf = Scan_CLI.conf [@@deriving show]
+type conf = {
+  audit_on : string list;
+  dry_run : bool;
+  suppress_errors : bool;
+  (* --code/--sca/--secrets/ *)
+  products : Semgrep_output_v1_t.product list;
+  scan_conf : Scan_CLI.conf;
+}
+[@@deriving show]
 
 (*
    Usage: parse_argv [| "semgrep-ci"; <args> |]

--- a/src/osemgrep/cli_ci/Ci_subcommand.ml
+++ b/src/osemgrep/cli_ci/Ci_subcommand.ml
@@ -8,6 +8,28 @@ module Out = Semgrep_output_v1_j
    Parse a semgrep-ci command, execute it and exit.
 
    Translated from ci.py (and partially from scans.py)
+
+   If 'semgrep ci' returns some networking errors, you may need to inspect
+   the backend logs as the error message returned by the backend to the CLI
+   might be short and may not contain the necessary information to debug.
+   Even using --debug might not be enough.
+   You can inspect the backend logs in Datadog and cloudwatch (and Metabase).
+   However, it's probably better first to connect to the 'dev2' backend
+   rather than 'prod' to have a lot less to search through.
+   You can filter out by `env: dev2` in Datadog. To connect to dev2,
+   you'll need to run semgrep ci like this:
+
+     SEMGREP_APP_URL=https://dev2.semgrep.dev SEMGREP_APP_TOKEN=... semgrep ci
+
+   Note that you'll first need to
+
+      SEMGREP_APP_URL=https://dev2.semgrep.dev semgrep login
+
+   as you'll need a separate app token for dev2. You can find the
+   actual token value in your ~/.semgrep/settings.yml file
+
+   Tip: you can store those environment variables in a dev2.sh env file
+   that you can source instead.
 *)
 
 (*****************************************************************************)

--- a/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -573,6 +573,9 @@ let run_scan_conf (conf : Scan_CLI.conf) : Exit_code.t =
 (* All the business logic after command-line parsing. Return the desired
    exit code. *)
 let run_conf (conf : Scan_CLI.conf) : Exit_code.t =
+  (* coupling: if you modify the pysemgrep fallback code below, you
+   * probably also need to modify it in Ci_subcommand.ml
+   *)
   (match conf.common.maturity with
   (* those are osemgrep-only option not available in pysemgrep,
    * so better print a good error message for it.


### PR DESCRIPTION
and then fallback to pysemgrep

test plan:
./osemgrep ci --help
generate nice man page now