### PR TITLE
fix(perf): reduce time spent on prefilter computation

### DIFF
--- a/changelog.d/gh-9040.fixed
+++ b/changelog.d/gh-9040.fixed
@@ -1,0 +1,5 @@
+Reduced the limits for the prefilter optimization so that rules that cause
+computing the prefilter to blow up will abort more quickly. This improves
+performance by 2-3 seconds for each of the slowest rules. May cause a
+slowdown if a rule that previously could be filtered out no longer will be,
+but based on testing this is unlikely.

--- a/src/optimizing/Analyze_rule.ml
+++ b/src/optimizing/Analyze_rule.ml
@@ -206,13 +206,13 @@ let rec (cnf : Rule.formula -> cnf_step0) =
       And (ys @ zs |> List.concat_map (function And ors -> ors))
   | R.Or (_, xs) ->
       let is_dangerously_large p q =
-        List.compare_length_with p 1_000_000 > 0
-        || List.compare_length_with q 1_000_000 > 0
+        List.compare_length_with p 10_000 > 0
+        || List.compare_length_with q 10_000 > 0
         ||
         let p_len = List.length p in
         let q_len = List.length q in
         (* Divide rather than multiply to avoid integer overflow *)
-        p_len > Int.div 10_000_000 q_len
+        p_len > Int.div 50_000 q_len
       in
       let ys = Common.map cnf xs in
       List.fold_left


### PR DESCRIPTION
Closes #9040 

Computing the prefilter can take a while for certain rule structures.
To prevent taking too much time, we have a CNF_exploded error based
on the length of the CNF being built (p) and then CNF being merged
with (q). We also check the new CNF that would be created (p * q).
Currently the limit before hitting CNF_exploded is very generous,
causing rules to potentially compute for 2-3 seconds before giving
up. While this is a small number, it's unnecessary. It also causes
problems if we don't correctly cache it.

I reduced the limits for both p/q and for p*q after timing multiple
options.

Values of p and q vs the runtimes and the number of explosions,
with p * q limited to 10,000,000 (p always set equal to q):

```
p and q	Runtime	Explosions
1000000	9.615	3
500000	4.588	3
250000	4.281	3
100000	4.338	3
50000	3.867	3
25000	3.922	3
10000	3.894	3
5000	3.906	3
4250	3.779	3
4000	3.361	5
3725	3.288	5
2500	3.32	5
```

Values of p * q vs the runtimes and number of explosions with
p and q both set to 10,000:

```
p * q	Runtime	Explosions
10000000	3.92	3
5000000	3.881	3
2500000	3.785	3
1000000	3.93	3
500000	3.816	3
250000	3.882	3
100000	3.855	3
50000	3.722	3
25000	3.926	3
20000	3.676	3
17500	3.743	3
15000	3.317	5
12500	3.251	5
10000	3.214	5
```

Based on these tables, I chose 10,000 as the max for p and q and
50,000 as the max for p * q. These still keep us comfortably in
the range of the existing number of explosions while making the
run significantly faster.

Note: we could make it even faster if we were willing to tolerate
more explosions than we currently do. Figuring out when this makes
sense is more difficult because the tradeoff is more complicated.
For now, let's just not spend time that doesn't get us anything


Test plan:

In addition to the tests above, I also timed a run with `-lang kotlin`
(because two kotlin rules are among the worst offenders) on a kotlin
repo with rules downloaded from r/all

- With the original values (10,000,000 for p*q and 1,000,000 for p and q) 
  and no caching: 1:25:55.88 total
- With the new values (50,000 for p*q and 10,000 for p and q)
  and no caching: 2:39.35 total
- With the original values and caching: 41.613 total
- With the new values and caching: 37.173 total
