### PR TITLE
fix(tests): Disable failing js test

### DIFF
--- a/js/tests/Test_jsoo.ml
+++ b/js/tests/Test_jsoo.ml
@@ -38,7 +38,7 @@ let skipped_tests =
     (* TODO: re-enable this when we fix the jsoo int overflow bug *)
     ("Go", [ 24 ]);
     (* TODO: investigate c_array_inits pattern parse error*)
-    ("C", [ 0 ]);
+    ("C", [ 2 ]);
   ]
 
 (* Filter to skip tests *)


### PR DESCRIPTION
This updates the index of the failing JS test to be correct. It looks like some tests were rearranged and the index changed.

## Test plan

Build test javascript workflow passes