### PR TITLE
feat(cohttp): custom CA certs

### DIFF
--- a/libs/networking/cohttp_lwt_unix_with_ctx/Cohttp_lwt_unix_with_ctx.ml
+++ b/libs/networking/cohttp_lwt_unix_with_ctx/Cohttp_lwt_unix_with_ctx.ml
@@ -1,0 +1,33 @@
+(* Why does this exist?
+ * Cohttp_lwt_unix is functorized by the implementation of the `Net` module, which
+ * determines how the library is to handle remote interactions -- in particular,
+ * SSL/TLS verification.
+ * All of these settings are ordinarily set to sensible defaults, but one thing
+ * it does not do in particular, which the Python `requests` library does, is read
+ * from an external env variable to whitelist some CA certs.
+ * Unfortunately, in the Cohttp_lwt_unix module, almost every single function takes
+ * in an optional parameter of this `ctx` value, which has a default value. If we
+ * want to change that `ctx` value, we would need to update every single call site,
+ * and keep doing that in perpetuity.
+ * It is easier to create a new functor, which allows us to produce an instance of
+ * Cohttp_lwt_unix, but one where the `ctx` default is different. That is what this
+ * module does.
+
+ *)
+module Make (Input : sig
+  val ctx : Conduit_lwt_unix.ctx
+end) =
+struct
+  module Net_with_ctx = struct
+    include Cohttp_lwt_unix.Net
+
+    let default_ctx =
+      {
+        Cohttp_lwt_unix.Net.resolver = Resolver_lwt_unix.system;
+        ctx = Input.ctx;
+      }
+  end
+
+  module Client : Cohttp_lwt.S.Client with type ctx = Cohttp_lwt_unix.Net.ctx =
+    Cohttp_lwt.Make_client (Net_with_ctx.IO) (Net_with_ctx)
+end

--- a/libs/networking/cohttp_lwt_unix_with_ctx/dune
+++ b/libs/networking/cohttp_lwt_unix_with_ctx/dune
@@ -1,0 +1,21 @@
+(library
+ (public_name networking.cohttp_lwt_unix_with_ctx)
+ (name networking_cohttp_lwt_unix_with_ctx)
+ (wrapped false)
+  (libraries
+    lwt
+    uri
+    cohttp-lwt
+    cohttp-lwt-unix
+    profiling
+  )
+  (preprocess
+    (pps
+      profiling.ppx
+      ppx_deriving.show
+      ppx_deriving.eq
+      ppx_hash
+      lwt_ppx
+     )
+   )
+)

--- a/src/osemgrep/cli/dune
+++ b/src/osemgrep/cli/dune
@@ -24,6 +24,9 @@
     osemgrep_cli_test
     osemgrep_configuring
 
+    ; networking
+    networking.cohttp_lwt_unix_with_ctx
+
     ; reusing code from Core_cli
     semgrep_core_cli
   )


### PR DESCRIPTION
## What:
This PR makes it such that we outsource to a local certfile when there is a `REQUESTS_CA_BUNDLE` or `CURL_CA_BUNDLE` env var set.

## Why:
The Python `requests` library behaves in this way, where it can be supplied additional CA certs to accept, according to TLS/SSL. For parity with Pysemgrep, we have to allow this behavior, so that users with proxies can still do things like use the VS Code extension (or Semgrep, more generally).

## How:
This is not the most straightforward thing to do, because while every method is parameterized by an optional `ctx` parameter which includes this information, we would have to change every single call site of this function in perpetuity.

It is easier to try and produce a module which is basically `Cohttp_lwt_unix`, but with the default set to one which incorporates the custom certs. That is what this PR does, by providing the `Cohttp_lwt_unix_with_ctx` functor, which can create a "patched" version of `Cohttp_lwt_unix`.

Some assembly required, which regrettably went into `CLI.ml`. I am open to putting that somewhere else, but wasn't sure where.

## Test plan:
I'm not clear on this part actually.

Closes PDX-187