### PR TITLE
Add 'make pro' for checking compatibility with semgrep-pro

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -195,3 +195,6 @@ bin
 
 # Artifacts from CI
 **/scripts/release/release_body.txt
+
+# Personal symlink to semgrep-proprietary used by 'make pro'
+semgrep-proprietary

--- a/.github/workflows/pr-checklist.yaml
+++ b/.github/workflows/pr-checklist.yaml
@@ -51,7 +51,7 @@ jobs:
 
             - [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
             - [ ] Tests included or PR comment includes a reproducible test plan
-            - [ ] Change was tested with Pro (point Pro's semgrep dependency to this branch and run `make test`, no need to open a Pro PR if it works)
+            - [ ] Change was tested with Pro: run `make pro` (if you have access to the semgrep-proprietary repo)
             - [ ] Documentation is up-to-date
             - [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
             - [ ] Change has no security implications (otherwise, ping security team)

--- a/.gitignore
+++ b/.gitignore
@@ -194,3 +194,6 @@ act/
 
 # Artifacts from CI
 scripts/release/release_body.txt
+
+# Personal symlink to semgrep-proprietary used by 'make pro'
+/semgrep-proprietary

--- a/Makefile
+++ b/Makefile
@@ -225,6 +225,25 @@ core-test-e2e:
 test-jsoo: build-semgrep-jsoo-debug
 	$(MAKE) -C js test
 
+# Test the compatibility with the main branch of semgrep-proprietary
+# in a separate work tree.
+.PHONY: pro
+pro:
+	test -L semgrep-proprietary || ln -s ../semgrep-proprietary .
+	@if ! test -e semgrep-proprietary; then \
+	  echo "** Please fix the symlink 'semgrep-proprietary'."; \
+	  echo "** Make it point to your semgrep-proprietary repo."; \
+	  exit 1; \
+	fi
+	set -eu && \
+	worktree_parent=$$(pwd)/.. && \
+	commit=$$(git rev-parse --short HEAD) && \
+	cd semgrep-proprietary && \
+	./scripts/check-compatibility \
+	  --worktree "$$worktree_parent"/semgrep-pro-compat \
+	  --semgrep-commit "$$commit" \
+	  --pro-commit origin/develop
+
 ###############################################################################
 # External dependencies installation targets
 ###############################################################################


### PR DESCRIPTION
`make pro` checks the compatibility of the current version of semgrep against semgrep-proprietary/develop. The same exists in the semgrep-proprietary repo where it's called `make compat` (https://github.com/returntocorp/semgrep-proprietary/pull/1097).  Maybe both should be called `make compat`?

I also updated the PR checkbox which is now:
> - [ ] Change was tested with Pro: run `make pro` (if you have access to the semgrep-proprietary repo)

^ but anyway, this checkbox will be removed shortly when https://github.com/returntocorp/semgrep/pull/9107 gets merged.

Test plan: Run `make pro`, fix the symlink as prompted if necessary.
