### PR TITLE
Fix --severity regression

### DIFF
--- a/changelog.d/gh-9062.fixed
+++ b/changelog.d/gh-9062.fixed
@@ -1,0 +1,1 @@
+The --severity=XXX scan flag is working again.

--- a/cli/src/semgrep/run_scan.py
+++ b/cli/src/semgrep/run_scan.py
@@ -404,7 +404,9 @@ def run_scan(
         filtered_rules = all_rules
     else:
         shown_severities = {out.MatchSeverity.from_json(s) for s in severity}
-        filtered_rules = [rule for rule in all_rules if rule.severity.value in severity]
+        filtered_rules = [
+            rule for rule in all_rules if rule.severity in shown_severities
+        ]
     filtered_rules = filter_exclude_rule(filtered_rules, exclude_rule)
 
     output_handler.handle_semgrep_errors(config_errors)

--- a/cli/tests/e2e/snapshots/test_severity/test_severity_error/results.json
+++ b/cli/tests/e2e/snapshots/test_severity/test_severity_error/results.json
@@ -1,0 +1,126 @@
+{
+  "errors": [],
+  "paths": {
+    "scanned": [
+      "targets/basic/inside.py",
+      "targets/basic/metavariable-comparison-bad-content.py",
+      "targets/basic/metavariable-comparison-base.py",
+      "targets/basic/metavariable-comparison-strip.py",
+      "targets/basic/metavariable-comparison.py",
+      "targets/basic/metavariable-regex-multi-regex.py",
+      "targets/basic/metavariable-regex-multi-rule.py",
+      "targets/basic/metavariable-regex.py",
+      "targets/basic/nosem.py",
+      "targets/basic/regex.py",
+      "targets/basic/stupid.py"
+    ]
+  },
+  "results": [
+    {
+      "check_id": "rules.open-from-request",
+      "end": {
+        "col": 15,
+        "line": 4,
+        "offset": 96
+      },
+      "extra": {
+        "engine_kind": "OSS",
+        "fingerprint": "0x42",
+        "is_ignored": false,
+        "lines": "    open(path)",
+        "message": "Unsafe open from request data",
+        "metadata": {},
+        "metavars": {
+          "$X": {
+            "abstract_content": "path",
+            "end": {
+              "col": 14,
+              "line": 4,
+              "offset": 95
+            },
+            "propagated_value": {
+              "svalue_abstract_content": "request.get(\"unsafe\")",
+              "svalue_end": {
+                "col": 33,
+                "line": 3,
+                "offset": 81
+              },
+              "svalue_start": {
+                "col": 12,
+                "line": 3,
+                "offset": 60
+              }
+            },
+            "start": {
+              "col": 10,
+              "line": 4,
+              "offset": 91
+            }
+          }
+        },
+        "severity": "ERROR",
+        "validation_state": "NO_VALIDATOR"
+      },
+      "path": "targets/basic/inside.py",
+      "start": {
+        "col": 5,
+        "line": 4,
+        "offset": 86
+      }
+    },
+    {
+      "check_id": "rules.open-from-request",
+      "end": {
+        "col": 12,
+        "line": 14,
+        "offset": 262
+      },
+      "extra": {
+        "engine_kind": "OSS",
+        "fingerprint": "0x42",
+        "is_ignored": false,
+        "lines": "    open(z)",
+        "message": "Unsafe open from request data",
+        "metadata": {},
+        "metavars": {
+          "$X": {
+            "abstract_content": "z",
+            "end": {
+              "col": 11,
+              "line": 14,
+              "offset": 261
+            },
+            "propagated_value": {
+              "svalue_abstract_content": "request.get(\"unsafe\")",
+              "svalue_end": {
+                "col": 26,
+                "line": 12,
+                "offset": 239
+              },
+              "svalue_start": {
+                "col": 5,
+                "line": 12,
+                "offset": 218
+              }
+            },
+            "start": {
+              "col": 10,
+              "line": 14,
+              "offset": 260
+            }
+          }
+        },
+        "severity": "ERROR",
+        "validation_state": "NO_VALIDATOR"
+      },
+      "path": "targets/basic/inside.py",
+      "start": {
+        "col": 5,
+        "line": 14,
+        "offset": 255
+      }
+    }
+  ],
+  "skipped_rules": [],
+  "version": "0.42"
+}

--- a/cli/tests/e2e/test_severity.py
+++ b/cli/tests/e2e/test_severity.py
@@ -10,6 +10,7 @@ def test_severity_error(run_semgrep_in_tmp: RunSemgrep, snapshot):
     assert json_str != ""
     assert '"severity": "INFO"' not in json_str
     assert '"severity": "WARNING"' not in json_str
+    snapshot.assert_match(json_str, "results.json")
 
 
 @pytest.mark.kinda_slow


### PR DESCRIPTION
This closes #9062

The regression was introduced in #8958 when switching
from Enum to ATD-defined MatchSeverity in semgrep_output_v1.atd
Not sure why mypy didn't complain about the
  `rule.severity.value in severity`
where we compare a MatchSeverity and a string.

Note that osemgrep --severity was working!

Anyway, this is fixed now.

test plan:
added test in test_severity.py
'make e2e'.