### PR TITLE
chore: remove hidden attribute from supply chain cli flag

### DIFF
--- a/changelog.d/gh-8975.fixed
+++ b/changelog.d/gh-8975.fixed
@@ -1,0 +1,1 @@
+add `--supply-chain` flag to `semgrep ci --help` documentation

--- a/cli/src/semgrep/commands/ci.py
+++ b/cli/src/semgrep/commands/ci.py
@@ -139,7 +139,6 @@ def fix_head_if_github_action(metadata: GitMeta) -> None:
 @click.option(
     "--supply-chain",
     is_flag=True,
-    hidden=True,
 )
 @click.option("--code", is_flag=True, hidden=True)
 @click.option("--beta-testing-secrets", is_flag=True, hidden=True)


### PR DESCRIPTION
Make `--supply-chain` flag visible via cli help message