### PR TITLE
fix: regression in react-nextjs-router-push test

### DIFF
--- a/changelog.d/pa-3089.fixed
+++ b/changelog.d/pa-3089.fixed
@@ -1,0 +1,4 @@
+Fix regression for the unused lambda change in react-nextjs-router-push test
+
+A lambda expression defined in a return expression is also treated as used at
+the location of the return expression.


### PR DESCRIPTION
handle unused lambda in return expression

test plan:
tested with `react-nextjs-router-push` test.

