### PR TITLE
fix(js): emit `CliOutput` instead of `CoreOutput`

### DIFF
--- a/js/engine/Main.ml
+++ b/js/engine/Main.ml
@@ -54,9 +54,7 @@ let _ =
            let default_config = Scan_CLI.default in
            let config : Core_scan_config.t =
              {
-               (Core_runner.core_scan_config_of_conf
-                  default_config.core_runner_conf)
-               with
+               Core_scan_config.default with
                rule_source = Some (Rule_file (Fpath.v (Js.to_string rule_file)));
                output_format = Json false;
                target_source = Some (Core_scan_config.Targets targets);

--- a/js/engine/dune
+++ b/js/engine/dune
@@ -4,6 +4,7 @@
   js_of_ocaml
   semgrep.running
   semgrep.semgrep_js_shared
+  semgrep.semgrep_node_js_shared
   tree-sitter.run
   ; semgrep.parsing_languages ; skipped to go from 16MB to 7MB
   )

--- a/js/engine/tests/__snapshots__/index.test.js.snap
+++ b/js/engine/tests/__snapshots__/index.test.js.snap
@@ -62,7 +62,7 @@ exports[`yaml parser parses a pattern with pattern-regex 1`] = `
       },
       "extra": {
         "engine_kind": "OSS",
-        "fingerprint": "b6ba932ffd60cc34c6c6db6498d4c93e744ee6e74dfd056f2b2159e6ecb3762cec50ed049e7676a58f83d62c6167859c3bc7dbe0bea61ae73527f0500dbcd591_0",
+        "fingerprint": "<MASKED>",
         "is_ignored": false,
         "lines": "foo: bar",
         "message": "test",
@@ -160,7 +160,7 @@ exports[`yaml parser parses a simple pattern 1`] = `
       },
       "extra": {
         "engine_kind": "OSS",
-        "fingerprint": "35874dfca3d0cc4d0d5251f2a293aeb00cd1f27307aef3f069025cbf3542493966f011fe42a15d75bbca998f83939e72380f462f58e84b67876c1e1fb60ea74a_0",
+        "fingerprint": "<MASKED>",
         "is_ignored": false,
         "lines": "foo: bar",
         "message": "test",

--- a/js/engine/tests/__snapshots__/index.test.js.snap
+++ b/js/engine/tests/__snapshots__/index.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`yaml parser parses a pattern with pattern-regex 1`] = `
 {
-  "engine_requested": "OSS",
   "errors": [],
   "explanations": [
     {
@@ -49,7 +48,9 @@ exports[`yaml parser parses a pattern with pattern-regex 1`] = `
     },
   ],
   "paths": {
-    "scanned": [],
+    "scanned": [
+      "test.yaml",
+    ],
   },
   "results": [
     {
@@ -61,8 +62,13 @@ exports[`yaml parser parses a pattern with pattern-regex 1`] = `
       },
       "extra": {
         "engine_kind": "OSS",
+        "fingerprint": "b6ba932ffd60cc34c6c6db6498d4c93e744ee6e74dfd056f2b2159e6ecb3762cec50ed049e7676a58f83d62c6167859c3bc7dbe0bea61ae73527f0500dbcd591_0",
+        "is_ignored": false,
+        "lines": "foo: bar",
         "message": "test",
+        "metadata": {},
         "metavars": {},
+        "severity": "ERROR",
         "validation_state": "NO_VALIDATOR",
       },
       "path": "test.yaml",
@@ -73,12 +79,6 @@ exports[`yaml parser parses a pattern with pattern-regex 1`] = `
       },
     },
   ],
-  "rules_by_engine": [
-    [
-      "test",
-      "OSS",
-    ],
-  ],
   "skipped_rules": [],
   "version": "<MASKED>",
 }
@@ -86,7 +86,6 @@ exports[`yaml parser parses a pattern with pattern-regex 1`] = `
 
 exports[`yaml parser parses a simple pattern 1`] = `
 {
-  "engine_requested": "OSS",
   "errors": [],
   "explanations": [
     {
@@ -147,7 +146,9 @@ exports[`yaml parser parses a simple pattern 1`] = `
     },
   ],
   "paths": {
-    "scanned": [],
+    "scanned": [
+      "test.yaml",
+    ],
   },
   "results": [
     {
@@ -159,7 +160,11 @@ exports[`yaml parser parses a simple pattern 1`] = `
       },
       "extra": {
         "engine_kind": "OSS",
+        "fingerprint": "35874dfca3d0cc4d0d5251f2a293aeb00cd1f27307aef3f069025cbf3542493966f011fe42a15d75bbca998f83939e72380f462f58e84b67876c1e1fb60ea74a_0",
+        "is_ignored": false,
+        "lines": "foo: bar",
         "message": "test",
+        "metadata": {},
         "metavars": {
           "$X": {
             "abstract_content": "bar",
@@ -175,6 +180,7 @@ exports[`yaml parser parses a simple pattern 1`] = `
             },
           },
         },
+        "severity": "ERROR",
         "validation_state": "NO_VALIDATOR",
       },
       "path": "test.yaml",
@@ -184,12 +190,6 @@ exports[`yaml parser parses a simple pattern 1`] = `
         "offset": 0,
       },
     },
-  ],
-  "rules_by_engine": [
-    [
-      "test",
-      "OSS",
-    ],
   ],
   "skipped_rules": [],
   "version": "<MASKED>",

--- a/js/engine/tests/index.test.js
+++ b/js/engine/tests/index.test.js
@@ -45,6 +45,12 @@ describe("yaml parser", () => {
         .replaceAll("PRO", "OSS")
     );
     result["version"] = "<MASKED>";
+    // The fingerprint here is inconsistent across CI and locally.
+    // We don't know why. It appears to not be because of the OCaml translation,
+    // because the blakejs library was also inconsistent across platforms.
+    result["results"].map(
+      (match) => (match["extra"]["fingerprint"] = "<MASKED>")
+    );
     expect(result).toMatchSnapshot();
   });
   test("parses a pattern with pattern-regex", async () => {
@@ -60,6 +66,9 @@ describe("yaml parser", () => {
         .replaceAll("PRO", "OSS")
     );
     result["version"] = "<MASKED>";
+    result["results"].map(
+      (match) => (match["extra"]["fingerprint"] = "<MASKED>")
+    );
     expect(result).toMatchSnapshot();
   });
 });

--- a/js/shared/core.js
+++ b/js/shared/core.js
@@ -19,7 +19,7 @@ function ocaml_terminal_size_get() {
 }
 
 //Provides: unix_open
-//Requires: caml_sys_open, caml_list_of_js_array, caml_list_to_js_array
+//Requires: caml_sys_fds, caml_list_of_js_array, caml_list_to_js_array, resolve_fs_device, MlFakeFd, MlFakeFile, caml_create_bytes, caml_raise_no_such_file, caml_raise_sys_error
 function unix_open(path, flags, perm) {
   // Why is this needed?
   // There is a Unix.open_flag type, which is different than
@@ -83,6 +83,7 @@ function unix_open(path, flags, perm) {
     }
   }
 
+  /* Produce the new flags, in the Stdlib.open_flag type */
   let parsed_flags = caml_list_to_js_array(flags);
   let translated_flags_nested = parsed_flags.map((flag) =>
     map_unix_flag_to_stdlib_flag(flag)
@@ -92,7 +93,96 @@ function unix_open(path, flags, perm) {
   );
   let new_flags = caml_list_of_js_array(translated_flags_flattened);
 
-  return caml_sys_open(path, new_flags, perm);
+  /* OK, here some weird stuff is happening.
+     Ideally, we could just hand everything off to caml_sys_open, and call
+     it a day.
+     Unfortunately, the APIs of Unix and Stdlib differ slightly. Not only
+     are their types of open_flag in a different order, but Unix.open_flag
+     supports O_RDWR, and Stdlib.open_flag has no corresponding variant.
+     This ultimately comes out of the fact that Stdlib only supports two
+     explicit functions which open out channels and in channels respectively,
+     and do not need to open one which can do both.
+     This is fine for the OCaml API, but disastrous for us, because we're
+     trying to piggy-back off the Stdlib implementation, which cannot do
+     both read and write.
+     Looking at the jsoo code for these file devices, however, there is no
+     reason why it _can't_ do both reading and writing at the same time,
+     in principle, but it has checks which raise exceptions when it detects
+     both Open_rdonly and Open_wronly, to be in line with the OCaml Stdlib
+     behavior.
+     To avoid having to implement all this virtual simulated file system
+     nonsense, we can still piggy-back off the caml_sys_open impl, but we
+     need to duck underneath the checks for conflicting flags.
+     Below, this code inlines the majority of the body of caml_sys_open,
+     but without the bad checks. We expect that this code should not really
+     change in the future.
+   */
+
+  /* inlined from caml_sys_open */
+  var f = {};
+  while (new_flags) {
+    switch (new_flags[1]) {
+      case 0:
+        f.rdonly = 1;
+        break;
+      case 1:
+        f.wronly = 1;
+        break;
+      case 2:
+        f.append = 1;
+        break;
+      case 3:
+        f.create = 1;
+        break;
+      case 4:
+        f.truncate = 1;
+        break;
+      case 5:
+        f.excl = 1;
+        break;
+      case 6:
+        f.binary = 1;
+        break;
+      case 7:
+        f.text = 1;
+        break;
+      case 8:
+        f.nonblock = 1;
+        break;
+    }
+    new_flags = new_flags[2];
+  }
+  var root = resolve_fs_device(path);
+
+  /* NOTE(bad-open):
+    So far, by inlining, we have avoided one check for the conflicting flags.
+    Unfortunately, the next call to root.device.open has one more, and it's a
+    lot of effort to go to inlining it, because there's a lot of object
+    properties it relies on.
+    However, root.device.open doesn't actually really care about the wronly
+    and rdonly flags, except to check for the conflict, and it passes back an
+    object which has the final flags set inside of it (for future use).
+    So what we can do is remove one of the flags, so as to remove the conflict,
+    and then set it in the resulting MlFakeFd object, as if nothing happened.
+   */
+  let is_wronly = false;
+  if (f.wronly) {
+    f.wronly = 0;
+    is_wronly = true;
+  }
+
+  /* inlined from caml_sys_open */
+  var file = root.device.open(root.rest, f);
+
+  /* see NOTE(bad-open) */
+  if (is_wronly) {
+    file.flags.wronly = 1;
+  }
+
+  /* inlined from caml_sys_open_internal */
+  let idx = caml_sys_fds.length;
+  caml_sys_fds[idx] = file;
+  return idx | 0;
 }
 
 //Provides: unix_environment const


### PR DESCRIPTION
## What:
This PR changes the `CoreOutput` emitted by the JS engine to `CliOutput` instead, which is needed by the Editor.

## Why:
The Editor does not understand the (quite similar) `CoreOutput` type, and this is making assumptions in the consumption step erroneous.

## How:
We call `Output.preprocess_result` in order to get the types right.

This actually surfaces an error introduced in #9090, which is that the `caml_sys_open` external call does not actually permit both reading and writing flags to be set at once. To fix this, some corresponding adjustments were made in `core.js`.

## Test plan:
`make test` in `js/engine` passes.

Closes PDX-6