### PR TITLE
osemgrep: use built-in semgrepignore patterns

### DIFF
--- a/cli/tests/e2e/test_ignores.py
+++ b/cli/tests/e2e/test_ignores.py
@@ -44,6 +44,9 @@ def test_file_not_relative_to_base_path(run_semgrep: RunSemgrep, snapshot):
     snapshot.assert_match(results.as_snapshot(), "results.txt")
 
 
+# Test the specification of a semgrepignore file via the environment
+# variable SEMGREP_R2C_INTERNAL_EXPLICIT_SEMGREPIGNORE.
+# This is for semgrep-action. See run_scan.py.
 @pytest.mark.kinda_slow
 @pytest.mark.osemfail
 def test_internal_explicit_semgrepignore(

--- a/cli/tests/e2e/test_ignores.py
+++ b/cli/tests/e2e/test_ignores.py
@@ -19,9 +19,9 @@ def test_semgrepignore(run_semgrep_in_tmp: RunSemgrep, tmp_path, snapshot):
     )
 
 
-# We provide no .semgrepignore but everything except find.js should still be ignored
+# We provide no .semgrepignore but everything except find.js should still
+# be ignored
 @pytest.mark.kinda_slow
-@pytest.mark.osemfail
 def test_default_semgrepignore(run_semgrep_in_tmp: RunSemgrep, snapshot):
     snapshot.assert_match(
         run_semgrep_in_tmp(

--- a/cli/tests/e2e/test_rule_parser.py
+++ b/cli/tests/e2e/test_rule_parser.py
@@ -41,9 +41,7 @@ def test_nonexisting_file(run_semgrep_in_tmp: RunSemgrep, snapshot):
     run_semgrep_in_tmp("rules/does_not_exist.yaml", assert_exit_code=7)
 
 
-# TODO: see comment in Scan_subcommand.ml.
 @pytest.mark.kinda_slow
-@pytest.mark.osemfail
 def test_rule_parser__empty(run_semgrep_in_tmp: RunSemgrep, snapshot):
     run_semgrep_in_tmp(f"rules/syntax/empty.yaml", assert_exit_code=7)
 

--- a/libs/gitignore/Gitignores_cache.ml
+++ b/libs/gitignore/Gitignores_cache.ml
@@ -21,10 +21,10 @@ let load t dir_path =
       let path = Ppath.to_fpath t.project_root dir_path in
       let patterns =
         List.fold_left
-          (fun acc (kind, name) ->
+          (fun acc (source_kind, name) ->
             let file_path = Fpath.add_seg path name in
             if Sys.file_exists (Fpath.to_string file_path) then
-              acc @ Parse_gitignore.from_file ~anchor ~kind file_path
+              acc @ Parse_gitignore.from_file ~anchor ~source_kind file_path
             else acc)
           [] t.gitignore_filenames
       in

--- a/libs/gitignore/Parse_gitignore.ml
+++ b/libs/gitignore/Parse_gitignore.ml
@@ -90,16 +90,16 @@ let parse_line ~anchor source_name source_kind line_number line_contents =
 (* Entry points *)
 (*****************************************************************************)
 
-let from_string ~anchor ~name ~kind str =
+let from_string ~anchor ~name ~source_kind str =
   let lines = read_lines_from_string str in
   Common.mapi
     (fun i contents ->
       let linenum = i + 1 in
-      parse_line ~anchor name kind linenum contents)
+      parse_line ~anchor name source_kind linenum contents)
     lines
   |> Common.map_filter (fun x -> x)
 
-let from_file ~anchor ~kind path =
+let from_file ~anchor ~source_kind path =
   Fpath.to_string path |> Common.read_file
-  |> from_string ~anchor ~name:(Fpath.to_string path) ~kind
+  |> from_string ~anchor ~name:(Fpath.to_string path) ~source_kind
 [@@profiling]

--- a/libs/gitignore/Parse_gitignore.mli
+++ b/libs/gitignore/Parse_gitignore.mli
@@ -7,12 +7,15 @@
 *)
 
 val from_file :
-  anchor:Glob.Pattern.t -> kind:string -> Fpath.t -> Gitignore.path_selectors
+  anchor:Glob.Pattern.t ->
+  source_kind:string ->
+  Fpath.t ->
+  Gitignore.path_selectors
 
 val from_string :
   anchor:Glob.Pattern.t ->
   name:string ->
-  kind:string ->
+  source_kind:string ->
   string ->
   Gitignore.path_selectors
 

--- a/src/targeting/Find_targets.ml
+++ b/src/targeting/Find_targets.ml
@@ -124,9 +124,14 @@ let get_reason_for_exclusion (sel_events : Gitignore.selection_event list) :
  *)
 let walk_skip_and_collect (conf : conf) (ign : Semgrepignore.t)
     (scan_root : fppath) : Fpath.t list * Out.skipped_target list =
-  (* Imperative style! walk and collect *)
-  let (res : Fpath.t list ref) = ref [] in
+  (* Imperative style! walk and collect.
+     This is for the sake of readability so let's try to make this as
+     readable as possible.
+  *)
+  let (selected_paths : Fpath.t list ref) = ref [] in
   let (skipped : Out.skipped_target list ref) = ref [] in
+  let add path = push path selected_paths in
+  let skip target = push target skipped in
 
   (* mostly a copy-paste of List_files.list_regular_files() *)
   let rec aux (dir : fppath) =
@@ -146,19 +151,19 @@ let walk_skip_and_collect (conf : conf) (ign : Semgrepignore.t)
            in
            let ppath = Ppath.add_seg dir.ppath name in
            (* skip hidden files (this includes big directories like .git/)
-            * TODO? maybe add a setting in conf?
-            * TODO? add a skip reason for those?
-            *)
+              TODO? maybe add a setting in conf? -> no, this is a job for
+              semgrepignore.
+              TODO: why are we doing this? It doesn't seem like pysemgrep
+              is doing this.
+           *)
            if name =~ "^\\." then
-             let skip =
+             skip
                {
                  Out.path = fpath;
                  reason = Out.Dotfile;
                  details = None;
                  rule_id = None;
                }
-             in
-             Common.push skip skipped
            else
              let status, selection_events = Semgrepignore.select ign ppath in
              match status with
@@ -167,7 +172,7 @@ let walk_skip_and_collect (conf : conf) (ign : Semgrepignore.t)
                      m "Ignoring path %s:\n%s" !!fpath
                        (Gitignore.show_selection_events selection_events));
                  let reason = get_reason_for_exclusion selection_events in
-                 let skip =
+                 skip
                    {
                      Out.path = fpath;
                      reason;
@@ -177,14 +182,12 @@ let walk_skip_and_collect (conf : conf) (ign : Semgrepignore.t)
                           semgrepignore";
                      rule_id = None;
                    }
-                 in
-                 Common.push skip skipped
              | Not_ignored -> (
                  (* TODO: check read permission? *)
                  match Unix.lstat !!fpath with
                  (* skipping symlinks *)
                  | { Unix.st_kind = S_LNK; _ } -> ()
-                 | { Unix.st_kind = S_REG; _ } -> Common.push fpath res
+                 | { Unix.st_kind = S_REG; _ } -> add fpath
                  | { Unix.st_kind = S_DIR; _ } ->
                      (* skipping submodules.
                       * TODO? should we add a skip_reason for it? pysemgrep
@@ -207,10 +210,9 @@ let walk_skip_and_collect (conf : conf) (ign : Semgrepignore.t)
                  | exception Unix.Unix_error (_err, _fun, _info) -> ()))
   in
   aux scan_root;
-  (* TODO? List.rev? anyway we gonna sort those files later no? or for
-   * displaying matches incrementally the order matters?
-   *)
-  (!res, !skipped)
+  (* Let's not worry about file order here until we have to.
+     They will be sorted later. *)
+  (!selected_paths, !skipped)
 
 (*************************************************************************)
 (* Grouping *)
@@ -280,7 +282,8 @@ let get_targets conf scanning_roots =
           *)
          let ign =
            Semgrepignore.create ?include_patterns:conf.include_
-             ~cli_patterns:conf.exclude ~exclusion_mechanism
+             ~cli_patterns:conf.exclude
+             ~builtin_semgrepignore:Semgrep_scan_legacy ~exclusion_mechanism
              ~project_root:(Rpath.to_fpath project_root)
              ()
          in

--- a/src/targeting/Find_targets_old.ml
+++ b/src/targeting/Find_targets_old.ml
@@ -246,7 +246,8 @@ let get_targets conf scanning_roots =
          in
          let ign =
            Semgrepignore.create ?include_patterns:conf.include_
-             ~cli_patterns:conf.exclude ~exclusion_mechanism ~project_root ()
+             ~cli_patterns:conf.exclude ~builtin_semgrepignore:Empty
+             ~exclusion_mechanism ~project_root ()
          in
          let paths, skipped_paths1 =
            paths

--- a/src/targeting/Semgrepignore.mli
+++ b/src/targeting/Semgrepignore.mli
@@ -9,6 +9,18 @@
 
 (* Holds project root, and some cached data *)
 type t
+
+(*
+   We have to support the legacy built-in semgrepignore patterns
+   when scanning for source code but we want something different
+   or empty when scanning for secrets.
+
+   The 'Empty' case is useful for testing.
+
+   TODO: combine the built-in semgrepignore files into one once
+   we have an extended syntax with sections.
+*)
+type builtin_semgrepignore = Empty | Semgrep_scan_legacy
 type exclusion_mechanism = Gitignore_and_semgrepignore | Only_semgrepignore
 
 (*
@@ -28,6 +40,7 @@ val create :
     *)
     string list ->
   ?cli_patterns:string list ->
+  builtin_semgrepignore:builtin_semgrepignore ->
   exclusion_mechanism:exclusion_mechanism ->
   project_root:Fpath.t ->
   unit ->

--- a/src/targeting/Unit_semgrepignore.ml
+++ b/src/targeting/Unit_semgrepignore.ml
@@ -29,6 +29,7 @@ let test_filter ?includes:include_patterns ?excludes:cli_patterns
       printf "--- Filtered files ---\n";
       let filter =
         Semgrepignore.create ?include_patterns ?cli_patterns
+          ~builtin_semgrepignore:Empty
           ~exclusion_mechanism:Gitignore_and_semgrepignore ~project_root:root ()
       in
       let error = ref false in


### PR DESCRIPTION
The implementation consists in adding another layer of semgrepignore rules that comes before all the other layers. Two more tests pass. Let's continue the effort.