### PR TITLE
Do not crash the whole scan because of weird targets

### DIFF
--- a/changelog.d/pa-3144.fixed
+++ b/changelog.d/pa-3144.fixed
@@ -1,0 +1,3 @@
+Target files that disappeared before the scan or that have special byte
+characters in their filename do not cause the whole scan to crash anymore.
+The file is skipped instead.

--- a/src/osemgrep/reporting/Skipped_report.ml
+++ b/src/osemgrep/reporting/Skipped_report.ml
@@ -60,6 +60,7 @@ let group_skipped (skipped : Out.skipped_target list) : skipped_targets_grouped
         | Minified
         | Binary
         | Dotfile
+        | Inexistent_file
         | Irrelevant_rule
         | Too_many_matches ->
             `Other)


### PR DESCRIPTION
Weird meaning inexistent or with weird filenames.

Closes PA-3144

test plan:
On Linux (can't create such filenames on macOS)
```
$ touch ''$'\320'
$ ls -l && ls | hexdump -x
total 0
-rw-r-----. 1 dsavints users 0 Sep 27 15:59 ''$'\320'
0000000    0ad0
0000002

$ semgrep --debug --config ~/test.yaml .
semgrep version 1.43.0
...
  Scanning 1 file (only git-tracked) with 1 Code rule:

  CODE RULES
  Scanning 1 file.
...

Passing whole rules directly to semgrep_core
Running Semgrep engine with command:
/home/pad/github/semgrep/cli/src/semgrep/bin/semgrep-core -json -rules /tmp/tmp876o7sst.json -j 16 -targets /tmp/tmpcn_tf58h -timeout 2 -timeout_threshold 3 -max_memory 0 -fast --debug
--- semgrep-core stderr ---
<semgrep-core stderr not captured, should be printed above>
--- end semgrep-core stderr ---
skipped 'Fpath(value='���')' [all rules]: SkipReason(value=InexistentFile()): File does not exist
semgrep ran in 0:00:00.196913 on 1 files
...
```