### PR TITLE
Revert "fix(ls): Use libev to better handle FDs (#9113)"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -243,7 +243,7 @@ install-deps-for-semgrep-core: semgrep.opam
 	&& ./configure \
 	&& ./scripts/install-tree-sitter-lib
 	# Install OCaml dependencies (globally) from *.opam files.
-	LIBRARY_PATH="/opt/homebrew/lib" opam install -y --deps-only ./ ./libs/ocaml-tree-sitter-core
+	opam install -y --deps-only ./ ./libs/ocaml-tree-sitter-core
 
 # This will fail if semgrep.opam isn't up-to-date (in git),
 # and dune isn't installed yet. You can always install dune with
@@ -274,7 +274,7 @@ install-deps: install-deps-for-semgrep-core
 # Here is why we need those external packages to compile semgrep-core:
 # - pcre-dev: for ocaml-pcre now used in semgrep-core
 # - gmp-dev: for osemgrep and its use of cohttp
-ALPINE_APK_DEPS_CORE=pcre-dev gmp-dev libev-dev
+ALPINE_APK_DEPS_CORE=pcre-dev gmp-dev
 
 # This target is used in our Dockerfile and a few GHA workflows.
 # There are pros and cons of having those commands here instead
@@ -320,7 +320,7 @@ install-deps-ALPINE-for-pysemgrep:
 # - pkg-config?
 # - coreutils?
 # - gettext?
-BREW_DEPS=pcre gmp pkg-config coreutils gettext libev
+BREW_DEPS=pcre gmp pkg-config coreutils gettext
 
 # see also scripts/osx-setup-for-release.sh that adjust those
 # external packages to force static-linking

--- a/dune-project
+++ b/dune-project
@@ -454,7 +454,6 @@ For more information see https://semgrep.dev
     ; concurrency
     lwt
     lwt_ppx
-    conf-libev ; for lwt, to get better FD perf
     ; jsoo
     (js_of_ocaml (= 5.4.0))
     (js_of_ocaml-compiler (= 5.4.0))

--- a/libs/lwt_platform/Lwt_platform.mli
+++ b/libs/lwt_platform/Lwt_platform.mli
@@ -7,9 +7,3 @@ val detach : ('a -> 'b) -> 'a -> 'b Lwt.t
 
 val init_preemptive : int -> int -> (string -> unit) -> unit
 (** [init_preemptive min max log] initializes the LWT preemptive scheduler. *)
-
-val set_engine : unit -> unit
-(** [set_engine ()] sets the LWT engine to libev if on Unix.
-    This is important as select/poll is not great, and can easily
-    run out of FDs, crashing the LS.
-  *)

--- a/libs/lwt_platform/js/Lwt_platform.ml
+++ b/libs/lwt_platform/js/Lwt_platform.ml
@@ -34,4 +34,3 @@ let run t =
 (* TODO: preemptive threads w/node workers *)
 let detach f x = f x |> Lwt.return
 let init_preemptive _ _ _ = ()
-let set_engine () = ()

--- a/libs/lwt_platform/unix/Lwt_platform.ml
+++ b/libs/lwt_platform/unix/Lwt_platform.ml
@@ -23,4 +23,3 @@
 let run = Lwt_main.run
 let detach = Lwt_preemptive.detach
 let init_preemptive = Lwt_preemptive.init
-let set_engine () = Lwt_engine.set (new Lwt_engine.libev ())

--- a/scripts/osx-setup-for-release.sh
+++ b/scripts/osx-setup-for-release.sh
@@ -49,10 +49,8 @@ make install-deps-for-semgrep-core
 # Remove dynamically linked libraries to force MacOS to use static ones.
 ls -l "$(brew --prefix)"/opt/pcre/lib || true
 ls -l "$(brew --prefix)"/opt/gmp/lib || true
-ls -l "$(brew --prefix)"/opt/libev/lib || true
 rm -f "$(brew --prefix)"/opt/pcre/lib/libpcre.1.dylib
 rm -f "$(brew --prefix)"/opt/gmp/lib/libgmp.10.dylib
-rm -f "$(brew --prefix)"/opt/libev/lib/libev.4.dylib
 
 # This needs to be done after make install-deps-xxx but before make core
 TREESITTER_LIBDIR=libs/ocaml-tree-sitter-core/tree-sitter/lib

--- a/semgrep.opam
+++ b/semgrep.opam
@@ -59,7 +59,6 @@ depends: [
   "digestif" {>= "1.0.0"}
   "lwt"
   "lwt_ppx"
-  "conf-libev"
   "js_of_ocaml" {= "5.4.0"}
   "js_of_ocaml-compiler" {= "5.4.0"}
   "js_of_ocaml-ppx" {= "5.4.0"}

--- a/src/osemgrep/language_server/LS.ml
+++ b/src/osemgrep/language_server/LS.ml
@@ -67,6 +67,5 @@ module LanguageServer = RPC_server.Make (MessageHandler)
 (* LET'S GOOOOOO *)
 let start () =
   Logs.debug (fun m -> m "Starting Semgrep Language Server");
-  Lwt_platform.set_engine ();
   let server = LanguageServer.create () in
   LanguageServer.start server

--- a/src/osemgrep/language_server/Test_LS_e2e.ml
+++ b/src/osemgrep/language_server/Test_LS_e2e.ml
@@ -970,10 +970,6 @@ let test_ls_no_folders () =
 
       send_exit info)
 
-let test_ls_libev () =
-  Lwt_platform.set_engine ();
-  Lwt.return_unit
-
 (*****************************************************************************)
 (* Entry point *)
 (*****************************************************************************)
@@ -1000,5 +996,4 @@ let lwt_tests =
       ("Test LS multi-workspaces", test_ls_multi);
       ("Test Login", test_login);
       ("Test LS with no folders", test_ls_no_folders);
-      ("Test LS with libev", test_ls_libev);
     ]


### PR DESCRIPTION
This reverts commit 5822fda68f8fe3a0425f10fa0bbb8f296041b0e4.

To address failures with Homebrew due to conf-libev.

Reviewers: please double check my conflict resolution in `src/osemgrep/language_server/Test_LS_e2e.ml`

Test plan: Automated tests

