### PR TITLE
bump menhir from 20220210 to 20230608

### DIFF
--- a/.github/workflows/build-test-core-x86-ocaml5.yml
+++ b/.github/workflows/build-test-core-x86-ocaml5.yml
@@ -24,6 +24,6 @@ jobs:
         path: ocaml-build-artifacts.tgz
         name: ocaml-build-artifacts-ocaml5-release
     runs-on: ubuntu-latest
-    container: returntocorp/ocaml:alpine5.0-2023-10-05
+    container: returntocorp/ocaml:alpine5.1-2023-10-17
     env:
       HOME: /root

--- a/.github/workflows/build-test-core-x86.yml
+++ b/.github/workflows/build-test-core-x86.yml
@@ -23,6 +23,6 @@ jobs:
     - name: Test semgrep-core
       run: opam exec -- make core-test
     runs-on: ubuntu-latest
-    container: returntocorp/ocaml:alpine-2023-10-12
+    container: returntocorp/ocaml:alpine-2023-10-17
     env:
       HOME: /root

--- a/.github/workflows/build-test-javascript.yml
+++ b/.github/workflows/build-test-javascript.yml
@@ -40,7 +40,7 @@ jobs:
         path: "\n            _build/default/js/engine/*.bc.js\n            _build/default/js/languages/*/*.bc.js\n
           \         "
         name: semgrep-js-ocaml-build-${{ github.sha }}
-    container: returntocorp/ocaml:alpine-2023-10-12
+    container: returntocorp/ocaml:alpine-2023-10-17
     env:
       HOME: /root
   test:

--- a/.github/workflows/libs/semgrep.libsonnet
+++ b/.github/workflows/libs/semgrep.libsonnet
@@ -74,7 +74,7 @@ local github_bot = {
 
   ocaml_alpine_container: {
     'runs-on': 'ubuntu-latest',
-    container: 'returntocorp/ocaml:alpine-2023-10-12',
+    container: 'returntocorp/ocaml:alpine-2023-10-17',
     // We need this hack because GHA tampers with the HOME in container
     // and this does not play well with 'opam' installed in /root
     env: {
@@ -84,7 +84,7 @@ local github_bot = {
 
   ocaml5_alpine_container: {
     'runs-on': 'ubuntu-latest',
-    container: 'returntocorp/ocaml:alpine5.0-2023-10-05',
+    container: 'returntocorp/ocaml:alpine5.1-2023-10-17',
     env: {
       HOME: '/root',
     },

--- a/.github/workflows/lint.jsonnet
+++ b/.github/workflows/lint.jsonnet
@@ -77,7 +77,7 @@ local pre_commit_ocaml_job(submodules=false) =
     // This custom image provides 'ocamlformat' with a specific version needed to check
     // OCaml code (must be the same than the one in dev/dev.opam)
     // See https://github.com/returntocorp/ocaml-layer/blob/master/configs/ubuntu.sh
-    container: 'returntocorp/ocaml:ubuntu-2023-10-05',
+    container: 'returntocorp/ocaml:ubuntu-2023-10-17',
     steps: [
       if submodules then actions.checkout_with_submodules() else actions.checkout(),
       // HOME in the container is tampered by GHA and modified from /root to /home/github

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,7 +28,7 @@ jobs:
         extra_args: --hook-stage manual
   pre-commit-ocaml:
     runs-on: ubuntu-latest
-    container: returntocorp/ocaml:ubuntu-2023-10-05
+    container: returntocorp/ocaml:ubuntu-2023-10-17
     steps:
     - uses: actions/checkout@v3
     - name: Check OCaml code with ocamlformat

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Publish match performance
       run: opam exec -- make report-perf-matching
     runs-on: ubuntu-latest
-    container: returntocorp/ocaml:alpine-2023-10-12
+    container: returntocorp/ocaml:alpine-2023-10-17
     env:
       HOME: /root
   test-osemgrep:
@@ -50,7 +50,7 @@ jobs:
       working-directory: cli
       run: make osempass
     runs-on: ubuntu-latest
-    container: returntocorp/ocaml:alpine-2023-10-12
+    container: returntocorp/ocaml:alpine-2023-10-17
     env:
       HOME: /root
   test-cli:

--- a/Dockerfile
+++ b/Dockerfile
@@ -95,7 +95,7 @@ COPY cli/src/semgrep/semgrep_interfaces cli/src/semgrep/semgrep_interfaces
 # Visit https://hub.docker.com/r/returntocorp/ocaml/tags to see the latest
 # images available.
 #
-FROM returntocorp/ocaml:alpine-2023-10-12 as semgrep-core-container
+FROM returntocorp/ocaml:alpine-2023-10-17 as semgrep-core-container
 
 WORKDIR /src/semgrep
 COPY --from=semgrep-core-files /src/semgrep .

--- a/dune-project
+++ b/dune-project
@@ -392,7 +392,7 @@ For more information see https://semgrep.dev
     (ocaml (>= 4.13.0))
     (dune (>= 2.7.0 ))
     ; parser generators
-    (menhir (= 20220210))
+    (menhir (= 20230608))
     ; standard libraries
     ; We don't use Base directly. If it's being used indirectly
     ; (is it, though?), we need a version that doesn't register

--- a/semgrep.opam
+++ b/semgrep.opam
@@ -16,7 +16,7 @@ bug-reports: "https://github.com/returntocorp/semgrep/issues"
 depends: [
   "ocaml" {>= "4.13.0"}
   "dune" {>= "3.7" & >= "2.7.0"}
-  "menhir" {= "20220210"}
+  "menhir" {= "20230608"}
   "base" {>= "v0.15.1"}
   "fpath"
   "bos"


### PR DESCRIPTION
Pulling this out of the OCaml 5.1 PR: https://github.com/returntocorp/semgrep/pull/8922/files#diff-1fb9d92d4f0b89e8c93cdefc87d39436b213422961c40453cf2fef5f4a195c57R396

Keeping this pinned on the old version slows down the build process because we've already updated ocaml-layer to the latest, so we have to pay the price of opam downgrade + recompile every time. We discussed on Slack awhile back that the changes are minimal so I'm not too concerned about this bump.

Also it means one less thing we need to do when we're ready to revisit 5.1

test plan:
- checks pass