### PR TITLE
tainting: Add `exact` option to sources and sanitizers

### DIFF
--- a/changelog.d/gh-5897.added
+++ b/changelog.d/gh-5897.added
@@ -2,6 +2,7 @@ taint-mode: Added a Boolean `exact` option to sources and sanitizers to make
 matching stricter (default is `false`).
 
 If you specify a source such as `foo(...)`, and Semgrep encounters `foo(x)`,
-by default both `foo(x)` and `x` will be considered tainted. If you add
+by default `foo(x)`, `foo`, and `x`, will all be considered tainted. If you add
 `exact: true` to the source specification, then only `foo(x)` will be regarded
-as tainted. The same applies to sanitizers.
+as tainted, that is the "exact" match for the specification. The same applies
+to "exact" sanitizers.

--- a/changelog.d/gh-5897.added
+++ b/changelog.d/gh-5897.added
@@ -1,0 +1,7 @@
+taint-mode: Added a Boolean `exact` option to sources and sanitizers to make
+matching stricter (default is `false`).
+
+If you specify a source such as `foo(...)`, and Semgrep encounters `foo(x)`,
+by default both `foo(x)` and `x` will be considered tainted. If you add
+`exact: true` to the source specification, then only `foo(x)` will be regarded
+as tainted. The same applies to sanitizers.

--- a/src/core/Rule.ml
+++ b/src/core/Rule.ml
@@ -163,7 +163,9 @@ type taint_spec = {
 }
 
 and taint_source = {
+  source_id : string;  (** See 'Parse_rule.parse_taint_source'. *)
   source_formula : formula;
+  source_exact : bool;
   source_by_side_effect : bool;
   source_control : bool;
   label : string;
@@ -192,7 +194,9 @@ and taint_source = {
  * because they are a bit confusing to use sometimes.
  *)
 and taint_sanitizer = {
+  sanitizer_id : string;
   sanitizer_formula : formula;
+  sanitizer_exact : bool;
   sanitizer_by_side_effect : bool;
   not_conflicting : bool;
       (* If [not_conflicting] is enabled, the sanitizer cannot conflict with
@@ -226,6 +230,7 @@ and taint_sink = {
  * will also be marked as tainted.
  *)
 and taint_propagator = {
+  propagator_id : string;
   propagator_formula : formula;
   propagator_by_side_effect : bool;
   from : MV.mvar wrap;

--- a/src/engine/Match_tainting_mode.ml
+++ b/src/engine/Match_tainting_mode.ml
@@ -379,19 +379,25 @@ let any_is_in_sources_matches rule any matches =
   let ( let* ) = option_bind_list in
   let* r = range_of_any any in
   matches
-  |> Common.map_filter (fun (rwm, ts) ->
+  |> Common.map_filter (fun (rwm, (ts : R.taint_source)) ->
          if Range.( $<=$ ) r rwm.RM.r then
            Some
              (let spec_pm = RM.range_to_pattern_match_adjusted rule rwm in
               let overlap = overlap_with ~match_range:rwm.RM.r r in
-              { D.spec = ts; spec_pm; range = r; overlap })
+              {
+                Taint_smatch.spec = ts;
+                spec_id = ts.source_id;
+                spec_pm;
+                range = r;
+                overlap;
+              })
          else None)
 
 (* Check whether `any` matches either the `from` or the `to` of any of the
  * `pattern-propagators`. Matches must be exact (overlap > 0.99) to make
  * taint propagation more precise and predictable. *)
 let any_is_in_propagators_matches rule any matches :
-    D.a_propagator D.tmatch list =
+    D.a_propagator Taint_smatch.t list =
   match range_of_any any with
   | None -> []
   | Some r ->
@@ -403,7 +409,13 @@ let any_is_in_propagators_matches rule any matches :
              let is_to = is_exact_match ~match_range:prop.to_ r in
              let mk_match kind =
                let spec : D.a_propagator = { kind; prop = prop.spec; var } in
-               { D.spec; spec_pm; range = r; overlap = 1.0 }
+               {
+                 Taint_smatch.spec;
+                 spec_id = prop.spec.propagator_id;
+                 spec_pm;
+                 range = r;
+                 overlap = 1.0;
+               }
              in
              (if is_from then [ mk_match `From ] else [])
              @ (if is_to then [ mk_match `To ] else [])
@@ -418,19 +430,31 @@ let any_is_in_sanitizers_matches rule any matches =
            Some
              (let spec_pm = RM.range_to_pattern_match_adjusted rule rwm in
               let overlap = overlap_with ~match_range:rwm.RM.r r in
-              { D.spec; spec_pm; range = r; overlap })
+              {
+                Taint_smatch.spec;
+                spec_id = spec.R.sanitizer_id;
+                spec_pm;
+                range = r;
+                overlap;
+              })
          else None)
 
 let any_is_in_sinks_matches rule any matches =
   let ( let* ) = option_bind_list in
   let* r = range_of_any any in
   matches
-  |> Common.map_filter (fun (rwm, spec) ->
+  |> Common.map_filter (fun (rwm, (spec : R.taint_sink)) ->
          if Range.( $<=$ ) r rwm.RM.r then
            Some
              (let spec_pm = RM.range_to_pattern_match_adjusted rule rwm in
               let overlap = overlap_with ~match_range:rwm.RM.r r in
-              { D.spec; spec_pm; range = r; overlap })
+              {
+                Taint_smatch.spec;
+                spec_id = spec.sink_id;
+                spec_pm;
+                range = r;
+                overlap;
+              })
          else None)
 
 let lazy_force x = Lazy.force x [@@profiling]
@@ -660,7 +684,7 @@ let add_to_env lang options taint_config env id ii opt_expr =
   let var_type = Typing.resolved_type_of_id_info lang var.id_info in
   let id_taints =
     taint_config.D.is_source (G.Tk (snd id))
-    |> Common.map (fun (x : _ D.tmatch) -> (x.spec_pm, x.spec))
+    |> Common.map (fun (x : _ Taint_smatch.t) -> (x.spec_pm, x.spec))
     (* These sources come from the parameters to a function,
         which are not within the normal control flow of a code.
         We can safely say there's no incoming taints to these sources.

--- a/src/metachecking/Translate_rule.ml
+++ b/src/metachecking/Translate_rule.ml
@@ -82,7 +82,9 @@ and translate_metavar_cond cond : [> `O of (string * Yaml.value) list ] =
 
 and translate_taint_source
     {
+      source_id = _;
       source_formula;
+      source_exact;
       source_by_side_effect;
       label;
       source_control;
@@ -98,6 +100,7 @@ and translate_taint_source
     | None -> []
     | Some { range; _ } -> [ ("requires", `String (range_to_string range)) ]
   in
+  let exact_obj = if source_exact then [ ("exact", `Bool true) ] else [] in
   let side_effect_obj =
     if source_by_side_effect then [ ("by-side-effect", `Bool true) ] else []
   in
@@ -106,7 +109,14 @@ and translate_taint_source
   in
   `O
     (List.concat
-       [ source_f; control_obj; label_obj; requires_obj; side_effect_obj ])
+       [
+         source_f;
+         exact_obj;
+         control_obj;
+         label_obj;
+         requires_obj;
+         side_effect_obj;
+       ])
 
 and translate_taint_sink { sink_id = _; sink_formula; sink_requires } :
     [> `O of (string * Yaml.value) list ] =
@@ -119,19 +129,26 @@ and translate_taint_sink { sink_id = _; sink_formula; sink_requires } :
   `O (List.concat [ sink_f; requires_obj ])
 
 and translate_taint_sanitizer
-    { sanitizer_formula; sanitizer_by_side_effect; not_conflicting } :
-    [> `O of (string * Yaml.value) list ] =
+    {
+      sanitizer_id = _;
+      sanitizer_formula;
+      sanitizer_exact;
+      sanitizer_by_side_effect;
+      not_conflicting;
+    } : [> `O of (string * Yaml.value) list ] =
   let (`O san_f) = translate_formula sanitizer_formula in
   let side_effect_obj =
     if sanitizer_by_side_effect then [ ("by-side-effect", `Bool true) ] else []
   in
+  let exact_obj = if sanitizer_exact then [ ("exact", `Bool true) ] else [] in
   let not_conflicting_obj =
     if not_conflicting then [ ("not-conflicting", `Bool true) ] else []
   in
-  `O (List.concat [ san_f; side_effect_obj; not_conflicting_obj ])
+  `O (List.concat [ san_f; exact_obj; side_effect_obj; not_conflicting_obj ])
 
 and translate_taint_propagator
     {
+      propagator_id = _;
       propagator_formula;
       propagator_by_side_effect;
       from;

--- a/src/parsing/Parse_rule.ml
+++ b/src/parsing/Parse_rule.ml
@@ -1362,7 +1362,11 @@ let parse_taint_requires env key x =
 (* TODO: can add a case where these take in only a single string *)
 let parse_taint_source ~(is_old : bool) env (key : key) (value : G.expr) :
     Rule.taint_source =
+  let source_id = "source:" ^ String.concat ":" env.path in
   let parse_from_dict dict f =
+    let source_exact =
+      take_opt dict env parse_bool "exact" |> Option.value ~default:false
+    in
     let source_by_side_effect =
       take_opt dict env parse_bool "by-side-effect"
       |> Option.value ~default:false
@@ -1377,7 +1381,9 @@ let parse_taint_source ~(is_old : bool) env (key : key) (value : G.expr) :
     let source_requires = take_opt dict env parse_taint_requires "requires" in
     let source_formula = f env dict in
     {
-      R.source_formula;
+      R.source_id;
+      source_formula;
+      source_exact;
       source_by_side_effect;
       source_control;
       label;
@@ -1392,7 +1398,9 @@ let parse_taint_source ~(is_old : bool) env (key : key) (value : G.expr) :
     | Left value ->
         let source_formula = R.P (parse_rule_xpattern env value) in
         {
+          source_id;
           source_formula;
+          source_exact = false;
           source_by_side_effect = false;
           source_control = false;
           label = R.default_source_label;
@@ -1402,6 +1410,7 @@ let parse_taint_source ~(is_old : bool) env (key : key) (value : G.expr) :
 
 let parse_taint_propagator ~(is_old : bool) env (key : key) (value : G.expr) :
     Rule.taint_propagator =
+  let propagator_id = "propagator:" ^ String.concat ":" env.path in
   let f =
     if is_old then parse_formula_old_from_dict else parse_formula_from_dict
   in
@@ -1424,7 +1433,8 @@ let parse_taint_propagator ~(is_old : bool) env (key : key) (value : G.expr) :
     in
     let propagator_formula = f env dict in
     {
-      R.propagator_formula;
+      R.propagator_id;
+      propagator_formula;
       propagator_by_side_effect;
       from;
       to_;
@@ -1437,7 +1447,11 @@ let parse_taint_propagator ~(is_old : bool) env (key : key) (value : G.expr) :
   parse_from_dict dict f
 
 let parse_taint_sanitizer ~(is_old : bool) env (key : key) (value : G.expr) =
+  let sanitizer_id = "sanitizer:" ^ String.concat ":" env.path in
   let parse_from_dict dict f =
+    let sanitizer_exact =
+      take_opt dict env parse_bool "exact" |> Option.value ~default:false
+    in
     let sanitizer_by_side_effect =
       take_opt dict env parse_bool "by-side-effect"
       |> Option.value ~default:false
@@ -1448,7 +1462,13 @@ let parse_taint_sanitizer ~(is_old : bool) env (key : key) (value : G.expr) =
       |> Option.value ~default:false
     in
     let sanitizer_formula = f env dict in
-    { sanitizer_formula; sanitizer_by_side_effect; R.not_conflicting }
+    {
+      sanitizer_id;
+      sanitizer_formula;
+      sanitizer_exact;
+      sanitizer_by_side_effect;
+      R.not_conflicting;
+    }
   in
   if is_old then
     let dict = yaml_to_dict env key value in
@@ -1458,7 +1478,9 @@ let parse_taint_sanitizer ~(is_old : bool) env (key : key) (value : G.expr) =
     | Left value ->
         let sanitizer_formula = R.P (parse_rule_xpattern env value) in
         {
+          sanitizer_id;
           sanitizer_formula;
+          sanitizer_exact = false;
           sanitizer_by_side_effect = false;
           R.not_conflicting = false;
         }
@@ -1466,7 +1488,7 @@ let parse_taint_sanitizer ~(is_old : bool) env (key : key) (value : G.expr) =
 
 let parse_taint_sink ~(is_old : bool) env (key : key) (value : G.expr) :
     Rule.taint_sink =
-  let sink_id = String.concat ":" env.path in
+  let sink_id = "sink:" ^ String.concat ":" env.path in
   let parse_from_dict dict f =
     let sink_requires = take_opt dict env parse_taint_requires "requires" in
     let sink_formula = f env dict in

--- a/src/tainting/Dataflow_tainting.mli
+++ b/src/tainting/Dataflow_tainting.mli
@@ -1,25 +1,6 @@
 type var = Dataflow_var_env.var
 (** A string of the form "<source name>:<sid>". *)
 
-type overlap = float
-(** Overlap ratio, only applies to AST nodes that fall in the range of a
- * source/sanitizer/sink annotation. It is a number in [0.0, 1.0], where
- * 1.0 means that the AST node matches the annotation perfectly. For
- * practical purposes we can interpret >0.99 as being the same as 1.0. *)
-
-type 'spec tmatch = {
-  spec : 'spec;
-      (** The specification on which the match is based, e.g. a taint source.
-      * This spec should have a pattern formula. *)
-  spec_pm : Pattern_match.t;
-      (** A pattern match obtained directly from the spec's pattern formula. *)
-  range : Range.t;
-      (** The range of this particular match, which will be a subrange of 'spec_pm',
-      * see note on 'Taint-tracking via ranges' in 'Match_tainting_mode.ml'. *)
-  overlap : overlap;
-      (** The overlap of this match ('range') with the spec match ('spec_pm'). *)
-}
-
 type a_propagator = {
   kind : [ `From | `To ];
   prop : Rule.taint_propagator;
@@ -31,10 +12,10 @@ type config = {
   rule_id : Rule_ID.t;  (** Taint rule id, for Deep Semgrep. *)
   track_control : bool;
       (** Whether the rule requires tracking "control taint". *)
-  is_source : AST_generic.any -> Rule.taint_source tmatch list;
+  is_source : AST_generic.any -> Rule.taint_source Taint_smatch.t list;
       (** Test whether 'any' is a taint source, this corresponds to
       * 'pattern-sources:' in taint-mode. *)
-  is_propagator : AST_generic.any -> a_propagator tmatch list;
+  is_propagator : AST_generic.any -> a_propagator Taint_smatch.t list;
       (** Test whether 'any' matches a taint propagator, this corresponds to
        * 'pattern-propagators:' in taint-mode.
        *
@@ -64,10 +45,10 @@ type config = {
        * anyhow it's clearly incorrect to taint `Shell`, so a better solution was
        * needed (hence `pattern-propagators`).
        *)
-  is_sink : AST_generic.any -> Rule.taint_sink tmatch list;
+  is_sink : AST_generic.any -> Rule.taint_sink Taint_smatch.t list;
       (** Test whether 'any' is a sink, this corresponds to 'pattern-sinks:'
       * in taint-mode. *)
-  is_sanitizer : AST_generic.any -> Rule.taint_sanitizer tmatch list;
+  is_sanitizer : AST_generic.any -> Rule.taint_sanitizer Taint_smatch.t list;
       (** Test whether 'any' is a sanitizer, this corresponds to
       * 'pattern-sanitizers:' in taint-mode. *)
   unify_mvars : bool;  (** Unify metavariables in sources and sinks? *)

--- a/src/tainting/Taint.ml
+++ b/src/tainting/Taint.ml
@@ -472,7 +472,7 @@ module Taint_set = struct
                * Otherwise we end up with taint sets where most of the taints are
                * essentially the same. This is probably due to
                * [see note "Taint-tracking via ranges" in Match_tainting_mode],
-               * and not having "Top_sources" [see note "Top sinks" in Dataflow_tainting].
+               * and not having "Top_sources" [see note "Top matches" in 'Taint_smatch'].
                *)
               let ts1' = of_list ts1 in
               let ts2' = of_list ts2 in

--- a/src/tainting/Taint_smatch.ml
+++ b/src/tainting/Taint_smatch.ml
@@ -1,0 +1,177 @@
+(* Iago Abal
+ *
+ * Copyright (C) 2023-present Semgrep Inc
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * version 2.1 as published by the Free Software Foundation, with the
+ * special exception on linking described in file LICENSE.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
+ * LICENSE for more details.
+ *)
+
+open Common
+module PM = Pattern_match
+
+type overlap = float
+
+type 'spec t = {
+  spec : 'spec;
+  spec_id : string;
+  spec_pm : PM.t;
+  range : Range.t;
+  overlap : overlap;
+}
+
+let is_exact x = x.overlap > 0.99
+
+type any = Any : 'a t -> any
+
+(* NOTE "Top matches":
+ * (See note "Taint-tracking via ranges" in 'Match_tainting_mode.ml' for context.)
+ *
+ * We use sub-range checks to determine whether a piece of code is a source/sink/etc,
+ * and this can lead to unintuitive results. For example,
+ *
+ *     sink(if tainted then ok1 else ok2)
+ *
+ * was reported as a tainted sink despite `if tainted then ok1 else ok2` is actually
+ * not tainted. The problem was that `tainted` is inside what `sink(...)` matches,
+ * and using a sub-range check we end up considering `tainted` itself as a sink.
+ *
+ * Unfortunately simply checking for exact matches is fragile, because sometimes we
+ * are not able to match sources/sinks/etc exactly. For example, if you want
+ * `echo ...;` to be a sink in PHP, you cannot omit the ';' as `echo` is not an
+ * expression. But in the IL, `echo` is represented as a `Call` instruction and
+ * the ';' is not part of the`iorig`.
+ *
+ * So, given a source/sink/etc specification, we check whether the spec matches
+ * any of the top-level nodes in the CFG (see 'IL.node_kind'). Given two matches,
+ * if one is contained inside the other, then we consider them the same match and
+ * we take the larger one as the canonical. We store the canonical matches in a
+ * 'Top_matches' data structure, and we use these "top matches" matches as a
+ * practical definition of what an "exact match" is.
+ *
+ * For example, if the sink specification is `echo ...;`, and the code we have is
+ * `echo $_GET['foo'];`, then this method will determine that `echo $_GET['foo']`
+ * is the best match we can get, and that becomes the definition of exact. Then,
+ * when we check whether an expression or instruction is a sink, if its range is a
+ * strict sub-range of one of these top matches, we simply disregard it (because it
+ * is not an exact match). In our example above the top sink match will be
+ * `sink(if tainted then ok1 else ok2)`, so we will disregard `tainted` as a sink
+ * because we know there is a better match.
+ *)
+module Top_matches = struct
+  (* For m, m' in S.t, not (m.range $<=$ m'.range) && not (m'.range $<=$ m.range) *)
+  module S = Set.Make (struct
+    type t = any
+
+    (* This compare function is subtle but it allows both `add` and `is_best_match`
+     * to be simple and quite efficient. *)
+    let compare (Any m1) (Any m2) =
+      let sink_id_cmp = String.compare m1.spec_id m2.spec_id in
+      if sink_id_cmp <> 0 then sink_id_cmp
+      else
+        (* If m1 is contained in m2 or vice-versa, then they are the *same* sink match.
+         * We only want to keep one match per sink, the best match! *)
+        let r1 = m1.range in
+        let r2 = m2.range in
+        if Range.(r1 $<=$ r2 || r2 $<=$ r1) then 0 else Stdlib.compare r1 r2
+  end)
+
+  type t = S.t
+
+  let empty = S.empty
+
+  let _debug xs =
+    xs |> S.elements
+    |> Common.map (fun (Any m) ->
+           m.spec_id ^ ":" ^ Range.content_at_range m.spec_pm.file m.range)
+    |> String.concat " ; "
+
+  let rec add (Any m' as x') top_matches =
+    (* We check if we have another match for the *same* source/sink/etc spec
+     * (i.e., same 'source_id'/'sink_id'/etc), and if so we must keep the
+     * best match and drop the other one. *)
+    match S.find_opt x' top_matches with
+    | None -> S.add x' top_matches
+    | Some (Any m as x) ->
+        let r = m.range in
+        let r' = m'.range in
+        (* Note that by `S`s definition, either `r` is contained in `r'` or vice-versa. *)
+        if r'.start > r.start || r'.end_ < r.end_ then
+          (* The new match is a worse fit so we keep the current one. *)
+          top_matches
+        else
+          (* We found a better (larger) match! *)
+          (* There may be several matches in `top_matches` that are subsumed by `m'`.
+           * E.g. we could have found sinks at ranges (1,5) and (6,10), and then
+           * we find that there is better sink match at range (1,10). This
+           * new larger match subsumes both (1,5) and (6, 10) matches.
+           * Thus, before we try adding `m'` to `top_matches`, we need to make sure
+           * that there is no other match `m` that is included in `m'`.
+           * Otherwise `m'` would be considered a duplicate and it would not
+           * be added (e.g., if we try adding the range (1,10) to a set that
+           * still contains the range (6,10), given our `compare` function above
+           * the (1,10) range will be considered a duplicate), hence the
+           * recursive call to `add` here. *)
+          add x' (S.remove x top_matches)
+
+  let is_best_match top_matches m' =
+    match S.find_opt (Any m') top_matches with
+    | None -> true
+    | Some (Any m) -> m.range =*= m'.range
+end
+
+let is_best_match = Top_matches.is_best_match
+
+let top_level_matches_in_nodes ~matches_of_orig flow =
+  (* We traverse the CFG and we check whether the top-level expressions match
+   * any taint specification. Those that do match a spec are potential
+   * "top-level matches". *)
+  (* TODO: This handles the common cases that people have more often complained
+   * about, it doesn't yet handle e.g. a sink specification like `sink([$SINK, ...])`
+   * (with `focus-metavariable: $SINK`), and code like `sink([ok1 if tainted else ok2])`.
+   * For that, we would need to visit subexpressions. *)
+  flow.CFG.reachable |> CFG.NodeiSet.to_seq
+  |> Seq.concat_map (fun ni ->
+         let origs_of_args args =
+           Seq.map (fun a -> (IL_helpers.exp_of_arg a).eorig) (List.to_seq args)
+         in
+         let node = flow.CFG.graph#nodes#assoc ni in
+         match node.IL.n with
+         | NInstr instr ->
+             let top_expr_origs : IL.orig Seq.t =
+               Seq.cons instr.iorig
+                 (match instr.i with
+                 | Call (_, c, args) -> Seq.cons c.eorig (origs_of_args args)
+                 | New (_, ty, _, args) ->
+                     let ty_origs =
+                       ty.exps |> List.to_seq |> Seq.map (fun e -> e.IL.eorig)
+                     in
+                     Seq.append ty_origs (origs_of_args args)
+                 | CallSpecial (_, _, args) -> origs_of_args args
+                 | Assign (_, e) -> List.to_seq [ e.eorig ]
+                 | AssignAnon _
+                 | FixmeInstr _ ->
+                     Seq.empty)
+             in
+             top_expr_origs |> Seq.concat_map (fun o -> matches_of_orig o)
+         | NCond (_, exp)
+         | NReturn (_, exp)
+         | NThrow (_, exp) ->
+             matches_of_orig exp.eorig
+         | Enter
+         | Exit
+         | TrueNode _
+         | FalseNode _
+         | Join
+         | NGoto _
+         | NLambda _
+         | NOther _
+         | NTodo _ ->
+             Seq.empty)
+  |> Seq.fold_left (fun s x -> Top_matches.add x s) Top_matches.empty

--- a/src/tainting/Taint_smatch.mli
+++ b/src/tainting/Taint_smatch.mli
@@ -1,0 +1,52 @@
+(** Taint spec-match(es)
+ *
+ * Matches of taint specifications (sources/propagators/sanitizers/sinks) *)
+
+type overlap = float
+(** A number in [0.0, 1.0], where 1.0 means that an AST node matches a taint spec
+ * perfectly. For example, if `foo(...)` is a source spec, `foo(x)` would be
+ * a perfect match, whereas the `x` in `foo(x)` would match the spec but loosely
+ * (see note on "Taint-tracking via ranges" in 'Match_tainting_mode'.)
+ *
+ * In practice we interpret >0.99 as being the same as 1.0, see 'is_exact'. *)
+
+type 'spec t = {
+  spec : 'spec;
+      (** The specification on which the match is based, e.g. a taint source.
+      * This spec should have a pattern formula. *)
+  spec_id : string;  (** See 'source_id' etc in 'Rule' and 'Parse_rule'. *)
+  spec_pm : Pattern_match.t;
+      (** What the spec's pattern formula actually matches in the target file. *)
+  range : Range.t;
+      (** The range of this particular match, which will be a subrange of 'spec_pm',
+      * see note on "Taint-tracking via ranges" in 'Match_tainting_mode.ml'. *)
+  overlap : overlap;
+      (** The overlap of this match ('range') with the spec match ('spec_pm'). *)
+}
+(** A match for a taint spec *)
+
+val is_exact : 'spec t -> bool
+(** An exact match, i.e. overlap 0.99. Typically useful for l-values. *)
+
+(** Any kind of spec-match (existential type). *)
+type any = Any : 'a t -> any
+
+(** In general we cannot guarantee truly exact (see 'is_exact') matches, e.g. some
+ * token may have been "lost" or something in the Generic-to-IL translation. Since
+ * we cannot rely on the 'overlap', we instead look for the "top-level" nodes in
+ * the CFG, and record whether they match any taint spec in this data structure.
+ * If one match is contained in another one, we only keep the _larges_ match.
+ * For example, given `foo(...)` then `foo(x)` will be recorded as a top-level
+ * match, whereas `foo` or `x` will not. *)
+module Top_matches : sig
+  type t
+
+  val _debug : t -> string
+end
+
+val is_best_match : Top_matches.t -> 'spec t -> bool
+(** Similar to 'is_exact' but based on "top matches". *)
+
+val top_level_matches_in_nodes :
+  matches_of_orig:(IL.orig -> any Seq.t) -> (IL.node, _) CFG.t -> Top_matches.t
+(** Collect the top-level matches in a CFG. *)

--- a/tests/rules/taint_exact_sanitizer.py
+++ b/tests/rules/taint_exact_sanitizer.py
@@ -1,0 +1,9 @@
+def yay_works():
+  decoded = baz(user_input)
+  # ruleid: missing
+  qux(decoded)
+
+def uh_oh():
+  decoded = baz(user_input)
+  # ruleid: missing
+  return foo.bar(qux(decoded))

--- a/tests/rules/taint_exact_sanitizer.py
+++ b/tests/rules/taint_exact_sanitizer.py
@@ -5,5 +5,7 @@ def yay_works():
 
 def uh_oh():
   decoded = baz(user_input)
+  # Because the sanitizer is "exact", the `decoded` is not considered sanitized
+  # as it would have normally been.
   # ruleid: missing
   return foo.bar(qux(decoded))

--- a/tests/rules/taint_exact_sanitizer.yaml
+++ b/tests/rules/taint_exact_sanitizer.yaml
@@ -5,6 +5,8 @@ rules:
       - pattern: user_input
     pattern-sanitizers:
       - exact: true
+        # Due to `exact: true`, only the output of `foo.bar()` will be considered
+        # as sanitized!
         pattern: foo.bar(...)
     pattern-sinks:
       - pattern: qux(...)

--- a/tests/rules/taint_exact_sanitizer.yaml
+++ b/tests/rules/taint_exact_sanitizer.yaml
@@ -1,0 +1,14 @@
+rules:
+  - id: missing
+    mode: taint
+    pattern-sources:
+      - pattern: user_input
+    pattern-sanitizers:
+      - exact: true
+        pattern: foo.bar(...)
+    pattern-sinks:
+      - pattern: qux(...)
+    message: Found unsafe potentially input thanks to taint mode!
+    languages:
+      - python
+    severity: WARNING

--- a/tests/rules/taint_exact_sources.py
+++ b/tests/rules/taint_exact_sources.py
@@ -10,13 +10,13 @@ def fn(params):
 def fn(params):
     params["sql"] = "select value from table where x = %s" % db_access.escape(
         params["test"]
-    )
+    ) # 'params' is sanitized here
     # ok: sql-injection
     db_access.mysql_dict(params)
 
 
 def fn(params):
-    params["sql"] = "select xyz from table"
+    params["sql"] = "select xyz from table" # 'params' is sanitized here
     # ok: sql-injection
     results = db_access.mysql_dict(params)
 
@@ -32,7 +32,7 @@ def fn(params):
 
 
 def fn(params):
-    params["name"] = "test"
+    params["name"] = "test" # 'params' is sanitized here
     params["sql"] = "select * from params where name = %(name)s" % params
     # ok: sql-injection
     db_access.mysql_update(params)
@@ -48,8 +48,11 @@ def fn(params):
 
 def fn(params):
     alt = params
-    params['name'] = 'x'
+    params['name'] = 'x' # 'params' is sanitized here
     params["sql"] = "select * from params where name = %(name)s" % alt
+    # but then is tainted again here ^^^
+    # note that we do not curretly understand that `alt` is an alias (rather than
+    # a copy) of `params`.
     # todook: sql-injection
     db_access.mysql_update(params)
 

--- a/tests/rules/taint_exact_sources.py
+++ b/tests/rules/taint_exact_sources.py
@@ -1,0 +1,63 @@
+from framework import db_access
+
+
+def fn(params):
+    params["sql"] = "select value from table where x = %s" % params["test"]
+    # ruleid: sql-injection
+    db_access.mysql_dict(params)
+
+
+def fn(params):
+    params["sql"] = "select value from table where x = %s" % db_access.escape(
+        params["test"]
+    )
+    # ok: sql-injection
+    db_access.mysql_dict(params)
+
+
+def fn(params):
+    params["sql"] = "select xyz from table"
+    # ok: sql-injection
+    results = db_access.mysql_dict(params)
+
+    # Just testing source/sink match here, accurate code is below in the for loop
+    params["sql"] = "delete from table2 where field = %s" % results
+    # ruleid: sql-injection
+    db_access.mysql_update(params)
+
+    for res in results:
+        params["sql"] = "delete from table2 where field = %s" % res["xyz"]
+        # ruleid: sql-injection
+        db_access.mysql_update(params)
+
+
+def fn(params):
+    params["name"] = "test"
+    params["sql"] = "select * from params where name = %(name)s" % params
+    # ok: sql-injection
+    db_access.mysql_update(params)
+
+
+def fn(params):
+    alt = params
+
+    params["sql"] = "select * from params where name = %(name)s" % alt
+    # ruleid: sql-injection
+    db_access.mysql_update(params)
+
+
+def fn(params):
+    alt = params
+    params['name'] = 'x'
+    params["sql"] = "select * from params where name = %(name)s" % alt
+    # todook: sql-injection
+    db_access.mysql_update(params)
+
+
+def fn(params):
+    alt = params.copy()
+    params['name'] = 'x'
+
+    params["sql"] = "select * from params where name = %(name)s" % alt
+    # ruleid: sql-injection
+    db_access.mysql_update(params)

--- a/tests/rules/taint_exact_sources.yaml
+++ b/tests/rules/taint_exact_sources.yaml
@@ -12,6 +12,10 @@ rules:
                 ...
           - focus-metavariable: $PARAMS
       - exact: true
+        # By using `exact: true`, `framework.db_access.mysql_dict(safe)` will not
+        # constitute a finding, because `safe` will not be considered a source.
+        # Only the "exact" match of the source specification, that is, the entire
+        # `framework.db_access.mysql_dict(safe)` expression will be a source.
         pattern: framework.db_access.mysql_dict(...)
     pattern-sinks:
       - patterns:

--- a/tests/rules/taint_exact_sources.yaml
+++ b/tests/rules/taint_exact_sources.yaml
@@ -1,0 +1,26 @@
+rules:
+  - id: sql-injection
+    message: Semgrep found a match
+    languages:
+      - python
+    severity: WARNING
+    mode: taint
+    pattern-sources:
+      - patterns:
+          - pattern: |
+              def $FN(..., $PARAMS, ...):
+                ...
+          - focus-metavariable: $PARAMS
+      - exact: true
+        pattern: framework.db_access.mysql_dict(...)
+    pattern-sinks:
+      - patterns:
+          - pattern-either:
+              - pattern: framework.db_access.mysql_dict($SINK)
+              - pattern: framework.db_access.mysql_update($SINK)
+          - focus-metavariable: $SINK
+    pattern-sanitizers:
+      - by-side-effect: true
+        patterns:
+          - pattern: framework.db_access.escape($INPUT)
+          - focus-metavariable: $INPUT

--- a/tests/rules/taint_param_default.yaml
+++ b/tests/rules/taint_param_default.yaml
@@ -5,6 +5,8 @@ rules:
     mode: taint
     pattern-sources:
       - patterns:
+          - pattern-inside: >
+              "..."
           - pattern: $URL
           - metavariable-pattern:
               metavariable: $URL


### PR DESCRIPTION
This option makes the identification of sources (sanitizers) stricter, or more precise, similar to what we already do for sinks. But it appears that many rules rely on the "non-exact" semantics of sources (sanitizers), so for now we keep the default as it was.

Related-to: 4020470dd7c ("tainting: Make identification of sinks more precise (#7215)")

Closes #5897
Closes PA-1752

test plan:
make test # new tests

