### PR TITLE
Make -test_rules a bit more CI friendly

### DIFF
--- a/libs/lib_parsing/Parsing_stat.ml
+++ b/libs/lib_parsing/Parsing_stat.ml
@@ -194,18 +194,19 @@ let print_regression_information ~ext xs newscore =
   in
   (* nosemgrep *)
   let score_path = (* Config_pfff.regression_data_dir *) "/tmp/pfff" in
-  dirname_opt
-  |> Option.iter (fun dirname ->
-         pr2 "------------------------------";
-         pr2 "regression testing information";
-         pr2 "------------------------------";
-         let str = Str.global_replace (Str.regexp "/") "__" dirname in
-         let file =
-           Filename.concat score_path
-             ("score_parsing__" ^ str ^ ext ^ ".marshalled")
-         in
-         logger#debug "saving regression info in %s" file;
-         Common2.regression_testing newscore file);
+  if Sys.file_exists score_path then
+    dirname_opt
+    |> Option.iter (fun dirname ->
+           pr2 "------------------------------";
+           pr2 "regression testing information";
+           pr2 "------------------------------";
+           let str = Str.global_replace (Str.regexp "/") "__" dirname in
+           let file =
+             Filename.concat score_path
+               ("score_parsing__" ^ str ^ ext ^ ".marshalled")
+           in
+           logger#debug "saving regression info in %s" file;
+           Common2.regression_testing newscore file);
   ()
 
 (*****************************************************************************)

--- a/libs/lib_parsing/Parsing_stat.ml
+++ b/libs/lib_parsing/Parsing_stat.ml
@@ -193,7 +193,7 @@ let print_regression_information ~ext xs newscore =
     | _ -> None
   in
   (* nosemgrep *)
-  let score_path = (* Config_pfff.regression_data_dir *) "/tmp/pfff" in
+  let score_path = (* Config_pfff.regression_data_dir *) "/tmp/parsing_stats" in
   if Sys.file_exists score_path then
     dirname_opt
     |> Option.iter (fun dirname ->
@@ -206,8 +206,8 @@ let print_regression_information ~ext xs newscore =
                ("score_parsing__" ^ str ^ ext ^ ".marshalled")
            in
            logger#debug "saving regression info in %s" file;
-           Common2.regression_testing newscore file);
-  ()
+           Common2.regression_testing newscore file)
+  else pr2 (spf "no regression info available: %s does not exist" score_path)
 
 (*****************************************************************************)
 (* Most problematic tokens *)

--- a/src/analyzing/CFG_build.ml
+++ b/src/analyzing/CFG_build.ml
@@ -111,9 +111,7 @@ let resolve_gotos state =
   !(state.gotos)
   |> List.iter (fun (srci, label_key) ->
          match Hashtbl.find_opt state.labels label_key with
-         | None ->
-             Common.pr2
-             @@ Common.spf "Could not resolve label: %s" (fst label_key)
+         | None -> logger#warning "Could not resolve label: %s" (fst label_key)
          | Some dsti -> state.g |> add_arc (srci, dsti));
   state.gotos := []
 

--- a/src/engine/Test_engine.ml
+++ b/src/engine/Test_engine.ml
@@ -283,6 +283,7 @@ let make_test_rule_file ~unit_testing ~get_xlang ~prepend_lang ~newscore
         | Ok () -> Hashtbl.add newscore !!file Common2.Ok
         | Error (num_errors, msg) ->
             pr2 msg;
+            pr2 "---";
             Hashtbl.add newscore !!file (Common2.Pb msg);
             total_mismatch := !total_mismatch + num_errors;
             if unit_testing then Alcotest.fail msg)
@@ -325,7 +326,8 @@ let make_tests ?(unit_testing = false) ?(get_xlang = None)
   let print_summary () =
     if not unit_testing then
       Parsing_stat.print_regression_information ~ext xs newscore;
-    pr2 (spf "total mismatch: %d" !total_mismatch)
+    pr2 (spf "total mismatch: %d" !total_mismatch);
+    if !total_mismatch > 0 then exit 1
   in
   (tests, print_summary)
 

--- a/src/engine/Test_engine.ml
+++ b/src/engine/Test_engine.ml
@@ -326,13 +326,13 @@ let make_tests ?(unit_testing = false) ?(get_xlang = None)
   let print_summary () =
     if not unit_testing then
       Parsing_stat.print_regression_information ~ext xs newscore;
-    pr2 (spf "total mismatch: %d" !total_mismatch);
-    if !total_mismatch > 0 then exit 1
+    pr2 (spf "total mismatch: %d" !total_mismatch)
   in
-  (tests, print_summary)
+  (tests, !total_mismatch, print_summary)
 
 let test_rules ?unit_testing xs =
   let paths = File.Path.of_strings xs in
-  let tests, print_summary = make_tests ?unit_testing paths in
+  let tests, total_mismatch, print_summary = make_tests ?unit_testing paths in
   tests |> List.iter (fun (_name, test) -> test ());
-  print_summary ()
+  print_summary ();
+  if total_mismatch > 0 then exit 1

--- a/src/engine/Test_engine.mli
+++ b/src/engine/Test_engine.mli
@@ -7,7 +7,7 @@ val make_tests :
   ?get_xlang:(Fpath.t -> Rule.rules -> Xlang.t) option ->
   ?prepend_lang:bool ->
   Fpath.t list ->
-  (string * (unit -> unit)) list * (unit -> unit)
+  (string * (unit -> unit)) list * int (* total mismatch *) * (unit -> unit)
 
 (* Run the tests and print a summary. *)
 val test_rules : ?unit_testing:bool -> Common.filename list -> unit

--- a/src/engine/Unit_engine.ml
+++ b/src/engine/Unit_engine.ml
@@ -544,7 +544,7 @@ let get_extract_source_lang file rules =
 let extract_tests () =
   let path = tests_path / "extract" in
   pack_tests "extract mode"
-    (let tests, _print_summary =
+    (let tests, _total_mismatch, _print_summary =
        Test_engine.make_tests ~unit_testing:true
          ~get_xlang:(Some get_extract_source_lang) [ path ]
      in
@@ -708,11 +708,11 @@ let lang_tainting_tests () =
 
 let full_rule_regression_tests () =
   let path = tests_path / "rules" in
-  let tests1, _print_summary =
+  let tests1, _total_mismatch, _print_summary =
     Test_engine.make_tests ~unit_testing:true ~prepend_lang:true [ path ]
   in
   let path = tests_path / "rules_v2" in
-  let tests2, _print_summary =
+  let tests2, _total_mismatch, _print_summary =
     Test_engine.make_tests ~unit_testing:true ~prepend_lang:true [ path ]
   in
   let tests = tests1 @ tests2 in
@@ -743,7 +743,7 @@ let full_rule_regression_tests () =
 let full_rule_taint_maturity_tests () =
   let path = tests_path / "taint_maturity" in
   pack_tests "taint maturity"
-    (let tests, _print_summary =
+    (let tests, _total_mismatch, _print_summary =
        Test_engine.make_tests ~unit_testing:true [ path ]
      in
      tests)
@@ -756,7 +756,7 @@ let full_rule_taint_maturity_tests () =
  *)
 let full_rule_semgrep_rules_regression_tests () =
   let path = tests_path / "semgrep-rules" in
-  let tests, _print_summary =
+  let tests, _total_mismatch, _print_summary =
     Test_engine.make_tests ~unit_testing:true [ path ]
   in
   let groups =


### PR DESCRIPTION
- Print a separator in between failed tests.
- Exit with non-zero if there is any failing test.
- Make 'print_regression_information' optional, it adds a lot of noise on the first run, when no 'score_parsing' file exists, which is the case for every CI run.

Also, changed a `pr2` to a `logger#warning` during CFG construction.

test plan:
% semgrep-core -test_rules .

