### PR TITLE
Avoid out-of-bounds crash when invalid byte position is provided

### DIFF
--- a/changelog.d/gh-9011.fixed
+++ b/changelog.d/gh-9011.fixed
@@ -1,0 +1,2 @@
+Avoid catastrophic `Invalid_argument: index out of bounds` errors
+when reporting the location of findings (#9011)

--- a/libs/lib_parsing/Pos.mli
+++ b/libs/lib_parsing/Pos.mli
@@ -34,6 +34,13 @@ val string_of_pos : t -> string
 (* Adjust line x col in a position *)
 (*****************************************************************************)
 
+(*
+   Return (line, column) from a byte position.
+
+   If the byte position is out of range, the functions of this type return
+   the first position or the last position in the file.
+   Empty files admit at least one valid byte position.
+*)
 type bytepos_to_linecol_fun = int -> int * int
 
 (* Can we deprecate those full_charpos_xxx? use

--- a/libs/lib_parsing/Pos.mli
+++ b/libs/lib_parsing/Pos.mli
@@ -38,7 +38,8 @@ val string_of_pos : t -> string
    Return (line, column) from a byte position.
 
    If the byte position is out of range, the functions of this type return
-   the first position or the last position in the file.
+   the nearest valid position which is either the first or the last position
+   in the range.
    Empty files admit at least one valid byte position.
 *)
 type bytepos_to_linecol_fun = int -> int * int


### PR DESCRIPTION
An external user encountered the following error:
```
11:37:41  Invalid_argument: index out of bounds
11:37:41  Raised by primitive operation at Pos.full_charpos_to_pos_large.(fun) in file "semgrep/libs/lib_parsing/Pos.ml", line 174, characters 22-30
11:37:41  Called from Xpattern_match_regexp.regexp_matcher.(fun) in file "semgrep/src/engine/Xpattern_match_regexp.ml", line 43, characters 28-60
```

I think I also ran into it in the past. I don't have input to reproduce this problem.

This PR is a workaround for the real problem(s). Instead of a crash, we return either the first or the last valid position in the file.

Internal ticket: https://linear.app/semgrep/issue/EA-211/1440-index-out-of-bounds-in-deep-scanscan-with-exn-handler

test plan: relying on existing CI tests
