### PR TITLE
fix(osemgrep): port extract mode for osemgrep

### DIFF
--- a/cli/src/semgrep/rule.py
+++ b/cli/src/semgrep/rule.py
@@ -58,6 +58,8 @@ class Rule:
 
         # add typescript to languages if the rule supports javascript.
         # TODO: Move this hack to lang.json
+        # coupling: if you move this hack, also fix
+        # Core_runner.add_typescript_to_javascript_rules_hack
         if any(
             language == LANGUAGE.resolve("javascript") for language in rule_languages
         ):

--- a/cli/tests/e2e/test_check.py
+++ b/cli/tests/e2e/test_check.py
@@ -126,7 +126,7 @@ def test_script(run_semgrep_in_tmp: RunSemgrep, snapshot):
     )
 
 
-@pytest.mark.osemfail
+@pytest.mark.osempass
 @pytest.mark.kinda_slow
 def test_extract(run_semgrep_in_tmp: RunSemgrep, snapshot):
     """
@@ -141,7 +141,7 @@ def test_extract(run_semgrep_in_tmp: RunSemgrep, snapshot):
     )
 
 
-@pytest.mark.osemfail
+@pytest.mark.osempass
 @pytest.mark.kinda_slow
 def test_extract_exclude(run_semgrep_in_tmp: RunSemgrep, snapshot):
     """
@@ -156,7 +156,7 @@ def test_extract_exclude(run_semgrep_in_tmp: RunSemgrep, snapshot):
     )
 
 
-@pytest.mark.osemfail
+@pytest.mark.osempass
 @pytest.mark.kinda_slow
 def test_extract_include(run_semgrep_in_tmp: RunSemgrep, snapshot):
     """
@@ -740,7 +740,7 @@ def test_metavariable_propagation_comparison(run_semgrep_in_tmp: RunSemgrep, sna
     )
 
 
-@pytest.mark.osemfail
+@pytest.mark.osempass
 @pytest.mark.kinda_slow
 def test_taint_mode(run_semgrep_in_tmp: RunSemgrep, snapshot):
     snapshot.assert_match(

--- a/src/core_scan/Core_scan.mli
+++ b/src/core_scan/Core_scan.mli
@@ -89,6 +89,17 @@ val extracted_targets_of_config :
    Generate a list of new targets, which are extracted from extract rules.
    The rule ids correspond to the rules to run against the generated
    targets.
+
+   Returns `new_targets, match_location_adjusters_map, file_map`
+
+   The second two return values allow us to map from the new targets to the real
+   original targets. This is necessary since the new targets are tmp files
+   that contain snippets of the original target.
+
+   The first map allows us to map back the location of matches to a location in
+   the original target.
+   The second map allows us to map from a tmp file to the original target it was
+   generated from.
 *)
 
 val rules_from_rule_source :

--- a/src/core_scan/Core_scan.mli
+++ b/src/core_scan/Core_scan.mli
@@ -84,6 +84,7 @@ val extracted_targets_of_config :
   * ( string (* filename *),
       Match_extract_mode.match_result_location_adjuster )
     Hashtbl.t
+  * (string, Fpath.t) Hashtbl.t
 (**
    Generate a list of new targets, which are extracted from extract rules.
    The rule ids correspond to the rules to run against the generated

--- a/src/engine/Match_extract_mode.ml
+++ b/src/engine/Match_extract_mode.ml
@@ -51,6 +51,10 @@ type match_result_location_adjuster =
   Core_profiling.partial_profiling Core_result.match_result ->
   Core_profiling.partial_profiling Core_result.match_result
 
+(* We need to keep track of the original target for each extracted one
+   for things like counting the number of scanned original files *)
+type assoc_extracted_target_to_original = string * Fpath.t
+
 (*****************************************************************************)
 (* Helpers *)
 (*****************************************************************************)
@@ -384,7 +388,9 @@ let extract_and_concat erule_table xtarget matches =
          (* Write out the extracted text in a tmpfile *)
          let (`Extract { Rule.dst_lang; _ }) = r.mode in
          let target = mk_extract_target dst_lang contents in
-         (target, map_res map_loc (Fpath.v target.path) xtarget.file))
+         ( target,
+           map_res map_loc (Fpath.v target.path) xtarget.file,
+           (target.path, xtarget.file) ))
 
 let extract_as_separate erule_table xtarget matches =
   matches
@@ -441,7 +447,10 @@ let extract_as_separate erule_table xtarget matches =
                    map_loc start_extract_pos line_offset col_offset
                      !!(xtarget.Xtarget.file)
              in
-             Some (target, map_res map_loc (Fpath.v target.path) xtarget.file)
+             Some
+               ( target,
+                 map_res map_loc (Fpath.v target.path) xtarget.file,
+                 (target.path, xtarget.file) )
          | Some ({ mode = `Extract { Rule.extract; _ }; id = id, _; _ }, None)
            ->
              report_unbound_mvar id extract m;

--- a/src/engine/Match_extract_mode.ml
+++ b/src/engine/Match_extract_mode.ml
@@ -51,9 +51,10 @@ type match_result_location_adjuster =
   Core_profiling.partial_profiling Core_result.match_result ->
   Core_profiling.partial_profiling Core_result.match_result
 
-(* We need to keep track of the original target for each extracted one
-   for things like counting the number of scanned original files *)
-type assoc_extracted_target_to_original = string * Fpath.t
+type original_target_for_extract_target = {
+  original_target : Fpath.t;
+  location_adjuster : match_result_location_adjuster;
+}
 
 (*****************************************************************************)
 (* Helpers *)
@@ -389,8 +390,11 @@ let extract_and_concat erule_table xtarget matches =
          let (`Extract { Rule.dst_lang; _ }) = r.mode in
          let target = mk_extract_target dst_lang contents in
          ( target,
-           map_res map_loc (Fpath.v target.path) xtarget.file,
-           (target.path, xtarget.file) ))
+           {
+             original_target = xtarget.file;
+             location_adjuster =
+               map_res map_loc (Fpath.v target.path) xtarget.file;
+           } ))
 
 let extract_as_separate erule_table xtarget matches =
   matches
@@ -449,8 +453,11 @@ let extract_as_separate erule_table xtarget matches =
              in
              Some
                ( target,
-                 map_res map_loc (Fpath.v target.path) xtarget.file,
-                 (target.path, xtarget.file) )
+                 {
+                   original_target = xtarget.file;
+                   location_adjuster =
+                     map_res map_loc (Fpath.v target.path) xtarget.file;
+                 } )
          | Some ({ mode = `Extract { Rule.extract; _ }; id = id, _; _ }, None)
            ->
              report_unbound_mvar id extract m;

--- a/src/engine/Match_extract_mode.mli
+++ b/src/engine/Match_extract_mode.mli
@@ -7,8 +7,10 @@ type match_result_location_adjuster =
   Core_profiling.partial_profiling Core_result.match_result ->
   Core_profiling.partial_profiling Core_result.match_result
 
-(* Keep track of the original target for each extracted one *)
-type assoc_extracted_target_to_original = string * Fpath.t
+type original_target_for_extract_target = {
+  original_target : Fpath.t;
+  location_adjuster : match_result_location_adjuster;
+}
 
 (*
    Generates a list of targets corresponding to extract mode rule matches in
@@ -23,7 +25,4 @@ val extract_nested_lang :
   timeout_threshold:int ->
   Rule.extract_rule list ->
   Xtarget.t ->
-  (Input_to_core_t.target
-  * match_result_location_adjuster
-  * assoc_extracted_target_to_original)
-  list
+  (Input_to_core_t.target * original_target_for_extract_target) list

--- a/src/engine/Match_extract_mode.mli
+++ b/src/engine/Match_extract_mode.mli
@@ -7,6 +7,9 @@ type match_result_location_adjuster =
   Core_profiling.partial_profiling Core_result.match_result ->
   Core_profiling.partial_profiling Core_result.match_result
 
+(* Keep track of the original target for each extracted one *)
+type assoc_extracted_target_to_original = string * Fpath.t
+
 (*
    Generates a list of targets corresponding to extract mode rule matches in
    the provided target file. The resulting target will be configured to run
@@ -20,4 +23,7 @@ val extract_nested_lang :
   timeout_threshold:int ->
   Rule.extract_rule list ->
   Xtarget.t ->
-  (Input_to_core_t.target * match_result_location_adjuster) list
+  (Input_to_core_t.target
+  * match_result_location_adjuster
+  * assoc_extracted_target_to_original)
+  list

--- a/src/engine/Test_engine.ml
+++ b/src/engine/Test_engine.ml
@@ -167,12 +167,13 @@ let make_test_rule_file ~unit_testing ~get_xlang ~prepend_lang ~newscore
             ~match_hook:(fun _ _ -> ())
             ~timeout:0. ~timeout_threshold:0 extract_rules xtarget
         in
-        let extract_targets, extract_result_map =
-          (List.fold_right (fun (t, fn) (ts, fn_tbl) ->
+        let extract_targets, extract_result_map, _extract_targets_map =
+          (List.fold_right (fun (t, fn, (newf, origf)) (ts, fn_tbl, file_tbl) ->
                Hashtbl.add fn_tbl t.Input_to_core_t.path fn;
-               (t :: ts, fn_tbl)))
+               Hashtbl.add file_tbl newf origf;
+               (t :: ts, fn_tbl, file_tbl)))
             extracted_ranges
-            ([], Hashtbl.create 5)
+            ([], Hashtbl.create 5, Hashtbl.create 5)
         in
         let xconf = Match_env.default_xconfig in
         let res =

--- a/src/engine/Test_engine.ml
+++ b/src/engine/Test_engine.ml
@@ -162,6 +162,9 @@ let make_test_rule_file ~unit_testing ~get_xlang ~prepend_lang ~newscore
               | mode -> Left { r with mode })
             rules
         in
+        (* coupling: This is basically duplicated from Core_scan
+           TODO we should test extract mode through integration tests
+           rather than duplicating all this *)
         let extracted_ranges =
           Match_extract_mode.extract_nested_lang
             ~match_hook:(fun _ _ -> ())

--- a/src/engine/Test_engine.ml
+++ b/src/engine/Test_engine.ml
@@ -167,14 +167,18 @@ let make_test_rule_file ~unit_testing ~get_xlang ~prepend_lang ~newscore
             ~match_hook:(fun _ _ -> ())
             ~timeout:0. ~timeout_threshold:0 extract_rules xtarget
         in
-        let extract_targets, extract_result_map, _extract_targets_map =
-          (List.fold_right (fun (t, fn, (newf, origf)) (ts, fn_tbl, file_tbl) ->
-               Hashtbl.add fn_tbl t.Input_to_core_t.path fn;
-               Hashtbl.add file_tbl newf origf;
-               (t :: ts, fn_tbl, file_tbl)))
-            extracted_ranges
-            ([], Hashtbl.create 5, Hashtbl.create 5)
+        let extract_targets =
+          List.fold_right (fun (t, _) ts -> t :: ts) extracted_ranges []
         in
+        let extract_result_map = Hashtbl.create 5 in
+        let extract_targets_map = Hashtbl.create 5 in
+        List.iter
+          (fun (t, { Match_extract_mode.original_target; location_adjuster }) ->
+            Hashtbl.add extract_result_map t.Input_to_core_t.path
+              location_adjuster;
+            Hashtbl.add extract_targets_map t.path original_target)
+          extracted_ranges;
+
         let xconf = Match_env.default_xconfig in
         let res =
           try

--- a/src/osemgrep/cli_scan/Core_runner.ml
+++ b/src/osemgrep/cli_scan/Core_runner.ml
@@ -2,6 +2,17 @@ open File.Operators
 module OutJ = Semgrep_output_v1_t
 module Env = Semgrep_envvars
 
+module LangSet = Set.Make (struct
+  let compare
+      (* This only compares the first language in the case of `L (lang :: _)`.
+         That should be fine because for the use of Xlang in this file,
+         `L _` should always be flattened out *)
+        a b =
+    String.compare (Xlang.to_string a) (Xlang.to_string b)
+
+  type t = Xlang.t
+end)
+
 (*************************************************************************)
 (* Prelude *)
 (*************************************************************************)
@@ -101,14 +112,51 @@ let group_rules_by_target_language rules : (Xlang.t * Rule.t list) list =
                 Hashtbl.replace tbl lang (rule :: rules)));
   Hashtbl.fold (fun lang rules acc -> (lang, rules) :: acc) tbl []
 
+let add_typescript_to_javascript_rules_hack all_rules =
+  (* If Javascript is one of the rule languages, we should also run on
+     Typescript files. This implementation mimics the hack in `rule.py`.
+     We could alternatively set this by changing lang.json, but we should
+     be careful to do that without affecting other things like the docs *)
+  all_rules
+  |> Common.map (fun r ->
+         match r.Rule.target_analyzer with
+         | LRegex
+         | LSpacegrep
+         | LAliengrep ->
+             r
+         | L (l, ls) ->
+             let lset = Set_.of_list ls in
+             let lset =
+               if l = Language.Js || Set_.mem Language.Js lset then
+                 Set_.add Language.Ts lset
+               else lset
+             in
+             { r with Rule.target_analyzer = L (l, lset |> Set_.elements) })
+
+(* Extract mode: we need to make sure to include rules that will apply
+   to targets that have been extracted. To do that, we'll detect the languages
+   that targets might be extracted to and include them in the jobs *)
+(* TODO it would be nicer to just extract the targets before splitting jobs,
+   but that would cause us to change things for the Core_scan shared path *)
+let detect_extract_languages all_rules =
+  List.fold_left
+    (fun acc { Rule.mode; _ } ->
+      match mode with
+      | `Extract { Rule.dst_lang; _ } -> LangSet.add dst_lang acc
+      | _ -> acc)
+    LangSet.empty all_rules
+
 let split_jobs_by_language all_rules all_targets : Lang_job.t list =
+  let all_rules = add_typescript_to_javascript_rules_hack all_rules in
+  let extract_languages = detect_extract_languages all_rules in
   all_rules |> group_rules_by_target_language
   |> Common.map_filter (fun (xlang, rules) ->
          let targets =
            all_targets
            |> List.filter (Filter_target.filter_target_for_xlang xlang)
          in
-         if Common.null targets then None
+         if Common.null targets && not (LangSet.mem xlang extract_languages)
+         then None
          else Some ({ xlang; targets; rules } : Lang_job.t))
 
 let core_scan_config_of_conf (conf : conf) : Core_scan_config.t =

--- a/src/osemgrep/reporting/Cli_json_output.ml
+++ b/src/osemgrep/reporting/Cli_json_output.ml
@@ -300,8 +300,7 @@ let cli_match_of_core_match (hrules : Rule.hrules) (m : OutJ.core_match) :
        extra_extra;
        validation_state;
        fix;
-       (* LATER *)
-       dataflow_trace = _;
+       dataflow_trace;
      };
   } ->
       let rule =
@@ -356,7 +355,7 @@ let cli_match_of_core_match (hrules : Rule.hrules) (m : OutJ.core_match) :
             fingerprint = match_based_id_partial rule rule_id metavars !!path;
             sca_info = None;
             fixed_lines = None;
-            dataflow_trace = None;
+            dataflow_trace;
             (* It's optional in the CLI output, but not in the core match results!
              *)
             engine_kind = Some engine_kind;


### PR DESCRIPTION
The goal of this PR was to make `test_check.py::test_extract` pass. This included several fixes because that test exercises a few things. I can separate out the PRs if people prefer

### Extract mode

First, I had to implement extract mode. Osemgrep only sends the rules with detected targets to `Core_scan.scan`, but since extract targets are produced during `Core_scan.scan`, this means extract mode doesn't work. To keep the shared code path similar, I now have the osemgrep targeting check for extract rules. If there are rules that could produce Javascript files, osemgrep will still send Javascript rules to `Core_scan.scan` even when they have no relevant targets.

I also then had to fix how we computed the scanned targets to take extract mode into account. The new method is more precise than what pysemgrep does and counts extracted targets only if there was a rule that scanned them.

### Javascript targeting

The extract mode tests also happen to test that Typescript files are scanned by Javascript rules. Pysemgrep handles this inelegantly by tacking on "Typescript" as a language to every Javascript rule. For now, I copied the same hack to osemgrep, since it was cheap to write.

### Taint traces

I also needed to pass through taint traces.

### Test plan

Test plan: automated tests. I also found a Typescript file and ran a Javascript rule to verify the targeting.

