### PR TITLE
devops: Fix trigger-semgrep-comparison-argo workflow by using remote in rev-parse

### DIFF
--- a/.github/workflows/trigger-semgrep-comparison-argo.yaml
+++ b/.github/workflows/trigger-semgrep-comparison-argo.yaml
@@ -1,5 +1,5 @@
 # This workflow triggers the `semgrep-comparison` Argo Workflow, which will
-# create a GitHub Check on this pull request (or specified branch if running manually.
+# create a GitHub Check on this pull request (or specified branch if running manually).
 # The `semgrep-comparison` workflow compares two Semgrep versions for timing differences.
 name: trigger-semgrep-comparison-argo
 
@@ -46,7 +46,7 @@ jobs:
             echo "sha=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
           elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             git fetch origin $BRANCH
-            SHA=$(git rev-parse $BRANCH)
+            SHA=$(git rev-parse origin/$BRANCH)
             echo "sha=$SHA" >> "$GITHUB_OUTPUT"
           fi
   trigger-semgrep-comparison-argo-workflow:


### PR DESCRIPTION
Previously, [this workflow failed with an ambiguous error](https://github.com/semgrep/semgrep/actions/runs/6802310005/job/18495136385), [even though it worked in `act`](https://github.com/semgrep/semgrep/pull/9171#issue-1980059793).

<img width="1384" alt="image" src="https://github.com/semgrep/semgrep/assets/2374948/973793d0-1770-4e9d-9801-b18d3075f93d">


Test plan:
* [I tested this change on a dummy repo, which succeeded.](https://github.com/minusworld/dvna/actions/runs/6803734370/job/18499694217)

<img width="1366" alt="image" src="https://github.com/semgrep/semgrep/assets/2374948/e3f7c415-7d89-490d-9591-d6f64e296296">
