### PR TITLE
cleanup: use Nonexistent_file and consolidate in targets_of_config

### DIFF
--- a/src/core_scan/Core_scan.mli
+++ b/src/core_scan/Core_scan.mli
@@ -142,9 +142,4 @@ val xtarget_of_file : Core_scan_config.t -> Xlang.t -> Fpath.t -> Xtarget.t
 val sort_targets_by_decreasing_size :
   Input_to_core_t.target list -> Input_to_core_t.target list
 
-(* filter targets that actually exist (according to Sys.file_exists) *)
-val filter_existing_targets :
-  Input_to_core_t.target list ->
-  Input_to_core_t.target list * Semgrep_output_v1_t.skipped_target list
-
 val parse_equivalences : Fpath.t option -> Equivalence.equivalences

--- a/src/osemgrep/reporting/Skipped_report.ml
+++ b/src/osemgrep/reporting/Skipped_report.ml
@@ -60,7 +60,7 @@ let group_skipped (skipped : Out.skipped_target list) : skipped_targets_grouped
         | Minified
         | Binary
         | Dotfile
-        | Inexistent_file
+        | Nonexistent_file
         | Irrelevant_rule
         | Too_many_matches ->
             `Other)


### PR DESCRIPTION
Following nat's recommendations in #8957

test plan:
```
$ make core
$ make copy-core-for-cli
$ cd cli; pipenv shell
$ cd ~/weird_filenames;
$ semgrep --debug --config ~/test.yaml .
...
skipped 'Fpath(value='���')' [all rules]: SkipReason(value=NonexistentFile()): File does not exist
semgrep ran in 0:00:00.200126 on 1 files
...
```