### PR TITLE
Do not run circleCI workflows on semgrep-ci branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,11 +139,24 @@ workflows:
   # no triggers, runs on every PRs
   semgrep:
     jobs:
-      - semgrep
+      - semgrep:
+          filters:
+            branches:
+              # we ignore those branches which are used by semgrep-ci
+              # because we can't signup semgrep-ci github app in circleCI
+              # and get annoying "block-unregister-user" error on those PRs
+              ignore:
+                - /release-.*/
+                - /update-semgrep-rules-.*/
 
   build-and-check:
     jobs:
-      - build-ubuntu
+      - build-ubuntu:
+          filters:
+            branches:
+              ignore:
+                - /release-.*/
+                - /update-semgrep-rules-.*/
 
   #----------------------------------------
   # Crons


### PR DESCRIPTION
test plan:
wait to see if circleCI workflows ran on this PR which
has the release-xxx branch name and so should not
trigger the circleCI workflow