### PR TITLE
fix(SSC): Allow arbitrary whitespace between dependencies in go.mod

### DIFF
--- a/changelog.d/sc-1076.fixed
+++ b/changelog.d/sc-1076.fixed
@@ -1,0 +1,1 @@
+go.mod parsing now correctly allows arbitrary newlines and whitespace between dependencies

--- a/cli/src/semdep/parsers/go_mod.py
+++ b/cli/src/semdep/parsers/go_mod.py
@@ -40,7 +40,8 @@ def multi_spec(spec: "Parser[A]") -> "Parser[List[Tuple[A,Optional[str]]]]":
     return (
         regex(r"[ \t]*\(\n")
         >> (
-            (regex(r"[ \t]*") >> pair(spec, comment.optional(None))) << string("\n")
+            (regex(r"[ \t]*") >> pair(spec, comment.optional(None)))
+            << string("\n").at_least(1)
         ).many()
         << string(")")
     ) | (regex(r"[ \t]*") >> pair(spec, comment.optional()).map(lambda x: [x]))

--- a/cli/src/semdep/parsers/go_mod.py
+++ b/cli/src/semdep/parsers/go_mod.py
@@ -2,7 +2,6 @@
 Parser for go.mod files
 Based on https://go.dev/ref/mod#go-mod-file
 """
-import re
 from pathlib import Path
 from typing import Dict
 from typing import List
@@ -39,10 +38,8 @@ comment = regex(r" *//([^\n]*)", flags=0, group=1)
 
 def multi_spec(spec: "Parser[A]") -> "Parser[List[Tuple[A,Optional[str]]]]":
     return (
-        regex(r"[ \t]*\(\n[ \t]*")
-        >> (
-            pair(spec, comment.optional(None)) << regex(r"\s+", flags=re.MULTILINE)
-        ).many()
+        regex(r"\s*\(\s+")
+        >> (pair(spec, comment.optional(None)) << regex(r"\s+")).many()
         << string(")")
     ) | (regex(r"[ \t]*") >> pair(spec, comment.optional()).map(lambda x: [x]))
 

--- a/cli/src/semdep/parsers/go_mod.py
+++ b/cli/src/semdep/parsers/go_mod.py
@@ -2,6 +2,7 @@
 Parser for go.mod files
 Based on https://go.dev/ref/mod#go-mod-file
 """
+import re
 from pathlib import Path
 from typing import Dict
 from typing import List
@@ -38,10 +39,9 @@ comment = regex(r" *//([^\n]*)", flags=0, group=1)
 
 def multi_spec(spec: "Parser[A]") -> "Parser[List[Tuple[A,Optional[str]]]]":
     return (
-        regex(r"[ \t]*\(\n")
+        regex(r"[ \t]*\(\n[ \t]*")
         >> (
-            (regex(r"[ \t]*") >> pair(spec, comment.optional(None)))
-            << string("\n").at_least(1)
+            pair(spec, comment.optional(None)) << regex(r"\s+", flags=re.MULTILINE)
         ).many()
         << string(")")
     ) | (regex(r"[ \t]*") >> pair(spec, comment.optional()).map(lambda x: [x]))

--- a/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awarego-sca.yaml-dependency_awarego_multi_newline/results.txt
+++ b/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awarego-sca.yaml-dependency_awarego_multi_newline/results.txt
@@ -1,0 +1,94 @@
+=== command
+SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERSION_CACHE_PATH="<MASKED>" SEMGREP_ENABLE_VERSION_CHECK="0" SEMGREP_SEND_METRICS="off" semgrep --strict --config rules/dependency_aware/go-sca.yaml --json targets/dependency_aware/go_multi_newline
+=== end of command
+
+=== exit code
+0
+=== end of exit code
+
+=== stdout - plain
+{
+  "errors": [],
+  "paths": {
+    "scanned": [
+      "targets/dependency_aware/go_multi_newline/go.mod",
+      "targets/dependency_aware/go_multi_newline/sca.go"
+    ]
+  },
+  "results": [
+    {
+      "check_id": "rules.dependency_aware.go-sca",
+      "end": {
+        "col": 14,
+        "line": 2,
+        "offset": 24
+      },
+      "extra": {
+        "engine_kind": "OSS",
+        "fingerprint": "0x42",
+        "is_ignored": false,
+        "lines": "\treturn bad()",
+        "message": "oh no",
+        "metadata": {},
+        "metavars": {},
+        "sca_info": {
+          "dependency_match": {
+            "dependency_pattern": {
+              "ecosystem": "gomod",
+              "package": "github.com/cheekybits/genny",
+              "semver_range": "== 99.99.99"
+            },
+            "found_dependency": {
+              "allowed_hashes": {},
+              "ecosystem": "gomod",
+              "line_number": 19,
+              "package": "github.com/cheekybits/genny",
+              "resolved_url": "github.com/cheekybits/genny",
+              "transitivity": "direct",
+              "version": "99.99.99"
+            },
+            "lockfile": "targets/dependency_aware/go_multi_newline/go.mod"
+          },
+          "reachability_rule": true,
+          "reachable": true,
+          "sca_finding_schema": 20220913
+        },
+        "severity": "WARNING",
+        "validation_state": "NO_VALIDATOR"
+      },
+      "path": "targets/dependency_aware/go_multi_newline/sca.go",
+      "start": {
+        "col": 9,
+        "line": 2,
+        "offset": 19
+      }
+    }
+  ],
+  "skipped_rules": [],
+  "version": "0.42"
+}
+=== end of stdout - plain
+
+=== stderr - plain
+
+
+┌─────────────┐
+│ Scan Status │
+└─────────────┘
+  Scanning 2 files tracked by git with 0 Code rules, 1 Supply Chain rule:
+
+
+  CODE RULES
+  Nothing to scan.
+
+  SUPPLY CHAIN RULES
+  Scanning 1 file.
+
+
+┌──────────────┐
+│ Scan Summary │
+└──────────────┘
+
+Ran 1 rule on 2 files: 1 finding.
+
+=== end of stderr - plain

--- a/cli/tests/e2e/targets/dependency_aware/go_multi_newline/go.mod
+++ b/cli/tests/e2e/targets/dependency_aware/go_multi_newline/go.mod
@@ -1,0 +1,66 @@
+// comment
+// second comment
+module github.com/foo
+
+go 1.18
+
+retract (
+    v1.0.0
+    [v1.0.0, v1.9.9]
+)
+
+require (
+	github.com/go-chi/chi/v5 v5.0.7
+	github.com/go-chi/render v1.0.2
+	github.com/lucasb-eyer/go-colorful v1.2.0
+
+	go.opentelemetry.io/otel/sdk v1.11.1
+	
+    github.com/cheekybits/genny v99.99.99
+
+)
+
+require (
+	github.com/ajg/form v1.5.1 // indirect
+	github.com/cenkalti/backoff/v4 v4.1.3 // indirect
+	github.com/felixge/httpsnoop v1.0.2 // indirect
+	github.com/go-logr/logr v1.2.3 // indirect
+	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0 // indirect
+	go.opentelemetry.io/contrib v1.0.0 // indirect
+
+
+	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.11.1 // indirect
+	
+    go.opentelemetry.io/otel/trace v1.11.1 // indirect
+	go.opentelemetry.io/proto/otlp v0.19.0 // indirect
+	golang.org/x/net v0.0.0-20220722155237-a158d28d115b // indirect
+	golang.org/x/text v0.3.8 // indirect
+	google.golang.org/genproto v0.0.0-20211118181313-81c1377c94b1 // indirect
+	google.golang.org/grpc v1.50.1 // indirect
+
+
+)
+
+require (
+	// comment
+	// second comment
+	github.com/riandyrn/otelchi v0.5.0
+	go.opentelemetry.io/otel v1.11.1
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.11.1
+    
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.11.1
+	golang.org/x/sys v0.2.0 // indirect
+
+	// interspersed comment
+
+	golang.org/x/tools v0.1.12
+	google.golang.org/protobuf v1.28.1 // indirect
+)
+
+replace (
+		// my comment with ending ()
+    github.com/riandyrn/otelchi v0.5.0 => github.com/riandyrn/otelchi v0.5.1
+   	go.opentelemetry.io/otel v1.11.1 => go.opentelemetry.io/otel v1.11.2
+)

--- a/cli/tests/e2e/targets/dependency_aware/go_multi_newline/sca.go
+++ b/cli/tests/e2e/targets/dependency_aware/go_multi_newline/sca.go
@@ -1,0 +1,3 @@
+func f() {
+	return bad()
+}

--- a/cli/tests/e2e/test_dependency_aware_rules.py
+++ b/cli/tests/e2e/test_dependency_aware_rules.py
@@ -40,6 +40,7 @@ pytestmark = pytest.mark.kinda_slow
             "dependency_aware/yarn",
         ),
         ("rules/dependency_aware/go-sca.yaml", "dependency_aware/go"),
+        ("rules/dependency_aware/go-sca.yaml", "dependency_aware/go_multi_newline"),
         ("rules/dependency_aware/ruby-sca.yaml", "dependency_aware/ruby"),
         (
             "rules/dependency_aware/ruby-sca.yaml",


### PR DESCRIPTION
Previously this was not accepted, now it is.
```
module test
go 1.20

require (
	foo v1.0.0

	bar v2.0.0


	baz v1.4.0
)
```
The way I would read this change:
* Before, we parsed: 
  * space or tabs, opening paren, newline
  * list of "spaces or tabs, stuff, newline"
* Now, we parse:
  * Any whitespace chars, opening paren, at least one whitespace char
  * list of "stuff, at least one whitespace"

Technically this is more permissive than the actual `go.mod` parser, but that's fine.

test included