### PR TITLE
feat: `--custom-binary` flag for `install-semgrep-pro`

### DIFF
--- a/changelog.d/custom-pro-binary.added
+++ b/changelog.d/custom-pro-binary.added
@@ -1,0 +1,1 @@
+`semgrep install-semgrep-pro` now takes an optional `--custom-binary` flag to install the specified `semgrep-core-proprietary` binary rather than downloading it.

--- a/scripts/test-pro.sh
+++ b/scripts/test-pro.sh
@@ -2,13 +2,10 @@
 
 set -e
 
-cp /root/semgrep-core-proprietary /usr/local/bin/semgrep-core-proprietary
-
-# We need to give it executable permissions or it won't run
-chmod +x /usr/local/bin/semgrep-core-proprietary
-
 # Relocate to the directory, because otherwise some weirdness happens and
 # we run with all the rules, taking ~30 minutes.
 cd /root || exit
+
+semgrep install-semgrep-pro --custom-binary /root/semgrep-core-proprietary
 
 semgrep --config "p/default-v2" . --pro


### PR DESCRIPTION
If the `--custom-binary` flag is passed to `semgrep install-semgrep-pro`, it will install the supplied binary rather than downloading it. It will not do any verification that the binary is correct.

This is in service of #9033, but may be more widely useful. I had trouble manually setting the version stamp correctly for the test-semgrep-pro CI job, and instead of sinking more time into debugging it, I decided to just implement this option.

In addition to making our own testing slightly easier, this could also enable people to run the Pro Engine offline without doing surgery on the installed package, if they have a way to acquire the `semgrep-core-proprietary` binary.

Test plan:

* Existing automated tests
* Rebased #9033 on top of this and verified that the test-semgrep-pro job succeeded
* `semgrep install-semgrep-pro` -> Downloads and installs `semgrep-core-proprietary`
* `semgrep install-semgrep-pro --custom-binary /path/to/binary` -> Copies the binary to the same location that it downloads it to.

