### PR TITLE
pass request_id + error to fail-open

### DIFF
--- a/cli/src/semgrep/app/scans.py
+++ b/cli/src/semgrep/app/scans.py
@@ -14,7 +14,6 @@ from typing import List
 from typing import Optional
 from typing import Set
 from typing import TYPE_CHECKING
-from uuid import uuid4
 
 import click
 import requests
@@ -48,7 +47,8 @@ class ScanCompleteResult:
 
 class ScanHandler:
     def __init__(self, dry_run: bool = False) -> None:
-        self.local_id = str(uuid4())
+        state = get_state()
+        self.local_id = str(state.request_id)
         self.scan_metadata = out.ScanMetadata(
             cli_version=out.Version(__VERSION__),
             unique_id=out.Uuid(self.local_id),

--- a/cli/src/semgrep/error_handler.py
+++ b/cli/src/semgrep/error_handler.py
@@ -42,7 +42,7 @@ class ErrorHandler:
     def pop_request(self) -> None:
         self.payload = {}
 
-    def capture_error(self, e: BaseException | None = None) -> None:
+    def capture_error(self, e: Optional[BaseException] = None) -> None:
         import traceback
 
         if sys.exc_info()[0] is not None:

--- a/cli/src/semgrep/state.py
+++ b/cli/src/semgrep/state.py
@@ -1,6 +1,8 @@
 from enum import auto
 from enum import Enum
 from typing import List
+from uuid import UUID
+from uuid import uuid4
 
 import click
 from attrs import Factory
@@ -30,6 +32,7 @@ class SemgrepState:
     """
 
     app_session: AppSession = Factory(AppSession)
+    request_id: UUID = Factory(uuid4)
     env: Env = Factory(Env)
     metrics: Metrics = Factory(Metrics)
     error_handler: ErrorHandler = Factory(ErrorHandler)

--- a/cli/tests/conftest.py
+++ b/cli/tests/conftest.py
@@ -502,3 +502,16 @@ def parse_lockfile_path_in_tmp_for_perf(
     (tmp_path / "rules").symlink_to(Path(TESTS_PATH / "e2e" / "rules").resolve())
     monkeypatch.chdir(tmp_path)
     return parse_lockfile_path
+
+
+class str_containing:
+    """Assert that a given string meets some expectations."""
+
+    def __init__(self, pattern, flags=0):
+        self._pattern = pattern
+
+    def __eq__(self, actual):
+        return self._pattern in actual
+
+    def __repr__(self):
+        return self._pattern

--- a/cli/tests/e2e/test_ci.py
+++ b/cli/tests/e2e/test_ci.py
@@ -1477,6 +1477,7 @@ def test_fail_auth_invalid_key_suppressed_by_default(
         "method": "POST",
         "status_code": 401,
         "request_id": scan_create.last_request.json()["scan_metadata"]["unique_id"],
+        "error": str_containing("INVALID_API_KEY_EXIT_CODE"),
     }
 
 

--- a/cli/tests/e2e/test_ci.py
+++ b/cli/tests/e2e/test_ci.py
@@ -19,8 +19,10 @@ from textwrap import dedent
 from typing import List
 
 import pytest
+from requests.exceptions import ConnectionError
 from ruamel.yaml import YAML
 from tests.conftest import make_semgrepconfig_file
+from tests.conftest import str_containing
 from tests.e2e.test_baseline import _git_commit
 from tests.e2e.test_baseline import _git_merge
 from tests.fixtures import RunSemgrep
@@ -1456,7 +1458,9 @@ def test_fail_auth_invalid_key_suppressed_by_default(
     """
     Test that an invalid api key returns exit code 13, even when errors are supressed
     """
-    requests_mock.post("https://semgrep.dev/api/cli/scans", status_code=401)
+    scan_create = requests_mock.post(
+        "https://semgrep.dev/api/cli/scans", status_code=401
+    )
     fail_open = requests_mock.post("https://fail-open.prod.semgrep.dev/failure")
     run_semgrep(
         options=["ci"],
@@ -1466,7 +1470,14 @@ def test_fail_auth_invalid_key_suppressed_by_default(
         env={"SEMGREP_APP_TOKEN": "fake-key-from-tests"},
         use_click_runner=True,
     )
+
     assert fail_open.called
+    assert fail_open.last_request.json() == {
+        "url": "https://semgrep.dev/api/cli/scans",
+        "method": "POST",
+        "status_code": 401,
+        "request_id": scan_create.last_request.json()["scan_metadata"]["unique_id"],
+    }
 
 
 @pytest.mark.osemfail
@@ -1543,6 +1554,35 @@ def test_fail_start_scan_error_handler(
     )
 
     mock_send.assert_called_once_with(mocker.ANY, 2)
+
+
+@pytest.mark.osemfail
+def test_fail_open_works_when_backend_is_down(
+    run_semgrep: RunSemgrep, mocker, git_tmp_path_with_commit, requests_mock
+):
+    """
+    Test that an invalid api key returns exit code 13, even when errors are supressed
+    """
+    scan_create = requests_mock.post(
+        "https://semgrep.dev/api/cli/scans", exc=ConnectionError
+    )
+    fail_open = requests_mock.post("https://fail-open.prod.semgrep.dev/failure")
+    run_semgrep(
+        options=["ci"],
+        target_name=None,
+        strict=False,
+        assert_exit_code=0,
+        env={"SEMGREP_APP_TOKEN": "fake-key-from-tests"},
+        use_click_runner=True,
+    )
+
+    assert fail_open.called
+    assert fail_open.last_request.json() == {
+        "url": "https://semgrep.dev/api/cli/scans",
+        "method": "POST",
+        "request_id": scan_create.last_request.json()["scan_metadata"]["unique_id"],
+        "error": str_containing("requests.exceptions.ConnectionError"),
+    }
 
 
 @pytest.mark.parametrize("scan_config", [BAD_CONFIG], ids=["bad_config"])


### PR DESCRIPTION
This PR updates the fail-open error handling code to send the unique request id in the payload and fixes the error capturing.
Sadly the existing tests in `test_error_handler` don't accurately test the implementation so this hasn't been working as expected for quite some time.

Given my current time constraints, I've added an e2e test for the ci command and made a quick fix to keep the error_handler tests passing and may try to come back to the error handler tests when time permits.