### PR TITLE
feat(secrets): Use `validation_state` for priority, not uniqueness

### DIFF
--- a/changelog.d/scrt-271.changed
+++ b/changelog.d/scrt-271.changed
@@ -1,0 +1,4 @@
+secrets: now performs more aggressive deduplication for instances where an
+invalid and valid match are reported at the same range. Instead of reporting
+both, we now report only the valid match when they are otherwise visually
+identical.

--- a/cli/src/semgrep/core_output.py
+++ b/cli/src/semgrep/core_output.py
@@ -24,6 +24,7 @@ from semgrep.error import OK_EXIT_CODE
 from semgrep.error import SemgrepCoreError
 from semgrep.error import TARGET_PARSE_FAILURE_EXIT_CODE
 from semgrep.rule import Rule
+from semgrep.rule_match import CliUniqueKey
 from semgrep.rule_match import RuleMatch
 from semgrep.rule_match import RuleMatchSet
 from semgrep.verbose_logging import getLogger
@@ -190,7 +191,7 @@ def core_matches_to_rule_matches(
             fix=fix,
         )
 
-    by_unique_key: Dict[Tuple, RuleMatch] = {}
+    by_unique_key: Dict[CliUniqueKey, RuleMatch] = {}
     for match in res.results:
         rule_match = convert_to_rule_match(match)
         curr = by_unique_key.setdefault(rule_match.cli_unique_key, rule_match)

--- a/cli/src/semgrep/rule_match.py
+++ b/cli/src/semgrep/rule_match.py
@@ -30,6 +30,9 @@ from semgrep.semgrep_interfaces.semgrep_output_v1 import Transitivity
 from semgrep.util import get_lines
 
 
+CliUniqueKey = Tuple[str, str, int, int, str, Optional[str]]
+
+
 def rstrip(value: Optional[str]) -> Optional[str]:
     return value.rstrip() if value is not None else None
 
@@ -91,7 +94,7 @@ class RuleMatch:
     lines: List[str] = field(init=False, repr=False)
     previous_line: str = field(init=False, repr=False)
     syntactic_context: str = field(init=False, repr=False)
-    cli_unique_key: Tuple = field(init=False, repr=False)
+    cli_unique_key: CliUniqueKey = field(init=False, repr=False)
     ci_unique_key: Tuple = field(init=False, repr=False)
     ordering_key: Tuple = field(init=False, repr=False)
     match_based_key: Tuple = field(init=False, repr=False)
@@ -196,7 +199,7 @@ class RuleMatch:
         return code
 
     @cli_unique_key.default
-    def get_cli_unique_key(self) -> Tuple:
+    def get_cli_unique_key(self) -> CliUniqueKey:
         """
         A unique key designed with data-completeness & correctness in mind.
 
@@ -244,6 +247,8 @@ class RuleMatch:
     def should_report_instead(self, other: "RuleMatch") -> bool:
         """
         Returns True iff we should report `self` in lieu of reporting `other`.
+        This is currently only used for the following items:
+        - secrets: a valid finding is reported over an invalid one
 
         Assumes that self.cli_unique_key == other.cli_unique_key
         """

--- a/cli/src/semgrep/rule_match.py
+++ b/cli/src/semgrep/rule_match.py
@@ -247,9 +247,13 @@ class RuleMatch:
 
         Assumes that self.cli_unique_key == other.cli_unique_key
         """
-        return isinstance(self.validation_state, out.ConfirmedValid) and not isinstance(
-            other.validation_state, out.ConfirmedValid
-        )
+        if self.validation_state is None:
+            return False
+        if other.validation_state is None:
+            return True
+        return isinstance(
+            self.validation_state.value, out.ConfirmedValid
+        ) and not isinstance(other.validation_state.value, out.ConfirmedValid)
 
     @ci_unique_key.default
     def get_ci_unique_key(self) -> Tuple:


### PR DESCRIPTION
With the addition of `anywhere` as a pattern key, we expect noise to increase if we report all invalid matches in certain contexts. For instance, a file with a secret of the form A + B (where we match on A, and include B via `anywhere`) will result in one valid match, but if the same file contains many such pairs we would get N valid matches and N^2 - N invalid matches (reduced post-deduplication to N invalid matches). However, all such invalid matches are ultimately noise, since for A1, ..., AN we only fundamentally care about the valid match (the one correspoding to (A1, B1), etc...).

To reduce noise, when two matches are considered equal under `cli_unique_key` we now add a mechanism for replacing "lower priority" matches with "higher priority" ones. For now, a finding is just higher priority if it is confirmed valid and the other finding is not.

This removes validation_state from `cli_unique_key` since two findings will be considered substatively equal at the same validation state, just able to be higher priority within that equivalence class.

Test plan: See https://github.com/semgrep/semgrep-proprietary/pull/1137
