### PR TITLE
[DRAFT] experimental cli-side treatment assignment

### DIFF
--- a/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -1019,12 +1019,14 @@ let cmdline_term ~allow_empty_config : conf Term.t =
                   Show.show_kind =
                     Show.DumpPattern (str, Lang.of_string lang_str);
                   json;
+                  logging_level = common.logging_level;
                 }
           | None, Some lang_str, [ file ] ->
               Some
                 {
                   Show.show_kind = Show.DumpAST (file, Lang.of_string lang_str);
                   json;
+                  logging_level = common.logging_level;
                 }
           | _, None, _ ->
               Error.abort "--dump-ast and -l/--lang must both be specified"
@@ -1038,11 +1040,26 @@ let cmdline_term ~allow_empty_config : conf Term.t =
           | Some _, _, _ :: _ ->
               Error.abort "Can't specify both -e and a target for --dump-ast")
       | _ when dump_engine_path ->
-          Some { Show.show_kind = Show.DumpEnginePath pro; json }
+          Some
+            {
+              Show.show_kind = Show.DumpEnginePath pro;
+              json;
+              logging_level = common.logging_level;
+            }
       | _ when dump_command_for_core ->
-          Some { Show.show_kind = Show.DumpCommandForCore; json }
+          Some
+            {
+              Show.show_kind = Show.DumpCommandForCore;
+              json;
+              logging_level = common.logging_level;
+            }
       | _ when show_supported_languages ->
-          Some { Show.show_kind = Show.SupportedLanguages; json }
+          Some
+            {
+              Show.show_kind = Show.SupportedLanguages;
+              json;
+              logging_level = common.logging_level;
+            }
       | _else_ -> None
     in
     (* ugly: validate should be a separate subcommand.

--- a/src/osemgrep/cli_show/Show_CLI.mli
+++ b/src/osemgrep/cli_show/Show_CLI.mli
@@ -12,6 +12,7 @@ type conf = {
   (* mix of --dump-ast/--dump-rule/... *)
   show_kind : show_kind;
   json : bool;
+  logging_level : Logs.level option;
 }
 
 and show_kind =
@@ -19,6 +20,7 @@ and show_kind =
   | SupportedLanguages
   | Identity
   | Deployment
+  | Bucket
   (* dumpers *)
   | DumpPattern of string * Lang.t
   | DumpAST of Fpath.t * Lang.t

--- a/src/osemgrep/cli_show/Show_subcommand.ml
+++ b/src/osemgrep/cli_show/Show_subcommand.ml
@@ -63,6 +63,7 @@ let run (conf : Show_CLI.conf) : Exit_code.t =
       Exit_code.ok
   | Identity -> Whoami.print Whoami.Identity
   | Deployment -> Whoami.print Whoami.Deployment
+  | Bucket -> Whoami.print Whoami.Bucket
   | SupportedLanguages ->
       Out.put (spf "supported languages are: %s" Xlang.supported_xlangs);
       Exit_code.ok (* dumpers *)

--- a/src/osemgrep/cli_show/Whoami.mli
+++ b/src/osemgrep/cli_show/Whoami.mli
@@ -2,6 +2,6 @@
    Show the current identity of the user running the command.
 *)
 
-type identity_kind = Identity | Deployment
+type identity_kind = Identity | Deployment | Bucket
 
 val print : identity_kind -> Exit_code.t


### PR DESCRIPTION
## Description

In order to help incrementally rollout `osemgrep` login, I'd like to draft out a scheme to generate a random number between 0 and 999 (i.e. 1000 buckets) to assign users into treatment groups (e.g. dispatch `osemgrep` vs `pysemgrep` login implementation).

### Candidate Designs

#### 1. Simple Random
We call `Random.in` 100, and check if the value is < cutoff (e.g. 10 for 10% rollout), then execute treatment

**PROS**
- simplest

**CONS**
- inconsistent or unpredictable behavior across attempts for users
- harder to predict, debug, and diagnose failures

#### 2. Client User ID
We convert a local client user ID into an integer, map to range of known size (e.g. 1000) and check if the value is < cutoff (e.g. 100 for 10% rollout), then execute treatment

**PROS**
- consistent and predictable behavior across attempts for most users
- degrades to scheme 1 when users create a new client user ID each run (e.g. docker users) 

**CONS**
- cannot dynamically adjust rollout %

#### 3. Server Side
We pass our local client user ID, event ID, and client version to our app backend and then determine the appropriate bucket.

**PROS**
- consistent and predictable behavior across attempts for most users
- can mimic scheme 2 or scheme 1
- can dynamically adjust rollout %

**CONS**
- most complex
- requires a new api call 
- adds network latency / new failure point


### Demo

```
$ sg show bucket --debug 
[00.00][DEBUG]: anonymous_user_id: 67490a1d-e17c-49a1-a326-0e4c7d266bba
[00.00][DEBUG]: bytes: gI\n\029\225|I\161\163&\014L}&k\186
[00.00][DEBUG]: int_repr: -1780881054194972255
[00.00]:  SUCCESS  bucket 255
```

```
$ sg show bucket --debug 
[00.00][DEBUG]: anonymous_user_id: 3588cf41-847c-47e0-bc59-e75c9f566021
[00.00][DEBUG]: bytes: 5\136\207A\132|G\224\188Y\231\\\159V`!
[00.00][DEBUG]: int_repr: 3857560961145391072
[00.00]:  SUCCESS  bucket 72
```