### PR TITLE
pysemgrep: handle azure git URLs

### DIFF
--- a/changelog.d/pa-3145.fixed
+++ b/changelog.d/pa-3145.fixed
@@ -1,0 +1,2 @@
+semgrep ci does not crash anymore when ran from git repositories coming from
+Azure projects with whitespaces in the name.

--- a/cli/src/semgrep/external/git_url_parser.py
+++ b/cli/src/semgrep/external/git_url_parser.py
@@ -125,8 +125,8 @@ class Parser(str):
             msg = "Invalid URL '{}'".format(self._url)
             raise ParserError(msg)
 
-        if cast(str, d.get('owner', '')).endswith('/_git'):  # Azure DevOps Git URLs
-            d['owner'] = cast(str, d['owner'])[:-len('/_git')]
+        if d['owner'] is not None and cast(str, d['owner']).endswith('/_git'):  # Azure DevOps Git URLs
+            d['owner'] = d['owner'][:-len('/_git')]
 
         return Parsed(**d)
 

--- a/cli/src/semgrep/external/git_url_parser.py
+++ b/cli/src/semgrep/external/git_url_parser.py
@@ -24,6 +24,8 @@
 #
 # 2023-06-02 patched by Martin Jambon to avoid potential ReDoS attacks
 # 2023-06-05 patched further by Martin Jambon to avoid potential ReDoS attacks
+# 2023-10-12 patched by Zach Zeleznick to handle Azure URLs like
+#   https://foobar.visualstudio.com/Data%20Classification/_git/Data%20Classification
 #
 
 import collections
@@ -48,8 +50,8 @@ POSSIBLE_REGEXES = (
                r'(?P<resource>[a-z0-9_.-]*)'
                r'[:/]*'
                r'(?P<port>(?<=:)[\d]+){0,1}'
-               r'(?P<pathname>\/((?P<owner>[\w\-\/]+)\/)?'
-               r'((?P<name>[\w\-\.]+?)(\.git|\/)?)?)$'),
+               r'(?P<pathname>\/((?P<owner>[\w\-%\/]+)\/)?'
+               r'((?P<name>[\w\-%\.]+?)(\.git|\/)?)?)$'),
     re.compile(r'(git\+)?'
                r'((?P<protocol>\w+)://)'
                r'((?P<user>\w+)@)?'
@@ -121,6 +123,9 @@ class Parser(str):
         else:
             msg = "Invalid URL '{}'".format(self._url)
             raise ParserError(msg)
+
+        if d.get('owner', '').endswith('/_git'):  # Azure DevOps Git URLs
+            d['owner'] = d['owner'][:-len('/_git')]
 
         return Parsed(**d)
 

--- a/cli/src/semgrep/external/git_url_parser.py
+++ b/cli/src/semgrep/external/git_url_parser.py
@@ -31,6 +31,7 @@
 import collections
 import re
 from typing import List
+from typing import cast
 
 Parsed = collections.namedtuple('Parsed', [
     'pathname',
@@ -124,8 +125,8 @@ class Parser(str):
             msg = "Invalid URL '{}'".format(self._url)
             raise ParserError(msg)
 
-        if d.get('owner', '').endswith('/_git'):  # Azure DevOps Git URLs
-            d['owner'] = d['owner'][:-len('/_git')]
+        if cast(str, d.get('owner', '')).endswith('/_git'):  # Azure DevOps Git URLs
+            d['owner'] = cast(str, d['owner'])[:-len('/_git')]
 
         return Parsed(**d)
 

--- a/cli/tests/e2e/test_meta.py
+++ b/cli/tests/e2e/test_meta.py
@@ -10,7 +10,11 @@ def test_git_url_parser():
         # This used to cause the URL parser to crash.
         (
             "https://test@dev.azure.com/test/TestName/_git/Core.Thing",
-            "https://dev.azure.com/test/TestName/_git/Core.Thing",
+            "https://dev.azure.com/test/TestName/Core.Thing",
+        ),
+        (
+            "https://foobar.visualstudio.com/Data%20Classification/_git/Data%20Classification",
+            "https://foobar.visualstudio.com/Data%20Classification/Data%20Classification",
         ),
         # This one has a "subgroup" structure, which we should be able to parse.
         (


### PR DESCRIPTION
This closes PA-3145

Note that osemgrep was not crashing on such URLs!

I just used the fix Zach found.

test plan:
git clone https://sebasrevuelta.visualstudio.com/Data%20Classification/_git/Data%20Classification
cd Data%20Classification
semgrep ci
now works