### PR TITLE
chore: Fix release process to avoid malformed Python wheels

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -123,7 +123,10 @@ FROM python:3.11-alpine AS semgrep-wheel
 WORKDIR /semgrep
 
 # Install some deps (build-base because ruamel.yaml has native code)
-RUN apk add --no-cache build-base zip bash
+#
+# libffi-dev is needed for installing Python dependencies in
+# scripts/build-wheels.sh on arm64
+RUN apk add --no-cache build-base zip bash libffi-dev
 
 # Copy in the CLI
 COPY cli ./cli

--- a/scripts/build-wheels.sh
+++ b/scripts/build-wheels.sh
@@ -7,9 +7,19 @@
 # It assumes the semgrep-core binary has been copied under cli/src/semgrep/bin
 # for pip to package semgrep correctly.
 
-set -e
-python3 -m pip install setuptools wheel
+set -ex
+# Need latest pip otherwise twine fails to install
+python3 -m pip install --upgrade pip
+# Need latest versions here otherwise we end up with a malformed package where
+# it marks the README as an RST file which fails to parse.
+python3 -m pip install --upgrade setuptools wheel twine
 cd cli && python3 setup.py sdist bdist_wheel "$@"
+
+# Do some sanity checks on the built packages. These checks are done as part of
+# uploading to pypi (in the gh-action-pypi-publish action), but we only run that
+# job on actual releases. Checking here will catch malformed packages on PR
+# rather than on release.
+twine check dist/*.whl
 
 # Zipping for a stable name to upload as an artifact
 zip -r dist.zip dist


### PR DESCRIPTION
The 1.47.0 release failed upon uploading to pypi because the wheel
included a DESCRIPTION.rst file which was actually our README. The
README is markdown, which is incompatible with the rst format. Previous
versions did not have this file at all, and instead the README was
correctly included in the METADATA file in the wheel, which allowed it
to be displayed correctly on pypi.

I believe that the workflow changes in https://github.com/semgrep/semgrep/pull/9081 caused this, but I am not
certain.

This PR does two things:

- Runs `twine check` on PRs. This catches the issue with malformed
  packages, as evidenced by the test plan.
- Upgrades to the latest version of setuptools and other Python
  packages. This solves the issue with malformed packages getting
  generated.

Test plan:

I verified that `twine check` catches the malformed wheel at PR time:
https://github.com/semgrep/semgrep/actions/runs/6748222634/job/18346377598

This run was before I fixed the underlying issue, and it is the same
error that caused the release to fail.

Then, I verified that updating the various Python packages fixed the
issue with the malformed wheel, shown by the fact that even with the
`twine check` step, the CI jobs on this PR are green.