### PR TITLE
devops: use slackapi/slack-github-action@ instead of curl

### DIFF
--- a/.github/workflows/build-test-javascript.yml
+++ b/.github/workflows/build-test-javascript.yml
@@ -76,9 +76,7 @@ jobs:
     - name: Build JS artifacts
       run: "\n        make -C js -j $(nproc) build\n      "
     - name: Test JS artifacts
-      run: "\n        make -C js -j $(nproc) test\n      "
-    - name: Run JS e2e tests
-      run: "\n        make -C js/tests\n      "
+      run: "\n        make -C js -j $(nproc) test\n        make -C js/tests\n      "
     - name: Package JS artifacts
       run: "\n        tar cvzf semgrep-js-artifacts.tar.gz \\\n          js/engine/dist/index.cjs
         \\\n          js/engine/dist/index.mjs \\\n          js/engine/dist/semgrep-engine.wasm

--- a/.github/workflows/libs/semgrep.libsonnet
+++ b/.github/workflows/libs/semgrep.libsonnet
@@ -95,4 +95,8 @@ local github_bot = {
   },
 
   github_bot: github_bot,
+  slack_channels: {
+    "#team-semgrep-core": "C01NXGX2EHZ",
+    "#team-frameworks-and-services": "C05TW5S2EFJ",
+  }
 }

--- a/.github/workflows/libs/semgrep.libsonnet
+++ b/.github/workflows/libs/semgrep.libsonnet
@@ -62,8 +62,9 @@ local github_bot = {
 // ----------------------------------------------------------------------------
 
 {
+  // see https://github.com/returntocorp/semgrep/settings/secrets/actions
+  // for a list of available secrets
   secrets: {
-    // this token is stored in the GHA secrets settings
     SEMGREP_APP_TOKEN: '${{ secrets.SEMGREP_APP_TOKEN }}',
     // for e2e-semgrep-ci.jsonnet
     E2E_APP_TOKEN: '${{ secrets.SEMGREP_E2E_APP_TOKEN }}',
@@ -72,6 +73,7 @@ local github_bot = {
   // of it and rely on opam.lock for caching issues
   opam_switch: '4.14.0',
 
+  // This is internally using OCaml 4.14.0
   ocaml_alpine_container: {
     'runs-on': 'ubuntu-latest',
     container: 'returntocorp/ocaml:alpine-2023-10-17',
@@ -82,6 +84,8 @@ local github_bot = {
     },
   },
 
+  // Not used in most workflows, but used in build-test-core-x86-ocaml5.jsonnet
+  // to check whether at least we can compile the code with OCaml 5(.1)
   ocaml5_alpine_container: {
     'runs-on': 'ubuntu-latest',
     container: 'returntocorp/ocaml:alpine5.1-2023-10-17',

--- a/.github/workflows/test-e2e-semgrep-ci.jsonnet
+++ b/.github/workflows/test-e2e-semgrep-ci.jsonnet
@@ -282,8 +282,8 @@ local notify_failure_job = {
 	|||,
 	},
       env: {
-	#TODO? use secrets.NOTIFICATIONS_URL? got error in CI then
-	SLACK_WEBHOOK_URL: "${{ secrets.DEPLOY_SLACK_WEBHOOK }}",
+	# Note that DEPLOY_SLACK_WEBHOOK does not seem to work
+	SLACK_WEBHOOK_URL: "${{ secrets.NOTIFICATIONS_URL }}",
 	SLACK_WEBHOOK_TYPE: "INCOMING_WEBHOOK",
       },
     },

--- a/.github/workflows/test-e2e-semgrep-ci.jsonnet
+++ b/.github/workflows/test-e2e-semgrep-ci.jsonnet
@@ -246,10 +246,10 @@ local wait_for_checks_job = {
 // ----------------------------------------------------------------------------
 // Failure notification
 // ----------------------------------------------------------------------------
-
+// References:
+// https://github.com/slackapi/slack-github-action
 // https://github.com/slackapi/slack-github-action#technique-3-slack-incoming-webhook
 // https://semgrepinc.slack.com/apps/A0F7XDUAZ-incoming-webhooks?tab=more_info
-//          channel-id: "C05TW5S2EFJ" # team-frameworks-and-services
 // alt:
 //           SLACK_BOT_TOKEN: ${{ secrets.R2C_SLACK_TOKEN }}
 //      run: |||
@@ -275,7 +275,7 @@ local notify_failure_job = {
       name: 'Notify Failure on Slack',
       uses: "slackapi/slack-github-action@v1.24.0",
       with: {
-        'channel-id': "C01NXGX2EHZ", # team-semgrep-core
+        'channel-id': semgrep.slack_channels['#team-semgrep-core'],
 	#'slack-message': "The `${{ github.workflow }}` workflow has failed! Please take a look: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
 	payload: |||
 	  { "text": "The `${{ github.workflow }}` workflow has failed! Please take a look: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" }

--- a/.github/workflows/test-e2e-semgrep-ci.jsonnet
+++ b/.github/workflows/test-e2e-semgrep-ci.jsonnet
@@ -273,13 +273,17 @@ local notify_failure_job = {
   steps: [
     {
       name: 'Notify Failure on Slack',
-      uses: "slackapi/slack-github-action@v1.23.0",
+      uses: "slackapi/slack-github-action@v1.24.0",
       with: {
         'channel-id': "C01NXGX2EHZ", # team-semgrep-core
-	'slack-message': "The `${{ github.workflow }}` workflow has failed! Please take a look: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+	#'slack-message': "The `${{ github.workflow }}` workflow has failed! Please take a look: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+	payload: |||
+	  { "text": "The `${{ github.workflow }}` workflow has failed! Please take a look: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" }
+	|||,
 	},
       env: {
-	SLACK_WEBHOOK_URL: "${{ secrets.NOTIFICATIONS_URL }}",
+	#TODO? use secrets.NOTIFICATIONS_URL? got error in CI then
+	SLACK_WEBHOOK_URL: "${{ secrets.DEPLOY_SLACK_WEBHOOK }}",
 	SLACK_WEBHOOK_TYPE: "INCOMING_WEBHOOK",
       },
     },

--- a/.github/workflows/test-e2e-semgrep-ci.yml
+++ b/.github/workflows/test-e2e-semgrep-ci.yml
@@ -131,12 +131,12 @@ jobs:
     if: failure()
     steps:
     - name: Notify Failure on Slack
-      uses: slackapi/slack-github-action@v1.23.0
+      uses: slackapi/slack-github-action@v1.24.0
       with:
         channel-id: C01NXGX2EHZ
-        slack-message: 'The `${{ github.workflow }}` workflow has failed! Please take
-          a look: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{
-          github.run_id }}'
+        payload: "\n\t  { \"text\": \"The `${{ github.workflow }}` workflow has failed!
+          Please take a look: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{
+          github.run_id }}\" }\n\t"
       env:
-        SLACK_WEBHOOK_URL: ${{ secrets.NOTIFICATIONS_URL }}
+        SLACK_WEBHOOK_URL: ${{ secrets.DEPLOY_SLACK_WEBHOOK }}
         SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/test-e2e-semgrep-ci.yml
+++ b/.github/workflows/test-e2e-semgrep-ci.yml
@@ -11,7 +11,6 @@ name: test-e2e-semgrep-ci
   - cron: 43 20 * * *
 jobs:
   get-inputs:
-    name: Get Inputs
     runs-on: ubuntu-22.04
     outputs:
       docker_tag: ${{ steps.get-inputs.outputs.docker_tag }}
@@ -64,7 +63,7 @@ jobs:
     - name: Run CI
       id: run-ci
       run: "\n        if semgrep ci --suppress-errors; then\n           exit 2\n        else\n
-        \          exit 0\n        fi\n      "
+        \          exit 3\n        fi\n      "
   semgrep-ci-on-pr:
     uses: ./.github/workflows/open-bump-pr.yml
     secrets: inherit
@@ -128,15 +127,16 @@ jobs:
     - semgrep-ci-fail-open-blocking-findings
     - wait-for-checks
     - get-inputs
-    name: Notify of Failure
     runs-on: ubuntu-20.04
     if: failure()
     steps:
-    - name: Notify Failure
-      run: "\n        curl --request POST \\\n        --url  ${{ secrets.SEMGREP_CI_E2E_NOTIFICATIONS_URL
-        }} \\\n        --header 'content-type: application/json' \\\n        --data
-        '{\n          \"workflow_run_url\": \"https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
-        for more details!\",\n          \"docker_tag\": \"${{ needs.get-inputs.outputs.docker_tag
-        }}\",\n          \"message\": \"The PR in `returntocorp/e2e` that had the
-        failure was ${{ needs.semgrep-ci-on-pr.outputs.pr-number }}\"\n         }\n
-        \     "
+    - name: Notify Failure on Slack
+      uses: slackapi/slack-github-action@v1.23.0
+      with:
+        channel-id: C01NXGX2EHZ
+        slack-message: 'The `${{ github.workflow }}` workflow has failed! Please take
+          a look: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{
+          github.run_id }}'
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.NOTIFICATIONS_URL }}
+        SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/test-e2e-semgrep-ci.yml
+++ b/.github/workflows/test-e2e-semgrep-ci.yml
@@ -138,5 +138,5 @@ jobs:
           Please take a look: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{
           github.run_id }}\" }\n\t"
       env:
-        SLACK_WEBHOOK_URL: ${{ secrets.DEPLOY_SLACK_WEBHOOK }}
+        SLACK_WEBHOOK_URL: ${{ secrets.NOTIFICATIONS_URL }}
         SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK


### PR DESCRIPTION
This was inspired by a recent PR from jonas in semgrep-app.

The advantage over curl is that we can specify here the destination.
With curl it's a two steps process where we need to configure
somewhere else the channel to send to

test plan:
activate workflow and observe notifications in #team-semgrep-core