### PR TITLE
Fix Tok.end_pos_of_loc to handle trailing newlines

### DIFF
--- a/changelog.d/lang-18.fixed
+++ b/changelog.d/lang-18.fixed
@@ -1,6 +1,6 @@
 Fixed how the end positions assigned to metavariable bindings are computed, in
 order to handle trailing newlines. This affected Semgrep's JSON output. If a
-metafariable `$X` was bound to a piece of text containing a trailing newline,
+metavariable `$X` was bound to a piece of text containing a trailing newline,
 such as "a\n", where the starting position was e.g. at line 1, Semgrep reported
 that the end position was at line 2, when in fact the text is entirely within
 line 1. If the text happened to be at the end of a file, Semgrep could report

--- a/changelog.d/lang-18.fixed
+++ b/changelog.d/lang-18.fixed
@@ -1,7 +1,7 @@
-Fixed how the end positions assigned to metavariable bindings are computed to
-handle trailing newlines. This affected Semgrep's JSON output. If a metafariable
-`$X` was bound to a piece of text containing a trailing newline, such as "a\n",
-where the starting position was at line 1, Semgrep reported that the end position
-was at line 2, when it fact the text is entirely within line 1. If the text
-happened to be at the end of a file, Semgrep could report an end position that
-was outside the bounds of the file.
+Fixed how the end positions assigned to metavariable bindings are computed, in
+order to handle trailing newlines. This affected Semgrep's JSON output. If a
+metafariable `$X` was bound to a piece of text containing a trailing newline,
+such as "a\n", where the starting position was e.g. at line 1, Semgrep reported
+that the end position was at line 2, when in fact the text is entirely within
+line 1. If the text happened to be at the end of a file, Semgrep could report
+an end position that was outside the bounds of the file.

--- a/changelog.d/lang-18.fixed
+++ b/changelog.d/lang-18.fixed
@@ -1,0 +1,7 @@
+Fixed how the end positions assigned to metavariable bindings are computed to
+handle trailing newlines. This affected Semgrep's JSON output. If a metafariable
+`$X` was bound to a piece of text containing a trailing newline, such as "a\n",
+where the starting position was at line 1, Semgrep reported that the end position
+was at line 2, when it fact the text is entirely within line 1. If the text
+happened to be at the end of a file, Semgrep could report an end position that
+was outside the bounds of the file.

--- a/cli/tests/e2e/snapshots/test_check/test_multiline/results.json
+++ b/cli/tests/e2e/snapshots/test_check/test_multiline/results.json
@@ -78,8 +78,8 @@
           "$MULTILINE": {
             "abstract_content": "\n    abc\n    def\n",
             "end": {
-              "col": 1,
-              "line": 14,
+              "col": 9,
+              "line": 13,
               "offset": 245
             },
             "start": {

--- a/cli/tests/e2e/snapshots/test_metavariable_pattern/test1/results.json
+++ b/cli/tests/e2e/snapshots/test_metavariable_pattern/test1/results.json
@@ -68,8 +68,8 @@
           "$SHELL": {
             "abstract_content": "\n          if ${{ steps.pss.outcome=='failure' }}; then FAILED=pss; fi\n          if ${{ steps.soc.outcome=='failure' }}; then FAILED=soc; fi\n          if ${{ steps.pushsync-chunks-1.outcome=='failure' }}; then FAILED=pushsync-chunks-1; fi\n          if ${{ steps.pushsync-chunks-2.outcome=='failure' }}; then FAILED=pushsync-chunks-2; fi\n          if ${{ steps.retrieval.outcome=='failure' }}; then FAILED=retrieval; fi\n          if ${{ steps.manifest.outcome=='failure' }}; then FAILED=manifest; fi\n          if ${{ steps.content-availability.outcome=='failure' }}; then FAILED=content-availability; fi\n          curl -sSf -X POST -H \"Content-Type: application/json\" -d \"{\\\"text\\\": \\\"**${RUN_TYPE}** Test Error\\nBranch: \\`${{ github.head_ref }}\\`\\nUser: @${{ github.event.pull_request.user.login }}\\nDebugging artifacts: [click](https://$BUCKET_NAME.$AWS_ENDPOINT/artifacts_$VERTAG.tar.gz)\\nStep failed: \\`${FAILED}\\`\\\"}\" https://foobar.test.org/hooks/${{ secrets.TUNSHELL_KEY }}\n",
             "end": {
-              "col": 1,
-              "line": 16,
+              "col": 378,
+              "line": 15,
               "offset": 1093
             },
             "start": {

--- a/cli/tests/e2e/snapshots/test_output/test_yaml_metavariables/report.json
+++ b/cli/tests/e2e/snapshots/test_output/test_yaml_metavariables/report.json
@@ -102,8 +102,8 @@
           "$VALUE": {
             "abstract_content": "\n    three\n",
             "end": {
-              "col": 1,
-              "line": 5,
+              "col": 11,
+              "line": 4,
               "offset": 45
             },
             "start": {
@@ -141,8 +141,8 @@
           "$VALUE": {
             "abstract_content": "\n   four\n",
             "end": {
-              "col": 1,
-              "line": 7,
+              "col": 9,
+              "line": 6,
               "offset": 62
             },
             "start": {
@@ -180,8 +180,8 @@
           "$VALUE": {
             "abstract_content": "       \n    fi\n\n    ve\n",
             "end": {
-              "col": 1,
-              "line": 11,
+              "col": 8,
+              "line": 10,
               "offset": 93
             },
             "start": {
@@ -219,8 +219,8 @@
           "$VALUE": {
             "abstract_content": "\n    si\n\n      x\n    \n",
             "end": {
-              "col": 1,
-              "line": 16,
+              "col": 6,
+              "line": 15,
               "offset": 123
             },
             "start": {
@@ -258,8 +258,8 @@
           "$VALUE": {
             "abstract_content": "\n    seven\n",
             "end": {
-              "col": 1,
-              "line": 18,
+              "col": 11,
+              "line": 17,
               "offset": 142
             },
             "start": {

--- a/libs/lib_parsing/Tok.ml
+++ b/libs/lib_parsing/Tok.ml
@@ -242,14 +242,21 @@ let content_of_tok_opt ii =
    inspecting the contents of the token, plus the start information.
 *)
 let end_pos_of_loc loc =
-  let line, col =
+  let line, col, trailing_nl =
     String.fold_left
-      (fun (line, col) c ->
+      (fun (line, col, after_nl) c ->
         match c with
-        | '\n' -> (line + 1, 0)
-        | _ -> (line, col + 1))
-      (loc.pos.line, loc.pos.column)
+        | '\n' when after_nl -> (line + 1, 0, true)
+        | '\n' -> (line, col, true)
+        | _ when after_nl -> (line + 1, 1, false)
+        | _ -> (line, col + 1, false))
+      (loc.pos.line, loc.pos.column, false)
       loc.str
+  in
+  let col =
+    (* THINK: We count a trailing newline as an extra character in the last line,
+     * is that the standard ? *)
+    if trailing_nl then col + 1 else col
   in
   (line, col, loc.pos.bytepos + String.length loc.str)
 

--- a/libs/lib_parsing/Unit_tok.ml
+++ b/libs/lib_parsing/Unit_tok.ml
@@ -1,0 +1,24 @@
+(*
+   Unit tests for Tok
+*)
+
+let test_end_pos_of_loc () =
+  let test ~str ~start ~expected =
+    let line, column, bytepos = start in
+    let expected_line, expected_col, expected_charpos = expected in
+    let loc : Tok.location =
+      { str; pos = { bytepos; line; column; file = "test.txt" } }
+    in
+    let line, col, charpos = Tok.end_pos_of_loc loc in
+    assert (line = expected_line);
+    assert (col = expected_col);
+    assert (charpos = expected_charpos)
+  in
+  test ~str:"a" ~start:(1, 0, 0) ~expected:(1, 1, 1);
+  test ~str:"a\n" ~start:(1, 0, 0) ~expected:(1, 2, 2);
+  test ~str:"a\nb" ~start:(1, 0, 0) ~expected:(2, 1, 3);
+  test ~str:"a\n\n" ~start:(1, 0, 0) ~expected:(2, 1, 3);
+  test ~str:"\n    line1\n    line2\n" ~start:(2, 11, 17) ~expected:(4, 10, 38)
+
+let tests =
+  Testutil.pack_tests "tok" [ ("end_pos_of_loc", test_end_pos_of_loc) ]

--- a/src/tests/Test.ml
+++ b/src/tests/Test.ml
@@ -52,6 +52,7 @@ let tests () =
       Unit_guess_lang.tests;
       Unit_memory_limit.tests;
       Unit_SPcre.tests;
+      Unit_tok.tests;
       Unit_regexp_engine.tests;
       Unit_Rpath.tests;
       Unit_immutable_buffer.tests;


### PR DESCRIPTION
If there was a trailing newline, we were counting one line too much.

Closes LANG-18

test plan:
make test # see Unit_tok.ml
Also, run LANG-18's example.

