### PR TITLE
fix(ls): gracefully handle unauthorized token

### DIFF
--- a/src/osemgrep/language_server/requests/Initialize_request.ml
+++ b/src/osemgrep/language_server/requests/Initialize_request.ml
@@ -67,6 +67,21 @@ let initialize_server server
           "intellij"
     | _ -> false
   in
+  (* Check the validity of the current API token here.
+     We do this asynchronously, since this is purely side-effecting,
+     and we don't care to percolate the monad.
+  *)
+  Lwt.async (fun () ->
+      let settings = Semgrep_settings.load () in
+      match settings.api_token with
+      | Some token ->
+          (* "if not valid", basically *)
+          if%lwt Semgrep_login.verify_token_async token |> Lwt.map not then (
+            RPC_server.notify_show_message ~kind:MessageType.Error
+              "Invalid Semgrep token detected, please log in again.";
+            Semgrep_settings.save { settings with api_token = None } |> ignore;
+            Lwt.return_unit)
+      | None -> Lwt.return_unit);
   (* We're using preemptive threads here as when semgrep scans run, they don't utilize Lwt at all,
       and so block the Lwt scheduler, meaning it cannot properly respond to requests until
       a scan is finished. With preemptive threads, the threads are guaranteed to run concurrently.

--- a/src/osemgrep/language_server/requests/dune
+++ b/src/osemgrep/language_server/requests/dune
@@ -6,4 +6,6 @@
    semgrep.language_server.scan_helpers
    semgrep.language_server.custom_requests
  )
+  (preprocess
+  (pps js_of_ocaml-ppx lwt_ppx))
 )

--- a/src/osemgrep/networking/Semgrep_login.ml
+++ b/src/osemgrep/networking/Semgrep_login.ml
@@ -55,6 +55,12 @@ let save_token_async ?(ident = None) token =
 let save_token ?(ident = None) token =
   Lwt_platform.run (save_token_async ~ident token)
 
+let verify_token_async token =
+  let%lwt resopt = Semgrep_App.get_deployment_from_token_async ~token in
+  Lwt.return (Option.is_some resopt)
+
+let verify_token token = Lwt_platform.run (verify_token_async token)
+
 let is_logged_in () =
   let settings = Semgrep_settings.load () in
   Option.is_some settings.api_token

--- a/src/osemgrep/networking/Semgrep_login.mli
+++ b/src/osemgrep/networking/Semgrep_login.mli
@@ -54,3 +54,9 @@ val fetch_token_async :
   * fails, it will return an error message. These will give users ~2 minutes to login
   * [wait_hook] is a function that will be called before each retry
   *)
+
+val verify_token_async : string -> bool Lwt.t
+(** [verify_token_async] verifies that a token is valid with the Semgrep App. *)
+
+val verify_token : string -> bool
+(** [verify_token] verifies that a token is valid with the Semgrep App. *)


### PR DESCRIPTION
## What:
This PR makes it so the language server does not crash upon pulling rules using an invalid token, and instead displays a helpful error message and prompts to re-log in.

## Why:
It's kind of a crappy user experience to have the LS crash entirely.

## How:
We now check if the token is valid on initialization of the language server. If it is invalid, we log the user out and prompt them to log in again.

## Test plan:
<img width="516" alt="image" src="https://github.com/semgrep/semgrep/assets/49291449/dd3aa552-cac5-4dfc-a4e1-38af58715d15">

with an authorization token with "666" liberally sprinkled into it

Closes PDX-184