### PR TITLE
fix(internal): Ensure we set local ID properly 

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -194,8 +194,7 @@ Semgrep, Inc will:
 
 > `anonymous_user_id: "5f52484c-3f82-4779-9353-b29bbd3193b6"`
 
-Semgrep generates a new random UUID and saves the ID locally to a `~/.semgrep/settings.yml` file
-when the ID is not present to help improve Semgrep products.
+To help improve Semgrep products, the Semgrep CLI generates a Universally Unique Identifier (UUID) which is saved locally to a `~/.semgrep/settings.yml` file when the ID does not already exist.
 
 The Semgrep team uses this ID to help answer the following questions:
 

--- a/cli/src/semgrep/commands/login.py
+++ b/cli/src/semgrep/commands/login.py
@@ -37,7 +37,7 @@ def login() -> NoReturn:
     """
     state = get_state()
     saved_login_token = auth._read_token_from_settings_file()
-    if saved_login_token:
+    if saved_login_token and saved_login_token != state.env.app_token:
         click.echo(
             f"API token already exists in {state.settings.path}. To login with a different token logout use `semgrep logout`"
         )

--- a/cli/src/semgrep/settings.py
+++ b/cli/src/semgrep/settings.py
@@ -11,6 +11,7 @@ If no settings have been configured on the system, DEFAULT_SETTINGS will be writ
 If the process does not have permission to the settings path, a PermissionError will be raised;
 callers should handle this gracefully.
 """
+import hashlib
 import os
 import uuid
 from pathlib import Path
@@ -48,7 +49,11 @@ def generate_anonymous_user_id(api_token: Optional[str]) -> str:
     return (
         str(uuid.uuid4())
         if api_token is None
-        else str(uuid.uuid5(uuid.UUID("0" * 32), api_token))
+        else str(
+            uuid.uuid5(
+                uuid.UUID("0" * 32), hashlib.sha256(api_token.encode()).hexdigest()
+            )
+        )
     )
 
 

--- a/cli/src/semgrep/settings.py
+++ b/cli/src/semgrep/settings.py
@@ -11,7 +11,6 @@ If no settings have been configured on the system, DEFAULT_SETTINGS will be writ
 If the process does not have permission to the settings path, a PermissionError will be raised;
 callers should handle this gracefully.
 """
-import hashlib
 import os
 import uuid
 from pathlib import Path
@@ -49,26 +48,22 @@ def generate_anonymous_user_id(api_token: Optional[str]) -> str:
     return (
         str(uuid.uuid4())
         if api_token is None
-        else str(
-            uuid.uuid5(
-                uuid.UUID("0" * 32), hashlib.sha256(api_token.encode()).hexdigest()
-            )
-        )
+        else str(uuid.uuid5(uuid.UUID("0" * 32), api_token))
     )
 
 
 def generate_default_settings(api_token: Optional[str] = None) -> SettingsSchema:
     anonymous_user_id = generate_anonymous_user_id(api_token)
+    logged_out_settings: SettingsSchema = {
+        "has_shown_metrics_notification": False,
+        "anonymous_user_id": anonymous_user_id,
+    }
     return (
-        {
-            "has_shown_metrics_notification": False,
-            "api_token": api_token,
-            "anonymous_user_id": anonymous_user_id,
-        }
+        logged_out_settings
         if api_token is not None
         else {
-            "has_shown_metrics_notification": False,
-            "anonymous_user_id": anonymous_user_id,
+            **logged_out_settings,
+            "api_token": api_token,
         }
     )
 

--- a/cli/src/semgrep/settings.py
+++ b/cli/src/semgrep/settings.py
@@ -53,11 +53,19 @@ def generate_anonymous_user_id(api_token: Optional[str]) -> str:
 
 
 def generate_default_settings(api_token: Optional[str] = None) -> SettingsSchema:
-    return {
-        "has_shown_metrics_notification": False,
-        "api_token": api_token,
-        "anonymous_user_id": generate_anonymous_user_id(api_token),
-    }
+    anonymous_user_id = generate_anonymous_user_id(api_token)
+    return (
+        {
+            "has_shown_metrics_notification": False,
+            "api_token": api_token,
+            "anonymous_user_id": anonymous_user_id,
+        }
+        if api_token is not None
+        else {
+            "has_shown_metrics_notification": False,
+            "anonymous_user_id": anonymous_user_id,
+        }
+    )
 
 
 @define

--- a/cli/src/semgrep/settings.py
+++ b/cli/src/semgrep/settings.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import Any
 from typing import cast
 from typing import Mapping
+from typing import Optional
 
 from attr import define
 from attr import field
@@ -34,7 +35,7 @@ yaml.default_flow_style = False
 
 class SettingsSchema(TypedDict, total=False):
     has_shown_metrics_notification: bool
-    api_token: str
+    api_token: Optional[str]
     anonymous_user_id: str
 
 
@@ -42,7 +43,21 @@ SettingsKeys = Literal[
     "has_shown_metrics_notification", "api_token", "anonymous_user_id"
 ]
 
-DEFAULT_SETTINGS: SettingsSchema = {"anonymous_user_id": str(uuid.uuid4())}
+
+def generate_anonymous_user_id(api_token: Optional[str]) -> str:
+    return (
+        str(uuid.uuid4())
+        if api_token is None
+        else str(uuid.uuid5(uuid.UUID("0" * 32), api_token))
+    )
+
+
+def generate_default_settings(api_token: Optional[str] = None) -> SettingsSchema:
+    return {
+        "has_shown_metrics_notification": False,
+        "api_token": api_token,
+        "anonymous_user_id": generate_anonymous_user_id(api_token),
+    }
 
 
 @define
@@ -64,8 +79,10 @@ class Settings:
     def get_default_contents(self) -> SettingsSchema:
         """If file exists, read file. Otherwise use default"""
         # Must perform access check first in case we don't have permission to stat the path
+        env = Env()
+        default_settings = generate_default_settings(env.app_token)
         if not os.access(self.path, os.R_OK) or not self.path.is_file():
-            return DEFAULT_SETTINGS.copy()
+            return default_settings
 
         with self.path.open() as fd:
             yaml_contents = yaml.load(fd)
@@ -74,9 +91,9 @@ class Settings:
             logger.warning(
                 f"Bad settings format; {self.path} will be overridden. Contents:\n{yaml_contents}"
             )
-            return DEFAULT_SETTINGS.copy()
+            return default_settings
 
-        return cast(SettingsSchema, {**DEFAULT_SETTINGS, **yaml_contents})
+        return cast(SettingsSchema, {**default_settings, **yaml_contents})
 
     def __attrs_post_init__(self) -> None:
         self.save()  # in case we retrieved default contents

--- a/cli/src/semgrep/settings.py
+++ b/cli/src/semgrep/settings.py
@@ -59,12 +59,12 @@ def generate_default_settings(api_token: Optional[str] = None) -> SettingsSchema
         "anonymous_user_id": anonymous_user_id,
     }
     return (
-        logged_out_settings
-        if api_token is not None
-        else {
+        {
             **logged_out_settings,
             "api_token": api_token,
         }
+        if api_token is not None
+        else logged_out_settings
     )
 
 

--- a/cli/tests/e2e-pro/test_login.py
+++ b/cli/tests/e2e-pro/test_login.py
@@ -16,6 +16,7 @@ def test_login(tmp_path, mocker):
 
     expected_logout_str = "Logged out (log back in with `semgrep login`)\n"
     fake_key = "key123"
+    alt_key = "key456"
 
     # Patch Token Validation:
     mocker.patch(
@@ -53,7 +54,7 @@ def test_login(tmp_path, mocker):
         cli,
         subcommand="login",
         args=[],
-        env={"SEMGREP_APP_TOKEN": fake_key},
+        env={"SEMGREP_APP_TOKEN": alt_key},
     )
     assert result.exit_code == 2
     assert "API token already exists in" in result.output


### PR DESCRIPTION
## Description
This PR fixes cases where Docker scans are creating new clients IDs instead of reusing a unique identifier for logged-in use cases.

### Test Plan
- [x] local validation succeeds
- [x] ci tests pass 
