### PR TITLE
fix(sca): correctly parse toolchain directive in go.mod

### DIFF
--- a/changelog.d/parsegomode.fixed
+++ b/changelog.d/parsegomode.fixed
@@ -1,0 +1,1 @@
+Correctly handle parsing toolchain directive in go.mod files

--- a/cli/src/semdep/parsers/go_mod.py
+++ b/cli/src/semdep/parsers/go_mod.py
@@ -55,6 +55,7 @@ dep_spec = regex(r"([^ \n]+) v([^ \n]+)", flags=0, group=(1, 2)) | comment.resul
 specs: Dict[str, "Parser[Optional[Tuple[str,...]]]"] = {
     "module": comment.result(None) | consume_line,
     "go": comment.result(None) | consume_line,
+    "toolchain": comment.result(None) | consume_line,
     "require": dep_spec,
     "exclude": dep_spec,
     "replace": comment.result(None) | consume_line,

--- a/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awarego-sca.yaml-dependency_awarego_toolchain/results.txt
+++ b/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awarego-sca.yaml-dependency_awarego_toolchain/results.txt
@@ -15,7 +15,54 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
       "targets/dependency_aware/go_toolchain/sca.go"
     ]
   },
-  "results": [],
+  "results": [
+    {
+      "check_id": "rules.dependency_aware.go-sca",
+      "end": {
+        "col": 0,
+        "line": 20,
+        "offset": 0
+      },
+      "extra": {
+        "engine_kind": "OSS",
+        "fingerprint": "0x42",
+        "is_ignored": false,
+        "lines": "\tgithub.com/cheekybits/genny v99.99.99\n)",
+        "message": "oh no",
+        "metadata": {},
+        "metavars": {},
+        "sca_info": {
+          "dependency_match": {
+            "dependency_pattern": {
+              "ecosystem": "gomod",
+              "package": "github.com/cheekybits/genny",
+              "semver_range": "== 99.99.99"
+            },
+            "found_dependency": {
+              "allowed_hashes": {},
+              "ecosystem": "gomod",
+              "line_number": 19,
+              "package": "github.com/cheekybits/genny",
+              "resolved_url": "github.com/cheekybits/genny",
+              "transitivity": "direct",
+              "version": "99.99.99"
+            },
+            "lockfile": "targets/dependency_aware/go_toolchain/go.mod"
+          },
+          "reachability_rule": true,
+          "reachable": false,
+          "sca_finding_schema": 20220913
+        },
+        "severity": "WARNING"
+      },
+      "path": "targets/dependency_aware/go_toolchain/go.mod",
+      "start": {
+        "col": 0,
+        "line": 19,
+        "offset": 0
+      }
+    }
+  ],
   "skipped_rules": [],
   "version": "0.42"
 }
@@ -35,17 +82,12 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
 
   SUPPLY CHAIN RULES
   Scanning 1 file.
-  Failed to parse [bold]targets/dependency_aware/go_toolchain/go.mod[/bold] at
-  [bold]7:1[/bold] - expected one of ['\n', ' *//([^\\n]*)', 'EOF', 'exclude',
-  'go', 'module', 'replace', 'require', 'retract']
-  7 | toolchain go1.21.0
-      ^
 
 
 ┌──────────────┐
 │ Scan Summary │
 └──────────────┘
 
-Ran 1 rule on 2 files: 0 findings.
+Ran 1 rule on 2 files: 1 finding.
 
 === end of stderr - plain

--- a/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awarego-sca.yaml-dependency_awarego_toolchain/results.txt
+++ b/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awarego-sca.yaml-dependency_awarego_toolchain/results.txt
@@ -1,0 +1,51 @@
+=== command
+SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERSION_CACHE_PATH="<MASKED>" SEMGREP_ENABLE_VERSION_CHECK="0" SEMGREP_SEND_METRICS="off" semgrep --strict --config rules/dependency_aware/go-sca.yaml --json targets/dependency_aware/go_toolchain
+=== end of command
+
+=== exit code
+0
+=== end of exit code
+
+=== stdout - plain
+{
+  "errors": [],
+  "paths": {
+    "scanned": [
+      "targets/dependency_aware/go_toolchain/go.mod",
+      "targets/dependency_aware/go_toolchain/sca.go"
+    ]
+  },
+  "results": [],
+  "skipped_rules": [],
+  "version": "0.42"
+}
+=== end of stdout - plain
+
+=== stderr - plain
+
+
+┌─────────────┐
+│ Scan Status │
+└─────────────┘
+  Scanning 2 files tracked by git with 0 Code rules, 1 Supply Chain rule:
+
+
+  CODE RULES
+  Nothing to scan.
+
+  SUPPLY CHAIN RULES
+  Scanning 1 file.
+  Failed to parse [bold]targets/dependency_aware/go_toolchain/go.mod[/bold] at
+  [bold]7:1[/bold] - expected one of ['\n', ' *//([^\\n]*)', 'EOF', 'exclude',
+  'go', 'module', 'replace', 'require', 'retract']
+  7 | toolchain go1.21.0
+      ^
+
+
+┌──────────────┐
+│ Scan Summary │
+└──────────────┘
+
+Ran 1 rule on 2 files: 0 findings.
+
+=== end of stderr - plain

--- a/cli/tests/e2e/targets/dependency_aware/go_toolchain/go.mod
+++ b/cli/tests/e2e/targets/dependency_aware/go_toolchain/go.mod
@@ -1,0 +1,57 @@
+// comment
+// second comment
+module github.com/foo
+
+go 1.18
+
+toolchain go1.21.0
+
+retract (
+    v1.0.0
+    [v1.0.0, v1.9.9]
+)
+
+require (
+	github.com/go-chi/chi/v5 v5.0.7
+	github.com/go-chi/render v1.0.2
+	github.com/lucasb-eyer/go-colorful v1.2.0
+	go.opentelemetry.io/otel/sdk v1.11.1
+	github.com/cheekybits/genny v99.99.99
+)
+
+require (
+	github.com/ajg/form v1.5.1 // indirect
+	github.com/cenkalti/backoff/v4 v4.1.3 // indirect
+	github.com/felixge/httpsnoop v1.0.2 // indirect
+	github.com/go-logr/logr v1.2.3 // indirect
+	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0 // indirect
+	go.opentelemetry.io/contrib v1.0.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.11.1 // indirect
+	go.opentelemetry.io/otel/trace v1.11.1 // indirect
+	go.opentelemetry.io/proto/otlp v0.19.0 // indirect
+	golang.org/x/net v0.0.0-20220722155237-a158d28d115b // indirect
+	golang.org/x/text v0.3.8 // indirect
+	google.golang.org/genproto v0.0.0-20211118181313-81c1377c94b1 // indirect
+	google.golang.org/grpc v1.50.1 // indirect
+)
+
+require (
+	// comment
+	// second comment
+	github.com/riandyrn/otelchi v0.5.0
+	go.opentelemetry.io/otel v1.11.1
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.11.1
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.11.1
+	golang.org/x/sys v0.2.0 // indirect
+	// interspersed comment
+	golang.org/x/tools v0.1.12
+	google.golang.org/protobuf v1.28.1 // indirect
+)
+
+replace (
+		// my comment with ending ()
+    github.com/riandyrn/otelchi v0.5.0 => github.com/riandyrn/otelchi v0.5.1
+   	go.opentelemetry.io/otel v1.11.1 => go.opentelemetry.io/otel v1.11.2
+)

--- a/cli/tests/e2e/targets/dependency_aware/go_toolchain/sca.go
+++ b/cli/tests/e2e/targets/dependency_aware/go_toolchain/sca.go
@@ -1,0 +1,3 @@
+func f() {
+	return bad()
+}

--- a/cli/tests/e2e/test_dependency_aware_rules.py
+++ b/cli/tests/e2e/test_dependency_aware_rules.py
@@ -40,6 +40,7 @@ pytestmark = pytest.mark.kinda_slow
             "dependency_aware/yarn",
         ),
         ("rules/dependency_aware/go-sca.yaml", "dependency_aware/go"),
+        ("rules/dependency_aware/go-sca.yaml", "dependency_aware/go_toolchain"),
         ("rules/dependency_aware/go-sca.yaml", "dependency_aware/go_multi_newline"),
         ("rules/dependency_aware/ruby-sca.yaml", "dependency_aware/ruby"),
         (


### PR DESCRIPTION
toolchain is a valid directive in go.mod files but we were not correctly handling it (and hard failing parsing the file as a whole). This PR correctly parses go.mod files with that directive

https://linear.app/semgrep/issue/SC-1133/toolchain-directive-in-gomod-file-throwing-an-error