### PR TITLE
fix fail-open error handling on python < 3.10

### DIFF
--- a/cli/src/semgrep/commands/wrapper.py
+++ b/cli/src/semgrep/commands/wrapper.py
@@ -5,9 +5,9 @@ from typing import Callable
 from typing import NoReturn
 from typing import Optional
 
+from semgrep import state
 from semgrep.error import FATAL_EXIT_CODE
 from semgrep.error import SemgrepError
-from semgrep.state import get_state
 from semgrep.verbose_logging import getLogger
 
 
@@ -57,11 +57,11 @@ def handle_command_errors(func: Callable) -> Callable:
         else:
             exit_code = 0
         finally:
-            metrics = get_state().metrics
+            metrics = state.get_state().metrics
             metrics.add_exit_code(exit_code)
             metrics.send()
 
-            error_handler = get_state().error_handler
+            error_handler = state.get_state().error_handler
             error_handler.capture_error(exc)
             exit_code = error_handler.send(exit_code)
 

--- a/cli/src/semgrep/error_handler.py
+++ b/cli/src/semgrep/error_handler.py
@@ -48,7 +48,9 @@ class ErrorHandler:
         if sys.exc_info()[0] is not None:
             self.payload["error"] = "".join(traceback.format_exc())
         elif e is not None:
-            self.payload["error"] = "".join(traceback.format_exception(e))
+            exc_type = e.__class__
+            tb = e.__traceback__
+            self.payload["error"] = "".join(traceback.format_exception(exc_type, e, tb))
 
     @property
     def is_enabled(self) -> bool:

--- a/cli/tests/unit/test_error_handler.py
+++ b/cli/tests/unit/test_error_handler.py
@@ -1,8 +1,12 @@
 from uuid import uuid4
 
 import pytest
+import requests
 from pytest_mock import MockerFixture
+from requests.exceptions import ConnectionError
+from tests.conftest import str_containing
 
+from semgrep.commands.wrapper import handle_command_errors
 from semgrep.error import FATAL_EXIT_CODE
 from semgrep.error_handler import ErrorHandler
 
@@ -13,8 +17,15 @@ FAIL_OPEN_URL = "https://fail-open.semgrep.dev/failure"
 
 
 @pytest.fixture
-def error_handler(mocker) -> ErrorHandler:
-    return ErrorHandler()
+def error_handler_enabled() -> bool:
+    return True
+
+
+@pytest.fixture
+def error_handler(error_handler_enabled) -> ErrorHandler:
+    error_handler = ErrorHandler()
+    error_handler.configure(suppress_errors=error_handler_enabled)
+    return error_handler
 
 
 class NetworkBlockedInTests(Exception):
@@ -27,49 +38,80 @@ def mock_get_token(mocker):
     yield mocked
 
 
-@pytest.fixture
-def mocked_state(mocker):
+@pytest.fixture(autouse=True)
+def mocked_state(mocker, error_handler):
     mocked = mocker.MagicMock()
     mocked.app_session.user_agent = FAKE_USER_AGENT
     mocked.request_id = uuid4()
     mocked.env.fail_open_url = FAIL_OPEN_URL.replace("/failure", "")
+    mocked.error_handler = error_handler
     mocker.patch("semgrep.state.get_state", return_value=mocked)
     yield mocked
 
 
+@pytest.fixture(autouse=True)
+def mock_broken_request(requests_mock):
+    return requests_mock.get(
+        "https://semgrep.dev/api/agent/deployments/current", exc=ConnectionError
+    )
+
+
+@pytest.fixture
+def fail_open_mock(requests_mock):
+    return requests_mock.post(FAIL_OPEN_URL)
+
+
+@handle_command_errors
+def fake_command():
+    requests.get("https://semgrep.dev/api/agent/deployments/current")
+
+
 @pytest.mark.quick
-def test_send_nominal(
-    error_handler, mocker: MockerFixture, mock_get_token, mocked_state
-) -> None:
+def test_send_nominal(fail_open_mock) -> None:
     """
     Check that data is posted to fail-open url and zero exit code is returned
     """
-    mocked_requests = mocker.patch("requests.post")
+    with pytest.raises(SystemExit) as exit_exc:
+        fake_command()
 
-    error_handler.configure(suppress_errors=True)
-    error_handler.push_request(
-        "get", "https://semgrep.dev/api/agent/deployments/current"
-    )
-    exit_code = error_handler.send(FATAL_EXIT_CODE)
+    assert exit_exc.type == SystemExit
+    assert exit_exc.value.code == 0
 
-    expected_payload = {
-        "method": "get",
-        "url": "https://semgrep.dev/api/agent/deployments/current",
-        "request_id": str(mocked_state.request_id),
-    }
+    assert fail_open_mock.called
+    payload = fail_open_mock.last_request.json()
+    assert payload["error"] == str_containing("Traceback")
 
-    expected_headers = {
-        "User-Agent": FAKE_USER_AGENT,
-        "Authorization": f"Bearer {FAKE_TOKEN}",
-    }
 
-    assert exit_code == 0
-    mocked_requests.assert_called_once_with(
-        FAIL_OPEN_URL,
-        headers=expected_headers,
-        json=expected_payload,
-        timeout=3,
-    )
+@pytest.mark.quick
+def test_send_timeout_success(requests_mock) -> None:
+    """
+    Check that no network does not cause failures and zero exit code is returned
+    """
+    fail_open_mock = requests_mock.post(FAIL_OPEN_URL, exc=ConnectionError)
+
+    with pytest.raises(SystemExit) as exit_exc:
+        fake_command()
+
+    assert exit_exc.type == SystemExit
+    assert exit_exc.value.code == 0
+    assert fail_open_mock.called
+
+
+@pytest.mark.quick
+@pytest.mark.parametrize("error_handler_enabled", [False])
+def test_send_skip(fail_open_mock) -> None:
+    """
+    Check that data is NOT posted to fail-open url and fatal exit code is returned
+    """
+    with pytest.raises(SystemExit) as exit_exc:
+        fake_command()
+
+    assert exit_exc.type == SystemExit
+    assert exit_exc.value.code == 2
+    assert not fail_open_mock.called
+
+
+## the rest of these tests might require more though, or just to be removed.
 
 
 @pytest.mark.quick
@@ -147,35 +189,3 @@ def test_send_nominal_with_trace(
         json=expected_payload,
         timeout=3,
     )
-
-
-@pytest.mark.quick
-def test_send_timeout_success(error_handler, mocker) -> None:
-    """
-    Check that no network does not cause failures and zero exit code is returned
-    """
-    mocker.patch("socket.getaddrinfo", side_effect=NetworkBlockedInTests)
-    import requests
-
-    # verify that network is blocked
-    with pytest.raises(NetworkBlockedInTests):
-        _ = requests.get("https://semgrep.dev", timeout=2)
-
-    error_handler.configure(suppress_errors=True)
-    exit_code = error_handler.send(FATAL_EXIT_CODE)
-
-    assert exit_code == 0
-
-
-@pytest.mark.quick
-def test_send_skip(error_handler, mocker) -> None:
-    """
-    Check that data is NOT posted to fail-open url and fatal exit code is returned
-    """
-    mocked_requests = mocker.patch("requests.post")
-
-    error_handler.configure(suppress_errors=False)
-    exit_code = error_handler.send(FATAL_EXIT_CODE)
-
-    assert exit_code == FATAL_EXIT_CODE
-    mocked_requests.assert_not_called()


### PR DESCRIPTION
In https://github.com/semgrep/semgrep/pull/9191 I added a call to `format_exception` with arguments that aren't supported prior to python 3.10.

Test coverage didn't catch this, so this PR both fixes the tests to ensure coverage and fixes the problematic implementation.