### PR TITLE
chore(js): testing message interpolation

### DIFF
--- a/js/engine/tests/__snapshots__/index.test.js.snap
+++ b/js/engine/tests/__snapshots__/index.test.js.snap
@@ -14,7 +14,7 @@ exports[`yaml parser interpolates metavariables in rule message 1`] = `
               "line": 9,
               "offset": 195,
             },
-            "path": "/Users/brandonspark/semgrep/js/engine/tests/test-interpolate-metavars.json",
+            "path": "test-interpolate-metavars.json",
             "start": {
               "col": 22,
               "line": 9,
@@ -49,7 +49,7 @@ exports[`yaml parser interpolates metavariables in rule message 1`] = `
                 },
                 "validation_state": "NO_VALIDATOR",
               },
-              "path": "/Users/brandonspark/semgrep/js/engine/tests/test.py",
+              "path": "test.py",
               "start": {
                 "col": 1,
                 "line": 1,
@@ -69,7 +69,7 @@ exports[`yaml parser interpolates metavariables in rule message 1`] = `
           "line": 7,
           "offset": 149,
         },
-        "path": "/Users/brandonspark/semgrep/js/engine/tests/test-interpolate-metavars.json",
+        "path": "test-interpolate-metavars.json",
         "start": {
           "col": 7,
           "line": 7,
@@ -104,7 +104,7 @@ exports[`yaml parser interpolates metavariables in rule message 1`] = `
             },
             "validation_state": "NO_VALIDATOR",
           },
-          "path": "/Users/brandonspark/semgrep/js/engine/tests/test.py",
+          "path": "test.py",
           "start": {
             "col": 1,
             "line": 1,
@@ -117,7 +117,7 @@ exports[`yaml parser interpolates metavariables in rule message 1`] = `
   ],
   "paths": {
     "scanned": [
-      "/Users/brandonspark/semgrep/js/engine/tests/test.py",
+      "test.py",
     ],
   },
   "results": [
@@ -153,7 +153,7 @@ exports[`yaml parser interpolates metavariables in rule message 1`] = `
         "severity": "WARNING",
         "validation_state": "NO_VALIDATOR",
       },
-      "path": "/Users/brandonspark/semgrep/js/engine/tests/test.py",
+      "path": "test.py",
       "start": {
         "col": 1,
         "line": 1,

--- a/js/engine/tests/__snapshots__/index.test.js.snap
+++ b/js/engine/tests/__snapshots__/index.test.js.snap
@@ -178,7 +178,7 @@ exports[`yaml parser parses a pattern with pattern-regex 1`] = `
           "line": 6,
           "offset": 99,
         },
-        "path": "/Users/brandonspark/semgrep/js/engine/tests/test-rule-yaml-regex.json",
+        "path": "test-rule-yaml-regex.json",
         "start": {
           "col": 24,
           "line": 6,
@@ -199,7 +199,7 @@ exports[`yaml parser parses a pattern with pattern-regex 1`] = `
             "metavars": {},
             "validation_state": "NO_VALIDATOR",
           },
-          "path": "/Users/brandonspark/semgrep/js/engine/tests/test.yaml",
+          "path": "test.yaml",
           "start": {
             "col": 1,
             "line": 1,
@@ -215,7 +215,7 @@ exports[`yaml parser parses a pattern with pattern-regex 1`] = `
   ],
   "paths": {
     "scanned": [
-      "/Users/brandonspark/semgrep/js/engine/tests/test.yaml",
+      "test.yaml",
     ],
   },
   "results": [
@@ -237,7 +237,7 @@ exports[`yaml parser parses a pattern with pattern-regex 1`] = `
         "severity": "ERROR",
         "validation_state": "NO_VALIDATOR",
       },
-      "path": "/Users/brandonspark/semgrep/js/engine/tests/test.yaml",
+      "path": "test.yaml",
       "start": {
         "col": 1,
         "line": 1,
@@ -262,7 +262,7 @@ exports[`yaml parser parses a simple pattern 1`] = `
           "line": 6,
           "offset": 96,
         },
-        "path": "/Users/brandonspark/semgrep/js/engine/tests/test-rule-yaml.json",
+        "path": "test-rule-yaml.json",
         "start": {
           "col": 18,
           "line": 6,
@@ -297,7 +297,7 @@ exports[`yaml parser parses a simple pattern 1`] = `
             },
             "validation_state": "NO_VALIDATOR",
           },
-          "path": "/Users/brandonspark/semgrep/js/engine/tests/test.yaml",
+          "path": "test.yaml",
           "start": {
             "col": 1,
             "line": 1,
@@ -313,7 +313,7 @@ exports[`yaml parser parses a simple pattern 1`] = `
   ],
   "paths": {
     "scanned": [
-      "/Users/brandonspark/semgrep/js/engine/tests/test.yaml",
+      "test.yaml",
     ],
   },
   "results": [
@@ -349,7 +349,7 @@ exports[`yaml parser parses a simple pattern 1`] = `
         "severity": "ERROR",
         "validation_state": "NO_VALIDATOR",
       },
-      "path": "/Users/brandonspark/semgrep/js/engine/tests/test.yaml",
+      "path": "test.yaml",
       "start": {
         "col": 1,
         "line": 1,

--- a/js/engine/tests/__snapshots__/index.test.js.snap
+++ b/js/engine/tests/__snapshots__/index.test.js.snap
@@ -1,5 +1,171 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`yaml parser interpolates metavariables in rule message 1`] = `
+{
+  "errors": [],
+  "explanations": [
+    {
+      "children": [
+        {
+          "children": [],
+          "loc": {
+            "end": {
+              "col": 33,
+              "line": 9,
+              "offset": 195,
+            },
+            "path": "/Users/brandonspark/semgrep/js/engine/tests/test-interpolate-metavars.json",
+            "start": {
+              "col": 22,
+              "line": 9,
+              "offset": 184,
+            },
+          },
+          "matches": [
+            {
+              "check_id": "test-interpolate-metavars",
+              "end": {
+                "col": 21,
+                "line": 1,
+                "offset": 20,
+              },
+              "extra": {
+                "engine_kind": "OSS",
+                "message": "Print content is $A",
+                "metavars": {
+                  "$A": {
+                    "abstract_content": ""Hello World"",
+                    "end": {
+                      "col": 20,
+                      "line": 1,
+                      "offset": 19,
+                    },
+                    "start": {
+                      "col": 7,
+                      "line": 1,
+                      "offset": 6,
+                    },
+                  },
+                },
+                "validation_state": "NO_VALIDATOR",
+              },
+              "path": "/Users/brandonspark/semgrep/js/engine/tests/test.py",
+              "start": {
+                "col": 1,
+                "line": 1,
+                "offset": 0,
+              },
+            },
+          ],
+          "op": [
+            "XPat",
+            "print($A)",
+          ],
+        },
+      ],
+      "loc": {
+        "end": {
+          "col": 17,
+          "line": 7,
+          "offset": 149,
+        },
+        "path": "/Users/brandonspark/semgrep/js/engine/tests/test-interpolate-metavars.json",
+        "start": {
+          "col": 7,
+          "line": 7,
+          "offset": 139,
+        },
+      },
+      "matches": [
+        {
+          "check_id": "test-interpolate-metavars",
+          "end": {
+            "col": 21,
+            "line": 1,
+            "offset": 20,
+          },
+          "extra": {
+            "engine_kind": "OSS",
+            "message": "Print content is $A",
+            "metavars": {
+              "$A": {
+                "abstract_content": ""Hello World"",
+                "end": {
+                  "col": 20,
+                  "line": 1,
+                  "offset": 19,
+                },
+                "start": {
+                  "col": 7,
+                  "line": 1,
+                  "offset": 6,
+                },
+              },
+            },
+            "validation_state": "NO_VALIDATOR",
+          },
+          "path": "/Users/brandonspark/semgrep/js/engine/tests/test.py",
+          "start": {
+            "col": 1,
+            "line": 1,
+            "offset": 0,
+          },
+        },
+      ],
+      "op": "And",
+    },
+  ],
+  "paths": {
+    "scanned": [
+      "/Users/brandonspark/semgrep/js/engine/tests/test.py",
+    ],
+  },
+  "results": [
+    {
+      "check_id": "test-interpolate-metavars",
+      "end": {
+        "col": 21,
+        "line": 1,
+        "offset": 20,
+      },
+      "extra": {
+        "engine_kind": "OSS",
+        "fingerprint": "<MASKED>",
+        "is_ignored": false,
+        "lines": "print("Hello World")",
+        "message": "Print content is "Hello World"",
+        "metadata": {},
+        "metavars": {
+          "$A": {
+            "abstract_content": ""Hello World"",
+            "end": {
+              "col": 20,
+              "line": 1,
+              "offset": 19,
+            },
+            "start": {
+              "col": 7,
+              "line": 1,
+              "offset": 6,
+            },
+          },
+        },
+        "severity": "WARNING",
+        "validation_state": "NO_VALIDATOR",
+      },
+      "path": "/Users/brandonspark/semgrep/js/engine/tests/test.py",
+      "start": {
+        "col": 1,
+        "line": 1,
+        "offset": 0,
+      },
+    },
+  ],
+  "skipped_rules": [],
+  "version": "<MASKED>",
+}
+`;
+
 exports[`yaml parser parses a pattern with pattern-regex 1`] = `
 {
   "errors": [],
@@ -12,7 +178,7 @@ exports[`yaml parser parses a pattern with pattern-regex 1`] = `
           "line": 6,
           "offset": 99,
         },
-        "path": "test-rule-yaml.json",
+        "path": "/Users/brandonspark/semgrep/js/engine/tests/test-rule-yaml-regex.json",
         "start": {
           "col": 24,
           "line": 6,
@@ -33,7 +199,7 @@ exports[`yaml parser parses a pattern with pattern-regex 1`] = `
             "metavars": {},
             "validation_state": "NO_VALIDATOR",
           },
-          "path": "test.yaml",
+          "path": "/Users/brandonspark/semgrep/js/engine/tests/test.yaml",
           "start": {
             "col": 1,
             "line": 1,
@@ -49,7 +215,7 @@ exports[`yaml parser parses a pattern with pattern-regex 1`] = `
   ],
   "paths": {
     "scanned": [
-      "test.yaml",
+      "/Users/brandonspark/semgrep/js/engine/tests/test.yaml",
     ],
   },
   "results": [
@@ -71,7 +237,7 @@ exports[`yaml parser parses a pattern with pattern-regex 1`] = `
         "severity": "ERROR",
         "validation_state": "NO_VALIDATOR",
       },
-      "path": "test.yaml",
+      "path": "/Users/brandonspark/semgrep/js/engine/tests/test.yaml",
       "start": {
         "col": 1,
         "line": 1,
@@ -96,7 +262,7 @@ exports[`yaml parser parses a simple pattern 1`] = `
           "line": 6,
           "offset": 96,
         },
-        "path": "test-rule-yaml.json",
+        "path": "/Users/brandonspark/semgrep/js/engine/tests/test-rule-yaml.json",
         "start": {
           "col": 18,
           "line": 6,
@@ -131,7 +297,7 @@ exports[`yaml parser parses a simple pattern 1`] = `
             },
             "validation_state": "NO_VALIDATOR",
           },
-          "path": "test.yaml",
+          "path": "/Users/brandonspark/semgrep/js/engine/tests/test.yaml",
           "start": {
             "col": 1,
             "line": 1,
@@ -147,7 +313,7 @@ exports[`yaml parser parses a simple pattern 1`] = `
   ],
   "paths": {
     "scanned": [
-      "test.yaml",
+      "/Users/brandonspark/semgrep/js/engine/tests/test.yaml",
     ],
   },
   "results": [
@@ -183,7 +349,7 @@ exports[`yaml parser parses a simple pattern 1`] = `
         "severity": "ERROR",
         "validation_state": "NO_VALIDATOR",
       },
-      "path": "test.yaml",
+      "path": "/Users/brandonspark/semgrep/js/engine/tests/test.yaml",
       "start": {
         "col": 1,
         "line": 1,

--- a/js/engine/tests/index.test.js
+++ b/js/engine/tests/index.test.js
@@ -32,44 +32,49 @@ describe("engine", () => {
   });
 });
 
+function executeSnapshotTest(engine, language, ruleFile, targetFile) {
+  const rulePath = path.resolve(`${__dirname}/${ruleFile}`);
+  const targetPath = path.resolve(`${__dirname}/${targetFile}`);
+
+  const result = JSON.parse(
+    engine
+      .execute(language, rulePath, `${__dirname}`, [targetPath])
+      .replaceAll("PRO", "OSS")
+  );
+  result["version"] = "<MASKED>";
+  // The fingerprint here is inconsistent across CI and locally.
+  // We don't know why. It appears to not be because of the OCaml translation,
+  // because the blakejs library was also inconsistent across platforms.
+  result["results"].map(
+    (match) => (match["extra"]["fingerprint"] = "<MASKED>")
+  );
+  expect(result).toMatchSnapshot();
+}
+
 describe("yaml parser", () => {
   test("parses a simple pattern", async () => {
     const engine = await enginePromise;
-    const rulePath = path.resolve(`${__dirname}/test-rule-yaml.json`);
-    const targetPath = path.resolve(`${__dirname}/test.yaml`);
-    const result = JSON.parse(
-      engine
-        .execute("yaml", rulePath, `${__dirname}`, [targetPath])
-        .replaceAll(rulePath, "test-rule-yaml.json")
-        .replaceAll(targetPath, "test.yaml")
-        .replaceAll("PRO", "OSS")
-    );
-    result["version"] = "<MASKED>";
-    // The fingerprint here is inconsistent across CI and locally.
-    // We don't know why. It appears to not be because of the OCaml translation,
-    // because the blakejs library was also inconsistent across platforms.
-    result["results"].map(
-      (match) => (match["extra"]["fingerprint"] = "<MASKED>")
-    );
-    expect(result).toMatchSnapshot();
+    executeSnapshotTest(engine, "yaml", "test-rule-yaml.json", "test.yaml");
   });
   test("parses a pattern with pattern-regex", async () => {
     const engine = await enginePromise;
-    const rulePath = path.resolve(`${__dirname}/test-rule-yaml-regex.json`);
-    const targetPath = path.resolve(`${__dirname}/test.yaml`);
-
-    const result = JSON.parse(
-      engine
-        .execute("yaml", rulePath, `${__dirname}`, [targetPath])
-        .replaceAll(rulePath, "test-rule-yaml.json")
-        .replaceAll(targetPath, "test.yaml")
-        .replaceAll("PRO", "OSS")
+    executeSnapshotTest(
+      engine,
+      "yaml",
+      "test-rule-yaml-regex.json",
+      "test.yaml"
     );
-    result["version"] = "<MASKED>";
-    result["results"].map(
-      (match) => (match["extra"]["fingerprint"] = "<MASKED>")
+  });
+  test("interpolates metavariables in rule message", async () => {
+    const engine = await enginePromise;
+    const python = require("../../languages/python/dist/index.cjs");
+    engine.addParser(await python.ParserFactory());
+    executeSnapshotTest(
+      engine,
+      "python",
+      "test-interpolate-metavars.json",
+      "test.py"
     );
-    expect(result).toMatchSnapshot();
   });
 });
 

--- a/js/engine/tests/index.test.js
+++ b/js/engine/tests/index.test.js
@@ -39,6 +39,8 @@ function executeSnapshotTest(engine, language, ruleFile, targetFile) {
   const result = JSON.parse(
     engine
       .execute(language, rulePath, `${__dirname}`, [targetPath])
+      .replaceAll(rulePath, ruleFile)
+      .replaceAll(targetPath, targetFile)
       .replaceAll("PRO", "OSS")
   );
   result["version"] = "<MASKED>";

--- a/js/engine/tests/test-interpolate-metavars.json
+++ b/js/engine/tests/test-interpolate-metavars.json
@@ -1,0 +1,15 @@
+{
+  "rules": [
+    {
+      "id": "test-interpolate-metavars",
+      "languages": ["python"],
+      "message": "Print content is $A",
+      "patterns": [
+        {
+          "pattern": "print($A)"
+        }
+      ],
+      "severity": "WARNING"
+    }
+  ]
+}


### PR DESCRIPTION
## What:
This PR adds a test for message interpolation of metavariables, which was added in https://github.com/semgrep/semgrep/pull/9132#9132 

## Test plan:
Automated tests.

Closes PDX-1
