### PR TITLE
fix: incorrect metadata change if multiple matches

### DIFF
--- a/changelog.d/scrt-231.fixed
+++ b/changelog.d/scrt-231.fixed
@@ -1,0 +1,4 @@
+Secrets: metadata overrides specified in validators were incorrectly applied on
+top of one another (on a per-rule basis), so that only the last was applied.
+Each update is now correctly applied independently to each finding based on the
+rule's validators.

--- a/cli/src/semgrep/core_output.py
+++ b/cli/src/semgrep/core_output.py
@@ -9,6 +9,7 @@ parsing and interpreting the semgrep-core profiling information).
 The precise type of the response from semgrep-core is specified in
 semgrep_interfaces/semgrep_output_v1.atd
 """
+import copy
 import dataclasses
 from dataclasses import replace
 from typing import Dict
@@ -174,6 +175,7 @@ def core_matches_to_rule_matches(
 
         metadata = rule.metadata
         if match.extra.metadata:
+            metadata = copy.deepcopy(metadata)
             metadata.update(match.extra.metadata.value)
 
         if match.extra.rendered_fix is not None:


### PR DESCRIPTION
Reported by @LewisArdern. We incorrectly shared a metadata blob on a per-rule basis, rather than on a per-finding basis. This resulted in updates to a finding's metadata being incorrectly applied to all findings for a given rule, such that later findings would modify the metadata of earlier ones. Now clones the metadata when modifying so that we can modify independently. 

Test plan: requires additional e2e tests in pro.