### PR TITLE
fix: Allow manual installation of Pro Engine when logged out

### DIFF
--- a/changelog.d/gh-9051.fixed
+++ b/changelog.d/gh-9051.fixed
@@ -1,0 +1,1 @@
+Fixed an issue that prevented the use of `semgrep install-semgrep-pro --custom-binary ...` when logged out.

--- a/cli/src/semgrep/commands/install.py
+++ b/cli/src/semgrep/commands/install.py
@@ -98,7 +98,7 @@ def run_install_semgrep_pro(custom_binary: Optional[str] = None) -> None:
     if semgrep_pro_path.exists():
         logger.info(f"Overwriting Semgrep Pro Engine already installed!")
 
-    if state.app_session.token is None and custom_binary is not None:
+    if state.app_session.token is None and custom_binary is None:
         logger.info("run `semgrep login` before running `semgrep install-semgrep-pro`")
         sys.exit(INVALID_API_KEY_EXIT_CODE)
 


### PR DESCRIPTION
In #9051, I accidentally inverted this condition and evidently tested only while logged in.

Test plan:

```
$ semgrep logout
$ semgrep install-semgrep-pro
$ semgrep install-semgrep-pro --custom-binary /path/to/bin
```

The first call to `install-semgrep-pro` fails. The second succeeds.

