### PR TITLE
Fix --sarif in the presence of errors

### DIFF
--- a/changelog.d/gh-9091.fixed
+++ b/changelog.d/gh-9091.fixed
@@ -1,0 +1,2 @@
+The --sarif does not crash when semgrep itself encountered errors
+while processing targets.

--- a/cli/src/semgrep/error.py
+++ b/cli/src/semgrep/error.py
@@ -96,7 +96,8 @@ class SemgrepError(Exception):
         return f"{level_tag} {self}"
 
 
-# used in text output and currently stored in our metrics payload.errors.errors
+# used in text and sarif output, and currently also stored in our metrics
+# payload.errors.errors
 def error_type_string(type_: out.ErrorType) -> str:
     # convert to the same string of out.ParseError for now
     if isinstance(type_.value, out.PartialParsing):

--- a/cli/src/semgrep/formatter/sarif.py
+++ b/cli/src/semgrep/formatter/sarif.py
@@ -8,6 +8,7 @@ from typing import Sequence
 
 import semgrep.semgrep_interfaces.semgrep_output_v1 as out
 from semgrep import __VERSION__
+from semgrep.error import error_type_string
 from semgrep.error import SemgrepError
 from semgrep.formatter.base import BaseFormatter
 from semgrep.rule import Rule
@@ -367,7 +368,7 @@ class SarifFormatter(BaseFormatter):
     @staticmethod
     def _semgrep_error_to_sarif_notification(error: SemgrepError) -> Mapping[str, Any]:
         cli_error = error.to_CliError()
-        descriptor = cli_error.type_
+        descriptor: str = error_type_string(cli_error.type_)
 
         error_to_sarif_level = {
             out.Error_(): "error",

--- a/cli/tests/e2e/snapshots/test_output/test_sarif_output_when_errors/results.sarif
+++ b/cli/tests/e2e/snapshots/test_output/test_sarif_output_when_errors/results.sarif
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://docs.oasis-open.org/sarif/sarif/v2.1.0/os/schemas/sarif-schema-2.1.0.json",
+  "runs": [
+    {
+      "invocations": [
+        {
+          "executionSuccessful": true,
+          "toolExecutionNotifications": [
+            {
+              "descriptor": {
+                "id": "SemgrepError"
+              },
+              "level": "error",
+              "message": {
+                "text": "File not found: targets/basic/inexistent.py"
+              }
+            }
+          ]
+        }
+      ],
+      "results": [],
+      "tool": {
+        "driver": {
+          "name": "semgrep",
+          "rules": [],
+          "semanticVersion": "placeholder"
+        }
+      }
+    }
+  ],
+  "version": "2.1.0"
+}

--- a/cli/tests/e2e/test_output.py
+++ b/cli/tests/e2e/test_output.py
@@ -382,6 +382,20 @@ def test_sarif_output_with_dataflow_traces(run_semgrep_in_tmp: RunSemgrep, snaps
 
 @pytest.mark.kinda_slow
 @pytest.mark.osemfail
+def test_sarif_output_when_errors(run_semgrep_in_tmp: RunSemgrep, snapshot):
+    snapshot.assert_match(
+        run_semgrep_in_tmp(
+            "rules/eqeq.yaml",
+            target_name="basic/inexistent.py",
+            output_format=OutputFormat.SARIF,
+            assert_exit_code=2,
+        ).stdout,
+        "results.sarif",
+    )
+
+
+@pytest.mark.kinda_slow
+@pytest.mark.osemfail
 def test_json_output_with_dataflow_traces(run_semgrep_in_tmp: RunSemgrep, snapshot):
     snapshot.assert_match(
         run_semgrep_in_tmp(


### PR DESCRIPTION
This closes #9091

The regression was introduced in #8988 when
we switched the representation of an error type in
semgrep_output_v1.atd

Mypy didn't spot the error because we didn't use types in
sarif.py to constrain descriptor, and we are using
untyped dictionary all over the place in sarif.py instead
of using proper schema.

test plan:
test file included

make e2e