### PR TITLE
chore(pysemgrep): split runner into subcommand and args

### DIFF
--- a/cli/tests/conftest.py
+++ b/cli/tests/conftest.py
@@ -394,9 +394,10 @@ def _run_semgrep(
 
     runner = SemgrepRunner(env=env, mix_stderr=False, use_click_runner=use_click_runner)
     click_result = runner.invoke(cli, subcommand=subcommand, args=args, input=stdin)
+    subcommand_prefix = f"{subcommand} " if subcommand else ""
     result = SemgrepResult(
         # the actual executable was either semgrep or osemgrep. Is it bad?
-        f"{env_string} semgrep {subcommand} {args}",
+        f"{env_string} semgrep {subcommand_prefix}{args}",
         click_result.stdout,
         click_result.stderr,
         click_result.exit_code,

--- a/cli/tests/conftest.py
+++ b/cli/tests/conftest.py
@@ -307,6 +307,7 @@ def _run_semgrep(
     config: Optional[Union[str, Path, List[str]]] = None,
     *,
     target_name: Optional[str] = "basic",
+    subcommand: Optional[str] = None,
     options: Optional[List[Union[str, Path]]] = None,
     output_format: Optional[OutputFormat] = OutputFormat.JSON,
     strict: bool = True,
@@ -392,7 +393,7 @@ def _run_semgrep(
     env_string = " ".join(f'{k}="{v}"' for k, v in env.items())
 
     runner = SemgrepRunner(env=env, mix_stderr=False, use_click_runner=use_click_runner)
-    click_result = runner.invoke(cli, args=args, input=stdin)
+    click_result = runner.invoke(cli, subcommand=subcommand, args=args, input=stdin)
     result = SemgrepResult(
         # the actual executable was either semgrep or osemgrep. Is it bad?
         f"{env_string} semgrep {args}",

--- a/cli/tests/conftest.py
+++ b/cli/tests/conftest.py
@@ -392,7 +392,7 @@ def _run_semgrep(
     env_string = " ".join(f'{k}="{v}"' for k, v in env.items())
 
     runner = SemgrepRunner(env=env, mix_stderr=False, use_click_runner=use_click_runner)
-    click_result = runner.invoke(cli, args, input=stdin)
+    click_result = runner.invoke(cli, args=args, input=stdin)
     result = SemgrepResult(
         # the actual executable was either semgrep or osemgrep. Is it bad?
         f"{env_string} semgrep {args}",

--- a/cli/tests/conftest.py
+++ b/cli/tests/conftest.py
@@ -396,7 +396,7 @@ def _run_semgrep(
     click_result = runner.invoke(cli, subcommand=subcommand, args=args, input=stdin)
     result = SemgrepResult(
         # the actual executable was either semgrep or osemgrep. Is it bad?
-        f"{env_string} semgrep {args}",
+        f"{env_string} semgrep {subcommand} {args}",
         click_result.stdout,
         click_result.stderr,
         click_result.exit_code,

--- a/cli/tests/e2e/test_baseline.py
+++ b/cli/tests/e2e/test_baseline.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Optional
 
 import pytest
-from tests.semgrep_runner import SEMGREP_BASE_COMMAND
+from tests.semgrep_runner import SEMGREP_BASE_SCAN_COMMAND
 
 pytestmark = pytest.mark.kinda_slow
 
@@ -101,7 +101,7 @@ def run_sentinel_scan(check: bool = True, base_commit: Optional[str] = None):
     env["SEMGREP_SETTINGS_FILE"] = unique_settings_file
     env["PATH"] = os.environ.get("PATH", "")
 
-    cmd = SEMGREP_BASE_COMMAND + [
+    cmd = SEMGREP_BASE_SCAN_COMMAND + [
         "--disable-version-check",
         "--metrics",
         "off",

--- a/cli/tests/e2e/test_check.py
+++ b/cli/tests/e2e/test_check.py
@@ -8,8 +8,8 @@ import pytest
 from tests.conftest import _clean_stdout
 from tests.conftest import mask_variable_text
 from tests.fixtures import RunSemgrep
-from tests.semgrep_runner import SEMGREP_BASE_COMMAND
-from tests.semgrep_runner import SEMGREP_BASE_COMMAND_STR
+from tests.semgrep_runner import SEMGREP_BASE_SCAN_COMMAND
+from tests.semgrep_runner import SEMGREP_BASE_SCAN_COMMAND_STR
 
 from semgrep.constants import OutputFormat
 
@@ -228,7 +228,7 @@ def test_stdin_input(snapshot):
         "has_shown_metrics_notification: true\n"
     )
     process = subprocess.Popen(
-        SEMGREP_BASE_COMMAND + ["--json", "-e", "a", "--lang", "js", "-"],
+        SEMGREP_BASE_SCAN_COMMAND + ["--json", "-e", "a", "--lang", "js", "-"],
         encoding="utf-8",
         env={
             **os.environ,
@@ -256,7 +256,7 @@ def test_subshell_input(snapshot):
         [
             "bash",
             "-c",
-            f"{SEMGREP_BASE_COMMAND_STR} --json -e 'a' --lang js <(echo 'a')",
+            f"{SEMGREP_BASE_SCAN_COMMAND_STR} --json -e 'a' --lang js <(echo 'a')",
         ],
         encoding="utf-8",
         env={
@@ -284,7 +284,7 @@ def test_multi_subshell_input(snapshot):
         [
             "bash",
             "-c",
-            f"{SEMGREP_BASE_COMMAND_STR} --json -e 'a' --lang js <(echo 'a') <(echo 'b + a')",
+            f"{SEMGREP_BASE_SCAN_COMMAND_STR} --json -e 'a' --lang js <(echo 'a') <(echo 'b + a')",
         ],
         encoding="utf-8",
         env={
@@ -604,7 +604,7 @@ def test_stack_size(run_semgrep_in_tmp: RunSemgrep, snapshot):
     # Do not just delete this assertion. It means the actual test below does
     # not accurately verify that we are solving the stack exhaustion
     output = subprocess.run(
-        f"ulimit -s 1000 && {SEMGREP_BASE_COMMAND_STR} --disable-version-check --metrics off --config {rulepath} --verbose {targetpath}",
+        f"ulimit -s 1000 && {SEMGREP_BASE_SCAN_COMMAND_STR} --disable-version-check --metrics off --config {rulepath} --verbose {targetpath}",
         shell=True,
         capture_output=True,
         encoding="utf-8",
@@ -617,7 +617,7 @@ def test_stack_size(run_semgrep_in_tmp: RunSemgrep, snapshot):
 
     # If only set soft limit, semgrep should raise it as necessary so we don't hit soft limit
     output = subprocess.run(
-        f"ulimit -S -s 1000 && {SEMGREP_BASE_COMMAND_STR} --disable-version-check --metrics off --config {rulepath} --verbose {targetpath}",
+        f"ulimit -S -s 1000 && {SEMGREP_BASE_SCAN_COMMAND_STR} --disable-version-check --metrics off --config {rulepath} --verbose {targetpath}",
         shell=True,
         capture_output=True,
         encoding="utf-8",

--- a/cli/tests/e2e/test_ci.py
+++ b/cli/tests/e2e/test_ci.py
@@ -1489,6 +1489,7 @@ def test_fail_auth_invalid_key_suppressed_by_default(
     }
 
 
+@pytest.mark.osemfail
 def test_fail_auth_invalid_response(
     run_semgrep: RunSemgrep, mocker, git_tmp_path_with_commit, requests_mock
 ):
@@ -1528,7 +1529,7 @@ def test_fail_auth_invalid_response_can_be_supressed(
     mock_send.assert_called_once_with(mocker.ANY, 2)
 
 
-# TODO: pass but for bad reasons I think, because we just don't handle the CLI args
+@pytest.mark.osemfail
 def test_fail_start_scan(run_semgrep: RunSemgrep, mocker, git_tmp_path_with_commit):
     """
     Test that failing to start scan does not have exit code 0 or 1
@@ -1661,7 +1662,7 @@ def test_fail_scan_findings(
     assert upload_results_mock.called
 
 
-# TODO: pass but for bad reasons I think, because we just don't handle the CLI args
+@pytest.mark.osemfail
 def test_fail_finish_scan(run_semgrep: RunSemgrep, mocker, git_tmp_path_with_commit):
     """
     Test failure to send findings has exit code > 1
@@ -1723,7 +1724,7 @@ def test_fail_finish_scan_error_handler(
     mock_send.assert_called_once_with(mocker.ANY, 2)
 
 
-# TODO: pass but for bad reasons I think, because we just don't handle the CLI args
+@pytest.mark.osemfail
 def test_git_failure(run_semgrep: RunSemgrep, git_tmp_path_with_commit, mocker):
     """
     Test failure from using git has exit code > 1

--- a/cli/tests/e2e/test_ci.py
+++ b/cli/tests/e2e/test_ci.py
@@ -824,7 +824,8 @@ def test_full_run(
         make_semgrepconfig_file(repo_copy_base, contents)
 
     result = run_semgrep(
-        options=["ci", "--no-suppress-errors"],
+        subcommand="ci",
+        options=["--no-suppress-errors"],
         strict=False,
         assert_exit_code=None,
         env=env,
@@ -965,7 +966,8 @@ def test_lockfile_parse_failure_reporting(
     ).strip()
 
     result = run_semgrep(
-        options=["ci", "--no-suppress-errors"],
+        subcommand="ci",
+        options=["--no-suppress-errors"],
         strict=False,
         assert_exit_code=None,
         env={"SEMGREP_APP_TOKEN": "fake-key-from-tests"},
@@ -1279,7 +1281,8 @@ def test_shallow_wrong_merge_base(
 
     # Scan the wrong thing first and verify we get more findings than expected (2 > 1)
     result = run_semgrep(
-        options=["ci", "--no-force-color", "--no-suppress-errors"],
+        subcommand="ci",
+        options=["--no-force-color", "--no-suppress-errors"],
         strict=False,
         assert_exit_code=None,
         env=env,
@@ -1300,7 +1303,8 @@ def test_shallow_wrong_merge_base(
 
     # Run again with greater depth
     result = run_semgrep(
-        options=["ci", "--no-force-color", "--no-suppress-errors"],
+        subcommand="ci",
+        options=["--no-force-color", "--no-suppress-errors"],
         strict=False,
         assert_exit_code=None,
         env={**env, "SEMGREP_GHA_MIN_FETCH_DEPTH": "100"},
@@ -1336,7 +1340,8 @@ def test_config_run(
     requests_mock.get("https://semgrep.dev/p/something", text=scan_config)
     result = run_semgrep(
         "p/something",
-        options=["ci", "--no-suppress-errors"],
+        subcommand="ci",
+        options=["--no-suppress-errors"],
         strict=False,
         assert_exit_code=1,
         env={"SEMGREP_APP_TOKEN": ""},
@@ -1362,7 +1367,8 @@ def test_outputs(
     run_semgrep: RunSemgrep,
 ):
     result = run_semgrep(
-        options=["ci", "--no-suppress-errors", format],
+        subcommand="ci",
+        options=["--no-suppress-errors", format],
         target_name=None,
         strict=False,
         assert_exit_code=None,
@@ -1382,7 +1388,8 @@ def test_nosem(
     git_tmp_path_with_commit, snapshot, mock_autofix, nosem, run_semgrep: RunSemgrep
 ):
     result = run_semgrep(
-        options=["ci", "--no-suppress-errors", nosem],
+        subcommand="ci",
+        options=["--no-suppress-errors", nosem],
         target_name=None,
         strict=False,
         assert_exit_code=1,
@@ -1406,7 +1413,8 @@ def test_dryrun(
 ):
     _, base_commit, head_commit = git_tmp_path_with_commit
     result = run_semgrep(
-        options=["ci", "--dry-run", "--no-suppress-errors"],
+        subcommand="ci",
+        options=["--dry-run", "--no-suppress-errors"],
         target_name=None,
         strict=False,
         assert_exit_code=None,
@@ -1431,7 +1439,6 @@ def test_dryrun(
     )
 
 
-@pytest.mark.osemfail
 def test_fail_auth_invalid_key(
     run_semgrep: RunSemgrep, mocker, git_tmp_path_with_commit, requests_mock
 ):
@@ -1441,7 +1448,8 @@ def test_fail_auth_invalid_key(
     requests_mock.post("https://semgrep.dev/api/cli/scans", status_code=401)
     fail_open = requests_mock.post("https://fail-open.prod.semgrep.dev/failure")
     run_semgrep(
-        options=["ci", "--no-suppress-errors"],
+        subcommand="ci",
+        options=["--no-suppress-errors"],
         target_name=None,
         strict=False,
         assert_exit_code=13,
@@ -1463,7 +1471,7 @@ def test_fail_auth_invalid_key_suppressed_by_default(
     )
     fail_open = requests_mock.post("https://fail-open.prod.semgrep.dev/failure")
     run_semgrep(
-        options=["ci"],
+        subcommand="ci",
         target_name=None,
         strict=False,
         assert_exit_code=0,
@@ -1481,7 +1489,6 @@ def test_fail_auth_invalid_key_suppressed_by_default(
     }
 
 
-@pytest.mark.osemfail
 def test_fail_auth_invalid_response(
     run_semgrep: RunSemgrep, mocker, git_tmp_path_with_commit, requests_mock
 ):
@@ -1490,7 +1497,8 @@ def test_fail_auth_invalid_response(
     """
     requests_mock.post("https://semgrep.dev/api/cli/scans", status_code=500)
     run_semgrep(
-        options=["ci", "--no-suppress-errors"],
+        subcommand="ci",
+        options=["--no-suppress-errors"],
         target_name=None,
         strict=False,
         assert_exit_code=2,
@@ -1509,7 +1517,7 @@ def test_fail_auth_invalid_response_can_be_supressed(
     requests_mock.post("https://semgrep.dev/api/cli/scans", status_code=500)
     mock_send = mocker.spy(ErrorHandler, "send")
     run_semgrep(
-        options=["ci"],
+        subcommand="ci",
         target_name=None,
         strict=False,
         assert_exit_code=0,
@@ -1527,7 +1535,8 @@ def test_fail_start_scan(run_semgrep: RunSemgrep, mocker, git_tmp_path_with_comm
     """
     mocker.patch.object(ScanHandler, "start_scan", side_effect=Exception("Timeout"))
     run_semgrep(
-        options=["ci", "--no-suppress-errors"],
+        subcommand="ci",
+        options=["--no-suppress-errors"],
         target_name=None,
         strict=False,
         assert_exit_code=2,
@@ -1546,7 +1555,7 @@ def test_fail_start_scan_error_handler(
     mocker.patch.object(ScanHandler, "start_scan", side_effect=Exception("Timeout"))
     mock_send = mocker.spy(ErrorHandler, "send")
     run_semgrep(
-        options=["ci"],
+        subcommand="ci",
         target_name=None,
         strict=False,
         assert_exit_code=0,
@@ -1569,7 +1578,7 @@ def test_fail_open_works_when_backend_is_down(
     )
     fail_open = requests_mock.post("https://fail-open.prod.semgrep.dev/failure")
     run_semgrep(
-        options=["ci"],
+        subcommand="ci",
         target_name=None,
         strict=False,
         assert_exit_code=0,
@@ -1593,7 +1602,8 @@ def test_bad_config(run_semgrep: RunSemgrep, git_tmp_path_with_commit):
     Test that bad rules has exit code > 1
     """
     result = run_semgrep(
-        options=["ci", "--no-suppress-errors"],
+        subcommand="ci",
+        options=["--no-suppress-errors"],
         target_name=None,
         strict=False,
         assert_exit_code=7,
@@ -1613,7 +1623,7 @@ def test_bad_config_error_handler(
     """
     mock_send = mocker.spy(ErrorHandler, "send")
     result = run_semgrep(
-        options=["ci"],
+        subcommand="ci",
         target_name=None,
         strict=False,
         assert_exit_code=0,
@@ -1639,7 +1649,8 @@ def test_fail_scan_findings(
     mock_send = mocker.spy(ErrorHandler, "send")
 
     run_semgrep(
-        options=["ci", "--suppress-errors"],
+        subcommand="ci",
+        options=["--suppress-errors"],
         target_name=None,
         strict=False,
         assert_exit_code=1,
@@ -1657,7 +1668,8 @@ def test_fail_finish_scan(run_semgrep: RunSemgrep, mocker, git_tmp_path_with_com
     """
     mocker.patch.object(ScanHandler, "report_findings", side_effect=Exception)
     run_semgrep(
-        options=["ci", "--no-suppress-errors"],
+        subcommand="ci",
+        options=["--no-suppress-errors"],
         target_name=None,
         strict=False,
         assert_exit_code=2,
@@ -1681,7 +1693,8 @@ def test_backend_exit_code(
         return_value=ScanCompleteResult(True, True, "some reason to fail"),
     )
     run_semgrep(
-        options=["ci", "--no-suppress-errors"],
+        subcommand="ci",
+        options=["--no-suppress-errors"],
         target_name=None,
         strict=False,
         assert_exit_code=1,
@@ -1700,7 +1713,7 @@ def test_fail_finish_scan_error_handler(
     mocker.patch.object(ScanHandler, "report_findings", side_effect=Exception)
     mock_send = mocker.spy(ErrorHandler, "send")
     run_semgrep(
-        options=["ci"],
+        subcommand="ci",
         target_name=None,
         strict=False,
         assert_exit_code=0,
@@ -1717,7 +1730,8 @@ def test_git_failure(run_semgrep: RunSemgrep, git_tmp_path_with_commit, mocker):
     """
     mocker.patch.object(GitMeta, "to_project_metadata", side_effect=Exception)
     run_semgrep(
-        options=["ci", "--no-suppress-errors"],
+        subcommand="ci",
+        options=["--no-suppress-errors"],
         target_name=None,
         strict=False,
         assert_exit_code=2,
@@ -1736,7 +1750,7 @@ def test_git_failure_error_handler(
     mocker.patch.object(GitMeta, "to_project_metadata", side_effect=Exception)
     mock_send = mocker.spy(ErrorHandler, "send")
     run_semgrep(
-        options=["ci"],
+        subcommand="ci",
         target_name=None,
         strict=False,
         assert_exit_code=0,
@@ -1785,7 +1799,8 @@ def test_query_dependency(
     complete_scan_mock,
 ):
     result = run_semgrep(
-        options=["ci", "--no-suppress-errors"],
+        subcommand="ci",
+        options=["--no-suppress-errors"],
         target_name=None,
         strict=False,
         assert_exit_code=None,
@@ -1817,7 +1832,7 @@ def test_metrics_enabled(
 ):
     mock_send = mocker.patch.object(Metrics, "_post_metrics")
     run_semgrep(
-        options=["ci"],
+        subcommand="ci",
         target_name=None,
         strict=False,
         assert_exit_code=1,
@@ -1862,7 +1877,8 @@ def test_existing_supply_chain_finding(
 ):
     repo_copy_base, base_commit, head_commit = git_tmp_path_with_commit
     result = run_semgrep(
-        options=["ci", "--no-suppress-errors"],
+        subcommand="ci",
+        options=["--no-suppress-errors"],
         target_name=None,
         strict=False,
         assert_exit_code=None,
@@ -1930,7 +1946,8 @@ def test_existing_supply_chain_finding(
     ).strip()
 
     result = run_semgrep(
-        options=["ci", "--no-suppress-errors", "--baseline-commit", head_commit],
+        subcommand="ci",
+        options=["--no-suppress-errors", "--baseline-commit", head_commit],
         target_name=None,
         strict=False,
         assert_exit_code=None,

--- a/cli/tests/e2e/test_cli_test.py
+++ b/cli/tests/e2e/test_cli_test.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 from tests.fixtures import RunSemgrep
-from tests.semgrep_runner import SEMGREP_BASE_COMMAND
+from tests.semgrep_runner import SEMGREP_BASE_SCAN_COMMAND
 
 from semgrep.constants import OutputFormat
 
@@ -165,7 +165,7 @@ def test_cli_test_from_entrypoint(snapshot):
     env = {}
     env["PATH"] = os.environ.get("PATH", "")
 
-    cmd = SEMGREP_BASE_COMMAND + [
+    cmd = SEMGREP_BASE_SCAN_COMMAND + [
         "--test",
         "--config",
         "rules/cli_test/multiple_annotations/multiple-annotations.yaml",

--- a/cli/tests/e2e/test_config_resolver.py
+++ b/cli/tests/e2e/test_config_resolver.py
@@ -41,7 +41,7 @@ def test_new_feature_registry_config(monkeypatch, snapshot, mocker, tmp_path):
         },
         use_click_runner=True,
     )
-    result = runner.invoke(cli, ["scan", "--config", "p/ci"])
+    result = runner.invoke(cli, subcommand="scan", args=["--config", "p/ci"])
     snapshot.assert_match(result.output, "output.txt")
 
 
@@ -87,7 +87,9 @@ def test_fallback_config_works(requests_mock, mocker, tmp_path):
         },
         use_click_runner=True,
     )
-    result = runner.invoke(cli, ["scan", "--debug", "--config", "supply-chain"])
+    result = runner.invoke(
+        cli, subcommand="scan", args=["--debug", "--config", "supply-chain"]
+    )
 
     assert (
         "https://fail-open.prod.semgrep.dev/"
@@ -118,6 +120,8 @@ def test_cloud_platform_scan_config(requests_mock, cli_option, tmp_path):
         },
         use_click_runner=True,
     )
-    result = runner.invoke(cli, ["scan", "--debug", "--config", cli_option])
+    result = runner.invoke(
+        cli, subcommand="scan", args=["--debug", "--config", cli_option]
+    )
 
     assert "loaded 1 configs" in result.stdout

--- a/cli/tests/e2e/test_help.py
+++ b/cli/tests/e2e/test_help.py
@@ -13,5 +13,5 @@ def test_help_text(tmp_path, snapshot, help_flag):
     runner = SemgrepRunner(
         env={"SEMGREP_SETTINGS_FILE": str(tmp_path / ".settings.yaml")}
     )
-    result = runner.invoke(cli, [help_flag], env={})
+    result = runner.invoke(cli, args=[help_flag], env={})
     snapshot.assert_match(result.output, "help.txt")

--- a/cli/tests/e2e/test_login.py
+++ b/cli/tests/e2e/test_login.py
@@ -59,7 +59,7 @@ def test_login(tmp_path, mocker):
     assert "API token already exists in" in result.output
 
     # Clear login
-    result = runner.invoke(cli, subcommand="login", args=[])
+    result = runner.invoke(cli, subcommand="logout", args=[])
     assert result.exit_code == 0
     assert result.output == expected_logout_str
 

--- a/cli/tests/e2e/test_login.py
+++ b/cli/tests/e2e/test_login.py
@@ -24,8 +24,8 @@ def test_login(tmp_path, mocker):
 
     # Logout
     result = runner.invoke(
+        "logout",
         cli,
-        ["logout"],
     )
     assert result.exit_code == 0
     assert result.output == expected_logout_str
@@ -33,7 +33,7 @@ def test_login(tmp_path, mocker):
     # Fail to login without a tty
     result = runner.invoke(
         cli,
-        ["login"],
+        subcommand="login",
         input=fake_key,
     )
     assert result.exit_code == 2
@@ -42,7 +42,7 @@ def test_login(tmp_path, mocker):
     # Login with env token
     result = runner.invoke(
         cli,
-        ["login"],
+        subcommand="login",
         env={"SEMGREP_APP_TOKEN": fake_key},
     )
     assert result.exit_code == 0
@@ -52,32 +52,26 @@ def test_login(tmp_path, mocker):
     # Login should fail on second call
     result = runner.invoke(
         cli,
-        ["login"],
+        subcommand="login",
         env={"SEMGREP_APP_TOKEN": fake_key},
     )
     assert result.exit_code == 2
     assert "API token already exists in" in result.output
 
     # Clear login
-    result = runner.invoke(
-        cli,
-        ["logout"],
-    )
+    result = runner.invoke(cli, subcommand="login")
     assert result.exit_code == 0
     assert result.output == expected_logout_str
 
     # Logout twice should work
-    result = runner.invoke(
-        cli,
-        ["logout"],
-    )
+    result = runner.invoke(cli, subcommand="logout")
     assert result.exit_code == 0
     assert result.output == expected_logout_str
 
     # Next we'll check registry config works while logged in, so we have to log back in
     result = runner.invoke(
         cli,
-        ["login"],
+        subcommand="login",
         env={"SEMGREP_APP_TOKEN": fake_key},
     )
     assert result.exit_code == 0
@@ -86,7 +80,7 @@ def test_login(tmp_path, mocker):
     # Run p/ci
     result = runner.invoke(
         cli,
-        ["--config", "r/python.lang.correctness.useless-eqeq.useless-eqeq"],
+        args=["--config", "r/python.lang.correctness.useless-eqeq.useless-eqeq"],
     )
     assert (
         result.exit_code == 7
@@ -94,7 +88,7 @@ def test_login(tmp_path, mocker):
 
     # Run policy with bad token -> no associated deployment_id
     result = runner.invoke(
-        cli, ["--config", "policy"], env={"SEMGREP_REPO_NAME": "test-repo"}
+        cli, args=["--config", "policy"], env={"SEMGREP_REPO_NAME": "test-repo"}
     )
     assert result.exit_code == 7
     assert "Invalid API Key" in result.output
@@ -104,7 +98,7 @@ def test_login(tmp_path, mocker):
     # Run policy without SEMGREP_REPO_NAME
     result = runner.invoke(
         cli,
-        ["--config", "policy"],
+        args=["--config", "policy"],
     )
     assert result.exit_code == 7
     assert "Need to set env var SEMGREP_REPO_NAME" in result.output
@@ -116,7 +110,7 @@ def test_login(tmp_path, mocker):
         side_effect=lambda url: ConfigFile(None, "invalid-conifg}", url),
     )
     result = runner.invoke(
-        cli, ["--config", "policy"], env={"SEMGREP_REPO_NAME": "org/repo"}
+        cli, args=["--config", "policy"], env={"SEMGREP_REPO_NAME": "org/repo"}
     )
     assert result.exit_code == 7
     assert mocked_config.called

--- a/cli/tests/e2e/test_login.py
+++ b/cli/tests/e2e/test_login.py
@@ -23,10 +23,7 @@ def test_login(tmp_path, mocker):
     )
 
     # Logout
-    result = runner.invoke(
-        "logout",
-        cli,
-    )
+    result = runner.invoke(cli, subcommand="logout", args=[])
     assert result.exit_code == 0
     assert result.output == expected_logout_str
 
@@ -34,6 +31,7 @@ def test_login(tmp_path, mocker):
     result = runner.invoke(
         cli,
         subcommand="login",
+        args=[],
         input=fake_key,
     )
     assert result.exit_code == 2
@@ -43,6 +41,7 @@ def test_login(tmp_path, mocker):
     result = runner.invoke(
         cli,
         subcommand="login",
+        args=[],
         env={"SEMGREP_APP_TOKEN": fake_key},
     )
     assert result.exit_code == 0
@@ -53,18 +52,19 @@ def test_login(tmp_path, mocker):
     result = runner.invoke(
         cli,
         subcommand="login",
+        args=[],
         env={"SEMGREP_APP_TOKEN": fake_key},
     )
     assert result.exit_code == 2
     assert "API token already exists in" in result.output
 
     # Clear login
-    result = runner.invoke(cli, subcommand="login")
+    result = runner.invoke(cli, subcommand="login", args=[])
     assert result.exit_code == 0
     assert result.output == expected_logout_str
 
     # Logout twice should work
-    result = runner.invoke(cli, subcommand="logout")
+    result = runner.invoke(cli, subcommand="logout", args=[])
     assert result.exit_code == 0
     assert result.output == expected_logout_str
 
@@ -72,6 +72,7 @@ def test_login(tmp_path, mocker):
     result = runner.invoke(
         cli,
         subcommand="login",
+        args=[],
         env={"SEMGREP_APP_TOKEN": fake_key},
     )
     assert result.exit_code == 0

--- a/cli/tests/e2e/test_metrics.py
+++ b/cli/tests/e2e/test_metrics.py
@@ -219,7 +219,8 @@ def test_metrics_payload(tmp_path, snapshot, mocker, monkeypatch, pro_flag):
         use_click_runner=True,
     )
     runner.invoke(
-        cli, ["scan", "--config=rule.yaml", "--metrics=on", "metrics_files"] + pro_flag
+        cli,
+        args=["scan", "--config=rule.yaml", "--metrics=on", "metrics_files"] + pro_flag,
     )
 
     payload = json.loads(mock_post.call_args.kwargs["data"])

--- a/cli/tests/e2e/test_metrics.py
+++ b/cli/tests/e2e/test_metrics.py
@@ -220,7 +220,8 @@ def test_metrics_payload(tmp_path, snapshot, mocker, monkeypatch, pro_flag):
     )
     runner.invoke(
         cli,
-        args=["scan", "--config=rule.yaml", "--metrics=on", "metrics_files"] + pro_flag,
+        subcommand="scan",
+        args=["--config=rule.yaml", "--metrics=on", "metrics_files"] + pro_flag,
     )
 
     payload = json.loads(mock_post.call_args.kwargs["data"])

--- a/cli/tests/e2e/test_parse_rate_metrics.py
+++ b/cli/tests/e2e/test_parse_rate_metrics.py
@@ -47,7 +47,7 @@ def test_parse_metrics(tmp_path, snapshot, mocker, monkeypatch):
 
     monkeypatch.chdir(tmp_path / "parse_metrics")
     SemgrepRunner(use_click_runner=True).invoke(
-        cli, ["scan", "--config=rules.yaml", "--metrics=on"]
+        cli, args=["scan", "--config=rules.yaml", "--metrics=on"]
     )
 
     payload = json.loads(mock_post.call_args.kwargs["data"])

--- a/cli/tests/e2e/test_parse_rate_metrics.py
+++ b/cli/tests/e2e/test_parse_rate_metrics.py
@@ -47,7 +47,7 @@ def test_parse_metrics(tmp_path, snapshot, mocker, monkeypatch):
 
     monkeypatch.chdir(tmp_path / "parse_metrics")
     SemgrepRunner(use_click_runner=True).invoke(
-        cli, args=["scan", "--config=rules.yaml", "--metrics=on"]
+        cli, subcommand="scan", args=["--config=rules.yaml", "--metrics=on"]
     )
 
     payload = json.loads(mock_post.call_args.kwargs["data"])

--- a/cli/tests/e2e/test_publish.py
+++ b/cli/tests/e2e/test_publish.py
@@ -8,52 +8,46 @@ from semgrep.cli import cli
 
 
 @pytest.mark.kinda_slow
-@pytest.mark.osemfail
 def test_publish(tmp_path, mocker):
     runner = SemgrepRunner(
         env={"SEMGREP_SETTINGS_FILE": str(tmp_path / ".settings.yaml")},
         use_click_runner=True,
+        mix_stderr=False,
     )
 
     tests_path = Path(TESTS_PATH / "e2e" / "targets" / "semgrep-publish" / "valid")
     valid_target = str(tests_path.resolve())
     valid_single_file_target = str((tests_path / "valid1.yaml").resolve())
 
-    result = runner.invoke(
-        cli,
-        ["logout"],
-    )
+    result = runner.invoke(cli, subcommand="logout")
     assert result.exit_code == 0
 
     # should require login
     result = runner.invoke(
         cli,
-        ["publish", valid_target],
+        "publish",
+        [valid_target],
     )
-    print(result.output)
     assert result.exit_code == 2
-    assert result.output == "run `semgrep login` before using upload\n"
+    assert "run `semgrep login` before using upload\n" in result.stderr
 
     mocker.patch(
         "semgrep.app.auth.get_deployment_from_token", return_value="deployment_name"
     )
 
     # log back in
-    result = runner.invoke(cli, ["login"], env={"SEMGREP_APP_TOKEN": "fakeapitoken"})
+    result = runner.invoke(cli, "login", [], env={"SEMGREP_APP_TOKEN": "fakeapitoken"})
     assert result.exit_code == 0
 
     # fails if no rule specified
-    result = runner.invoke(
-        cli,
-        ["publish"],
-    )
+    result = runner.invoke(cli, "publish", [])
     assert result.exit_code == 2
 
     # fails if invalid rule specified
     result = runner.invoke(
         cli,
+        "publish",
         [
-            "publish",
             str(
                 Path(
                     TESTS_PATH / "e2e" / "targets" / "semgrep-publish" / "invalid"
@@ -67,8 +61,8 @@ def test_publish(tmp_path, mocker):
     # fails if a yaml with more than one rule is specified
     result = runner.invoke(
         cli,
+        "publish",
         [
-            "publish",
             str(
                 Path(
                     TESTS_PATH / "e2e" / "targets" / "semgrep-publish" / "multirule"
@@ -85,7 +79,8 @@ def test_publish(tmp_path, mocker):
     # fails if --visibility=public without --rule-id
     result = runner.invoke(
         cli,
-        ["publish", "--visibility=public", valid_target],
+        "publish",
+        ["--visibility=public", valid_target],
     )
     assert result.exit_code == 2
     assert (
@@ -95,7 +90,8 @@ def test_publish(tmp_path, mocker):
 
     result = runner.invoke(
         cli,
-        ["publish", "--visibility=public", valid_single_file_target],
+        "publish",
+        ["--visibility=public", valid_single_file_target],
     )
     assert result.exit_code == 2
     assert "--visibility=public requires --registry-id" in result.output

--- a/cli/tests/e2e/test_publish.py
+++ b/cli/tests/e2e/test_publish.py
@@ -13,7 +13,6 @@ def test_publish(tmp_path, mocker):
     runner = SemgrepRunner(
         env={"SEMGREP_SETTINGS_FILE": str(tmp_path / ".settings.yaml")},
         use_click_runner=True,
-        mix_stderr=False,
     )
 
     tests_path = Path(TESTS_PATH / "e2e" / "targets" / "semgrep-publish" / "valid")
@@ -30,7 +29,7 @@ def test_publish(tmp_path, mocker):
         args=[valid_target],
     )
     assert result.exit_code == 2
-    assert "run `semgrep login` before using upload\n" in result.stderr
+    assert result.output == "run `semgrep login` before using upload\n"
 
     mocker.patch(
         "semgrep.app.auth.get_deployment_from_token", return_value="deployment_name"

--- a/cli/tests/e2e/test_utility_commands.py
+++ b/cli/tests/e2e/test_utility_commands.py
@@ -2,13 +2,13 @@ import re
 import subprocess
 
 import pytest
-from tests.semgrep_runner import SEMGREP_BASE_COMMAND
+from tests.semgrep_runner import SEMGREP_BASE_SCAN_COMMAND
 
 
 @pytest.mark.kinda_slow
 def test_version():
     result = subprocess.check_output(
-        SEMGREP_BASE_COMMAND + ["--version", "--disable-version-check"],
+        SEMGREP_BASE_SCAN_COMMAND + ["--version", "--disable-version-check"],
         encoding="utf-8",
     )
 
@@ -19,7 +19,7 @@ def test_version():
 @pytest.mark.osemfail
 def test_dump_command_for_core():
     semgrep_core_command = subprocess.check_output(
-        SEMGREP_BASE_COMMAND
+        SEMGREP_BASE_SCAN_COMMAND
         + [
             "--config",
             "tests/e2e/rules/eqeq-basic.yaml",
@@ -38,7 +38,7 @@ def test_dump_command_for_core():
 @pytest.mark.osemfail
 def test_dump_engine():
     result = subprocess.check_output(
-        SEMGREP_BASE_COMMAND + ["--dump-engine-path"],
+        SEMGREP_BASE_SCAN_COMMAND + ["--dump-engine-path"],
         encoding="utf-8",
     )
 

--- a/cli/tests/fixtures.py
+++ b/cli/tests/fixtures.py
@@ -17,6 +17,7 @@ class RunSemgrep(Protocol):
         self,
         config: str | Path | list[str] | None = None,
         *,
+        subcommand: str | None = None,
         target_name: str | None = "basic",
         options: list[str | Path] | None = None,
         output_format: OutputFormat | None = OutputFormat.JSON,

--- a/cli/tests/qa/test_public_repos.py
+++ b/cli/tests/qa/test_public_repos.py
@@ -12,7 +12,7 @@ import appdirs
 import pytest
 
 from ..conftest import TESTS_PATH
-from ..semgrep_runner import SEMGREP_BASE_COMMAND
+from ..semgrep_runner import SEMGREP_BASE_SCAN_COMMAND
 from .public_repos import REPOS
 
 # Some improbable string that was implanted in test targets [how?] [why?].
@@ -53,7 +53,7 @@ def chdir(dirname=None):
 
 
 def assert_sentinel_results(repo_path, sentinel_path, language):
-    cmd = SEMGREP_BASE_COMMAND + [
+    cmd = SEMGREP_BASE_SCAN_COMMAND + [
         "--disable-version-check",
         "--pattern",
         SENTINEL_PATTERN,
@@ -164,7 +164,7 @@ def test_semgrep_on_repo(monkeypatch, tmp_path, repo):
             sentinel_file.write(sentinel_info["file_contents"])
         assert_sentinel_results(repo_path, sentinel_path, language)
 
-    cmd = SEMGREP_BASE_COMMAND + [
+    cmd = SEMGREP_BASE_SCAN_COMMAND + [
         "--disable-version-check",
         "--config=rules/regex-sentinel.yaml",
         "--strict",

--- a/cli/tests/semgrep_runner.py
+++ b/cli/tests/semgrep_runner.py
@@ -148,8 +148,8 @@ class SemgrepRunner:
     def invoke(
         self,
         python_cli,
+        args: Union[str, Sequence[str]],
         subcommand: Optional[str] = None,
-        args: Optional[Union[str, Sequence[str]]] = None,
         input: Optional[str] = None,
         env=None,
     ) -> Result:

--- a/cli/tests/semgrep_runner.py
+++ b/cli/tests/semgrep_runner.py
@@ -23,7 +23,6 @@ from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Sequence
-from typing import Tuple
 from typing import Union
 
 from click.testing import CliRunner


### PR DESCRIPTION
## What:
This PR splits the Semgrep runner in `pysemgrep` such that the subcommand is isolated from the arguments.

## Why:
When running `osemgrep` tests, this really messes things up, because the `SEMGREP_BASE_COMMAND` will insert options _before_ the subcommand name. This is OK in `pysemgrep`, but a parse error in `osemgrep`, causing us to fail `osemgrep` tests.

## How:
Made the core runner now take in optional `subcommand` and `args` arguments, separately.

## Test plan:
Automated tests.