### PR TITLE
New 'semgrep test' subcommand! (skeleton)

### DIFF
--- a/changelog.d/subcommand_test.added
+++ b/changelog.d/subcommand_test.added
@@ -1,0 +1,4 @@
+A new subcommand 'semgrep test', which is an alias for 'semgrep scan
+--test'. This means that if you were running semgrep on a test
+directory, you will now have to use 'semgrep scan test' otherwise it
+will be interpreted as the new 'semgrep test' subcommand.

--- a/src/engine/Test_engine.ml
+++ b/src/engine/Test_engine.ml
@@ -102,6 +102,7 @@ let find_target_of_yaml_file file =
 let make_test_rule_file ~unit_testing ~get_xlang ~prepend_lang ~newscore
     ~total_mismatch file =
   let test () =
+    Logs.info (fun m -> m "processing rule file %s" !!file);
     logger#info "processing rule file %s" !!file;
     match Parse_rule.parse file with
     | [] -> logger#info "file %s is empty or all rules were skipped" !!file

--- a/src/osemgrep/cli/CLI.ml
+++ b/src/osemgrep/cli/CLI.ml
@@ -106,6 +106,7 @@ let known_subcommands =
     "install-ci";
     "interactive";
     "show";
+    "test";
   ]
 
 let dispatch_subcommand (caps : Cap.all_caps) (argv : string array) =
@@ -183,7 +184,7 @@ let dispatch_subcommand (caps : Cap.all_caps) (argv : string array) =
             Show_subcommand.main
               (caps :> < Cap.stdout ; Cap.network >)
               subcmd_argv
-        (* LATER: "test" *)
+        | "test" -> Test_subcommand.main subcmd_argv
         | _else_ ->
             if experimental then
               (* this should never happen because we default to 'scan',

--- a/src/osemgrep/cli_scan/Scan_CLI.mli
+++ b/src/osemgrep/cli_scan/Scan_CLI.mli
@@ -35,7 +35,7 @@ type conf = {
   version : bool;
   show : Show_CLI.conf option;
   validate : Validate_subcommand.conf option;
-  test : Test_subcommand.conf option;
+  test : Test_CLI.conf option;
   ls : bool;
 }
 [@@deriving show]

--- a/src/osemgrep/cli_test/Test_CLI.ml
+++ b/src/osemgrep/cli_test/Test_CLI.ml
@@ -1,0 +1,162 @@
+module Arg = Cmdliner.Arg
+module Term = Cmdliner.Term
+module Cmd = Cmdliner.Cmd
+module H = Cmdliner_
+
+(*****************************************************************************)
+(* Prelude *)
+(*****************************************************************************)
+(*
+   'semgrep test' command-line arguments processing.
+*)
+
+(*****************************************************************************)
+(* Types and constants *)
+(*****************************************************************************)
+
+(*
+   The result of parsing a 'semgrep test' command.
+   This is also used in Scan_CLI.ml to transform legacy
+   commands such as 'semgrep scan --tests <dir>' into the
+   new 'semgrep test <dir>'
+*)
+type conf = {
+  target : target_kind;
+  ignore_todo : bool;
+  (* TODO? do we need those options? people use the JSON output?
+   * the playground? and the optimizations and strict?
+   *)
+  json : bool;
+  (* take the whole core_runner_conf? like for validate? *)
+  optimizations : bool;
+  strict : bool;
+  common : CLI_common.conf;
+}
+
+(* alt: we could accept multiple dirs, and multiple files
+ * TODO? should we restrict the config_str to File or Dir?
+ *)
+and target_kind =
+  | Dir of Fpath.t * Rules_config.config_string option (* optional --config *)
+  | File of Fpath.t * Rules_config.config_string (* mandatory --config *)
+[@@deriving show]
+
+(*************************************************************************)
+(* Command-line flags *)
+(*************************************************************************)
+
+(* ------------------------------------------------------------------ *)
+(* Flags *)
+(* ------------------------------------------------------------------ *)
+let o_test_ignore_todo : bool Term.t =
+  H.negatable_flag [ "test-ignore-todo" ] ~neg_options:[ "no-test-ignore-todo" ]
+    ~default:false
+    ~doc:
+      {|If --test-ignore-todo, ignores rules marked as '#todoruleid:' in
+test files.
+|}
+
+let o_json : bool Term.t =
+  let info = Arg.info [ "json" ] ~doc:{|Output results in JSON format.|} in
+  Arg.value (Arg.flag info)
+
+(* coupling: similar to Scan_CLI.o_strict? *)
+let o_strict : bool Term.t =
+  let info = Arg.info [ "strict" ] ~doc:{|???.|} in
+  Arg.value (Arg.flag info)
+
+(* coupling: Scan_CLI.o_config *)
+let o_config : string list Term.t =
+  let info =
+    Arg.info [ "c"; "f"; "config" ]
+      ~env:(Cmd.Env.info "SEMGREP_RULES")
+      ~doc:
+        {|YAML configuration file, directory of YAML files ending in
+.yml|.yaml, URL of a configuration file, or Semgrep registry entry name.
+
+Use --config auto to automatically obtain rules tailored to this project;
+your project URL will be used to log in to the Semgrep registry.
+
+To run multiple rule files simultaneously, use --config before every YAML,
+URL, or Semgrep registry entry name.
+For example `semgrep --config p/python --config myrules/myrule.yaml`
+
+See https://semgrep.dev/docs/writing-rules/rule-syntax for information on
+configuration file format.
+|}
+  in
+  Arg.value (Arg.opt_all Arg.string [] info)
+
+(* ------------------------------------------------------------------ *)
+(* Positional arguments *)
+(* ------------------------------------------------------------------ *)
+
+let o_args : string list Term.t =
+  let info =
+    Arg.info [] ~docv:"STRINGS" ~doc:{|Directories containing tests.|}
+  in
+  Arg.value (Arg.pos_all Arg.string [] info)
+
+(*************************************************************************)
+(* Command-line parsing: turn argv into conf *)
+(*************************************************************************)
+let target_kind_of_roots_and_config target_roots config =
+  match (target_roots, config) with
+  | [ x ], [ config ] ->
+      let file_str = Fpath.to_string x in
+      if Sys.file_exists file_str && Sys.is_directory file_str then
+        Dir (x, Some config)
+      else File (x, config)
+  | [ x ], [] ->
+      let file_str = Fpath.to_string x in
+      if Sys.is_directory file_str then Dir (x, None)
+      else
+        (* was raise Exception but cleaner abort I think *)
+        Error.abort "--config is required when running a test on single file"
+  | _ :: _ :: _, _ ->
+      (* stricter: better error message '(directory or file)' *)
+      Error.abort "only one target (directory or file) allowed for tests"
+  | _, _ :: _ :: _ ->
+      (* stricter: removed 'config directory' *)
+      Error.abort "only one config allowed for tests"
+      (* target_roots should always contain at least ["."] *)
+  | [], _ -> assert false
+
+let cmdline_term : conf Term.t =
+  (* !The parameters must be in alphabetic orders to match the order
+   * of the corresponding '$ o_xx $' further below! *)
+  let combine args common config json strict test_ignore_todo =
+    let target =
+      target_kind_of_roots_and_config (Fpath_.of_strings args) config
+    in
+    {
+      target;
+      strict;
+      json;
+      ignore_todo = test_ignore_todo;
+      common;
+      optimizations = true;
+    }
+  in
+  Term.(
+    const combine $ o_args $ CLI_common.o_common $ o_config $ o_json $ o_strict
+    $ o_test_ignore_todo)
+
+let doc = "testing the rules"
+
+let man : Cmdliner.Manpage.block list =
+  [
+    `S Cmdliner.Manpage.s_description;
+    `P "See https://semgrep.dev/docs/writing-rules/testing-rules/";
+  ]
+  @ CLI_common.help_page_bottom
+
+let cmdline_info : Cmd.info = Cmd.info "semgrep test" ~doc ~man
+
+(*****************************************************************************)
+(* Entry point *)
+(*****************************************************************************)
+
+let parse_argv (argv : string array) : conf =
+  let cmd : conf Cmd.t = Cmd.v cmdline_info cmdline_term in
+  CLI_common.eval_value ~argv cmd

--- a/src/osemgrep/cli_test/Test_CLI.mli
+++ b/src/osemgrep/cli_test/Test_CLI.mli
@@ -1,0 +1,39 @@
+(*
+   'semgrep test' command-line parsing.
+*)
+
+(*
+   The result of parsing a 'semgrep test' command.
+   This is also used in Scan_CLI.ml to transform legacy
+   commands such as 'semgrep scan --tests <dir>' into the
+   new 'semgrep test <dir>'
+*)
+type conf = {
+  target : target_kind;
+  ignore_todo : bool;
+  json : bool;
+  optimizations : bool;
+  strict : bool;
+  common : CLI_common.conf;
+}
+
+and target_kind =
+  | Dir of Fpath.t * Rules_config.config_string option (* optional --config *)
+  | File of Fpath.t * Rules_config.config_string (* mandatory --config *)
+[@@deriving show]
+
+(*
+   Usage: parse_argv [| "semgrep-test"; <args> |]
+
+   Turn argv into a conf structure.
+
+   This function may raise an exn in case of an error parsing argv
+   but this should be caught by CLI.safe_run.
+*)
+val parse_argv : string array -> conf
+
+(* used also in cli_scan for --tests *)
+val o_test_ignore_todo : bool Cmdliner.Term.t
+
+val target_kind_of_roots_and_config :
+  Fpath.t list -> Rules_config.config_string list -> target_kind

--- a/src/osemgrep/cli_test/Test_subcommand.ml
+++ b/src/osemgrep/cli_test/Test_subcommand.ml
@@ -15,26 +15,6 @@ open Fpath_.Operators
 (* Types *)
 (*****************************************************************************)
 
-type conf = {
-  target : target_kind;
-  ignore_todo : bool;
-  (* TODO? do we need those options? people use the JSON output?
-   * the playground? and the optimizations and strict?
-   *)
-  json : bool;
-  (* take the whole core_runner_conf? like for validate? *)
-  optimizations : bool;
-  strict : bool;
-}
-
-(* alt: we could accept multiple dirs, and multiple files
- * TODO? should we restrict the config_str to File or Dir?
- *)
-and target_kind =
-  | Dir of Fpath.t * Rules_config.config_string option (* optional --config *)
-  | File of Fpath.t * Rules_config.config_string (* mandatory --config *)
-[@@deriving show]
-
 (*************************************************************************)
 (* Helpers *)
 (*************************************************************************)
@@ -368,7 +348,7 @@ let get_config_filenames _targets = failwith "TODO"
 (* TODO: reuse Rule_tests.ml *)
 let get_config_test_filenames _a _b = failwith "TODO"
 
-let run_conf (conf : conf) : Exit_code.t =
+let _run_conf_TODO (conf : Test_CLI.conf) : Exit_code.t =
   let config_filenames = get_config_filenames conf.target in
   let config_test_filenames =
     get_config_test_filenames conf.target config_filenames
@@ -670,6 +650,17 @@ let run_conf (conf : conf) : Exit_code.t =
     exit_code
 
 (*****************************************************************************)
+(* Pad's temporary version *)
+(*****************************************************************************)
+let run_conf (conf : Test_CLI.conf) : Exit_code.t =
+  CLI_common.setup_logging ~force_color:true ~level:conf.common.logging_level;
+  (* Metrics_.configure Metrics_.On; *)
+  Logs.debug (fun m -> m "conf = %s" (Test_CLI.show_conf conf));
+  failwith "TODO"
+
+(*****************************************************************************)
 (* Entry point *)
 (*****************************************************************************)
-(* TODO: let main ... *)
+let main (argv : string array) : Exit_code.t =
+  let conf = Test_CLI.parse_argv argv in
+  run_conf conf

--- a/src/osemgrep/cli_test/Test_subcommand.mli
+++ b/src/osemgrep/cli_test/Test_subcommand.mli
@@ -1,19 +1,13 @@
-(* There is currently no 'semgrep test' subcommand. Tests are run via
- * 'semgrep scan --test ...' but internally it's quite similar to
- * a subcommand.
+(*
+   Parse a semgrep-test command, execute it and exit.
+
+   Usage: main [| "semgrep-test"; ... |]
+
+   This function returns an exit code to be passed to the 'exit' function.
+*)
+val main : string array -> Exit_code.t
+
+(* called from main() but also from Scan_subcommand.ml to manage the legacy
+ * way to show things (e.g., 'semgrep scan --tests <dir>')
  *)
-
-type conf = {
-  target : target_kind;
-  ignore_todo : bool;
-  json : bool;
-  optimizations : bool;
-  strict : bool;
-}
-
-and target_kind =
-  | Dir of Fpath.t * Rules_config.config_string option (* optional --config *)
-  | File of Fpath.t * Rules_config.config_string (* mandatory --config *)
-[@@deriving show]
-
-val run_conf : conf -> Exit_code.t
+val run_conf : Test_CLI.conf -> Exit_code.t


### PR DESCRIPTION
This is an alias to 'semgrep scan --test'

test plan:
```
./bin/osemgrep test tests/semgrep-rules/ocaml/ --debug --config p/ocaml
[00.00][DEBUG]: Logging setup for osemgrep
[00.00][DEBUG]: Executed as: ./bin/osemgrep test tests/semgrep-rules/ocaml/ --debug --config p/ocaml
[00.00][DEBUG]: conf = { Test_CLI.target =
  (Test_CLI.Dir (tests/semgrep-rules/ocaml/, (Some "p/ocaml")));
  ignore_todo = false; json = false; optimizations = true; strict = false;
  common =
  { CLI_common.logging_level = (Some DEBUG); profile = false;
    maturity = Maturity.Default }
  }
Fatal error: exception Failure: TODO
Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
Called from CLI.dispatch_subcommand in file "src/osemgrep/cli/CLI.ml", line 188, characters 12-44
Called from CLI.main in file "src/osemgrep/cli/CLI.ml", line 305, characters 18-75
Called from Dune__exe__Main.(fun) in file "src/main/Main.ml", line 59, characters 26-44
Called from Dune__exe__Main in file "src/main/Main.ml", line 53, characters 2-699
```