### PR TITLE
logging: Reduce noise in -debug's output

### DIFF
--- a/libs/commons/SPcre.ml
+++ b/libs/commons/SPcre.ml
@@ -93,8 +93,7 @@ let log_error subj err =
     if len < 200 then subj
     else sprintf "%s ... (%i bytes)" (Str.first_chars subj 200) len
   in
-  logger#error "PCRE error: %s on input %S" (string_of_error err)
-    string_fragment
+  logger#info "PCRE error: %s on input %S" (string_of_error err) string_fragment
 
 let pmatch_noerr ?iflags ?flags ?rex ?pos ?callout ?(on_error = false) subj =
   match pmatch ?iflags ?flags ?rex ?pos ?callout subj with

--- a/src/analyzing/Dataflow_svalue.ml
+++ b/src/analyzing/Dataflow_svalue.ml
@@ -468,7 +468,7 @@ let set_svalue_ref id_info c' =
     match !(id_info.id_svalue) with
     | None -> id_info.id_svalue := Some c'
     | Some c -> id_info.id_svalue := Some (refine c c')
-  else logger#error "Cycle check failed for %s := ..." (G.show_id_info id_info)
+  else logger#info "Cycle check failed for %s := ..." (G.show_id_info id_info)
 (* (G.show_svalue c') *)
 
 (*****************************************************************************)


### PR DESCRIPTION
PCRE errors and failed cycle checks are unlikely to help us diagnose any crash.

test plan:
`semgrep -c p/default-v2 path/to/repo --debug` is less noisy

