### PR TITLE
fix(ci): run OSS engine when running only supply chain rules

### DIFF
--- a/changelog.d/supply-chain-oss.changed
+++ b/changelog.d/supply-chain-oss.changed
@@ -1,0 +1,2 @@
+When running `semgrep ci --supply-chain`, defaults to using OSS engine even if
+PRO engine would otherwise be used (turned on in semgrep.dev, or with `--pro` flag)

--- a/cli/src/semgrep/commands/ci.py
+++ b/cli/src/semgrep/commands/ci.py
@@ -368,12 +368,14 @@ def ci(
         scan_handler and "secrets" in scan_handler.enabled_products
     )
 
+    supply_chain_only = supply_chain and not code and not run_secrets
     engine_type = EngineType.decide_engine_type(
         requested_engine=requested_engine,
         scan_handler=scan_handler,
         git_meta=metadata,
         run_secrets=run_secrets,
         enable_pro_diff_scan=diff_depth >= 0,
+        supply_chain_only=supply_chain_only,
     )
 
     # set default settings for selected engine type

--- a/cli/src/semgrep/engine.py
+++ b/cli/src/semgrep/engine.py
@@ -14,6 +14,9 @@ from semgrep.meta import GitMeta
 from semgrep.semgrep_core import SemgrepCore
 from semgrep.semgrep_interfaces import semgrep_output_v1 as out
 from semgrep.util import sub_check_output
+from semgrep.verbose_logging import getLogger
+
+logger = getLogger(__name__)
 
 
 class EngineType(Enum):
@@ -35,6 +38,7 @@ class EngineType(Enum):
         git_meta: Optional[GitMeta] = None,
         run_secrets: bool = False,
         enable_pro_diff_scan: bool = False,
+        supply_chain_only: bool = False,
     ) -> "EngineType":
         """Select which Semgrep engine type to use if none is explicitly requested.
 
@@ -58,6 +62,12 @@ class EngineType(Enum):
                 and not enable_pro_diff_scan
             ):
                 requested_engine = cls.PRO_INTRAFILE
+
+        if requested_engine != cls.OSS and supply_chain_only:
+            logger.info(
+                "Running only supply chain rules so running without Semgrep Pro Engine"
+            )
+            return cls.OSS
 
         return requested_engine or cls.OSS
 

--- a/cli/src/semgrep/engine.py
+++ b/cli/src/semgrep/engine.py
@@ -63,11 +63,12 @@ class EngineType(Enum):
             ):
                 requested_engine = cls.PRO_INTRAFILE
 
+        # Using PRO_LANG engine since PRO_INTERFILE defaults to -j 1
         if requested_engine != cls.OSS and supply_chain_only:
             logger.info(
-                "Running only supply chain rules so running without Semgrep Pro Engine"
+                "Running only supply chain rules so running without extra interfile analysis"
             )
-            return cls.OSS
+            return cls.PRO_LANG
 
         return requested_engine or cls.OSS
 

--- a/cli/src/semgrep/engine.py
+++ b/cli/src/semgrep/engine.py
@@ -63,8 +63,12 @@ class EngineType(Enum):
             ):
                 requested_engine = cls.PRO_INTRAFILE
 
-        # Using PRO_LANG engine since PRO_INTERFILE defaults to -j 1
-        if requested_engine != cls.OSS and supply_chain_only:
+        # Using PRO_LANG engine since PRO_INTERFILE/PRO_INTRAFILE defaults to -j 1
+        # note if using OSS, then will keep using OSS
+        if (
+            requested_engine in {cls.PRO_INTERFILE, cls.PRO_INTRAFILE}
+            and supply_chain_only
+        ):
             logger.info(
                 "Running only supply chain rules so running without extra interfile analysis"
             )

--- a/cli/tests/unit/test_engine_type.py
+++ b/cli/tests/unit/test_engine_type.py
@@ -74,5 +74,5 @@ def test_decide_engine_type(
             enable_pro_diff_scan=enable_pro_diff,
             supply_chain_only=True,
         )
-        == ET.OSS
+        == ET.PRO_LANG
     )

--- a/cli/tests/unit/test_engine_type.py
+++ b/cli/tests/unit/test_engine_type.py
@@ -65,3 +65,14 @@ def test_decide_engine_type(
         )
         == expected
     )
+
+    assert (
+        ET.decide_engine_type(
+            requested_engine=requested,
+            scan_handler=scan_handler,
+            git_meta=git_meta,
+            enable_pro_diff_scan=enable_pro_diff,
+            supply_chain_only=True,
+        )
+        == ET.OSS
+    )

--- a/cli/tests/unit/test_engine_type.py
+++ b/cli/tests/unit/test_engine_type.py
@@ -66,6 +66,8 @@ def test_decide_engine_type(
         == expected
     )
 
+    # Expect engine to be non-interfile/intrafile pro
+    expected_supply_chain_only_engine = expected if expected == ET.OSS else ET.PRO_LANG
     assert (
         ET.decide_engine_type(
             requested_engine=requested,
@@ -74,5 +76,5 @@ def test_decide_engine_type(
             enable_pro_diff_scan=enable_pro_diff,
             supply_chain_only=True,
         )
-        == ET.PRO_LANG
+        == expected_supply_chain_only_engine
     )


### PR DESCRIPTION
Scans running `--supply-chain` with pro engine on for some customers were taking over an hour. Supply chain rules do not need taint or interfile (or most likely cause is pro engine defaults to one core job), so default to using OSS engine.

Relevant Issue: https://linear.app/semgrep/issue/EA-244/scans-run-with-supply-chainshouldnt-also-run-supply-chain-rules-on