### PR TITLE
devops: Add build and push steps for perf benchmark container

### DIFF
--- a/.github/workflows/tests.jsonnet
+++ b/.github/workflows/tests.jsonnet
@@ -494,6 +494,26 @@ local push_docker_nonroot_job = {
   },
 };
 
+local build_test_docker_performance_tests_job = build_test_docker_nonroot_job + {
+  with: super.with + {
+    'docker-flavor': |||
+      latest=auto
+      suffix=-performance-tests,onlatest=true
+    |||,
+    'artifact-name': 'image-test-performance-tests',
+    target: 'performance-tests',
+  },
+};
+
+local push_docker_performance_tests_job = push_docker_nonroot_job + {
+  needs: [
+    'build-test-docker-performance-tests',
+  ],
+  with: super.with + {
+    'artifact-name': 'image-test-performance-tests',
+  }
+};
+
 // ----------------------------------------------------------------------------
 // Semgrep Pro
 // ----------------------------------------------------------------------------
@@ -548,6 +568,8 @@ local ignore_md = {
     'push-docker': push_docker_job,
     'build-test-docker-nonroot': build_test_docker_nonroot_job,
     'push-docker-nonroot': push_docker_nonroot_job,
+    'build-test-docker-performance-tests': build_test_docker_performance_tests_job,
+    'push-docker-performance-tests': push_docker_performance_tests_job,
     // Semgrep-pro mismatch check
     'test-semgrep-pro': test_semgrep_pro_job,
     // The inherit jobs also included from releases.yml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -290,6 +290,38 @@ jobs:
       artifact-name: image-test-nonroot
       repository-name: returntocorp/semgrep
       dry-run: false
+  build-test-docker-performance-tests:
+    needs:
+    - build-test-docker
+    secrets: inherit
+    uses: ./.github/workflows/build-test-docker.yaml
+    with:
+      artifact-name: image-test-performance-tests
+      docker-flavor: |
+        latest=auto
+        suffix=-performance-tests,onlatest=true
+      docker-tags: |
+        type=semver,pattern={{version}}
+        type=semver,pattern={{major}}.{{minor}}
+        type=ref,event=pr
+        type=ref,event=branch
+        type=sha,event=branch
+        type=edge
+      enable-tests: false
+      file: Dockerfile
+      repository-name: returntocorp/semgrep
+      target: performance-tests
+  push-docker-performance-tests:
+    needs:
+    - build-test-docker-performance-tests
+    if: github.ref == 'refs/heads/develop' || (github.actor != 'dependabot[bot]' &&
+      !(github.event.pull_request.head.repo.full_name != github.repository))
+    secrets: inherit
+    uses: ./.github/workflows/push-docker.yaml
+    with:
+      artifact-name: image-test-performance-tests
+      dry-run: false
+      repository-name: returntocorp/semgrep
   test-semgrep-pro:
     needs:
     - build-test-docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -268,3 +268,19 @@ RUN rm /usr/local/bin/osemgrep && \
 ENV PATH="$PATH:/home/semgrep/bin"
 
 USER semgrep
+
+###############################################################################
+# Step 5 (optional) performance testing
+###############################################################################
+
+# Build target that exposes the performance benchmark tests in perf/ for
+# use in running performance benchmarks from a test build container, e.g., on PRs
+FROM semgrep-cli AS performance-tests
+
+COPY perf /semgrep/perf
+
+RUN apk add --no-cache make
+
+WORKDIR /semgrep/perf
+
+ENTRYPOINT ["make"]


### PR DESCRIPTION
This PR introduces new Docker build steps (based on the nonroot variant) which incorporates the performance benchmarking scripts in the `perf/` directory.

The built container image will be pushed to Semgrep Dockerhub repository with the tag suffix `-performance-tests`. From there it can be pulled to systems for perf testing. Changes to the `perf/` directory will be built into the container image.

This PR doesn't use the container yet--that is forthcoming in future PRs.

### Test plan:

Manual test of docker target:

```
➜  semgrep git:(gh/praeacetabular-101df9) ✗> docker build . -t semgrep-performance-tests:test --target performance-tests
Building 0.0s (0/1)                                                            
[+] Building 0.1s (2/2)                                                            
 => [internal] load build definition from Dockerfile                          0.0s
 => => transferring dockerfile: 12.80kB                                       0.0s
 => [internal] load .dockerignore                                             0.0s
 => => transferring context: 35B                                              0.0s
[... snipped ...]
 => [semgrep-core-files 1/5] FROM docker.io/library/busybox:stable@sha256:3f  0.0s
 => [semgrep-cli  1/12] FROM docker.io/library/python:3.11.4-alpine@sha256:6  0.0s
 => [semgrep-core-container 1/6] FROM docker.io/returntocorp/ocaml:alpine-20  0.0s
 => CACHED [semgrep-cli  2/12] WORKDIR /semgrep                               0.0s
 => CACHED [semgrep-cli  3/12] RUN apk upgrade --no-cache &&     apk add --n  0.0s
 => [semgrep-cli  4/12] COPY cli ./                                           2.0s
 => CACHED [semgrep-core-files 2/5] WORKDIR /src/semgrep                      0.0s
 => [semgrep-core-files 3/5] COPY . .                                        15.8s
 => [semgrep-cli  5/12] RUN apk add --no-cache --virtual=.build-deps build  202.9s
 => [semgrep-core-files 4/5] RUN rm -rf cli js .github .circleci Dockerfile   0.8s
 => [semgrep-core-files 5/5] COPY cli/src/semgrep/semgrep_interfaces cli/src  0.1s
 => CACHED [semgrep-core-container 2/6] WORKDIR /src/semgrep                  0.0s
 => [semgrep-core-container 3/6] COPY --from=semgrep-core-files /src/semgre  10.0s
 => [semgrep-core-container 4/6] RUN make install-deps-ALPINE-for-semgrep-  198.7s
 => [semgrep-cli  6/12] COPY Dockerfile /Dockerfile                           0.1s
 => [semgrep-core-container 5/6] WORKDIR /src/semgrep                         0.1s
 => [semgrep-core-container 6/6] RUN eval "$(opam env)" &&    make minimal  227.1s
 => [semgrep-cli  7/12] COPY --from=semgrep-core-container /src/semgrep/_bui  0.7s
 => [semgrep-cli  8/12] RUN ln -s semgrep-core /usr/local/bin/osemgrep        0.7s
 => [semgrep-cli  9/12] WORKDIR /src                                          0.1s
 => [semgrep-cli 10/12] RUN adduser -D -u 1000 -h /home/semgrep semgrep       0.5s
 => [semgrep-cli 11/12] RUN printf "[safe]\n directory = /src"  > ~root/.git  0.5s
 => [semgrep-cli 12/12] RUN printf "[safe]\n directory = /src"  > ~semgrep/.  0.5s
 => [performance-tests 1/3] COPY perf /semgrep/perf                           0.2s
 => [performance-tests 2/3] RUN apk add --no-cache make                       1.4s
 => [performance-tests 3/3] WORKDIR /semgrep/perf                             0.1s
 => exporting to image                                                        4.0s
 => => exporting layers                                                       4.0s
 => => writing image sha256:d83b2ca302044c3a1c1587604ba8202b4d530a9113b44ce0  0.0s
 => => naming to docker.io/library/semgrep-performance-tests:test             0.0s

Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them                                                                           
 
➜  semgrep git:(gh/praeacetabular-101df9) ✗> docker run --rm semgrep-performance-tests:test
2023-11-13 22:05:14,944 - /semgrep/perf/config.py - DEBUG - Using config at /semgrep/perf/configs/ci_small_repos.yaml
2023-11-13 22:05:14,983 - /semgrep/perf/./run-benchmarks - INFO - Setting up benchmark run for run 'zulip'
2023-11-13 22:05:14,984 - /semgrep/perf/./run-benchmarks - INFO - Rule cache for run zulip created at bench/rules_cache/zulip
2023-11-13 22:05:14,984 - /semgrep/perf/./run-benchmarks - INFO - Checking for rule config 'RuleConfig(config_str='rules/zulip/semgrep.yml')' in cache
2023-11-13 22:05:14,985 - /semgrep/perf/config.py - DEBUG - Checking if config string is a path. Resolved path is /semgrep/perf/rules/zulip/semgrep.yml
2023-11-13 22:05:14,986 - /semgrep/perf/config.py - INFO - Config 'rules/zulip/semgrep.yml' is already on filesystem. Copying to cache at 'bench/rules_cache/zulip/rules.zulip.semgrep.yml.yaml'
2023-11-13 22:05:14,986 - /semgrep/perf/config.py - DEBUG - Copying rules file from /semgrep/perf/rules/zulip/semgrep.yml to bench/rules_cache/zulip/rules.zulip.semgrep.yml.yaml
2023-11-13 22:05:14,987 - /semgrep/perf/./run-benchmarks - INFO - Generating 'prep' file at bench/zulip/prep
[... snipped ...]
2023-11-13 22:05:16,785 - /semgrep/perf/./run-benchmarks - INFO - Checking for rule config 'RuleConfig(config_str='r2c-rules/r2c-security-audit.yml')' in cache
2023-11-13 22:05:16,786 - /semgrep/perf/config.py - DEBUG - Checking if config string is a path. Resolved path is /semgrep/perf/r2c-rules/r2c-security-audit.yml
2023-11-13 22:05:16,786 - /semgrep/perf/config.py - INFO - Config 'r2c-rules/r2c-security-audit.yml' is already on filesystem. Copying to cache at 'bench/rules_cache/gotree/r2c-rules.r2c-security-audit.yml.yaml'
2023-11-13 22:05:16,786 - /semgrep/perf/config.py - DEBUG - Copying rules file from /semgrep/perf/r2c-rules/r2c-security-audit.yml to bench/rules_cache/gotree/r2c-rules.r2c-security-audit.yml.yaml
2023-11-13 22:05:16,789 - /semgrep/perf/./run-benchmarks - INFO - Generating 'prep' file at bench/gotree/prep
Obtaining a shallow clone of git repo 'zulip', commit 829f9272d2c4299a0c0a37a09802248d8136c0a8
hint: Using 'master' as the name for the initial branch. This default branch name
hint: is subject to change. To configure the initial branch name to use in all
hint: of your new repositories, which will suppress this warning, call:
hint: 
hint: 	git config --global init.defaultBranch <name>
hint: 
hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
hint: 'development'. The just-created branch can be renamed via this command:
hint: 
hint: 	git branch -m <name>
Initialized empty Git repository in /semgrep/perf/bench/zulip/input/zulip/.git/
From https://github.com/zulip/zulip
 * branch            829f9272d2c4299a0c0a37a09802248d8136c0a8 -> FETCH_HEAD
Switched to a new branch 'tmp'
------ semgrep.bench.zulip.std ------
current directory: /semgrep/perf/bench/zulip
semgrep command: semgrep --config /semgrep/perf/bench/rules_cache/zulip --strict --json --timeout 0 --metrics=off --no-git-ignore --time /semgrep/perf/bench/zulip/input/zulip
extra arguments for semgrep-core: ''
semgrep exit status: 0
success
semgrep.bench.zulip.std.duration = 5.993 s
Result: 22 findings, 0 parse errors
------ semgrep.bench.zulip.no-gc-tuning ------
current directory: /semgrep/perf/bench/zulip
semgrep command: semgrep --config /semgrep/perf/bench/rules_cache/zulip --strict --json --timeout 0 --metrics=off --no-git-ignore --time /semgrep/perf/bench/zulip/input/zulip
extra arguments for semgrep-core: '-no_gc_tuning'
semgrep exit status: 0
success
semgrep.bench.zulip.no-gc-tuning.duration = 5.823 s
Result: 22 findings, 0 parse errors
------ semgrep.bench.zulip.no-filter-irrelevant-rules ------
current directory: /semgrep/perf/bench/zulip
semgrep command: semgrep --config /semgrep/perf/bench/rules_cache/zulip --strict --json --timeout 0 --metrics=off --no-git-ignore --time /semgrep/perf/bench/zulip/input/zulip
extra arguments for semgrep-core: '-no_filter_irrelevant_rules'
semgrep exit status: 0
success
semgrep.bench.zulip.no-filter-irrelevant-rules.duration = 7.002 s
Result: 22 findings, 0 parse errors
Obtaining a shallow clone of git repo 'pytest-flakefinder', commit a502101f4bc3c65cc32931218addc315b876cecb
hint: Using 'master' as the name for the initial branch. This default branch name
hint: is subject to change. To configure the initial branch name to use in all
hint: of your new repositories, which will suppress this warning, call:
hint: 
hint: 	git config --global init.defaultBranch <name>
hint: 
hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
hint: 'development'. The just-created branch can be renamed via this command:
hint: 
hint: 	git branch -m <name>
Initialized empty Git repository in /semgrep/perf/bench/dropbox/input/pytest-flakefinder/.git/
From https://github.com/dropbox/pytest-flakefinder
 * branch            a502101f4bc3c65cc32931218addc315b876cecb -> FETCH_HEAD
Switched to a new branch 'tmp'
------ semgrep.bench.dropbox.std ------
current directory: /semgrep/perf/bench/dropbox
semgrep command: semgrep --config /semgrep/perf/bench/rules_cache/dropbox --strict --json --timeout 0 --metrics=off --no-git-ignore --time /semgrep/perf/bench/dropbox/input/pytest-flakefinder
extra arguments for semgrep-core: ''
semgrep exit status: 0
success
semgrep.bench.dropbox.std.duration = 2.171 s
Result: 0 findings, 0 parse errors
------ semgrep.bench.dropbox.no-gc-tuning ------
current directory: /semgrep/perf/bench/dropbox
semgrep command: semgrep --config /semgrep/perf/bench/rules_cache/dropbox --strict --json --timeout 0 --metrics=off --no-git-ignore --time /semgrep/perf/bench/dropbox/input/pytest-flakefinder
extra arguments for semgrep-core: '-no_gc_tuning'
semgrep exit status: 0
success
semgrep.bench.dropbox.no-gc-tuning.duration = 1.868 s
Result: 0 findings, 0 parse errors
------ semgrep.bench.dropbox.no-filter-irrelevant-rules ------
current directory: /semgrep/perf/bench/dropbox
semgrep command: semgrep --config /semgrep/perf/bench/rules_cache/dropbox --strict --json --timeout 0 --metrics=off --no-git-ignore --time /semgrep/perf/bench/dropbox/input/pytest-flakefinder
extra arguments for semgrep-core: '-no_filter_irrelevant_rules'
semgrep exit status: 0
success
semgrep.bench.dropbox.no-filter-irrelevant-rules.duration = 1.901 s
Result: 0 findings, 0 parse errors
Obtaining a shallow clone of git repo 'bifrost', commit d5adc9ba09898d0776277125892ee3ec84d7055f
hint: Using 'master' as the name for the initial branch. This default branch name
hint: is subject to change. To configure the initial branch name to use in all
hint: of your new repositories, which will suppress this warning, call:
hint: 
hint: 	git config --global init.defaultBranch <name>
hint: 
hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
hint: 'development'. The just-created branch can be renamed via this command:
hint: 
hint: 	git branch -m <name>
Initialized empty Git repository in /semgrep/perf/bench/coinbase/input/bifrost/.git/
From https://github.com/coinbase/bifrost
 * branch            d5adc9ba09898d0776277125892ee3ec84d7055f -> FETCH_HEAD
Switched to a new branch 'tmp'
------ semgrep.bench.coinbase.std ------
current directory: /semgrep/perf/bench/coinbase
semgrep command: semgrep --config /semgrep/perf/bench/rules_cache/coinbase --strict --json --timeout 0 --metrics=off --no-git-ignore --time /semgrep/perf/bench/coinbase/input/bifrost
extra arguments for semgrep-core: ''
[1]    84350 killed     docker run --rm semgrep-performance-tests:test
```

New jobs pass:
* [build-test-docker-performance-tests](https://github.com/semgrep/semgrep/actions/runs/6856491977/job/18643807880?pr=9239#logs):
* [push-docker-performance-tests](https://github.com/semgrep/semgrep/actions/runs/6856491977/job/18643831556?pr=9239#logs)

Pull and run pushed container:
```
➜  semgrep git:(gh/praeacetabular-101df9) ✗ docker pull returntocorp/semgrep:pr-9239-performance-tests
pr-9239-performance-tests: Pulling from returntocorp/semgrep
7264a8db6415: Already exists 
66e1d5e70e42: Already exists 
64dfa579cd50: Already exists 
afa58c10ee34: Already exists 
cd87b3fa61f8: Already exists 
2e893b615cde: Already exists 
b23459e5b97d: Already exists 
27ac8c3989ce: Pulling fs layer 
b4a95a997bc5: Pull complete 
bd507db142d9: Pull complete 
5c7e519faf9b: Pull complete 
216d32155b34: Pull complete 
82903a0a4c4a: Pull complete 
587f3fa4d4dd: Pull complete 
2a81ff02a7c3: Pull complete 
5ce9860235ec: Pull complete 
ca411391fd52: Pull complete 
f38b8c3c9246: Pull complete 
bd9ddc54bea9: Pull complete 
Digest: sha256:9e1fa51c2de469c687827effb8c83a6421608376ce57f7454c8127e7e80790fd
Status: Downloaded newer image for returntocorp/semgrep:pr-9239-performance-tests
docker.io/returntocorp/semgrep:pr-9239-performance-tests
➜  semgrep git:(gh/praeacetabular-101df9) ✗ docker run --rm returntocorp/semgrep:pr-9239-performance-tests
./run-benchmarks
2023-11-13 23:04:40,403 - /semgrep/perf/config.py - DEBUG - Using config at /semgrep/perf/configs/ci_small_repos.yaml
2023-11-13 23:04:40,446 - /semgrep/perf/./run-benchmarks - INFO - Setting up benchmark run for run 'zulip'
2023-11-13 23:04:40,446 - /semgrep/perf/./run-benchmarks - INFO - Rule cache for run zulip created at bench/rules_cache/zulip
2023-11-13 23:04:40,446 - /semgrep/perf/./run-benchmarks - INFO - Checking for rule config 'RuleConfig(config_str='rules/zulip/semgrep.yml')' in cache
2023-11-13 23:04:40,447 - /semgrep/perf/config.py - DEBUG - Checking if config string is a path. Resolved path is /semgrep/perf/rules/zulip/semgrep.yml
2023-11-13 23:04:40,447 - /semgrep/perf/config.py - INFO - Config 'rules/zulip/semgrep.yml' is already on filesystem. Copying to cache at 'bench/rules_cache/zulip/rules.zulip.semgrep.yml.yaml'
2023-11-13 23:04:40,448 - /semgrep/perf/config.py - DEBUG - Copying rules file from /semgrep/perf/rules/zulip/semgrep.yml to bench/rules_cache/zulip/rules.zulip.semgrep.yml.yaml
2023-11-13 23:04:40,448 - /semgrep/perf/./run-benchmarks - INFO - Generating 'prep' file at bench/zulip/prep
[... snipped ...]
Obtaining a shallow clone of git repo 'zulip', commit 829f9272d2c4299a0c0a37a09802248d8136c0a8
hint: Using 'master' as the name for the initial branch. This default branch name
hint: is subject to change. To configure the initial branch name to use in all
hint: of your new repositories, which will suppress this warning, call:
hint: 
hint:   git config --global init.defaultBranch <name>
hint: 
hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
hint: 'development'. The just-created branch can be renamed via this command:
hint: 
hint:   git branch -m <name>
Initialized empty Git repository in /semgrep/perf/bench/zulip/input/zulip/.git/
From https://github.com/zulip/zulip
 * branch            829f9272d2c4299a0c0a37a09802248d8136c0a8 -> FETCH_HEAD
Switched to a new branch 'tmp'
------ semgrep.bench.zulip.std ------
current directory: /semgrep/perf/bench/zulip
semgrep command: semgrep --config /semgrep/perf/bench/rules_cache/zulip --strict --json --timeout 0 --metrics=off --no-git-ignore --time /semgrep/perf/bench/zulip/input/zulip
extra arguments for semgrep-core: ''
[1]    86770 killed     docker run --rm returntocorp/semgrep:pr-9239-performance-tests