### PR TITLE
--config policy uses new cli endpoint

### DIFF
--- a/cli/src/semgrep/config_resolver.py
+++ b/cli/src/semgrep/config_resolver.py
@@ -292,13 +292,10 @@ class ConfigLoader:
         """
         state = get_state()
 
-        if is_policy_id(self._config_path):
-            products = [out.Product(out.SAST())]
-        else:
-            products = [
-                out.Product.from_json(PRODUCT_NAMES[p])
-                for p in self._config_path.split(",")
-            ]
+        products = [
+            out.Product.from_json(PRODUCT_NAMES[p])
+            for p in self._config_path.split(",")
+        ]
 
         # Require SEMGREP_REPO_NAME env var if SAST or Secrets are requested
         require_repo_name = any(

--- a/cli/src/semgrep/config_resolver.py
+++ b/cli/src/semgrep/config_resolver.py
@@ -124,11 +124,6 @@ class ConfigLoader:
             add_metrics_for_products(config_str)
             self._config_path = config_str
             self._supports_fallback_config = True
-        elif is_policy_id(config_str):
-            state.metrics.add_feature("config", "policy")
-            self._origin = ConfigType.SEMGREP_CLOUD_PLATFORM
-            self._config_path = config_str
-            self._supports_fallback_config = True
         elif is_registry_id(config_str):
             state.metrics.add_feature("config", f"registry:prefix-{config_str[0]}")
             self._config_path = registry_id_to_url(config_str)
@@ -955,6 +950,7 @@ def url_for_policy() -> str:
 
 PRODUCT_NAMES = {
     "code": "sast",
+    "policy": "sast",
     "secrets": "secrets",
     "supply-chain": "sca",
 }
@@ -969,7 +965,10 @@ def is_product_names(config_str: str) -> bool:
 def add_metrics_for_products(config_str: str) -> None:
     state = get_state()
     for product_name in config_str.split(","):
-        state.metrics.add_feature("config", PRODUCT_NAMES[product_name])
+        if is_policy_id(product_name):
+            state.metrics.add_feature("config", "policy")
+        else:
+            state.metrics.add_feature("config", PRODUCT_NAMES[product_name])
 
 
 def is_policy_id(config_str: str) -> bool:

--- a/cli/src/semgrep/config_resolver.py
+++ b/cli/src/semgrep/config_resolver.py
@@ -947,7 +947,7 @@ def url_for_policy() -> str:
 
 PRODUCT_NAMES = {
     "code": "sast",
-    "policy": "sast",
+    "policy": "sast",  # although policy isn't a product, it's effectively an alias for code
     "secrets": "secrets",
     "supply-chain": "sca",
 }

--- a/cli/tests/e2e/test_login.py
+++ b/cli/tests/e2e/test_login.py
@@ -95,7 +95,9 @@ def test_login(tmp_path, mocker):
     ), "registry should refuse to send rules to invalid token"
 
     # Run policy with bad token -> no associated deployment_id
-    result = runner.invoke(cli, ["--config", "policy"])
+    result = runner.invoke(
+        cli, ["--config", "policy"], env={"SEMGREP_REPO_NAME": "test-repo"}
+    )
     assert result.exit_code == 7
     assert "Invalid API Key" in result.output
 

--- a/cli/tests/unit/test_config_resolver.py
+++ b/cli/tests/unit/test_config_resolver.py
@@ -34,12 +34,7 @@ def mocked_state(mocker):
 
 @pytest.mark.parametrize(
     "product",
-    [
-        "code",
-        "secrets",
-        "supply-chain",
-        "code,secrets",
-    ],
+    ["code", "secrets", "supply-chain", "code,secrets", "policy"],
 )
 class TestConfigLoaderForProducts:
     @pytest.fixture


### PR DESCRIPTION
Related https://github.com/semgrep/semgrep/pull/9205/files

## Context

In PR #9205, we switch `--config <product>` to use the same endpoint as `semgrep ci`. This continues those improvements by also moving `--config policy` over.

