### PR TITLE
Don't run 'git submodule update' as part of 'make setup'.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -404,7 +404,6 @@ homebrew-setup:
 # important dependencies change.
 .PHONY: setup
 setup: semgrep.opam
-	git submodule update --init
 	opam update -y
 	$(MAKE) install-deps-for-semgrep-core
 


### PR DESCRIPTION
The same change was made recently in semgrep-proprietary. It avoids interfering with the developer's work in progress.

The instructions in INSTALL.md already tell the user/dev to run `git submodule update ...` before `make setup`.
