### PR TITLE
Fix our tests to reset g_errors and leave a good state

### DIFF
--- a/src/core/Core_error.ml
+++ b/src/core/Core_error.ml
@@ -1,6 +1,6 @@
 (* Yoann Padioleau
  *
- * Copyright (C) 2021 Semgrep Inc.
+ * Copyright (C) 2021-2023 Semgrep Inc.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
@@ -102,7 +102,7 @@ let mk_error_tok opt_rule_id tok msg err =
   let loc = Tok.unsafe_loc_of_tok tok in
   mk_error opt_rule_id loc msg err
 
-let error rule_id loc msg err =
+let push_error rule_id loc msg err =
   Common.push (mk_error (Some rule_id) loc msg err) g_errors
 
 let error_of_invalid_rule_error ((kind, rule_id, pos) : R.invalid_rule_error) :

--- a/src/core/Core_error.mli
+++ b/src/core/Core_error.mli
@@ -16,9 +16,10 @@ type t = {
 }
 [@@deriving show]
 
-val g_errors : t list ref
-
 module ErrorSet : Set.S with type elt = t
+
+(* !!global!! modified by push_error() below *)
+val g_errors : t list ref
 
 (*****************************************************************************)
 (* Converter functions *)
@@ -31,7 +32,8 @@ val mk_error :
   Semgrep_output_v1_t.error_type ->
   t
 
-val error :
+(* modifies g_errors *)
+val push_error :
   Rule_ID.t -> Tok.location -> string -> Semgrep_output_v1_t.error_type -> unit
 
 (* Convert an invalid rule into an error.
@@ -49,6 +51,7 @@ val exn_to_error : Rule_ID.t option -> string (* filename *) -> Exception.t -> t
 (* Try with error *)
 (*****************************************************************************)
 
+(* note that this modifies g_errors! *)
 val try_with_exn_to_error : string (* filename *) -> (unit -> unit) -> unit
 
 val try_with_print_exn_and_reraise :

--- a/src/core/Globals.ml
+++ b/src/core/Globals.ml
@@ -1,0 +1,56 @@
+(* Yoann Padioleau
+ *
+ * Copyright (C) 2023 Semgrep Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * version 2.1 as published by the Free Software Foundation, with the
+ * special exception on linking described in file LICENSE.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
+ * LICENSE for more details.
+ *)
+
+(*****************************************************************************)
+(* Prelude *)
+(*****************************************************************************)
+(* The goal of this module is mostly to document the "dangerous" globals
+ * used inside Semgrep.
+ *
+ * Ultimately, we want to elimitate all globals. Until now, those globals did
+ * not create too many issues because of the use of Parmap and fork
+ * in Core_scan.ml (the modifications of those globals in the child process
+ * do not affect the state in the parent process), but as soon as we migrate to
+ * using domains instead with OCaml 5.0, those globals will haunt us back.
+ * Maybe Domain-local-storage globals could help, but even better if we
+ * can eliminate them.
+ *
+ * To find candidates for those "dangerous" globals, you can start with:
+ *  $ ./bin/osemgrep --experimental -e 'val $V: $T ref' -l ocaml src/ libs/
+ *  $ ./bin/osemgrep --experimental -e 'let $V: $T = ref $X' -l ocaml src/ libs/
+ *)
+
+(*****************************************************************************)
+(* Entry point *)
+(*****************************************************************************)
+
+(* Useful for defensive programming, especially in tests which may leave
+ * bad state behind.
+ * Note that it's currently unused, because we should prefer to fix our tests
+ * to restore the globals they modified, but as a last resort, you can
+ * use this function.
+ *)
+let reset () =
+  Core_error.g_errors := [];
+  Core_profiling.mode := Core_profiling.MNo_info;
+  AST_generic_equals.busy_with_equal := AST_generic_equals.Not_busy;
+  Rule.last_matched_rule := None;
+  (* TODO?
+   * - semgrep-pro hooks?
+   * - Match_patterns.last_matched_rule?
+   * - Http_helpers.client_ref?
+   * - many more
+   *)
+  ()

--- a/src/engine/Test_engine.ml
+++ b/src/engine/Test_engine.ml
@@ -266,7 +266,7 @@ let make_test_rule_file ~unit_testing ~get_xlang ~prepend_lang ~newscore
         |> List.iter
              (fun
                (res : Core_profiling.partial_profiling Core_result.match_result)
-             -> res.matches |> List.iter Core_json_output.match_to_error);
+             -> res.matches |> List.iter Core_json_output.match_to_push_error);
         (if not (E.ErrorSet.is_empty res.errors) then
            let errors =
              E.ErrorSet.elements res.errors
@@ -274,6 +274,7 @@ let make_test_rule_file ~unit_testing ~get_xlang ~prepend_lang ~newscore
            in
            failwith (spf "parsing error(s) on %s:\n%s" !!file errors));
         let actual_errors = !E.g_errors in
+        E.g_errors := [];
         actual_errors
         |> List.iter (fun e ->
                logger#info "found error: %s" (E.string_of_error e));

--- a/src/engine/Unit_engine.ml
+++ b/src/engine/Unit_engine.ml
@@ -326,9 +326,6 @@ let regression_tests_for_lang ~polyglot_pattern_path files lang =
                | Ok fix_file -> Some (File.read_file fix_file)
                | Error _ -> None
              in
-
-             E.g_errors := [];
-
              (* old: semgrep-core used to support user-defined
               * equivalences, but the feature has been now deprecated.
               *
@@ -342,15 +339,16 @@ let regression_tests_for_lang ~polyglot_pattern_path files lang =
                match_pattern ~lang
                  ~hook:(fun { Pattern_match.range_loc; _ } ->
                    let start_loc, _end_loc = range_loc in
-                   E.error
+                   E.push_error
                      (Rule_ID.of_string "test-pattern")
                      start_loc "" Out.SemgrepMatchFound)
                  ~file ~pattern ~fix_pattern
              in
+             let actual = !E.g_errors in
+             E.g_errors := [];
              (match fix_pattern with
              | Some _ -> compare_fixes ~polyglot_pattern_path ~file matches
              | None -> ());
-             let actual = !E.g_errors in
              let expected = E.expected_error_lines_of_files [ !!file ] in
              E.compare_actual_to_expected_for_alcotest actual expected ))
 

--- a/src/experiments/synthesizing/Unit_synthesizer_targets.ml
+++ b/src/experiments/synthesizing/Unit_synthesizer_targets.ml
@@ -72,13 +72,17 @@ let ranges_matched lang file pattern : Range.t list =
   (* Are equivalences necessary for this? *)
   let matches =
     Match_patterns.check
-      ~hook:(fun { Pattern_match.tokens = (lazy xs); _ } ->
-        let toks = xs |> List.filter Tok.is_origintok in
-        let minii, _maxii = Tok_range.min_max_toks_by_pos toks in
-        let minii_loc = Tok.unsafe_loc_of_tok minii in
-        E.error
-          (Rule_ID.of_string "Synthesizer-tests")
-          minii_loc "" Out.SemgrepMatchFound)
+      ~hook:(fun { Pattern_match.tokens = (lazy _xs); _ } ->
+        ()
+        (* TODO: commented because push_error below leaves a bad state
+           for other tests, and anyway the code does not seem used
+                let toks = xs |> List.filter Tok.is_origintok in
+                let minii, _maxii = Tok_range.min_max_toks_by_pos toks in
+                let minii_loc = Tok.unsafe_loc_of_tok minii in
+                E.push_error
+                  (Rule_ID.of_string "Synthesizer-tests")
+                  minii_loc "" Out.SemgrepMatchFound
+        *))
       (Rule_options.default_config, equiv)
       [ rule ] (file, lang, ast)
   in

--- a/src/metachecking/Check_rule.mli
+++ b/src/metachecking/Check_rule.mli
@@ -1,4 +1,3 @@
-(* will populate Core_error.errors *)
 val check : Rule.t -> Core_error.t list
 
 (* to test -check_rules *)

--- a/src/metachecking/Unit_metachecking.ml
+++ b/src/metachecking/Unit_metachecking.ml
@@ -37,7 +37,7 @@ let metachecker_checks_tests () =
             let file = Fpath.v file in
             ( Fpath.basename file,
               fun () ->
-                E.g_errors := [];
+                (* note that try_with_exn_to_error also modifies g_errors *)
                 E.try_with_exn_to_error !!file (fun () ->
                     let rules = Parse_rule.parse file in
                     rules
@@ -45,6 +45,7 @@ let metachecker_checks_tests () =
                            let errs = Check_rule.check rule in
                            E.g_errors := errs @ !E.g_errors));
                 let actual = !E.g_errors in
+                E.g_errors := [];
                 let expected = E.expected_error_lines_of_files [ !!file ] in
                 E.compare_actual_to_expected_for_alcotest actual expected )))
 

--- a/src/reporting/Core_json_output.ml
+++ b/src/reporting/Core_json_output.ml
@@ -397,6 +397,7 @@ let core_output_of_matches_and_errors render_fix (res : Core_result.t) :
     Common.partition_either (match_to_match render_fix) res.matches
   in
   let errs = !E.g_errors @ new_errs @ res.errors in
+  E.g_errors := [];
   let skipped_targets, profiling =
     match res.extra with
     | Core_profiling.Debug { skipped_targets; profiling } ->
@@ -443,9 +444,9 @@ let core_output_of_matches_and_errors render_fix (res : Core_result.t) :
 (* this is used only in the testing code, to reuse the
  * Semgrep_error_code.compare_actual_to_expected
  *)
-let error loc (rule : Pattern_match.rule_id) =
-  E.error rule.id loc rule.message Out.SemgrepMatchFound
+let push_error loc (rule : Pattern_match.rule_id) =
+  E.push_error rule.id loc rule.message Out.SemgrepMatchFound
 
-let match_to_error x =
+let match_to_push_error x =
   let min_loc, _max_loc = x.range_loc in
-  error min_loc x.rule_id
+  push_error min_loc x.rule_id

--- a/src/reporting/Core_json_output.mli
+++ b/src/reporting/Core_json_output.mli
@@ -8,6 +8,7 @@ val match_to_match :
   Pattern_match.t ->
   (Semgrep_output_v1_t.core_match, Core_error.t) Common.either
 
+(* Note that this uses and reset !Core_error.g_errors internally *)
 val core_output_of_matches_and_errors :
   render_fix option -> Core_result.t -> Semgrep_output_v1_t.core_output
 
@@ -22,4 +23,4 @@ val error_to_error : Core_error.t -> Semgrep_output_v1_t.core_error
 (* This is used only in the testing code, to reuse the
  * Semgrep_error_code.compare_actual_to_expected
  *)
-val match_to_error : Pattern_match.t -> unit
+val match_to_push_error : Pattern_match.t -> unit


### PR DESCRIPTION
Also introduced Globals.ml

test plan:
when used with https://github.com/semgrep/semgrep/pull/9300,
the osemgrep tests are now passing because g_errors
is in a good state (empty) at the start of the test