### PR TITLE
fix: tainting: Compute labels for an expression via fixpoint

### DIFF
--- a/changelog.d/taint-labels.fixed
+++ b/changelog.d/taint-labels.fixed
@@ -1,0 +1,2 @@
+taint-mode: If an expressions is tainted by multiple labels A and B, with B
+requiring A, the expression will now get boths labels A and B.

--- a/tests/rules/taint_labels6.yaml
+++ b/tests/rules/taint_labels6.yaml
@@ -5,14 +5,8 @@ rules:
     languages: [py]
     mode: taint
     pattern-sources:
-      - by-side-effect: true
+      - by-side-effect: only
         label: closed
-        patterns:
-          - pattern: $FILE.close()
-          - focus-metavariable: $FILE
-      - by-side-effect: true
-        label: closed_twice
-        requires: closed
         patterns:
           - pattern: $FILE.close()
           - focus-metavariable: $FILE
@@ -24,7 +18,7 @@ rules:
               $FILE = open(...)
           - focus-metavariable: $FILE
     pattern-sinks:
-      - requires: closed_twice and not reopened
+      - requires: closed and not reopened
         patterns:
           - pattern: $FILE.close(...)
           - focus-metavariable: $FILE

--- a/tests/rules/taint_labels_rec.rs
+++ b/tests/rules/taint_labels_rec.rs
@@ -1,0 +1,8 @@
+async fn test(client: Client, id: String) -> Option<Json<Post>> {
+    // `id` has label INPUT and also FORMAT at the same time, but
+    // FORMAT requires INPUT. So first we need to taint it with
+    // INPUT, and then we need to check again for more labels, and
+    // we will realized FORMAT also applies to it.
+    // ruleid: test
+    client.post(format!("https://{}", id));
+}

--- a/tests/rules/taint_labels_rec.yaml
+++ b/tests/rules/taint_labels_rec.yaml
@@ -1,0 +1,29 @@
+rules:
+- id: test
+  message: Test
+  severity: ERROR
+  languages:
+  - rust
+  mode: taint
+  pattern-sources:
+  - label: INPUT
+    patterns:
+    # 'focus-metavariable' is better but to reproduce this issue
+    # we need 'pattern' here.
+    - pattern: $PARAM
+    - pattern-inside: |
+        fn $FUNC(..., $PARAM : String, ...) {
+          ...
+        }
+  - label: FORMAT
+    patterns:
+    - focus-metavariable: $X
+    - pattern: |
+        format!("...", $X)
+    requires: INPUT
+  pattern-sinks:
+  - patterns:
+    - pattern: $CLIENT.post($QUERY)
+    - focus-metavariable: $QUERY
+    requires: FORMAT
+


### PR DESCRIPTION
If an expression E is tainted by two labels, say A, and B which requires A, then E was only getting taint A. This only worked for the specific case of l-values because, by accident, we were checking their taint twice, first as an l-value and then as a regular expression. PR #8414 fixed this, but then exposed this taint-labels issue breaking Pro rule rust.rocket.ssrf.reqwest-taint.

Note that test 'taint_labels6' was abusing this problem in taint labels to implement a double-close check. This can be done now in a proper way with `by-side-effect: only` thanks to PR #8414.

Here we compute the labels of an expression E using a fixpoint, we keep adding labels as we are able to meet their 'requires', until we reach a fixpoint.

Follows: d00c6e67deb ("tainting: Add `by-side-effect: only` option to sources (#8414)")
Fixes Pro rule rust.rocket.ssrf.reqwest-taint

test plan:
make test # new test
Run rust.rocket.ssrf.reqwest-taint's test
See CI job 'test-pro-rules', rust/rocket/ssrf/reqwest-taint.rs:61 is no longer reported as a mismatch, and there are no new mismatches wrt develop.

