### PR TITLE
tainting: Make identification of sinks (even) more precise

### DIFF
--- a/changelog.d/pa-3284.fixed
+++ b/changelog.d/pa-3284.fixed
@@ -1,0 +1,33 @@
+In version 1.14.0 (pa-2477) we made sink-matching more precise when the sink
+specification was like:
+
+```yaml
+pattern-sinks:
+  - patterns:
+     - pattern: sink($X, ...)
+     - focus-metavariable: $X
+```
+
+Where the sink specification most likely has the intent to specify the first
+argument of `sink` as a sink, and `sink(ok1 if tainted else ok2)` should _NOT_
+produce a finding, because `tainted` is not really what is being passed to
+the `sink` function.
+
+But we only intercepted the most simple pattern above, and more complex sink
+specifications that had the same intent were not properly recognized.
+
+Now we have generalized that pattern to cover more complex cases like:
+
+```yaml
+patterns:
+ - pattern-either:
+   - patterns:
+     - pattern-inside: |
+         def foo(...):
+           ...
+     - pattern: sink1($X)
+   - patterns:
+     - pattern: sink2($X)
+     - pattern-not: bar(...)
+ - focus-metavariable: $X
+```

--- a/src/core/Rule.ml
+++ b/src/core/Rule.ml
@@ -337,7 +337,9 @@ let is_sink_func_with_focus sink_formula =
   in
   let rec is_call_pattern = function
     | P { pat = Sem ((lazy (E { e = Call _; _ })), _); _ } -> true
-    | Or (_tok, formulas) -> List.for_all is_call_pattern formulas
+    | Or (_tok, formulas) ->
+        (* Each case in an 'Or' is independent, all must be call patterns. *)
+        List.for_all is_call_pattern formulas
     | And (_, { conjuncts; focus = []; _ }) ->
         (* NOTE: No `focus-metavariable:` here to make sure this is matching a call. *)
         is_call_pattern_conjuncts conjuncts
@@ -354,7 +356,8 @@ let is_sink_func_with_focus sink_formula =
     let remaining_conjuncts =
       List.filter (fun f -> not (is_inside_or_not f)) conjuncts
     in
-    List.for_all is_call_pattern remaining_conjuncts
+    remaining_conjuncts <> []
+    && List.for_all is_call_pattern remaining_conjuncts
   in
   match sink_formula with
   (* THINK: Should we just assume that if there is 'focus' then the match should

--- a/src/core/Rule.ml
+++ b/src/core/Rule.ml
@@ -253,10 +253,17 @@ and taint_sink = {
        *       - ...
        *     - focus-metavariable: $MVAR
        *
-       * where we can infer that there is a clear preference for a "more exact" match
-       * of the sink vs other sink  patterns such as `sink(...)`. We infer that the
-       * function call itself is not the sink, but it is either the <func> or one
-       * (or more) of the <args>.
+       * that is, it matches a function call, and focuses on a specific part of
+       * the match.
+       *
+       * Then we infer that there is a preference for a "more precise" match of
+       * the sink, in constrast with other sink patterns such as `sink(...)`. We
+       * infer that the function call itself is not the sink, but more likely it
+       * is either the <func> or one (or more) of the <args>.
+       *
+       * WHY BOTHER WITH ALL THIS? Well, because for a long time most sink specs
+       * were of the form `sink(...)` and we want to maintain backwards
+       * compatibility for all those rules out there.
        *)
       (* TODO: Add `exact: true` option to sinks so one can skip this heuristic, and
        * it could be a good default for "syntax 2.0". The current behavior could be
@@ -313,19 +320,11 @@ let get_sink_requires { sink_requires; _ } =
   | None -> PLabel default_source_label
   | Some { precondition; _ } -> precondition
 
-(* Check if a formula has the following shape:
- *
- *     patterns:
- *     - pattern-either:
- *       - patterns:
- *         - pattern-inside: |
- *             <P>
- *         - pattern: <func>(<args>)
- *       - ...
- *     - focus-metavariable: $MVAR
+(* Check if a formula is matching a function call and focusing on one of
+ * its subexpressions.
  *
  * See 'taint_sink', field 'sink_is_func_with_focus'. *)
-let is_func_sink_with_focus sink_formula =
+let is_sink_func_with_focus sink_formula =
   let rec is_inside_or_not = function
     | Inside _
     | Not _ ->
@@ -349,12 +348,17 @@ let is_func_sink_with_focus sink_formula =
     | Anywhere _ ->
         false
   and is_call_pattern_conjuncts conjuncts =
-    let _insides_and_nots, remaining_conjuncts =
-      List.partition is_inside_or_not conjuncts
+    (* The conjuncts that are 'inside' or 'not' (or an OR of those) can be
+     * disregarded, they just provide context. But the remaining conjuncts
+     * must all correspond to a func-call pattern. *)
+    let remaining_conjuncts =
+      List.filter (fun f -> not (is_inside_or_not f)) conjuncts
     in
     List.for_all is_call_pattern remaining_conjuncts
   in
   match sink_formula with
+  (* THINK: Should we just assume that if there is 'focus' then the match should
+   * be exact regardless of whether the 'conjuncts' are matching a function call? *)
   | And (_, { conjuncts; focus = [ _focus ]; _ }) ->
       is_call_pattern_conjuncts conjuncts
   | __else__ -> false

--- a/src/core/Rule.ml
+++ b/src/core/Rule.ml
@@ -235,6 +235,32 @@ and taint_sink = {
        * The sink will only trigger a finding if the data that reaches it
        * has a set of labels attached that satisfies the 'requires'.
        *)
+  sink_is_func_with_focus : bool;
+      (* True if the 'sink_formula' has the following shape:
+       *
+       *     patterns:
+       *     - pattern: <func>(<args>)
+       *     - focus-metavariable: $MVAR
+       *
+       * or, more generally, a shape like:
+       *
+       *     patterns:
+       *     - pattern-either:
+       *       - patterns:
+       *         - pattern-inside: |
+       *             <P>
+       *         - pattern: <func>(<args>)
+       *       - ...
+       *     - focus-metavariable: $MVAR
+       *
+       * where we can infer that there is a clear preference for a "more exact" match
+       * of the sink vs other sink  patterns such as `sink(...)`. We infer that the
+       * function call itself is not the sink, but it is either the <func> or one
+       * (or more) of the <args>.
+       *)
+      (* TODO: Add `exact: true` option to sinks so one can skip this heuristic, and
+       * it could be a good default for "syntax 2.0". The current behavior could be
+       * `exact: compat`, and the old behavior could be `exact: false`. *)
 }
 
 (* e.g. if we want to specify that adding tainted data to a `HashMap` makes
@@ -286,6 +312,52 @@ let get_sink_requires { sink_requires; _ } =
   match sink_requires with
   | None -> PLabel default_source_label
   | Some { precondition; _ } -> precondition
+
+(* Check if a formula has the following shape:
+ *
+ *     patterns:
+ *     - pattern-either:
+ *       - patterns:
+ *         - pattern-inside: |
+ *             <P>
+ *         - pattern: <func>(<args>)
+ *       - ...
+ *     - focus-metavariable: $MVAR
+ *
+ * See 'taint_sink', field 'sink_is_func_with_focus'. *)
+let is_func_sink_with_focus sink_formula =
+  let rec is_inside_or_not = function
+    | Inside _
+    | Not _ ->
+        true
+    | Or (_, formulas) -> List.for_all is_inside_or_not formulas
+    | P _
+    | And _
+    | Anywhere _ ->
+        false
+  in
+  let rec is_call_pattern = function
+    | P { pat = Sem ((lazy (E { e = Call _; _ })), _); _ } -> true
+    | Or (_tok, formulas) -> List.for_all is_call_pattern formulas
+    | And (_, { conjuncts; focus = []; _ }) ->
+        (* NOTE: No `focus-metavariable:` here to make sure this is matching a call. *)
+        is_call_pattern_conjuncts conjuncts
+    | P _
+    | Inside _
+    | Not _
+    | And _
+    | Anywhere _ ->
+        false
+  and is_call_pattern_conjuncts conjuncts =
+    let _insides_and_nots, remaining_conjuncts =
+      List.partition is_inside_or_not conjuncts
+    in
+    List.for_all is_call_pattern remaining_conjuncts
+  in
+  match sink_formula with
+  | And (_, { conjuncts; focus = [ _focus ]; _ }) ->
+      is_call_pattern_conjuncts conjuncts
+  | __else__ -> false
 
 (*****************************************************************************)
 (* Extract mode (semgrep as a preprocessor) *)

--- a/src/metachecking/Translate_rule.ml
+++ b/src/metachecking/Translate_rule.ml
@@ -121,7 +121,8 @@ and translate_taint_source
          side_effect_obj;
        ])
 
-and translate_taint_sink { sink_id = _; sink_formula; sink_requires } :
+and translate_taint_sink
+    { sink_id = _; sink_formula; sink_requires; sink_is_func_with_focus = _ } :
     [> `O of (string * Yaml.value) list ] =
   let (`O sink_f) = translate_formula sink_formula in
   let requires_obj =

--- a/src/parsing/Parse_rule.ml
+++ b/src/parsing/Parse_rule.ml
@@ -396,7 +396,8 @@ let parse_taint_sink ~(is_old : bool) env (key : key) (value : G.expr) :
   let parse_from_dict dict f =
     let sink_requires = take_opt dict env parse_taint_requires "requires" in
     let sink_formula = f env dict in
-    { R.sink_id; sink_formula; sink_requires }
+    let sink_is_func_with_focus = Rule.is_func_sink_with_focus sink_formula in
+    { R.sink_id; sink_formula; sink_requires; sink_is_func_with_focus }
   in
   if is_old then
     let dict = yaml_to_dict env key value in
@@ -407,7 +408,10 @@ let parse_taint_sink ~(is_old : bool) env (key : key) (value : G.expr) :
         let sink_formula =
           R.P (Parse_rule_formula.parse_rule_xpattern env value)
         in
-        { sink_id; sink_formula; sink_requires = None }
+        let sink_is_func_with_focus =
+          Rule.is_func_sink_with_focus sink_formula
+        in
+        { sink_id; sink_formula; sink_requires = None; sink_is_func_with_focus }
     | Right dict ->
         parse_from_dict dict Parse_rule_formula.parse_formula_from_dict
 

--- a/src/parsing/Parse_rule.ml
+++ b/src/parsing/Parse_rule.ml
@@ -396,7 +396,7 @@ let parse_taint_sink ~(is_old : bool) env (key : key) (value : G.expr) :
   let parse_from_dict dict f =
     let sink_requires = take_opt dict env parse_taint_requires "requires" in
     let sink_formula = f env dict in
-    let sink_is_func_with_focus = Rule.is_func_sink_with_focus sink_formula in
+    let sink_is_func_with_focus = Rule.is_sink_func_with_focus sink_formula in
     { R.sink_id; sink_formula; sink_requires; sink_is_func_with_focus }
   in
   if is_old then
@@ -409,7 +409,7 @@ let parse_taint_sink ~(is_old : bool) env (key : key) (value : G.expr) :
           R.P (Parse_rule_formula.parse_rule_xpattern env value)
         in
         let sink_is_func_with_focus =
-          Rule.is_func_sink_with_focus sink_formula
+          Rule.is_sink_func_with_focus sink_formula
         in
         { sink_id; sink_formula; sink_requires = None; sink_is_func_with_focus }
     | Right dict ->

--- a/src/tainting/Dataflow_tainting.ml
+++ b/src/tainting/Dataflow_tainting.ml
@@ -1516,7 +1516,7 @@ let check_tainted_instr env instr : Taints.t * Lval_env.t =
         (* After we introduced Top_sinks, we need to explicitly support sinks like
          * `sink(...)` by considering that all of the parameters are sinks. To make
          * sure that we are backwards compatible, we do this for any sink that does
-         * not match the `is_func_sink_with_focus` pattern.
+         * not match the `Rule.is_func_sink_with_focus` form.
          *)
         check_orig_if_sink { env with lval_env } instr.iorig all_args_taints
           ~filter_sinks:(fun m -> not m.spec.sink_is_func_with_focus);

--- a/tests/rules/taint_best_fit_sink5.java
+++ b/tests/rules/taint_best_fit_sink5.java
@@ -1,0 +1,16 @@
+public class Test {
+
+    public static void test1() {
+        String str = Config.load('str');
+        //ok: test
+        sink1("Abc", String.format("Bearer %s", str));
+    }
+
+    public static void test2() {
+        String str = "45678";
+        //ruleid: test
+        sink2("123", str);
+    }
+
+}
+

--- a/tests/rules/taint_best_fit_sink5.yaml
+++ b/tests/rules/taint_best_fit_sink5.yaml
@@ -1,0 +1,21 @@
+rules:
+  - id: test
+    severity: WARNING
+    languages:
+      - java
+    message: Test
+    options:
+      taint_only_propagate_through_assignments: true
+    mode: taint
+    pattern-sources:
+      - patterns:
+          - pattern: |
+              "..."
+          - pattern-not: |
+              ""
+    pattern-sinks:
+      - patterns:
+          - pattern-either:
+              - pattern: sink1("Abc", $VAL)
+              - pattern: sink2("123", $VAL)
+          - focus-metavariable: $VAL

--- a/tests/rules/taint_best_fit_sink6.java
+++ b/tests/rules/taint_best_fit_sink6.java
@@ -1,0 +1,16 @@
+public class Test {
+
+    public static void test1() {
+        String str = Config.load('str');
+        //ok: test
+        sink1("Abc", String.format("Bearer %s", str));
+    }
+
+    public static void test2() {
+        String str = "45678";
+        //ruleid: test
+        sink2("123", str);
+    }
+
+}
+

--- a/tests/rules/taint_best_fit_sink6.yaml
+++ b/tests/rules/taint_best_fit_sink6.yaml
@@ -1,0 +1,28 @@
+rules:
+  - id: test
+    severity: WARNING
+    languages:
+      - java
+    message: Test
+    options:
+      taint_only_propagate_through_assignments: true
+    mode: taint
+    pattern-sources:
+      - patterns:
+          - pattern: |
+              "..."
+          - pattern-not: |
+              ""
+    pattern-sinks:
+      - patterns:
+          - pattern-either:
+              - patterns:
+                - pattern-inside: |
+                    public void $M() {
+                      ...
+                    }
+                - pattern: sink1("Abc", $VAL)
+              - patterns:
+                - pattern: sink2("123", $VAL)
+                - pattern-not: sink1(...)
+          - focus-metavariable: $VAL


### PR DESCRIPTION
Improves on PR #7245 to detect a lot more cases where the intent of a sink specification is to declare the argument of a function call as the sink.

This is to avoid that code like `sink(ok1 if tainted else ok2)` will generate a finding.

Eventually we may add an `exact:` option to sinks as we did for sources, but that is out of the scope of this PR.

Follows: d09dc5ab050 ("tainting: Make identification of sinks more precise (#7245)")

Closes PA-3284

test plan:
make test # new test

