### PR TITLE
fix: link C# definitions with later initializations

### DIFF
--- a/src/naming/Naming_AST.ml
+++ b/src/naming/Naming_AST.ml
@@ -388,6 +388,7 @@ let is_resolvable_name_ctx env lang =
       | Lang.Java
       | Lang.Kotlin
       | Lang.Apex
+      | Lang.Csharp
       (* true for JS/TS so that we can resolve class methods *)
       | Lang.Js
       | Lang.Ts
@@ -408,6 +409,7 @@ let resolved_name_kind env lang =
       | Lang.Java
       | Lang.Kotlin
       | Lang.Apex
+      | Lang.Csharp
       (* true for JS/TS to resolve class methods. *)
       | Lang.Js
       | Lang.Ts

--- a/tests/patterns/csharp/decl_before_init.cs
+++ b/tests/patterns/csharp/decl_before_init.cs
@@ -19,8 +19,8 @@ public class HomeCtrl : Controller
     }
 
     public string Something2(string value) {
-      // MATCH: 
       IFoobar _foobar2 = getFoobar();
+      // MATCH: 
       return _foobar2.Find(value);
     }
 

--- a/tests/patterns/csharp/decl_before_init.cs
+++ b/tests/patterns/csharp/decl_before_init.cs
@@ -1,0 +1,28 @@
+using System.Diagnostics;
+using Microsoft.AspNetCore.Mvc;
+
+namespace MvcMovie.Controllers;
+
+public class HomeCtrl : Controller
+{
+
+    private readonly IFoobar _foobar;
+
+    public HomeCtrl()
+    {
+        _foobar = getFoobar();
+    }
+
+    public string Something1(string value) {
+      // MATCH: 
+      return _foobar.Find(value);
+    }
+
+    public string Something2(string value) {
+      // MATCH: 
+      IFoobar _foobar2 = getFoobar();
+      return _foobar2.Find(value);
+    }
+
+}
+

--- a/tests/patterns/csharp/decl_before_init.sgrep
+++ b/tests/patterns/csharp/decl_before_init.sgrep
@@ -1,0 +1,1 @@
+(IFoobar $F).Find(...)


### PR DESCRIPTION
C# is like Java in that fields can be defined at the top of a class. Support this.

Test plan: see added tests

