### PR TITLE
New semgrep rule to forbid use of Http_helpers outside networking/

### DIFF
--- a/semgrep.jsonnet
+++ b/semgrep.jsonnet
@@ -31,6 +31,27 @@ local semgrep_rules = [
       exclude: ['Common.ml', 'common2.ml'],
     },
   },
+  {
+    id: 'no-http-outside-networking',
+    match: {
+      pattern: 'Http_helpers.$F ...',
+      where: [
+        {
+          metavariable: '$F',
+          regex: '^(get|post)',
+        },
+      ],
+    },
+    languages: ['ocaml'],
+    severity: 'ERROR',
+    message: |||
+      Do not use Http_helpers outside the networking/ directory. Move the code
+      in one of the networking/ modules and hide it behind a typed interface.
+    |||,
+    paths: {
+      exclude: ['networking'],
+    },
+  },
 ];
 
 local todo_skipped_for_now = [

--- a/src/osemgrep/cli_show/Show_subcommand.ml
+++ b/src/osemgrep/cli_show/Show_subcommand.ml
@@ -61,8 +61,8 @@ let run (conf : Show_CLI.conf) : Exit_code.t =
       Out.put Version.version;
       (* TODO? opportunity to perform version-check? *)
       Exit_code.ok
-  | Identity -> Whoami.invoke Identity
-  | Deployment -> Whoami.invoke Deployment
+  | Identity -> Whoami.print Whoami.Identity
+  | Deployment -> Whoami.print Whoami.Deployment
   | SupportedLanguages ->
       Out.put (spf "supported languages are: %s" Xlang.supported_xlangs);
       Exit_code.ok (* dumpers *)

--- a/src/osemgrep/cli_show/Whoami.ml
+++ b/src/osemgrep/cli_show/Whoami.ml
@@ -1,39 +1,36 @@
+module OutJ = Semgrep_output_v1_j
+
 (*****************************************************************************)
 (* Main logic *)
 (*****************************************************************************)
-module Http_helpers = Http_helpers.Make (Lwt_platform)
 
-type identity = Identity | Deployment
+type identity_kind = Identity | Deployment
 
-let caller_to_endpoint ~caller : string =
-  match caller with
-  | Identity -> "api/agent/identity"
-  | Deployment -> "api/agent/deployments/current"
-
-let get_identity_async ~token ~caller =
-  let headers =
-    [
-      ("Authorization", Fmt.str "Bearer %s" token);
-      ("User-Agent", Fmt.str "Semgrep/%s" Version.version);
-    ]
-  in
-  let endpoint = caller_to_endpoint ~caller in
-  let url = Uri.(with_path !Semgrep_envvars.v.semgrep_url endpoint) in
-  let%lwt res = Http_helpers.get_async ~headers url in
-  match res with
-  | Ok body -> Lwt.return body
-  | Error msg ->
-      Logs.err (fun m ->
-          m "Failed to download config from %s: %s" (Uri.to_string url) msg);
-      Lwt.return ""
-
-let get_identity ~token ~caller =
-  Lwt_platform.run (get_identity_async ~token ~caller)
-
-let invoke (caller : identity) : Exit_code.t =
+let print (kind : identity_kind) : Exit_code.t =
   let settings = Semgrep_settings.load () in
   let api_token = settings.Semgrep_settings.api_token in
   match api_token with
+  | Some token ->
+      (match kind with
+      | Identity ->
+          let id = Lwt_platform.run (Semgrep_App.get_identity_async ~token) in
+          Logs.app (fun m ->
+              m "%s You are logged in as %s" (Logs_helpers.success_tag ()) id)
+      | Deployment -> (
+          let (x : OutJ.deployment_config option) =
+            Lwt_platform.run
+              (Semgrep_App.get_deployment_from_token_async ~token)
+          in
+          match x with
+          | None -> failwith "no deployment_config"
+          | Some x ->
+              (* TODO? return just x.name? *)
+              let str = OutJ.string_of_deployment_config x in
+              Logs.app (fun m ->
+                  m "%s Your deployment info is %s"
+                    (Logs_helpers.success_tag ())
+                    str)));
+      Exit_code.ok
   | None ->
       Logs.err (fun m ->
           m
@@ -41,8 +38,3 @@ let invoke (caller : identity) : Exit_code.t =
              `semgrep whoami`"
             (Logs_helpers.warn_tag ()));
       Exit_code.fatal
-  | Some token ->
-      let identity = get_identity ~token ~caller in
-      Logs.app (fun m ->
-          m "%s You are logged in as %s" (Logs_helpers.success_tag ()) identity);
-      Exit_code.ok

--- a/src/osemgrep/cli_show/Whoami.mli
+++ b/src/osemgrep/cli_show/Whoami.mli
@@ -2,7 +2,6 @@
    Show the current identity of the user running the command.
 *)
 
-type identity = Identity | Deployment
+type identity_kind = Identity | Deployment
 
-(* internal *)
-val invoke : identity -> Exit_code.t
+val print : identity_kind -> Exit_code.t

--- a/src/osemgrep/networking/Semgrep_App.mli
+++ b/src/osemgrep/networking/Semgrep_App.mli
@@ -67,6 +67,8 @@ val report_failure :
 val upload_rule_to_registry :
   token:Auth.token -> JSON.yojson -> (string, int * string) result
 
+val get_identity_async : token:Auth.token -> string Lwt.t
+
 (* lwt-friendly versions for the language-server *)
 
 val get_deployment_from_token_async :


### PR DESCRIPTION
Dogfood!!

test plan:
make check

also
```
$ ./bin/osemgrep show identity
 SUCCESS  You are logged in as {"identity":"cli_aryx_valid-from-2023-11-24T14:40:34.950906"}
$ ./bin/osemgrep show deployment
 SUCCESS  Your deployment info is {"id":1,"name":"returntocorp","organization_id":9,"display_name":"returntocorp","scm_name":"semgrep","slug":"returntocorp","source_type":"github","has_autofix":true,"has_deepsemgrep":true,"has_triage_via_comment":true,"has_dependency_query":true,"default_user_role":"member"}
$ make check
./bin/osemgrep --experimental --config semgrep.jsonnet --error
--exclude tests
...
0 findings
```