### PR TITLE
osemgrep: add skip_libs parameter to setup_logging

### DIFF
--- a/libs/commons/Logs_helpers.ml
+++ b/libs/commons/Logs_helpers.ml
@@ -16,6 +16,23 @@ open Common
 (* in seconds *)
 let time_program_start = ref 0.
 
+let default_skip_libs =
+  [
+    "ca-certs";
+    "bos";
+    "cohttp.lwt.client";
+    "cohttp.lwt.io";
+    "conduit_lwt_server";
+    "mirage-crypto-rng.lwt";
+    "mirage-crypto-rng-lwt";
+    "mirage-crypto-rng.unix";
+    "handshake";
+    "tls.config";
+    "tls.tracing";
+    "eio_linux";
+    "x509";
+  ]
+
 (*****************************************************************************)
 (* Helpers *)
 (*****************************************************************************)
@@ -76,7 +93,7 @@ let enable_logging () =
   Logs.set_reporter (reporter ());
   ()
 
-let setup_logging ~force_color ~level =
+let setup_logging ?(skip_libs = default_skip_libs) ~force_color ~level () =
   let style_renderer = if force_color then Some `Ansi_tty else None in
   Fmt_tty.setup_std_outputs ?style_renderer ();
   Logs.set_level ~all:true level;
@@ -88,19 +105,7 @@ let setup_logging ~force_color ~level =
   Logs.Src.list ()
   |> List.iter (fun src ->
          match Logs.Src.name src with
-         | "ca-certs"
-         | "bos"
-         | "cohttp.lwt.client"
-         | "cohttp.lwt.io"
-         | "conduit_lwt_server"
-         | "mirage-crypto-rng.lwt"
-         | "mirage-crypto-rng-lwt"
-         | "mirage-crypto-rng.unix"
-         | "handshake"
-         | "tls.config"
-         | "tls.tracing"
-         | "x509" ->
-             Logs.Src.set_level src None
+         | x when List.mem x skip_libs -> Logs.Src.set_level src None
          (* those are the one we are really interested in *)
          | "application" -> ()
          | s -> failwith ("Logs library not handled: " ^ s))

--- a/libs/commons/Logs_helpers.mli
+++ b/libs/commons/Logs_helpers.mli
@@ -26,11 +26,17 @@
    to setup_logging.
 *)
 val enable_logging : unit -> unit
+val default_skip_libs : string list
 
 (* Setup the Logs library. This call is necessary before any logging
    calls, otherwise your log will not go anywhere (not even on stderr).
 *)
-val setup_logging : force_color:bool -> level:Logs.level option -> unit
+val setup_logging :
+  ?skip_libs:string list ->
+  force_color:bool ->
+  level:Logs.level option ->
+  unit ->
+  unit
 
 (* TODO:
    Logs.Error, Logs.Warning, and friends should apply the appropriate color

--- a/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -839,7 +839,7 @@ let cmdline_term ~allow_empty_config : conf Term.t =
     (* ugly: call setup_logging ASAP so the Logs.xxx below are displayed
      * correctly *)
     Logs_helpers.setup_logging ~force_color
-      ~level:common.CLI_common.logging_level;
+      ~level:common.CLI_common.logging_level ();
 
     let target_roots = target_roots |> File.Path.of_strings in
 

--- a/src/osemgrep/core/CLI_common.ml
+++ b/src/osemgrep/core/CLI_common.ml
@@ -76,7 +76,7 @@ let setup_logging ~force_color ~level =
    * logging/output we want in osemgrep, so this is a good opportunity
    * to evaluate a new logging library.
    *)
-  Logs_helpers.setup_logging ~force_color ~level;
+  Logs_helpers.setup_logging ~force_color ~level ();
   (* TOPORT
         # Setup file logging
         # env.user_log_file dir must exist

--- a/src/tests/Test.ml
+++ b/src/tests/Test.ml
@@ -117,7 +117,7 @@ let main () =
   Parsing_init.init ();
   Data_init.init ();
   Core_CLI.register_exception_printers ();
-  Logs_helpers.setup_logging ~force_color:false ~level:(Some Logs.Debug);
+  Logs_helpers.setup_logging ~force_color:false ~level:(Some Logs.Debug) ();
   let alcotest_tests = Testutil.to_alcotest (tests_with_delayed_error ()) in
   Alcotest.run "semgrep-core" alcotest_tests
 


### PR DESCRIPTION
This will help semgrep-server provides its own list
of libs to skip

test plan:
make core