### PR TITLE
fix: tainting: Do not taint subexpressions of `by-side-effect: only`

### DIFF
--- a/changelog.d/pa-3282.fixed
+++ b/changelog.d/pa-3282.fixed
@@ -1,0 +1,21 @@
+taint-mode: Fixed a bug in the recently added `by-side-effect: only` option
+causing that when matching l-values of the form `l.x` and `l[i]`, the `l`
+occurence would unexpectedly become tainted too. This led to FPs in some
+typestate rules like those checking for double-lock double-free.
+
+Now a source such as:
+
+```yaml
+- by-side-effect: only
+  patterns:
+  - pattern: lock($L)
+  - focus-metavariable: $L
+```
+
+will not produce FPs on code such as:
+
+```python
+lock(obj.l)
+unlock(obj.l)
+lock(obj.l)
+```

--- a/changelog.d/pa-3282.fixed
+++ b/changelog.d/pa-3282.fixed
@@ -1,7 +1,7 @@
 taint-mode: Fixed a bug in the recently added `by-side-effect: only` option
 causing that when matching l-values of the form `l.x` and `l[i]`, the `l`
 occurence would unexpectedly become tainted too. This led to FPs in some
-typestate rules like those checking for double-lock double-free.
+typestate rules like those checking for double-lock or double-free.
 
 Now a source such as:
 

--- a/src/tainting/Dataflow_tainting.ml
+++ b/src/tainting/Dataflow_tainting.ml
@@ -352,8 +352,8 @@ let partition_sources_by_side_effect sources_matches =
   |> Common.partition_either3 (fun (m : R.taint_source TM.t) ->
          match m.spec.source_by_side_effect with
          | R.Only -> Left3 m
-         (* A 'Yes' should be a 'Yes' regardless of whether the match is exact,
-          * whether the match is exact or not is/should be taken into consideeration
+         (* A 'Yes' should be a 'Yes' regardless of whether the match is exact...
+          * Whether the match is exact or not is/should be taken into consideration
           * later on. Same as for 'Only'. But for backwards-compatibility we keep
           * it this way for now. *)
          | R.Yes when TM.is_exact m -> Middle3 m

--- a/tests/rules/taint_typestate.py
+++ b/tests/rules/taint_typestate.py
@@ -1,7 +1,23 @@
-def test():
+def test1(l):
     lock(l)
     unlock(l)
     #ok: test
     lock(l)
     #ruleid: test
     lock(l)
+
+def test2(obj):
+    lock(obj.l)
+    unlock(obj.l)
+    # ok: test
+    lock(obj.l)
+    # ruleid: test
+    lock(obj.l)
+
+def test3(obj):
+    lock(obj[0])
+    unlock(obj[0])
+    # ok: test
+    lock(obj[0])
+    # ruleid: test
+    lock(obj[0])

--- a/tests/rules/taint_typestate2.cpp
+++ b/tests/rules/taint_typestate2.cpp
@@ -1,0 +1,13 @@
+void test1(Foo *p) {
+    // ok: test
+    delete p;
+    // ruleid: test
+    delete p;
+}
+
+void test2(Foo *p) {
+    // ok: test
+    delete p->field;
+    // ruleid: test
+    delete p->field;
+}

--- a/tests/rules/taint_typestate2.yaml
+++ b/tests/rules/taint_typestate2.yaml
@@ -1,0 +1,18 @@
+rules:
+  - id: test
+    languages:
+      - cpp
+    message: Test
+    severity: ERROR
+    mode: taint
+    pattern-sources:
+      - by-side-effect: only
+        patterns:
+          - pattern: |
+              delete $VAR;
+          - focus-metavariable: $VAR
+    pattern-sinks:
+      - patterns:
+          - pattern: |
+              delete $VAR;
+          - focus-metavariable: $VAR


### PR DESCRIPTION
When a source is `by-side-effect: only`, it must be an "exact" source. E.g., if a source matches `l.x`, the `l` is not a source.

Fixes: d00c6e67deb ("tainting: Add `by-side-effect: only` option to sources (#8414)")

Closes PA-3282

test plan:
make test # new tests

