### PR TITLE
devops: Add semgrep-comparison trigger to tests

### DIFF
--- a/.github/workflows/tests.jsonnet
+++ b/.github/workflows/tests.jsonnet
@@ -387,7 +387,7 @@ local trigger_semgrep_comparison_argo = {
   needs: [
     'push-docker',
   ],
-  uses: './trigger-semgrep-comparison-argo.yml',
+  uses: './.github/workflows/trigger-semgrep-comparison-argo.yml',
 };
 
 // ----------------------------------------------------------------------------

--- a/.github/workflows/tests.jsonnet
+++ b/.github/workflows/tests.jsonnet
@@ -382,6 +382,14 @@ local benchmarks_full_job = {
   ],
 };
 
+local trigger_semgrep_comparison_argo = {
+  secrets: 'inherit',
+  needs: [
+    'push-docker',
+  ],
+  uses: './trigger-semgrep-comparison-argo.yml',
+};
+
 // ----------------------------------------------------------------------------
 // Docker
 // ----------------------------------------------------------------------------
@@ -572,6 +580,8 @@ local ignore_md = {
     'push-docker-performance-tests': push_docker_performance_tests_job,
     // Semgrep-pro mismatch check
     'test-semgrep-pro': test_semgrep_pro_job,
+    // trigger argo workflows
+    'trigger-semgrep-comparison-argo': trigger_semgrep_comparison_argo,
     // The inherit jobs also included from releases.yml
     'build-test-core-x86': {
       uses: './.github/workflows/build-test-core-x86.yml',

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -334,9 +334,9 @@ jobs:
       artifact-name: image-test
       repository-name: returntocorp/semgrep
   trigger-semgrep-comparison-argo:
-    uses: ./trigger-semgrep-comparison-argo.yml
     needs:
     - push-docker
+    uses: ./.github/workflows/trigger-semgrep-comparison-argo.yml
     secrets: inherit
   build-test-core-x86:
     uses: ./.github/workflows/build-test-core-x86.yml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -333,6 +333,11 @@ jobs:
     with:
       artifact-name: image-test
       repository-name: returntocorp/semgrep
+  trigger-semgrep-comparison-argo:
+    uses: ./trigger-semgrep-comparison-argo.yml
+    needs:
+    - push-docker
+    secrets: inherit
   build-test-core-x86:
     uses: ./.github/workflows/build-test-core-x86.yml
     secrets: inherit


### PR DESCRIPTION
Depends on https://github.com/semgrep/semgrep/pull/9243.

This PR adds the trigger for the `semgrep-comparison` Argo Workflow to `tests.yml`. This will trigger a new check-run on PRs which runs the `semgrep-comparison` benchmarks against `develop`.

### Test plan

Run the `trigger-semgrep-comparison-argo` workflow with `workflow_dispatch`. This is an adequate approximation of how it will behave on a PR; however, there may be some GHA-isms that I missed which may require follow-up PRs.

I could test `tests.yml` with `act`, but that requires a lot of additional setup to mimic our secrets, environments, etc.

![image](https://github.com/semgrep/semgrep/assets/2374948/c3e8462f-a567-473b-86f4-bd077e62a91c)

![image](https://github.com/semgrep/semgrep/assets/2374948/11ae4d70-5279-43fb-879c-8a67469da455)


Oh, actually this PR ran the changes to the workflow. See the job `semgrep-compare-github-cmmn7` below!

![image](https://github.com/semgrep/semgrep/assets/2374948/68f50951-fedd-441f-ae0f-1954e8c1b4d3)


