### PR TITLE
Use latest interface with separate rule_severity and error_severity

### DIFF
--- a/cli/src/semgrep/core_output.py
+++ b/cli/src/semgrep/core_output.py
@@ -45,10 +45,12 @@ def _core_location_to_error_span(location: out.Location) -> out.ErrorSpan:
 def core_error_to_semgrep_error(err: out.CoreError) -> SemgrepCoreError:
     # Hackily convert the level string to Semgrep expectations
     level_str = err.severity.kind
-    if level_str.upper() == "WARNING":
+    if level_str.upper() == "WARNING_":
         level_str = "WARN"
     if level_str.upper() == "ERROR_":
         level_str = "ERROR"
+    if level_str.upper() == "INFO_":
+        level_str = "INFO"
     level = Level[level_str.upper()]
 
     spans: Optional[List[out.ErrorSpan]] = None

--- a/cli/src/semgrep/error.py
+++ b/cli/src/semgrep/error.py
@@ -42,6 +42,7 @@ INVALID_API_KEY_EXIT_CODE = 13
 SCAN_FAIL_EXIT_CODE = 14
 
 
+# TODO: reuse Out.ErrorSeverity
 class Level(Enum):
     ERROR = 4  # Always an error
     WARN = 3  # Only an error if "strict" is set

--- a/cli/src/semgrep/formatter/json.py
+++ b/cli/src/semgrep/formatter/json.py
@@ -24,7 +24,7 @@ class JsonFormatter(BaseFormatter):
         extra = out.CliMatchExtra(
             message=rule_match.message,
             metadata=out.RawJson(rule_match.metadata),
-            severity=out.RuleSeverity.from_json(rule_match.severity.value),
+            severity=out.MatchSeverity.from_json(rule_match.severity.value),
             fingerprint=rule_match.match_based_id,
             # 'lines' already contains '\n' at the end of each line
             lines="".join(rule_match.lines).rstrip(),

--- a/cli/src/semgrep/formatter/json.py
+++ b/cli/src/semgrep/formatter/json.py
@@ -24,7 +24,7 @@ class JsonFormatter(BaseFormatter):
         extra = out.CliMatchExtra(
             message=rule_match.message,
             metadata=out.RawJson(rule_match.metadata),
-            severity=out.Severity.from_json(rule_match.severity.value),
+            severity=out.RuleSeverity.from_json(rule_match.severity.value),
             fingerprint=rule_match.match_based_id,
             # 'lines' already contains '\n' at the end of each line
             lines="".join(rule_match.lines).rstrip(),

--- a/src/core/Core_error.ml
+++ b/src/core/Core_error.ml
@@ -235,28 +235,28 @@ let string_of_error err =
     (Out.string_of_core_error_kind err.typ)
     err.msg details
 
-let severity_of_error typ =
-  match (typ : Out.core_error_kind) with
-  | SemgrepMatchFound -> Out.Error
-  | MatchingError -> Warning
-  | TooManyMatches -> Warning
-  | LexicalError -> Warning
-  | ParseError -> Warning
-  | PartialParsing _ -> Warning
-  | SpecifiedParseError -> Warning
-  | AstBuilderError -> Error
-  | RuleParseError -> Error
-  | PatternParseError _ -> Error
-  | InvalidYaml -> Warning
-  | FatalError -> Error
-  | Timeout -> Warning
-  | OutOfMemory -> Warning
-  | TimeoutDuringInterfile -> Error
-  | OutOfMemoryDuringInterfile -> Error
+let severity_of_error (typ : Out.core_error_kind) : Out.error_severity =
+  match typ with
+  | SemgrepMatchFound -> `Error
+  | MatchingError -> `Warning
+  | TooManyMatches -> `Warning
+  | LexicalError -> `Warning
+  | ParseError -> `Warning
+  | PartialParsing _ -> `Warning
+  | SpecifiedParseError -> `Warning
+  | AstBuilderError -> `Error
+  | RuleParseError -> `Error
+  | PatternParseError _ -> `Error
+  | InvalidYaml -> `Warning
+  | FatalError -> `Error
+  | Timeout -> `Warning
+  | OutOfMemory -> `Warning
+  | TimeoutDuringInterfile -> `Error
+  | OutOfMemoryDuringInterfile -> `Error
   | IncompatibleRule _
   | MissingPlugin ->
       (* Running into an incompatible rule may be normal, with nothing to fix *)
-      Info
+      `Info
 
 (*****************************************************************************)
 (* Try with error *)

--- a/src/core/Core_error.mli
+++ b/src/core/Core_error.mli
@@ -61,7 +61,7 @@ val try_with_print_exn_and_reraise : Common.filename -> (unit -> unit) -> unit
 val string_of_error : t -> string
 
 val severity_of_error :
-  Semgrep_output_v1_t.core_error_kind -> Semgrep_output_v1_t.severity
+  Semgrep_output_v1_t.core_error_kind -> Semgrep_output_v1_t.error_severity
 
 (*****************************************************************************)
 (* Helpers for unit testing *)

--- a/src/core/Rule.ml
+++ b/src/core/Rule.ml
@@ -126,7 +126,7 @@ and focus_mv_list = tok * MV.mvar list [@@deriving show, eq, hash]
 (*****************************************************************************)
 
 (* this is now defined in semgrep_output_v1.atd *)
-type severity = Semgrep_output_v1_t.rule_severity [@@deriving show, eq]
+type severity = Semgrep_output_v1_t.match_severity [@@deriving show, eq]
 
 type validation_state = Semgrep_output_v1_t.validation_state
 [@@deriving show, eq]

--- a/src/core/Rule.ml
+++ b/src/core/Rule.ml
@@ -126,7 +126,7 @@ and focus_mv_list = tok * MV.mvar list [@@deriving show, eq, hash]
 (*****************************************************************************)
 
 (* this is now defined in semgrep_output_v1.atd *)
-type severity = Semgrep_output_v1_t.severity [@@deriving show, eq]
+type severity = Semgrep_output_v1_t.rule_severity [@@deriving show, eq]
 
 type validation_state = Semgrep_output_v1_t.validation_state
 [@@deriving show, eq]
@@ -855,7 +855,7 @@ let rule_of_xpattern (xlang : Xlang.t) (xpat : Xpattern.t) : rule =
     max_version = None;
     (* alt: could put xpat.pstr for the message *)
     message = "";
-    severity = Error;
+    severity = `Error;
     target_selector;
     target_analyzer;
     options = None;

--- a/src/core_cli/Core_command.ml
+++ b/src/core_cli/Core_command.ml
@@ -127,7 +127,7 @@ let minirule_of_pattern lang pattern_string pattern =
     pattern;
     inside = false;
     message = "";
-    severity = Error;
+    severity = `Error;
     langs = [ lang ];
     fix = None;
   }

--- a/src/engine/Match_search_mode.ml
+++ b/src/engine/Match_search_mode.ml
@@ -171,7 +171,7 @@ let (mini_rule_of_pattern :
      * we just care about the matching result.
      *)
     message = "";
-    severity = Error;
+    severity = `Error;
     langs =
       (match xlang with
       | L (x, xs) -> x :: xs

--- a/src/engine/Unit_engine.ml
+++ b/src/engine/Unit_engine.ml
@@ -287,7 +287,7 @@ let match_pattern ~lang ~hook ~file ~pattern ~fix_pattern =
       pattern;
       inside = false;
       message = "";
-      severity = Error;
+      severity = `Error;
       langs = [ lang ];
       pattern_string = "test: no need for pattern string";
       fix = fix_pattern;

--- a/src/experiments/synthesizing/Unit_synthesizer_targets.ml
+++ b/src/experiments/synthesizing/Unit_synthesizer_targets.ml
@@ -62,7 +62,7 @@ let ranges_matched lang file pattern : Range.t list =
       pattern;
       inside = false;
       message = "";
-      severity = Error;
+      severity = `Error;
       langs = [ lang ];
       pattern_string = "test: no need for pattern string";
       fix = None;

--- a/src/osemgrep/cli_ci/Ci_subcommand.ml
+++ b/src/osemgrep/cli_ci/Ci_subcommand.ml
@@ -324,7 +324,7 @@ let partition_findings ~keep_ignored (results : Out.cli_match list) =
 (*****************************************************************************)
 
 (* from rule_match.py *)
-let severity_to_int (severity : Out.rule_severity) =
+let severity_to_int (severity : Rule.severity) =
   match severity with
   | `Experiment -> `Int 4
   | `Warning -> `Int 1
@@ -334,7 +334,7 @@ let severity_to_int (severity : Out.rule_severity) =
       `Int 0
 
 (* this is used for sorting matches for findings *)
-let ord_of_severity (severity : Out.rule_severity) : int =
+let ord_of_severity (severity : Rule.severity) : int =
   match severity with
   | `Experiment -> 0
   | `Inventory -> 1

--- a/src/osemgrep/cli_ci/Ci_subcommand.ml
+++ b/src/osemgrep/cli_ci/Ci_subcommand.ml
@@ -324,23 +324,23 @@ let partition_findings ~keep_ignored (results : Out.cli_match list) =
 (*****************************************************************************)
 
 (* from rule_match.py *)
-let severity_to_int (severity : Out.severity) =
+let severity_to_int (severity : Out.rule_severity) =
   match severity with
-  | Experiment -> `Int 4
-  | Warning -> `Int 1
-  | Error -> `Int 2
-  | Inventory
-  | Info ->
+  | `Experiment -> `Int 4
+  | `Warning -> `Int 1
+  | `Error -> `Int 2
+  | `Inventory
+  | `Info ->
       `Int 0
 
 (* this is used for sorting matches for findings *)
-let ord_of_severity (severity : Out.severity) : int =
+let ord_of_severity (severity : Out.rule_severity) : int =
   match severity with
-  | Experiment -> 0
-  | Inventory -> 1
-  | Info -> 2
-  | Warning -> 3
-  | Error -> 4
+  | `Experiment -> 0
+  | `Inventory -> 1
+  | `Info -> 2
+  | `Warning -> 3
+  | `Error -> 4
 
 let finding_of_cli_match _commit_date index (m : Out.cli_match) : Out.finding =
   let (r : Out.finding) =
@@ -474,7 +474,7 @@ let findings_and_complete ~has_blocking_findings ~commit_date ~engine_requested
   in
   if
     new_ignored
-    |> List.exists (fun (m : Out.cli_match) -> m.extra.severity =*= Experiment)
+    |> List.exists (fun (m : Out.cli_match) -> m.extra.severity =*= `Experiment)
   then
     Logs.app (fun m -> m "Some experimental rules were run during execution.");
 

--- a/src/osemgrep/cli_interactive/Interactive_subcommand.ml
+++ b/src/osemgrep/cli_interactive/Interactive_subcommand.ml
@@ -501,7 +501,7 @@ let mk_fake_rule xlang formula =
     max_version = None;
     (* alt: could put xpat.pstr for the message *)
     message = "";
-    severity = Error;
+    severity = `Error;
     target_selector;
     target_analyzer;
     options = None;

--- a/src/osemgrep/cli_scan/Output.ml
+++ b/src/osemgrep/cli_scan/Output.ml
@@ -22,9 +22,9 @@ module Out = Semgrep_output_v1_j
 (* Helpers *)
 (*****************************************************************************)
 
-let string_of_severity (severity : Out.severity) : string =
+let string_of_severity (severity : Out.rule_severity) : string =
   (* this contains the enclosing "" *)
-  let s = Out.string_of_severity severity in
+  let s = Out.string_of_rule_severity severity in
   (* let's remove the enclosing "" *)
   match JSON.json_of_string s with
   | JSON.String s -> s

--- a/src/osemgrep/cli_scan/Output.ml
+++ b/src/osemgrep/cli_scan/Output.ml
@@ -22,9 +22,9 @@ module Out = Semgrep_output_v1_j
 (* Helpers *)
 (*****************************************************************************)
 
-let string_of_severity (severity : Out.rule_severity) : string =
+let string_of_severity (severity : Out.match_severity) : string =
   (* this contains the enclosing "" *)
-  let s = Out.string_of_rule_severity severity in
+  let s = Out.string_of_match_severity severity in
   (* let's remove the enclosing "" *)
   match JSON.json_of_string s with
   | JSON.String s -> s

--- a/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -91,7 +91,7 @@ let exit_code_of_errors ~strict (errors : Out.core_error list) : Exit_code.t =
       (* alt: raise a Semgrep_error that would be catched by CLI_Common
        * wrapper instead of returning an exit code directly? *)
       match () with
-      | _ when x.severity =*= Out.Error ->
+      | _ when x.severity =*= `Error ->
           Cli_json_output.exit_code_of_error_type x.error_type
       | _ when strict -> Cli_json_output.exit_code_of_error_type x.error_type
       | _else_ -> Exit_code.ok)

--- a/src/osemgrep/core/Severity.ml
+++ b/src/osemgrep/core/Severity.ml
@@ -5,7 +5,7 @@
  *
  * TODO: there are (too) many places where we define severity:
  *  - rule_schema_v1.yaml
- *  - severity in semgrep_output_v1.atd
+ *  - error_severity and rule_severity in semgrep_output_v1.atd
  *  - DONE level in Error.ml
  * We should remove some of those.
  *
@@ -18,6 +18,7 @@
 
 (* valid for rules and for findings, but also for semgrep errors
    found in rules, and in semgrep --severity
+   TODO: remove, use semgrep_output_v1.error_severity instead
 *)
 type t = [ `Error | `Warning | `Info ] [@@deriving show]
 
@@ -42,6 +43,9 @@ let to_string (x : t) =
         raise ValueError(f"invalid rule severity value: {value}")
 *)
 
+(* TODO: for this we should actually allow rule_severity, not just
+ * error_severity
+ *)
 (* for CLI --severity input *)
 let converter =
   Cmdliner.Arg.enum
@@ -50,9 +54,9 @@ let converter =
 (* for CLI --severity filtering *)
 let of_rule_severity_opt (x : Rule.severity) : t option =
   match x with
-  | Error -> Some `Error
-  | Warning -> Some `Warning
-  | Info -> Some `Info
-  | Inventory
-  | Experiment ->
+  | `Error -> Some `Error
+  | `Warning -> Some `Warning
+  | `Info -> Some `Info
+  | `Inventory
+  | `Experiment ->
       None

--- a/src/osemgrep/language_server/util/Convert_utils.ml
+++ b/src/osemgrep/language_server/util/Convert_utils.ml
@@ -8,13 +8,13 @@ let range_of_cli_match (m : Out.cli_match) =
       (Position.create ~line:(m.start.line - 1) ~character:(m.start.col - 1))
     ~end_:(Position.create ~line:(m.end_.line - 1) ~character:(m.end_.col - 1))
 
-let convert_severity (severity : Out.severity) : DiagnosticSeverity.t =
+let convert_severity (severity : Out.rule_severity) : DiagnosticSeverity.t =
   match severity with
-  | Error -> Error
-  | Warning -> Warning
-  | Experiment
-  | Info
-  | Inventory ->
+  | `Error -> Error
+  | `Warning -> Warning
+  | `Experiment
+  | `Info
+  | `Inventory ->
       Information
 
 let workspace_folders_to_paths =

--- a/src/osemgrep/language_server/util/Convert_utils.ml
+++ b/src/osemgrep/language_server/util/Convert_utils.ml
@@ -8,7 +8,7 @@ let range_of_cli_match (m : Out.cli_match) =
       (Position.create ~line:(m.start.line - 1) ~character:(m.start.col - 1))
     ~end_:(Position.create ~line:(m.end_.line - 1) ~character:(m.end_.col - 1))
 
-let convert_severity (severity : Out.rule_severity) : DiagnosticSeverity.t =
+let convert_severity (severity : Out.match_severity) : DiagnosticSeverity.t =
   match severity with
   | `Error -> Error
   | `Warning -> Warning

--- a/src/osemgrep/language_server/util/Convert_utils.mli
+++ b/src/osemgrep/language_server/util/Convert_utils.mli
@@ -2,7 +2,7 @@ val range_of_cli_match : Semgrep_output_v1_t.cli_match -> Lsp.Types.Range.t
 (** [range_of_cli_match cli_match] returns the lsp range of the given cli_match. *)
 
 val convert_severity :
-  Semgrep_output_v1_t.rule_severity -> Lsp.Types.DiagnosticSeverity.t
+  Semgrep_output_v1_t.match_severity -> Lsp.Types.DiagnosticSeverity.t
 (** [convert_severity s] returns the lsp severity corresponding to the semgrep severity [s]. *)
 
 val workspace_folders_to_paths :

--- a/src/osemgrep/language_server/util/Convert_utils.mli
+++ b/src/osemgrep/language_server/util/Convert_utils.mli
@@ -2,7 +2,7 @@ val range_of_cli_match : Semgrep_output_v1_t.cli_match -> Lsp.Types.Range.t
 (** [range_of_cli_match cli_match] returns the lsp range of the given cli_match. *)
 
 val convert_severity :
-  Semgrep_output_v1_t.severity -> Lsp.Types.DiagnosticSeverity.t
+  Semgrep_output_v1_t.rule_severity -> Lsp.Types.DiagnosticSeverity.t
 (** [convert_severity s] returns the lsp severity corresponding to the semgrep severity [s]. *)
 
 val workspace_folders_to_paths :

--- a/src/osemgrep/reporting/Cli_json_output.ml
+++ b/src/osemgrep/reporting/Cli_json_output.ml
@@ -114,14 +114,11 @@ let core_location_to_error_span (loc : Out.location) : Out.error_span =
   }
 
 (* LATER: move also to Severity.ml and reuse types there *)
-let level_of_severity (severity : Out.severity) : Severity.t =
+let level_of_severity (severity : Out.error_severity) : Severity.t =
   match severity with
-  | Error -> `Error
-  | Warning -> `Warning
-  | Info
-  | Experiment
-  | Inventory ->
-      `Info
+  | `Error -> `Error
+  | `Warning -> `Warning
+  | `Info -> `Info
 
 let error_type_string (error_type : Out.core_error_kind) : string =
   match error_type with

--- a/src/osemgrep/reporting/Rules_report.ml
+++ b/src/osemgrep/reporting/Rules_report.ml
@@ -27,7 +27,7 @@ let pp_rules ppf (rules_source, filtered_rules) =
   Fmt.pf ppf "Rules:@.";
   let exp, normal =
     filtered_rules
-    |> List.partition (fun (rule : Rule.t) -> rule.severity =*= Experiment)
+    |> List.partition (fun (rule : Rule.t) -> rule.severity =*= `Experiment)
   in
 
   let rule_id r = fst r.Rule.id in

--- a/src/parsing/Parse_rule.ml
+++ b/src/parsing/Parse_rule.ml
@@ -443,11 +443,11 @@ let parse_languages ~id (options : Rule_options_t.t) langs :
 
 let parse_severity ~id (s, t) : Rule.severity =
   match s with
-  | "ERROR" -> Error
-  | "WARNING" -> Warning
-  | "INFO" -> Info
-  | "INVENTORY" -> Inventory
-  | "EXPERIMENT" -> Experiment
+  | "ERROR" -> `Error
+  | "WARNING" -> `Warning
+  | "INFO" -> `Info
+  | "INVENTORY" -> `Inventory
+  | "EXPERIMENT" -> `Experiment
   | s ->
       Rule.raise_error (Some id)
         (InvalidRule


### PR DESCRIPTION
Once this is merged I can start to remove Severity.ml,
and the Level class in error.py and the RuleSeverity class in
constants.py

test plan:
make core
make e2e