### PR TITLE
fix: AST_to_IL: handle definition expressions

### DIFF
--- a/changelog.d/pa-3262.fixed
+++ b/changelog.d/pa-3262.fixed
@@ -1,0 +1,14 @@
+In expression-based languages, definitions are also expressions.
+
+This change allows dataflow to properly handle definition expressions.
+
+For example, the pattern `0 == 0` will match `x == 0` in
+
+```elixir
+def f(c) do
+  x = (y = 0)
+  x == 0
+end
+```
+
+because now dataflow is able to handle the expression `y = 0`.

--- a/src/analyzing/AST_to_IL.ml
+++ b/src/analyzing/AST_to_IL.ml
@@ -259,7 +259,7 @@ let mk_class_constructor_name (ty : G.type_) cons_id_info =
 let add_entity_name ctx ident =
   { entity_names = IdentSet.add (H.str_of_ident ident) ctx.entity_names }
 
-let def_expr_evaluates_to_value (lang:Lang.t) =
+let def_expr_evaluates_to_value (lang : Lang.t) =
   match lang with
   | Elixir -> true
   | _else_ -> false
@@ -1107,6 +1107,9 @@ and stmt_expr env ?e_gen st =
       expr_opt env None
   | G.DefStmt (ent, G.VarDef { G.vinit = Some e; vtype = _typTODO })
     when def_expr_evaluates_to_value env.lang ->
+      (* We may end up here due to Elixir_to_elixir's parsing. Other languages
+       * such as Ruby, Julia, and C seem to result in Assignments, not DefStmts.
+       *)
       let e = expr env e in
       let lv = lval_of_ent env ent in
       mk_i (Assign (lv, e)) (Related (G.S st)) |> add_instr env;

--- a/src/analyzing/AST_to_IL.ml
+++ b/src/analyzing/AST_to_IL.ml
@@ -259,6 +259,11 @@ let mk_class_constructor_name (ty : G.type_) cons_id_info =
 let add_entity_name ctx ident =
   { entity_names = IdentSet.add (H.str_of_ident ident) ctx.entity_names }
 
+let def_expr_evaluates_to_value (lang:Lang.t) =
+  match lang with
+  | Elixir -> true
+  | _else_ -> false
+
 (*****************************************************************************)
 (* lvalue *)
 (*****************************************************************************)
@@ -1100,7 +1105,8 @@ and stmt_expr env ?e_gen st =
   | G.Return (t, eorig, _) ->
       mk_s (Return (t, expr_opt env eorig)) |> add_stmt env;
       expr_opt env None
-  | G.DefStmt (ent, G.VarDef { G.vinit = Some e; vtype = _typTODO }) ->
+  | G.DefStmt (ent, G.VarDef { G.vinit = Some e; vtype = _typTODO })
+    when def_expr_evaluates_to_value env.lang ->
       let e = expr env e in
       let lv = lval_of_ent env ent in
       mk_i (Assign (lv, e)) (Related (G.S st)) |> add_instr env;

--- a/src/analyzing/AST_to_IL.ml
+++ b/src/analyzing/AST_to_IL.ml
@@ -1103,14 +1103,8 @@ and stmt_expr env ?e_gen st =
   | G.DefStmt (ent, G.VarDef { G.vinit = Some e; vtype = _typTODO }) ->
       let e = expr env e in
       let lv = lval_of_ent env ent in
-      let i = mk_i (Assign (lv, e)) (Related (G.S st)) in
-      mk_s (Instr i) |> add_stmt env;
-      let eorig =
-        match e_gen with
-        | None -> related_exp (G.e (G.StmtExpr st))
-        | Some e_gen -> SameAs e_gen
-      in
-      mk_e (Fetch lv) eorig
+      mk_i (Assign (lv, e)) (Related (G.S st)) |> add_instr env;
+      mk_e (Fetch lv) (related_exp (G.e (G.StmtExpr st)))
   | __else__ ->
       (* In any case, let's make sure the statement is in the IL translation
        * so that e.g. taint can do its job. *)

--- a/src/analyzing/AST_to_IL.ml
+++ b/src/analyzing/AST_to_IL.ml
@@ -1100,6 +1100,17 @@ and stmt_expr env ?e_gen st =
   | G.Return (t, eorig, _) ->
       mk_s (Return (t, expr_opt env eorig)) |> add_stmt env;
       expr_opt env None
+  | G.DefStmt (ent, G.VarDef { G.vinit = Some e; vtype = _typTODO }) ->
+      let e = expr env e in
+      let lv = lval_of_ent env ent in
+      let i = mk_i (Assign (lv, e)) (Related (G.S st)) in
+      mk_s (Instr i) |> add_stmt env;
+      let eorig =
+        match e_gen with
+        | None -> related_exp (G.e (G.StmtExpr st))
+        | Some e_gen -> SameAs e_gen
+      in
+      mk_e (Fetch lv) eorig
   | __else__ ->
       (* In any case, let's make sure the statement is in the IL translation
        * so that e.g. taint can do its job. *)

--- a/tests/taint_maturity/elixir/taint_if.ex
+++ b/tests/taint_maturity/elixir/taint_if.ex
@@ -36,7 +36,7 @@ defmodule Test do
     def test3(c) do
         x = "tainted"
         y = if c do
-                #todoruleid: taint-maturity
+                #ruleid: taint-maturity
                 sink(x)
                 sanitize(x)
             else

--- a/tests/taint_maturity/elixir/taint_seq.ex
+++ b/tests/taint_maturity/elixir/taint_seq.ex
@@ -31,4 +31,12 @@ defmodule Test do
     sink(x)
   end
 
+  def test5(c) do
+      x = y = "tainted"
+      #ruleid: taint-maturity
+      sink(x)
+      #ruleid: taint-maturity
+      sink(y)
+  end
+
 end


### PR DESCRIPTION
Partially helps: [PA-3185](https://linear.app/semgrep/issue/PA-3185).

Closes PA-3262.

This PR allows tainting to find a missing match in taint_if.ex.

Previously, definition expressions were not handled, and it resulted in an incomplete CFG for one of the functions.

This PR results in a complete CFG, so tainting was able to properly analyze that function.

Tested with `make core-test`.

