### PR TITLE
fix: Refuse to run out of date semgrep-core-proprietary

### DIFF
--- a/changelog.d/gh-8873.fixed
+++ b/changelog.d/gh-8873.fixed
@@ -1,0 +1,1 @@
+Semgrep will now refuse to run incompatible versions of the Pro Engine, rather than crashing with a confusing error message.

--- a/cli/bin/semgrep
+++ b/cli/bin/semgrep
@@ -55,15 +55,36 @@ class CoreNotFound(Exception):
  
     def __str__(self):
         return(self.value)
-           
+
+# Similar to cli/src/semgrep/engine.py check_is_correct_pro_version
+def is_correct_pro_version(core_path):
+    # We want to be careful about what we import here in order to keep this
+    # script lightweight. However, this file just defines a single constant and
+    # it takes well under a millisecond to import this.
+    from semgrep import __VERSION__
+    # Duplicate of cli/src/semgrep/semgrep_core.py pro_version_stamp_path
+    stamp_path = core_path.parent / "pro-installed-by.txt"
+    if stamp_path.is_file():
+        with stamp_path.open('r') as f:
+            version_at_install = f.readline().strip()
+            return version_at_install == __VERSION__
+    else:
+        return False
+
 # similar to cli/src/semgrep/semgrep_core.py compute_executable_path()
-def find_semgrep_core_path(core="semgrep-core", extra_message=""):
+def find_semgrep_core_path(pro=False, extra_message=""):
+    if pro:
+        core = "semgrep-core-proprietary"
+    else:
+        core = "semgrep-core"
     # First, try the packaged binary.
     try:
         # the use of .path causes a DeprecationWarning hence the
         # filterwarnings above
         with importlib.resources.path("semgrep.bin", core) as path:
             if path.is_file():
+                if pro and not is_correct_pro_version(path):
+                    raise CoreNotFound(f"The installed version of {core} is out of date.{extra_message}")
                 return str(path)
     except FileNotFoundError as e:
         pass
@@ -102,7 +123,7 @@ def exec_pysemgrep():
 def exec_osemgrep():
     if "--pro" in sys.argv:
         try:
-            path = find_semgrep_core_path(core="semgrep-core-proprietary",
+            path = find_semgrep_core_path(pro=True,
                                       extra_message="\nYou may need to run `semgrep install-semgrep-pro`"    )
         except CoreNotFound as e:
             print(str(e), file=sys.stderr)

--- a/cli/src/semgrep/commands/install.py
+++ b/cli/src/semgrep/commands/install.py
@@ -43,6 +43,18 @@ def determine_semgrep_pro_path() -> Path:
     return semgrep_pro_path
 
 
+# This places a stamp alongside the semgrep-core-proprietary binary indicating
+# which version of Semgrep installed it. This allows us to ensure that we are
+# not running an out-of-date binary if Semgrep is later upgraded but the
+# semgrep-core-proprietary binary remains in place.
+#
+# See also engine.py check_is_correct_pro_version
+def add_semgrep_pro_version_stamp() -> None:
+    path = SemgrepCore.pro_version_stamp_path()
+    with path.open("w") as f:
+        f.write(__VERSION__)
+
+
 def download_semgrep_pro(
     state: SemgrepState, platform_kind: str, destination: Path
 ) -> None:
@@ -158,6 +170,7 @@ def run_install_semgrep_pro(custom_binary: Optional[str] = None) -> None:
     if semgrep_pro_path.exists():
         semgrep_pro_path.unlink()
     semgrep_pro_path_tmp.rename(semgrep_pro_path)
+    add_semgrep_pro_version_stamp()
     logger.info(f"\nSuccessfully installed Semgrep Pro Engine (version {version})!")
 
 

--- a/cli/src/semgrep/semgrep_core.py
+++ b/cli/src/semgrep/semgrep_core.py
@@ -9,6 +9,8 @@ from semgrep.verbose_logging import getLogger
 
 logger = getLogger(__name__)
 
+VERSION_STAMP_FILENAME = "pro-installed-by.txt"
+
 
 def compute_executable_path(exec_name: str) -> Optional[str]:
     """
@@ -82,3 +84,7 @@ class SemgrepCore:
             cls._PRO_PATH_ = compute_executable_path("semgrep-core-proprietary")
 
         return Path(cls._PRO_PATH_) if cls._PRO_PATH_ is not None else None
+
+    @classmethod
+    def pro_version_stamp_path(cls) -> Path:
+        return cls.path().parent / VERSION_STAMP_FILENAME


### PR DESCRIPTION
Currently, if you install semgrep-core-proprietary, then upgrade Semgrep, then try to run the Pro Engine, Semgrep will use the old version of semgrep-core-proprietary. This often results in crashes. Instead, we should ask users to update semgrep-core-proprietary.

Since the semgrep-core-proprietary binary does not know what version of Semgrep it has been built for, the simplest way to accomplish this is to add a file alongside the binary indicating which version of Semgrep installed it. When we execute semgrep-core-proprietary, we can look at that file. If it's different than the current version of Semgrep, we refuse to run the old binary.

Fixes #8873

Test plan:

Rebase onto the v1.44.0 tag to ensure compatibility with the latest released version of `semgrep-core-proprietary` and run the following manual tests:

- `semgrep scan --pro --config rules.yaml`
  - With no semgrep-core-proprietary installed (nice error message)
  - With semgrep-core-proprietary installed (success)
  - With `pro-installed-by.txt` changed to a different version (nice error message)
  - With `pro-installed-by.txt` removed (nice error message)
- `semgrep scan --pro --config rules.yaml --legacy`
  - With no semgrep-core-proprietary installed (bad error message, but same as before)
  - With semgrep-core-proprietary installed (success)
  - With `pro-installed-by.txt` changed to a different version (bad error message, same as when it's not installed)
  - With `pro-installed-by.txt` removed (same bad error message)
- `semgrep scan --config rules.yaml`
  - With no semgrep-core-proprietary installed (works fine)
  - With semgrep-core-proprietary installed (works fine)
  - With `pro-installed-by.txt` changed to a different version (works fine)
  - With `pro-installed-by.txt` removed (works fine)
- `semgrep ci` with Pro toggle on
  - With no semgrep-core-proprietary installed (downloads and runs)
  - With semgrep-core-proprietary installed (runs)
  - With `pro-installed-by.txt` changed to a different version (downloads and runs)
  - With `pro-installed-by.txt` removed (downloads and runs)
- `semgrep ci` with Pro toggle off
  - With no semgrep-core-proprietary installed (runs)
  - With semgrep-core-proprietary installed (runs)
  - With `pro-installed-by.txt` changed to a different version (runs)
  - With `pro-installed-by.txt` removed (runs)

