### PR TITLE
feat(matching): locationally aware bindings

### DIFF
--- a/changelog.d/pa-3230.added
+++ b/changelog.d/pa-3230.added
@@ -1,0 +1,14 @@
+Matching: Matches with the same range but bindings in different locations
+will now no longer deduplicate.
+
+For instance, the pattern `$FUNC(..., $A, ...)` would produce only
+one match on the target file:
+```
+foo(true, true)
+```
+because you would have two matches to the range of the call, and both
+bindings of `$A` would be to `true`.
+
+Now, the deduplication logic sees that the bindings of `$A` are in
+different places, and thus should not be considered the same, and
+produce two matches.

--- a/src/core/Metavariable.ml
+++ b/src/core/Metavariable.ml
@@ -156,6 +156,20 @@ let mvalue_of_any = function
   | Anys _ ->
       None
 
+let location_aware_equal_mvalue mval1 mval2 =
+  let ranges_equal =
+    let any1, any2 = (mvalue_to_any mval1, mvalue_to_any mval2) in
+    let range1, range2 =
+      ( AST_generic_helpers.range_of_any_opt any1,
+        AST_generic_helpers.range_of_any_opt any2 )
+    in
+    match (range1, range2) with
+    | Some range1, Some range2 ->
+        [%eq: Tok.location * Tok.location] range1 range2
+    | _ -> true
+  in
+  ranges_equal && equal_mvalue mval1 mval2
+
 (* This is used for metavariable-pattern: where we need to transform the content
  * of a metavariable into a program so we can use evaluate_formula on it *)
 let program_of_mvalue : mvalue -> G.program option =

--- a/src/core/Metavariable.ml
+++ b/src/core/Metavariable.ml
@@ -164,8 +164,8 @@ let location_aware_equal_mvalue mval1 mval2 =
         AST_generic_helpers.range_of_any_opt any2 )
     in
     match (range1, range2) with
-    | Some range1, Some range2 ->
-        [%eq: Tok.location * Tok.location] range1 range2
+    | Some (l1, r1), Some (l2, r2) ->
+        Tok.equal_location l1 l2 && Tok.equal_location r1 r2
     | _ -> true
   in
   ranges_equal && equal_mvalue mval1 mval2

--- a/src/core/Metavariable.mli
+++ b/src/core/Metavariable.mli
@@ -34,6 +34,17 @@ type mvalue =
 *)
 type bindings = (mvar * mvalue) list [@@deriving show, eq]
 
+(* Mvalue equality reduces to equality on ASTs, which ignores the tokens
+   and instead compares the structure. It may optionally include the ident
+   info IDs, but the point is that it's agnostic to the positions of the
+   mvalues.
+   Sometimes we don't want this behavior. For instance, if we have two
+   matches which have $A bound to "true", but in different places in the
+   source, we might want to consider those matches different.
+   This equality function simply first discriminates on location of the
+   mvalues, and then checks for their literal equality, to make that
+   possible.
+*)
 val location_aware_equal_mvalue : mvalue -> mvalue -> bool
 
 (* return whether a string could be a metavariable name (e.g., "$FOO", but not

--- a/src/core/Metavariable.mli
+++ b/src/core/Metavariable.mli
@@ -34,6 +34,8 @@ type mvalue =
 *)
 type bindings = (mvar * mvalue) list [@@deriving show, eq]
 
+val location_aware_equal_mvalue : mvalue -> mvalue -> bool
+
 (* return whether a string could be a metavariable name (e.g., "$FOO", but not
  * "FOO"). This mostly check for the regexp $[A-Z_][A-Z_0-9]* but
  * also handles special variables like $_GET in PHP which are actually

--- a/src/core/Pattern_match.ml
+++ b/src/core/Pattern_match.ml
@@ -89,6 +89,12 @@ type t = {
   tokens : Tok.t list Lazy.t; [@equal fun _a _b -> true]
   (* metavars for the pattern match *)
   env : Metavariable.bindings;
+      [@equal
+        fun a b ->
+          List.equal
+            (fun (s1, m1) (s2, m2) ->
+              s1 = s2 && Metavariable.location_aware_equal_mvalue m1 m2)
+            a b]
   (* Lazy since construction involves forcing lazy token lists. *)
   (* We used to have `[@equal fun _a _b -> true]` here, but this causes issues with
      multiple findings to the same sink (but different sources) being removed

--- a/src/core/Pattern_match.ml
+++ b/src/core/Pattern_match.ml
@@ -93,6 +93,10 @@ type t = {
         fun a b ->
           List.equal
             (fun (s1, m1) (s2, m2) ->
+              (* See the comment in Metavariable.mli for location_aware_equal_mvalue,
+                 but basically we would like to consider matches different if they
+                 metavariables bound to the same content, but at different locations.
+              *)
               s1 = s2 && Metavariable.location_aware_equal_mvalue m1 m2)
             a b]
   (* Lazy since construction involves forcing lazy token lists. *)

--- a/tests/rules/different_binding_locations.py
+++ b/tests/rules/different_binding_locations.py
@@ -1,0 +1,6 @@
+foo(
+  # ruleid: different-binding-locations
+  True,
+  # ruleid: different-binding-locations
+  True
+)

--- a/tests/rules/different_binding_locations.yaml
+++ b/tests/rules/different_binding_locations.yaml
@@ -1,0 +1,12 @@
+rules:
+  - id: different-binding-locations
+    message: |
+      We should know the two different choices for
+      $A are different, and produce different matches!
+    languages:
+      - python
+    severity: WARNING
+    patterns:
+      - pattern: |
+          $FUNC(..., $A, ...)
+      - focus-metavariable: $A


### PR DESCRIPTION
## What:
This PR makes match deduplication now aware of the locations of the match's metavariable bindings.

## Why:
This makes examples like the pattern `$FUNC(..., $A, ...)` now produce two matches on the target
```
foo(true, true)
```
instead of 1.

See https://semgrepinc.slack.com/archives/C01AX0QCEET/p1698878438860509 for more.

## How:
When comparing two pattern matches, instead of using the default equality on `Metavariable.bindings`, we compare the mvalues being mapped to using `Metavariable.location_aware_equal_mvalue`, which first computes the ranges of the mvalues and checks if they are the same. If they are the same, only then will it proceed to check for structural equality.

If we cannot compute a range for some reason, they are considered equal, so that we compare structurally.

## Test plan:
`make test`

Closes PA-3230