### PR TITLE
tests: Make mini-benchmarks workflow less noisy

### DIFF
--- a/perf/compare-perf
+++ b/perf/compare-perf
@@ -151,7 +151,7 @@ def main() -> None:
     else:
         mean_perc_str = f"{-mean_perc:.1f}% faster"
 
-    if mean_rel_dur > 1.07:
+    if mean_rel_dur > 1.15:
         errors += 1
         messages.append(
             f"🚫 The whole benchmark suite is too slow: "
@@ -174,7 +174,7 @@ def main() -> None:
         messages.append(
             "Individual deviations greater than 20% from the baseline are reported. "
             "An individual performance degradation of over 30% or "
-            "a global degradation of over 7% is an error and will block "
+            "a global degradation of over 15% is an error and will block "
             "the pull request. "
             "See run output for full results "
             "('Show all checks' > 'Tests / semgrep benchmark tests' 'Details')."


### PR DESCRIPTION
We get a lot of "The whole benchmark suite is too slow" comments in PRs and we tend to ignore them, and this is just "training" us to ignore them too when the perf deviation is larger and actually worth investigating.

So, let's raise the global threshold from 7% (~1 seconds slower) to 15% (~2 seconds slower). Given that we run these benchmarks in GHA, that the entire benchmark is ~1 second slower can easily be attributed to noise.

Also, this is less critical nowadays since we have a more comprehensive benchmark in the form of an Argo workflow that we run nightly and on-demand. (And hopefully it will soon run on CI too.)

test plan:
No "The whole benchmark suite is too slow" comment in this PR

