### PR TITLE
chore: Use tag instead of whole image

### DIFF
--- a/.github/workflows/trigger-semgrep-comparison-argo.jsonnet
+++ b/.github/workflows/trigger-semgrep-comparison-argo.jsonnet
@@ -30,8 +30,8 @@ local util = import 'libs/util.libsonnet';
       'https://argoworkflows-dev2.corp.r2c.dev/api/v1/events/security-research/semgrep-compare',
       [
         {name: 'ruleset', value: 'p/default-v2'},
-        {name: 'container_image_base', value: "${{ needs.setup-docker-tag.outputs.docker-tag == 'develop' && 'returntocorp/semgrep:latest' || 'returntocorp/semgrep:develop' }}" },
-        {name: 'container_image_development', value: 'returntocorp/semgrep:${{ needs.setup-docker-tag.outputs.docker-tag }}' },
+        {name: 'container_image_base', value: "${{ needs.setup-docker-tag.outputs.docker-tag == 'develop' && 'latest' || 'develop' }}" },
+        {name: 'container_image_development', value: '${{ needs.setup-docker-tag.outputs.docker-tag }}' },
       ],
     ),
   },

--- a/.github/workflows/trigger-semgrep-comparison-argo.yml
+++ b/.github/workflows/trigger-semgrep-comparison-argo.yml
@@ -51,8 +51,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - env:
-          CONTAINER_IMAGE_BASE: ${{ needs.setup-docker-tag.outputs.docker-tag == 'develop' && 'returntocorp/semgrep:latest' || 'returntocorp/semgrep:develop' }}
-          CONTAINER_IMAGE_DEVELOPMENT: returntocorp/semgrep:${{ needs.setup-docker-tag.outputs.docker-tag }}
+          CONTAINER_IMAGE_BASE: ${{ needs.setup-docker-tag.outputs.docker-tag == 'develop' && 'latest' || 'develop' }}
+          CONTAINER_IMAGE_DEVELOPMENT: ${{ needs.setup-docker-tag.outputs.docker-tag }}
           REPOSITORY: ${{ github.repository }}
           RULESET: p/default-v2
           SHA: ${{ needs.get-sha.outputs.sha }}


### PR DESCRIPTION
I switched the Argo Workflow to accept only tags. This PR updates the GHA trigger to send only tags.

Test plan:
* Trigger the Argo WF with only tags
```
✗ curl -X POST https://argoworkflows-dev2.corp.r2c.dev/api/v1/events/security-research/semgrep-compare -H "Authorization: ..." -d '{"repository": "returntocorp/WebGoat", "sha": "78d5bf174b43296f79d33ea26398f39cf681bffc", "ruleset": "p/default-v2", "container_image_base": "latest", "container_image_development": "develop"}'
```

![image](https://github.com/semgrep/semgrep/assets/2374948/350abc2b-9d8a-4571-b718-a157af24c73e)


