### PR TITLE
fix(osemgrep): Add protos and migrations to built-in semgrep ignore

### DIFF
--- a/src/targeting/Semgrepignore.ml
+++ b/src/targeting/Semgrepignore.ml
@@ -56,6 +56,11 @@ type exclusion_mechanism = Gitignore_and_semgrepignore | Only_semgrepignore
    The legacy built-in semgrepignore.
 
    It was copied from templates/.semgrepignore in the Python source.
+
+   NOTE: As of 2023-11-20, we have added proto files and migrations
+   to our built-in ignored list as a sane default for most users. This
+   fixed a rare segfault for Mac OS users, and speeds up local scans
+   more generally.
 *)
 let builtin_semgrepignore_for_semgrep_scan =
   {|
@@ -75,6 +80,12 @@ vendor/
 test/
 tests/
 *_test.go
+
+# Proto files
+**/protos/
+
+# ORM Migrations
+**/migrations/versions/
 
 # Semgrep rules folder
 .semgrep


### PR DESCRIPTION
## Description
There was an observed slowdown in `1.49.0` for our `semgrep-app` repository. When trying to reproduce this issue locally, I was unable to scan `semgrep-app` on my local machine – encountering a segfault – until I conditionally added `migrations` to a local `.semgrepignore`. While this segfault was not encountered while running via docker, scanning proto files or migrations is generally not desirable.