### PR TITLE
Extract mode v2 syntax, with test

### DIFF
--- a/tests/syntax_v2/extract.yaml
+++ b/tests/syntax_v2/extract.yaml
@@ -1,0 +1,15 @@
+rules:
+  - id: extract-javascript-from-html
+    match: |
+        <script>$...BODY</script>
+    languages:
+      - html
+    paths:
+      include:
+        - '*.html'
+    severity: INFO
+    message: "extract"
+    extract:
+      metavariable: $...BODY
+      dest-language: typescript
+      reduce: concat


### PR DESCRIPTION
test plan:
```
./bin/osemgrep --develop --validate --config tests/syntax_v2/extract.yaml
{ rules =
  [{ id = "extract-javascript-from-html"; message = "extract";
     severity = `Info; languages = [`Html];
     match_ =
     (Some { pattern = (Some "<script>$...BODY</script>\n"); regex = None;
             all = None; any = None; not = None; inside = None;
             anywhere = None; where = None });
     taint = None; project_depends_on = None;
     extract =
     (Some { metavariable = "$...BODY"; dest_language = (Some `Typescript);
             dest_rules = None; reduce = (Some `Concat); transform = None });
     paths = (Some { include_ = (Some ["*.html"]); exclude_ = None });
     fix = None; fix_regex = None; options = None; metadata = None;
     min_version = None; max_version = None }
    ];
  missed = None }
```