### PR TITLE
ojsonnet: pass env also in substitution strategy

### DIFF
--- a/libs/ojsonnet/Eval_jsonnet_subst.mli
+++ b/libs/ojsonnet/Eval_jsonnet_subst.mli
@@ -1,3 +1,3 @@
 (* may raise Eval_jsonnet_common.Error *)
-val eval_expr : Core_jsonnet.expr -> Value_jsonnet.value_
+val eval_program : Core_jsonnet.program -> Value_jsonnet.value_
 val manifest_value : Value_jsonnet.value_ -> JSON.t

--- a/libs/ojsonnet/Test_ojsonnet.ml
+++ b/libs/ojsonnet/Test_ojsonnet.ml
@@ -14,13 +14,13 @@ let dump_jsonnet_core file =
 let dump_jsonnet_value file =
   let ast = Parse_jsonnet.parse_program file in
   let core = Desugar_jsonnet.desugar_program ~use_std:true file ast in
-  let value_ = Eval_jsonnet_subst.eval_expr core in
+  let value_ = Eval_jsonnet_subst.eval_program core in
   pr2 (Value_jsonnet.show_value_ value_)
 
 let dump_jsonnet_json file =
   let ast = Parse_jsonnet.parse_program file in
   let core = Desugar_jsonnet.desugar_program file ast in
-  let value_ = Eval_jsonnet_subst.eval_expr core in
+  let value_ = Eval_jsonnet_subst.eval_program core in
   let json = Eval_jsonnet_subst.manifest_value value_ in
   let str = JSON.string_of_json json in
   pr2 str
@@ -29,7 +29,7 @@ let perf_test_jsonnet file =
   let ast = Parse_jsonnet.parse_program file in
   let core = Desugar_jsonnet.desugar_program file ast in
   let start_time = Sys.time () in
-  let value_ = Eval_jsonnet_subst.eval_expr core in
+  let value_ = Eval_jsonnet_subst.eval_program core in
   let _ = Eval_jsonnet_subst.manifest_value value_ in
   let end_time = Sys.time () in
   let approx_dif = string_of_float (end_time -. start_time) in

--- a/libs/ojsonnet/Unit_jsonnet_subst.ml
+++ b/libs/ojsonnet/Unit_jsonnet_subst.ml
@@ -37,7 +37,7 @@ let test_maker dirs pass_or_fail =
                     let core = Desugar_jsonnet.desugar_program file ast in
                     (* Currently slightly hacky, since we later may want to test for errors thrown *)
                     try
-                      let value_ = Eval_jsonnet_subst.eval_expr core in
+                      let value_ = Eval_jsonnet_subst.eval_program core in
                       let json =
                         JSON.to_yojson
                           (Eval_jsonnet_subst.manifest_value value_)

--- a/tools/ojsonnet/Main.ml
+++ b/tools/ojsonnet/Main.ml
@@ -64,7 +64,7 @@ let o_subst : bool Term.t =
   Arg.value (Arg.flag info)
 
 let o_envir : bool Term.t =
-  let info = Arg.info [ "env" ] ~doc:"Evaluate using environment model" in
+  let info = Arg.info [ "envir" ] ~doc:"Evaluate using environment model" in
   Arg.value (Arg.flag info)
 
 (* alt: use subcommands in ojsonnet but not worth the complexity *)
@@ -137,7 +137,7 @@ let interpret eval_strategy (file : Fpath.t) : JSON.t =
   let core = Desugar_jsonnet.desugar_program file ast in
   match eval_strategy with
   | Substitution ->
-      let value_ = Eval_jsonnet_subst.eval_expr core in
+      let value_ = Eval_jsonnet_subst.eval_program core in
       let json = Eval_jsonnet_subst.manifest_value value_ in
       json
   | Environment ->


### PR DESCRIPTION
This is for the depth field, for log_call

test plan:
make core