### PR TITLE
Log the source PCRE pattern in case of an error.

### DIFF
--- a/libs/aliengrep/Pat_compile.ml
+++ b/libs/aliengrep/Pat_compile.ml
@@ -19,8 +19,8 @@ type metavariable_kind =
 type metavariable = metavariable_kind * string [@@deriving show, eq]
 
 type t = {
-  pcre_pattern : string; [@printer fun fmt -> Format.fprintf fmt "{|%s|}"]
-  pcre : Pcre.regexp; [@opaque] [@equal fun _ _ -> true]
+  pcre : SPcre.t;
+      [@printer fun fmt (x : SPcre.t) -> Format.fprintf fmt "{|%s|}" x.pattern]
   (*
      List of the PCRE capturing groups that we care about for extracting
      metavariable values.
@@ -49,8 +49,8 @@ let pat = {|
 |}
 ;;
 
-let rex = Pcre.regexp ~flags:[`EXTENDED] pat in
-Pcre.extract_all ~rex {|xx ab ab xx|};;
+let rex = SPcre.regexp ~flags:[`EXTENDED] pat in
+SPcre.extract_all ~rex {|xx ab ab xx|};;
 - : string array array = [|[|"ab ab"; ""; ""; "ab"|]|]
 
      Note that you'd get more matches if the word pattern was inlined
@@ -447,7 +447,7 @@ let compile conf pattern_ast =
             m "Failed to compile PCRE pattern:\n%s\n" pcre_pattern);
         Exception.reraise e
   in
-  { pcre_pattern; pcre; metavariable_groups }
+  { pcre; metavariable_groups }
 
 let from_string conf pat_str =
   Pat_parser.from_string conf pat_str |> compile conf

--- a/libs/aliengrep/Pat_compile.mli
+++ b/libs/aliengrep/Pat_compile.mli
@@ -11,8 +11,7 @@ type metavariable_kind =
 type metavariable = metavariable_kind * string [@@deriving show, eq]
 
 type t = private {
-  pcre_pattern : string;
-  pcre : Pcre.regexp; [@opaque]
+  pcre : SPcre.t;
   metavariable_groups : (int * metavariable) list;
 }
 [@@deriving show, eq]

--- a/libs/aliengrep/Pat_lexer.ml
+++ b/libs/aliengrep/Pat_lexer.ml
@@ -9,8 +9,7 @@ open Printf
 
 type compiled_conf = {
   conf : Conf.t;
-  pcre_pattern : string;
-  pcre_regexp : Pcre.regexp;
+  pcre : SPcre.t; (* holds the source pattern and the compiled regexp *)
 }
 
 type token =
@@ -68,7 +67,7 @@ let compile conf =
         other_10;
       ]
   in
-  let pcre_regexp =
+  let pcre =
     try SPcre.regexp pat with
     | exn ->
         let e = Exception.catch exn in
@@ -77,7 +76,7 @@ let compile conf =
               pat);
         Exception.reraise e
   in
-  { conf; pcre_pattern = pat; pcre_regexp }
+  { conf; pcre }
 
 let char_of_string str =
   if String.length str <> 1 then
@@ -85,12 +84,12 @@ let char_of_string str =
   else str.[0]
 
 let read_string ?(source_name = "<pattern>") conf str =
-  match SPcre.full_split ~rex:conf.pcre_regexp str with
+  match SPcre.full_split ~rex:conf.pcre str with
   | Error pcre_err ->
       pattern_error source_name
         (sprintf "PCRE error while parsing aliengrep pattern: %s; pattern: %s"
            (SPcre.show_error pcre_err)
-           conf.pcre_pattern)
+           conf.pcre.pattern)
   | Ok res ->
       res
       |> List.filter_map (function
@@ -102,7 +101,7 @@ let read_string ?(source_name = "<pattern>") conf str =
                  (sprintf
                     "Internal error while parsing aliengrep pattern: Text node \
                      %S; pattern: %s"
-                    txt conf.pcre_pattern)
+                    txt conf.pcre.pattern)
            | Pcre.Group (_, "") ->
                (* no capture *)
                None

--- a/libs/aliengrep/Pcre_util.ml
+++ b/libs/aliengrep/Pcre_util.ml
@@ -66,4 +66,4 @@ let quote =
     | '\t' -> {|\t|}
     | c (* other whitespace or '#' *) -> sprintf {|\x%02X|} (Char.code c)
   in
-  fun str -> Pcre.quote str |> Pcre.substitute ~rex ~subst
+  fun str -> Pcre.quote str |> SPcre.substitute ~rex ~subst

--- a/libs/commons/Regexp_engine.mli
+++ b/libs/commons/Regexp_engine.mli
@@ -2,7 +2,7 @@
    Type that holds the original pattern in PCRE syntax as well as its
    compiled form.
 *)
-type t
+type t = SPcre.t
 
 (* Extract the pattern in PCRE syntax *)
 val pcre_pattern : t -> string

--- a/libs/commons/SPcre.mli
+++ b/libs/commons/SPcre.mli
@@ -3,7 +3,19 @@
    sense for semgrep.
 
    The "S" in "SPcre" stands for Semgrep.
+
+   If you need a function from Pcre that is not being exposed by this module,
+   please add it.
 *)
+
+(*
+   The type holding the source pattern and a compiled regexp.
+
+   Note that the default 'equal' function is based only on the source
+   patterns and doesn't take into account compilation options.
+*)
+type t = private { pattern : string; regexp : Pcre.regexp }
+[@@deriving show, eq]
 
 (*
   val show : Pcre.error -> string
@@ -36,7 +48,7 @@ val regexp :
   ?flags:Pcre.cflag list ->
   ?chtables:Pcre.chtables ->
   string ->
-  Pcre.regexp
+  t
 
 (*
    Same as Pcre.pmatch but makes errors explicit.
@@ -46,7 +58,7 @@ val regexp :
 val pmatch :
   ?iflags:Pcre.irflag ->
   ?flags:Pcre.rflag list ->
-  ?rex:Pcre.regexp ->
+  rex:t ->
   ?pos:int ->
   ?callout:Pcre.callout ->
   string ->
@@ -56,7 +68,7 @@ val pmatch :
 val pmatch_noerr :
   ?iflags:Pcre.irflag ->
   ?flags:Pcre.rflag list ->
-  ?rex:Pcre.regexp ->
+  rex:t ->
   ?pos:int ->
   ?callout:Pcre.callout ->
   ?on_error:bool ->
@@ -70,7 +82,7 @@ val pmatch_noerr :
 val exec :
   ?iflags:Pcre.irflag ->
   ?flags:Pcre.rflag list ->
-  ?rex:Pcre.regexp ->
+  rex:t ->
   ?pos:int ->
   ?callout:Pcre.callout ->
   string ->
@@ -80,7 +92,7 @@ val exec :
 val exec_noerr :
   ?iflags:Pcre.irflag ->
   ?flags:Pcre.rflag list ->
-  ?rex:Pcre.regexp ->
+  rex:t ->
   ?pos:int ->
   ?callout:Pcre.callout ->
   string ->
@@ -93,7 +105,7 @@ val exec_noerr :
 val exec_all :
   ?iflags:Pcre.irflag ->
   ?flags:Pcre.rflag list ->
-  ?rex:Pcre.regexp ->
+  rex:t ->
   ?pos:int ->
   ?callout:Pcre.callout ->
   string ->
@@ -104,7 +116,7 @@ val exec_all :
 val exec_to_strings :
   ?iflags:Pcre.irflag ->
   ?flags:Pcre.rflag list ->
-  ?rex:Pcre.regexp ->
+  rex:t ->
   ?pos:int ->
   ?callout:Pcre.callout ->
   string ->
@@ -114,7 +126,7 @@ val exec_to_strings :
 val exec_all_noerr :
   ?iflags:Pcre.irflag ->
   ?flags:Pcre.rflag list ->
-  ?rex:Pcre.regexp ->
+  rex:t ->
   ?pos:int ->
   ?callout:Pcre.callout ->
   string ->
@@ -124,7 +136,7 @@ val exec_all_noerr :
 val split :
   ?iflags:Pcre.irflag ->
   ?flags:Pcre.rflag list ->
-  ?rex:Pcre.regexp ->
+  rex:t ->
   ?pos:int ->
   ?max:int ->
   ?callout:Pcre.callout ->
@@ -135,7 +147,7 @@ val split :
 val full_split :
   ?iflags:Pcre.irflag ->
   ?flags:Pcre.rflag list ->
-  ?rex:Pcre.regexp ->
+  rex:t ->
   ?pos:int ->
   ?max:int ->
   ?callout:Pcre.callout ->
@@ -146,7 +158,7 @@ val full_split :
 val split_noerr :
   ?iflags:Pcre.irflag ->
   ?flags:Pcre.rflag list ->
-  ?rex:Pcre.regexp ->
+  rex:t ->
   ?pos:int ->
   ?max:int ->
   ?callout:Pcre.callout ->
@@ -162,3 +174,32 @@ val split_noerr :
    See issue https://github.com/mmottl/pcre-ocaml/issues/24
 *)
 val register_exception_printer : unit -> unit
+
+val substitute :
+  ?iflags:Pcre.irflag ->
+  ?flags:Pcre.rflag list ->
+  rex:t ->
+  ?pos:int ->
+  ?callout:Pcre.callout ->
+  subst:(string -> string) ->
+  string ->
+  string
+
+val extract_all :
+  ?iflags:Pcre.irflag ->
+  ?flags:Pcre.rflag list ->
+  rex:t ->
+  ?pos:int ->
+  ?full_match:bool ->
+  ?callout:Pcre.callout ->
+  string ->
+  string array array
+
+(*
+   Exception-less version of Pcre.get_named_substring.
+
+   Ok None: variable name is valid but unbound
+   Error msg: no such variable in the original pattern
+*)
+val get_named_substring :
+  t -> string -> Pcre.substrings -> (string option, string) Result.t

--- a/libs/spacegrep/src/lib/Comment.ml
+++ b/libs/spacegrep/src/lib/Comment.ml
@@ -27,14 +27,14 @@ let replace_end_of_line_comment ~start src =
   (* match from first occurrence of 'start' in the line until the
      end of line or end of input *)
   let rex = sprintf "%s[^\n]*\n?" (Pcre.quote start) |> SPcre.regexp in
-  Pcre.substitute ~rex ~subst:whiteout_ascii src
+  SPcre.substitute ~rex ~subst:whiteout_ascii src
 
 let replace_multiline_comment ~start ~end_ src =
   let rex =
     sprintf "%s.*?%s" (Pcre.quote start) (Pcre.quote end_)
     |> SPcre.regexp ~flags:[ `DOTALL ]
   in
-  Pcre.substitute ~rex ~subst:whiteout_ascii src
+  SPcre.substitute ~rex ~subst:whiteout_ascii src
 
 (* Apply comment filters from left to right *)
 let remove_comments_from_string style src =

--- a/src/engine/String_literal.ml
+++ b/src/engine/String_literal.ml
@@ -9,7 +9,7 @@
 let approximate_unescape =
   let rex = SPcre.regexp "\\\\[\\\\'\"]" in
   fun s ->
-    Pcre.substitute ~rex
+    SPcre.substitute ~rex
       ~subst:(fun s ->
         assert (String.length s = 2);
         String.sub s 1 1)

--- a/src/reporting/Nosemgrep.ml
+++ b/src/reporting/Nosemgrep.ml
@@ -68,8 +68,11 @@ let recognise_and_collect ~rex line =
   SPcre.exec_all ~rex line
   |> Result.map
        (Array.map (fun subst ->
-            try Some (Pcre.get_named_substring rex "ids" subst) with
-            | _ -> None))
+            match SPcre.get_named_substring rex "ids" subst with
+            | Ok opt_s -> opt_s
+            | Error _errmsg ->
+                (* TODO: log something? *)
+                None))
   |> Result.to_option
 
 (*

--- a/src/reporting/Nosemgrep.mli
+++ b/src/reporting/Nosemgrep.mli
@@ -10,8 +10,8 @@ val process_ignores :
 (* used by osemgrep but also by the language_server *)
 
 val rule_id_re_str : string
-val nosem_inline_re : Pcre.regexp
-val nosem_previous_line_re : Pcre.regexp
+val nosem_inline_re : SPcre.t
+val nosem_previous_line_re : SPcre.t
 
 (* used for the incremental display of matches *)
 


### PR DESCRIPTION
The pattern is now stored in `SPcre.t` which we're already using as a wrapper around `Pcre.regexp`.

This needs some testing. I'll get back to this later unless someone helps me.