### PR TITLE
tainting: Tweak taint_only_propagate_through_assignments option

### DIFF
--- a/changelog.d/pa-2193.changed
+++ b/changelog.d/pa-2193.changed
@@ -1,0 +1,3 @@
+taint-mode: Tweaked experimental option `taint_only_propagate_through_assignments`
+so that when it is enabled, `tainted.field` and `tainted(args)` will no longer
+propagate taint.

--- a/tests/rules/taint_no_builtin_props1.py
+++ b/tests/rules/taint_no_builtin_props1.py
@@ -1,0 +1,19 @@
+
+def bad():
+    x = source()
+    y = x
+    z = y
+    #ruleid: test
+    sink(z)
+
+def ok1():
+    x = source()
+    y = x.a
+    #ok: test
+    sink(y)
+
+def ok2():
+    x = source()
+    y = x()
+    #ok: test
+    sink(y)

--- a/tests/rules/taint_no_builtin_props1.yaml
+++ b/tests/rules/taint_no_builtin_props1.yaml
@@ -1,0 +1,12 @@
+rules:
+- id: test
+  severity: WARNING
+  message: Test
+  languages: [python]
+  mode: taint
+  options:
+    taint_only_propagate_through_assignments: true
+  pattern-sources:
+  - pattern: source(...)
+  pattern-sinks:
+  - pattern: sink(...)

--- a/tests/rules/taint_no_builtin_props2.py
+++ b/tests/rules/taint_no_builtin_props2.py
@@ -1,0 +1,7 @@
+def test():
+    file = open("test.txt")
+    file.close()
+    # While working on PR #9273 we introduced a regression that caused the above
+    # sanitizer to not work.
+    #ok: test
+    sink(file)

--- a/tests/rules/taint_no_builtin_props2.yaml
+++ b/tests/rules/taint_no_builtin_props2.yaml
@@ -1,0 +1,20 @@
+rules:
+  - id: test
+    message: Test
+    severity: WARNING
+    languages: [python]
+    options:
+      taint_only_propagate_through_assignments: true
+    mode: taint
+    pattern-sources:
+      - by-side-effect: true
+        patterns:
+          - pattern: $FILE = open(...)
+          - focus-metavariable: $FILE
+    pattern-sanitizers:
+      - by-side-effect: true
+        patterns:
+          - pattern: $FILE.close(...)
+          - focus-metavariable: $FILE
+    pattern-sinks:
+      - pattern: sink(...)


### PR DESCRIPTION
So that, with this option enabled, neither field accesses `tainted.field` nor function calls `tainted(args)` will propagate taint.

Follows: de77d971301 ("tainting:  Add experimental option `taint_only_propagate_through_assignments` (#6529)")

test plan:
make test # new test

