### PR TITLE
make is now 'make core', make test is now make core-test

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -178,7 +178,6 @@ scripts/oncall-email/yesterday.json
 # Do not check in compiled binaries
 cli/src/semgrep/bin/*
 !cli/src/semgrep/bin/__init__.py
-bin
 
 # Ignore bench files
 **/perf/bench

--- a/.gitignore
+++ b/.gitignore
@@ -177,7 +177,6 @@ log_config.json
 # Do not check in compiled binaries
 /cli/src/semgrep/bin/*
 !/cli/src/semgrep/bin/__init__.py
-/bin
 
 # Ignore bench files
 perf/bench

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,6 +27,7 @@ repos:
       - id: check-merge-conflict
       - id: check-shebang-scripts-are-executable
       - id: check-symlinks
+        exclude: "^bin"
       - id: check-toml
       - id: check-vcs-permalinks
       - id: check-xml

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@
 #
 # Then to compile semgrep simply type:
 #
-#     $ make
+#     $ make all
 #
 # See INSTALL.md for more information
 # See also https://semgrep.dev/docs/contributing/contributing-code/
@@ -63,11 +63,14 @@
 # not exist but we still want 'make setup' to succeed
 -include libs/ocaml-tree-sitter-core/tree-sitter-config.mk
 
-# First (and default) target. Routine build.
-# It assumes all dependencies and configuration are already in place and
-# correct.
-.PHONY: build
-build:
+# First (and default) target.
+.PHONY: default
+default: core
+
+# Routine build. It assumes all dependencies and configuration are already in
+# place and correct.
+.PHONY: all
+all:
 	# OCaml compilation
 	$(MAKE) core
 	$(MAKE) copy-core-for-cli
@@ -90,14 +93,11 @@ unused-libs:
 core:
 	$(MAKE) minimal-build
 	# make executables easily accessible for manual testing:
-	test -e bin || ln -s _build/install/default/bin .
 	ln -s semgrep-core bin/osemgrep
 
 #history: was called the 'all' target in semgrep-core/Makefile before
 .PHONY: core-bc
 core-bc: minimal-build-bc
-	# make executables easily accessible for manual testing:
-	test -e bin || ln -s _build/install/default/bin .
 	ln -s semgrep-core.bc bin/osemgrep.bc
 
 # Make binaries available to pysemgrep
@@ -192,7 +192,11 @@ uninstall:
 
 # Note that this target is actually not used in CI; it's only for local dev
 .PHONY: test
-test:
+test: core-test
+
+# Note that this target is actually not used in CI; it's only for local dev
+.PHONY: test-all
+test-all:
 	$(MAKE) core-test
 	$(MAKE) -C cli test
 	$(MAKE) -C cli osempass

--- a/bin
+++ b/bin
@@ -1,0 +1,1 @@
+_build/install/default/bin


### PR DESCRIPTION
Many time I forget to type 'make core' and then I need to wait (or
kill) the build of the JS stuff. Simpler to have 'make all' to
build all and the default 'make' that just builds core.

Same for test and test-all

test plan:
make
make test
make all
make test-all