### PR TITLE
Specify secrets syntax v1 in rule_schema_v2.atd

### DIFF
--- a/libs/commons/JSON.ml
+++ b/libs/commons/JSON.ml
@@ -81,7 +81,7 @@ let rec ezjsonm_to_yojson (json : ezjsonm) : yojson =
   | `A xs -> `List (xs |> List.map ezjsonm_to_yojson)
   | `String s -> `String s
   | `Bool b -> `Bool b
-  (* TODO? detect if int and return Int instead? *)
+  | `Float x when Float.is_integer x -> `Int (int_of_float x)
   | `Float f -> `Float f
   | `Null -> `Null
 

--- a/tests/syntax_v2/validators.yaml
+++ b/tests/syntax_v2/validators.yaml
@@ -1,0 +1,23 @@
+rules:
+  - id: rule
+    message: Found GH secret
+    severity: INFO
+    languages:
+      - python
+    match: "\"$SECRET\""
+    validators:
+    - http:
+        request:
+          url: http://www.example.com/api/america
+          method: GET
+          headers:
+            authorization: Bearer $SECRET
+            user-agent: semgrep
+        response:
+          - match:
+              - status-code: 2
+            result:
+              validity: valid
+              message: "TEST 0"
+              metadata:
+                test: 0


### PR DESCRIPTION
test plan:
```
$ ./bin/osemgrep --develop --validate --config tests/syntax_v2/validators.yaml
{ rules =
  [{ id = "rule"; message = "Found GH secret"; severity = `Info;
     languages = [`Python];
     match_ =
     (Some { pattern = (Some "\"$SECRET\""); regex = None; all = None;
             any = None; not = None; inside = None; anywhere = None;
             where = None });
     taint = None; project_depends_on = None; extract = None;
     validators =
     (Some [{ http =
              { request =
                { url = "http://www.example.com/api/america"; method_ = `GET;
                  headers =
                  [("authorization", "Bearer $SECRET");
                    ("user-agent", "semgrep")];
                  auth = None; body = None };
                response =
                [{ match_ =
                   [{ status_code = (Some 2); headers = None; content = None
                      }
                     ];
                   result =
                   { validity = `Valid; severity = None;
                     metadata = (Some `Assoc ([("test", `Int (0))]));
                     message = (Some "TEST 0") }
                   }
                  ]
                }
              }
             ]);
     paths = None; fix = None; fix_regex = None; options = None;
     metadata = None; min_version = None; max_version = None }
    ];
  missed = None }
```