### PR TITLE
bump pre-commit Semgrep Jsonnet version to 1.44

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -179,7 +179,7 @@ repos:
   # Dogfood! running semgrep in pre-commit!
   # ----------------------------------------------------------
   - repo: https://github.com/returntocorp/semgrep
-    rev: v1.39.0
+    rev: v1.44.0
     hooks:
       - id: semgrep
         name: Semgrep Jsonnet


### PR DESCRIPTION
Changes to `Test_jsoo.ml` were failing the Semgrep Jsonnet pre-commit hook w/ an error with `String.rindex_from / Bytes.rindex_from`. Bumping to the latest version of Semgrep seemed to fix things.

Test plan:
- checks pass