### PR TITLE
chore: add back `--pro` to the metrics test

### DIFF
--- a/cli/tests/e2e/snapshots/test_metrics/test_metrics_payload/pro_flag1/metrics-payload.json
+++ b/cli/tests/e2e/snapshots/test_metrics/test_metrics_payload/pro_flag1/metrics-payload.json
@@ -1,0 +1,71 @@
+{
+  "anonymous_user_id": "11111111-1111-1111-1111-111111111111",
+  "environment": {
+    "ci": null,
+    "configNamesHash": "d3e03c9938537c0a0668cec7204f37f1e9da87d03e18e8cc444dd7454b36c4d5",
+    "integrationName": "funkyintegration",
+    "isAuthenticated": false,
+    "isDiffScan": false,
+    "projectHash": null,
+    "rulesHash": "7f693c12172d20798fe56ef8555cf42accb11ae6fc115d0d87405f2a988e9805",
+    "version": "x.x.x"
+  },
+  "errors": {
+    "errors": [],
+    "returnCode": 0
+  },
+  "event_id": "00000000-0000-0000-0000-000000000000",
+  "extension": {},
+  "parse_rate": {
+    "csharp": {
+      "bytes_parsed": 1492,
+      "num_bytes": 1492,
+      "num_targets": 2,
+      "targets_parsed": 2
+    },
+    "java": {
+      "bytes_parsed": 300,
+      "num_bytes": 300,
+      "num_targets": 1,
+      "targets_parsed": 1
+    }
+  },
+  "performance": {
+    "numRules": 2,
+    "numTargets": 3,
+    "profilingTimes": {
+      "config_time": 0.0,
+      "core_time": 0.0,
+      "ignores_time": 0.0,
+      "total_time": 0.0
+    },
+    "totalBytesScanned": 1792
+  },
+  "sent_at": "2017-03-03T00:00:00+09:00",
+  "started_at": "2017-03-03T00:00:00+09:00",
+  "value": {
+    "engineRequested": "PRO_INTERFILE",
+    "features": [
+      "cli-flag/config",
+      "cli-flag/metrics",
+      "cli-flag/requested_engine",
+      "cli-flag/targets",
+      "config/local",
+      "language/csharp",
+      "language/java",
+      "subcommand/scan"
+    ],
+    "interfileLanguagesUsed": [
+      "C#"
+    ],
+    "numFindings": 2,
+    "numIgnored": 0,
+    "proFeatures": {
+      "diffDepth": -1
+    },
+    "ruleHashesWithFindings": {
+      "7d0af7d79e44c9bafdba5c83bacbb44c5b663c3c3efe1eec1676df5158303eb4": 1,
+      "d9b9091bec0a312e3cbf9735b69e80411a0131779938f802de3899fec6354aa7": 1
+    }
+  }
+}

--- a/cli/tests/e2e/test_metrics.py
+++ b/cli/tests/e2e/test_metrics.py
@@ -181,7 +181,7 @@ def _mask_version(value: str) -> str:
     sys.version_info < (3, 8),
     reason="snapshotting mock call kwargs doesn't work on py3.7",
 )
-@mark.parametrize("pro_flag", [[]])  # TODO add back test for pro, ["--pro"]])
+@mark.parametrize("pro_flag", [[], ["--pro"]])
 @pytest.mark.osemfail
 def test_metrics_payload(tmp_path, snapshot, mocker, monkeypatch, pro_flag):
     # make the formatted timestamp strings deterministic


### PR DESCRIPTION
Now that semgrep-pro has been updated, this test should work. Add it back!

Test plan: automated tests

