### PR TITLE
Update deprecated params in trigger-doc-update.yml

### DIFF
--- a/.github/workflows/trigger-doc-update.yml
+++ b/.github/workflows/trigger-doc-update.yml
@@ -16,8 +16,8 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@v1
         with:
-          app_id: ${{ secrets.SEMGREP_DOCS_RELEASE_APP_ID }}
-          private_key: ${{ secrets.SEMGREP_DOCS_RELEASE_PRIVATE_KEY }}
+          app-id: ${{ secrets.SEMGREP_DOCS_RELEASE_APP_ID }}
+          private-key: ${{ secrets.SEMGREP_DOCS_RELEASE_PRIVATE_KEY }}
           repositories: "semgrep-docs"
       - name: Trigger doc update workflow
         env:


### PR DESCRIPTION
`app_id` and `private_key` are becoming deprecated, fixing.

