### PR TITLE
fix(prefilter): setup the cache before all rules are run

### DIFF
--- a/changelog.d/ea-208.fixed
+++ b/changelog.d/ea-208.fixed
@@ -1,0 +1,3 @@
+Fixed a bug with pre-filtering introduced in 1.42.0 that caused significant slowdowns,
+particularly for Kotlin repos. Kotlin repos running default pro rules may see a 30 minute
+speedup.

--- a/src/core_scan/Core_scan.ml
+++ b/src/core_scan/Core_scan.ml
@@ -852,6 +852,8 @@ let scan ?match_hook config ((valid_rules, invalid_rules), rules_parse_time) :
 
   let all_targets = targets @ new_extracted_targets in
 
+  let rule_filter_cache = Hashtbl.create (List.length valid_rules) in
+
   (* Let's go! *)
   logger#info "processing %d files, skipping %d files" (List.length all_targets)
     (List.length skipped);
@@ -887,6 +889,7 @@ let scan ?match_hook config ((valid_rules, invalid_rules), rules_parse_time) :
                nested_formula = false;
                matching_explanations = config.matching_explanations;
                filter_irrelevant_rules = config.filter_irrelevant_rules;
+               rule_filter_cache;
              }
            in
            let matches =

--- a/src/engine/Match_env.ml
+++ b/src/engine/Match_env.ml
@@ -50,6 +50,7 @@ type xconfig = {
    *)
   matching_explanations : bool;
   filter_irrelevant_rules : bool;
+  rule_filter_cache : Analyze_rule.prefilter_cache;
 }
 
 type env = {
@@ -105,4 +106,5 @@ let default_xconfig =
      * true when running as part of the regular code path (not testing code)
      *)
     filter_irrelevant_rules = false;
+    rule_filter_cache = Hashtbl.create 10;
   }

--- a/src/engine/Match_rules.ml
+++ b/src/engine/Match_rules.ml
@@ -73,12 +73,15 @@ let skipped_target_of_rule (file_and_more : Xtarget.t) (rule : R.rule) :
     rule_id = Some (Rule_ID.to_string rule_id);
   }
 
-let is_relevant_rule_for_xtarget ~cache r xconf xtarget =
+let is_relevant_rule_for_xtarget r xconf xtarget =
   let { Xtarget.file; lazy_content; _ } = xtarget in
   let xconf = Match_env.adjust_xconfig_with_rule_options xconf r.R.options in
   let is_relevant =
     if xconf.filter_irrelevant_rules then (
-      match Analyze_rule.regexp_prefilter_of_rule ~cache r with
+      match
+        Analyze_rule.regexp_prefilter_of_rule
+          ~cache:(Some xconf.rule_filter_cache) r
+      with
       | None -> true
       | Some (prefilter_formula, func) ->
           let content = Lazy.force lazy_content in
@@ -97,13 +100,10 @@ let is_relevant_rule_for_xtarget ~cache r xconf xtarget =
    all of the nontaint rules, and the rules which we skip due to prefiltering.
 *)
 let group_rules xconf rules xtarget =
-  let cache = Some (Hashtbl.create 101) in
   let relevant_taint_rules, relevant_nontaint_rules, skipped_rules =
     rules
     |> Common.partition_either3 (fun r ->
-           let relevant_rule =
-             is_relevant_rule_for_xtarget cache r xconf xtarget
-           in
+           let relevant_rule = is_relevant_rule_for_xtarget r xconf xtarget in
            match r.R.mode with
            | _ when not relevant_rule -> Right3 r
            | `Taint _ as mode -> Left3 { r with mode }

--- a/src/engine/Match_rules.mli
+++ b/src/engine/Match_rules.mli
@@ -18,8 +18,4 @@ val check :
 
 (* for osemgrep interactive *)
 val is_relevant_rule_for_xtarget :
-  cache:Analyze_rule.prefilter_cache option ->
-  Rule.t ->
-  Match_env.xconfig ->
-  Xtarget.t ->
-  bool
+  Rule.t -> Match_env.xconfig -> Xtarget.t -> bool

--- a/src/osemgrep/cli_interactive/Interactive_subcommand.ml
+++ b/src/osemgrep/cli_interactive/Interactive_subcommand.ml
@@ -606,6 +606,7 @@ let buffer_matches_of_new_iformula (new_iform : iformula_zipper) (state : state)
       matching_explanations = false;
       (* set to true for the -fast optimization! *)
       filter_irrelevant_rules = true;
+      rule_filter_cache = Hashtbl.create 10;
     }
   in
   if !(state.should_continue_iterating_targets) then

--- a/src/osemgrep/cli_interactive/Interactive_subcommand.ml
+++ b/src/osemgrep/cli_interactive/Interactive_subcommand.ml
@@ -546,8 +546,7 @@ let buffer_matches_of_xtarget state (fake_rule : Rule.search_rule) xconf xtarget
     =
   let hook _s (_m : Pattern_match.t) = () in
   if
-    (* Since it's just a single rule, we don't need to cache it *)
-    Match_rules.is_relevant_rule_for_xtarget ~cache:None
+    Match_rules.is_relevant_rule_for_xtarget
       (fake_rule :> Rule.rule)
       xconf xtarget
   then


### PR DESCRIPTION
The filter irrelevant rules optimization uses a cache to avoid recomputing the prefilter. In returntocorp/semgrep#8787 I fixed
a problem with tests caused by having a global cache for the prefilter. However, in doing so, I created the cache 
in Match_rules, forgetting that the `Match_rules` entry point is called per file. This meant that the cache would 
essentially be reset for each file, which meant that it wasn't doing anything.

This PR fixes that error by including it in the Match_env.xconfig instead and creating it when the scan is kicked off.

Fixes PR #8787

Test plan:
Run p/default against https://github.com/square/leakcanary, it should complete in ~40s instead of ~30min.
See also returntocorp/semgrep-proprietary#1057

