### PR TITLE
Revert to OCaml 4

### DIFF
--- a/.github/workflows/build-test-core-x86-ocaml5.yaml
+++ b/.github/workflows/build-test-core-x86-ocaml5.yaml
@@ -1,9 +1,7 @@
 # This workflow builds and test semgrep-core. It also generates an
-# ocaml-build-artifacts.tgz file which is used in many other jobs such
-# as test-cli in tests.yml or build-wheels-manylinux in
-# build-test-manylinux-x86.yaml
+# ocaml-build-artifacts-ocaml5.tgz file.
 
-name: build-test-core-x86
+name: build-test-core-x86-ocaml5
 
 on:
   workflow_dispatch:
@@ -11,13 +9,13 @@ on:
 
 jobs:
   build-test-core-x86:
-    name: Build Test Semgrep Core
+    name: Build Test Semgrep Core with OCaml 5
     runs-on: ubuntu-latest
-    # This container has opam already installed, as well as an opam switch 4.14.0
+    # This container has opam already installed, as well as an opam switch 5.0.0
     # already created, and a big set of packages already installed. Thus,
     # the 'make install-deps-ALPINE-for-semgrep-core' below is very fast and
     # almost a noop.
-    container: returntocorp/ocaml:alpine-2023-06-16
+    container: returntocorp/ocaml:alpine5.0-2023-09-29
     # We need this hack because GHA tampers with the HOME in container
     # and this does not play well with 'opam' installed in /root
     env:
@@ -34,12 +32,12 @@ jobs:
           make install-deps-ALPINE-for-semgrep-core
           make install-deps-for-semgrep-core
           make core
-          mkdir -p ocaml-build-artifacts/bin
-          cp bin/semgrep-core ocaml-build-artifacts/bin/
-          tar czf ocaml-build-artifacts.tgz ocaml-build-artifacts
+          mkdir -p ocaml-build-artifacts-ocaml5/bin
+          cp bin/semgrep-core ocaml-build-artifacts-ocaml5/bin/
+          tar czf ocaml-build-artifacts-ocaml5.tgz ocaml-build-artifacts-ocaml5
       - uses: actions/upload-artifact@v3
         with:
-          path: ocaml-build-artifacts.tgz
-          name: ocaml-build-artifacts-release
+          path: ocaml-build-artifacts-ocaml5.tgz
+          name: ocaml-build-artifacts-ocaml5-release
       - name: Test semgrep-core
         run: opam exec -- make core-test

--- a/.github/workflows/build-test-core-x86-ocaml5.yaml
+++ b/.github/workflows/build-test-core-x86-ocaml5.yaml
@@ -1,3 +1,5 @@
+# coupling: This is a copy of build-test-core-x86.yaml but for OCaml 5.
+
 # This workflow builds and test semgrep-core. It also generates an
 # ocaml-build-artifacts-ocaml5.tgz file.
 

--- a/.github/workflows/build-test-javascript.yaml
+++ b/.github/workflows/build-test-javascript.yaml
@@ -19,7 +19,7 @@ on:
 jobs:
   build-semgrep-js-ocaml:
     runs-on: ubuntu-latest-16-core
-    container: returntocorp/ocaml:alpine5.0-2023-09-29
+    container: returntocorp/ocaml:alpine-2023-06-16
     # We need this hack because GHA tampers with the HOME in container
     # and this does not play well with 'opam' installed in /root
     env:

--- a/.github/workflows/build-test-osx-arm64.yaml
+++ b/.github/workflows/build-test-osx-arm64.yaml
@@ -32,7 +32,7 @@ jobs:
         "ghcr.io/cirruslabs/macos-monterey-xcode:latest",
       ]
     env:
-      OPAM_SWITCH_NAME: "5.0.0"
+      OPAM_SWITCH_NAME: "4.14.0"
     steps:
       - name: Setup runner directory
         run: |

--- a/.github/workflows/build-test-osx-x86.yaml
+++ b/.github/workflows/build-test-osx-x86.yaml
@@ -64,7 +64,7 @@ jobs:
       # This name is used in the cache key. If we update to a newer version of
       # ocaml, we'll want to change the OPAM_SWITCH_NAME as well to avoid issues
       # with caching.
-      OPAM_SWITCH_NAME: "5.0.0"
+      OPAM_SWITCH_NAME: "4.14.0"
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/lint.jsonnet
+++ b/.github/workflows/lint.jsonnet
@@ -119,6 +119,10 @@ local pre_commit_ocaml_job =
         // to debug errors in pre-commit, use instead:
         // opam exec -- pre-commit run --verbose --all lint-ocaml || cat /root/.cache/pre-commit/pre-commit.log
         run: |||
+          # When installing ocamlformat.0.26.1 OPAM will try to rebuild some packages
+          # and for that it requires 'autoconf'.
+          apt-get install -y autoconf
+          opam update --yes # so that OPAM knows about ocamlformat.0.26.1
           opam install -y ocamlformat.0.26.1
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           opam exec -- pre-commit run --verbose --all lint-ocaml

--- a/.github/workflows/lint.jsonnet
+++ b/.github/workflows/lint.jsonnet
@@ -88,7 +88,7 @@ local pre_commit_ocaml_job =
     // This custom image provides 'ocamlformat' with a specific version needed to check
     // OCaml code (must be the same than the one in dev/dev.opam)
     // See https://github.com/returntocorp/ocaml-layer/blob/master/configs/ubuntu.sh
-    container: 'returntocorp/ocaml:ubuntu5.0-2023-09-29',
+    container: 'returntocorp/ocaml:ubuntu-2023-06-16',
     // HOME in the container is tampered by GHA and modified from /root to /home/github
     // which then confuses opam below which can not find its ~/.opam (which is at /root/.opam)
     // hence the ugly use of 'env: HOME ...' below.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,9 +40,12 @@ jobs:
         env:
           HOME: /root
         run:
-          "\n          opam install -y ocamlformat.0.26.1\n          git config --global
-          --add safe.directory \"$GITHUB_WORKSPACE\"\n          opam exec -- pre-commit
-          run --verbose --all lint-ocaml\n        "
+          "\n          # When installing ocamlformat.0.26.1 OPAM will try to rebuild
+          some packages\n          # and for that it requires 'autoconf'.\n          apt-get
+          install -y autoconf\n          opam update --yes # so that OPAM knows about
+          ocamlformat.0.26.1\n          opam install -y ocamlformat.0.26.1\n          git
+          config --global --add safe.directory \"$GITHUB_WORKSPACE\"\n          opam
+          exec -- pre-commit run --verbose --all lint-ocaml\n        "
   github-actions:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,7 +31,7 @@ jobs:
           extra_args: --hook-stage manual
   pre-commit-ocaml:
     runs-on: ubuntu-latest
-    container: returntocorp/ocaml:ubuntu5.0-2023-09-29
+    container: returntocorp/ocaml:ubuntu-2023-06-16
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
   test-core:
     name: test semgrep-core
     runs-on: ubuntu-22.04
-    container: returntocorp/ocaml:alpine5.0-2023-09-29
+    container: returntocorp/ocaml:alpine-2023-06-16
     env:
       HOME: /root
     steps:
@@ -67,7 +67,7 @@ jobs:
   test-osemgrep:
     name: test osemgrep
     runs-on: ubuntu-22.04
-    container: returntocorp/ocaml:alpine5.0-2023-09-29
+    container: returntocorp/ocaml:alpine-2023-06-16
     env:
       HOME: /root
     steps:
@@ -97,7 +97,7 @@ jobs:
   build-semgrep-js-ocaml-test:
     name: build semgrep js ocaml for tests
     runs-on: ubuntu-latest-16-core
-    container: returntocorp/ocaml:alpine5.0-2023-09-29
+    container: returntocorp/ocaml:alpine-2023-06-16
     # We need this hack because GHA tampers with the HOME in container
     # and this does not play well with 'opam' installed in /root
     env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,7 +78,7 @@ COPY cli/src/semgrep/semgrep_interfaces cli/src/semgrep/semgrep_interfaces
 # update: we actually started to use depot.dev to speedup multi-arch (arm)
 # docker image, so maybe we could use it to get rid of ocaml-layer
 #
-# Note that the Docker base image below currently uses OCaml 5.0
+# Note that the Docker base image below currently uses OCaml 4.14.0
 # coupling: if you modify the OCaml version there, you probably also need
 # to modify:
 # - scripts/{osx-setup-for-release,setup-m1-builder}.sh
@@ -95,7 +95,7 @@ COPY cli/src/semgrep/semgrep_interfaces cli/src/semgrep/semgrep_interfaces
 # Visit https://hub.docker.com/r/returntocorp/ocaml/tags to see the latest
 # images available.
 #
-FROM returntocorp/ocaml:alpine5.0-2023-09-29 as semgrep-core-container
+FROM returntocorp/ocaml:alpine-2023-09-13 as semgrep-core-container
 
 WORKDIR /src/semgrep
 COPY --from=semgrep-core-files /src/semgrep .

--- a/Makefile
+++ b/Makefile
@@ -305,18 +305,6 @@ VIRTENV='virtualenv==20.21.0'
 # https://stackoverflow.com/questions/63515454/why-does-pip3-install-pipenv-give-error-error-cannot-uninstall-distlib
 install-deps-ALPINE-for-pysemgrep:
 	apk add --no-cache $(ALPINE_APK_DEPS_PYSEMGREP)
-# This uninstall step is here because of some weirdness with how
-# `pip install virtualenv==20.21.0` interacts with the version of `virtualenv`
-# on the current Docker image (which is 20.24.5). We get the same attribute error
-# as is described above.
-# The previous Docker image (with virtualenv 20.23.0) has no issues with the
-# `pip install` step following this, but for some reason the newer image does.
-# This version of `virtualenv` was installed along with a newer version of
-# `pre-commit`, and seems to be one of the only disparities which is causing this
-# issue to recur.
-# The easiest solution was to just cause an uninstall prior to the reinstallation
-# step, as it will allow the test to pass.
-	pip uninstall -y virtualenv
 	pip install --no-cache-dir --ignore-installed distlib $(PIPENV) $(VIRTENV)
 
 # -------------------------------------------------

--- a/cli/tests/e2e/test_check.py
+++ b/cli/tests/e2e/test_check.py
@@ -595,13 +595,7 @@ def test_max_memory(run_semgrep_in_tmp: RunSemgrep, snapshot):
     snapshot.assert_match(stderr, "error.txt")
 
 
-# It seems that OCaml 5.0 does not use the system stack https://github.com/ocaml-multicore/docs/blob/main/ocaml_5_design.md#stack-layout
-# note that it says it manages its own runtime stack, which are managed in fibers
-# fiber stacks are allocated w/ mallloc + free aka its in the heap.
-# So I thionk this test is no longer valid as of OCaml 5.0. The exception is C calls
-# but ocaml handles the runtime stack switching to system stack for them so we should be good
 @pytest.mark.slow
-@pytest.mark.skip(reason="OCaml 5.0 does not use system stack")
 def test_stack_size(run_semgrep_in_tmp: RunSemgrep, snapshot):
     """
     Verify that semgrep raises the soft stack limit if possible

--- a/dev/dev.opam
+++ b/dev/dev.opam
@@ -15,8 +15,6 @@ depends: [
   # - .github/workflows/lint.yml and its pre-commit-ocaml job
   "ocamlformat" {= "0.26.1" }  # used by the pre-commit hook
   "feather" # used by hello_script.ml
-  # This is not the version of `ocaml-lsp-server` used by the VSCode extension,
-  # but Austin said it's OK to update.
-  "ocaml-lsp-server" {= "1.15.1-5.0"}
+  "ocaml-lsp-server" {= "1.15.1-4.14"} # used by the VSCode extension
   "earlybird" {= "1.2.1"} # used by the VSCode extension
 ]

--- a/dune-project
+++ b/dune-project
@@ -389,10 +389,10 @@ For more information see https://semgrep.dev
 ;TODO: restore  "bisect_ppx" {>= "2.5.0"} once can use ppxlib 0.22.0
   (depends
     ; core deps
-    (ocaml (>= 5.0.0))
+    (ocaml (>= 4.13.0))
     (dune (>= 2.7.0 ))
     ; parser generators
-    (menhir (= 20220210))
+    (menhir (= 20211128)) ; Newer versions cause massive build slowdowns
     ; standard libraries
     ; We don't use Base directly. If it's being used indirectly
     ; (is it, though?), we need a version that doesn't register
@@ -434,8 +434,7 @@ For more information see https://semgrep.dev
     ; misc
     ocamlgraph
     parmap
-    ; Lower versions of `semver` are incompatible with OCaml 5.0.
-    (semver (>= 0.2.1))
+    semver
     uri
     uuidm
     (lsp (= 1.15.1-5.0))

--- a/dune-project
+++ b/dune-project
@@ -392,7 +392,7 @@ For more information see https://semgrep.dev
     (ocaml (>= 4.13.0))
     (dune (>= 2.7.0 ))
     ; parser generators
-    (menhir (= 20211128)) ; Newer versions cause massive build slowdowns
+    (menhir (= 20220210))
     ; standard libraries
     ; We don't use Base directly. If it's being used indirectly
     ; (is it, though?), we need a version that doesn't register

--- a/libs/process_limits/Unit_memory_limit.ml
+++ b/libs/process_limits/Unit_memory_limit.ml
@@ -23,27 +23,22 @@ let with_debug_alarm f =
 (*
    Grow the stack until some limit expressed in bytes.
 *)
-let grow_stack _goal_bytes =
-  let rec aux i =
+let grow_stack goal_bytes =
+  let rec aux () =
     let stack_size = get_stack_size_in_bytes () in
-    (* Magic number amount of times to run this. We can't count on
-       (Gc.quick_stat).stack_size in OCaml 5.0, because experimental results
-       seem to indicate it's no longer being updated. We just pick a
-       number of times to inflate the stack, and hope it's good enough.
-    *)
-    if i > 5000 then
+    if stack_size < goal_bytes then
       (* Allocate enough to trigger GC alarms regularly, before making
          the recursive call. *)
       let data = List.init 100 (fun _ -> ()) in
       (* Prevent tail-call optimization *)
-      data :: aux (i + 1)
+      data :: aux ()
     else (
       (* Trigger the hook that will run the GC alarm. This is cheating. *)
       Gc.full_major ();
       printf "grow_stack: stack reached %i bytes\n%!" stack_size;
       [])
   in
-  with_debug_alarm (fun () -> aux 0 |> ignore)
+  with_debug_alarm (fun () -> aux () |> ignore)
 
 let grow_heap goal_bytes =
   let rec aux acc =

--- a/scripts/osx-setup-for-release.sh
+++ b/scripts/osx-setup-for-release.sh
@@ -25,7 +25,7 @@ opam update
 brew uninstall --force semgrep
 brew uninstall --force tree-sitter
 
-SWITCH_NAME="${1:-5.0.0}"
+SWITCH_NAME="${1:-4.14.0}"
 
 #coupling: this should be the same version than in our Dockerfile
 if opam switch "${SWITCH_NAME}" ; then

--- a/scripts/setup-m1-builder.sh
+++ b/scripts/setup-m1-builder.sh
@@ -20,8 +20,8 @@ brew update # Needed to sidestep bintray brownout
 brew install opam pkg-config coreutils python pcre
 opam init --no-setup --bare;
 #coupling: this should be the same version than in our Dockerfile
-opam switch create 5.0.0;
-opam switch 5.0.0;
+opam switch create 4.14.0;
+opam switch 4.14.0;
 git submodule update --init --recursive --depth 1
 
 eval "$(opam env)"

--- a/semgrep.opam
+++ b/semgrep.opam
@@ -14,9 +14,9 @@ license: "LGPL-2.1"
 homepage: "https://semgrep.dev"
 bug-reports: "https://github.com/returntocorp/semgrep/issues"
 depends: [
-  "ocaml" {>= "5.0.0"}
+  "ocaml" {>= "4.13.0"}
   "dune" {>= "3.7" & >= "2.7.0"}
-  "menhir" {= "20220210"}
+  "menhir" {= "20211128"}
   "base" {>= "v0.15.1"}
   "fpath"
   "bos"
@@ -44,7 +44,7 @@ depends: [
   "pcre"
   "ocamlgraph"
   "parmap"
-  "semver" {>= "0.2.1"}
+  "semver"
   "uri"
   "uuidm"
   "lsp" {= "1.15.1-5.0"}

--- a/semgrep.opam
+++ b/semgrep.opam
@@ -16,7 +16,7 @@ bug-reports: "https://github.com/returntocorp/semgrep/issues"
 depends: [
   "ocaml" {>= "4.13.0"}
   "dune" {>= "3.7" & >= "2.7.0"}
-  "menhir" {= "20211128"}
+  "menhir" {= "20220210"}
   "base" {>= "v0.15.1"}
   "fpath"
   "bos"

--- a/src/core_scan/Core_scan.ml
+++ b/src/core_scan/Core_scan.ml
@@ -121,9 +121,6 @@ let debug_extract_mode = ref false
  *
  * We also have had stack overflows. OCaml <=4.14.0, we avoided this using
  * `Common.map`, which is tail-recursive, instead of `List.map`.
- *
- * TODO: `List.map` becomes tail recursive in OCaml 5.1 due to TRMC. We can safely
- * switch over to it then.
  *)
 
 (*****************************************************************************)

--- a/tests/parsing/dockerfile/semgrep.dockerfile
+++ b/tests/parsing/dockerfile/semgrep.dockerfile
@@ -6,17 +6,8 @@
 # of the 'semgrep-python' wrapping.
 #
 
-# The docker base image below in the FROM currently uses OCaml 4.14.0
-# See https://github.com/returntocorp/ocaml-layer/blob/master/configs/alpine.sh
-#
-# coupling: if you modify the OCaml version there, you probably also need
-# to modify:
-# - scripts/osx-release.sh
-# - doc/SEMGREP_CORE_CONTRIBUTING.md
-# - https://github.com/Homebrew/homebrew-core/blob/master/Formula/semgrep.rb
-# Note that many .github/workflows/ use returntocorp/ocaml:alpine, which should
-# be the latest, but may differ from this one.
-FROM returntocorp/ocaml:alpine-2021-07-15 as build-semgrep-core
+# NOTE: This is just a test file for the Dockerfile parser !
+FROM returntocorp/ocaml:fake-tag as build-semgrep-core
 
 USER root
 # for ocaml-pcre now used in semgrep-core

--- a/tests/parsing/dockerfile/semgrep.dockerfile
+++ b/tests/parsing/dockerfile/semgrep.dockerfile
@@ -6,8 +6,8 @@
 # of the 'semgrep-python' wrapping.
 #
 
-# The docker base image below in the FROM currently uses OCaml 5.0
-# See https://github.com/returntocorp/ocaml-layer/blob/master/configs/alpine5.0.sh
+# The docker base image below in the FROM currently uses OCaml 4.14.0
+# See https://github.com/returntocorp/ocaml-layer/blob/master/configs/alpine.sh
 #
 # coupling: if you modify the OCaml version there, you probably also need
 # to modify:
@@ -16,7 +16,7 @@
 # - https://github.com/Homebrew/homebrew-core/blob/master/Formula/semgrep.rb
 # Note that many .github/workflows/ use returntocorp/ocaml:alpine, which should
 # be the latest, but may differ from this one.
-FROM returntocorp/ocaml:alpine5.0-2023-09-29 as build-semgrep-core
+FROM returntocorp/ocaml:alpine-2021-07-15 as build-semgrep-core
 
 USER root
 # for ocaml-pcre now used in semgrep-core


### PR DESCRIPTION
OCaml 5 has serious regressions regarding memory usage, running p/default-v2 on 46 repos from stress-test-monorepo we observed a 45% average increase in memory usage, in some cases Semgrep used almost twice as much memory as with OCaml 4.

This reverts "feat!: OCaml 5.0 (#8194)"
(commit b44a7026ec0df32852d99cfabefc9b842f83aec1).

But we keep a CI workflow checking that we can still build with OCaml 5.

test plan:
Run p/default on a subset of stress-test-monorepo

