### PR TITLE
Use rule_schema_v2.atd to validate rule

### DIFF
--- a/src/core/dune
+++ b/src/core/dune
@@ -64,3 +64,13 @@
  (targets semgrep_output_v1_t.ml semgrep_output_v1_t.mli)
  (deps    semgrep_output_v1.atd)
  (action  (run atdgen -t %{deps})))
+
+(rule
+ (targets rule_schema_v2_j.ml rule_schema_v2_j.mli)
+ (deps    rule_schema_v2.atd)
+ (action  (run atdgen -j -j-std -j-defaults %{deps})))
+
+(rule
+ (targets rule_schema_v2_t.ml rule_schema_v2_t.mli)
+ (deps    rule_schema_v2.atd)
+ (action  (run atdgen -t %{deps})))

--- a/src/core/rule_schema_v2.atd
+++ b/src/core/rule_schema_v2.atd
@@ -1,0 +1,1 @@
+../../interfaces/semgrep_interfaces/rule_schema_v2.atd

--- a/src/core/rule_schema_v2_adapter.ml
+++ b/src/core/rule_schema_v2_adapter.ml
@@ -1,0 +1,1 @@
+../../interfaces/semgrep_interfaces/rule_schema_v2_adapter.ml

--- a/src/osemgrep/cli_ci/Ci_subcommand.ml
+++ b/src/osemgrep/cli_ci/Ci_subcommand.ml
@@ -179,6 +179,7 @@ let scan_config_and_rules_from_deployment ~dry_run
       unique_id = Uuidm.v `V4;
       (* TODO: should look at conf.secrets, conf.sca, conf.code, etc. *)
       requested_products = [];
+      dry_run = false;
     }
   in
   (* TODO:

--- a/src/osemgrep/cli_scan/Validate_subcommand.ml
+++ b/src/osemgrep/cli_scan/Validate_subcommand.ml
@@ -60,10 +60,30 @@ type conf = {
 let metarules_pack = "p/semgrep-rule-lints"
 
 (*****************************************************************************)
+(* Experiment *)
+(*****************************************************************************)
+
+let parse_rule_with_atd_experiment_and_exit (file : Fpath.t) : unit =
+  let s = File.read_file file in
+  let atd = Rule_schema_v2_j.rules_of_string s in
+  pr2_gen atd;
+  exit 0
+
+(*****************************************************************************)
 (* Entry point *)
 (*****************************************************************************)
 
 let run (conf : conf) : Exit_code.t =
+  (* small experiment *)
+  (match conf with
+  | {
+   common = { maturity = Maturity.Develop; _ };
+   rules_source = Rules_source.Configs [ file ];
+   _;
+  } ->
+      parse_rule_with_atd_experiment_and_exit (Fpath.v file)
+  | _else_ -> ());
+
   let settings = Semgrep_settings.load () in
   let token_opt = settings.api_token in
   (* Checking (1) and (2). Parsing the rules is already a form of validation.

--- a/src/osemgrep/cli_scan/dune
+++ b/src/osemgrep/cli_scan/dune
@@ -10,6 +10,7 @@
     bos
     commons
 
+    semgrep_core
     semgrep_core_cli
     semgrep_targeting
 

--- a/tests/rule_formats/new_syntax_basic.json
+++ b/tests/rule_formats/new_syntax_basic.json
@@ -1,0 +1,11 @@
+{
+  "rules": [
+    {
+      "id": "x",
+      "message": "nope",
+      "languages": ["python"],
+      "severity": "WARNING",
+      "match": "foo(...)"
+    }
+  ]
+}


### PR DESCRIPTION
See also https://github.com/semgrep/semgrep-interfaces/pull/181

test plan:
```
$ ./bin/osemgrep --develop --validate --config tests/rule_formats/new_syntax_basic.json
([("x", "nope", -685964740, [-184214980], ((-557306320, "foo(...)")), 0, 0, 395056008, 0, 0, 0, 0, 0, 0, 0, 0)])
```