### PR TITLE
fix(osemgrep): Enforce consistent ordering of files and rules for scan report table

### DIFF
--- a/src/osemgrep/reporting/Status_report.ml
+++ b/src/osemgrep/reporting/Status_report.ml
@@ -60,6 +60,17 @@ let pp_status ~num_rules ~num_targets ~respect_git_ignore lang_jobs ppf =
              (String.capitalize_ascii src, [ List.length xs ]))
     in
     Fmt.pf ppf "@.";
+    let compare (lang, rules_targets) (lang', rules_targets') =
+      match (rules_targets, rules_targets') with
+      | [ rules; targets ], [ rules'; targets' ] -> (
+          match -compare targets targets' with
+          | 0 -> (
+              match -compare rules rules' with
+              | 0 -> compare lang lang'
+              | cmp -> cmp)
+          | cmp -> cmp)
+      | _ -> failwith "Unexpected pattern"
+    in
     let xlang_label = function
       | Xlang.LSpacegrep
       | Xlang.LAliengrep
@@ -80,5 +91,7 @@ let pp_status ~num_rules ~num_targets ~respect_git_ignore lang_jobs ppf =
                | [ (_, [ r1; t1 ]) ], others ->
                    (lang, [ rules + r1; targets + t1 ]) :: others
                | _ -> assert false)
-             [] )
+             []
+        (* Sort by files desc, rules desc, lang asc *)
+        |> List.sort compare )
       ("Origin", [ "Rules" ], rule_origins)


### PR DESCRIPTION
## Description
For our scan report table, we should expect a consistent ordering. Here we will enforce sorting by files desc, rules desc, lang asc.

## Demo

`$ sg scan --experimental`

#### Before
```
  Scanning 1775 files tracked by git with 1103 Code rules:

  Language      Rules   Files          Origin      Rules
 ─────────────────────────────        ───────────────────
  java            120       1          Community     969
  html              1       2
  yaml             28      10
  <multilang>     111    1775
  bash              4      26
  json              4      79
  ts              179       3
  python          240     175
  dockerfile        5       2
  js              179      14
  c                11      12
  go               80       1
  ocaml             6    1012
```

#### After
```
  Scanning 1775 files tracked by git with 1103 Code rules:

  Language      Rules   Files          Origin      Rules
 ─────────────────────────────        ───────────────────
  <multilang>     111    5325          Community     969
  ocaml             6    1012
  python          240     175
  json              4      79
  bash              5      26
  js              179      14
  c                11      12
  yaml             28      10
  ts              179       3
  dockerfile        5       2
  html              1       2
  java            120       1
  go               80       1
```

### Test Plan
- [x] validate locally
- [ ] ci tests pass