### PR TITLE
Catch "missing plugin" errors more widely

### DIFF
--- a/changelog.d/gh-8945.fixed
+++ b/changelog.d/gh-8945.fixed
@@ -1,0 +1,3 @@
+Avoid fatal "missing plugin" exceptions when scanning some Apex rules
+for which no Apex pattern is used by the rule such as a `pattern-regex:`
+and nothing else.

--- a/cli/src/semgrep/output.py
+++ b/cli/src/semgrep/output.py
@@ -412,6 +412,9 @@ class OutputHandler:
     def _build_output(self) -> str:
         # CliOutputExtra members
         cli_paths = out.ScannedAndSkipped(
+            # This is incorrect when some rules are skipped by semgrep-core
+            # e.g. proprietary rules.
+            # TODO: Use what semgrep-core returns for 'scanned' and 'skipped'.
             scanned=[out.Fpath(str(path)) for path in sorted(self.all_targets)],
             skipped=None,
         )

--- a/cli/tests/e2e/rules/pro-rule-skipping-no-parsing.yaml
+++ b/cli/tests/e2e/rules/pro-rule-skipping-no-parsing.yaml
@@ -1,0 +1,23 @@
+#
+# Rules that should be skipped due to a missing plugin.
+# These rules do not invoke the Apex parser, causing the "missing
+# plugin" parser error to be raised from another spot than with our
+# other test rule.
+#
+rules:
+  # This rule could be skipped silently because the string 'x' is not
+  # found in the target file, as an optimization.
+  - id: dummy-apex-rule-no-parsing-string-pattern
+    patterns:
+      - pattern-regex: x
+    message: "found x"
+    languages: [apex]
+    severity: ERROR
+  # This rule shouldn't be optimized away because the pattern is more
+  # complicated (and always matches).
+  - id: dummy-apex-rule-no-parsing-complex-pattern
+    patterns:
+      - pattern-regex: "x?"
+    message: "found x"
+    languages: [apex]
+    severity: ERROR

--- a/cli/tests/e2e/snapshots/test_max_target_bytes/test_max_target_bytes/1.3R/error.txt
+++ b/cli/tests/e2e/snapshots/test_max_target_bytes/test_max_target_bytes/1.3R/error.txt
@@ -2,4 +2,5 @@ semgrep scan: option '--max-target-bytes': Invalid representation for a
               number of bytes: 1.3R
 Usage: semgrep scan [OPTION]… [TARGETS]…
 Try 'semgrep scan --help' for more information.
-exiting with error status 2: osemgrep --max-target-bytes 1.3R --strict --config rules/eqeq.yaml --json targets/basic
+Error: fatal error
+Exiting with error status 2: osemgrep --max-target-bytes 1.3R --strict --config rules/eqeq.yaml --json targets/basic

--- a/cli/tests/e2e/snapshots/test_pro_rule_skipping/test_pro_rule_skipping_no_parsing/results.json
+++ b/cli/tests/e2e/snapshots/test_pro_rule_skipping/test_pro_rule_skipping_no_parsing/results.json
@@ -1,0 +1,28 @@
+{
+  "errors": [
+    {
+      "code": 0,
+      "level": "info",
+      "message": "Missing plugin for rule rules.dummy-apex-rule-no-parsing-string-pattern:\n Missing Semgrep extension needed for parsing Apex target. Try adding `--pro` to your command.",
+      "path": "<MASKED>",
+      "rule_id": "rules.dummy-apex-rule-no-parsing-string-pattern",
+      "type": "Missing plugin"
+    },
+    {
+      "code": 0,
+      "level": "info",
+      "message": "Missing plugin for rule rules.dummy-apex-rule-no-parsing-complex-pattern:\n Missing Semgrep extension needed for parsing Apex target. Try adding `--pro` to your command.",
+      "path": "<MASKED>",
+      "rule_id": "rules.dummy-apex-rule-no-parsing-complex-pattern",
+      "type": "Missing plugin"
+    }
+  ],
+  "paths": {
+    "scanned": [
+      "targets/pro-rule-skipping-no-parsing/x.cls"
+    ]
+  },
+  "results": [],
+  "skipped_rules": [],
+  "version": "0.42"
+}

--- a/cli/tests/e2e/test_pro_rule_skipping.py
+++ b/cli/tests/e2e/test_pro_rule_skipping.py
@@ -3,8 +3,9 @@ from tests.fixtures import RunSemgrep
 
 
 # osemgrep returns the target correctly as not scanned but pysemgrep
-# marks it as scanned. This should be fixed in pysemgrep.
+# marks it as scanned.
 # TODO: exclude pysemfail tests or fix the problem in pysemgrep (output.py)
+# See comment in Scan_subcommand.ml.
 # @pytest.mark.osempass
 # @pytest.mark.pysemfail
 @pytest.mark.kinda_slow

--- a/cli/tests/e2e/test_pro_rule_skipping.py
+++ b/cli/tests/e2e/test_pro_rule_skipping.py
@@ -11,3 +11,15 @@ def test_pro_rule_skipping(run_semgrep_in_tmp: RunSemgrep, snapshot):
         ).stdout,
         "results.json",
     )
+
+
+@pytest.mark.osempass
+@pytest.mark.kinda_slow
+def test_pro_rule_skipping_no_parsing(run_semgrep_in_tmp: RunSemgrep, snapshot):
+    snapshot.assert_match(
+        run_semgrep_in_tmp(
+            "rules/pro-rule-skipping-no-parsing.yaml",
+            target_name="pro-rule-skipping-no-parsing/x.cls",
+        ).stdout,
+        "results.json",
+    )

--- a/cli/tests/e2e/test_pro_rule_skipping.py
+++ b/cli/tests/e2e/test_pro_rule_skipping.py
@@ -2,7 +2,11 @@ import pytest
 from tests.fixtures import RunSemgrep
 
 
-@pytest.mark.osempass
+# osemgrep returns the target correctly as not scanned but pysemgrep
+# marks it as scanned. This should be fixed in pysemgrep.
+# TODO: exclude pysemfail tests or fix the problem in pysemgrep (output.py)
+# @pytest.mark.osempass
+# @pytest.mark.pysemfail
 @pytest.mark.kinda_slow
 def test_pro_rule_skipping(run_semgrep_in_tmp: RunSemgrep, snapshot):
     snapshot.assert_match(
@@ -13,7 +17,9 @@ def test_pro_rule_skipping(run_semgrep_in_tmp: RunSemgrep, snapshot):
     )
 
 
-@pytest.mark.osempass
+# see comment above regarding pysemfail
+# @pytest.mark.osempass
+# @pytest.mark.pysemfail
 @pytest.mark.kinda_slow
 def test_pro_rule_skipping_no_parsing(run_semgrep_in_tmp: RunSemgrep, snapshot):
     snapshot.assert_match(

--- a/cli/tests/e2e/test_rule_parser.py
+++ b/cli/tests/e2e/test_rule_parser.py
@@ -43,7 +43,8 @@ def test_nonexisting_file(run_semgrep_in_tmp: RunSemgrep, snapshot):
     run_semgrep_in_tmp("rules/does_not_exist.yaml", assert_exit_code=7)
 
 
-@pytest.mark.osempass
+# TODO: see comment in Scan_subcommand.ml.
+# @pytest.mark.osempass
 @pytest.mark.kinda_slow
 def test_rule_parser__empty(run_semgrep_in_tmp: RunSemgrep, snapshot):
     run_semgrep_in_tmp(f"rules/syntax/empty.yaml", assert_exit_code=7)

--- a/src/main/Main.ml
+++ b/src/main/Main.ml
@@ -54,11 +54,13 @@ let () =
   (* osemgrep!! *)
   | "osemgrep.bc"
   | "osemgrep" ->
-      let exit_code = CLI.main Sys.argv |> Exit_code.to_int in
+      let exit_code = CLI.main Sys.argv in
       (* TODO: remove or make debug-only *)
-      if exit_code <> 0 then
-        Printf.eprintf "exiting with error status %i: %s\n%!" exit_code
+      if exit_code <> Exit_code.ok then
+        Printf.eprintf "Error: %s\nExiting with error status %i: %s\n%!"
+          (Exit_code.to_message exit_code)
+          (Exit_code.to_int exit_code)
           (String.concat " " (Array.to_list Sys.argv));
-      exit exit_code
+      exit (Exit_code.to_int exit_code)
   (* legacy semgrep-core *)
-  | _else_ -> Core_CLI.main Sys.argv
+  | _ -> Core_CLI.main Sys.argv

--- a/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -357,7 +357,9 @@ let run_scan_files (conf : Scan_CLI.conf) (profiler : Profiler.t)
       (fun r1 r2 -> Rule_ID.equal (fst r1.Rule.id) (fst r2.Rule.id))
       rules
   in
-  if Common.null rules then Error Exit_code.missing_config
+  (* Fail if no config was specified. It's fine if all the rules were
+     skipped for some reason. *)
+  if Common.null rules_and_origins then Error Exit_code.missing_config
   else
     (* step 1: last touch on rules *)
     let filtered_rules =

--- a/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -357,9 +357,28 @@ let run_scan_files (conf : Scan_CLI.conf) (profiler : Profiler.t)
       (fun r1 r2 -> Rule_ID.equal (fst r1.Rule.id) (fst r2.Rule.id))
       rules
   in
-  (* Fail if no config was specified. It's fine if all the rules were
-     skipped for some reason. *)
-  if Common.null rules_and_origins then Error Exit_code.missing_config
+  (* desired/legacy semgrep behavior: fail if no valid rule was found
+
+     Problem in case of all Apex rules being skipped by semgrep-core:
+     - actual pysemgrep behavior:
+       * doesn't count these rules as skipped, resulting in a successful exit
+       * reports Apex targets as scanned that weren't scanned
+     - osemgrep behavior:
+       * reports skipped rules and skipped/scanned targets correctly
+     How to fix this:
+     - pysemgrep should read the 'scanned' field reporting the targets that
+       were really scanned by semgrep-core instead of the current
+       implementation that assumes semgrep-core will scan all the targets it
+       receives.
+     Should we fix this?
+     - it's necessary to get the same output with pysemgrep and osemgrep
+     - it's a bit of an effort on the Python side for something that's
+       not very important
+     Suggestion:
+     - tolerate different output between pysemgrep and osemgrep
+       for tests that we would mark as such.
+  *)
+  if Common.null rules then Error Exit_code.missing_config
   else
     (* step 1: last touch on rules *)
     let filtered_rules =

--- a/src/parsing/Parse_rule.ml
+++ b/src/parsing/Parse_rule.ml
@@ -133,11 +133,7 @@ let try_and_raise_invalid_pattern_if_error (env : env) (s, t) f =
   (* TODO: capture and adjust pos of parsing error exns instead of using [t] *)
   | exn ->
       let error_kind : R.invalid_rule_error_kind =
-        match exn with
-        | Parsing_plugin.Missing_plugin msg -> MissingPlugin msg
-        | exn ->
-            InvalidPattern
-              (s, env.target_analyzer, Common.exn_to_s exn, env.path)
+        InvalidPattern (s, env.target_analyzer, Common.exn_to_s exn, env.path)
       in
       Rule.raise_error (Some env.id) (InvalidRule (error_kind, env.id, t))
 

--- a/src/parsing/Parsing_plugin.ml
+++ b/src/parsing/Parsing_plugin.ml
@@ -6,17 +6,51 @@ open Common
 
 exception Missing_plugin of string
 
+let missing_plugins : (Lang.t, unit) Hashtbl.t = Hashtbl.create 10
+
 type pattern_parser = string -> AST_generic.any Tree_sitter_run.Parsing_result.t
 
 type target_file_parser =
   Common.filename -> AST_generic.program Tree_sitter_run.Parsing_result.t
 
+let missing_plugin_msg lang =
+  spf
+    "Missing Semgrep extension needed for parsing %s target. Try adding \
+     `--pro` to your command."
+    (Lang.to_string lang)
+
+let check_if_missing lang =
+  if Hashtbl.mem missing_plugins lang then Error (missing_plugin_msg lang)
+  else Ok ()
+
+let check_if_missing_analyzer (analyzer : Xlang.t) =
+  match analyzer with
+  | LRegex
+  | LSpacegrep
+  | LAliengrep ->
+      Ok ()
+  | L (lang, other_langs) -> (
+      match check_if_missing lang with
+      | Ok () -> (
+          other_langs
+          |> List.find_map (fun lang ->
+                 match check_if_missing lang with
+                 | Ok () -> None
+                 | Error msg -> Some msg)
+          |> function
+          | None -> Ok ()
+          | Some msg -> Error msg)
+      | Error _ as res -> res)
+
 (* Create and manage the reference holding a plugin. *)
 let make lang =
   let parsers = ref None in
+  Hashtbl.add missing_plugins lang ();
   let register ~parse_pattern ~parse_target =
     match !parsers with
-    | None -> parsers := Some (parse_pattern, parse_target)
+    | None ->
+        parsers := Some (parse_pattern, parse_target);
+        Hashtbl.remove missing_plugins lang
     | Some _existing_parsers ->
         (* This is a bug *)
         let msg =
@@ -30,14 +64,7 @@ let make lang =
   let is_available () = !parsers <> None in
   let parse_pattern file =
     match !parsers with
-    | None ->
-        let msg =
-          spf
-            "Missing Semgrep extension needed for parsing %s target. Try \
-             adding `--pro` to your command."
-            (Lang.to_string lang)
-        in
-        raise (Missing_plugin msg)
+    | None -> raise (Missing_plugin (missing_plugin_msg lang))
     | Some (parse_pattern, _) -> parse_pattern file
   in
   let parse_target file =

--- a/src/parsing/Parsing_plugin.mli
+++ b/src/parsing/Parsing_plugin.mli
@@ -11,6 +11,13 @@ type pattern_parser = string -> AST_generic.any Tree_sitter_run.Parsing_result.t
 type target_file_parser =
   Common.filename -> AST_generic.program Tree_sitter_run.Parsing_result.t
 
+(* Return an error message in case of a missing plugin. *)
+val check_if_missing : Lang.t -> (unit, string) Result.t
+
+(* Call 'check_is_missing' if any target programming language with a missing
+   plugin is involved with this analyzer. *)
+val check_if_missing_analyzer : Xlang.t -> (unit, string) Result.t
+
 module type T = sig
   (* Register parsing functions for a language. *)
   val register_parsers :


### PR DESCRIPTION
This moves the spot where we catch "missing plugin" errors occurring when running Apex rules without the Apex plugin. This was a problem for rules targeting Apex files for which there was no Apex pattern to parse (e.g. only `pattern-regex`) which was resulting in a delayed exception that wasn't caught or no error at all.

Internal ticket: https://linear.app/semgrep/issue/PA-3173/revisit-pro-rule-skipping-since-its-actually-not-working