### PR TITLE
ci: update build env from alpine 3.12 -> 3.18

### DIFF
--- a/.github/workflows/build-test-core-x86-ocaml5.yml
+++ b/.github/workflows/build-test-core-x86-ocaml5.yml
@@ -14,6 +14,8 @@ jobs:
     - uses: actions/checkout@v3
       with:
         submodules: true
+    - name: Configure git safedir properly
+      run: git config --global --add safe.directory $(pwd)
     - name: Build semgrep-core
       run: "\n          eval $(opam env)\n          make install-deps-ALPINE-for-semgrep-core\n
         \         make install-deps-for-semgrep-core\n          make core\n\n          mkdir

--- a/.github/workflows/build-test-core-x86-ocaml5.yml
+++ b/.github/workflows/build-test-core-x86-ocaml5.yml
@@ -24,6 +24,6 @@ jobs:
         path: ocaml-build-artifacts.tgz
         name: ocaml-build-artifacts-ocaml5-release
     runs-on: ubuntu-latest
-    container: returntocorp/ocaml:alpine5.1-2023-10-17
+    container: returntocorp/ocaml:alpine5.1-2023-11-07
     env:
       HOME: /root

--- a/.github/workflows/build-test-core-x86.jsonnet
+++ b/.github/workflows/build-test-core-x86.jsonnet
@@ -33,6 +33,7 @@ local job(container=semgrep.ocaml_alpine_container, artifact=artifact_name, run_
     steps: [
       gha.speedy_checkout_step,
       actions.checkout_with_submodules(),
+      gha.git_safedir,
       {
         name: 'Build semgrep-core',
         run: |||

--- a/.github/workflows/build-test-core-x86.yml
+++ b/.github/workflows/build-test-core-x86.yml
@@ -11,6 +11,8 @@ jobs:
     - uses: actions/checkout@v3
       with:
         submodules: true
+    - name: Configure git safedir properly
+      run: git config --global --add safe.directory $(pwd)
     - name: Build semgrep-core
       run: "\n          eval $(opam env)\n          make install-deps-ALPINE-for-semgrep-core\n
         \         make install-deps-for-semgrep-core\n          make core\n\n          mkdir

--- a/.github/workflows/build-test-core-x86.yml
+++ b/.github/workflows/build-test-core-x86.yml
@@ -23,6 +23,6 @@ jobs:
     - name: Test semgrep-core
       run: opam exec -- make core-test
     runs-on: ubuntu-latest
-    container: returntocorp/ocaml:alpine-2023-10-17
+    container: returntocorp/ocaml:alpine-2023-11-07
     env:
       HOME: /root

--- a/.github/workflows/build-test-javascript.jsonnet
+++ b/.github/workflows/build-test-javascript.jsonnet
@@ -66,6 +66,7 @@ local build_job =
     steps: [
       gha.speedy_checkout_step,
       actions.checkout_with_submodules(),
+      gha.git_safedir,
       // TODO: we should just call 'make install-deps-for-semgrep-core'
       {
         name: 'Set up tree-sitter',

--- a/.github/workflows/build-test-javascript.yml
+++ b/.github/workflows/build-test-javascript.yml
@@ -22,6 +22,8 @@ jobs:
     - uses: actions/checkout@v3
       with:
         submodules: true
+    - name: Configure git safedir properly
+      run: git config --global --add safe.directory $(pwd)
     - name: Set up tree-sitter
       run: (cd libs/ocaml-tree-sitter-core && ./configure && ./scripts/install-tree-sitter-lib)
     - name: Cache git checkout

--- a/.github/workflows/build-test-javascript.yml
+++ b/.github/workflows/build-test-javascript.yml
@@ -39,7 +39,7 @@ jobs:
         retention-days: 1
         path: "\n            _build/default/js/**/*.bc.js\n          "
         name: semgrep-js-ocaml-build-${{ github.sha }}
-    container: returntocorp/ocaml:alpine-2023-10-17
+    container: returntocorp/ocaml:alpine-2023-11-07
     env:
       HOME: /root
   test:

--- a/.github/workflows/libs/gha.libsonnet
+++ b/.github/workflows/libs/gha.libsonnet
@@ -9,6 +9,10 @@
     name: 'Make checkout speedy',
     run: 'git config --global fetch.parallel 50',
   },
+  git_safedir: {
+    name: 'Configure git safedir properly',
+    run: "git config --global --add safe.directory $(pwd)",
+  },
   // stay away dependabot, bad dog.
   dependabot_guard: {
     'if': "(github.actor != 'dependabot[bot]')",

--- a/.github/workflows/libs/semgrep.libsonnet
+++ b/.github/workflows/libs/semgrep.libsonnet
@@ -84,7 +84,7 @@ local github_bot = {
 
   ocaml5_alpine_container: {
     'runs-on': 'ubuntu-latest',
-    container: 'returntocorp/ocaml:alpine5.1-2023-10-17',
+    container: 'returntocorp/ocaml:alpine5.1-2023-11-07',
     env: {
       HOME: '/root',
     },

--- a/.github/workflows/libs/semgrep.libsonnet
+++ b/.github/workflows/libs/semgrep.libsonnet
@@ -74,7 +74,7 @@ local github_bot = {
 
   ocaml_alpine_container: {
     'runs-on': 'ubuntu-latest',
-    container: 'returntocorp/ocaml:alpine-2023-10-17',
+    container: 'returntocorp/ocaml:alpine-2023-11-07',
     // We need this hack because GHA tampers with the HOME in container
     // and this does not play well with 'opam' installed in /root
     env: {

--- a/.github/workflows/tests.jsonnet
+++ b/.github/workflows/tests.jsonnet
@@ -169,7 +169,10 @@ local test_osemgrep_job =
       {
         name: 'Run pytest for osemgrep known passing tests',
         'working-directory': 'cli',
-        run: 'make osempass',
+        run: |||
+          git config --global --add safe.directory "$(pwd)"
+          make osempass
+        |||,
       },
     ],
   };

--- a/.github/workflows/tests.jsonnet
+++ b/.github/workflows/tests.jsonnet
@@ -5,6 +5,7 @@
 // - we can build Linux and MacOS binaries and python "wheels" for pypi
 // - we don't have any perf regressions in our benchmarks
 
+local gha = import 'libs/gha.libsonnet';
 local actions = import 'libs/actions.libsonnet';
 local semgrep = import 'libs/semgrep.libsonnet';
 
@@ -94,7 +95,9 @@ local test_semgrep_core_job =
   semgrep.ocaml_alpine_container
   {
     steps: [
+      gha.speedy_checkout_step,
       actions.checkout_with_submodules(),
+      gha.git_safedir,
       {
         name: 'Build semgrep-core',
         run: |||
@@ -142,7 +145,9 @@ local test_osemgrep_job =
   semgrep.ocaml_alpine_container
   {
     steps: [
+      gha.speedy_checkout_step,
       actions.checkout_with_submodules(),
+      gha.git_safedir,
       {
         name: 'Build semgrep-core',
         run: |||

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Publish match performance
       run: opam exec -- make report-perf-matching
     runs-on: ubuntu-latest
-    container: returntocorp/ocaml:alpine-2023-10-17
+    container: returntocorp/ocaml:alpine-2023-11-07
     env:
       HOME: /root
   test-osemgrep:
@@ -50,7 +50,7 @@ jobs:
       working-directory: cli
       run: make osempass
     runs-on: ubuntu-latest
-    container: returntocorp/ocaml:alpine-2023-10-17
+    container: returntocorp/ocaml:alpine-2023-11-07
     env:
       HOME: /root
   test-cli:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,9 +13,13 @@ name: tests
 jobs:
   test-semgrep-core:
     steps:
+    - name: Make checkout speedy
+      run: git config --global fetch.parallel 50
     - uses: actions/checkout@v3
       with:
         submodules: true
+    - name: Configure git safedir properly
+      run: git config --global --add safe.directory $(pwd)
     - name: Build semgrep-core
       run: "\n          eval $(opam env)\n          make install-deps-ALPINE-for-semgrep-core\n
         \         make install-deps-for-semgrep-core\n          make core\n        "
@@ -35,9 +39,13 @@ jobs:
       HOME: /root
   test-osemgrep:
     steps:
+    - name: Make checkout speedy
+      run: git config --global fetch.parallel 50
     - uses: actions/checkout@v3
       with:
         submodules: true
+    - name: Configure git safedir properly
+      run: git config --global --add safe.directory $(pwd)
     - name: Build semgrep-core
       run: "\n          eval $(opam env)\n          make install-deps-ALPINE-for-semgrep-core\n
         \         make install-deps-for-semgrep-core\n          make core\n        "

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,7 +48,8 @@ jobs:
         pipenv install --dev)\n        "
     - name: Run pytest for osemgrep known passing tests
       working-directory: cli
-      run: make osempass
+      run: "\n          git config --global --add safe.directory \"$(pwd)\"\n          make
+        osempass\n        "
     runs-on: ubuntu-latest
     container: returntocorp/ocaml:alpine-2023-11-07
     env:

--- a/cli/tests/e2e/test_ci.py
+++ b/cli/tests/e2e/test_ci.py
@@ -73,6 +73,7 @@ USED_GITHUB_VARS = set(
         f"git grep --recurse-submodules -hPo 'GITHUB_[\\w_]*' {_cli_src}",
         shell=True,
         capture_output=True,
+        check=True,
     )
     .stdout.decode()
     .strip()


### PR DESCRIPTION
This image has been updated to use alpine 3.18
Test plan: let CI do it's thing.