### PR TITLE
osemgrep: Filter the filtered rule count by excluding rules without targets in printed stats

### DIFF
--- a/src/core/Core_result.ml
+++ b/src/core/Core_result.ml
@@ -52,6 +52,7 @@ type t = {
   matches : Pattern_match.t list;
   errors : Core_error.t list;
   skipped_rules : Rule.invalid_rule_error list;
+  rules_with_targets : Rule.rule list;
   (* may contain also skipped_target information *)
   extra : Core_profiling.t Core_profiling.debug_info;
   explanations : Matching_explanation.t list option;
@@ -89,6 +90,7 @@ let mk_final_result_with_just_errors (errors : Core_error.t list) : t =
     errors;
     (* default values *)
     matches = [];
+    rules_with_targets = [];
     skipped_rules = [];
     extra = No_info;
     explanations = None;
@@ -317,6 +319,7 @@ let make_final_result
     errors;
     extra;
     skipped_rules;
+    rules_with_targets = [];
     explanations = (if explanations =*= [] then None else Some explanations);
     rules_by_engine =
       rules_with_engine |> Common.map (fun (r, ek) -> (fst r.Rule.id, ek));

--- a/src/core/Core_result.mli
+++ b/src/core/Core_result.mli
@@ -15,6 +15,7 @@ type t = {
    * in textual reports) or for tools (e.g., the playground).
    *)
   skipped_rules : Rule.invalid_rule_error list;
+  rules_with_targets : Rule.rule list;
   (* may contain skipped_target info *)
   extra : Core_profiling.t Core_profiling.debug_info;
   explanations : Matching_explanation.t list option;

--- a/src/osemgrep/cli_scan/Core_runner.ml
+++ b/src/osemgrep/cli_scan/Core_runner.ml
@@ -243,6 +243,10 @@ let mk_scan_func_for_osemgrep (core_scan_func : Core_scan.core_scan_func) :
      See https://www.notion.so/r2cdev/Osemgrep-scanning-algorithm-5962232bfd74433ba50f97c86bd1a0f3
   *)
   let lang_jobs = split_jobs_by_language all_rules all_targets in
+  let rules_with_targets =
+    List.map (fun { Lang_job.rules; _ } -> rules) lang_jobs
+    |> List.flatten |> Common.uniq_by ( == )
+  in
   Logs.app (fun m ->
       m "%a"
         (fun ppf () ->
@@ -267,6 +271,7 @@ let mk_scan_func_for_osemgrep (core_scan_func : Core_scan.core_scan_func) :
           res with
           errors = rule_errors @ res.errors;
           skipped_rules = invalid_rules @ res.skipped_rules;
+          rules_with_targets;
         }
       in
 

--- a/src/osemgrep/cli_scan/Core_runner.ml
+++ b/src/osemgrep/cli_scan/Core_runner.ml
@@ -244,8 +244,8 @@ let mk_scan_func_for_osemgrep (core_scan_func : Core_scan.core_scan_func) :
   *)
   let lang_jobs = split_jobs_by_language all_rules all_targets in
   let rules_with_targets =
-    List.map (fun { Lang_job.rules; _ } -> rules) lang_jobs
-    |> List.flatten |> Common.uniq_by ( == )
+    List.concat_map (fun { Lang_job.rules; _ } -> rules) lang_jobs
+    |> Common.uniq_by ( == )
   in
   Logs.app (fun m ->
       m "%a"

--- a/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -483,6 +483,14 @@ let run_scan_files (conf : Scan_CLI.conf) (profiler : Profiler.t)
     in
     Profiler.stop_ign profiler ~name:"total_time";
 
+    let rules_with_targets =
+      match exn_and_matches with
+      | Ok r ->
+          r.rules_with_targets
+          |> Common.map (fun (rv : Rule.rule) -> Rule_ID.to_string (fst rv.id))
+      | _ -> []
+    in
+
     if Metrics_.is_enabled () then (
       Metrics_.add_errors cli_output.errors;
       Metrics_.add_rules_hashes_and_rules_profiling ?profiling:res.core.time
@@ -509,7 +517,7 @@ let run_scan_files (conf : Scan_CLI.conf) (profiler : Profiler.t)
             skipped_groups ));
     Logs.app (fun m ->
         m "Ran %s on %s: %s."
-          (String_utils.unit_str (List.length filtered_rules) "rule")
+          (String_utils.unit_str (List.length rules_with_targets) "rule")
           (String_utils.unit_str (List.length cli_output.paths.scanned) "file")
           (String_utils.unit_str (List.length cli_output.results) "finding"));
 


### PR DESCRIPTION
## Description

When we display the rule stats we currently do not filter out rules without any targets (e.g. Java rules without `.java` files). This PR applies another filter pass to our set of rules before printing out the counts, matching the python implementation (see #9130).

Visual Aid: https://jamboard.google.com/d/1VgYvqKEYs0zjHdz1PbMSgpiXEFTvJUBCh3T1gm367bI/viewer?f=0