### PR TITLE
chore: remove node dependencies from engine

### DIFF
--- a/js/engine/dune
+++ b/js/engine/dune
@@ -4,7 +4,6 @@
   js_of_ocaml
   semgrep.running
   semgrep.semgrep_js_shared
-  semgrep.semgrep_node_js_shared
   tree-sitter.run
   ; semgrep.parsing_languages ; skipped to go from 16MB to 7MB
   )


### PR DESCRIPTION
## What:
This PR removes `node_js_shared` from the engine.

## Why:
It's not necessary, we only need those dependencies for the Unix calls, which are not called from just the scans themselves in the engine. This will cause Turbo Mode to emit an error in the Playground.

## Test plan:
Observe that by running the App locally, with a newly-built version of the JS Engine, will no longer emit a warning for `node:process`.