### PR TITLE
fix(output): use correct url for gitlab output

### DIFF
--- a/changelog.d/gitlab.fixed
+++ b/changelog.d/gitlab.fixed
@@ -1,0 +1,2 @@
+In gitlab output, use correct url attached to rule instead of generating it.
+This fixes url for supply chain findings.

--- a/cli/src/semgrep/formatter/gitlab_sast.py
+++ b/cli/src/semgrep/formatter/gitlab_sast.py
@@ -25,17 +25,6 @@ def _to_gitlab_severity(semgrep_severity: out.MatchSeverity) -> str:
     return conversion_table.get(semgrep_severity, "Unknown")
 
 
-def _construct_semgrep_rule_url(rule_id: str) -> str:
-    # this is a hack to fix name -> registry disagreement
-    components = rule_id.split(".")
-    result = []
-    for chunk in components:
-        if chunk not in result:
-            result.append(chunk)
-    rule_name = ".".join(result)
-    return f"https://semgrep.dev/r/{rule_name}"
-
-
 class GitlabSastFormatter(BaseFormatter):
     def _format_rule_match(self, rule_match: RuleMatch) -> Mapping[str, Any]:
         result: Dict[str, Any] = {
@@ -75,7 +64,7 @@ class GitlabSastFormatter(BaseFormatter):
                     "type": "semgrep_type",
                     "name": f"Semgrep - {rule_match.rule_id}",
                     "value": rule_match.rule_id,
-                    "url": _construct_semgrep_rule_url(rule_match.rule_id),
+                    "url": rule_match.metadata.get("source"),
                 }
             ],
             "flags": [],

--- a/cli/src/semgrep/rule_match.py
+++ b/cli/src/semgrep/rule_match.py
@@ -13,7 +13,6 @@ from typing import Iterator
 from typing import List
 from typing import Optional
 from typing import Tuple
-from typing import TYPE_CHECKING
 from uuid import UUID
 
 from attrs import evolve
@@ -29,9 +28,6 @@ from semgrep.semgrep_interfaces.semgrep_output_v1 import Direct
 from semgrep.semgrep_interfaces.semgrep_output_v1 import Transitive
 from semgrep.semgrep_interfaces.semgrep_output_v1 import Transitivity
 from semgrep.util import get_lines
-
-if TYPE_CHECKING:
-    from semgrep.rule import Rule
 
 
 def rstrip(value: Optional[str]) -> Optional[str]:

--- a/cli/tests/e2e/rules/eqeq.yaml
+++ b/cli/tests/e2e/rules/eqeq.yaml
@@ -29,6 +29,7 @@ rules:
     severity: ERROR
     metadata:
       shortlink: https://sg.run/xyz1
+      source: https://semgrep.dev/r/eqeq-bad
   - id: python37-compatability-os-module
     patterns:
       - pattern-not-inside: |

--- a/cli/tests/e2e/snapshots/test_check/test_basic_rule__absolute/results.json
+++ b/cli/tests/e2e/snapshots/test_check/test_basic_rule__absolute/results.json
@@ -85,7 +85,8 @@
         "lines": "    return a + b == a + b",
         "message": "useless comparison operation `a + b == a + b` or `a + b != a + b`",
         "metadata": {
-          "shortlink": "https://sg.run/xyz1"
+          "shortlink": "https://sg.run/xyz1",
+          "source": "https://semgrep.dev/r/eqeq-bad"
         },
         "metavars": {
           "$X": {

--- a/cli/tests/e2e/snapshots/test_check/test_basic_rule__local/results.json
+++ b/cli/tests/e2e/snapshots/test_check/test_basic_rule__local/results.json
@@ -85,7 +85,8 @@
         "lines": "    return a + b == a + b",
         "message": "useless comparison operation `a + b == a + b` or `a + b != a + b`",
         "metadata": {
-          "shortlink": "https://sg.run/xyz1"
+          "shortlink": "https://sg.run/xyz1",
+          "source": "https://semgrep.dev/r/eqeq-bad"
         },
         "metavars": {
           "$X": {

--- a/cli/tests/e2e/snapshots/test_check/test_basic_rule__relative/results.json
+++ b/cli/tests/e2e/snapshots/test_check/test_basic_rule__relative/results.json
@@ -85,7 +85,8 @@
         "lines": "    return a + b == a + b",
         "message": "useless comparison operation `a + b == a + b` or `a + b != a + b`",
         "metadata": {
-          "shortlink": "https://sg.run/xyz1"
+          "shortlink": "https://sg.run/xyz1",
+          "source": "https://semgrep.dev/r/eqeq-bad"
         },
         "metavars": {
           "$X": {

--- a/cli/tests/e2e/snapshots/test_check/test_multiple_configs_different_origins/results.json
+++ b/cli/tests/e2e/snapshots/test_check/test_multiple_configs_different_origins/results.json
@@ -124,7 +124,8 @@
         "lines": "    return a + b == a + b",
         "message": "useless comparison operation `a + b == a + b` or `a + b != a + b`",
         "metadata": {
-          "shortlink": "https://sg.run/xyz1"
+          "shortlink": "https://sg.run/xyz1",
+          "source": "https://semgrep.dev/r/eqeq-bad"
         },
         "metavars": {
           "$X": {

--- a/cli/tests/e2e/snapshots/test_ci/test_dryrun/None/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_dryrun/None/results.txt
@@ -120,6 +120,7 @@ Would have sent findings and ignores blob: {
                 "dev.semgrep.actions": [
                     "block"
                 ],
+                "source": "https://semgrep.dev/r/taint-test",
                 "semgrep.dev": {
                     "rule": {
                         "rule_id": "abcf",
@@ -212,6 +213,7 @@ Would have sent findings and ignores blob: {
             "syntactic_id": "33cc4a1a63bda19779c4f4bd6491df4a",
             "metadata": {
                 "dev.semgrep.actions": [],
+                "source": "https://semgrep.dev/-/advisories/supply-chain1",
                 "sca-kind": "upgrade-only"
             },
             "is_blocking": false,
@@ -258,6 +260,7 @@ Would have sent findings and ignores blob: {
             "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
             "metadata": {
                 "dev.semgrep.actions": [],
+                "source": "https://semgrep.dev/r/abceversion1",
                 "semgrep.dev": {
                     "rule": {
                         "rule_id": "abce",
@@ -295,6 +298,7 @@ Would have sent findings and ignores blob: {
                 "dev.semgrep.actions": [
                     "block"
                 ],
+                "source": "https://semgrep.dev/r/eqeq-four",
                 "semgrep.dev": {
                     "rule": {
                         "rule_id": "abce",
@@ -329,6 +333,7 @@ Would have sent findings and ignores blob: {
             "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
             "metadata": {
                 "dev.semgrep.actions": [],
+                "source": "https://semgrep.dev/r/eqeq-five",
                 "semgrep.dev": {
                     "rule": {
                         "rule_id": "abcd",
@@ -361,7 +366,9 @@ Would have sent findings and ignores blob: {
             "index": 0,
             "commit_date": <MASKED>
             "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-            "metadata": {},
+            "metadata": {
+                "source": "https://semgrep.dev/r/eqeq-bad"
+            },
             "is_blocking": true,
             "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4",
             "hashes": {
@@ -384,7 +391,9 @@ Would have sent findings and ignores blob: {
             "index": 0,
             "commit_date": <MASKED>
             "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-            "metadata": {},
+            "metadata": {
+                "source": "https://semgrep.dev/r/eqeq-bad"
+            },
             "is_blocking": true,
             "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0",
             "hashes": {
@@ -407,7 +416,9 @@ Would have sent findings and ignores blob: {
             "index": 0,
             "commit_date": <MASKED>
             "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-            "metadata": {},
+            "metadata": {
+                "source": "https://semgrep.dev/r/eqeq-bad"
+            },
             "is_blocking": true,
             "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0",
             "hashes": {
@@ -430,7 +441,9 @@ Would have sent findings and ignores blob: {
             "index": 3,
             "commit_date": <MASKED>
             "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-            "metadata": {},
+            "metadata": {
+                "source": "https://semgrep.dev/r/eqeq-bad"
+            },
             "is_blocking": true,
             "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3",
             "hashes": {
@@ -453,7 +466,9 @@ Would have sent findings and ignores blob: {
             "index": 1,
             "commit_date": <MASKED>
             "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-            "metadata": {},
+            "metadata": {
+                "source": "https://semgrep.dev/r/eqeq-bad"
+            },
             "is_blocking": true,
             "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1",
             "hashes": {
@@ -476,7 +491,9 @@ Would have sent findings and ignores blob: {
             "index": 0,
             "commit_date": <MASKED>
             "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-            "metadata": {},
+            "metadata": {
+                "source": "https://semgrep.dev/r/eqeq-bad"
+            },
             "is_blocking": true,
             "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0",
             "hashes": {
@@ -503,6 +520,7 @@ Would have sent findings and ignores blob: {
             "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
             "metadata": {
                 "dev.semgrep.actions": [],
+                "source": "https://semgrep.dev/r/abceversion1",
                 "semgrep.dev": {
                     "rule": {
                         "rule_id": "abce",
@@ -540,6 +558,7 @@ Would have sent findings and ignores blob: {
                 "dev.semgrep.actions": [
                     "block"
                 ],
+                "source": "https://semgrep.dev/r/eqeq-four",
                 "semgrep.dev": {
                     "rule": {
                         "rule_id": "abce",
@@ -574,6 +593,7 @@ Would have sent findings and ignores blob: {
             "syntactic_id": "6ed37cfa23475cee444f54947efb9da4",
             "metadata": {
                 "dev.semgrep.actions": [],
+                "source": "https://semgrep.dev/r/eqeq-five",
                 "semgrep.dev": {
                     "rule": {
                         "rule_id": "abcd",
@@ -606,7 +626,9 @@ Would have sent findings and ignores blob: {
             "index": 0,
             "commit_date": <MASKED>
             "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-            "metadata": {},
+            "metadata": {
+                "source": "https://semgrep.dev/r/eqeq-bad"
+            },
             "is_blocking": true,
             "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0",
             "hashes": {
@@ -629,7 +651,9 @@ Would have sent findings and ignores blob: {
             "index": 0,
             "commit_date": <MASKED>
             "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-            "metadata": {},
+            "metadata": {
+                "source": "https://semgrep.dev/r/eqeq-bad"
+            },
             "is_blocking": true,
             "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0",
             "hashes": {
@@ -652,7 +676,9 @@ Would have sent findings and ignores blob: {
             "index": 2,
             "commit_date": <MASKED>
             "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-            "metadata": {},
+            "metadata": {
+                "source": "https://semgrep.dev/r/eqeq-bad"
+            },
             "is_blocking": true,
             "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2",
             "hashes": {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines-overwrite-autodetected-variables/findings_and_ignores.json
@@ -16,6 +16,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/taint-test",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcf",
@@ -108,6 +109,7 @@
       "syntactic_id": "33cc4a1a63bda19779c4f4bd6491df4a",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/-/advisories/supply-chain1",
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
@@ -154,6 +156,7 @@
       "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -191,6 +194,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -225,6 +229,7 @@
       "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -260,7 +265,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4",
       "hashes": {
@@ -283,7 +290,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0",
       "hashes": {
@@ -306,7 +315,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0",
       "hashes": {
@@ -329,7 +340,9 @@
       "index": 3,
       "commit_date": "sanitized",
       "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3",
       "hashes": {
@@ -352,7 +365,9 @@
       "index": 1,
       "commit_date": "sanitized",
       "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1",
       "hashes": {
@@ -375,7 +390,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0",
       "hashes": {
@@ -402,6 +419,7 @@
       "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -439,6 +457,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -473,6 +492,7 @@
       "syntactic_id": "6ed37cfa23475cee444f54947efb9da4",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -508,7 +528,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0",
       "hashes": {
@@ -531,7 +553,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0",
       "hashes": {
@@ -554,7 +578,9 @@
       "index": 2,
       "commit_date": "sanitized",
       "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2",
       "hashes": {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines/findings_and_ignores.json
@@ -16,6 +16,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/taint-test",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcf",
@@ -108,6 +109,7 @@
       "syntactic_id": "33cc4a1a63bda19779c4f4bd6491df4a",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/-/advisories/supply-chain1",
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
@@ -154,6 +156,7 @@
       "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -191,6 +194,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -225,6 +229,7 @@
       "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -260,7 +265,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4",
       "hashes": {
@@ -283,7 +290,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0",
       "hashes": {
@@ -306,7 +315,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0",
       "hashes": {
@@ -329,7 +340,9 @@
       "index": 3,
       "commit_date": "sanitized",
       "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3",
       "hashes": {
@@ -352,7 +365,9 @@
       "index": 1,
       "commit_date": "sanitized",
       "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1",
       "hashes": {
@@ -375,7 +390,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0",
       "hashes": {
@@ -402,6 +419,7 @@
       "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -439,6 +457,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -473,6 +492,7 @@
       "syntactic_id": "6ed37cfa23475cee444f54947efb9da4",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -508,7 +528,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0",
       "hashes": {
@@ -531,7 +553,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0",
       "hashes": {
@@ -554,7 +578,9 @@
       "index": 2,
       "commit_date": "sanitized",
       "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2",
       "hashes": {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket-overwrite-autodetected-variables/findings_and_ignores.json
@@ -16,6 +16,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/taint-test",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcf",
@@ -108,6 +109,7 @@
       "syntactic_id": "33cc4a1a63bda19779c4f4bd6491df4a",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/-/advisories/supply-chain1",
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
@@ -154,6 +156,7 @@
       "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -191,6 +194,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -225,6 +229,7 @@
       "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -260,7 +265,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4",
       "hashes": {
@@ -283,7 +290,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0",
       "hashes": {
@@ -306,7 +315,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0",
       "hashes": {
@@ -329,7 +340,9 @@
       "index": 3,
       "commit_date": "sanitized",
       "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3",
       "hashes": {
@@ -352,7 +365,9 @@
       "index": 1,
       "commit_date": "sanitized",
       "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1",
       "hashes": {
@@ -375,7 +390,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0",
       "hashes": {
@@ -402,6 +419,7 @@
       "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -439,6 +457,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -473,6 +492,7 @@
       "syntactic_id": "6ed37cfa23475cee444f54947efb9da4",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -508,7 +528,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0",
       "hashes": {
@@ -531,7 +553,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0",
       "hashes": {
@@ -554,7 +578,9 @@
       "index": 2,
       "commit_date": "sanitized",
       "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2",
       "hashes": {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket/findings_and_ignores.json
@@ -16,6 +16,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/taint-test",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcf",
@@ -108,6 +109,7 @@
       "syntactic_id": "33cc4a1a63bda19779c4f4bd6491df4a",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/-/advisories/supply-chain1",
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
@@ -154,6 +156,7 @@
       "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -191,6 +194,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -225,6 +229,7 @@
       "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -260,7 +265,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4",
       "hashes": {
@@ -283,7 +290,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0",
       "hashes": {
@@ -306,7 +315,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0",
       "hashes": {
@@ -329,7 +340,9 @@
       "index": 3,
       "commit_date": "sanitized",
       "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3",
       "hashes": {
@@ -352,7 +365,9 @@
       "index": 1,
       "commit_date": "sanitized",
       "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1",
       "hashes": {
@@ -375,7 +390,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0",
       "hashes": {
@@ -402,6 +419,7 @@
       "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -439,6 +457,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -473,6 +492,7 @@
       "syntactic_id": "6ed37cfa23475cee444f54947efb9da4",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -508,7 +528,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0",
       "hashes": {
@@ -531,7 +553,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0",
       "hashes": {
@@ -554,7 +578,9 @@
       "index": 2,
       "commit_date": "sanitized",
       "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2",
       "hashes": {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite-overwrite-autodetected-variables/findings_and_ignores.json
@@ -16,6 +16,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/taint-test",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcf",
@@ -108,6 +109,7 @@
       "syntactic_id": "33cc4a1a63bda19779c4f4bd6491df4a",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/-/advisories/supply-chain1",
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
@@ -154,6 +156,7 @@
       "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -191,6 +194,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -225,6 +229,7 @@
       "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -260,7 +265,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4",
       "hashes": {
@@ -283,7 +290,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0",
       "hashes": {
@@ -306,7 +315,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0",
       "hashes": {
@@ -329,7 +340,9 @@
       "index": 3,
       "commit_date": "sanitized",
       "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3",
       "hashes": {
@@ -352,7 +365,9 @@
       "index": 1,
       "commit_date": "sanitized",
       "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1",
       "hashes": {
@@ -375,7 +390,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0",
       "hashes": {
@@ -402,6 +419,7 @@
       "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -439,6 +457,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -473,6 +492,7 @@
       "syntactic_id": "6ed37cfa23475cee444f54947efb9da4",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -508,7 +528,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0",
       "hashes": {
@@ -531,7 +553,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0",
       "hashes": {
@@ -554,7 +578,9 @@
       "index": 2,
       "commit_date": "sanitized",
       "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2",
       "hashes": {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite/findings_and_ignores.json
@@ -16,6 +16,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/taint-test",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcf",
@@ -108,6 +109,7 @@
       "syntactic_id": "33cc4a1a63bda19779c4f4bd6491df4a",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/-/advisories/supply-chain1",
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
@@ -154,6 +156,7 @@
       "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -191,6 +194,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -225,6 +229,7 @@
       "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -260,7 +265,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4",
       "hashes": {
@@ -283,7 +290,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0",
       "hashes": {
@@ -306,7 +315,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0",
       "hashes": {
@@ -329,7 +340,9 @@
       "index": 3,
       "commit_date": "sanitized",
       "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3",
       "hashes": {
@@ -352,7 +365,9 @@
       "index": 1,
       "commit_date": "sanitized",
       "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1",
       "hashes": {
@@ -375,7 +390,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0",
       "hashes": {
@@ -402,6 +419,7 @@
       "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -439,6 +457,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -473,6 +492,7 @@
       "syntactic_id": "6ed37cfa23475cee444f54947efb9da4",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -508,7 +528,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0",
       "hashes": {
@@ -531,7 +553,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0",
       "hashes": {
@@ -554,7 +578,9 @@
       "index": 2,
       "commit_date": "sanitized",
       "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2",
       "hashes": {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci-overwrite-autodetected-variables/findings_and_ignores.json
@@ -16,6 +16,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/taint-test",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcf",
@@ -108,6 +109,7 @@
       "syntactic_id": "33cc4a1a63bda19779c4f4bd6491df4a",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/-/advisories/supply-chain1",
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
@@ -154,6 +156,7 @@
       "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -191,6 +194,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -225,6 +229,7 @@
       "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -260,7 +265,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4",
       "hashes": {
@@ -283,7 +290,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0",
       "hashes": {
@@ -306,7 +315,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0",
       "hashes": {
@@ -329,7 +340,9 @@
       "index": 3,
       "commit_date": "sanitized",
       "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3",
       "hashes": {
@@ -352,7 +365,9 @@
       "index": 1,
       "commit_date": "sanitized",
       "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1",
       "hashes": {
@@ -375,7 +390,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0",
       "hashes": {
@@ -402,6 +419,7 @@
       "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -439,6 +457,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -473,6 +492,7 @@
       "syntactic_id": "6ed37cfa23475cee444f54947efb9da4",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -508,7 +528,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0",
       "hashes": {
@@ -531,7 +553,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0",
       "hashes": {
@@ -554,7 +578,9 @@
       "index": 2,
       "commit_date": "sanitized",
       "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2",
       "hashes": {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci/findings_and_ignores.json
@@ -16,6 +16,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/taint-test",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcf",
@@ -108,6 +109,7 @@
       "syntactic_id": "33cc4a1a63bda19779c4f4bd6491df4a",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/-/advisories/supply-chain1",
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
@@ -154,6 +156,7 @@
       "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -191,6 +194,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -225,6 +229,7 @@
       "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -260,7 +265,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4",
       "hashes": {
@@ -283,7 +290,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0",
       "hashes": {
@@ -306,7 +315,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0",
       "hashes": {
@@ -329,7 +340,9 @@
       "index": 3,
       "commit_date": "sanitized",
       "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3",
       "hashes": {
@@ -352,7 +365,9 @@
       "index": 1,
       "commit_date": "sanitized",
       "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1",
       "hashes": {
@@ -375,7 +390,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0",
       "hashes": {
@@ -402,6 +419,7 @@
       "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -439,6 +457,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -473,6 +492,7 @@
       "syntactic_id": "6ed37cfa23475cee444f54947efb9da4",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -508,7 +528,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0",
       "hashes": {
@@ -531,7 +553,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0",
       "hashes": {
@@ -554,7 +578,9 @@
       "index": 2,
       "commit_date": "sanitized",
       "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2",
       "hashes": {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/findings_and_ignores.json
@@ -16,6 +16,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/taint-test",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcf",
@@ -108,6 +109,7 @@
       "syntactic_id": "33cc4a1a63bda19779c4f4bd6491df4a",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/-/advisories/supply-chain1",
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
@@ -154,6 +156,7 @@
       "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -191,6 +194,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -225,6 +229,7 @@
       "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -260,7 +265,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4",
       "hashes": {
@@ -283,7 +290,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0",
       "hashes": {
@@ -306,7 +315,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0",
       "hashes": {
@@ -329,7 +340,9 @@
       "index": 3,
       "commit_date": "sanitized",
       "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3",
       "hashes": {
@@ -352,7 +365,9 @@
       "index": 1,
       "commit_date": "sanitized",
       "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1",
       "hashes": {
@@ -375,7 +390,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0",
       "hashes": {
@@ -402,6 +419,7 @@
       "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -439,6 +457,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -473,6 +492,7 @@
       "syntactic_id": "6ed37cfa23475cee444f54947efb9da4",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -508,7 +528,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0",
       "hashes": {
@@ -531,7 +553,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0",
       "hashes": {
@@ -554,7 +578,9 @@
       "index": 2,
       "commit_date": "sanitized",
       "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2",
       "hashes": {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr-semgrepconfig/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr-semgrepconfig/findings_and_ignores.json
@@ -16,6 +16,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/taint-test",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcf",
@@ -108,6 +109,7 @@
       "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -145,6 +147,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -179,6 +182,7 @@
       "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -214,7 +218,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4",
       "hashes": {
@@ -237,7 +243,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0",
       "hashes": {
@@ -260,7 +268,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0",
       "hashes": {
@@ -283,7 +293,9 @@
       "index": 3,
       "commit_date": "sanitized",
       "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3",
       "hashes": {
@@ -306,7 +318,9 @@
       "index": 1,
       "commit_date": "sanitized",
       "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1",
       "hashes": {
@@ -329,7 +343,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0",
       "hashes": {
@@ -356,6 +372,7 @@
       "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -393,6 +410,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -427,6 +445,7 @@
       "syntactic_id": "6ed37cfa23475cee444f54947efb9da4",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -462,7 +481,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0",
       "hashes": {
@@ -485,7 +506,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0",
       "hashes": {
@@ -508,7 +531,9 @@
       "index": 2,
       "commit_date": "sanitized",
       "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2",
       "hashes": {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr/findings_and_ignores.json
@@ -16,6 +16,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/taint-test",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcf",
@@ -108,6 +109,7 @@
       "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -145,6 +147,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -179,6 +182,7 @@
       "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -214,7 +218,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4",
       "hashes": {
@@ -237,7 +243,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0",
       "hashes": {
@@ -260,7 +268,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0",
       "hashes": {
@@ -283,7 +293,9 @@
       "index": 3,
       "commit_date": "sanitized",
       "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3",
       "hashes": {
@@ -306,7 +318,9 @@
       "index": 1,
       "commit_date": "sanitized",
       "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1",
       "hashes": {
@@ -329,7 +343,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0",
       "hashes": {
@@ -356,6 +372,7 @@
       "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -393,6 +410,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -427,6 +445,7 @@
       "syntactic_id": "6ed37cfa23475cee444f54947efb9da4",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -462,7 +481,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0",
       "hashes": {
@@ -485,7 +506,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0",
       "hashes": {
@@ -508,7 +531,9 @@
       "index": 2,
       "commit_date": "sanitized",
       "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2",
       "hashes": {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push-special-env-vars/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push-special-env-vars/findings_and_ignores.json
@@ -16,6 +16,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/taint-test",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcf",
@@ -108,6 +109,7 @@
       "syntactic_id": "33cc4a1a63bda19779c4f4bd6491df4a",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/-/advisories/supply-chain1",
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
@@ -154,6 +156,7 @@
       "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -191,6 +194,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -225,6 +229,7 @@
       "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -260,7 +265,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4",
       "hashes": {
@@ -283,7 +290,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0",
       "hashes": {
@@ -306,7 +315,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0",
       "hashes": {
@@ -329,7 +340,9 @@
       "index": 3,
       "commit_date": "sanitized",
       "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3",
       "hashes": {
@@ -352,7 +365,9 @@
       "index": 1,
       "commit_date": "sanitized",
       "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1",
       "hashes": {
@@ -375,7 +390,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0",
       "hashes": {
@@ -402,6 +419,7 @@
       "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -439,6 +457,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -473,6 +492,7 @@
       "syntactic_id": "6ed37cfa23475cee444f54947efb9da4",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -508,7 +528,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0",
       "hashes": {
@@ -531,7 +553,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0",
       "hashes": {
@@ -554,7 +578,9 @@
       "index": 2,
       "commit_date": "sanitized",
       "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2",
       "hashes": {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/findings_and_ignores.json
@@ -16,6 +16,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/taint-test",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcf",
@@ -108,6 +109,7 @@
       "syntactic_id": "33cc4a1a63bda19779c4f4bd6491df4a",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/-/advisories/supply-chain1",
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
@@ -154,6 +156,7 @@
       "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -191,6 +194,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -225,6 +229,7 @@
       "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -260,7 +265,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4",
       "hashes": {
@@ -283,7 +290,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0",
       "hashes": {
@@ -306,7 +315,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0",
       "hashes": {
@@ -329,7 +340,9 @@
       "index": 3,
       "commit_date": "sanitized",
       "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3",
       "hashes": {
@@ -352,7 +365,9 @@
       "index": 1,
       "commit_date": "sanitized",
       "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1",
       "hashes": {
@@ -375,7 +390,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0",
       "hashes": {
@@ -402,6 +419,7 @@
       "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -439,6 +457,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -473,6 +492,7 @@
       "syntactic_id": "6ed37cfa23475cee444f54947efb9da4",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -508,7 +528,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0",
       "hashes": {
@@ -531,7 +553,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0",
       "hashes": {
@@ -554,7 +578,9 @@
       "index": 2,
       "commit_date": "sanitized",
       "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2",
       "hashes": {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-push/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-push/findings_and_ignores.json
@@ -16,6 +16,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/taint-test",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcf",
@@ -108,6 +109,7 @@
       "syntactic_id": "33cc4a1a63bda19779c4f4bd6491df4a",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/-/advisories/supply-chain1",
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
@@ -154,6 +156,7 @@
       "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -191,6 +194,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -225,6 +229,7 @@
       "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -260,7 +265,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4",
       "hashes": {
@@ -283,7 +290,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0",
       "hashes": {
@@ -306,7 +315,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0",
       "hashes": {
@@ -329,7 +340,9 @@
       "index": 3,
       "commit_date": "sanitized",
       "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3",
       "hashes": {
@@ -352,7 +365,9 @@
       "index": 1,
       "commit_date": "sanitized",
       "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1",
       "hashes": {
@@ -375,7 +390,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0",
       "hashes": {
@@ -402,6 +419,7 @@
       "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -439,6 +457,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -473,6 +492,7 @@
       "syntactic_id": "6ed37cfa23475cee444f54947efb9da4",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -508,7 +528,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0",
       "hashes": {
@@ -531,7 +553,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0",
       "hashes": {
@@ -554,7 +578,9 @@
       "index": 2,
       "commit_date": "sanitized",
       "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2",
       "hashes": {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-special-env-vars/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-special-env-vars/findings_and_ignores.json
@@ -16,6 +16,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/taint-test",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcf",
@@ -108,6 +109,7 @@
       "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -145,6 +147,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -179,6 +182,7 @@
       "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -214,7 +218,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4",
       "hashes": {
@@ -237,7 +243,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0",
       "hashes": {
@@ -260,7 +268,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0",
       "hashes": {
@@ -283,7 +293,9 @@
       "index": 3,
       "commit_date": "sanitized",
       "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3",
       "hashes": {
@@ -306,7 +318,9 @@
       "index": 1,
       "commit_date": "sanitized",
       "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1",
       "hashes": {
@@ -329,7 +343,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0",
       "hashes": {
@@ -356,6 +372,7 @@
       "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -393,6 +410,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -427,6 +445,7 @@
       "syntactic_id": "6ed37cfa23475cee444f54947efb9da4",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -462,7 +481,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0",
       "hashes": {
@@ -485,7 +506,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0",
       "hashes": {
@@ -508,7 +531,9 @@
       "index": 2,
       "commit_date": "sanitized",
       "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2",
       "hashes": {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab/findings_and_ignores.json
@@ -16,6 +16,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/taint-test",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcf",
@@ -108,6 +109,7 @@
       "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -145,6 +147,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -179,6 +182,7 @@
       "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -214,7 +218,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4",
       "hashes": {
@@ -237,7 +243,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0",
       "hashes": {
@@ -260,7 +268,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0",
       "hashes": {
@@ -283,7 +293,9 @@
       "index": 3,
       "commit_date": "sanitized",
       "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3",
       "hashes": {
@@ -306,7 +318,9 @@
       "index": 1,
       "commit_date": "sanitized",
       "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1",
       "hashes": {
@@ -329,7 +343,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0",
       "hashes": {
@@ -356,6 +372,7 @@
       "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -393,6 +410,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -427,6 +445,7 @@
       "syntactic_id": "6ed37cfa23475cee444f54947efb9da4",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -462,7 +481,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0",
       "hashes": {
@@ -485,7 +506,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0",
       "hashes": {
@@ -508,7 +531,9 @@
       "index": 2,
       "commit_date": "sanitized",
       "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2",
       "hashes": {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/findings_and_ignores.json
@@ -16,6 +16,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/taint-test",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcf",
@@ -108,6 +109,7 @@
       "syntactic_id": "33cc4a1a63bda19779c4f4bd6491df4a",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/-/advisories/supply-chain1",
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
@@ -154,6 +156,7 @@
       "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -191,6 +194,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -225,6 +229,7 @@
       "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -260,7 +265,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4",
       "hashes": {
@@ -283,7 +290,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0",
       "hashes": {
@@ -306,7 +315,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0",
       "hashes": {
@@ -329,7 +340,9 @@
       "index": 3,
       "commit_date": "sanitized",
       "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3",
       "hashes": {
@@ -352,7 +365,9 @@
       "index": 1,
       "commit_date": "sanitized",
       "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1",
       "hashes": {
@@ -375,7 +390,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0",
       "hashes": {
@@ -402,6 +419,7 @@
       "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -439,6 +457,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -473,6 +492,7 @@
       "syntactic_id": "6ed37cfa23475cee444f54947efb9da4",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -508,7 +528,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0",
       "hashes": {
@@ -531,7 +553,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0",
       "hashes": {
@@ -554,7 +578,9 @@
       "index": 2,
       "commit_date": "sanitized",
       "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2",
       "hashes": {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-overwrite-autodetected-variables/findings_and_ignores.json
@@ -16,6 +16,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/taint-test",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcf",
@@ -108,6 +109,7 @@
       "syntactic_id": "33cc4a1a63bda19779c4f4bd6491df4a",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/-/advisories/supply-chain1",
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
@@ -154,6 +156,7 @@
       "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -191,6 +194,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -225,6 +229,7 @@
       "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -260,7 +265,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4",
       "hashes": {
@@ -283,7 +290,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0",
       "hashes": {
@@ -306,7 +315,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0",
       "hashes": {
@@ -329,7 +340,9 @@
       "index": 3,
       "commit_date": "sanitized",
       "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3",
       "hashes": {
@@ -352,7 +365,9 @@
       "index": 1,
       "commit_date": "sanitized",
       "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1",
       "hashes": {
@@ -375,7 +390,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0",
       "hashes": {
@@ -402,6 +419,7 @@
       "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -439,6 +457,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -473,6 +492,7 @@
       "syntactic_id": "6ed37cfa23475cee444f54947efb9da4",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -508,7 +528,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0",
       "hashes": {
@@ -531,7 +553,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0",
       "hashes": {
@@ -554,7 +578,9 @@
       "index": 2,
       "commit_date": "sanitized",
       "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2",
       "hashes": {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins/findings_and_ignores.json
@@ -16,6 +16,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/taint-test",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcf",
@@ -108,6 +109,7 @@
       "syntactic_id": "33cc4a1a63bda19779c4f4bd6491df4a",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/-/advisories/supply-chain1",
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
@@ -154,6 +156,7 @@
       "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -191,6 +194,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -225,6 +229,7 @@
       "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -260,7 +265,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4",
       "hashes": {
@@ -283,7 +290,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0",
       "hashes": {
@@ -306,7 +315,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0",
       "hashes": {
@@ -329,7 +340,9 @@
       "index": 3,
       "commit_date": "sanitized",
       "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3",
       "hashes": {
@@ -352,7 +365,9 @@
       "index": 1,
       "commit_date": "sanitized",
       "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1",
       "hashes": {
@@ -375,7 +390,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0",
       "hashes": {
@@ -402,6 +419,7 @@
       "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -439,6 +457,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -473,6 +492,7 @@
       "syntactic_id": "6ed37cfa23475cee444f54947efb9da4",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -508,7 +528,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0",
       "hashes": {
@@ -531,7 +553,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0",
       "hashes": {
@@ -554,7 +578,9 @@
       "index": 2,
       "commit_date": "sanitized",
       "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2",
       "hashes": {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/findings_and_ignores.json
@@ -16,6 +16,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/taint-test",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcf",
@@ -108,6 +109,7 @@
       "syntactic_id": "33cc4a1a63bda19779c4f4bd6491df4a",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/-/advisories/supply-chain1",
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
@@ -154,6 +156,7 @@
       "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -191,6 +194,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -225,6 +229,7 @@
       "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -260,7 +265,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4",
       "hashes": {
@@ -283,7 +290,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0",
       "hashes": {
@@ -306,7 +315,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0",
       "hashes": {
@@ -329,7 +340,9 @@
       "index": 3,
       "commit_date": "sanitized",
       "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3",
       "hashes": {
@@ -352,7 +365,9 @@
       "index": 1,
       "commit_date": "sanitized",
       "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1",
       "hashes": {
@@ -375,7 +390,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0",
       "hashes": {
@@ -402,6 +419,7 @@
       "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -439,6 +457,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -473,6 +492,7 @@
       "syntactic_id": "6ed37cfa23475cee444f54947efb9da4",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -508,7 +528,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0",
       "hashes": {
@@ -531,7 +553,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0",
       "hashes": {
@@ -554,7 +578,9 @@
       "index": 2,
       "commit_date": "sanitized",
       "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2",
       "hashes": {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-self-hosted/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-self-hosted/findings_and_ignores.json
@@ -16,6 +16,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/taint-test",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcf",
@@ -108,6 +109,7 @@
       "syntactic_id": "33cc4a1a63bda19779c4f4bd6491df4a",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/-/advisories/supply-chain1",
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
@@ -154,6 +156,7 @@
       "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -191,6 +194,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -225,6 +229,7 @@
       "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -260,7 +265,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4",
       "hashes": {
@@ -283,7 +290,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0",
       "hashes": {
@@ -306,7 +315,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0",
       "hashes": {
@@ -329,7 +340,9 @@
       "index": 3,
       "commit_date": "sanitized",
       "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3",
       "hashes": {
@@ -352,7 +365,9 @@
       "index": 1,
       "commit_date": "sanitized",
       "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1",
       "hashes": {
@@ -375,7 +390,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0",
       "hashes": {
@@ -402,6 +419,7 @@
       "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -439,6 +457,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -473,6 +492,7 @@
       "syntactic_id": "6ed37cfa23475cee444f54947efb9da4",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -508,7 +528,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0",
       "hashes": {
@@ -531,7 +553,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0",
       "hashes": {
@@ -554,7 +578,9 @@
       "index": 2,
       "commit_date": "sanitized",
       "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2",
       "hashes": {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis-overwrite-autodetected-variables/findings_and_ignores.json
@@ -16,6 +16,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/taint-test",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcf",
@@ -108,6 +109,7 @@
       "syntactic_id": "33cc4a1a63bda19779c4f4bd6491df4a",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/-/advisories/supply-chain1",
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
@@ -154,6 +156,7 @@
       "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -191,6 +194,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -225,6 +229,7 @@
       "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -260,7 +265,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4",
       "hashes": {
@@ -283,7 +290,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0",
       "hashes": {
@@ -306,7 +315,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0",
       "hashes": {
@@ -329,7 +340,9 @@
       "index": 3,
       "commit_date": "sanitized",
       "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3",
       "hashes": {
@@ -352,7 +365,9 @@
       "index": 1,
       "commit_date": "sanitized",
       "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1",
       "hashes": {
@@ -375,7 +390,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0",
       "hashes": {
@@ -402,6 +419,7 @@
       "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -439,6 +457,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -473,6 +492,7 @@
       "syntactic_id": "6ed37cfa23475cee444f54947efb9da4",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -508,7 +528,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0",
       "hashes": {
@@ -531,7 +553,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0",
       "hashes": {
@@ -554,7 +578,9 @@
       "index": 2,
       "commit_date": "sanitized",
       "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2",
       "hashes": {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis/findings_and_ignores.json
@@ -16,6 +16,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/taint-test",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcf",
@@ -108,6 +109,7 @@
       "syntactic_id": "33cc4a1a63bda19779c4f4bd6491df4a",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/-/advisories/supply-chain1",
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
@@ -154,6 +156,7 @@
       "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -191,6 +194,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -225,6 +229,7 @@
       "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -260,7 +265,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4",
       "hashes": {
@@ -283,7 +290,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0",
       "hashes": {
@@ -306,7 +315,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0",
       "hashes": {
@@ -329,7 +340,9 @@
       "index": 3,
       "commit_date": "sanitized",
       "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3",
       "hashes": {
@@ -352,7 +365,9 @@
       "index": 1,
       "commit_date": "sanitized",
       "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1",
       "hashes": {
@@ -375,7 +390,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0",
       "hashes": {
@@ -402,6 +419,7 @@
       "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -439,6 +457,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -473,6 +492,7 @@
       "syntactic_id": "6ed37cfa23475cee444f54947efb9da4",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -508,7 +528,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0",
       "hashes": {
@@ -531,7 +553,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0",
       "hashes": {
@@ -554,7 +578,9 @@
       "index": 2,
       "commit_date": "sanitized",
       "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2",
       "hashes": {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-unparsable_url/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-unparsable_url/findings_and_ignores.json
@@ -16,6 +16,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/taint-test",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcf",
@@ -108,6 +109,7 @@
       "syntactic_id": "33cc4a1a63bda19779c4f4bd6491df4a",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/-/advisories/supply-chain1",
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
@@ -154,6 +156,7 @@
       "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -191,6 +194,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -225,6 +229,7 @@
       "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -260,7 +265,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4",
       "hashes": {
@@ -283,7 +290,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0",
       "hashes": {
@@ -306,7 +315,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0",
       "hashes": {
@@ -329,7 +340,9 @@
       "index": 3,
       "commit_date": "sanitized",
       "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3",
       "hashes": {
@@ -352,7 +365,9 @@
       "index": 1,
       "commit_date": "sanitized",
       "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1",
       "hashes": {
@@ -375,7 +390,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0",
       "hashes": {
@@ -402,6 +419,7 @@
       "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -439,6 +457,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -473,6 +492,7 @@
       "syntactic_id": "6ed37cfa23475cee444f54947efb9da4",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -508,7 +528,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0",
       "hashes": {
@@ -531,7 +553,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0",
       "hashes": {
@@ -554,7 +578,9 @@
       "index": 2,
       "commit_date": "sanitized",
       "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2",
       "hashes": {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines-overwrite-autodetected-variables/findings_and_ignores.json
@@ -16,6 +16,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/taint-test",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcf",
@@ -108,6 +109,7 @@
       "syntactic_id": "33cc4a1a63bda19779c4f4bd6491df4a",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/-/advisories/supply-chain1",
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
@@ -154,6 +156,7 @@
       "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -191,6 +194,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -225,6 +229,7 @@
       "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -257,7 +262,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4",
       "hashes": {
@@ -280,7 +287,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0",
       "hashes": {
@@ -303,7 +312,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0",
       "hashes": {
@@ -326,7 +337,9 @@
       "index": 3,
       "commit_date": "sanitized",
       "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3",
       "hashes": {
@@ -349,7 +362,9 @@
       "index": 1,
       "commit_date": "sanitized",
       "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1",
       "hashes": {
@@ -372,7 +387,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0",
       "hashes": {
@@ -399,6 +416,7 @@
       "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -436,6 +454,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -470,6 +489,7 @@
       "syntactic_id": "6ed37cfa23475cee444f54947efb9da4",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -502,7 +522,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0",
       "hashes": {
@@ -525,7 +547,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0",
       "hashes": {
@@ -548,7 +572,9 @@
       "index": 2,
       "commit_date": "sanitized",
       "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2",
       "hashes": {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines/findings_and_ignores.json
@@ -16,6 +16,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/taint-test",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcf",
@@ -108,6 +109,7 @@
       "syntactic_id": "33cc4a1a63bda19779c4f4bd6491df4a",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/-/advisories/supply-chain1",
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
@@ -154,6 +156,7 @@
       "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -191,6 +194,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -225,6 +229,7 @@
       "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -257,7 +262,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4",
       "hashes": {
@@ -280,7 +287,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0",
       "hashes": {
@@ -303,7 +312,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0",
       "hashes": {
@@ -326,7 +337,9 @@
       "index": 3,
       "commit_date": "sanitized",
       "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3",
       "hashes": {
@@ -349,7 +362,9 @@
       "index": 1,
       "commit_date": "sanitized",
       "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1",
       "hashes": {
@@ -372,7 +387,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0",
       "hashes": {
@@ -399,6 +416,7 @@
       "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -436,6 +454,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -470,6 +489,7 @@
       "syntactic_id": "6ed37cfa23475cee444f54947efb9da4",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -502,7 +522,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0",
       "hashes": {
@@ -525,7 +547,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0",
       "hashes": {
@@ -548,7 +572,9 @@
       "index": 2,
       "commit_date": "sanitized",
       "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2",
       "hashes": {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket-overwrite-autodetected-variables/findings_and_ignores.json
@@ -16,6 +16,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/taint-test",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcf",
@@ -108,6 +109,7 @@
       "syntactic_id": "33cc4a1a63bda19779c4f4bd6491df4a",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/-/advisories/supply-chain1",
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
@@ -154,6 +156,7 @@
       "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -191,6 +194,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -225,6 +229,7 @@
       "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -257,7 +262,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4",
       "hashes": {
@@ -280,7 +287,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0",
       "hashes": {
@@ -303,7 +312,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0",
       "hashes": {
@@ -326,7 +337,9 @@
       "index": 3,
       "commit_date": "sanitized",
       "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3",
       "hashes": {
@@ -349,7 +362,9 @@
       "index": 1,
       "commit_date": "sanitized",
       "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1",
       "hashes": {
@@ -372,7 +387,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0",
       "hashes": {
@@ -399,6 +416,7 @@
       "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -436,6 +454,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -470,6 +489,7 @@
       "syntactic_id": "6ed37cfa23475cee444f54947efb9da4",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -502,7 +522,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0",
       "hashes": {
@@ -525,7 +547,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0",
       "hashes": {
@@ -548,7 +572,9 @@
       "index": 2,
       "commit_date": "sanitized",
       "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2",
       "hashes": {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket/findings_and_ignores.json
@@ -16,6 +16,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/taint-test",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcf",
@@ -108,6 +109,7 @@
       "syntactic_id": "33cc4a1a63bda19779c4f4bd6491df4a",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/-/advisories/supply-chain1",
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
@@ -154,6 +156,7 @@
       "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -191,6 +194,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -225,6 +229,7 @@
       "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -257,7 +262,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4",
       "hashes": {
@@ -280,7 +287,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0",
       "hashes": {
@@ -303,7 +312,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0",
       "hashes": {
@@ -326,7 +337,9 @@
       "index": 3,
       "commit_date": "sanitized",
       "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3",
       "hashes": {
@@ -349,7 +362,9 @@
       "index": 1,
       "commit_date": "sanitized",
       "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1",
       "hashes": {
@@ -372,7 +387,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0",
       "hashes": {
@@ -399,6 +416,7 @@
       "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -436,6 +454,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -470,6 +489,7 @@
       "syntactic_id": "6ed37cfa23475cee444f54947efb9da4",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -502,7 +522,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0",
       "hashes": {
@@ -525,7 +547,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0",
       "hashes": {
@@ -548,7 +572,9 @@
       "index": 2,
       "commit_date": "sanitized",
       "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2",
       "hashes": {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite-overwrite-autodetected-variables/findings_and_ignores.json
@@ -16,6 +16,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/taint-test",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcf",
@@ -108,6 +109,7 @@
       "syntactic_id": "33cc4a1a63bda19779c4f4bd6491df4a",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/-/advisories/supply-chain1",
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
@@ -154,6 +156,7 @@
       "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -191,6 +194,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -225,6 +229,7 @@
       "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -257,7 +262,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4",
       "hashes": {
@@ -280,7 +287,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0",
       "hashes": {
@@ -303,7 +312,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0",
       "hashes": {
@@ -326,7 +337,9 @@
       "index": 3,
       "commit_date": "sanitized",
       "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3",
       "hashes": {
@@ -349,7 +362,9 @@
       "index": 1,
       "commit_date": "sanitized",
       "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1",
       "hashes": {
@@ -372,7 +387,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0",
       "hashes": {
@@ -399,6 +416,7 @@
       "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -436,6 +454,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -470,6 +489,7 @@
       "syntactic_id": "6ed37cfa23475cee444f54947efb9da4",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -502,7 +522,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0",
       "hashes": {
@@ -525,7 +547,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0",
       "hashes": {
@@ -548,7 +572,9 @@
       "index": 2,
       "commit_date": "sanitized",
       "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2",
       "hashes": {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite/findings_and_ignores.json
@@ -16,6 +16,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/taint-test",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcf",
@@ -108,6 +109,7 @@
       "syntactic_id": "33cc4a1a63bda19779c4f4bd6491df4a",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/-/advisories/supply-chain1",
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
@@ -154,6 +156,7 @@
       "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -191,6 +194,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -225,6 +229,7 @@
       "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -257,7 +262,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4",
       "hashes": {
@@ -280,7 +287,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0",
       "hashes": {
@@ -303,7 +312,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0",
       "hashes": {
@@ -326,7 +337,9 @@
       "index": 3,
       "commit_date": "sanitized",
       "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3",
       "hashes": {
@@ -349,7 +362,9 @@
       "index": 1,
       "commit_date": "sanitized",
       "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1",
       "hashes": {
@@ -372,7 +387,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0",
       "hashes": {
@@ -399,6 +416,7 @@
       "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -436,6 +454,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -470,6 +489,7 @@
       "syntactic_id": "6ed37cfa23475cee444f54947efb9da4",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -502,7 +522,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0",
       "hashes": {
@@ -525,7 +547,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0",
       "hashes": {
@@ -548,7 +572,9 @@
       "index": 2,
       "commit_date": "sanitized",
       "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2",
       "hashes": {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci-overwrite-autodetected-variables/findings_and_ignores.json
@@ -16,6 +16,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/taint-test",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcf",
@@ -108,6 +109,7 @@
       "syntactic_id": "33cc4a1a63bda19779c4f4bd6491df4a",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/-/advisories/supply-chain1",
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
@@ -154,6 +156,7 @@
       "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -191,6 +194,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -225,6 +229,7 @@
       "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -257,7 +262,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4",
       "hashes": {
@@ -280,7 +287,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0",
       "hashes": {
@@ -303,7 +312,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0",
       "hashes": {
@@ -326,7 +337,9 @@
       "index": 3,
       "commit_date": "sanitized",
       "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3",
       "hashes": {
@@ -349,7 +362,9 @@
       "index": 1,
       "commit_date": "sanitized",
       "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1",
       "hashes": {
@@ -372,7 +387,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0",
       "hashes": {
@@ -399,6 +416,7 @@
       "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -436,6 +454,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -470,6 +489,7 @@
       "syntactic_id": "6ed37cfa23475cee444f54947efb9da4",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -502,7 +522,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0",
       "hashes": {
@@ -525,7 +547,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0",
       "hashes": {
@@ -548,7 +572,9 @@
       "index": 2,
       "commit_date": "sanitized",
       "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2",
       "hashes": {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci/findings_and_ignores.json
@@ -16,6 +16,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/taint-test",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcf",
@@ -108,6 +109,7 @@
       "syntactic_id": "33cc4a1a63bda19779c4f4bd6491df4a",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/-/advisories/supply-chain1",
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
@@ -154,6 +156,7 @@
       "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -191,6 +194,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -225,6 +229,7 @@
       "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -257,7 +262,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4",
       "hashes": {
@@ -280,7 +287,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0",
       "hashes": {
@@ -303,7 +312,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0",
       "hashes": {
@@ -326,7 +337,9 @@
       "index": 3,
       "commit_date": "sanitized",
       "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3",
       "hashes": {
@@ -349,7 +362,9 @@
       "index": 1,
       "commit_date": "sanitized",
       "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1",
       "hashes": {
@@ -372,7 +387,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0",
       "hashes": {
@@ -399,6 +416,7 @@
       "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -436,6 +454,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -470,6 +489,7 @@
       "syntactic_id": "6ed37cfa23475cee444f54947efb9da4",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -502,7 +522,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0",
       "hashes": {
@@ -525,7 +547,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0",
       "hashes": {
@@ -548,7 +572,9 @@
       "index": 2,
       "commit_date": "sanitized",
       "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2",
       "hashes": {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/findings_and_ignores.json
@@ -16,6 +16,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/taint-test",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcf",
@@ -108,6 +109,7 @@
       "syntactic_id": "33cc4a1a63bda19779c4f4bd6491df4a",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/-/advisories/supply-chain1",
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
@@ -154,6 +156,7 @@
       "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -191,6 +194,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -225,6 +229,7 @@
       "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -257,7 +262,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4",
       "hashes": {
@@ -280,7 +287,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0",
       "hashes": {
@@ -303,7 +312,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0",
       "hashes": {
@@ -326,7 +337,9 @@
       "index": 3,
       "commit_date": "sanitized",
       "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3",
       "hashes": {
@@ -349,7 +362,9 @@
       "index": 1,
       "commit_date": "sanitized",
       "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1",
       "hashes": {
@@ -372,7 +387,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0",
       "hashes": {
@@ -399,6 +416,7 @@
       "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -436,6 +454,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -470,6 +489,7 @@
       "syntactic_id": "6ed37cfa23475cee444f54947efb9da4",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -502,7 +522,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0",
       "hashes": {
@@ -525,7 +547,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0",
       "hashes": {
@@ -548,7 +572,9 @@
       "index": 2,
       "commit_date": "sanitized",
       "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2",
       "hashes": {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr-semgrepconfig/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr-semgrepconfig/findings_and_ignores.json
@@ -16,6 +16,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/taint-test",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcf",
@@ -108,6 +109,7 @@
       "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -145,6 +147,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -179,6 +182,7 @@
       "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -211,7 +215,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4",
       "hashes": {
@@ -234,7 +240,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0",
       "hashes": {
@@ -257,7 +265,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0",
       "hashes": {
@@ -280,7 +290,9 @@
       "index": 3,
       "commit_date": "sanitized",
       "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3",
       "hashes": {
@@ -303,7 +315,9 @@
       "index": 1,
       "commit_date": "sanitized",
       "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1",
       "hashes": {
@@ -326,7 +340,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0",
       "hashes": {
@@ -353,6 +369,7 @@
       "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -390,6 +407,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -424,6 +442,7 @@
       "syntactic_id": "6ed37cfa23475cee444f54947efb9da4",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -456,7 +475,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0",
       "hashes": {
@@ -479,7 +500,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0",
       "hashes": {
@@ -502,7 +525,9 @@
       "index": 2,
       "commit_date": "sanitized",
       "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2",
       "hashes": {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr/findings_and_ignores.json
@@ -16,6 +16,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/taint-test",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcf",
@@ -108,6 +109,7 @@
       "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -145,6 +147,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -179,6 +182,7 @@
       "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -211,7 +215,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4",
       "hashes": {
@@ -234,7 +240,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0",
       "hashes": {
@@ -257,7 +265,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0",
       "hashes": {
@@ -280,7 +290,9 @@
       "index": 3,
       "commit_date": "sanitized",
       "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3",
       "hashes": {
@@ -303,7 +315,9 @@
       "index": 1,
       "commit_date": "sanitized",
       "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1",
       "hashes": {
@@ -326,7 +340,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0",
       "hashes": {
@@ -353,6 +369,7 @@
       "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -390,6 +407,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -424,6 +442,7 @@
       "syntactic_id": "6ed37cfa23475cee444f54947efb9da4",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -456,7 +475,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0",
       "hashes": {
@@ -479,7 +500,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0",
       "hashes": {
@@ -502,7 +525,9 @@
       "index": 2,
       "commit_date": "sanitized",
       "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2",
       "hashes": {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push-special-env-vars/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push-special-env-vars/findings_and_ignores.json
@@ -16,6 +16,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/taint-test",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcf",
@@ -108,6 +109,7 @@
       "syntactic_id": "33cc4a1a63bda19779c4f4bd6491df4a",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/-/advisories/supply-chain1",
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
@@ -154,6 +156,7 @@
       "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -191,6 +194,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -225,6 +229,7 @@
       "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -257,7 +262,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4",
       "hashes": {
@@ -280,7 +287,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0",
       "hashes": {
@@ -303,7 +312,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0",
       "hashes": {
@@ -326,7 +337,9 @@
       "index": 3,
       "commit_date": "sanitized",
       "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3",
       "hashes": {
@@ -349,7 +362,9 @@
       "index": 1,
       "commit_date": "sanitized",
       "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1",
       "hashes": {
@@ -372,7 +387,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0",
       "hashes": {
@@ -399,6 +416,7 @@
       "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -436,6 +454,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -470,6 +489,7 @@
       "syntactic_id": "6ed37cfa23475cee444f54947efb9da4",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -502,7 +522,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0",
       "hashes": {
@@ -525,7 +547,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0",
       "hashes": {
@@ -548,7 +572,9 @@
       "index": 2,
       "commit_date": "sanitized",
       "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2",
       "hashes": {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/findings_and_ignores.json
@@ -16,6 +16,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/taint-test",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcf",
@@ -108,6 +109,7 @@
       "syntactic_id": "33cc4a1a63bda19779c4f4bd6491df4a",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/-/advisories/supply-chain1",
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
@@ -154,6 +156,7 @@
       "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -191,6 +194,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -225,6 +229,7 @@
       "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -257,7 +262,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4",
       "hashes": {
@@ -280,7 +287,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0",
       "hashes": {
@@ -303,7 +312,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0",
       "hashes": {
@@ -326,7 +337,9 @@
       "index": 3,
       "commit_date": "sanitized",
       "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3",
       "hashes": {
@@ -349,7 +362,9 @@
       "index": 1,
       "commit_date": "sanitized",
       "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1",
       "hashes": {
@@ -372,7 +387,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0",
       "hashes": {
@@ -399,6 +416,7 @@
       "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -436,6 +454,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -470,6 +489,7 @@
       "syntactic_id": "6ed37cfa23475cee444f54947efb9da4",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -502,7 +522,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0",
       "hashes": {
@@ -525,7 +547,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0",
       "hashes": {
@@ -548,7 +572,9 @@
       "index": 2,
       "commit_date": "sanitized",
       "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2",
       "hashes": {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-push/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-push/findings_and_ignores.json
@@ -16,6 +16,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/taint-test",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcf",
@@ -108,6 +109,7 @@
       "syntactic_id": "33cc4a1a63bda19779c4f4bd6491df4a",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/-/advisories/supply-chain1",
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
@@ -154,6 +156,7 @@
       "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -191,6 +194,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -225,6 +229,7 @@
       "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -257,7 +262,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4",
       "hashes": {
@@ -280,7 +287,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0",
       "hashes": {
@@ -303,7 +312,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0",
       "hashes": {
@@ -326,7 +337,9 @@
       "index": 3,
       "commit_date": "sanitized",
       "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3",
       "hashes": {
@@ -349,7 +362,9 @@
       "index": 1,
       "commit_date": "sanitized",
       "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1",
       "hashes": {
@@ -372,7 +387,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0",
       "hashes": {
@@ -399,6 +416,7 @@
       "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -436,6 +454,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -470,6 +489,7 @@
       "syntactic_id": "6ed37cfa23475cee444f54947efb9da4",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -502,7 +522,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0",
       "hashes": {
@@ -525,7 +547,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0",
       "hashes": {
@@ -548,7 +572,9 @@
       "index": 2,
       "commit_date": "sanitized",
       "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2",
       "hashes": {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-special-env-vars/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-special-env-vars/findings_and_ignores.json
@@ -16,6 +16,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/taint-test",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcf",
@@ -108,6 +109,7 @@
       "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -145,6 +147,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -179,6 +182,7 @@
       "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -211,7 +215,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4",
       "hashes": {
@@ -234,7 +240,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0",
       "hashes": {
@@ -257,7 +265,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0",
       "hashes": {
@@ -280,7 +290,9 @@
       "index": 3,
       "commit_date": "sanitized",
       "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3",
       "hashes": {
@@ -303,7 +315,9 @@
       "index": 1,
       "commit_date": "sanitized",
       "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1",
       "hashes": {
@@ -326,7 +340,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0",
       "hashes": {
@@ -353,6 +369,7 @@
       "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -390,6 +407,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -424,6 +442,7 @@
       "syntactic_id": "6ed37cfa23475cee444f54947efb9da4",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -456,7 +475,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0",
       "hashes": {
@@ -479,7 +500,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0",
       "hashes": {
@@ -502,7 +525,9 @@
       "index": 2,
       "commit_date": "sanitized",
       "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2",
       "hashes": {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab/findings_and_ignores.json
@@ -16,6 +16,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/taint-test",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcf",
@@ -108,6 +109,7 @@
       "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -145,6 +147,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -179,6 +182,7 @@
       "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -211,7 +215,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4",
       "hashes": {
@@ -234,7 +240,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0",
       "hashes": {
@@ -257,7 +265,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0",
       "hashes": {
@@ -280,7 +290,9 @@
       "index": 3,
       "commit_date": "sanitized",
       "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3",
       "hashes": {
@@ -303,7 +315,9 @@
       "index": 1,
       "commit_date": "sanitized",
       "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1",
       "hashes": {
@@ -326,7 +340,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0",
       "hashes": {
@@ -353,6 +369,7 @@
       "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -390,6 +407,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -424,6 +442,7 @@
       "syntactic_id": "6ed37cfa23475cee444f54947efb9da4",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -456,7 +475,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0",
       "hashes": {
@@ -479,7 +500,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0",
       "hashes": {
@@ -502,7 +525,9 @@
       "index": 2,
       "commit_date": "sanitized",
       "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2",
       "hashes": {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/findings_and_ignores.json
@@ -16,6 +16,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/taint-test",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcf",
@@ -108,6 +109,7 @@
       "syntactic_id": "33cc4a1a63bda19779c4f4bd6491df4a",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/-/advisories/supply-chain1",
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
@@ -154,6 +156,7 @@
       "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -191,6 +194,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -225,6 +229,7 @@
       "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -257,7 +262,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4",
       "hashes": {
@@ -280,7 +287,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0",
       "hashes": {
@@ -303,7 +312,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0",
       "hashes": {
@@ -326,7 +337,9 @@
       "index": 3,
       "commit_date": "sanitized",
       "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3",
       "hashes": {
@@ -349,7 +362,9 @@
       "index": 1,
       "commit_date": "sanitized",
       "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1",
       "hashes": {
@@ -372,7 +387,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0",
       "hashes": {
@@ -399,6 +416,7 @@
       "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -436,6 +454,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -470,6 +489,7 @@
       "syntactic_id": "6ed37cfa23475cee444f54947efb9da4",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -502,7 +522,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0",
       "hashes": {
@@ -525,7 +547,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0",
       "hashes": {
@@ -548,7 +572,9 @@
       "index": 2,
       "commit_date": "sanitized",
       "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2",
       "hashes": {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-overwrite-autodetected-variables/findings_and_ignores.json
@@ -16,6 +16,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/taint-test",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcf",
@@ -108,6 +109,7 @@
       "syntactic_id": "33cc4a1a63bda19779c4f4bd6491df4a",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/-/advisories/supply-chain1",
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
@@ -154,6 +156,7 @@
       "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -191,6 +194,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -225,6 +229,7 @@
       "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -257,7 +262,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4",
       "hashes": {
@@ -280,7 +287,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0",
       "hashes": {
@@ -303,7 +312,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0",
       "hashes": {
@@ -326,7 +337,9 @@
       "index": 3,
       "commit_date": "sanitized",
       "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3",
       "hashes": {
@@ -349,7 +362,9 @@
       "index": 1,
       "commit_date": "sanitized",
       "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1",
       "hashes": {
@@ -372,7 +387,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0",
       "hashes": {
@@ -399,6 +416,7 @@
       "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -436,6 +454,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -470,6 +489,7 @@
       "syntactic_id": "6ed37cfa23475cee444f54947efb9da4",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -502,7 +522,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0",
       "hashes": {
@@ -525,7 +547,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0",
       "hashes": {
@@ -548,7 +572,9 @@
       "index": 2,
       "commit_date": "sanitized",
       "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2",
       "hashes": {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins/findings_and_ignores.json
@@ -16,6 +16,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/taint-test",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcf",
@@ -108,6 +109,7 @@
       "syntactic_id": "33cc4a1a63bda19779c4f4bd6491df4a",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/-/advisories/supply-chain1",
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
@@ -154,6 +156,7 @@
       "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -191,6 +194,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -225,6 +229,7 @@
       "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -257,7 +262,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4",
       "hashes": {
@@ -280,7 +287,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0",
       "hashes": {
@@ -303,7 +312,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0",
       "hashes": {
@@ -326,7 +337,9 @@
       "index": 3,
       "commit_date": "sanitized",
       "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3",
       "hashes": {
@@ -349,7 +362,9 @@
       "index": 1,
       "commit_date": "sanitized",
       "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1",
       "hashes": {
@@ -372,7 +387,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0",
       "hashes": {
@@ -399,6 +416,7 @@
       "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -436,6 +454,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -470,6 +489,7 @@
       "syntactic_id": "6ed37cfa23475cee444f54947efb9da4",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -502,7 +522,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0",
       "hashes": {
@@ -525,7 +547,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0",
       "hashes": {
@@ -548,7 +572,9 @@
       "index": 2,
       "commit_date": "sanitized",
       "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2",
       "hashes": {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/findings_and_ignores.json
@@ -16,6 +16,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/taint-test",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcf",
@@ -108,6 +109,7 @@
       "syntactic_id": "33cc4a1a63bda19779c4f4bd6491df4a",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/-/advisories/supply-chain1",
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
@@ -154,6 +156,7 @@
       "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -191,6 +194,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -225,6 +229,7 @@
       "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -257,7 +262,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4",
       "hashes": {
@@ -280,7 +287,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0",
       "hashes": {
@@ -303,7 +312,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0",
       "hashes": {
@@ -326,7 +337,9 @@
       "index": 3,
       "commit_date": "sanitized",
       "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3",
       "hashes": {
@@ -349,7 +362,9 @@
       "index": 1,
       "commit_date": "sanitized",
       "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1",
       "hashes": {
@@ -372,7 +387,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0",
       "hashes": {
@@ -399,6 +416,7 @@
       "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -436,6 +454,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -470,6 +489,7 @@
       "syntactic_id": "6ed37cfa23475cee444f54947efb9da4",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -502,7 +522,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0",
       "hashes": {
@@ -525,7 +547,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0",
       "hashes": {
@@ -548,7 +572,9 @@
       "index": 2,
       "commit_date": "sanitized",
       "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2",
       "hashes": {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-self-hosted/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-self-hosted/findings_and_ignores.json
@@ -16,6 +16,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/taint-test",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcf",
@@ -108,6 +109,7 @@
       "syntactic_id": "33cc4a1a63bda19779c4f4bd6491df4a",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/-/advisories/supply-chain1",
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
@@ -154,6 +156,7 @@
       "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -191,6 +194,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -225,6 +229,7 @@
       "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -257,7 +262,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4",
       "hashes": {
@@ -280,7 +287,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0",
       "hashes": {
@@ -303,7 +312,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0",
       "hashes": {
@@ -326,7 +337,9 @@
       "index": 3,
       "commit_date": "sanitized",
       "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3",
       "hashes": {
@@ -349,7 +362,9 @@
       "index": 1,
       "commit_date": "sanitized",
       "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1",
       "hashes": {
@@ -372,7 +387,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0",
       "hashes": {
@@ -399,6 +416,7 @@
       "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -436,6 +454,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -470,6 +489,7 @@
       "syntactic_id": "6ed37cfa23475cee444f54947efb9da4",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -502,7 +522,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0",
       "hashes": {
@@ -525,7 +547,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0",
       "hashes": {
@@ -548,7 +572,9 @@
       "index": 2,
       "commit_date": "sanitized",
       "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2",
       "hashes": {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis-overwrite-autodetected-variables/findings_and_ignores.json
@@ -16,6 +16,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/taint-test",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcf",
@@ -108,6 +109,7 @@
       "syntactic_id": "33cc4a1a63bda19779c4f4bd6491df4a",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/-/advisories/supply-chain1",
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
@@ -154,6 +156,7 @@
       "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -191,6 +194,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -225,6 +229,7 @@
       "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -257,7 +262,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4",
       "hashes": {
@@ -280,7 +287,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0",
       "hashes": {
@@ -303,7 +312,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0",
       "hashes": {
@@ -326,7 +337,9 @@
       "index": 3,
       "commit_date": "sanitized",
       "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3",
       "hashes": {
@@ -349,7 +362,9 @@
       "index": 1,
       "commit_date": "sanitized",
       "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1",
       "hashes": {
@@ -372,7 +387,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0",
       "hashes": {
@@ -399,6 +416,7 @@
       "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -436,6 +454,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -470,6 +489,7 @@
       "syntactic_id": "6ed37cfa23475cee444f54947efb9da4",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -502,7 +522,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0",
       "hashes": {
@@ -525,7 +547,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0",
       "hashes": {
@@ -548,7 +572,9 @@
       "index": 2,
       "commit_date": "sanitized",
       "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2",
       "hashes": {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis/findings_and_ignores.json
@@ -16,6 +16,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/taint-test",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcf",
@@ -108,6 +109,7 @@
       "syntactic_id": "33cc4a1a63bda19779c4f4bd6491df4a",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/-/advisories/supply-chain1",
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
@@ -154,6 +156,7 @@
       "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -191,6 +194,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -225,6 +229,7 @@
       "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -257,7 +262,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4",
       "hashes": {
@@ -280,7 +287,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0",
       "hashes": {
@@ -303,7 +312,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0",
       "hashes": {
@@ -326,7 +337,9 @@
       "index": 3,
       "commit_date": "sanitized",
       "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3",
       "hashes": {
@@ -349,7 +362,9 @@
       "index": 1,
       "commit_date": "sanitized",
       "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1",
       "hashes": {
@@ -372,7 +387,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0",
       "hashes": {
@@ -399,6 +416,7 @@
       "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -436,6 +454,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -470,6 +489,7 @@
       "syntactic_id": "6ed37cfa23475cee444f54947efb9da4",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -502,7 +522,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0",
       "hashes": {
@@ -525,7 +547,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0",
       "hashes": {
@@ -548,7 +572,9 @@
       "index": 2,
       "commit_date": "sanitized",
       "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2",
       "hashes": {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-unparsable_url/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-unparsable_url/findings_and_ignores.json
@@ -16,6 +16,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/taint-test",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcf",
@@ -108,6 +109,7 @@
       "syntactic_id": "33cc4a1a63bda19779c4f4bd6491df4a",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/-/advisories/supply-chain1",
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
@@ -154,6 +156,7 @@
       "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -191,6 +194,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -225,6 +229,7 @@
       "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -257,7 +262,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4",
       "hashes": {
@@ -280,7 +287,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0",
       "hashes": {
@@ -303,7 +312,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0",
       "hashes": {
@@ -326,7 +337,9 @@
       "index": 3,
       "commit_date": "sanitized",
       "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3",
       "hashes": {
@@ -349,7 +362,9 @@
       "index": 1,
       "commit_date": "sanitized",
       "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1",
       "hashes": {
@@ -372,7 +387,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0",
       "hashes": {
@@ -399,6 +416,7 @@
       "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -436,6 +454,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -470,6 +489,7 @@
       "syntactic_id": "6ed37cfa23475cee444f54947efb9da4",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -502,7 +522,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0",
       "hashes": {
@@ -525,7 +547,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0",
       "hashes": {
@@ -548,7 +572,9 @@
       "index": 2,
       "commit_date": "sanitized",
       "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2",
       "hashes": {

--- a/cli/tests/e2e/snapshots/test_ci/test_lockfile_parse_failure_reporting/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_lockfile_parse_failure_reporting/findings_and_ignores.json
@@ -16,6 +16,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/taint-test",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcf",
@@ -108,6 +109,7 @@
       "syntactic_id": "33cc4a1a63bda19779c4f4bd6491df4a",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/-/advisories/supply-chain1",
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
@@ -154,6 +156,7 @@
       "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -191,6 +194,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -225,6 +229,7 @@
       "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -257,7 +262,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4",
       "hashes": {
@@ -280,7 +287,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0",
       "hashes": {
@@ -303,7 +312,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0",
       "hashes": {
@@ -326,7 +337,9 @@
       "index": 3,
       "commit_date": "sanitized",
       "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3",
       "hashes": {
@@ -349,7 +362,9 @@
       "index": 1,
       "commit_date": "sanitized",
       "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1",
       "hashes": {
@@ -372,7 +387,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0",
       "hashes": {
@@ -399,6 +416,7 @@
       "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/abceversion1",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -436,6 +454,7 @@
         "dev.semgrep.actions": [
           "block"
         ],
+        "source": "https://semgrep.dev/r/eqeq-four",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abce",
@@ -470,6 +489,7 @@
       "syntactic_id": "6ed37cfa23475cee444f54947efb9da4",
       "metadata": {
         "dev.semgrep.actions": [],
+        "source": "https://semgrep.dev/r/eqeq-five",
         "semgrep.dev": {
           "rule": {
             "rule_id": "abcd",
@@ -502,7 +522,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0",
       "hashes": {
@@ -525,7 +547,9 @@
       "index": 0,
       "commit_date": "sanitized",
       "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0",
       "hashes": {
@@ -548,7 +572,9 @@
       "index": 2,
       "commit_date": "sanitized",
       "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
+      "metadata": {
+        "source": "https://semgrep.dev/r/eqeq-bad"
+      },
       "is_blocking": true,
       "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2",
       "hashes": {

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---gitlab-sast/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---gitlab-sast/results.txt
@@ -263,7 +263,7 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
         {
           "name": "Semgrep - supply-chain1",
           "type": "semgrep_type",
-          "url": "https://semgrep.dev/r/supply-chain1",
+          "url": "https://semgrep.dev/-/advisories/supply-chain1",
           "value": "supply-chain1"
         }
       ],

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---gitlab-secrets/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---gitlab-secrets/results.txt
@@ -316,7 +316,7 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
         {
           "name": "Semgrep - supply-chain1",
           "type": "semgrep_type",
-          "url": "https://semgrep.dev/r/supply-chain1",
+          "url": "https://semgrep.dev/-/advisories/supply-chain1",
           "value": "supply-chain1"
         }
       ],

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---json/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---json/results.txt
@@ -30,7 +30,9 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
         "is_ignored": false,
         "lines": "    a == a",
         "message": "useless comparison",
-        "metadata": {},
+        "metadata": {
+          "source": "https://semgrep.dev/r/eqeq-bad"
+        },
         "metavars": {
           "$X": {
             "abstract_content": "a",
@@ -69,7 +71,9 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
         "is_ignored": false,
         "lines": "    a == a",
         "message": "useless comparison",
-        "metadata": {},
+        "metadata": {
+          "source": "https://semgrep.dev/r/eqeq-bad"
+        },
         "metavars": {
           "$X": {
             "abstract_content": "a",
@@ -108,7 +112,9 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
         "is_ignored": false,
         "lines": "    a == a",
         "message": "useless comparison",
-        "metadata": {},
+        "metadata": {
+          "source": "https://semgrep.dev/r/eqeq-bad"
+        },
         "metavars": {
           "$X": {
             "abstract_content": "a",
@@ -147,7 +153,9 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
         "is_ignored": false,
         "lines": "    y == y",
         "message": "useless comparison",
-        "metadata": {},
+        "metadata": {
+          "source": "https://semgrep.dev/r/eqeq-bad"
+        },
         "metavars": {
           "$X": {
             "abstract_content": "y",
@@ -200,7 +208,8 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
               "version_id": "version1"
             },
             "src": "unchanged"
-          }
+          },
+          "source": "https://semgrep.dev/r/eqeq-five"
         },
         "metavars": {
           "$X": {
@@ -252,7 +261,8 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
               "version_id": "version2"
             },
             "src": "new-version"
-          }
+          },
+          "source": "https://semgrep.dev/r/eqeq-four"
         },
         "metavars": {
           "$X": {
@@ -362,7 +372,8 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
               "version_id": "version1"
             },
             "src": "new-rule"
-          }
+          },
+          "source": "https://semgrep.dev/r/taint-test"
         },
         "metavars": {
           "$X": {
@@ -417,7 +428,8 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
         "message": "found a dependency",
         "metadata": {
           "dev.semgrep.actions": [],
-          "sca-kind": "upgrade-only"
+          "sca-kind": "upgrade-only",
+          "source": "https://semgrep.dev/-/advisories/supply-chain1"
         },
         "metavars": {},
         "sca_info": {

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---sarif/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---sarif/results.txt
@@ -488,6 +488,11 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
               "fullDescription": {
                 "text": "useless comparison"
               },
+              "help": {
+                "markdown": "useless comparison\n\n<b>References:</b>\n - [Semgrep Rule](https://semgrep.dev/r/eqeq-bad)\n",
+                "text": "useless comparison"
+              },
+              "helpUri": "https://semgrep.dev/r/eqeq-bad",
               "id": "eqeq-bad",
               "name": "eqeq-bad",
               "properties": {
@@ -505,6 +510,11 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
               "fullDescription": {
                 "text": "useless comparison to 5"
               },
+              "help": {
+                "markdown": "useless comparison to 5\n\n<b>References:</b>\n - [Semgrep Rule](https://semgrep.dev/r/eqeq-five)\n",
+                "text": "useless comparison to 5"
+              },
+              "helpUri": "https://semgrep.dev/r/eqeq-five",
               "id": "eqeq-five",
               "name": "eqeq-five",
               "properties": {
@@ -522,6 +532,11 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
               "fullDescription": {
                 "text": "useless comparison to 4"
               },
+              "help": {
+                "markdown": "useless comparison to 4\n\n<b>References:</b>\n - [Semgrep Rule](https://semgrep.dev/r/eqeq-four)\n",
+                "text": "useless comparison to 4"
+              },
+              "helpUri": "https://semgrep.dev/r/eqeq-four",
               "id": "eqeq-four",
               "name": "eqeq-four",
               "properties": {
@@ -539,6 +554,11 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
               "fullDescription": {
                 "text": "found a dependency"
               },
+              "help": {
+                "markdown": "found a dependency\n\n<b>References:</b>\n - [Semgrep Rule](https://semgrep.dev/-/advisories/supply-chain1)\n",
+                "text": "found a dependency"
+              },
+              "helpUri": "https://semgrep.dev/-/advisories/supply-chain1",
               "id": "supply-chain1",
               "name": "supply-chain1",
               "properties": {
@@ -556,6 +576,11 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
               "fullDescription": {
                 "text": "unsafe use of danger"
               },
+              "help": {
+                "markdown": "unsafe use of danger\n\n<b>References:</b>\n - [Semgrep Rule](https://semgrep.dev/r/taint-test)\n",
+                "text": "unsafe use of danger"
+              },
+              "helpUri": "https://semgrep.dev/r/taint-test",
               "id": "taint-test",
               "name": "taint-test",
               "properties": {

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---gitlab-sast/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---gitlab-sast/results.txt
@@ -263,7 +263,7 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
         {
           "name": "Semgrep - supply-chain1",
           "type": "semgrep_type",
-          "url": "https://semgrep.dev/r/supply-chain1",
+          "url": "https://semgrep.dev/-/advisories/supply-chain1",
           "value": "supply-chain1"
         }
       ],

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---gitlab-secrets/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---gitlab-secrets/results.txt
@@ -316,7 +316,7 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
         {
           "name": "Semgrep - supply-chain1",
           "type": "semgrep_type",
-          "url": "https://semgrep.dev/r/supply-chain1",
+          "url": "https://semgrep.dev/-/advisories/supply-chain1",
           "value": "supply-chain1"
         }
       ],

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---json/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---json/results.txt
@@ -30,7 +30,9 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
         "is_ignored": false,
         "lines": "    a == a",
         "message": "useless comparison",
-        "metadata": {},
+        "metadata": {
+          "source": "https://semgrep.dev/r/eqeq-bad"
+        },
         "metavars": {
           "$X": {
             "abstract_content": "a",
@@ -69,7 +71,9 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
         "is_ignored": false,
         "lines": "    a == a",
         "message": "useless comparison",
-        "metadata": {},
+        "metadata": {
+          "source": "https://semgrep.dev/r/eqeq-bad"
+        },
         "metavars": {
           "$X": {
             "abstract_content": "a",
@@ -108,7 +112,9 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
         "is_ignored": false,
         "lines": "    a == a",
         "message": "useless comparison",
-        "metadata": {},
+        "metadata": {
+          "source": "https://semgrep.dev/r/eqeq-bad"
+        },
         "metavars": {
           "$X": {
             "abstract_content": "a",
@@ -147,7 +153,9 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
         "is_ignored": false,
         "lines": "    y == y",
         "message": "useless comparison",
-        "metadata": {},
+        "metadata": {
+          "source": "https://semgrep.dev/r/eqeq-bad"
+        },
         "metavars": {
           "$X": {
             "abstract_content": "y",
@@ -197,7 +205,8 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
               "version_id": "version1"
             },
             "src": "unchanged"
-          }
+          },
+          "source": "https://semgrep.dev/r/eqeq-five"
         },
         "metavars": {
           "$X": {
@@ -249,7 +258,8 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
               "version_id": "version2"
             },
             "src": "new-version"
-          }
+          },
+          "source": "https://semgrep.dev/r/eqeq-four"
         },
         "metavars": {
           "$X": {
@@ -359,7 +369,8 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
               "version_id": "version1"
             },
             "src": "new-rule"
-          }
+          },
+          "source": "https://semgrep.dev/r/taint-test"
         },
         "metavars": {
           "$X": {
@@ -414,7 +425,8 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
         "message": "found a dependency",
         "metadata": {
           "dev.semgrep.actions": [],
-          "sca-kind": "upgrade-only"
+          "sca-kind": "upgrade-only",
+          "source": "https://semgrep.dev/-/advisories/supply-chain1"
         },
         "metavars": {},
         "sca_info": {

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---sarif/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---sarif/results.txt
@@ -434,6 +434,11 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
               "fullDescription": {
                 "text": "useless comparison"
               },
+              "help": {
+                "markdown": "useless comparison\n\n<b>References:</b>\n - [Semgrep Rule](https://semgrep.dev/r/eqeq-bad)\n",
+                "text": "useless comparison"
+              },
+              "helpUri": "https://semgrep.dev/r/eqeq-bad",
               "id": "eqeq-bad",
               "name": "eqeq-bad",
               "properties": {
@@ -451,6 +456,11 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
               "fullDescription": {
                 "text": "useless comparison to 5"
               },
+              "help": {
+                "markdown": "useless comparison to 5\n\n<b>References:</b>\n - [Semgrep Rule](https://semgrep.dev/r/eqeq-five)\n",
+                "text": "useless comparison to 5"
+              },
+              "helpUri": "https://semgrep.dev/r/eqeq-five",
               "id": "eqeq-five",
               "name": "eqeq-five",
               "properties": {
@@ -468,6 +478,11 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
               "fullDescription": {
                 "text": "useless comparison to 4"
               },
+              "help": {
+                "markdown": "useless comparison to 4\n\n<b>References:</b>\n - [Semgrep Rule](https://semgrep.dev/r/eqeq-four)\n",
+                "text": "useless comparison to 4"
+              },
+              "helpUri": "https://semgrep.dev/r/eqeq-four",
               "id": "eqeq-four",
               "name": "eqeq-four",
               "properties": {
@@ -485,6 +500,11 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
               "fullDescription": {
                 "text": "found a dependency"
               },
+              "help": {
+                "markdown": "found a dependency\n\n<b>References:</b>\n - [Semgrep Rule](https://semgrep.dev/-/advisories/supply-chain1)\n",
+                "text": "found a dependency"
+              },
+              "helpUri": "https://semgrep.dev/-/advisories/supply-chain1",
               "id": "supply-chain1",
               "name": "supply-chain1",
               "properties": {
@@ -502,6 +522,11 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
               "fullDescription": {
                 "text": "unsafe use of danger"
               },
+              "help": {
+                "markdown": "unsafe use of danger\n\n<b>References:</b>\n - [Semgrep Rule](https://semgrep.dev/r/taint-test)\n",
+                "text": "unsafe use of danger"
+              },
+              "helpUri": "https://semgrep.dev/r/taint-test",
               "id": "taint-test",
               "name": "taint-test",
               "properties": {

--- a/cli/tests/e2e/snapshots/test_max_target_bytes/test_max_target_bytes/1MB/results.json
+++ b/cli/tests/e2e/snapshots/test_max_target_bytes/test_max_target_bytes/1MB/results.json
@@ -85,7 +85,8 @@
         "lines": "    return a + b == a + b",
         "message": "useless comparison operation `a + b == a + b` or `a + b != a + b`",
         "metadata": {
-          "shortlink": "https://sg.run/xyz1"
+          "shortlink": "https://sg.run/xyz1",
+          "source": "https://semgrep.dev/r/eqeq-bad"
         },
         "metavars": {
           "$X": {

--- a/cli/tests/e2e/snapshots/test_output/test_output_format/--json/results.out
+++ b/cli/tests/e2e/snapshots/test_output/test_output_format/--json/results.out
@@ -20,7 +20,8 @@
         "lines": "    return a + b == a + b",
         "message": "useless comparison operation `a + b == a + b` or `a + b != a + b`",
         "metadata": {
-          "shortlink": "https://sg.run/xyz1"
+          "shortlink": "https://sg.run/xyz1",
+          "source": "https://semgrep.dev/r/eqeq-bad"
         },
         "metavars": {
           "$X": {

--- a/cli/tests/e2e/snapshots/test_output/test_output_format_osemfail/--gitlab-sast/results.out
+++ b/cli/tests/e2e/snapshots/test_output/test_output_format_osemfail/--gitlab-sast/results.out
@@ -38,7 +38,7 @@
         {
           "name": "Semgrep - rules.eqeq-is-bad",
           "type": "semgrep_type",
-          "url": null,
+          "url": "https://semgrep.dev/r/eqeq-bad",
           "value": "rules.eqeq-is-bad"
         }
       ],

--- a/cli/tests/e2e/snapshots/test_output/test_output_format_osemfail/--gitlab-sast/results.out
+++ b/cli/tests/e2e/snapshots/test_output/test_output_format_osemfail/--gitlab-sast/results.out
@@ -38,7 +38,7 @@
         {
           "name": "Semgrep - rules.eqeq-is-bad",
           "type": "semgrep_type",
-          "url": "https://semgrep.dev/r/rules.eqeq-is-bad",
+          "url": null,
           "value": "rules.eqeq-is-bad"
         }
       ],

--- a/cli/tests/e2e/snapshots/test_output/test_output_format_osemfail/--gitlab-secrets/results.out
+++ b/cli/tests/e2e/snapshots/test_output/test_output_format_osemfail/--gitlab-secrets/results.out
@@ -42,7 +42,7 @@
         {
           "name": "Semgrep - rules.eqeq-is-bad",
           "type": "semgrep_type",
-          "url": null,
+          "url": "https://semgrep.dev/r/eqeq-bad",
           "value": "rules.eqeq-is-bad"
         }
       ],

--- a/cli/tests/e2e/snapshots/test_output/test_output_format_osemfail/--gitlab-secrets/results.out
+++ b/cli/tests/e2e/snapshots/test_output/test_output_format_osemfail/--gitlab-secrets/results.out
@@ -42,7 +42,7 @@
         {
           "name": "Semgrep - rules.eqeq-is-bad",
           "type": "semgrep_type",
-          "url": "https://semgrep.dev/r/rules.eqeq-is-bad",
+          "url": null,
           "value": "rules.eqeq-is-bad"
         }
       ],

--- a/cli/tests/e2e/snapshots/test_output/test_output_format_osemfail/--sarif/results.out
+++ b/cli/tests/e2e/snapshots/test_output/test_output_format_osemfail/--sarif/results.out
@@ -67,6 +67,11 @@
               "fullDescription": {
                 "text": "useless comparison operation `$X == $X` or `$X != $X`"
               },
+              "help": {
+                "markdown": "useless comparison operation `$X == $X` or `$X != $X`\n\n<b>References:</b>\n - [Semgrep Rule](https://semgrep.dev/r/eqeq-bad)\n",
+                "text": "useless comparison operation `$X == $X` or `$X != $X`"
+              },
+              "helpUri": "https://semgrep.dev/r/eqeq-bad",
               "id": "rules.eqeq-is-bad",
               "name": "rules.eqeq-is-bad",
               "properties": {

--- a/cli/tests/e2e/snapshots/test_output/test_sarif_output_with_nosemgrep_and_error/results.sarif
+++ b/cli/tests/e2e/snapshots/test_output/test_sarif_output_with_nosemgrep_and_error/results.sarif
@@ -72,6 +72,11 @@
               "fullDescription": {
                 "text": "useless comparison operation `$X == $X` or `$X != $X`"
               },
+              "help": {
+                "markdown": "useless comparison operation `$X == $X` or `$X != $X`\n\n<b>References:</b>\n - [Semgrep Rule](https://semgrep.dev/r/eqeq-bad)\n",
+                "text": "useless comparison operation `$X == $X` or `$X != $X`"
+              },
+              "helpUri": "https://semgrep.dev/r/eqeq-bad",
               "id": "rules.eqeq-is-bad",
               "name": "rules.eqeq-is-bad",
               "properties": {

--- a/cli/tests/e2e/test_ci.py
+++ b/cli/tests/e2e/test_ci.py
@@ -259,6 +259,8 @@ def scan_config():
           message: "useless comparison"
           languages: [python]
           severity: ERROR
+          metadata:
+            source: https://semgrep.dev/r/eqeq-bad
         - id: eqeq-five
           pattern: $X == 5
           message: "useless comparison to 5"
@@ -266,6 +268,7 @@ def scan_config():
           severity: ERROR
           metadata:
             dev.semgrep.actions: []
+            source: https://semgrep.dev/r/eqeq-five
             semgrep.dev:
                 rule:
                     rule_id: "abcd"
@@ -281,6 +284,7 @@ def scan_config():
           severity: ERROR
           metadata:
             dev.semgrep.actions: ["block"]
+            source: https://semgrep.dev/r/eqeq-four
             semgrep.dev:
                 rule:
                     rule_id: abce
@@ -295,6 +299,7 @@ def scan_config():
           severity: ERROR
           metadata:
             dev.semgrep.actions: []
+            source: https://semgrep.dev/r/abceversion1
             semgrep.dev:
                 rule:
                     rule_id: abce
@@ -314,6 +319,7 @@ def scan_config():
             - pattern: sink($X)
           metadata:
             dev.semgrep.actions: ["block"]
+            source: https://semgrep.dev/r/taint-test
             semgrep.dev:
                 rule:
                     rule_id: abcf
@@ -331,6 +337,7 @@ def scan_config():
             version: == 99.99.99
           metadata:
             dev.semgrep.actions: []
+            source: https://semgrep.dev/-/advisories/supply-chain1
             sca-kind: upgrade-only
         - id: supply-chain2
           message: "found a dependency"
@@ -342,6 +349,7 @@ def scan_config():
             version: == 99.99.99
           metadata:
             dev.semgrep.actions: []
+            source: https://semgrep.dev/-/advisories/supply-chain2
             sca-kind: upgrade-only
         - id: supply-chain3
           message: "found another dependency but its a bad one >:D"
@@ -353,6 +361,7 @@ def scan_config():
             version: == 99.99.99
           metadata:
             dev.semgrep.actions: ["block"]
+            source: https://semgrep.dev/-/advisories/supply-chain3
             sca-kind: reachable
         """
     ).lstrip()


### PR DESCRIPTION
Old gitlab output for ssc rules was generating a url to the wrong place. The rule metadata already includes where the rules is located (and sarif output already uses this) so just use that metadata instead of generating url ourselves