### PR TITLE
remove python lockfile parsing case sensitivity

### DIFF
--- a/cli/src/semdep/parsers/pipfile.py
+++ b/cli/src/semdep/parsers/pipfile.py
@@ -56,7 +56,7 @@ def parse_pipfile(
             manifest_path,
             manifest,
             ScaParserName(Pipfile()),
-            preprocessors.CombinedPreprocessor(),
+            preprocessors.CommentRemover(),
         )
         if manifest_path
         else None,
@@ -65,7 +65,7 @@ def parse_pipfile(
     if not parsed_lockfile:
         return [], errors
 
-    deps = parsed_lockfile.as_dict()["default"].as_dict()
+    deps = {k.lower(): v for k, v in parsed_lockfile.as_dict()["default"].as_dict().items()}
 
     # According to PEP 426: pypi distributions are case insensitive and consider hyphens and underscores to be equivalent
     sanitized_manifest_deps = (

--- a/cli/src/semdep/parsers/pipfile.py
+++ b/cli/src/semdep/parsers/pipfile.py
@@ -56,7 +56,7 @@ def parse_pipfile(
             manifest_path,
             manifest,
             ScaParserName(Pipfile()),
-            preprocessors.CommentRemover(),
+            preprocessors.CombinedPreprocessor(),
         )
         if manifest_path
         else None,

--- a/cli/src/semdep/parsers/pipfile.py
+++ b/cli/src/semdep/parsers/pipfile.py
@@ -97,7 +97,7 @@ def parse_pipfile(
         version = version.replace("==", "")
         output.append(
             FoundDependency(
-                package=package,
+                package=package.lower(),
                 version=version,
                 ecosystem=Ecosystem(Pypi()),
                 resolved_url=None,

--- a/cli/src/semdep/parsers/pipfile.py
+++ b/cli/src/semdep/parsers/pipfile.py
@@ -65,7 +65,7 @@ def parse_pipfile(
     if not parsed_lockfile:
         return [], errors
 
-    deps = parsed_lockfile.as_dict()["default"].as_dict()
+    deps = {k.lower(): v for k, v in parsed_lockfile.as_dict()["default"].as_dict().items()}
 
     # According to PEP 426: pypi distributions are case insensitive and consider hyphens and underscores to be equivalent
     sanitized_manifest_deps = (

--- a/cli/src/semdep/parsers/poetry.py
+++ b/cli/src/semdep/parsers/poetry.py
@@ -159,13 +159,13 @@ def parse_poetry(
             lockfile_path,
             poetry,
             ScaParserName(PoetryLock()),
-            preprocessors.CommentRemover(),
+            preprocessors.CombinedPreprocessor(),
         ),
         DependencyFileToParse(
             manifest_path,
             manifest,
             ScaParserName(PyprojectToml()),
-            preprocessors.CommentRemover(),
+            preprocessors.CombinedPreprocessor(),
         )
         if manifest_path
         else None,

--- a/cli/src/semdep/parsers/poetry.py
+++ b/cli/src/semdep/parsers/poetry.py
@@ -94,7 +94,7 @@ key_value_list = key_value.sep_by(new_lines)
 # category = "main"
 # optional = false
 # python-versions = ">=3.6"
-poetry_dep = mark_line(string("[[package]]\n") >> key_value_list.map(lambda x: dict(x)))
+poetry_dep = mark_line(string("[[package]]\n") >> key_value_list.map(lambda x: {k.lower(): v.lower() for k, v in dict(x).items()}))
 
 # Poetry Source which we ignore
 # Example:

--- a/cli/src/semdep/parsers/poetry.py
+++ b/cli/src/semdep/parsers/poetry.py
@@ -94,7 +94,7 @@ key_value_list = key_value.sep_by(new_lines)
 # category = "main"
 # optional = false
 # python-versions = ">=3.6"
-poetry_dep = mark_line(string("[[package]]\n") >> key_value_list.map(lambda x: dict(x)))
+poetry_dep = mark_line(string("[[package]]\n") >> key_value_list.map(lambda x: {k.lower(): v.lower() for k, v in dict(x).items()}))
 
 # Poetry Source which we ignore
 # Example:
@@ -159,13 +159,13 @@ def parse_poetry(
             lockfile_path,
             poetry,
             ScaParserName(PoetryLock()),
-            preprocessors.CombinedPreprocessor(),
+            preprocessors.CommentRemover(),
         ),
         DependencyFileToParse(
             manifest_path,
             manifest,
             ScaParserName(PyprojectToml()),
-            preprocessors.CombinedPreprocessor(),
+            preprocessors.CommentRemover(),
         )
         if manifest_path
         else None,

--- a/cli/src/semdep/parsers/poetry.py
+++ b/cli/src/semdep/parsers/poetry.py
@@ -189,7 +189,7 @@ def parse_poetry(
             continue
         output.append(
             FoundDependency(
-                package=dep["name"],
+                package=dep["name"].lower(),
                 version=dep["version"],
                 ecosystem=Ecosystem(Pypi()),
                 allowed_hashes={},

--- a/cli/src/semdep/parsers/preprocessors.py
+++ b/cli/src/semdep/parsers/preprocessors.py
@@ -17,7 +17,7 @@ class CommentRemover:
 
 
 class CombinedPreprocessor:
-    def __init__(self):
+    def __init__(self) -> None:
         self.comment_remover = CommentRemover()
 
     def __call__(self, target: str) -> str:

--- a/cli/src/semdep/parsers/preprocessors.py
+++ b/cli/src/semdep/parsers/preprocessors.py
@@ -14,12 +14,3 @@ class CommentRemover:
 
     def __call__(self, target: str) -> str:
         return self.pattern.sub(r"\1\2", target)
-
-
-class CombinedPreprocessor:
-    def __init__(self):
-        self.comment_remover = CommentRemover()
-
-    def __call__(self, target: str) -> str:
-        lowercase_content = target.lower()
-        return self.comment_remover(lowercase_content)

--- a/cli/src/semdep/parsers/preprocessors.py
+++ b/cli/src/semdep/parsers/preprocessors.py
@@ -14,3 +14,12 @@ class CommentRemover:
 
     def __call__(self, target: str) -> str:
         return self.pattern.sub(r"\1\2", target)
+
+
+class CombinedPreprocessor:
+    def __init__(self):
+        self.comment_remover = CommentRemover()
+
+    def __call__(self, target: str) -> str:
+        lowercase_content = target.lower()
+        return self.comment_remover(lowercase_content)

--- a/cli/src/semdep/parsers/requirements.py
+++ b/cli/src/semdep/parsers/requirements.py
@@ -65,7 +65,7 @@ dep = package.bind(
         >> whitespace.optional()
         >> version_specifier.sep_by(string(",") >> whitespace.optional()).bind(
             lambda version_specifiers: upto("\n").optional()
-            >> success((package, [x for x in version_specifiers if x]))
+            >> success((package.lower(), [x for x in version_specifiers if x])) 
         )
     )
 )
@@ -85,15 +85,6 @@ requirements = (
     .sep_by(string("\n").at_least(1))
     .map(lambda xs: [(l, x) for (l, x) in xs if x])
 )
-
-
-# We preprocess the file to remove comments
-# It's much easier to just strip them out than to weave them into parsing
-
-
-# first remove comments
-# https://github.com/pypa/pip/blob/e69e265cb7b60fb2dacbbb2ab8fa3baaf24bfe4d/src/pip/_internal/req/req_file.py#LL45
-COMMENT_REGEX = r"(^|\s+)#.*$"
 
 
 def get_manifest_deps(

--- a/cli/src/semdep/parsers/requirements.py
+++ b/cli/src/semdep/parsers/requirements.py
@@ -65,7 +65,7 @@ dep = package.bind(
         >> whitespace.optional()
         >> version_specifier.sep_by(string(",") >> whitespace.optional()).bind(
             lambda version_specifiers: upto("\n").optional()
-            >> success((package, [x for x in version_specifiers if x]))
+            >> success((package.lower(), [x for x in version_specifiers if x])) 
         )
     )
 )
@@ -101,13 +101,13 @@ def parse_requirements(
             lockfile_path,
             requirements,
             ScaParserName(Requirements()),
-            preprocessors.CombinedPreprocessor(),
+            preprocessors.CommentRemover(),
         ),
         DependencyFileToParse(
             manifest_path,
             requirements,
             ScaParserName(Requirements()),
-            preprocessors.CombinedPreprocessor(),
+            preprocessors.CommentRemover(),
         )
         if manifest_path
         else None,

--- a/cli/src/semdep/parsers/requirements.py
+++ b/cli/src/semdep/parsers/requirements.py
@@ -127,7 +127,7 @@ def parse_requirements(
             continue
         output.append(
             FoundDependency(
-                package=package,
+                package=package.lower(),
                 version=version,
                 ecosystem=Ecosystem(Pypi()),
                 allowed_hashes={},

--- a/cli/src/semdep/parsers/requirements.py
+++ b/cli/src/semdep/parsers/requirements.py
@@ -87,15 +87,6 @@ requirements = (
 )
 
 
-# We preprocess the file to remove comments
-# It's much easier to just strip them out than to weave them into parsing
-
-
-# first remove comments
-# https://github.com/pypa/pip/blob/e69e265cb7b60fb2dacbbb2ab8fa3baaf24bfe4d/src/pip/_internal/req/req_file.py#LL45
-COMMENT_REGEX = r"(^|\s+)#.*$"
-
-
 def get_manifest_deps(
     parsed: Optional[List[Tuple[int, Tuple[str, List[Tuple[str, str]]]]]]
 ) -> Optional[Set[str]]:
@@ -110,13 +101,13 @@ def parse_requirements(
             lockfile_path,
             requirements,
             ScaParserName(Requirements()),
-            preprocessors.CommentRemover(),
+            preprocessors.CombinedPreprocessor(),
         ),
         DependencyFileToParse(
             manifest_path,
             requirements,
             ScaParserName(Requirements()),
-            preprocessors.CommentRemover(),
+            preprocessors.CombinedPreprocessor(),
         )
         if manifest_path
         else None,


### PR DESCRIPTION
Python import statements are case sensitive, but requirements.txt, pipfile.lock, and poetry.lock are not. 

requirements.txt, pipfile.lock, and poetry.lock should always be lowercase, unless manually edited. 

Commit applies a preprocessor to convert all characters in the lock file to lowercase when passed to the parser.