### PR TITLE
fix(ls): don't crash on custom methods sent w/ no params

### DIFF
--- a/changelog.d/language-server.fixed
+++ b/changelog.d/language-server.fixed
@@ -1,0 +1,1 @@
+* The language server will no longer crash on startup for intellij

--- a/src/osemgrep/language_server/custom_requests/Login.ml
+++ b/src/osemgrep/language_server/custom_requests/Login.ml
@@ -5,9 +5,7 @@ module Out = Semgrep_output_v1_t
 
 let meth = "semgrep/login"
 
-let on_request (server : RPC_server.t) params : Yojson.Safe.t option =
-  ignore server;
-  ignore params;
+let on_request (_server : RPC_server.t) __params : Yojson.Safe.t option =
   if Semgrep_login.is_logged_in () then (
     RPC_server.notify_show_message ~kind:MessageType.Info
       "Already logged in to Semgrep Code";

--- a/src/osemgrep/language_server/custom_requests/Login.ml
+++ b/src/osemgrep/language_server/custom_requests/Login.ml
@@ -7,20 +7,16 @@ let meth = "semgrep/login"
 
 let on_request (server : RPC_server.t) params : Yojson.Safe.t option =
   ignore server;
-  match params with
-  | None ->
-      if Semgrep_login.is_logged_in () then (
-        RPC_server.notify_show_message ~kind:MessageType.Info
-          "Already logged in to Semgrep Code";
-        None)
-      else
-        let id, uri = Semgrep_login.make_login_url () in
-        Some
-          (`Assoc
-            [
-              ("url", `String (Uri.to_string uri));
-              ("sessionId", `String (Uuidm.to_string id));
-            ])
-  | Some _ ->
-      Logs.warn (fun m -> m "semgrep/login got params but expected none");
-      None
+  ignore params;
+  if Semgrep_login.is_logged_in () then (
+    RPC_server.notify_show_message ~kind:MessageType.Info
+      "Already logged in to Semgrep Code";
+    None)
+  else
+    let id, uri = Semgrep_login.make_login_url () in
+    Some
+      (`Assoc
+        [
+          ("url", `String (Uri.to_string uri));
+          ("sessionId", `String (Uuidm.to_string id));
+        ])

--- a/src/osemgrep/language_server/notifications/LoginFinish.ml
+++ b/src/osemgrep/language_server/notifications/LoginFinish.ml
@@ -25,10 +25,8 @@ let of_jsonrpc_params params : (Uri.t * Uuidm.t) option =
 (* Entry point *)
 (*****************************************************************************)
 
-let on_notification server params : unit =
+let on_notification _server params : unit =
   (* Emulating a poor man's writer's monad, mixed with some LWT goodness. *)
-  ignore server;
-  ignore params;
   let ( let^ ) (x : (_, string) Result.t Lwt.t) f : unit Lwt.t =
     let%lwt result = x in
     match result with
@@ -38,27 +36,32 @@ let on_notification server params : unit =
         Lwt.return ()
     | Ok y -> f y
   in
-  (* All of this is side-effecting, so we can run it asynchronously, and
-     return to the main event loop.
-  *)
-  Lwt.async (fun () ->
-      let^ _url, sessionId =
-        of_jsonrpc_params params
-        |> Option.to_result ~none:"got invalid parameters"
-        |> Lwt.return
-      in
-      let^ token, _ =
-        Semgrep_login.fetch_token_async ~min_wait_ms:wait_before_retry_in_ms
-          ~max_retries sessionId
-      in
-      let^ _deployment =
-        Semgrep_App.get_deployment_from_token_async token
-        |> Lwt.map (Option.to_result ~none:"failed to get deployment")
-      in
-      (* TODO: state.app_session.authenticate()
-         basically, just add the token to the metrics once that exists
+  match params with
+  | None ->
+      Logs.warn (fun m ->
+          m "semgrep/loginFinish got no params but expected some")
+  | Some _ ->
+      (* All of this is side-effecting, so we can run it asynchronously, and
+         return to the main event loop.
       *)
-      RPC_server.notify_show_message ~kind:MessageType.Info
-        "Successfully logged into Semgrep Code";
-      let^ _deployment = Semgrep_login.save_token_async token in
-      Lwt.return ())
+      Lwt.async (fun () ->
+          let^ _url, sessionId =
+            of_jsonrpc_params params
+            |> Option.to_result ~none:"got invalid parameters"
+            |> Lwt.return
+          in
+          let^ token, _ =
+            Semgrep_login.fetch_token_async ~min_wait_ms:wait_before_retry_in_ms
+              ~max_retries sessionId
+          in
+          let^ _deployment =
+            Semgrep_App.get_deployment_from_token_async token
+            |> Lwt.map (Option.to_result ~none:"failed to get deployment")
+          in
+          (* TODO: state.app_session.authenticate()
+             basically, just add the token to the metrics once that exists
+          *)
+          RPC_server.notify_show_message ~kind:MessageType.Info
+            "Successfully logged into Semgrep Code";
+          let^ _deployment = Semgrep_login.save_token_async token in
+          Lwt.return ())

--- a/src/osemgrep/language_server/notifications/LoginFinish.ml
+++ b/src/osemgrep/language_server/notifications/LoginFinish.ml
@@ -28,6 +28,7 @@ let of_jsonrpc_params params : (Uri.t * Uuidm.t) option =
 let on_notification server params : unit =
   (* Emulating a poor man's writer's monad, mixed with some LWT goodness. *)
   ignore server;
+  ignore params;
   let ( let^ ) (x : (_, string) Result.t Lwt.t) f : unit Lwt.t =
     let%lwt result = x in
     match result with
@@ -37,32 +38,27 @@ let on_notification server params : unit =
         Lwt.return ()
     | Ok y -> f y
   in
-  match params with
-  | None ->
-      Logs.warn (fun m ->
-          m "semgrep/loginFinish got no params but expected some")
-  | Some _ ->
-      (* All of this is side-effecting, so we can run it asynchronously, and
-         return to the main event loop.
+  (* All of this is side-effecting, so we can run it asynchronously, and
+     return to the main event loop.
+  *)
+  Lwt.async (fun () ->
+      let^ _url, sessionId =
+        of_jsonrpc_params params
+        |> Option.to_result ~none:"got invalid parameters"
+        |> Lwt.return
+      in
+      let^ token, _ =
+        Semgrep_login.fetch_token_async ~min_wait_ms:wait_before_retry_in_ms
+          ~max_retries sessionId
+      in
+      let^ _deployment =
+        Semgrep_App.get_deployment_from_token_async token
+        |> Lwt.map (Option.to_result ~none:"failed to get deployment")
+      in
+      (* TODO: state.app_session.authenticate()
+         basically, just add the token to the metrics once that exists
       *)
-      Lwt.async (fun () ->
-          let^ _url, sessionId =
-            of_jsonrpc_params params
-            |> Option.to_result ~none:"got invalid parameters"
-            |> Lwt.return
-          in
-          let^ token, _ =
-            Semgrep_login.fetch_token_async ~min_wait_ms:wait_before_retry_in_ms
-              ~max_retries sessionId
-          in
-          let^ _deployment =
-            Semgrep_App.get_deployment_from_token_async token
-            |> Lwt.map (Option.to_result ~none:"failed to get deployment")
-          in
-          (* TODO: state.app_session.authenticate()
-             basically, just add the token to the metrics once that exists
-          *)
-          RPC_server.notify_show_message ~kind:MessageType.Info
-            "Successfully logged into Semgrep Code";
-          let^ _deployment = Semgrep_login.save_token_async token in
-          Lwt.return ())
+      RPC_server.notify_show_message ~kind:MessageType.Info
+        "Successfully logged into Semgrep Code";
+      let^ _deployment = Semgrep_login.save_token_async token in
+      Lwt.return ())

--- a/src/osemgrep/language_server/scan_helpers/Scan_helpers.ml
+++ b/src/osemgrep/language_server/scan_helpers/Scan_helpers.ml
@@ -45,33 +45,35 @@ let run_semgrep ?(targets = None) ?(rules = None) ?(git_ref = None)
     let runner_conf = Session.runner_conf session in
     (* This is currently just ripped from Scan_subcommand. *)
     let scan_func =
-      if session.user_settings.pro_intrafile then
-        match !Scan_subcommand.hook_pro_scan_func_for_osemgrep with
-        | None ->
-            (* TODO: improve this error message depending on what the
-             * instructions should be *)
-            failwith
+      let pro_intrafile = session.user_settings.pro_intrafile in
+      match !Scan_subcommand.hook_pro_scan_func_for_osemgrep with
+      | Some pro_scan_func when pro_intrafile ->
+          (* THINK: files or folders? *)
+          let roots = targets in
+          (* For now, we're going to just hard-code it at a whole scan, and
+             using the intrafile pro engine.
+             Interfile would likely be too intensive (and require us to target
+             folders, not the affected files)
+          *)
+          let diff_config = Differential_scan_config.WholeScan in
+          pro_scan_func roots ~diff_config
+            Engine_type.(
+              PRO
+                {
+                  extra_languages = true;
+                  analysis = Interprocedural;
+                  secrets_config = None;
+                })
+      | _ ->
+          (* TODO: improve this error message depending on what the
+           * instructions should be *)
+          if pro_intrafile then
+            RPC_server.notify_show_message Lsp.Types.MessageType.Error
               "You have requested running semgrep with a setting that requires \
                the pro engine, but do not have the pro engine. You may need to \
                acquire a different binary."
-        | Some pro_scan_func ->
-            (* THINK: files or folders? *)
-            let roots = targets in
-            (* For now, we're going to just hard-code it at a whole scan, and
-               using the intrafile pro engine.
-               Interfile would likely be too intensive (and require us to target
-               folders, not the affected files)
-            *)
-            let diff_config = Differential_scan_config.WholeScan in
-            pro_scan_func roots ~diff_config
-              Engine_type.(
-                PRO
-                  {
-                    extra_languages = true;
-                    analysis = Interprocedural;
-                    secrets_config = None;
-                  })
-      else Core_runner.mk_scan_func_for_osemgrep Core_scan.scan_with_exn_handler
+            |> ignore;
+          Core_runner.mk_scan_func_for_osemgrep Core_scan.scan_with_exn_handler
     in
     scan_func ~respect_git_ignore:true ~file_match_results_hook:None runner_conf
       rules [] targets


### PR DESCRIPTION
Previously we would crash/not handle login/loginstatus if params were passed since we didn't expect them. This fixes that'

## Test plan
tested locally with the intellij plugin. The intellij plugin insists on sending params everytime, even if none are provided.