### PR TITLE
feat(ls): intrafile scanning

### DIFF
--- a/src/osemgrep/language_server/requests/Initialize_request.ml
+++ b/src/osemgrep/language_server/requests/Initialize_request.ml
@@ -43,11 +43,15 @@ let initialize_server server
       initializationOptions |> member "doHover" |> to_bool_option
       |> Option.value ~default:false
     in
+    let pro_intrafile =
+      scan_options |> member "pro_intrafile" |> to_bool_option
+      |> Option.value ~default:false
+    in
     let res =
       scan_options |> User_settings.t_of_yojson
       |> Result.value ~default:server.session.user_settings
     in
-    { res with do_hover }
+    { res with do_hover; pro_intrafile }
   in
   let workspace_folders =
     match (workspaceFolders, rootUri) with

--- a/src/osemgrep/language_server/scan_helpers/Scan_helpers.ml
+++ b/src/osemgrep/language_server/scan_helpers/Scan_helpers.ml
@@ -44,7 +44,7 @@ let run_semgrep ?(targets = None) ?(rules = None) ?(git_ref = None)
     let targets = Option.value ~default:(Session.targets session) targets in
     let runner_conf = Session.runner_conf session in
     let scan_func =
-      if true then
+      if session.user_settings.pro_intrafile then
         match !Scan_subcommand.hook_pro_scan_func_for_osemgrep with
         | None ->
             (* TODO: improve this error message depending on what the

--- a/src/osemgrep/language_server/scan_helpers/Scan_helpers.ml
+++ b/src/osemgrep/language_server/scan_helpers/Scan_helpers.ml
@@ -43,6 +43,7 @@ let run_semgrep ?(targets = None) ?(rules = None) ?(git_ref = None)
   let res =
     let targets = Option.value ~default:(Session.targets session) targets in
     let runner_conf = Session.runner_conf session in
+    (* This is currently just ripped from Scan_subcommand. *)
     let scan_func =
       if session.user_settings.pro_intrafile then
         match !Scan_subcommand.hook_pro_scan_func_for_osemgrep with
@@ -56,6 +57,11 @@ let run_semgrep ?(targets = None) ?(rules = None) ?(git_ref = None)
         | Some pro_scan_func ->
             (* THINK: files or folders? *)
             let roots = targets in
+            (* For now, we're going to just hard-code it at a whole scan, and
+               using the intrafile pro engine.
+               Interfile would likely be too intensive (and require us to target
+               folders, not the affected files)
+            *)
             let diff_config = Differential_scan_config.WholeScan in
             pro_scan_func roots ~diff_config
               (Engine_type.PRO Engine_type.Intrafile)

--- a/src/osemgrep/language_server/server/User_settings.ml
+++ b/src/osemgrep/language_server/server/User_settings.ml
@@ -36,6 +36,7 @@ type t = {
   only_git_dirty : bool; [@key "onlyGitDirty"] [@default true]
   ci : bool; [@default true]
   do_hover : bool; [@default false]
+  pro_intrafile : bool; [@default false]
 }
 [@@deriving yojson]
 
@@ -52,6 +53,7 @@ let default =
     only_git_dirty = true;
     ci = true (* Secret setting for testing purposes *);
     do_hover = false;
+    pro_intrafile = false;
   }
 
 let t_of_yojson json = of_yojson json

--- a/src/osemgrep/language_server/server/User_settings.mli
+++ b/src/osemgrep/language_server/server/User_settings.mli
@@ -10,6 +10,7 @@ type t = {
   only_git_dirty : bool;
   ci : bool;
   do_hover : bool;
+  pro_intrafile : bool;
 }
 
 val default : t


### PR DESCRIPTION
## What:
This PR makes it possible to run intrafile scans using the Pro Engine from the LS.

## Why:
It would be cool if people could do not just OSS scans, but intrafile scans via the LSP.

## How:
Made it so that the LSP has the ability to invoke the Pro Engine hook, depending on if it receives a `pro_intrafile` option.

## Test plan:
See https://github.com/semgrep/semgrep-vscode/pull/76