### PR TITLE
Not suppressing errors leads to failure, not success

### DIFF
--- a/src/osemgrep/cli_ci/Ci_CLI.ml
+++ b/src/osemgrep/cli_ci/Ci_CLI.ml
@@ -96,7 +96,7 @@ let o_suppress_errors : bool Term.t =
       {|Configures how the CI command reacts when an error occurs.
 If true, encountered errors are suppressed and the exit code is zero (success).
 If false, encountered errors are not suppressed and the exit code is non-zero
-(success).|}
+(failure).|}
 
 (*************************************************************************)
 (* Turn argv into conf *)


### PR DESCRIPTION
The help text for `--suppress-errors` had a repetition of "success" where it appears to mean "failure" the second time, when it refers to non-zero exit codes.