### PR TITLE
fix: tainting: Do not clean LHS if there were side-effects

### DIFF
--- a/changelog.d/pa-3164.fixed
+++ b/changelog.d/pa-3164.fixed
@@ -1,0 +1,16 @@
+taint-mode: When we encountered an assignment `lval := expr` where `expr` returned
+no taints, we automatically cleaned `lval`.  This was correct in the early days of
+taint-mode, before we introduced taint by side-effect, but it is wrong now. The LHS
+`lval` may be tainted by side-effect, in which case we cannot clean it just because
+`expr` returns no taint. Now that we introduced `by-side-effect: only` it is also
+possible for `expr` to taint `lval` by side-effect and return no immediate taint.
+
+This kind of source should now work as expected:
+
+```yaml
+- by-side-effect: true
+  patterns:
+    - pattern: |
+        $X = source()
+    - focus-metavariable: $X
+```

--- a/tests/rules/taint_by_side_effect_lhs.py
+++ b/tests/rules/taint_by_side_effect_lhs.py
@@ -1,0 +1,4 @@
+def test():
+    x = source()
+    #ruleid: test
+    sink(x)

--- a/tests/rules/taint_by_side_effect_lhs.yaml
+++ b/tests/rules/taint_by_side_effect_lhs.yaml
@@ -1,0 +1,17 @@
+rules:
+  - id: test
+    languages:
+      - python
+    message: Test
+    mode: taint
+    pattern-sinks:
+      - pattern: |
+          sink(...)
+    pattern-sources:
+      - by-side-effect: true
+        patterns:
+          - pattern: |
+              $X = source()
+          - focus-metavariable: $X
+    severity: ERROR
+


### PR DESCRIPTION
When we encountered an assignment `lval := expr` where `expr` returned no taints, we automatically cleaned `lval`. This was correct in the early days of taint-mode, before we introduced taint by side-effect, but it is wrong now. The LHS `lval` may be tainted by side-effect, in which case we cannot clean it just because `expr` returns no taint. Now that we introduced `by-side-effect: only` it is also possible for `expr` to taint `lval` by side-effect and return no immediate taint.

Needs PR semgrep/semgrep-rules-jsonnet#398 to update a bunch of 'todoruleid's that are fixed by this PR.

Closes PA-3164

test plan:
make test # new test

