### PR TITLE
parity(osemgrep): Enable Passing SEMGREP_APP_TOKEN to osemgrep scan subcommand

### DIFF
--- a/src/osemgrep/cli_login/Logout_subcommand.ml
+++ b/src/osemgrep/cli_login/Logout_subcommand.ml
@@ -13,7 +13,7 @@
    exit code. *)
 let run_conf (conf : Logout_CLI.conf) : Exit_code.t =
   CLI_common.setup_logging ~force_color:false ~level:conf.common.logging_level;
-  let settings = Semgrep_settings.load () in
+  let settings = Semgrep_settings.load ~include_env:false () in
   match settings.Semgrep_settings.api_token with
   | None ->
       Logs.app (fun m ->

--- a/src/osemgrep/configuring/Semgrep_settings.ml
+++ b/src/osemgrep/configuring/Semgrep_settings.ml
@@ -78,7 +78,7 @@ let to_yaml { has_shown_metrics_notification; api_token; anonymous_user_id } =
 (* Entry points *)
 (*****************************************************************************)
 
-let load ?(maturity = Maturity.Default) () =
+let load ?(maturity = Maturity.Default) ?(include_env = true) () =
   let settings = !Semgrep_envvars.v.user_settings_file in
   Logs.debug (fun m -> m "Loading settings from %a" Fpath.pp settings);
   try
@@ -105,9 +105,11 @@ let load ?(maturity = Maturity.Default) () =
             | Ok s -> s)
       in
       let settings =
-        match !Semgrep_envvars.v.app_token with
-        | Some token -> { decoded with api_token = Some token }
-        | None -> decoded
+        if include_env then
+          match !Semgrep_envvars.v.app_token with
+          | Some token -> { decoded with api_token = Some token }
+          | None -> decoded
+        else decoded
       in
       settings
     else (

--- a/src/osemgrep/configuring/Semgrep_settings.mli
+++ b/src/osemgrep/configuring/Semgrep_settings.mli
@@ -8,7 +8,7 @@ type t = {
 }
 
 (* loading the ~/.semgrep/settings.yml in memory *)
-val load : ?maturity:Maturity.t -> unit -> t
+val load : ?maturity:Maturity.t -> ?include_env:bool -> unit -> t
 
 (* returns whether the save was successful *)
 val save : t -> bool


### PR DESCRIPTION
## Description
This PR ensures we enable passing in `SEMGREP_APP_TOKEN` to our `scan subcommand` 

```python
# `semgrep/cli/src/semgrep/app/auth.py`
def get_token() -> Optional[str]:
    """
    Get saved token in following order:
    - env var
    - settings file
    - None
    """
    state = get_state()
    if state.env.app_token is not None:
        logger.debug(f"Using environment variable SEMGREP_APP_TOKEN as api token")
        return state.env.app_token

    return _read_token_from_settings_file()
```

**Addresses**:  PA-3302