### PR TITLE
sync semgrep.opam with dune-project

### DIFF
--- a/.github/workflows/build-test-core-x86-ocaml5.yml
+++ b/.github/workflows/build-test-core-x86-ocaml5.yml
@@ -24,6 +24,6 @@ jobs:
         path: ocaml-build-artifacts.tgz
         name: ocaml-build-artifacts-ocaml5-release
     runs-on: ubuntu-latest
-    container: returntocorp/ocaml:alpine5.0-2023-09-29
+    container: returntocorp/ocaml:alpine5.0-2023-10-05
     env:
       HOME: /root

--- a/.github/workflows/build-test-core-x86.yml
+++ b/.github/workflows/build-test-core-x86.yml
@@ -23,6 +23,6 @@ jobs:
     - name: Test semgrep-core
       run: opam exec -- make core-test
     runs-on: ubuntu-latest
-    container: returntocorp/ocaml:alpine-2023-06-16
+    container: returntocorp/ocaml:alpine-2023-10-12
     env:
       HOME: /root

--- a/.github/workflows/build-test-javascript.yml
+++ b/.github/workflows/build-test-javascript.yml
@@ -40,7 +40,7 @@ jobs:
         path: "\n            _build/default/js/engine/*.bc.js\n            _build/default/js/languages/*/*.bc.js\n
           \         "
         name: semgrep-js-ocaml-build-${{ github.sha }}
-    container: returntocorp/ocaml:alpine-2023-06-16
+    container: returntocorp/ocaml:alpine-2023-10-12
     env:
       HOME: /root
   test:

--- a/.github/workflows/libs/semgrep.libsonnet
+++ b/.github/workflows/libs/semgrep.libsonnet
@@ -74,7 +74,7 @@ local github_bot = {
 
   ocaml_alpine_container: {
     'runs-on': 'ubuntu-latest',
-    container: 'returntocorp/ocaml:alpine-2023-06-16',
+    container: 'returntocorp/ocaml:alpine-2023-10-12',
     // We need this hack because GHA tampers with the HOME in container
     // and this does not play well with 'opam' installed in /root
     env: {
@@ -84,7 +84,7 @@ local github_bot = {
 
   ocaml5_alpine_container: {
     'runs-on': 'ubuntu-latest',
-    container: 'returntocorp/ocaml:alpine5.0-2023-09-29',
+    container: 'returntocorp/ocaml:alpine5.0-2023-10-05',
     env: {
       HOME: '/root',
     },

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Publish match performance
       run: opam exec -- make report-perf-matching
     runs-on: ubuntu-latest
-    container: returntocorp/ocaml:alpine-2023-06-16
+    container: returntocorp/ocaml:alpine-2023-10-12
     env:
       HOME: /root
   test-osemgrep:
@@ -50,7 +50,7 @@ jobs:
       working-directory: cli
       run: make osempass
     runs-on: ubuntu-latest
-    container: returntocorp/ocaml:alpine-2023-06-16
+    container: returntocorp/ocaml:alpine-2023-10-12
     env:
       HOME: /root
   test-cli:

--- a/Dockerfile
+++ b/Dockerfile
@@ -95,7 +95,7 @@ COPY cli/src/semgrep/semgrep_interfaces cli/src/semgrep/semgrep_interfaces
 # Visit https://hub.docker.com/r/returntocorp/ocaml/tags to see the latest
 # images available.
 #
-FROM returntocorp/ocaml:alpine-2023-09-13 as semgrep-core-container
+FROM returntocorp/ocaml:alpine-2023-10-12 as semgrep-core-container
 
 WORKDIR /src/semgrep
 COPY --from=semgrep-core-files /src/semgrep .

--- a/Makefile
+++ b/Makefile
@@ -296,16 +296,12 @@ ALPINE_APK_DEPS_PYSEMGREP=python3 python3-dev
 # We could update to a more recent version.
 # coupling: if you modify the version, please modify also .github/workflows/*
 PIPENV='pipenv==2022.6.7'
-#TODO: virtualenv 20.22.0 is causing the build to fail with some weird errors:
-# 'AttributeError: module 'virtualenv.create.via_global_ref.builtin.cpython.mac_os' has no attribute 'CPython2macOsArmFramework'
-# so I pinned an older version
-VIRTENV='virtualenv==20.21.0'
 
 # For '--ignore-installed distlib' below see
 # https://stackoverflow.com/questions/63515454/why-does-pip3-install-pipenv-give-error-error-cannot-uninstall-distlib
 install-deps-ALPINE-for-pysemgrep:
 	apk add --no-cache $(ALPINE_APK_DEPS_PYSEMGREP)
-	pip install --no-cache-dir --ignore-installed distlib $(PIPENV) $(VIRTENV)
+	pip install --no-cache-dir --ignore-installed distlib $(PIPENV)
 
 # -------------------------------------------------
 # Ubuntu

--- a/semgrep.opam
+++ b/semgrep.opam
@@ -21,6 +21,7 @@ depends: [
   "fpath"
   "bos"
   "alcotest"
+  "alcotest-js"
   "fmt"
   "ocolor"
   "ANSITerminal"
@@ -55,9 +56,9 @@ depends: [
   "digestif" {>= "1.0.0"}
   "lwt"
   "lwt_ppx"
-  "js_of_ocaml" {= "5.1.1"}
-  "js_of_ocaml-compiler" {= "5.1.1"}
-  "js_of_ocaml-ppx" {= "5.1.1"}
+  "js_of_ocaml" {= "5.4.0"}
+  "js_of_ocaml-compiler" {= "5.4.0"}
+  "js_of_ocaml-ppx" {= "5.4.0"}
   "ctypes_stubs_js"
   "integers_stubs_js"
   "odoc" {with-doc}


### PR DESCRIPTION
Not sure why `semgrep.opam` wasn't updated -- `dune-project` was updated a few weeks ago (https://github.com/returntocorp/semgrep/pull/8773), maybe it was never built from the root of the repo? (cc @ajbt200128)

test plan:
- checks pass