### PR TITLE
C/C++: tainting: Track `this->xyz` l-values

### DIFF
--- a/changelog.d/gh-1058.fixed
+++ b/changelog.d/gh-1058.fixed
@@ -1,0 +1,35 @@
+Taint analysis: track `ptr->field` l-values in C++
+
+In C++, we now track tainted field access via pointer dereference. For
+instance, consider the following code snippet:
+```
+void test_intra_001() {
+  TestObject *obj = new TestObject();
+
+  obj->a = taint_source();
+  obj->b = SAFE_STR;
+
+  // ok: cpp-tainted-field-ptr
+  sink(obj->b, __LINE__);
+  // ruleid: cpp-tainted-field-ptr
+  sink(obj->a, __LINE__);
+}
+```
+
+This can be matched by the rule:
+```
+rules:
+  - id: cpp-tainted-field-ptr
+    languages:
+      - cpp
+    message: testing flows though C++ ptrs
+    severity: INFO
+    mode: taint
+    pattern-sources:
+      - pattern: taint_source()
+    pattern-sinks:
+      - patterns:
+          - pattern: sink($X, ...)
+          - focus-metavariable:
+              - $X
+```

--- a/src/tainting/Taint_lval_env.ml
+++ b/src/tainting/Taint_lval_env.ml
@@ -78,7 +78,12 @@ let normalize_lval lval =
   let { IL.base; rev_offset } = lval in
   let* base, rev_offset =
     match base with
+    (* explicit dereference of `ptr` e.g. `ptr->x` *)
+    | Mem { e = Fetch { base = Var x; rev_offset = [] }; _ } ->
+        Some (IL.Var x, rev_offset)
     | Var _ -> Some (base, rev_offset)
+    (* explicit dereference of `this` e.g. `this->x` *)
+    | Mem { e = Fetch { base = VarSpecial (This, _); rev_offset = [] }; _ }
     | VarSpecial _ -> (
         match List.rev rev_offset with
         (* this.x o_1 ... o_N becomes x o_1 ... o_N *)

--- a/tests/rules/taint_cpp_ptr_field.cpp
+++ b/tests/rules/taint_cpp_ptr_field.cpp
@@ -1,0 +1,11 @@
+void test_intra_001() {
+  TestObject *obj = new TestObject();
+
+  obj->a = taint_source();
+  obj->b = SAFE_STR;
+
+  // ok: cpp-tainted-field-ptr
+  sink(obj->b, __LINE__);
+  // ruleid: cpp-tainted-field-ptr
+  sink(obj->a, __LINE__);
+}

--- a/tests/rules/taint_cpp_ptr_field.yaml
+++ b/tests/rules/taint_cpp_ptr_field.yaml
@@ -1,0 +1,15 @@
+rules:
+  - id: cpp-tainted-field-ptr
+    languages:
+      - cpp
+    message: testing flows though C++ ptrs
+    severity: INFO
+    mode: taint
+    pattern-sources:
+      - pattern: taint_source()
+    pattern-sinks:
+      - patterns:
+          - pattern: sink($X, ...)
+          - focus-metavariable:
+              - $X
+


### PR DESCRIPTION
Test Plan: https://github.com/returntocorp/semgrep-proprietary/pull/1052