### PR TITLE
update semgrep used in pre-commit for jsonnet

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -180,7 +180,7 @@ repos:
   # Dogfood! running semgrep in pre-commit!
   # ----------------------------------------------------------
   - repo: https://github.com/returntocorp/semgrep
-    rev: v1.44.0
+    rev: v1.48.0
     hooks:
       - id: semgrep
         name: Semgrep Jsonnet


### PR DESCRIPTION
Previously, 1.44 was used which exhibits an invalid argument in rindex_from, fixed in #9035

