### PR TITLE
fix: tainting: Remove Pro-hack for `lval = new ...`

### DIFF
--- a/changelog.d/pa-3283.fixed
+++ b/changelog.d/pa-3283.fixed
@@ -1,5 +1,5 @@
 taint-mode: Removed a hack that made `lval = new ...` assignments to not clean
-the `lval` despite the RHS was not tainted. This caused FPs in doble-free rules.
+the `lval` despite the RHS was not tainted. This caused FPs in double-free rules.
 For example, given this source:
 
 ```yaml

--- a/changelog.d/pa-3283.fixed
+++ b/changelog.d/pa-3283.fixed
@@ -1,0 +1,23 @@
+taint-mode: Removed a hack that made `lval = new ...` assignments to not clean
+the `lval` despite the RHS was not tainted. This caused FPs in doble-free rules.
+For example, given this source:
+
+```yaml
+pattern-sources:
+  - by-side-effect: only
+    patterns:
+      - pattern: delete $VAR;
+      - focus-metavariable: $VAR
+```
+
+And the code below:
+
+```cpp
+while (nondet) {
+  int *v = new int;
+  delete v; // FP
+}
+```
+
+The `delete v` statement was reported as a double-free, because Semgrep did not
+consider that `v = new int` would clean the taint in `v`.

--- a/src/tainting/Taint_lval_env.ml
+++ b/src/tainting/Taint_lval_env.ml
@@ -300,6 +300,11 @@ let equal_by_lval { tainted = tainted1; cleaned = cleaned1; _ }
       let equal_tainted =
         LvalMap.merge
           (fun lv opt_taint1 opt_taint2 ->
+            (* We need to consider both extensions of 'lval' as well as its
+             * prefixes. E.g. given `x.a`, if `x` is tainted then `x.a` is
+             * tainted too; and if `x.a.b` is tainted in one environment and
+             * not in the other, that implies that the taint "signature" of
+             * `x.a` has changed. *)
             if lval_is_prefix lval lv || lval_is_prefix lv lval then
               match (opt_taint1, opt_taint2) with
               | None, None -> None

--- a/src/tainting/Taint_lval_env.ml
+++ b/src/tainting/Taint_lval_env.ml
@@ -106,6 +106,7 @@ let normalize_lval lval =
   in
   Some { IL.base; rev_offset }
 
+(* Test whether 'lval1' is the same as, or a prefix of, 'lval2'. *)
 let lval_is_prefix lval1 lval2 =
   let open IL in
   let eq_name x y = LV.compare_name x y = 0 in
@@ -287,6 +288,30 @@ let equal
   && VarMap.equal Taints.equal propagated1 propagated2 (* needed ? *)
   && LvalSet.equal cleaned1 cleaned2
   && Taints.equal control1 control2
+
+let equal_by_lval { tainted = tainted1; _ } { tainted = tainted2; _ } lval =
+  match normalize_lval lval with
+  | None ->
+      (* Cannot track taint for this l-value; e.g. because the base is not a simple
+         variable. We just return the same environment untouched. *)
+      false
+  | Some lval ->
+      LvalMap.merge
+        (fun lv opt_taint1 opt_taint2 ->
+          if lval_is_prefix lval lv then
+            match (opt_taint1, opt_taint2) with
+            | None, None -> None
+            | Some _, None
+            | None, Some _ ->
+                (* not equals *)
+                (* TODO: Check if `t` is the empty set ? *)
+                Some ()
+            | Some t1, Some t2 ->
+                if Taints.equal t1 t2 then None else (* not equals *)
+                                                  Some ()
+          else None)
+        tainted1 tainted2
+      |> LvalMap.is_empty
 
 let to_string taint_to_str { tainted; propagated; cleaned; control } =
   (* FIXME: lval_to_str *)

--- a/src/tainting/Taint_lval_env.ml
+++ b/src/tainting/Taint_lval_env.ml
@@ -289,29 +289,40 @@ let equal
   && LvalSet.equal cleaned1 cleaned2
   && Taints.equal control1 control2
 
-let equal_by_lval { tainted = tainted1; _ } { tainted = tainted2; _ } lval =
+let equal_by_lval { tainted = tainted1; cleaned = cleaned1; _ }
+    { tainted = tainted2; cleaned = cleaned2; _ } lval =
   match normalize_lval lval with
   | None ->
       (* Cannot track taint for this l-value; e.g. because the base is not a simple
          variable. We just return the same environment untouched. *)
       false
   | Some lval ->
-      LvalMap.merge
-        (fun lv opt_taint1 opt_taint2 ->
-          if lval_is_prefix lval lv then
-            match (opt_taint1, opt_taint2) with
-            | None, None -> None
-            | Some _, None
-            | None, Some _ ->
-                (* not equals *)
-                (* TODO: Check if `t` is the empty set ? *)
-                Some ()
-            | Some t1, Some t2 ->
-                if Taints.equal t1 t2 then None else (* not equals *)
-                                                  Some ()
-          else None)
-        tainted1 tainted2
-      |> LvalMap.is_empty
+      let equal_tainted =
+        LvalMap.merge
+          (fun lv opt_taint1 opt_taint2 ->
+            if lval_is_prefix lval lv || lval_is_prefix lv lval then
+              match (opt_taint1, opt_taint2) with
+              | None, None -> None
+              | Some _, None
+              | None, Some _ ->
+                  (* not equals *)
+                  (* TODO: Check if `t` is the empty set ? *)
+                  Some ()
+              | Some t1, Some t2 ->
+                  if Taints.equal t1 t2 then None else (* not equals *)
+                                                    Some ()
+            else None)
+          tainted1 tainted2
+        |> LvalMap.is_empty
+      in
+      equal_tainted
+      && LvalSet.equal
+           (cleaned1
+           |> LvalSet.filter (fun lv ->
+                  lval_is_prefix lval lv || lval_is_prefix lv lval))
+           (cleaned2
+           |> LvalSet.filter (fun lv ->
+                  lval_is_prefix lval lv || lval_is_prefix lv lval))
 
 let to_string taint_to_str { tainted; propagated; cleaned; control } =
   (* FIXME: lval_to_str *)

--- a/src/tainting/Taint_lval_env.mli
+++ b/src/tainting/Taint_lval_env.mli
@@ -70,5 +70,10 @@ val union : env -> env -> env
      best case scenario to reduce FPs. *)
 
 val equal : env -> env -> bool
+
+val equal_by_lval : env -> env -> IL.lval -> bool
+(** Check whether two environments assign the exact same taint to and l-value
+ * and each one of its extensions. *)
+
 val to_string : (Taint.taints -> string) -> env -> string
 val seq_of_tainted : env -> (IL.lval * Taint.taints) Seq.t

--- a/src/tainting/Taint_lval_env.mli
+++ b/src/tainting/Taint_lval_env.mli
@@ -72,7 +72,7 @@ val union : env -> env -> env
 val equal : env -> env -> bool
 
 val equal_by_lval : env -> env -> IL.lval -> bool
-(** Check whether two environments assign the exact same taint to and l-value
+(** Check whether two environments assign the exact same taint to an l-value
  * and each one of its extensions. *)
 
 val to_string : (Taint.taints -> string) -> env -> string

--- a/tests/rules/taint_typestate3.cpp
+++ b/tests/rules/taint_typestate3.cpp
@@ -1,0 +1,11 @@
+void test() {
+  while (nondet) {
+    int *v1 = new int;
+    int *v2;
+    v2 = new int;
+    // ok: test
+    delete v1;
+    // ok: test
+    delete v2;
+  }
+}

--- a/tests/rules/taint_typestate3.yaml
+++ b/tests/rules/taint_typestate3.yaml
@@ -1,0 +1,17 @@
+rules:
+  - id: test
+    languages:
+      - cpp
+    message: Test
+    mode: taint
+    pattern-sources:
+      - by-side-effect: only
+        patterns:
+          - pattern: delete $VAR;
+          - focus-metavariable: $VAR
+    pattern-sinks:
+      - patterns:
+          - pattern: delete $VAR;
+          - focus-metavariable: $VAR
+    severity: ERROR
+


### PR DESCRIPTION
The hack consisted in not cleaning the taint in `lval` when the RHS was a `new`-expression. This is because for `lval = new ...` we are tainting `lval` by side-effect, and we do not want Semgrep to clean that taint afterwards.

In principle, this hack could have been removed after PR #9263, once we were explicitly checking for side-effectful updates to `lval` and only cleaning `lval` if there were none. But PR #9263 was only looking for changes to `lval` itself, and we have to look for changes to `lval` as well as to any of its extensions `lval.a1. ... .aN`. If the taint of e.g. `lval.x` has been updated, we should also not clean `lval`.

Once PR #9263 is fixed, this hack for `new` is no longer needed and, in fact, it was causing FPs in double-free rules, when an object is both allocated and freed inside a loop.

Fixes: e93afb54fb7 (fix: tainting: Do not clean LHS if there were side-effects (#9263)")

Closes PA-3283

test plan:
make test # new test
And CI workflow 'check-semgrep-pro' must pass.
