### PR TITLE
fix(workflow): use exact version of pypa/gh-action-pypi-publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Build parked packages
         run: pipenv run python setup.py park
       - name: Publish to Pypi
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         if: ${{ !contains(github.ref,'-test-release') }}
         with:
           user: __token__
@@ -78,7 +78,7 @@ jobs:
           skip_existing: true
           packages_dir: cli/dist/
       - name: Publish to test Pypi
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         if: ${{ contains(github.ref,'-test-release') }}
         with:
           repository_url: https://test.pypi.org/legacy/
@@ -228,7 +228,7 @@ jobs:
         # Don't unzip tar.gz because it already exists from ./manylinux-x86-wheel/dist.zip.
         run: unzip ./osx-arm64-wheel/dist.zip "*.whl"
       - name: Publish to Pypi
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         if: ${{ !contains(github.ref, '-test-release') && needs.inputs.outputs.dry-run != 'true' }}
         with:
           user: __token__


### PR DESCRIPTION
We've been using the `master` version which is now sunset (https://github.com/pypa/gh-action-pypi-publish#-master-branch-sunset-).

It's been causing warnings, e.g. in the last release.  (Example: https://github.com/semgrep/semgrep/actions/runs/6726476178/job/18283967998?pr=9136)

This PR changes the version to `release/v1` as recommended on the official documentation.

Closes PA-3235.

