### PR TITLE
parse number literal macrobody in C++

### DIFF
--- a/languages/cpp/tree-sitter/Parse_cpp_tree_sitter.ml
+++ b/languages/cpp/tree-sitter/Parse_cpp_tree_sitter.ml
@@ -619,10 +619,27 @@ let map_preproc_def (env : env) ((v1, v2, v3, v4) : CST.preproc_def) =
   let v2 = str env v2 (* pattern [a-zA-Z_]\w* *) in
   let v3 =
     match v3 with
-    | Some tok ->
-        let x = token env tok (* preproc_arg *) in
-        (* TODO: we should parse this x! can be DefineExpr, etc. *)
-        DefineTodo ("MacroBody", x)
+    | Some tok -> (
+        let parse_number_literal t s =
+          match Common2.int_of_string_c_octal_opt s with
+          | Some i -> Some (C (Int (Some i, t)))
+          | None -> (
+              match float_of_string_opt s with
+              | Some f -> Some (C (Float (Some f, t)))
+              | None -> None)
+        in
+        let remove_comment s =
+          match Str.split (Str.regexp "//\\|/\\*") s with
+          | s :: _ -> Some (s |> String.trim)
+          | [] -> None
+        in
+        (* TODO: parse exprs other than number literals. *)
+        match token env tok (* preproc_arg *) with
+        | OriginTok { str; _ } as t -> (
+            match str |> remove_comment >>= parse_number_literal t with
+            | Some c -> DefineExpr c
+            | None -> DefineTodo ("MacroBody", t))
+        | t -> DefineTodo ("MacroBody", t))
     | None -> DefineEmpty
   in
   let _v4 = token env v4 (* "\n" *) in


### PR DESCRIPTION
Parse the macro body when there are no macro parameters, and the raw string token for the macro body can be converted to numbers.