### PR TITLE
tests: Ignore "deepsemgrep-ruleid" annotation

### DIFF
--- a/src/core/Core_error.ml
+++ b/src/core/Core_error.ml
@@ -311,10 +311,10 @@ let default_error_regexp = ".*\\(ERROR\\|MATCH\\):"
 
 let (expected_error_lines_of_files :
       ?regexp:string ->
-      ?ok_regexp:string option ->
+      ?ok_regexp:string ->
       string (* filename *) list ->
       (string (* filename *) * int) (* line *) list) =
- fun ?(regexp = default_error_regexp) ?(ok_regexp = None) test_files ->
+ fun ?(regexp = default_error_regexp) ?ok_regexp test_files ->
   test_files
   |> List.concat_map (fun file ->
          Common.cat file |> Common.index_list_1

--- a/src/core/Core_error.mli
+++ b/src/core/Core_error.mli
@@ -70,7 +70,7 @@ val severity_of_error :
 (* extract all the lines with ERROR: comment in test files *)
 val expected_error_lines_of_files :
   ?regexp:string ->
-  ?ok_regexp:string option ->
+  ?ok_regexp:string ->
   string (* filename *) list ->
   (string (* filename *) * int) (* line with ERROR *) list
 

--- a/src/engine/Test_engine.ml
+++ b/src/engine/Test_engine.ml
@@ -121,13 +121,20 @@ let make_test_rule_file ~unit_testing ~get_xlang ~prepend_lang ~newscore
         in
 
         (* expected *)
-        (* not tororuleid! not ok:! not todook:
+        (* we expect ruleid: or todook:
+           not todoruleid: and not ok:
            see https://semgrep.dev/docs/writing-rules/testing-rules/
            for the meaning of those labels.
+           Plus, SR has (ab)used "deepsemgrep-ruleid" in
+           java/servlets/security/tainted-cmd-from-http-request-deepsemgrep.java
+           and we want to ignore it too, hence the [^-].
+           TODO: We should find a better name than "deepsemgrep-ruleid" and
+             add support for it in semgrep-pro.
         *)
-        let regexp = ".*\\b\\(ruleid\\|todook\\):.*" in
+        let regexp = {|.*\b\(ruleid\|todook\):.*|} in
+        let ok_regexp = {|.*deepsemgrep-ruleid.*|} in
         let expected_error_lines =
-          E.expected_error_lines_of_files ~regexp [ !!target ]
+          E.expected_error_lines_of_files ~regexp ~ok_regexp [ !!target ]
         in
 
         (* actual *)


### PR DESCRIPTION
test plan:
CI checks (test-pro-rules should be green)

