### PR TITLE
Specify SSC in rule_syntax_v2.atd with tests

### DIFF
--- a/interfaces/Rule_options.atd
+++ b/interfaces/Rule_options.atd
@@ -28,6 +28,8 @@
            A default value would be set with '<field default="true">'
            and this would be translated into 'True' for Python and whatever
            means "true" in other languages.
+
+   coupling: with semgrep-interfaces/rule_schema_v2.atd
 *)
 
 (* !!Do not rename the fields because they can be referenced in rules!! *)

--- a/src/core/dune
+++ b/src/core/dune
@@ -71,13 +71,14 @@
  (deps    semgrep_output_v1.atd)
  (action  (run atdgen -t %{deps})))
 
-; derive show automatically, note the use of -j-strict-fields here!
+; note the use of -j-strict-fields here!
 (rule
  (targets rule_schema_v2_j.ml rule_schema_v2_j.mli)
  (deps    rule_schema_v2.atd)
  (action  (run atdgen -j -j-std -j-defaults -j-strict-fields %{deps})))
 
+; derive show for the type defs
 (rule
  (targets rule_schema_v2_t.ml rule_schema_v2_t.mli)
  (deps    rule_schema_v2.atd)
- (action  (run atdgen -deriving-conv show -t %{deps})))
+ (action  (run atdgen -deriving-conv "show{with_path=false}" -t %{deps})))

--- a/tests/syntax_v2/depends_on.yaml
+++ b/tests/syntax_v2/depends_on.yaml
@@ -1,0 +1,10 @@
+rules:
+  - id: js-sca
+    match: bad()
+    r2c-internal-project-depends-on:
+      namespace: npm
+      package: bad-lib
+      version: < 0.0.8
+    message: oh no
+    languages: [js]
+    severity: WARNING

--- a/tests/syntax_v2/depends_on_either.yaml
+++ b/tests/syntax_v2/depends_on_either.yaml
@@ -1,0 +1,14 @@
+rules:
+  - id: go-sca
+    match: bad()
+    r2c-internal-project-depends-on:
+      depends-on-either:
+        - namespace: gomod
+          package: github.com/cheekybits/genny
+          version: "== 99.99.99"
+        - namespace: gomod
+          package: github.com/cheekybits/genny
+          version: "<= 98.98.98"
+    message: oh no
+    languages: [go]
+    severity: WARNING

--- a/tests/syntax_v2/options.yaml
+++ b/tests/syntax_v2/options.yaml
@@ -1,0 +1,10 @@
+rules:
+  - id: test-ac-matching
+    languages:
+      - php
+    message: Working!
+    options:
+      commutative_boolop: true
+    match: |
+      !check1($stuff) && !check2($stuff)
+    severity: WARNING

--- a/tests/syntax_v2/options_comments.yaml
+++ b/tests/syntax_v2/options_comments.yaml
@@ -1,0 +1,10 @@
+rules:
+- id: ignore-comments
+  languages:
+  - generic
+  match: |
+    a b
+  options:
+    generic_comment_style: cpp
+  message: found
+  severity: ERROR


### PR DESCRIPTION
test plan:
```
$ ./bin/osemgrep --develop --validate --config tests/syntax_v2/depends_on.yaml
{ rules =
  [{ id = "js-sca"; message = "oh no"; severity = `Warning;
     languages = [`Js];
     match_ =
     (Some { pattern = (Some "bad()"); regex = None; all = None; any = None;
             not = None; inside = None; anywhere = None; where = None });
     taint = None; extract = None;
     project_depends_on =
     (Some `DependsBasic ({ namespace = `Npm; package = "bad-lib";
                            version = "< 0.0.8" }));
     paths = None; fix = None; fix_regex = None; metadata = None;
     options = None; version = None; min_version = None; max_version = None }
    ];
  missed = None }
$ make build-core-test && ./test v2
...
Test Successful in 0.104s. 27 tests run.
```