### PR TITLE
fix(internal): Unify Local IDs between Scan and Findings

### DIFF
--- a/cli/src/semgrep/app/scans.py
+++ b/cli/src/semgrep/app/scans.py
@@ -48,7 +48,7 @@ class ScanCompleteResult:
 class ScanHandler:
     def __init__(self, dry_run: bool = False) -> None:
         state = get_state()
-        self.local_id = str(state.request_id)
+        self.local_id = str(state.local_scan_id)
         self.scan_metadata = out.ScanMetadata(
             cli_version=out.Version(__VERSION__),
             unique_id=out.Uuid(self.local_id),

--- a/cli/src/semgrep/config_resolver.py
+++ b/cli/src/semgrep/config_resolver.py
@@ -306,7 +306,7 @@ class ConfigLoader:
             meta=out.RawJson({}),  # required for now, but we won't populate it
             scan_metadata=out.ScanMetadata(
                 cli_version=out.Version(__VERSION__),
-                unique_id=out.Uuid(str(state.request_id)),
+                unique_id=out.Uuid(str(state.local_scan_id)),
                 requested_products=products,
                 dry_run=True,  # semgrep scan never submits findings, so always a dry run
             ),

--- a/cli/src/semgrep/error_handler.py
+++ b/cli/src/semgrep/error_handler.py
@@ -95,7 +95,7 @@ class ErrorHandler:
         if "error" not in self.payload:
             self.capture_error()
 
-        self.payload["request_id"] = str(state.request_id)
+        self.payload["request_id"] = str(state.local_scan_id)
 
         try:
             requests.post(url, headers=headers, json=self.payload, timeout=3)

--- a/cli/src/semgrep/semgrep_types.py
+++ b/cli/src/semgrep/semgrep_types.py
@@ -4,6 +4,8 @@ from typing import Collection
 from typing import Mapping
 from typing import NewType
 from typing import Optional
+from uuid import UUID
+from uuid import uuid4
 
 from attrs import frozen
 
@@ -17,6 +19,16 @@ Shebang = str
 
 JOIN_MODE = Mode("join")
 SEARCH_MODE = DEFAULT_MODE = Mode("search")
+FROZEN_ID: UUID = uuid4()
+
+
+def get_frozen_id() -> UUID:
+    """
+    Return a frozen UUID to identify a local scan and its corresponding results (if any)
+    within the Semgrep App. We avoid initializing this UUID within our state object to
+    prevent circular dependencies.
+    """
+    return FROZEN_ID
 
 
 class Language(str):
@@ -109,6 +121,5 @@ class _LanguageData:
 
 
 LANGUAGE = _LanguageData()
-
 
 ALLOWED_GLOB_TYPES = ("include", "exclude")

--- a/cli/src/semgrep/state.py
+++ b/cli/src/semgrep/state.py
@@ -2,7 +2,6 @@ from enum import auto
 from enum import Enum
 from typing import List
 from uuid import UUID
-from uuid import uuid4
 
 import click
 from attrs import Factory

--- a/cli/src/semgrep/state.py
+++ b/cli/src/semgrep/state.py
@@ -12,6 +12,7 @@ from semgrep.app.session import AppSession
 from semgrep.env import Env
 from semgrep.error_handler import ErrorHandler
 from semgrep.metrics import Metrics
+from semgrep.semgrep_types import get_frozen_id
 from semgrep.settings import Settings
 from semgrep.terminal import Terminal
 
@@ -32,7 +33,7 @@ class SemgrepState:
     """
 
     app_session: AppSession = Factory(AppSession)
-    request_id: UUID = Factory(uuid4)
+    local_scan_id: UUID = get_frozen_id()
     env: Env = Factory(Env)
     metrics: Metrics = Factory(Metrics)
     error_handler: ErrorHandler = Factory(ErrorHandler)

--- a/cli/tests/e2e/test_metrics.py
+++ b/cli/tests/e2e/test_metrics.py
@@ -192,8 +192,8 @@ def test_metrics_payload(tmp_path, snapshot, mocker, monkeypatch, pro_flag):
     os.environ["TZ"] = "Asia/Tokyo"
     time.tzset()
 
-    # make the event ID deterministic
-    mocker.patch("uuid.uuid4", return_value=uuid.UUID("0" * 32))
+    # this makes event_id deterministic
+    mocker.patch("semgrep.metrics.get_frozen_id", return_value=uuid.UUID("0" * 32))
     mocker.patch("semgrep.metrics.mock_float", return_value=0.0)
     mocker.patch("semgrep.metrics.mock_int", return_value=0)
 

--- a/cli/tests/unit/test_config_resolver.py
+++ b/cli/tests/unit/test_config_resolver.py
@@ -26,7 +26,7 @@ def mock_env(monkeypatch):
 @pytest.fixture
 def mocked_state(mocker):
     mocked = mocker.MagicMock()
-    mocked.request_id = uuid4()
+    mocked.local_scan_id = uuid4()
     mocked.env.semgrep_url = API_URL
     mocker.patch("semgrep.config_resolver.get_state", return_value=mocked)
     return mocked

--- a/cli/tests/unit/test_error_handler.py
+++ b/cli/tests/unit/test_error_handler.py
@@ -42,7 +42,7 @@ def mock_get_token(mocker):
 def mocked_state(mocker, error_handler):
     mocked = mocker.MagicMock()
     mocked.app_session.user_agent = FAKE_USER_AGENT
-    mocked.request_id = uuid4()
+    mocked.local_scan_id = uuid4()
     mocked.env.fail_open_url = FAIL_OPEN_URL.replace("/failure", "")
     mocked.error_handler = error_handler
     mocker.patch("semgrep.state.get_state", return_value=mocked)
@@ -135,7 +135,7 @@ def test_send_with_scan_id(
         "method": "get",
         "url": "https://semgrep.dev/api/agent/deployments/current",
         "scan_id": 1234,
-        "request_id": str(mocked_state.request_id),
+        "request_id": str(mocked_state.local_scan_id),
     }
 
     expected_headers = {
@@ -175,7 +175,7 @@ def test_send_nominal_with_trace(
 
     expected_payload = {
         "error": expected_traceback,
-        "request_id": str(mocked_state.request_id),
+        "request_id": str(mocked_state.local_scan_id),
     }
     expected_headers = {
         "User-Agent": FAKE_USER_AGENT,


### PR DESCRIPTION
## Description
Instead of generating a shared UUID for scan telemetry and finding uploads for the same corresponding scan, we instead generated 2 separate UUIDs. This PR ensures we use the same UUID for debugging customer issues and associating product usage.