### PR TITLE
Fix testing for Apex rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -191,12 +191,19 @@ test:
 #coupling: this is run by .github/workflow/tests.yml
 .PHONY: core-test
 core-test:
-	# The test executable has a few options that can be useful in some contexts.
-	dune build ./_build/default/src/tests/test.exe
+	$(MAKE) build-core-test
 	# The following command ensures that we can call 'test.exe --help'
 	# from the directory of the checkout
 	./_build/default/src/tests/test.exe --show-errors --help 2>&1 >/dev/null
 	./scripts/run-core-test
+
+# Please keep this standalone target.
+# We want to rebuild the tests without re-running all of them.
+.PHONY: build-core-test
+build-core-test:
+	# The test executable has a few options that can be useful in some
+	# contexts.
+	dune build ./_build/default/src/tests/test.exe
 
 .PHONY: test-bc
 test-bc:

--- a/src/core/Rule.ml
+++ b/src/core/Rule.ml
@@ -672,6 +672,24 @@ type error = {
 exception Error of error
 
 (*
+   Determine if an error can be skipped. This is for presumably well-formed
+   rules that aren't compatible with the current version of semgrep
+   and shouldn't cause a failure.
+*)
+let is_skippable_error (kind : invalid_rule_error_kind) =
+  match kind with
+  | InvalidLanguage _
+  | InvalidPattern _
+  | InvalidRegexp _
+  | DeprecatedFeature _
+  | MissingPositiveTermInAnd
+  | InvalidOther _ ->
+      false
+  | IncompatibleRule _
+  | MissingPlugin _ ->
+      true
+
+(*
    You must provide a rule ID for a rule to be reported properly as an invalid
    rule. The argument is not optional because it's important to not forget to
    specify a rule ID whenever possible.

--- a/src/parsing/Parse_rule.ml
+++ b/src/parsing/Parse_rule.ml
@@ -2118,8 +2118,9 @@ let parse_xpattern xlang (str, tok) =
 (*****************************************************************************)
 
 let parse file =
-  let xs, skipped = parse_file ~error_recovery:false file in
-  assert (skipped =*= []);
+  let xs, _skipped = parse_file ~error_recovery:false file in
+  (* The skipped rules include Apex rules and other rules that are always
+     skippable. *)
   xs
 
 (*****************************************************************************)


### PR DESCRIPTION
This updates the semgrep-rules submodule which comes with Apex rules for the first time. These rules are skipped without an error in `semgrep` but were fatal in the tests. This PR fixes these errors in tests.

https://github.com/returntocorp/semgrep/pull/9069
https://github.com/returntocorp/semgrep/actions/runs/6620419067/job/17982797112?pr=9069
