### PR TITLE
fix: Lwt_platform.sleep for spinner

### DIFF
--- a/libs/lwt_platform/Lwt_platform.mli
+++ b/libs/lwt_platform/Lwt_platform.mli
@@ -13,3 +13,6 @@ val set_engine : unit -> unit
     This is important as select/poll is not great, and can easily
     run out of FDs, crashing the LS.
   *)
+
+val sleep : float -> unit Lwt.t
+(** [sleep delay] returns a promise that will be resolved after [delay] seconds. *)

--- a/libs/lwt_platform/js/Lwt_platform.ml
+++ b/libs/lwt_platform/js/Lwt_platform.ml
@@ -35,3 +35,4 @@ let run t =
 let detach f x = f x |> Lwt.return
 let init_preemptive _ _ _ = ()
 let set_engine () = ()
+let (sleep : float -> 'a Lwt.t) = Js_of_ocaml_lwt.Lwt_js.sleep

--- a/libs/lwt_platform/js/dune
+++ b/libs/lwt_platform/js/dune
@@ -3,6 +3,7 @@
  (name lwt_platform_js)
   (libraries
     lwt
+    js_of_ocaml-lwt
   )
  (implements lwt_platform)
 )

--- a/libs/lwt_platform/unix/Lwt_platform.ml
+++ b/libs/lwt_platform/unix/Lwt_platform.ml
@@ -24,3 +24,4 @@ let run = Lwt_main.run
 let detach = Lwt_preemptive.detach
 let init_preemptive = Lwt_preemptive.init
 let set_engine () = Lwt_engine.set (new Lwt_engine.libev ())
+let sleep = Lwt_unix.sleep

--- a/src/osemgrep/cli/CLI.ml
+++ b/src/osemgrep/cli/CLI.ml
@@ -312,7 +312,6 @@ let main argv : Exit_code.t =
   Parsing_init.init ();
   Data_init.init ();
   Http_helpers_.client_ref := Some (module Cohttp_lwt_unix.Client);
-  Console_Spinner.lwt_platform_sleep_setup ();
 
   metrics_init ();
   (* TOPORT: maybe_set_git_safe_directories() *)

--- a/src/osemgrep/cli_ui/Console_Spinner.mli
+++ b/src/osemgrep/cli_ui/Console_Spinner.mli
@@ -6,4 +6,3 @@
 val show_spinner : int -> unit
 val spinner_async : unit -> 'a Lwt.t
 val erase_spinner : unit -> unit
-val lwt_platform_sleep_setup : unit -> unit

--- a/src/osemgrep/language_server/Test_LS_e2e.ml
+++ b/src/osemgrep/language_server/Test_LS_e2e.ml
@@ -994,6 +994,7 @@ let test_ls_libev () =
 (*****************************************************************************)
 
 let promise_tests =
+  ignore test_login;
   [
     ("Test LS", test_ls_specs);
     ("Test LS exts", test_ls_ext);


### PR DESCRIPTION
Per @ajbt200128 we need to make src/osemgrep/language_server/custom_requests/ async for tests.