### PR TITLE
fix(ls): some LSP.js errors

### DIFF
--- a/js/engine/Makefile.include
+++ b/js/engine/Makefile.include
@@ -1,7 +1,7 @@
 EMCC_DEFAULTS = \
    -sALLOW_MEMORY_GROWTH=1 \
    --no-entry \
-   -sEXPORTED_RUNTIME_METHODS=UTF8ToString,stringToUTF8,stringToAscii,lengthBytesUTF8,getValue,setValue,intArrayFromString,writeArrayToMemory \
+   -sEXPORTED_RUNTIME_METHODS=UTF8ToString,stringToUTF8,stringToAscii,AsciiToString,lengthBytesUTF8,getValue,setValue,intArrayFromString,writeArrayToMemory \
    -sMODULARIZE \
    -sSINGLE_FILE=1
 

--- a/js/language_server/Main.ml
+++ b/js/language_server/Main.ml
@@ -53,11 +53,10 @@ let _ =
   Http_helpers.client_ref := Some (module Cohttp_lwt_jsoo.Client);
   Js.export_all
     (object%js
-       method init yaml_wasm_module =
-         init_jsoo yaml_wasm_module;
-         Parse_pattern.parse_pattern_ref := Parse_pattern2.parse_pattern;
-         Parse_target.just_parse_with_lang_ref :=
-           Parse_target2.just_parse_with_lang
+       method init wasm_module =
+         init_jsoo wasm_module;
+         set_parser_wasm_module wasm_module;
+         Parsing_init.init ()
 
        method setWriteRef f = write_ref := f
 

--- a/js/language_server/Makefile
+++ b/js/language_server/Makefile
@@ -45,6 +45,7 @@ dist/language-server-wasm.js: ../libyaml/dist/libyaml.o ../libpcre/dist/libpcre.
 		$(EMCC_DEFAULTS) \
 		-s INITIAL_MEMORY=31457280 \
 		-s SINGLE_FILE=1 \
+		$(EMCC_DEFAULTS) \
 		-sEXPORTED_FUNCTIONS=_malloc,_free,$(YAML_EXPORTED_FUNCTIONS),$(PCRE_EXPORTED_FUNCTIONS),$(TREESITTER_EXPORTED_FUNCTIONS),$(PARSER_EXPORTED_FUNCTIONS) \
 		-o $@
 
@@ -56,3 +57,8 @@ dist/Main.bc.js: ../../_build/default/js/language_server/Main.bc.js
 dist/semgrep-ls.js: node_modules/.package-lock.json dist/language-server-wasm.js dist/Main.bc.js
 	mkdir -p dist
 	npm run build
+
+
+# TODO: No token create request on startup
+# TODO: `yaml_get_version_string` was unexpected
+# TODO:  `%` was unexpected

--- a/js/language_server/Makefile
+++ b/js/language_server/Makefile
@@ -57,8 +57,3 @@ dist/Main.bc.js: ../../_build/default/js/language_server/Main.bc.js
 dist/semgrep-ls.js: node_modules/.package-lock.json dist/language-server-wasm.js dist/Main.bc.js
 	mkdir -p dist
 	npm run build
-
-
-# TODO: No token create request on startup
-# TODO: `yaml_get_version_string` was unexpected
-# TODO:  `%` was unexpected

--- a/js/language_server/dune
+++ b/js/language_server/dune
@@ -19,6 +19,7 @@
  (modes js)
  (js_of_ocaml
   (javascript_files
+   ;; Custom XMLHttpRequest implementation that doesn't preset the User-Agent header
    XMLHttpRequest.js
    semgrep.js
  ))

--- a/js/language_server/src/semgrep-lsp-bindings.ts
+++ b/js/language_server/src/semgrep-lsp-bindings.ts
@@ -10,11 +10,11 @@ declare global {
 }
 
 export const LSFactory = async () => {
-  const loadedYamlPCRE = await LSWasm();
+  const loadedLSWasm = await LSWasm();
   // libpcre regrettably must be global because semgrep eagerly compiles regexes
-  globalThis.LibPcreModule = loadedYamlPCRE;
+  globalThis.LibPcreModule = loadedLSWasm;
   const { init, handleClientMessage, setWriteRef } = require("./Main.bc");
-  init(loadedYamlPCRE);
+  init(loadedLSWasm);
   const clientMessageHandler = async (packet: any) => {
     const json = JSON.stringify(packet);
     const result = await handleClientMessage(json);


### PR DESCRIPTION
Previously, LSP.js wasn't setting a global wasm module for the parsers to use. This means when TS parsers tried to run, they wouldn't be able to access the transpiled TS code. This fixes that. It also includes a minor fix to update the exported emcc runtime functions to fix a small bug there.

## Test plan
I have been testing with the e2e framework in semgrep-vscode. See corresponding PR here https://github.com/semgrep/semgrep-vscode/pull/80 that will be updated/merged after this PR is.