### PR TITLE
fix: Gracefully handle metavariable-regex against resolved values

### DIFF
--- a/libs/ast_generic/AST_generic_helpers.ml
+++ b/libs/ast_generic/AST_generic_helpers.ml
@@ -570,6 +570,12 @@ let range_of_tokens tokens =
   List.filter Tok.is_origintok tokens |> Tok_range.min_max_toks_by_pos
 [@@profiling]
 
+let range_of_tokens_opt tokens =
+  match List.filter Tok.is_origintok tokens with
+  | [] -> None
+  | tokens -> Some (Tok_range.min_max_toks_by_pos tokens)
+[@@profiling]
+
 let range_of_any_opt any =
   (* Even if the ranges are cached, calling `extract_ranges` to get them
    * is extremely expensive (due to `mk_visitor`). Testing taint-mode

--- a/libs/ast_generic/AST_generic_helpers.mli
+++ b/libs/ast_generic/AST_generic_helpers.mli
@@ -136,6 +136,7 @@ val info_of_any : AST_generic.any -> Tok.t
 (* may raise NoTokenLocation *)
 val first_info_of_any : AST_generic.any -> Tok.t
 val range_of_tokens : Tok.t list -> Tok_range.t
+val range_of_tokens_opt : Tok.t list -> Tok_range.t option
 val range_of_any_opt : AST_generic.any -> (Tok.location * Tok.location) option
 
 val nearest_any_of_pos :

--- a/src/engine/Metavariable_regex.ml
+++ b/src/engine/Metavariable_regex.ml
@@ -12,6 +12,8 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
  * LICENSE for more details.
  *)
+
+open Common
 module MV = Metavariable
 module RM = Range_with_metavars
 module G = AST_generic
@@ -72,9 +74,17 @@ let get_metavar_regex_capture_bindings env ~file r (mvar, re_str) =
              So we carry a base offset of the metavariable's start, so that we can
              perform that calculation.
           *)
-          let mast_start_loc =
-            mval |> MV.ii_of_mval |> AST_generic_helpers.range_of_tokens |> fst
-            |> Tok.unsafe_loc_of_tok
+          let* mast_start_loc =
+            (* metavariable-regex doesn't make sense on synthetic ASTs such as
+             * those created for resolved names, which are used pervasively by
+             * the Pro Engine. It should only try to match when we actually have
+             * underlying text to match against. So, if there is no legitimate
+             * source location associated with the mevariable, we'll just fail
+             * to match here. *)
+            let* start, _ =
+              mval |> MV.ii_of_mval |> AST_generic_helpers.range_of_tokens_opt
+            in
+            Some (Tok.unsafe_loc_of_tok start)
           in
           let mval_start_pos = mast_start_loc.pos in
 


### PR DESCRIPTION
As noted inline, it's probably best to just not match a `metavariable-regex` against a completely synthetic AST.

Test plan:

Update the Pro Engine to use this version of Semgrep, then verify that the following test case does not error:

```
rules:
- id: broken
  languages:
  - java
  severity: ERROR
  message: asdf
  options:
    interfile: true
  patterns:
    - pattern: |
        new $X.$Y()
    - metavariable-regex:
        metavariable: $Y
        regex: ^(Test)$
```

```
package foo.bar;

public class Test {
  public static void main(String[] args) {
    // MATCH:
    new foo.bar.Test();
  }
}
```

