### PR TITLE
chore: fix hanging LS test

### DIFF
--- a/src/osemgrep/language_server/Test_LS_e2e.ml
+++ b/src/osemgrep/language_server/Test_LS_e2e.ml
@@ -947,6 +947,12 @@ let test_ls_multi () =
 
 let test_login () =
   with_session (fun info ->
+      (* If we don't log out prior to starting this test, the LS will complain
+         we're already logged in, and not display the correct behavior.
+      *)
+      let settings = Semgrep_settings.load () in
+      if not (Semgrep_settings.save { settings with api_token = None }) then
+        Alcotest.fail "failed to save settings to log out in ls e2e test";
       let root, files = mock_files () in
       Testutil_files.with_chdir root (fun () ->
           let%lwt () = check_startup info [ root ] files in
@@ -962,6 +968,7 @@ let test_login () =
           in
 
           assert (Regexp_engine.unanchored_match login_url_regex url);
+          Semgrep_settings.save settings |> ignore;
           send_exit info))
 
 let test_ls_no_folders () =


### PR DESCRIPTION
This PR fixes the hanging "Test Login" test, which would hang if you were logged in (because the LS would complain).