### PR TITLE
Update mentions of Semgrep Support in help text

### DIFF
--- a/src/osemgrep/cli_ci/Ci_CLI.ml
+++ b/src/osemgrep/cli_ci/Ci_CLI.ml
@@ -83,7 +83,7 @@ let o_secrets : bool Term.t =
     Arg.info [ "secrets" ]
       ~doc:
         {|Support for secret validation. Requires Semgrep Secrets,
-contact support@semgrep.com for more information this.|}
+contact support@semgrep.com for more information on this.|}
   in
   Arg.value (Arg.flag info)
 

--- a/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -526,7 +526,7 @@ let o_secrets : bool Term.t =
       [ "beta-testing-secrets-enabled" ]
       ~doc:
         {|Enable support for secret validation. Requires Semgrep Secrets,
-contact support@semgrep.com for more information on on this.|}
+contact support@semgrep.com for more information on this.|}
   in
   Arg.value (Arg.flag info)
 
@@ -557,7 +557,7 @@ let o_oss : bool Term.t =
   Arg.value (Arg.flag info)
 
 let blurb =
-  "Requires Semgrep Pro Engine."
+  "Requires Semgrep Pro Engine. See https://semgrep.dev/products/pro-engine/ for more."
 
 let o_pro_languages : bool Term.t =
   let info =

--- a/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -526,7 +526,7 @@ let o_secrets : bool Term.t =
       [ "beta-testing-secrets-enabled" ]
       ~doc:
         {|Enable support for secret validation. Requires Semgrep Secrets,
-contact support@semgrep.com for more informationon this.|}
+contact support@semgrep.com for more information on on this.|}
   in
   Arg.value (Arg.flag info)
 
@@ -557,8 +557,7 @@ let o_oss : bool Term.t =
   Arg.value (Arg.flag info)
 
 let blurb =
-  "Requires Semgrep Pro Engine, contact support@semgrep.com for more \
-   information on this."
+  "Requires Semgrep Pro Engine."
 
 let o_pro_languages : bool Term.t =
   let info =


### PR DESCRIPTION
* Trying Pro Engine is now self-serve, so replace support mention with link to resource.
* Improve grammar on Secrets support mentions.