### PR TITLE
fix(osemgrep): Implement `--scan-unknown-extensions` for osemgrep

### DIFF
--- a/cli/bin/semgrep
+++ b/cli/bin/semgrep
@@ -152,6 +152,7 @@ def exec_osemgrep():
         # If you call semgrep-core as osemgrep, then we get
         # osemgrep behavior, see src/main/Main.ml
         sys.argv[0] = "osemgrep"
+    print(sys.argv)
     os.execvp(str(path), sys.argv)
 
 # Needed for similar reasons as in pysemgrep, but only for the legacy

--- a/cli/bin/semgrep
+++ b/cli/bin/semgrep
@@ -152,7 +152,6 @@ def exec_osemgrep():
         # If you call semgrep-core as osemgrep, then we get
         # osemgrep behavior, see src/main/Main.ml
         sys.argv[0] = "osemgrep"
-    print(sys.argv)
     os.execvp(str(path), sys.argv)
 
 # Needed for similar reasons as in pysemgrep, but only for the legacy

--- a/cli/tests/e2e/test_check.py
+++ b/cli/tests/e2e/test_check.py
@@ -78,7 +78,7 @@ def test_deduplication(run_semgrep_in_tmp: RunSemgrep, snapshot):
     )
 
 
-@pytest.mark.osemfail
+@pytest.mark.osempass
 @pytest.mark.kinda_slow
 def test_noextension_filtering(run_semgrep_in_tmp: RunSemgrep, snapshot):
     """
@@ -95,7 +95,7 @@ def test_noextension_filtering(run_semgrep_in_tmp: RunSemgrep, snapshot):
     )
 
 
-@pytest.mark.osemfail
+@pytest.mark.osempass
 @pytest.mark.kinda_slow
 def test_noextension_filtering_optimizations(run_semgrep_in_tmp: RunSemgrep, snapshot):
     """

--- a/src/core/Differential_scan_config.ml
+++ b/src/core/Differential_scan_config.ml
@@ -30,6 +30,7 @@ let default_depth = 2
    option is used, `targets` are automatically calculated based on the
    output from the `git diff` command between the baseline commit and
    the head commit. *)
+(* TODO should these be Target_file.target_files? *)
 type t =
   | BaseLine of Fpath.t list (* implies depth 0 *)
   | Depth of Fpath.t list (* starting point *) * int (* depth *)

--- a/src/core/Target_file.ml
+++ b/src/core/Target_file.ml
@@ -1,0 +1,19 @@
+type provided_target_language_info =
+  (* The default *)
+  | NoSpecialTargeting
+  (* When `--scan-unknown-extensions` is provided, explicitly passed files
+     are scanned with all languages in the rule *)
+  | ExplicitFileScanUnknownExtension (* | TODO Lang for -lang? *)
+[@@deriving show]
+
+type target_file = Fpath.t * provided_target_language_info [@@deriving show]
+type target_files = target_file list [@@deriving show]
+type t = target_file [@@deriving show]
+
+(* Helper functions for converting between Fpath lists and target_files *)
+
+let no_info_target_files_of_fpaths : Fpath.t list -> target_files =
+  Common.map (fun x -> (x, NoSpecialTargeting))
+
+let v (file, _info) = file
+let fpaths_of_target_files : target_files -> Fpath.t list = Common.map v

--- a/src/core/Target_file.ml
+++ b/src/core/Target_file.ml
@@ -12,7 +12,7 @@ type t = target_file [@@deriving show]
 
 (* Helper functions for converting between Fpath lists and target_files *)
 
-let no_info_target_files_of_fpaths : Fpath.t list -> target_files =
+let non_special_target_files_of_fpaths : Fpath.t list -> target_files =
   Common.map (fun x -> (x, NoSpecialTargeting))
 
 let v (file, _info) = file

--- a/src/osemgrep/cli_interactive/Interactive_subcommand.ml
+++ b/src/osemgrep/cli_interactive/Interactive_subcommand.ml
@@ -1244,7 +1244,10 @@ let run (conf : Interactive_CLI.conf) : Exit_code.t =
    *)
   let xlang = Xlang.L (conf.lang, []) in
   let targets =
-    targets |> List.filter (Filter_target.filter_target_for_xlang xlang)
+    targets
+    (* In interactive mode, scan-unknown-extensions never applies *)
+    |> Target_file.fpaths_of_target_files
+    |> List.filter (Filter_target.filter_target_for_xlang xlang)
   in
   let config = Core_runner.core_scan_config_of_conf conf.core_runner_conf in
   let config = { config with roots = conf.target_roots; lang = Some xlang } in

--- a/src/osemgrep/cli_scan/Core_runner.ml
+++ b/src/osemgrep/cli_scan/Core_runner.ml
@@ -120,6 +120,7 @@ let split_jobs_by_language all_rules all_targets : Lang_job.t list =
   let targets_with_unknown_extension =
     get_targets_with_unknown_extension all_targets
   in
+  Common.pr2 (Target_file.show_target_files all_targets);
   let all_targets = Target_file.fpaths_of_target_files all_targets in
   all_rules |> group_rules_by_target_language
   |> Common.map_filter (fun (xlang, rules) ->

--- a/src/osemgrep/cli_scan/Core_runner.ml
+++ b/src/osemgrep/cli_scan/Core_runner.ml
@@ -120,7 +120,6 @@ let split_jobs_by_language all_rules all_targets : Lang_job.t list =
   let targets_with_unknown_extension =
     get_targets_with_unknown_extension all_targets
   in
-  Common.pr2 (Target_file.show_target_files all_targets);
   let all_targets = Target_file.fpaths_of_target_files all_targets in
   all_rules |> group_rules_by_target_language
   |> Common.map_filter (fun (xlang, rules) ->

--- a/src/osemgrep/cli_scan/Core_runner.mli
+++ b/src/osemgrep/cli_scan/Core_runner.mli
@@ -36,7 +36,7 @@ type scan_func_for_osemgrep =
   (* LATER? use Config_resolve.rules_and_origin instead? *)
   Rule.rules ->
   Rule.invalid_rule_error list ->
-  Fpath.t list ->
+  Target_file.target_files ->
   Core_result.result_or_exn
 
 (* Core_scan_func adapter to be used in osemgrep.
@@ -58,4 +58,5 @@ val mk_scan_func_for_osemgrep :
 val core_scan_config_of_conf : conf -> Core_scan_config.t
 
 (* reused in semgrep-server *)
-val split_jobs_by_language : Rule.t list -> Fpath.t list -> Lang_job.t list
+val split_jobs_by_language :
+  Rule.t list -> Target_file.target_files -> Lang_job.t list

--- a/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -337,7 +337,7 @@ let scan_baseline_and_remove_duplicates (conf : Scan_CLI.conf)
                         (all_in_baseline, paths_in_scanned)
                     | _ ->
                         ( paths_in_match
-                          |> Target_file.no_info_target_files_of_fpaths,
+                          |> Target_file.non_special_target_files_of_fpaths,
                           [] )
                   in
                   core baseline_targets
@@ -447,7 +447,8 @@ let run_scan_files (conf : Scan_CLI.conf) (profiler : Profiler.t)
                   Some { diffDepth = Some diff_depth };
                 (targets, added_or_modified)
             | _ ->
-                ( added_or_modified |> Target_file.no_info_target_files_of_fpaths,
+                ( added_or_modified
+                  |> Target_file.non_special_target_files_of_fpaths,
                   [] )
           in
           let head_scan_result =

--- a/src/osemgrep/cli_scan/Scan_subcommand.mli
+++ b/src/osemgrep/cli_scan/Scan_subcommand.mli
@@ -25,7 +25,7 @@ val run_scan_files :
   Scan_CLI.conf ->
   Profiler.t ->
   Rule_fetching.rules_and_origin list ->
-  Fpath.t list * Semgrep_output_v1_t.skipped_target list ->
+  Target_file.target_files * Semgrep_output_v1_t.skipped_target list ->
   ( Rule.rule list * Core_runner.result * Semgrep_output_v1_t.cli_output,
     Exit_code.t )
   result

--- a/src/osemgrep/cli_scan/Validate_subcommand.ml
+++ b/src/osemgrep/cli_scan/Validate_subcommand.ml
@@ -113,6 +113,7 @@ let run (conf : conf) : Exit_code.t =
                  | Other_origin ->
                      (* TODO: stricter: warn if no origin (meaning URL or registry) *)
                      None)
+          |> Target_file.no_info_target_files_of_fpaths
         in
         let in_docker = !Semgrep_envvars.v.in_docker in
         let (config : Rules_config.t) =

--- a/src/osemgrep/cli_scan/Validate_subcommand.ml
+++ b/src/osemgrep/cli_scan/Validate_subcommand.ml
@@ -113,7 +113,7 @@ let run (conf : conf) : Exit_code.t =
                  | Other_origin ->
                      (* TODO: stricter: warn if no origin (meaning URL or registry) *)
                      None)
-          |> Target_file.no_info_target_files_of_fpaths
+          |> Target_file.non_special_target_files_of_fpaths
         in
         let in_docker = !Semgrep_envvars.v.in_docker in
         let (config : Rules_config.t) =

--- a/src/osemgrep/language_server/Unit_LS.ml
+++ b/src/osemgrep/language_server/Unit_LS.ml
@@ -132,7 +132,10 @@ let session_targets () =
     let user_settings = { session.user_settings with only_git_dirty } in
     let session = { session with user_settings; workspace_folders } in
     let session = set_session_targets session workspace_folders in
-    let targets = session |> Session.targets |> Common.map Fpath.to_string in
+    let targets =
+      session |> Session.targets |> Target_file.fpaths_of_target_files
+      |> Common.map Fpath.to_string
+    in
     let targets = Common.sort targets in
     let expected = Common.sort expected in
     Alcotest.(check (list string)) "targets" expected targets

--- a/src/osemgrep/language_server/scan_helpers/Scan_helpers.mli
+++ b/src/osemgrep/language_server/scan_helpers/Scan_helpers.mli
@@ -1,5 +1,5 @@
 val run_semgrep :
-  ?targets:Fpath.t list option ->
+  ?targets:Target_file.target_files option ->
   ?rules:Rule.rules option ->
   ?git_ref:string option ->
   RPC_server.t ->

--- a/src/osemgrep/language_server/server/Session.ml
+++ b/src/osemgrep/language_server/server/Session.ml
@@ -102,7 +102,7 @@ let targets session =
     && ((not session.user_settings.only_git_dirty)
        || member_folder_dirty_files file folder)
   in
-  let member_workspaces t =
+  let member_workspaces (t, _info) =
     List.exists (fun f -> member_workspace_folder t f) session.workspace_folders
   in
   let workspace_targets f =

--- a/src/osemgrep/language_server/server/Session.mli
+++ b/src/osemgrep/language_server/server/Session.mli
@@ -37,7 +37,7 @@ val cache_session : t -> unit Lwt.t
     as in [t.user_settings], and CI if an api token is available. This is an asynchronous operation,
     and so the rules are stored in a [session_cache] *)
 
-val targets : t -> Fpath.t list
+val targets : t -> Target_file.target_files
 (** [targets t] returns the list of targets for the session. This is a list of files in
     workspace folders, with includes and excludes in [t.user_settings], and git
     status taken into account if [t.user_settings.only_git_dirty] is set *)

--- a/src/targeting/Filter_target.ml
+++ b/src/targeting/Filter_target.ml
@@ -19,6 +19,8 @@
 (* Helpers *)
 (*************************************************************************)
 
+let all_langs = Language.list |> Common.map (fun { Language.id; _ } -> id)
+
 (*************************************************************************)
 (* Entry points *)
 (*************************************************************************)
@@ -34,6 +36,13 @@ let filter_target_for_xlang (xlang : Xlang.t) (path : Fpath.t) : bool =
   | LSpacegrep
   | LAliengrep ->
       true
+
+(* Note that this is NOT the equivalent of running `filter_target_for_xlang`
+   on every language for the given path. Instead, it just checks whether
+   the extension is in the set of exts for languages. This more closely adheres
+   to the original Python implementation of `filter_known_extensions` *)
+let filter_target_has_known_extension (path : Fpath.t) : bool =
+  List.exists (fun l -> Guess_lang.check_lang_extension l path) all_langs
 
 (* Used by Run_semgrep.semgrep_with_rules().
  * See also https://semgrep.dev/docs/writing-rules/rule-syntax/#paths

--- a/src/targeting/Filter_target.mli
+++ b/src/targeting/Filter_target.mli
@@ -4,3 +4,6 @@ val filter_target_for_xlang : Xlang.t -> Fpath.t -> bool
 (* Select the file if it satisfies the include: exclude: constraints
  * in a rule paths: field *)
 val filter_paths : Rule.paths -> Fpath.t -> bool
+
+(* Return true if the target has a known extension *)
+val filter_target_has_known_extension : Fpath.t -> bool

--- a/src/targeting/Find_targets.ml
+++ b/src/targeting/Find_targets.ml
@@ -213,7 +213,7 @@ let walk_skip_and_collect (conf : conf) (ign : Semgrepignore.t)
   (* Let's not worry about file order here until we have to.
      They will be sorted later. *)
   (* Target files found in directories always have the language inferred *)
-  (!selected_paths |> Target_file.no_info_target_files_of_fpaths, !skipped)
+  (!selected_paths |> Target_file.non_special_target_files_of_fpaths, !skipped)
 
 (*************************************************************************)
 (* Grouping *)

--- a/src/targeting/Find_targets.mli
+++ b/src/targeting/Find_targets.mli
@@ -45,7 +45,7 @@ type conf = {
 val get_targets :
   conf ->
   Fpath.t list (* scanning roots *) ->
-  Fpath.t list * Semgrep_output_v1_t.skipped_target list
+  Target_file.t list * Semgrep_output_v1_t.skipped_target list
 
 (* internals used also in Find_targets_old.ml *)
 val get_reason_for_exclusion :

--- a/src/targeting/Guess_lang.ml
+++ b/src/targeting/Guess_lang.ml
@@ -184,6 +184,21 @@ let is_executable_script cmd_names =
     ( Not has_an_extension,
       And (is_executable, uses_shebang_command_name cmd_names) )
 
+(* Matches if
+   - language has extension in Lang.ext_of_lang
+
+   This is so that we can make our check for unknown extensions work
+   the same way as the Python one. See Filter_target for more info
+*)
+let check_lang_extension lang path =
+  match has_lang_extension lang with
+  | And _
+  | Or _
+  | Not _ ->
+      (* This should be impossible *)
+      false
+  | Test_path f -> f path
+
 (*
    Matches if either
    - language has extension in Lang.ext_of_lang

--- a/src/targeting/Guess_lang.mli
+++ b/src/targeting/Guess_lang.mli
@@ -32,3 +32,9 @@ val inspect_files :
    if it looks like it's in the desired format.
 *)
 val get_first_block : ?block_size:int -> Fpath.t -> string
+
+(*
+   Check whether a path has any of the extensions for a language.
+   Does not check any other features of the path.
+*)
+val check_lang_extension : Language.t -> Fpath.t -> bool


### PR DESCRIPTION
The `--scan-unknown-extensions` option asks semgrep to scan files that are explicitly passed and have unknown extensions with all the given rules.

To handle this in osemgrep, when we perform file targeting, for each file, if it's explicitly passed and `--scan-unknown-extensions` is true, the file is marked as an explicitly passed file that we should consider checking for an unknown extension. Later, when we partition the jobs by language, we add on the files with unknown extensions to each job.

Test plan: in addition to the existing automated tests, I also ran
```
osemgrep --scan-unknown-extensions --strict --config rules/eqeq-python.yaml --json targets/basic/stupid_no_extension targets/basic/nosem.py targets/nosem_invalid_id/ --experimental
```

and modified `eqeq-python.yaml` to have a javascript rule with the pattern `$F(...)`.

I expected findings on `targets/basic/stupid_no_extension` and `targets/nosem_invalid_id/nosem_invalid_id.js`. I expected a partial parse error on `targets/basic/stupid_no_extension` but not on `targets/basic.nosem.py`, since we attempt to scan the former with both python and javascript but not the latter.

In this test, I found another error---`targets/nosem_invalid_id/nosem_invalid_id.js` was erroneously gitignored
---but I was able to confirm that it would have been scanned.

