### PR TITLE
osemgrep: switch to objects for Git_meta.ml

### DIFF
--- a/src/osemgrep/cli_ci/Ci_subcommand.ml
+++ b/src/osemgrep/cli_ci/Ci_subcommand.ml
@@ -216,7 +216,7 @@ let scan_id_and_rules_from_deployment ~dry_run (prj_meta : Out.project_metadata)
 (*****************************************************************************)
 
 (* from meta.py *)
-let generate_meta_from_environment (_baseline_ref : Digestif.SHA1.t option) :
+let generate_meta_from_environment (baseline_ref : Digestif.SHA1.t option) :
     Project_metadata.t =
   let extract_env term =
     let argv = [| "empty" |] and info_ = Cmdliner.Cmd.info "" in
@@ -238,8 +238,8 @@ let generate_meta_from_environment (_baseline_ref : Digestif.SHA1.t option) :
       Github_metadata.make env
   | _else ->
       let env = extract_env Git_metadata.env in
-      (* TODO baseline_ref *)
-      Git_metadata.make env
+      (new Git_metadata.git_meta baseline_ref env)#project_metadata
+
 (* https://docs.gitlab.com/ee/ci/variables/predefined_variables.html *)
 (* match Sys.getenv_opt "GITLAB_CI" with
    | Some "true" -> return GitlabMeta(baseline_ref)

--- a/src/osemgrep/cli_ci/Git_metadata.mli
+++ b/src/osemgrep/cli_ci/Git_metadata.mli
@@ -13,6 +13,27 @@ type env = {
 
 include Project_metadata.S with type env := env
 
+class git_meta :
+  ?scan_environment:string ->
+  baseline_ref:Digestif.SHA1.t option ->
+  env ->
+object
+  method project_metadata : Semgrep_output_v1_t.project_metadata
+
+  (* to be overriden in the children *)
+  method branch : string option
+  method ci_job_url : Uri.t option
+  method commit_sha : Digestif.SHA1.t option
+  method commit_timestamp : string option
+  method event_name : string
+  method is_full_scan : bool
+  method pr_id : string option
+  method pr_title : string option
+  method repo_name : string
+  method repo_url : Uri.t option
+  method merge_base_ref : Digestif.SHA1.t option
+end
+
 (* used in Github_metadata.ml *)
 val get_event_name : env -> string option
 val get_branch : env -> string option


### PR DESCRIPTION
The original implementation in meta.py was using objects
so let's use objects too. Romain's original approach
was to use regular modules, but we need dynamic dispatch
here so simpler to just use oo.

test plan:
make core-test (but there is no tests using Git_meta.ml I think)