### PR TITLE
chore: start adding secrets to osemgrep

### DIFF
--- a/cli/bin/semgrep
+++ b/cli/bin/semgrep
@@ -121,7 +121,9 @@ def exec_pysemgrep():
 # we can always tell users to run pysemgrep instead of semgrep and be sure
 # they'll get the old behavior.
 def exec_osemgrep():
-    if "--pro" in sys.argv:
+    argv = sys.argv
+    if ("--pro" in argv or
+        "--beta-testing-secrets-enabled" in argv):
         try:
             path = find_semgrep_core_path(pro=True,
                                       extra_message="\nYou may need to run `semgrep install-semgrep-pro`"    )

--- a/src/osemgrep/cli_scan/Scan_CLI.mli
+++ b/src/osemgrep/cli_scan/Scan_CLI.mli
@@ -22,10 +22,6 @@ type conf = {
   strict : bool;
   rewrite_rule_ids : bool;
   engine_type : Engine_type.t;
-  (* Indicates the user requested Semgrep Secrets postprocessors to
-     validate secret findings. *)
-  run_secrets : bool;
-  allow_untrusted_validators : bool;
   (* Performance options *)
   core_runner_conf : Core_runner.conf;
   (* Display options *)

--- a/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -322,7 +322,7 @@ let scan_baseline_and_remove_duplicates (conf : Scan_CLI.conf)
                   in
                   let baseline_targets, baseline_diff_targets =
                     match conf.engine_type with
-                    | PRO Interfile ->
+                    | PRO Engine_type.{ analysis = Deep_interfile; _ } ->
                         let all_in_baseline, _ =
                           Find_targets.get_targets conf.targeting_conf
                             conf.target_roots
@@ -436,7 +436,7 @@ let run_scan_files (conf : Scan_CLI.conf) (profiler : Profiler.t)
               status.added @ status.modified |> Common.map Fpath.v
             in
             match conf.engine_type with
-            | PRO Interfile ->
+            | PRO Engine_type.{ analysis = Deep_interfile; _ } ->
                 Metrics_.g.payload.value.proFeatures <-
                   Some { diffDepth = Some diff_depth };
                 (targets, added_or_modified)

--- a/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -322,7 +322,7 @@ let scan_baseline_and_remove_duplicates (conf : Scan_CLI.conf)
                   in
                   let baseline_targets, baseline_diff_targets =
                     match conf.engine_type with
-                    | PRO Engine_type.{ analysis = Deep_interfile; _ } ->
+                    | PRO Engine_type.{ analysis = Interprocedural; _ } ->
                         let all_in_baseline, _ =
                           Find_targets.get_targets conf.targeting_conf
                             conf.target_roots
@@ -436,7 +436,7 @@ let run_scan_files (conf : Scan_CLI.conf) (profiler : Profiler.t)
               status.added @ status.modified |> Common.map Fpath.v
             in
             match conf.engine_type with
-            | PRO Engine_type.{ analysis = Deep_interfile; _ } ->
+            | PRO Engine_type.{ analysis = Interfile; _ } ->
                 Metrics_.g.payload.value.proFeatures <-
                   Some { diffDepth = Some diff_depth };
                 (targets, added_or_modified)

--- a/src/osemgrep/configuring/Engine_type.ml
+++ b/src/osemgrep/configuring/Engine_type.ml
@@ -1,11 +1,14 @@
 (* TODO merge with src/core/Engine_kind.ml *)
-(* TODO Intrafile -> Intraprocedural and remove deep *)
-type analysis_flavor = Intrafile | Deep_intrafile | Deep_interfile
+
+type analysis_flavor = OSS_intrafile | Deep_intrafile | Deep_interfile
 [@@deriving show]
 
 type secrets_config = { allow_all_origins : bool } [@@deriving show]
 
 type pro_flavor = {
+  (* Right now code_config is inlined because it really only has one nob = extra_languages, after talking
+     with Raghav and milan analysis_flavor is really a shared feature of all products using
+     the pro-engine. *)
   extra_languages : bool;
   analysis : analysis_flavor;
   secrets_config : secrets_config option; (* None = Disabled *)
@@ -16,5 +19,5 @@ type t = OSS | PRO of pro_flavor [@@deriving show]
 
 let make ~extra_languages ~analysis ~secrets_config =
   match (extra_languages, analysis, secrets_config) with
-  | false, Intrafile, None -> OSS
+  | false, OSS_intrafile, None -> OSS
   | _ -> PRO { extra_languages; analysis; secrets_config }

--- a/src/osemgrep/configuring/Engine_type.ml
+++ b/src/osemgrep/configuring/Engine_type.ml
@@ -1,3 +1,20 @@
 (* TODO merge with src/core/Engine_kind.ml *)
-type pro_flavor = Language_only | Intrafile | Interfile [@@deriving show]
+(* TODO Intrafile -> Intraprocedural and remove deep *)
+type analysis_flavor = Intrafile | Deep_intrafile | Deep_interfile
+[@@deriving show]
+
+type secrets_config = { allow_all_origins : bool } [@@deriving show]
+
+type pro_flavor = {
+  extra_languages : bool;
+  analysis : analysis_flavor;
+  secrets_config : secrets_config option; (* None = Disabled *)
+}
+[@@deriving show]
+
 type t = OSS | PRO of pro_flavor [@@deriving show]
+
+let make ~extra_languages ~analysis ~secrets_config =
+  match (extra_languages, analysis, secrets_config) with
+  | false, Intrafile, None -> OSS
+  | _ -> PRO { extra_languages; analysis; secrets_config }

--- a/src/osemgrep/configuring/Engine_type.ml
+++ b/src/osemgrep/configuring/Engine_type.ml
@@ -1,23 +1,23 @@
-(* TODO merge with src/core/Engine_kind.ml *)
+(* Note that we also have Engine_kind.t, which is an alias to semgrep_output_v1.engine_type with
+   Just OSS | Pro. This might seem redundant with Engine_kind but here we are more concerned
+   about configuring the engine, whereas Engine_kind.t is more useful as metrics for the users.
+*)
 
-type analysis_flavor = OSS_intrafile | Deep_intrafile | Deep_interfile
+type analysis_flavor = Intraprocedural | Interprocedural | Interfile
 [@@deriving show]
 
-type secrets_config = { allow_all_origins : bool } [@@deriving show]
+type secrets_config = {
+  (* Typically secrets will only run validators from semgrep.dev the
+     allow_all_origins flag bypasses this security check. *)
+  allow_all_origins : bool;
+}
+[@@deriving show]
 
-type pro_flavor = {
-  (* Right now code_config is inlined because it really only has one nob = extra_languages, after talking
-     with Raghav and milan analysis_flavor is really a shared feature of all products using
-     the pro-engine. *)
+type pro_config = {
   extra_languages : bool;
   analysis : analysis_flavor;
   secrets_config : secrets_config option; (* None = Disabled *)
 }
 [@@deriving show]
 
-type t = OSS | PRO of pro_flavor [@@deriving show]
-
-let make ~extra_languages ~analysis ~secrets_config =
-  match (extra_languages, analysis, secrets_config) with
-  | false, OSS_intrafile, None -> OSS
-  | _ -> PRO { extra_languages; analysis; secrets_config }
+type t = OSS | PRO of pro_config [@@deriving show]

--- a/src/osemgrep/language_server/scan_helpers/Scan_helpers.ml
+++ b/src/osemgrep/language_server/scan_helpers/Scan_helpers.ml
@@ -64,7 +64,9 @@ let run_semgrep ?(targets = None) ?(rules = None) ?(git_ref = None)
             *)
             let diff_config = Differential_scan_config.WholeScan in
             pro_scan_func roots ~diff_config
-              (Engine_type.PRO Engine_type.Intrafile)
+              Engine_type.(
+                make ~extra_languages:true ~analysis:Deep_intrafile
+                  ~secrets_config:None)
       else Core_runner.mk_scan_func_for_osemgrep Core_scan.scan_with_exn_handler
     in
     scan_func ~respect_git_ignore:true ~file_match_results_hook:None runner_conf

--- a/src/osemgrep/language_server/scan_helpers/Scan_helpers.ml
+++ b/src/osemgrep/language_server/scan_helpers/Scan_helpers.ml
@@ -65,8 +65,12 @@ let run_semgrep ?(targets = None) ?(rules = None) ?(git_ref = None)
             let diff_config = Differential_scan_config.WholeScan in
             pro_scan_func roots ~diff_config
               Engine_type.(
-                make ~extra_languages:true ~analysis:Deep_intrafile
-                  ~secrets_config:None)
+                PRO
+                  {
+                    extra_languages = true;
+                    analysis = Interprocedural;
+                    secrets_config = None;
+                  })
       else Core_runner.mk_scan_func_for_osemgrep Core_scan.scan_with_exn_handler
     in
     scan_func ~respect_git_ignore:true ~file_match_results_hook:None runner_conf


### PR DESCRIPTION
Implementation of secrets in osemgrep-pro is in [this PR](https://github.com/semgrep/semgrep-proprietary/pull/1106) along with the test plan.

