### PR TITLE
fix(tests): Disable HTTP tests

### DIFF
--- a/src/tests/Test.ml
+++ b/src/tests/Test.ml
@@ -74,7 +74,9 @@ let tests () =
       Unit_LS.tests;
       Unit_Login.tests;
       Unit_Fetching.tests;
-      Unit_Networking.tests;
+      (* Networking tests disabled as they will get rate limited sometimes *)
+      (* And the SSL issues they've been testing have been stable *)
+      (*Unit_Networking.tests;*)
       Test_LS_e2e.tests;
       (* End OSemgrep tests *)
       Aliengrep.Unit_tests.tests;


### PR DESCRIPTION
The unit HTTP tests fail sometimes, because they would get rate limited. I'm ok disabling them as it seems we haven't been running into SSL issues. Not deleting the tests in case we need to bring them back though.