### PR TITLE
pysemgrep: cleanup error.py

### DIFF
--- a/cli/src/semgrep/output.py
+++ b/cli/src/semgrep/output.py
@@ -5,7 +5,6 @@ from collections import defaultdict
 from functools import reduce
 from pathlib import Path
 from typing import Any
-from typing import cast
 from typing import Collection
 from typing import Dict
 from typing import FrozenSet
@@ -331,9 +330,9 @@ class OutputHandler:
             # errors, they didn't affect the whether files were analyzed, but were a different
             # kind of error (for example, baseline commit not found)
             semgrep_core_errors = [
-                cast(SemgrepCoreError, err)
+                err
                 for err in self.semgrep_structured_errors
-                if SemgrepError.semgrep_error_type(err) == "SemgrepCoreError"
+                if isinstance(err, SemgrepCoreError)
             ]
 
             failed_to_analyze_lines_by_path = self._make_failed_to_analyze(

--- a/src/core/Core_error.ml
+++ b/src/core/Core_error.ml
@@ -40,7 +40,7 @@ let logger = Logging.get_logger [ __MODULE__ ]
  *)
 type t = {
   rule_id : Rule_ID.t option;
-  typ : Out.core_error_kind;
+  typ : Out.error_type;
   loc : Tok.location;
   msg : string;
   details : string option;
@@ -69,7 +69,7 @@ let please_file_issue_text =
 
 let mk_error opt_rule_id loc msg err =
   let msg =
-    match (err : Out.core_error_kind) with
+    match (err : Out.error_type) with
     | MatchingError
     | AstBuilderError
     | FatalError
@@ -88,6 +88,9 @@ let mk_error opt_rule_id loc msg err =
     | PatternParseError _
     | PartialParsing _
     | IncompatibleRule _
+    | SemgrepError
+    | InvalidRuleSchemaError
+    | UnknownLanguageError
     | MissingPlugin ->
         msg
   in
@@ -232,10 +235,10 @@ let string_of_error err =
   spf "%s:%d:%d: %s: %s%s"
     (source_of_string pos.Tok.pos.file)
     pos.Tok.pos.line pos.Tok.pos.column
-    (Out.string_of_core_error_kind err.typ)
+    (Out.string_of_error_type err.typ)
     err.msg details
 
-let severity_of_error (typ : Out.core_error_kind) : Out.error_severity =
+let severity_of_error (typ : Out.error_type) : Out.error_severity =
   match typ with
   | SemgrepMatchFound -> `Error
   | MatchingError -> `Warning
@@ -253,6 +256,9 @@ let severity_of_error (typ : Out.core_error_kind) : Out.error_severity =
   | OutOfMemory -> `Warning
   | TimeoutDuringInterfile -> `Error
   | OutOfMemoryDuringInterfile -> `Error
+  | SemgrepError -> `Error
+  | InvalidRuleSchemaError -> `Error
+  | UnknownLanguageError -> `Error
   | IncompatibleRule _
   | MissingPlugin ->
       (* Running into an incompatible rule may be normal, with nothing to fix *)

--- a/src/core/Core_error.mli
+++ b/src/core/Core_error.mli
@@ -8,7 +8,7 @@
 
 type t = {
   rule_id : Rule_ID.t option;
-  typ : Semgrep_output_v1_t.core_error_kind;
+  typ : Semgrep_output_v1_t.error_type;
   loc : Tok.location;
   msg : string;
   (* ?? diff with msg? *)
@@ -28,15 +28,11 @@ val mk_error :
   Rule_ID.t option ->
   Tok.location ->
   string ->
-  Semgrep_output_v1_t.core_error_kind ->
+  Semgrep_output_v1_t.error_type ->
   t
 
 val error :
-  Rule_ID.t ->
-  Tok.location ->
-  string ->
-  Semgrep_output_v1_t.core_error_kind ->
-  unit
+  Rule_ID.t -> Tok.location -> string -> Semgrep_output_v1_t.error_type -> unit
 
 (* Convert an invalid rule into an error.
    TODO: return None for rules that are being skipped due to version
@@ -61,7 +57,7 @@ val try_with_print_exn_and_reraise : Common.filename -> (unit -> unit) -> unit
 val string_of_error : t -> string
 
 val severity_of_error :
-  Semgrep_output_v1_t.core_error_kind -> Semgrep_output_v1_t.error_severity
+  Semgrep_output_v1_t.error_type -> Semgrep_output_v1_t.error_severity
 
 (*****************************************************************************)
 (* Helpers for unit testing *)

--- a/src/osemgrep/core/Exit_code.ml
+++ b/src/osemgrep/core/Exit_code.ml
@@ -17,11 +17,15 @@ let of_int x = x
 let ok = 0
 let findings = 1
 let fatal = 2
+
+(* a.k.a. target_parse_failure *)
 let invalid_code = 3
+
+(* a.k.a rule_parse_failure *)
 let invalid_pattern = 4
 let unparseable_yaml = 5
 
-(* let need_arbitrary_code_exec = 6 *)
+(* old: let need_arbitrary_code_exec = 6 *)
 let missing_config = 7
 let invalid_language = 8
 

--- a/src/osemgrep/reporting/Cli_json_output.mli
+++ b/src/osemgrep/reporting/Cli_json_output.mli
@@ -8,7 +8,7 @@ val cli_output_of_core_results :
   Semgrep_output_v1_j.cli_output
 
 (* internals used in Scan_subcommant.ml *)
-val exit_code_of_error_type : Semgrep_output_v1_t.core_error_kind -> Exit_code.t
+val exit_code_of_error_type : Semgrep_output_v1_t.error_type -> Exit_code.t
 
 (* internals used also for incremental display of matches *)
 val cli_match_of_core_match :


### PR DESCRIPTION
This is one step towards using semgrep_output_v1.error_type
for the type: field in the CLI JSON output

test plan:
make e2e