### PR TITLE
Add support for ci scan results as output

### DIFF
--- a/cli/src/semgrep/app/scans.py
+++ b/cli/src/semgrep/app/scans.py
@@ -70,6 +70,7 @@ class ScanHandler:
         self._scan_params: str = ""
         self._rules: str = ""
         self._enabled_products: List[str] = []
+        self.ci_scan_results: Optional[out.CiScanResults] = None
 
     @property
     def deployment_id(self) -> Optional[int]:
@@ -338,7 +339,7 @@ class ScanHandler:
             or os.getenv("BITBUCKET_TOKEN")
         )
 
-        ci_scan_results = out.CiScanResults(
+        self.ci_scan_results = out.CiScanResults(
             # send a backup token in case the app is not available
             token=token,
             findings=findings,
@@ -349,9 +350,11 @@ class ScanHandler:
             contributions=contributions,
         )
         if self._dependency_query:
-            ci_scan_results.dependencies = out.CiScanDependencies(lockfile_dependencies)
+            self.ci_scan_results.dependencies = out.CiScanDependencies(
+                lockfile_dependencies
+            )
 
-        findings_and_ignores = ci_scan_results.to_json()
+        findings_and_ignores = self.ci_scan_results.to_json()
 
         if any(
             isinstance(match.severity.value, out.Experiment) for match in new_ignored

--- a/cli/src/semgrep/commands/ci.py
+++ b/cli/src/semgrep/commands/ci.py
@@ -1,4 +1,5 @@
 import atexit
+import json
 import os
 import sys
 import time
@@ -154,6 +155,12 @@ def fix_head_if_github_action(metadata: GitMeta) -> None:
     default=True,
     envvar="SEMGREP_SUPPRESS_ERRORS",
 )
+@click.option(
+    "--internal-ci-scan-results",
+    "internal_ci_scan_results",
+    is_flag=True,
+    hidden=True,
+)
 @handle_command_errors
 def ci(
     ctx: click.Context,
@@ -164,6 +171,7 @@ def ci(
     # TODO: Remove after October 2023. Left for a error message
     # redirect to `--secrets` aka run_secrets_flag.
     beta_testing_secrets: bool,
+    internal_ci_scan_results: bool,
     code: bool,
     config: Optional[Tuple[str, ...]],
     debug: bool,
@@ -538,17 +546,18 @@ def ci(
     num_nonblocking_findings = len(nonblocking_matches)
     num_blocking_findings = len(blocking_matches)
 
-    output_handler.output(
-        non_cai_matches_by_rule,
-        all_targets=output_extra.all_targets,
-        ignore_log=ignore_log,
-        profiler=profiler,
-        filtered_rules=[*blocking_rules, *nonblocking_rules],
-        extra=output_extra,
-        severities=shown_severities,
-        is_ci_invocation=True,
-        engine_type=engine_type,
-    )
+    if not internal_ci_scan_results:
+        output_handler.output(
+            non_cai_matches_by_rule,
+            all_targets=output_extra.all_targets,
+            ignore_log=ignore_log,
+            profiler=profiler,
+            filtered_rules=[*blocking_rules, *nonblocking_rules],
+            extra=output_extra,
+            severities=shown_severities,
+            is_ci_invocation=True,
+            engine_type=engine_type,
+        )
 
     logger.info("CI scan completed successfully.")
     logger.info(
@@ -577,6 +586,18 @@ def ci(
                 contributions,
                 engine_type,
                 progress_bar,
+            )
+
+        if internal_ci_scan_results:
+            # console.print() would go to stderr; here we print() directly to stdout
+            print(
+                json.dumps(
+                    scan_handler.ci_scan_results.to_json()
+                    if scan_handler.ci_scan_results
+                    else {},
+                    sort_keys=True,
+                    default=lambda x: x.to_json(),
+                )
             )
 
         if complete_result.success:

--- a/src/osemgrep/cli_ci/Ci_CLI.ml
+++ b/src/osemgrep/cli_ci/Ci_CLI.ml
@@ -81,6 +81,12 @@ contact support@semgrep.com for more information this.|}
   in
   Arg.value (Arg.flag info)
 
+let o_internal_ci_scan_results : bool Term.t =
+  let info =
+    Arg.info [ "internal-ci-scan-results" ] ~doc:{|<internal, do not use>|}
+  in
+  Arg.value (Arg.flag info)
+
 let o_suppress_errors : bool Term.t =
   H.negatable_flag_with_env [ "suppress-errors" ]
     ~neg_options:[ "no-suppress-errors" ]
@@ -103,7 +109,8 @@ let cmdline_term : conf Term.t =
    * variables (Romain's idea).
    *)
   let combine scan_conf audit_on beta_testing_secrets code dry_run secrets
-      supply_chain suppress_errors _git_meta _github_meta =
+      supply_chain suppress_errors _internal_ci_scan_results _git_meta
+      _github_meta =
     let products =
       (if beta_testing_secrets || secrets then [ `Secrets ] else [])
       @ (if code then [ `SAST ] else [])
@@ -115,8 +122,8 @@ let cmdline_term : conf Term.t =
     const combine
     $ Scan_CLI.cmdline_term ~allow_empty_config:true
     $ o_audit_on $ o_beta_testing_secrets $ o_code $ o_dry_run $ o_secrets
-    $ o_supply_chain $ o_suppress_errors $ Git_metadata.env
-    $ Github_metadata.env)
+    $ o_internal_ci_scan_results $ o_supply_chain $ o_suppress_errors
+    $ Git_metadata.env $ Github_metadata.env)
 
 let doc = "the recommended way to run semgrep in CI"
 

--- a/src/osemgrep/cli_ci/Ci_CLI.ml
+++ b/src/osemgrep/cli_ci/Ci_CLI.ml
@@ -60,6 +60,12 @@ findings. Instead will print out json objects it would have sent.|}
   in
   Arg.value (Arg.flag info)
 
+let o_internal_ci_scan_results : bool Term.t =
+  let info =
+    Arg.info [ "internal-ci-scan-results" ] ~doc:{|<internal, do not use>|}
+  in
+  Arg.value (Arg.flag info)
+
 let o_supply_chain : bool Term.t =
   let info = Arg.info [ "supply-chain" ] in
   Arg.value (Arg.flag info)
@@ -78,12 +84,6 @@ let o_secrets : bool Term.t =
       ~doc:
         {|Support for secret validation. Requires Semgrep Secrets,
 contact support@semgrep.com for more information this.|}
-  in
-  Arg.value (Arg.flag info)
-
-let o_internal_ci_scan_results : bool Term.t =
-  let info =
-    Arg.info [ "internal-ci-scan-results" ] ~doc:{|<internal, do not use>|}
   in
   Arg.value (Arg.flag info)
 
@@ -108,8 +108,8 @@ let cmdline_term : conf Term.t =
    * it below so we can get a nice man page documenting those environment
    * variables (Romain's idea).
    *)
-  let combine scan_conf audit_on beta_testing_secrets code dry_run secrets
-      supply_chain suppress_errors _internal_ci_scan_results _git_meta
+  let combine scan_conf audit_on beta_testing_secrets code dry_run
+      _internal_ci_scan_results secrets supply_chain suppress_errors _git_meta
       _github_meta =
     let products =
       (if beta_testing_secrets || secrets then [ `Secrets ] else [])
@@ -121,9 +121,9 @@ let cmdline_term : conf Term.t =
   Term.(
     const combine
     $ Scan_CLI.cmdline_term ~allow_empty_config:true
-    $ o_audit_on $ o_beta_testing_secrets $ o_code $ o_dry_run $ o_secrets
-    $ o_internal_ci_scan_results $ o_supply_chain $ o_suppress_errors
-    $ Git_metadata.env $ Github_metadata.env)
+    $ o_audit_on $ o_beta_testing_secrets $ o_code $ o_dry_run
+    $ o_internal_ci_scan_results $ o_secrets $ o_supply_chain
+    $ o_suppress_errors $ Git_metadata.env $ Github_metadata.env)
 
 let doc = "the recommended way to run semgrep in CI"
 


### PR DESCRIPTION
Adds py/osemgrep support for using the internal `--internal-ci-scan-results` flag that will output the `CiScanResults` json to stdout. 

Tested this manually with both osemgrep and pysemgrep. 

New PR for https://github.com/returntocorp/semgrep/pull/9078
