### PR TITLE
fix sarif output error: Update sarif.py

### DIFF
--- a/cli/src/semgrep/formatter/sarif.py
+++ b/cli/src/semgrep/formatter/sarif.py
@@ -372,6 +372,7 @@ class SarifFormatter(BaseFormatter):
         error_to_sarif_level = {
             out.Error_(): "error",
             out.Warning_(): "warning",
+            out.Info_(): "note",
         }
         level = error_to_sarif_level[error.level.value]
 


### PR DESCRIPTION
fixed error when writing sarif output (missing dict item)

