### PR TITLE
Fix test-semgrep-e2e-ci notify failure list

### DIFF
--- a/.github/workflows/test-e2e-semgrep-ci.jsonnet
+++ b/.github/workflows/test-e2e-semgrep-ci.jsonnet
@@ -116,8 +116,6 @@ local semgrep_ci_fail_open_job = {
   ],
 };
 
-// Note that this job is not in the notify_failure_job.needs.
-// TODO? why not in notify_failure_job.needs?
 local semgrep_ci_fail_open_blocking_findings_job = {
   'runs-on': 'ubuntu-22.04',
   env: {
@@ -264,6 +262,7 @@ local notify_failure_job = {
     'semgrep-ci',
     'semgrep-ci-on-pr',
     'semgrep-ci-fail-open',
+    'semgrep-ci-fail-open-blocking-findings',
     'wait-for-checks',
     'get-inputs',
   ],

--- a/.github/workflows/test-e2e-semgrep-ci.yml
+++ b/.github/workflows/test-e2e-semgrep-ci.yml
@@ -125,6 +125,7 @@ jobs:
     - semgrep-ci
     - semgrep-ci-on-pr
     - semgrep-ci-fail-open
+    - semgrep-ci-fail-open-blocking-findings
     - wait-for-checks
     - get-inputs
     name: Notify of Failure


### PR DESCRIPTION
Not sure why this jobs was not part of the condition
to report failure notifications

test plan:
trigger this workflow and look at action plan for this job
and see all arrows pointing to the notify failure final job