### PR TITLE
Parse virtual specifier in cpp menhir parser

### DIFF
--- a/languages/cpp/menhir/lexer_cpp.mll
+++ b/languages/cpp/menhir/lexer_cpp.mll
@@ -106,6 +106,10 @@ let keyword_table = Common.hash_of_list [
   "mutable", (fun ii -> Tmutable ii);
   "virtual", (fun ii -> Tvirtual ii);
 
+  (* virtual specifier *)
+  "final", (fun ii -> Tfinal ii);
+  "override", (fun ii -> Toverride ii);
+
   (* c++0x:  *)
   "constexpr", (fun ii -> Tconstexpr ii);
   "thread_local", (fun ii -> Tthread_local ii);

--- a/languages/cpp/menhir/parser_cpp.mly
+++ b/languages/cpp/menhir/parser_cpp.mly
@@ -171,6 +171,7 @@ open Parser_cpp_mly_helper
    Toperator
    Tpublic Tprivate Tprotected    Tfriend
    Tvirtual
+   Tfinal Toverride
    Tnamespace Tusing
    Tbool    Tfalse Ttrue
    Twchar_t
@@ -1080,17 +1081,17 @@ direct_d:
      { (fst $1, fun x->(snd $1) (nQ,(TArray (($2,None,$3),x)))) }
  | direct_d "[" const_expr "]"
      { (fst $1, fun x->(snd $1) (nQ,(TArray (($2, Some $3, $4),x)))) }
- | direct_d "(" ")" const_opt exn_spec?
+ | direct_d "(" ")" const_opt exn_spec? optl(virtual_specifier+)
      { (fst $1, fun x-> (snd $1)
          (nQ, (TFunction {
            ft_ret= x; ft_params = ($2, [], $3);
-           ft_specs = []; ft_const = $4; ft_throw = Option.to_list $5; ft_requires = None; })))
+           ft_specs = $6; ft_const = $4; ft_throw = Option.to_list $5; ft_requires = None; })))
      }
- | direct_d "(" parameter_type_list ")" const_opt exn_spec?
+ | direct_d "(" parameter_type_list ")" const_opt exn_spec? optl(virtual_specifier+)
      { (fst $1, fun x-> (snd $1)
           (nQ,(TFunction {
             ft_ret = x; ft_params = ($2,$3,$4);
-            ft_specs = []; ft_const = $5; ft_throw = Option.to_list $6; ft_requires = None;})))
+            ft_specs = $7; ft_const = $5; ft_throw = Option.to_list $6; ft_requires = None;})))
      }
 
 (*----------------------------*)
@@ -1759,6 +1760,9 @@ unnamed_namespace_definition: Tnamespace "{" optl(declaration_cpp+) "}"
 (*************************************************************************)
 (* Function definition *)
 (*************************************************************************)
+virtual_specifier:
+| Tfinal { M (Final ($1)) }
+| Toverride { M (Override ($1)) }
 
 function_definition:
  | decl_spec_seq declarator function_body

--- a/languages/cpp/menhir/token_helpers_cpp.ml
+++ b/languages/cpp/menhir/token_helpers_cpp.ml
@@ -415,6 +415,8 @@ let visitor_info_of_tok f = function
   | TIdent_MacroIterator (s, i) -> TIdent_MacroIterator (s, f i)
   | TIdent_MacroDecl (s, i) -> TIdent_MacroDecl (s, f i)
   | Tconst_MacroDeclConst i -> Tconst_MacroDeclConst (f i)
+  | Tfinal i -> Tfinal (f i)
+  | Toverride i -> Toverride (f i)
   (*  | TMacroTop          (s,i) -> TMacroTop             (s,f i) *)
   | TCPar_EOL i -> TCPar_EOL (f i)
   | TAny_Action i -> TAny_Action (f i)

--- a/tests/rules/assign_in_cond_expr_cpp.cpp
+++ b/tests/rules/assign_in_cond_expr_cpp.cpp
@@ -6,6 +6,8 @@ void assignment_expression_parens() {
   }
 
   void *data2 = NULL;
+  // 11/10/2023: tree-sitter-cpp can't parse assignments in conditional
+  // expression. only menhir cpp parser can parse this for now.
   while ((data2 = get_taint())) {
     // ruleid: assign-in-cond-expr
     sink(data2);
@@ -13,6 +15,10 @@ void assignment_expression_parens() {
 }
 
 class Foo {
+  // added to check if menhir parser can parse virtual specifiers.
+  // minimized version of https://semgrep.dev/playground/s/zzBG
+  //
+  // TODO: safe to remove once tree-sitter-cpp successfully parses this file.
   void bar() override {};
 };
 

--- a/tests/rules/assign_in_cond_expr_cpp.cpp
+++ b/tests/rules/assign_in_cond_expr_cpp.cpp
@@ -1,0 +1,18 @@
+void assignment_expression_parens() {
+  void *data = get_taint();
+  if (nondet) {
+    // ruleid: assign-in-cond-expr
+    sink(data);
+  }
+
+  void *data2 = NULL;
+  while ((data2 = get_taint())) {
+    // ruleid: assign-in-cond-expr
+    sink(data2);
+  }
+}
+
+class Foo {
+  void bar() override {};
+};
+

--- a/tests/rules/assign_in_cond_expr_cpp.yaml
+++ b/tests/rules/assign_in_cond_expr_cpp.yaml
@@ -1,0 +1,13 @@
+rules:
+  - id: assign-in-cond-expr
+    languages:
+      - cpp
+      - c
+    message: testing assignments in conditional expression.
+    mode: taint
+    pattern-sinks:
+      - pattern: sink($X)
+    pattern-sources:
+      - pattern: get_taint()
+    severity: ERROR
+


### PR DESCRIPTION
This commit addresses a parsing error in the menhir parser for the sample target file related to the [`local-variable-malloc-free`](https://semgrep.dev/playground/s/zzBG) rule.

Recently, the tree-sitter-cpp parser was updated to support parsing fold expressions (C++17), causing a parsing failure in assignments within conditional expressions. While we await a proper fix upstream in tree-sitter-cpp, we may utilize the menhir backup parser for handling assignment parsing in conditional expressions. Although we don't intend to allocate more resources to enhance the menhir parser, it is throwing a parsing error in one of our example test codes in the rule database. Therefore, it seems worthwhile to make a targeted fix.

