### PR TITLE
fix: make pre-commit fail if ocamlformat not installed.

### DIFF
--- a/scripts/lint-ocaml
+++ b/scripts/lint-ocaml
@@ -45,6 +45,7 @@ normally done with the following command:
 
 For now, let's pretend everything is fine.
 EOF
+  exit 1
 fi
 
 #to debug: git diff


### PR DESCRIPTION
Simple fix to add non-zero exit code when ocamlformat isn't installed.

Testing:
* `pre-commit run --all-files lint-ocaml` 
    * says the hook failed when ocamlformat not installed.
    * says the hook passed when ocamlformat is installed.
 * Relying on CI to make sure this doesn't break anything else.
    
