### PR TITLE
fix: Better error message when semgrep-core-proprietary is missing

### DIFF
--- a/cli/src/semgrep/core_runner.py
+++ b/cli/src/semgrep/core_runner.py
@@ -727,7 +727,29 @@ class CoreRunner:
             )
 
         with exit_stack:
+            if self._binary_path is None:
+                if engine.is_pro:
+                    logger.error(
+                        f"""
+Semgrep Pro is either uninstalled or it is out of date.
+
+Try installing Semgrep Pro (`semgrep install-semgrep-pro`).
+                        """
+                    )
+                else:
+                    # This really shouldn't happen, but let's cover our bases
+                    logger.error(
+                        f"""
+Could not find the semgrep-core executable. Your Semgrep install is likely corrupted. Please uninstall Semgrep and try again.
+                        """
+                    )
+                sys.exit(2)
             cmd = [
+                # bugfix: self._binary_path is an Optional[Path]. The
+                # recommended way to convert a Path to a string is to use the
+                # str function. However, mypy allows the use of str to convert
+                # Optional values to strings. Make sure to check against None
+                # even though mypy won't warn you.
                 str(self._binary_path),
                 "-json",
             ]


### PR DESCRIPTION
I noticed when testing #9033 that with `--legacy`, which always uses pysemgrep rather than osemgrep, we got bad error messages when running `semgrep scan --pro` without the Pro Engine already installed:

```
Semgrep Pro crashed during execution (unknown reason).
This can sometimes happen because either Semgrep Pro or Semgrep is out of date.

Try updating your version of Semgrep Pro (`semgrep install-semgrep-pro`) or your version of Semgrep (`pip install semgrep/brew install semgrep`).
If both are up-to-date and the crash persists, please contact support to report an issue!
When reporting the issue, please re-run the semgrep command with the
`--debug` flag so as to print more details about what happened, if you can.

Exception raised: `[Errno 2] No such file or directory: 'None'`
```

My PR did not introduce this error message, but it did make it so that we would get it (instead of a different crash message) when `semgrep-core-proprietary` was out of date.

Several people reported encountering this problem without specifying `--legacy`. I don't know how to reproduce the error without `--legacy`, but regardless this should solve the problem.

As noted inline, mypy could not catch this.

Test plan:

At the root of this repository, run `semgrep scan --pro --legacy` without having `semgrep-core-proprietary` installed. Before this change, observe the error message included in the summary above.

After this change, observe that the output ends with:

```
Semgrep Pro is either uninstalled or it is out of date.

Try installing Semgrep Pro (`semgrep install-semgrep-pro`).
```

Then, run `semgrep install-semgrep-pro` and retry the scan. It passes.

Then, navigate to the location where `semgrep-core-proprietary` is installed and change the version in `pro-installed-by.txt`. Try the scan again and observe the same error message as when the engine is not installed.

I was not able to trigger the error message I added for if `semgrep-core` is missing. When I deleted `semgrep-core` from my install, I got an error from some earlier code.

