### PR TITLE
Fix wrong default engine type when secret beta is enabled

### DIFF
--- a/changelog.d/ea-248.fixed
+++ b/changelog.d/ea-248.fixed
@@ -1,0 +1,2 @@
+Fixed a bug where enabling the secret beta causes the default scan mode to be
+set to OSS, even when the Pro flag is turned on in the web UI.

--- a/cli/src/semgrep/engine.py
+++ b/cli/src/semgrep/engine.py
@@ -46,7 +46,11 @@ class EngineType(Enum):
         """
         # Change default to pro-engine intrafile if secrets was requested.
         # Secrets is built into pro-engine, but any pro-setting should work.
-        if requested_engine is None and run_secrets:
+        if (
+            not (scan_handler and scan_handler.deepsemgrep)
+            and requested_engine is None
+            and run_secrets
+        ):
             requested_engine = cls.PRO_LANG
         elif run_secrets and requested_engine is cls.OSS:
             # Should be impossible if the CLI gates impossible arguemnet combinations.


### PR DESCRIPTION
Fixed a bug where enabling the secret beta causes the default scan mode to be set to OSS, even when the Pro flag is turned on in the web UI.

Test Plan:
I've tested the following combination of options:
`semgrep ci` + `pro` turned on + `secret` turned on = pro inter-file scan
`semgrep ci` + `pro` turned on + `secret` turned off = pro inter-file scan
`semgrep ci --diff-depth 2 --baseline-commit ...` + `pro` turned on + `secret` turned on = pro inter-file diff scan
`semgrep ci --diff-depth 2 --baseline-commit ...` + `pro` turned on + `secret` turned off = pro inter-file diff scan
`semgrep ci` + `pro` turned off + `secret` turned on = oss scan