### PR TITLE
osemprep: text output for secrets.

### DIFF
--- a/libs/networking/http_mock_client/Http_mock_client.ml
+++ b/libs/networking/http_mock_client/Http_mock_client.ml
@@ -105,12 +105,13 @@ let body_of_file ?(trim = false) path =
 let check_body expected_body actual_body =
   let%lwt actual_body_content = Cohttp_lwt.Body.to_string actual_body in
   let%lwt expected_body_content = Cohttp_lwt.Body.to_string expected_body in
-  Alcotest.(check string) "body" expected_body_content actual_body_content;
+  (* Using "" prevents always printing "ASSERT name" to stderr *)
+  Alcotest.(check string) "" expected_body_content actual_body_content;
   Lwt.return_unit
 
 let check_method expected_meth actual_meth =
   Alcotest.(check string)
-    "method"
+    "" (* Using "" prevents always printing "ASSERT name" to stderr *)
     (Cohttp.Code.string_of_method expected_meth)
     (Cohttp.Code.string_of_method actual_meth)
 
@@ -121,8 +122,8 @@ let check_header req header header_val =
       Alcotest.fail
         (Printf.sprintf "header %s not found. Headers: %s" header
            (Cohttp.Header.to_string (Cohttp.Request.headers req)))
-  | Some actual_header ->
-      Alcotest.(check string) "header" header_val actual_header
+  (* Using "" prevents always printing "ASSERT name" to stderr *)
+  | Some actual_header -> Alcotest.(check string) "" header_val actual_header
 
 let check_headers expected_headers actual_headers =
   let lowercase_and_sort xs =
@@ -134,8 +135,9 @@ let check_headers expected_headers actual_headers =
   let expected_headers =
     expected_headers |> Header.to_list |> lowercase_and_sort
   in
+  (* Using "" prevents always printing "ASSERT name" to stderr *)
   Alcotest.(check (list (pair string string)))
-    "headers" expected_headers actual_headers
+    "" expected_headers actual_headers
 
 let get_header req header =
   Cohttp.Header.get (Cohttp.Request.headers req) header

--- a/libs/networking/http_mock_client/Http_mock_client.ml
+++ b/libs/networking/http_mock_client/Http_mock_client.ml
@@ -105,13 +105,16 @@ let body_of_file ?(trim = false) path =
 let check_body expected_body actual_body =
   let%lwt actual_body_content = Cohttp_lwt.Body.to_string actual_body in
   let%lwt expected_body_content = Cohttp_lwt.Body.to_string expected_body in
-  (* Using "" prevents always printing "ASSERT name" to stderr *)
+  (* Passing "" for the name of the check prevents an otherwise
+     unconditional print to stderr of the string "Assert <name>". *)
   Alcotest.(check string) "" expected_body_content actual_body_content;
   Lwt.return_unit
 
 let check_method expected_meth actual_meth =
+  (* Passing "" for the name of the check prevents an otherwise
+     unconditional print to stderr of the string "Assert <name>". *)
   Alcotest.(check string)
-    "" (* Using "" prevents always printing "ASSERT name" to stderr *)
+    ""
     (Cohttp.Code.string_of_method expected_meth)
     (Cohttp.Code.string_of_method actual_meth)
 
@@ -122,7 +125,8 @@ let check_header req header header_val =
       Alcotest.fail
         (Printf.sprintf "header %s not found. Headers: %s" header
            (Cohttp.Header.to_string (Cohttp.Request.headers req)))
-  (* Using "" prevents always printing "ASSERT name" to stderr *)
+  (* Passing "" for the name of the check prevents an otherwise
+     unconditional print to stderr of the string "Assert <name>". *)
   | Some actual_header -> Alcotest.(check string) "" header_val actual_header
 
 let check_headers expected_headers actual_headers =
@@ -135,7 +139,8 @@ let check_headers expected_headers actual_headers =
   let expected_headers =
     expected_headers |> Header.to_list |> lowercase_and_sort
   in
-  (* Using "" prevents always printing "ASSERT name" to stderr *)
+  (* Passing "" for the name of the check prevents an otherwise
+     unconditional print to stderr of the string "Assert <name>". *)
   Alcotest.(check (list (pair string string)))
     "" expected_headers actual_headers
 

--- a/src/osemgrep/reporting/Matches_report.ml
+++ b/src/osemgrep/reporting/Matches_report.ml
@@ -363,7 +363,8 @@ let pp_cli_output ~max_chars_per_line ~max_lines_per_finding ~color_output ppf
              | Some `Confirmed_invalid -> `Invalid
              | Some `Validation_error -> `Validation_error
              | Some `No_validator
-             | None -> `Unvalidated))
+             | None ->
+                 `Unvalidated))
   |> (fun groups ->
        (* TO PORT:
           if not is_ci_invocation: *)

--- a/src/osemgrep/reporting/Matches_report.ml
+++ b/src/osemgrep/reporting/Matches_report.ml
@@ -37,7 +37,6 @@ let group_titles = function
 let sort_by_groups als =
   (* This is the order that groups will be desplayed in. *)
   let group_order = function
-    | `Merged -> 0
     | `Blocking -> 1
     | `Reachable -> 2
     | `Valid -> 3
@@ -47,6 +46,7 @@ let sort_by_groups als =
     | `Nonblocking -> 7
     | `Unreachable -> 8
     | `Invalid -> 9
+    | `Merged -> 10
   in
   let compare_group x y = group_order x - group_order y in
   als |> List.stable_sort (fun (g1, _) (g2, _) -> compare_group g1 g2)
@@ -361,9 +361,9 @@ let pp_cli_output ~max_chars_per_line ~max_lines_per_finding ~color_output ppf
              match m.extra.validation_state with
              | Some `Confirmed_valid -> `Valid
              | Some `Confirmed_invalid -> `Invalid
-             | Some (`No_validator | `Validation_error)
-             | None ->
-                 `Unvalidated))
+             | Some `Validation_error -> `Validation_error
+             | Some `No_validator
+             | None -> `Unvalidated))
   |> (fun groups ->
        (* TO PORT:
           if not is_ci_invocation: *)

--- a/src/osemgrep/reporting/dune
+++ b/src/osemgrep/reporting/dune
@@ -11,6 +11,7 @@
 
    osemgrep_core
    semgrep.reporting
+   semgrep.targeting
  )
  (preprocess
    (pps

--- a/src/targeting/Product.ml
+++ b/src/targeting/Product.ml
@@ -5,3 +5,21 @@ module Out = Semgrep_output_v1_t
 let _proof_that_input_subtype_output_product (x : In.product) : Out.product = x
 let _proof_that_output_subtype_input_product (x : Out.product) : In.product = x
 let all = [ `SAST; `SCA; `Secrets ]
+
+let of_cli_match (m : Out.cli_match) =
+  let metadata_product_opt =
+    try
+      match Yojson.Basic.Util.member "product" m.extra.metadata with
+      | `String "secrets" -> Some `Secrets
+      | `String "sca" -> Some `SCA
+      | `String ("code" | "sast") -> Some `SAST
+      | _ -> None
+    with
+    | _ -> None
+  in
+  match metadata_product_opt with
+  (* Not sure if this is correct. Assuming the product is SCA if there
+     is sca_info. *)
+  | None when Option.is_some m.extra.sca_info -> `SCA
+  | Some p -> p
+  | _ -> `SAST

--- a/src/targeting/Product.mli
+++ b/src/targeting/Product.mli
@@ -3,3 +3,4 @@
    Semgrep_output_v1_t.product. *)
 
 val all : Semgrep_output_v1_t.product list
+val of_cli_match : Semgrep_output_v1_t.cli_match -> Semgrep_output_v1_t.product


### PR DESCRIPTION
This implements just a little bit more of the text output of the osemgrep cli and adds the corresponding results for secrets.

- Also modifies some asserts in the network mocking library that were causing noisy prints to standard error.

### Test Plan:
CI + [See this semgrep-proprietary PR](https://github.com/semgrep/semgrep-proprietary/pull/1117)
