### PR TITLE
fix(ci): allow CLI and actions file to use print function

### DIFF
--- a/semgrep.yml
+++ b/semgrep.yml
@@ -43,6 +43,10 @@ rules:
         - languages/*
         - scripts/*
         - tools/*
+        - Core_actions.ml
+        - Core_CLI.ml
+        - Pro_actions.ml
+        - Pro_core_CLI.ml
 
   - id: use-pytest-mock
     pattern: import unittest.mock


### PR DESCRIPTION
If we update any of these files, then pre-commit will complain.

But these files seem to expect to have print functions, so adding to the exclude list.

Tested: tried adding a fake function with a print function in these files and pre-commit passes.