### PR TITLE
feat: `semgrep-internal-pattern-anywhere`

### DIFF
--- a/cli/src/semgrep/rule_lang.py
+++ b/cli/src/semgrep/rule_lang.py
@@ -463,6 +463,7 @@ class RuleValidation:
         "pattern-either",
         "pattern-regex",
         "patterns",
+        "semgrep-internal-patterns-allow-disjoint",
         "pattern-sinks",
         "pattern-sources",
         "join",

--- a/cli/src/semgrep/rule_lang.py
+++ b/cli/src/semgrep/rule_lang.py
@@ -463,7 +463,6 @@ class RuleValidation:
         "pattern-either",
         "pattern-regex",
         "patterns",
-        "semgrep-internal-patterns-allow-disjoint",
         "pattern-sinks",
         "pattern-sources",
         "join",

--- a/cli/src/semgrep/rule_match.py
+++ b/cli/src/semgrep/rule_match.py
@@ -210,20 +210,25 @@ class RuleMatch:
         Used for deduplication in the CLI before writing output.
         """
         return (
-            # REVIEW: comment still relevant?
-            # NOTE: We include the previous scan's rules in the config for consistent fixed status work.
-            # For unique hashing/grouping, previous and current scan rules must have distinct check IDs.
-            # Hence, previous scan rules are annotated with a unique check ID, while the original ID is kept in metadata.
-            # As check_id is used for cli_unique_key, this patch fetches the check ID from metadata for previous scan findings.
-            # TODO: Once the fixed status work is stable, all findings should fetch the check ID from metadata.
-            # This fallback prevents breaking current scan results if an issue arises.
+            # NOTE: We include the previous scan's rules in the config for
+            # consistent fixed status work. For unique hashing/grouping,
+            # previous and current scan rules must have distinct check IDs.
+            # Hence, previous scan rules are annotated with a unique check ID,
+            # while the original ID is kept in metadata. As check_id is used
+            # for cli_unique_key, this patch fetches the check ID from metadata
+            # for previous scan findings.
+            # TODO: Once the fixed status work is stable, all findings should
+            # fetch the check ID from metadata. This fallback prevents breaking
+            # current scan results if an issue arises.
             self.annotated_rule_name if self.from_transient_scan else self.rule_id,
             str(self.path),
             self.start.offset,
             self.end.offset,
             self.message,
             # TODO: Bring this back.
-            # This is necessary so we don't deduplicate taint findings which have different sources.
+            # This is necessary so we don't deduplicate taint findings which
+            # have different sources.
+            #
             # self.match.extra.dataflow_trace.to_json_string
             # if self.match.extra.dataflow_trace
             # else None,

--- a/cli/src/semgrep/rule_match.py
+++ b/cli/src/semgrep/rule_match.py
@@ -209,23 +209,15 @@ class RuleMatch:
 
         Used for deduplication in the CLI before writing output.
         """
-        if self.from_transient_scan:
+        return (
+            # REVIEW: comment still relevant?
             # NOTE: We include the previous scan's rules in the config for consistent fixed status work.
             # For unique hashing/grouping, previous and current scan rules must have distinct check IDs.
             # Hence, previous scan rules are annotated with a unique check ID, while the original ID is kept in metadata.
             # As check_id is used for cli_unique_key, this patch fetches the check ID from metadata for previous scan findings.
             # TODO: Once the fixed status work is stable, all findings should fetch the check ID from metadata.
             # This fallback prevents breaking current scan results if an issue arises.
-            return (
-                self.annotated_rule_name,
-                str(self.path),
-                self.start.offset,
-                self.end.offset,
-                self.message,
-                None,
-            )
-        return (
-            self.rule_id,
+            self.annotated_rule_name if self.from_transient_scan else self.rule_id,
             str(self.path),
             self.start.offset,
             self.end.offset,
@@ -236,6 +228,14 @@ class RuleMatch:
             # if self.match.extra.dataflow_trace
             # else None,
             None,
+            # TODO: it may be better to instead consider the validator with
+            # metavariables interpolated in, as this gives a greater picture of
+            # the differences in validation (different validation attempts
+            # would then be considered different, rather than only outcomes).
+            # However, this would require us to carry much more information
+            # about the rule around with the match, so I've gone for a simpler
+            # option here.
+            self.match.extra.validation_state,
         )
 
     @ci_unique_key.default

--- a/cli/tests/e2e/snapshots/test_rule_validation/test_validation_of_invalid_rules/rulesinvalid-rulesinvalid-pattern-operator.yaml/results.txt
+++ b/cli/tests/e2e/snapshots/test_rule_validation/test_validation_of_invalid_rules/rulesinvalid-rulesinvalid-pattern-operator.yaml/results.txt
@@ -7,4 +7,4 @@ semgrep error: Invalid rule schema
 One of these properties is missing: 'all', 'any', 'anywhere', 'inside', 'not', 'pattern', 'regex', 'taint'
 
 [ERROR] Rule parse error in rule eqeq:
- Expected one of pattern,all,any,regex,taint,not,inside to be present
+ Expected one of pattern,all,any,regex,taint,not,inside,anywhere to be present

--- a/src/core/Rule.ml
+++ b/src/core/Rule.ml
@@ -79,6 +79,7 @@ type formula =
    * https://github.com/returntocorp/semgrep/issues/1218
    *)
   | Inside of tok * formula
+  | Anywhere of tok * formula
 
 (* The conjunction must contain at least
  * one positive "term" (unless it's inside a CondNestedFormula, in which
@@ -782,14 +783,15 @@ let () = Printexc.register_printer opt_string_of_exn
    Evaluation order means that we will only visit children after parents.
    So we keep a reference cell around, and set it to true whenever we descend
    under an inside.
-   That way, pattern leaves underneath an Inside will properly be paired with
-   a true boolean.
+   That way, pattern leaves underneath an Inside/Anywhere will properly be
+   paired with a true boolean.
 *)
 let visit_new_formula f formula =
   let bref = ref false in
   let rec visit_new_formula f formula =
     match formula with
     | P p -> f p ~inside:!bref
+    | Anywhere (_, formula)
     | Inside (_, formula) ->
         Common.save_excursion bref true (fun () -> visit_new_formula f formula)
     | Not (_, x) -> visit_new_formula f x
@@ -801,18 +803,20 @@ let visit_new_formula f formula =
 
 (* used by the metachecker for precise error location *)
 let tok_of_formula = function
-  | And (t, _) -> t
+  | And (t, _)
   | Or (t, _)
+  | Inside (t, _)
+  | Anywhere (t, _)
   | Not (t, _) ->
       t
   | P p -> snd p.pstr
-  | Inside (t, _) -> t
 
 let kind_of_formula = function
   | P _ -> "pattern"
   | Or _
   | And _
   | Inside _
+  | Anywhere _
   | Not _ ->
       "formula"
 
@@ -864,6 +868,7 @@ let split_and (xs : formula list) : formula list * (tok * formula) list =
          | P _
          | And _
          | Inside _
+         | Anywhere _
          | Or _ ->
              Left e
          (* negatives *)

--- a/src/core/Rule.ml
+++ b/src/core/Rule.ml
@@ -79,6 +79,13 @@ type formula =
    * https://github.com/returntocorp/semgrep/issues/1218
    *)
   | Inside of tok * formula
+  (* alt: Could do this under a `where` (call it something like `also`).
+     Preferred this since existing where conditions are predicates on
+     metavariables and this is an additional separate formula. Additionally,
+     this version opens this up more naturally for negation (not
+     straightforward to negate a where clause, but can just use `not` for a
+     formula)
+  *)
   | Anywhere of tok * formula
 
 (* The conjunction must contain at least

--- a/src/engine/Match_search_mode.ml
+++ b/src/engine/Match_search_mode.ml
@@ -331,7 +331,8 @@ let run_selector_on_ranges env selector_opt ranges =
         (List.length res.matches);
       res.matches
       |> Common.map RM.match_result_to_range
-      |> RM.intersect_ranges env.xconf.config !debug_matches ranges
+      |> RM.intersect_ranges env.xconf.config ~debug_matches:!debug_matches
+           ranges
 
 let apply_focus_on_ranges env (focus_mvars_list : R.focus_mv_list list)
     (ranges : RM.ranges) : RM.ranges =
@@ -789,7 +790,8 @@ and evaluate_formula (env : env) (opt_context : RM.t option) (e : R.formula) :
             posrs
             |> List.fold_left
                  (fun acc r ->
-                   RM.intersect_ranges env.xconf.config !debug_matches acc r)
+                   RM.intersect_ranges env.xconf.config
+                     ~debug_matches:!debug_matches acc r)
                  ranges
           in
           (* optimization of `pattern: $X` *)

--- a/src/engine/Match_search_mode.ml
+++ b/src/engine/Match_search_mode.ml
@@ -725,6 +725,10 @@ and evaluate_formula (env : env) (opt_context : RM.t option) (e : R.formula) :
       let ranges, expls = evaluate_formula env opt_context formula in
       let expl = if_explanations env ranges [ expls ] (Out.Inside, tok) in
       (Common.map (fun r -> { r with RM.kind = RM.Inside }) ranges, expl)
+  | R.Anywhere (tok, formula) ->
+      let ranges, expls = evaluate_formula env opt_context formula in
+      let expl = if_explanations env ranges [ expls ] (Out.Anywhere, tok) in
+      (Common.map (fun r -> { r with RM.kind = RM.Anywhere }) ranges, expl)
   | R.Or (tok, xs) ->
       let ranges, expls =
         xs |> Common.map (evaluate_formula env opt_context) |> Common2.unzip

--- a/src/engine/Range_with_metavars.ml
+++ b/src/engine/Range_with_metavars.ml
@@ -106,7 +106,7 @@ let inside_compatible x y =
  * alt: we could do the rewriting ourselves, detecting that the
  * metavariable-regex has the wrong scope.
  *)
-let intersect_ranges config debug_matches xs ys =
+let intersect_ranges config ~debug_matches xs ys =
   let left_merge u v =
     if included_in config u v && inside_compatible u v then
       (* [r1] extended with [r2.mvars], assumes [included_in config r1 r2] *)

--- a/src/engine/Range_with_metavars.ml
+++ b/src/engine/Range_with_metavars.ml
@@ -109,7 +109,7 @@ let inside_compatible x y =
 let intersect_ranges config ~debug_matches xs ys =
   let left_merge u v =
     if included_in config u v && inside_compatible u v then
-      (* [r1] extended with [r2.mvars], assumes [included_in config r1 r2] *)
+      (* [u] extended with [v.mvars], assumes [included_in config u v] *)
       let v_only_mvars =
         v.mvars
         |> List.filter (fun (mvar, _) -> not (List.mem_assoc mvar u.mvars))

--- a/src/engine/Range_with_metavars.ml
+++ b/src/engine/Range_with_metavars.ml
@@ -1,4 +1,4 @@
-type range_kind = Plain | Inside | Regexp [@@deriving show]
+type range_kind = Plain | Inside | Anywhere | Regexp [@@deriving show]
 
 (* range with metavars *)
 type t = {
@@ -60,7 +60,7 @@ let (range_to_pattern_match_adjusted : Rule.t -> t -> Pattern_match.t) =
 let logger = Logging.get_logger [ __MODULE__ ]
 
 let included_in config rv1 rv2 =
-  Range.( $<=$ ) rv1.r rv2.r
+  (Range.( $<=$ ) rv1.r rv2.r || rv2.kind = Anywhere)
   && rv1.mvars
      |> List.for_all (fun (mvar, mval1) ->
             match List.assoc_opt mvar rv2.mvars with
@@ -107,27 +107,26 @@ let inside_compatible x y =
  * metavariable-regex has the wrong scope.
  *)
 let intersect_ranges config debug_matches xs ys =
-  let left_merge r1 r2 =
-    (* [r1] extended with [r2.mvars], assumes [included_in config r1 r2] *)
-    let r2_only_mvars =
-      r2.mvars
-      |> List.filter (fun (mvar, _) -> not (List.mem_assoc mvar r1.mvars))
-    in
-    { r1 with mvars = r2_only_mvars @ r1.mvars }
+  let left_merge u v =
+    if included_in config u v && inside_compatible u v then
+      (* [r1] extended with [r2.mvars], assumes [included_in config r1 r2] *)
+      let v_only_mvars =
+        v.mvars
+        |> List.filter (fun (mvar, _) -> not (List.mem_assoc mvar u.mvars))
+      in
+      Some { u with mvars = v_only_mvars @ u.mvars }
+    else None
   in
-  let left_included_merge us vs =
+  let merge p us vs =
     us
-    |> Common2.map_flatten (fun u ->
-           vs
-           |> Common.map_filter (fun v ->
-                  if included_in config u v && inside_compatible u v then
-                    Some (left_merge u v)
-                  else None))
+    |> Common2.map_flatten (fun u -> vs |> Common.map_filter (fun v -> p u v))
   in
   if debug_matches then
     logger#info "intersect_range:\n\t%s\nvs\n\t%s" (show_ranges xs)
       (show_ranges ys);
-  left_included_merge xs ys @ left_included_merge ys xs
+  merge left_merge xs ys
+  (* TODO: just call merge once? *)
+  @ merge (Fun.flip left_merge) xs ys
 [@@profiling]
 
 let difference_ranges config pos neg =
@@ -147,8 +146,9 @@ let difference_ranges config pos neg =
                     (* pattern-not-regex: x and y exclude each other *)
                     | Regexp -> included_in config x y || included_in config y x
                     (* pattern-not: we require the ranges to be equal *)
-                    | Plain -> included_in config x y && included_in config y x)
-             ))
+                    | Plain -> included_in config x y && included_in config y x
+                    (* not: { anywhere: y } -- y cannot occur *)
+                    | Anywhere -> true)))
   in
   surviving_pos
 [@@profiling]

--- a/src/engine/Range_with_metavars.mli
+++ b/src/engine/Range_with_metavars.mli
@@ -4,7 +4,7 @@
 (* Since pattern-inside is different from just anding two patterns, *)
 (* we use range_kind to distinguish whether this came from matching *)
 (* a pattern-inside, normal pattern, or regexp *)
-type range_kind = Plain | Inside | Regexp [@@deriving show]
+type range_kind = Plain | Inside | Anywhere | Regexp [@@deriving show]
 
 type t = {
   r : Range.t;
@@ -23,6 +23,7 @@ val range_to_pattern_match_adjusted : Rule.rule -> t -> Pattern_match.t
 
 (* Set functions *)
 
+(* REVIEW: convert these bools to named args? *)
 val intersect_ranges :
   Rule_options.t -> bool (* debug_matches *) -> ranges -> ranges -> ranges
 

--- a/src/engine/Range_with_metavars.mli
+++ b/src/engine/Range_with_metavars.mli
@@ -23,8 +23,7 @@ val range_to_pattern_match_adjusted : Rule.rule -> t -> Pattern_match.t
 
 (* Set functions *)
 
-(* REVIEW: convert these bools to named args? *)
 val intersect_ranges :
-  Rule_options.t -> bool (* debug_matches *) -> ranges -> ranges -> ranges
+  Rule_options.t -> debug_matches:bool -> ranges -> ranges -> ranges
 
 val difference_ranges : Rule_options.t -> ranges -> ranges -> ranges

--- a/src/metachecking/Check_rule.ml
+++ b/src/metachecking/Check_rule.ml
@@ -109,7 +109,9 @@ let unknown_metavar_in_comparison env f =
         [ metavars; ellipsis_metavars; regexp_captured_mvars ]
         |> Common.map Set.of_list
         |> List.fold_left Set.union Set.empty
-    | Inside (_, f) -> collect_metavars f
+    | Inside (_, f)
+    | Anywhere (_, f) ->
+        collect_metavars f
     | Not (_, _) -> Set.empty
     | Or (_, xs) ->
         let mv_sets = Common.map collect_metavars xs in

--- a/src/metachecking/Translate_rule.ml
+++ b/src/metachecking/Translate_rule.ml
@@ -227,6 +227,7 @@ and translate_formula f : [> `O of (string * Yaml.value) list ] =
       | Aliengrep _ ->
           `O [ ("pattern", `String (fst pstr)) ]
       | Regexp _ -> `O [ ("regex", `String (fst pstr)) ])
+  | Anywhere (_, f) -> `O [ ("anywhere", (translate_formula f :> Yaml.value)) ]
   | Inside (_, f) -> `O [ ("inside", (translate_formula f :> Yaml.value)) ]
   | And (_, { conjuncts; focus; conditions; _ }) ->
       let mk_focus_obj (_, mv_list) =

--- a/tests/rules/anywhere_global.py
+++ b/tests/rules/anywhere_global.py
@@ -1,0 +1,12 @@
+MAKE_BAR_INSECURE = True
+
+def foo():
+    # ruleid: anywhere-global
+    bar()
+    foo()
+    if (MAKE_BAR_INSECURE):
+        print("Hello, world!")
+    return 2
+
+# ruleid: anywhere-global
+bar()

--- a/tests/rules/anywhere_global.yaml
+++ b/tests/rules/anywhere_global.yaml
@@ -1,0 +1,11 @@
+rules:
+  - id: anywhere-global
+    languages:
+      - python
+    message: You're calling bar with an insecure global flag
+    metadata:
+    patterns:
+    - semgrep-internal-pattern-anywhere:
+        pattern: "MAKE_BAR_INSECURE = True"
+    - pattern: "bar(...)"
+    severity: ERROR

--- a/tests/rules/anywhere_include.c
+++ b/tests/rules/anywhere_include.c
@@ -1,0 +1,8 @@
+#include "legacy-io-header.h"
+
+int main(int argc, char **argv) {
+        if (argc != 2) return 1;
+
+        // ruleid: legacy-io
+        printk("Hello, %s", argv[1]);
+}

--- a/tests/rules/anywhere_include.yaml
+++ b/tests/rules/anywhere_include.yaml
@@ -1,0 +1,11 @@
+rules:
+  - id: legacy-io
+    languages:
+      - c
+    message: You're calling bar with an insecure global flag
+    metadata:
+    patterns:
+    - semgrep-internal-pattern-anywhere:
+        pattern: '#include "legacy-io-header.h"'
+    - pattern: "printk(...)"
+    severity: ERROR

--- a/tests/rules/anywhere_metavar.py
+++ b/tests/rules/anywhere_metavar.py
@@ -1,0 +1,17 @@
+def foo():
+    # ruleid: du-same-file
+    foo()
+    # ruleid: du-same-file
+    bar()
+    g()
+    baz()
+
+
+def bar():
+    quux()
+    # ruleid: du-same-file
+    bar()
+    f()
+    # ruleid: du-same-file
+    foo()
+

--- a/tests/rules/anywhere_metavar.yaml
+++ b/tests/rules/anywhere_metavar.yaml
@@ -1,0 +1,13 @@
+rules:
+  - id: du-same-file
+    languages:
+      - python
+    message: Found!
+    metadata:
+    patterns:
+    - semgrep-internal-pattern-anywhere:
+        pattern: |
+          def $F(...):
+              ...
+    - pattern: "$F(...)"
+    severity: ERROR

--- a/tests/rules_v2/anywhere_global.py
+++ b/tests/rules_v2/anywhere_global.py
@@ -1,0 +1,12 @@
+MAKE_BAR_INSECURE = True
+
+def foo():
+    # ruleid: anywhere-global
+    bar()
+    foo()
+    if (MAKE_BAR_INSECURE):
+        print("Hello, world!")
+    return 2
+
+# ruleid: anywhere-global
+bar()

--- a/tests/rules_v2/anywhere_global.yaml
+++ b/tests/rules_v2/anywhere_global.yaml
@@ -1,0 +1,11 @@
+rules:
+  - id: anywhere-global
+    languages:
+      - python
+    message: You're calling bar with an insecure global flag
+    metadata:
+    match:
+      all:
+        - anywhere: "MAKE_BAR_INSECURE = True"
+        - "bar(...)"
+    severity: ERROR

--- a/tests/rules_v2/anywhere_include.c
+++ b/tests/rules_v2/anywhere_include.c
@@ -1,0 +1,8 @@
+#include "legacy-io-header.h"
+
+int main(int argc, char **argv) {
+        if (argc != 2) return 1;
+
+        // ruleid: legacy-io
+        printk("Hello, %s", argv[1]);
+}

--- a/tests/rules_v2/anywhere_include.yaml
+++ b/tests/rules_v2/anywhere_include.yaml
@@ -1,0 +1,11 @@
+rules:
+  - id: legacy-io
+    languages:
+      - c
+    message: You're calling bar with an insecure global flag
+    metadata:
+    match:
+      all:
+      - anywhere: '#include "legacy-io-header.h"'
+      - "printk(...)"
+    severity: ERROR

--- a/tests/rules_v2/anywhere_metavar.py
+++ b/tests/rules_v2/anywhere_metavar.py
@@ -1,0 +1,17 @@
+def foo():
+    # ruleid: du-same-file
+    foo()
+    # ruleid: du-same-file
+    bar()
+    g()
+    baz()
+
+
+def bar():
+    quux()
+    # ruleid: du-same-file
+    bar()
+    f()
+    # ruleid: du-same-file
+    foo()
+

--- a/tests/rules_v2/anywhere_metavar.yaml
+++ b/tests/rules_v2/anywhere_metavar.yaml
@@ -1,0 +1,12 @@
+rules:
+  - id: du-same-file
+    languages:
+      - python
+    message: Found!
+    match:
+      all:
+      - anywhere: |
+          def $F(...):
+              ...
+      - "$F(...)"
+    severity: ERROR


### PR DESCRIPTION
[Scope doc](https://www.notion.so/semgrep/semgrep-internal-patterns-anywhere-bd56b763e470494bba9213523c45a5cf?pvs=4)

This introduces an additional pattern key,
`semgrep-internal-pattern-anywhere` (`anywhere`, in the "new" syntax),
which results in the subpattern being combined without respect to range
at a `patterns` (bzw. `all`) or similar. I.e., a pattern like

```yaml
patterns:
- pattern: A
- semgrep-internal-pattern-anywhere: { pattern: B }
```

will result in a finding at occurences of `A` if `B` is present anywhere
(in the same file). Since the combination is without respect to range,
the range associated with the pattern under
`semgrep-internal-pattern-anywhere` is discarded and matches only occur
(range-wise) at A. Importantly, metavariables are still treated
"normally" in that they are required to unify, so

```yaml
patterns:
- pattern: $F(...)
- semgrep-internal-pattern-anywhere:
  - pattern: |
      def $F(...):
          ...
```

would match all calls to all functions that were defined in the same
file.

Test plan:
- [x] OSS tests (8efa548e533dcfedcae15b86f223557dccb20da6)
- [ ] Pro tests (PR forthcoming)