### PR TITLE
hardcode docker image name to returntocorp/semgrep

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,7 +102,7 @@ jobs:
         type=semver,pattern={{version}}
         # tag image with major.minor (ex. "1.2")
         type=semver,pattern={{major}}.{{minor}}
-      repository-name: ${{ github.repository }}
+      repository-name: returntocorp/semgrep
       artifact-name: image-release
       file: Dockerfile
       target: semgrep-cli
@@ -128,7 +128,7 @@ jobs:
         type=semver,pattern={{version}}
         # tag image with major.minor version (ex. "1.2-nonroot")
         type=semver,pattern={{major}}.{{minor}}
-      repository-name: ${{ github.repository }}
+      repository-name: returntocorp/semgrep
       artifact-name: image-release-nonroot
       file: Dockerfile
       target: nonroot
@@ -178,7 +178,7 @@ jobs:
     secrets: inherit
     with:
       artifact-name: image-release
-      repository-name: ${{ github.repository }}
+      repository-name: returntocorp/semgrep
       dry-run: ${{ needs.inputs.outputs.dry-run == 'true' }}
 
   push-docker-nonroot:
@@ -187,7 +187,7 @@ jobs:
     secrets: inherit
     with:
       artifact-name: image-release-nonroot
-      repository-name: ${{ github.repository }}
+      repository-name: returntocorp/semgrep
       dry-run: ${{ needs.inputs.outputs.dry-run == 'true' }}
 
   upload-wheels:

--- a/.github/workflows/tests.jsonnet
+++ b/.github/workflows/tests.jsonnet
@@ -11,6 +11,8 @@ local semgrep = import 'libs/semgrep.libsonnet';
 // some jobs rely on artifacts produced by this workflow
 local core_x86 = import 'build-test-core-x86.jsonnet';
 
+local docker_repository_name = 'returntocorp/semgrep';
+
 // ----------------------------------------------------------------------------
 // Helpers
 // ----------------------------------------------------------------------------
@@ -420,7 +422,7 @@ local build_test_docker_job = {
     'docker-tags': docker_tags,
     // ??
     'artifact-name': 'image-test',
-    'repository-name': '${{ github.repository }}',
+    'repository-name': docker_repository_name,
     file: 'Dockerfile',
     // see the Dockerfile, this is the name root variant
     target: 'semgrep-cli',
@@ -444,7 +446,7 @@ local build_test_docker_nonroot_job = {
     |||,
     'docker-tags': docker_tags,
     'artifact-name': 'image-test-nonroot',
-    'repository-name': '${{ github.repository }}',
+    'repository-name': docker_repository_name,
     file: 'Dockerfile',
     // see the Dockerfile, this is the name of the nonroot variant
     target: 'nonroot',
@@ -465,7 +467,7 @@ local push_docker_job = {
   secrets: 'inherit',
   with: {
     'artifact-name': 'image-test',
-    'repository-name': '${{ github.repository }}',
+    'repository-name': docker_repository_name,
     'dry-run': false,
   },
 };
@@ -479,7 +481,7 @@ local push_docker_nonroot_job = {
   secrets: 'inherit',
   with: {
     'artifact-name': 'image-test-nonroot',
-    'repository-name': '${{ github.repository }}',
+    'repository-name': docker_repository_name,
     'dry-run': false,
   },
 };
@@ -498,7 +500,7 @@ local test_semgrep_pro_job = {
   secrets: 'inherit',
   with: {
     'artifact-name': 'image-test',
-    'repository-name': '${{ github.repository }}',
+    'repository-name': docker_repository_name,
   },
 };
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -241,7 +241,7 @@ jobs:
       docker-tags: "\n  type=semver,pattern={{version}}\n  type=semver,pattern={{major}}.{{minor}}\n
         \ type=ref,event=pr\n  type=ref,event=branch\n  type=sha,event=branch\n  type=edge\n"
       artifact-name: image-test
-      repository-name: ${{ github.repository }}
+      repository-name: returntocorp/semgrep
       file: Dockerfile
       target: semgrep-cli
       enable-tests: true
@@ -254,7 +254,7 @@ jobs:
     secrets: inherit
     with:
       artifact-name: image-test
-      repository-name: ${{ github.repository }}
+      repository-name: returntocorp/semgrep
       dry-run: false
   build-test-docker-nonroot:
     needs:
@@ -266,7 +266,7 @@ jobs:
       docker-tags: "\n  type=semver,pattern={{version}}\n  type=semver,pattern={{major}}.{{minor}}\n
         \ type=ref,event=pr\n  type=ref,event=branch\n  type=sha,event=branch\n  type=edge\n"
       artifact-name: image-test-nonroot
-      repository-name: ${{ github.repository }}
+      repository-name: returntocorp/semgrep
       file: Dockerfile
       target: nonroot
       enable-tests: false
@@ -279,7 +279,7 @@ jobs:
     secrets: inherit
     with:
       artifact-name: image-test-nonroot
-      repository-name: ${{ github.repository }}
+      repository-name: returntocorp/semgrep
       dry-run: false
   test-semgrep-pro:
     needs:
@@ -291,7 +291,7 @@ jobs:
     secrets: inherit
     with:
       artifact-name: image-test
-      repository-name: ${{ github.repository }}
+      repository-name: returntocorp/semgrep
   build-test-core-x86:
     uses: ./.github/workflows/build-test-core-x86.yml
     secrets: inherit


### PR DESCRIPTION
We base our docker image name off of the repo name, which bit us when the GitHub org got renamed from `returntocorp` to `semgrep`. This PR hardcodes our docker image name to `returntocorp/semgrep`.