### PR TITLE
Cleanup Test_engine.ml part1

### DIFF
--- a/src/core_cli/Core_CLI.ml
+++ b/src/core_cli/Core_CLI.ml
@@ -393,7 +393,7 @@ let all_actions () =
       Arg_.mk_action_n_conv Fpath.v (Check_rule.stat_files Parse_rule.parse) );
     ( "-test_rules",
       " <files or dirs>",
-      Arg_.mk_action_n_arg Test_engine.test_rules );
+      Arg_.mk_action_n_conv Fpath.v Test_engine.test_rules );
     ( "-parse_rules",
       " <files or dirs>",
       Arg_.mk_action_n_arg Test_parsing.test_parse_rules );

--- a/src/engine/Test_engine.ml
+++ b/src/engine/Test_engine.ml
@@ -322,7 +322,8 @@ let make_test_rule_file ?(fail_callback = fun _i m -> Alcotest.fail m)
       let name = spf "Missing target file for rule file %s" !!file in
       Alcotest_ext.create ~skipped:true name test
 
-let make_tests ?fail_callback ?(get_xlang = None) ?(prepend_lang = false) xs =
+let make_tests ?fail_callback ?(get_xlang = None) ?(prepend_lang = false)
+    (xs : Fpath.t list) : unit Alcotest_ext.t list =
   let fullxs, _skipped_paths =
     xs |> UFile.files_of_dirs_or_files_no_vcs_nofilter
     |> List.filter Parse_rule.is_valid_rule_filename
@@ -331,7 +332,7 @@ let make_tests ?fail_callback ?(get_xlang = None) ?(prepend_lang = false) xs =
   fullxs
   |> List_.map (make_test_rule_file ?fail_callback ~get_xlang ~prepend_lang)
 
-let test_rules paths =
+let test_rules (paths : Fpath.t list) : unit =
   let total_mismatch = ref 0 in
   let fail_callback num_errors _msg =
     total_mismatch := !total_mismatch + num_errors

--- a/src/engine/Test_engine.ml
+++ b/src/engine/Test_engine.ml
@@ -324,12 +324,8 @@ let make_test_rule_file ?(fail_callback = fun _i m -> Alcotest.fail m)
 
 let make_tests ?fail_callback ?(get_xlang = None) ?(prepend_lang = false)
     (xs : Fpath.t list) : unit Alcotest_ext.t list =
-  let fullxs, _skipped_paths =
-    xs |> UFile.files_of_dirs_or_files_no_vcs_nofilter
-    |> List.filter Parse_rule.is_valid_rule_filename
-    |> Skip_code.filter_files_if_skip_list ~root:xs
-  in
-  fullxs
+  xs |> UFile.files_of_dirs_or_files_no_vcs_nofilter
+  |> List.filter Parse_rule.is_valid_rule_filename
   |> List_.map (make_test_rule_file ?fail_callback ~get_xlang ~prepend_lang)
 
 let test_rules (paths : Fpath.t list) : unit =

--- a/src/engine/Test_engine.mli
+++ b/src/engine/Test_engine.mli
@@ -1,6 +1,5 @@
 (*
-   Create a list of tests for regression testing and a reference to use
-   to know the number of tests which failed once each test ran once.
+   Create a list of tests for regression testing
 *)
 val make_tests :
   ?fail_callback:
@@ -11,7 +10,7 @@ val make_tests :
   ?get_xlang:(Fpath.t -> Rule.rules -> Xlang.t) option ->
   ?prepend_lang:bool ->
   Fpath.t list ->
-  Alcotest_ext.test list * int ref (* total mismatch *)
+  Alcotest_ext.test list
 
 (* [test_rules dirs] run the tests discovered under [dirs]
  * and print a summary.

--- a/src/engine/Test_engine.mli
+++ b/src/engine/Test_engine.mli
@@ -1,13 +1,19 @@
 (*
-   Create a list of tests for unit testing and a function to print
-   a summary once each test ran once.
+   Create a list of tests for regression testing and a reference to use
+   to know the number of tests which failed once each test ran once.
 *)
 val make_tests :
-  ?unit_testing:bool ->
+  ?fail_callback:
+    ((* default to Alcotest.fail msg *)
+     int (* num errors *) ->
+    string (* msg *) ->
+    unit) ->
   ?get_xlang:(Fpath.t -> Rule.rules -> Xlang.t) option ->
   ?prepend_lang:bool ->
   Fpath.t list ->
-  Alcotest_ext.test list * int ref (* total mismatch *) * (unit -> unit)
+  Alcotest_ext.test list * int ref (* total mismatch *)
 
-(* Run the tests and print a summary. *)
-val test_rules : ?unit_testing:bool -> string (* filename *) list -> unit
+(* [test_rules dirs] run the tests discovered under [dirs]
+ * and print a summary.
+ *)
+val test_rules : Fpath.t list -> unit

--- a/src/engine/Unit_engine.ml
+++ b/src/engine/Unit_engine.ml
@@ -655,10 +655,7 @@ let get_extract_source_lang file rules =
 let extract_tests () =
   let path = tests_path / "extract" in
   pack_tests_pro "extract mode"
-    (let tests, _total_mismatch =
-       Test_engine.make_tests ~get_xlang:(Some get_extract_source_lang) [ path ]
-     in
-     tests)
+    (Test_engine.make_tests ~get_xlang:(Some get_extract_source_lang) [ path ])
 
 (*****************************************************************************)
 (* Tainting tests *)
@@ -814,13 +811,9 @@ let lang_tainting_tests () =
 
 let full_rule_regression_tests () =
   let path = tests_path / "rules" in
-  let tests1, _total_mismatch =
-    Test_engine.make_tests ~prepend_lang:true [ path ]
-  in
+  let tests1 = Test_engine.make_tests ~prepend_lang:true [ path ] in
   let path = tests_path / "rules_v2" in
-  let tests2, _total_mismatch =
-    Test_engine.make_tests ~prepend_lang:true [ path ]
-  in
+  let tests2 = Test_engine.make_tests ~prepend_lang:true [ path ] in
   let tests = tests1 @ tests2 in
   let groups =
     tests
@@ -848,9 +841,7 @@ let full_rule_regression_tests () =
  *)
 let full_rule_taint_maturity_tests () =
   let path = tests_path / "taint_maturity" in
-  pack_tests_pro "taint maturity"
-    (let tests, _total_mismatch = Test_engine.make_tests [ path ] in
-     tests)
+  pack_tests_pro "taint maturity" (Test_engine.make_tests [ path ])
 
 (*
    Special exclusions for Semgrep JS
@@ -873,7 +864,7 @@ let mark_todo_js test =
  *)
 let full_rule_semgrep_rules_regression_tests () =
   let path = tests_path / "semgrep-rules" in
-  let tests, _total_mismatch = Test_engine.make_tests [ path ] in
+  let tests = Test_engine.make_tests [ path ] in
   let groups =
     tests
     |> List_.map_filter (fun (test : Alcotest_ext.test) ->

--- a/src/engine/Unit_engine.ml
+++ b/src/engine/Unit_engine.ml
@@ -655,9 +655,8 @@ let get_extract_source_lang file rules =
 let extract_tests () =
   let path = tests_path / "extract" in
   pack_tests_pro "extract mode"
-    (let tests, _total_mismatch, _print_summary =
-       Test_engine.make_tests ~unit_testing:true
-         ~get_xlang:(Some get_extract_source_lang) [ path ]
+    (let tests, _total_mismatch =
+       Test_engine.make_tests ~get_xlang:(Some get_extract_source_lang) [ path ]
      in
      tests)
 
@@ -815,12 +814,12 @@ let lang_tainting_tests () =
 
 let full_rule_regression_tests () =
   let path = tests_path / "rules" in
-  let tests1, _total_mismatch, _print_summary =
-    Test_engine.make_tests ~unit_testing:true ~prepend_lang:true [ path ]
+  let tests1, _total_mismatch =
+    Test_engine.make_tests ~prepend_lang:true [ path ]
   in
   let path = tests_path / "rules_v2" in
-  let tests2, _total_mismatch, _print_summary =
-    Test_engine.make_tests ~unit_testing:true ~prepend_lang:true [ path ]
+  let tests2, _total_mismatch =
+    Test_engine.make_tests ~prepend_lang:true [ path ]
   in
   let tests = tests1 @ tests2 in
   let groups =
@@ -850,9 +849,7 @@ let full_rule_regression_tests () =
 let full_rule_taint_maturity_tests () =
   let path = tests_path / "taint_maturity" in
   pack_tests_pro "taint maturity"
-    (let tests, _total_mismatch, _print_summary =
-       Test_engine.make_tests ~unit_testing:true [ path ]
-     in
+    (let tests, _total_mismatch = Test_engine.make_tests [ path ] in
      tests)
 
 (*
@@ -876,9 +873,7 @@ let mark_todo_js test =
  *)
 let full_rule_semgrep_rules_regression_tests () =
   let path = tests_path / "semgrep-rules" in
-  let tests, _total_mismatch, _print_summary =
-    Test_engine.make_tests ~unit_testing:true [ path ]
-  in
+  let tests, _total_mismatch = Test_engine.make_tests [ path ] in
   let groups =
     tests
     |> List_.map_filter (fun (test : Alcotest_ext.test) ->

--- a/src/osemgrep/cli_test/Test_subcommand.ml
+++ b/src/osemgrep/cli_test/Test_subcommand.ml
@@ -656,7 +656,17 @@ let run_conf (conf : Test_CLI.conf) : Exit_code.t =
   CLI_common.setup_logging ~force_color:true ~level:conf.common.logging_level;
   (* Metrics_.configure Metrics_.On; *)
   Logs.debug (fun m -> m "conf = %s" (Test_CLI.show_conf conf));
-  failwith "TODO"
+
+  match conf.target with
+  | Test_CLI.Dir (dir, None) ->
+      let fail_callback _num _msg = () in
+      let tests, total_mismatch =
+        Test_engine.make_tests ~fail_callback [ dir ]
+      in
+      tests |> List.iter (fun (test : Alcotest_ext.test) -> test.func ());
+      Logs.app (fun m -> m "total mismatch: %d" !total_mismatch);
+      if !total_mismatch > 0 then Exit_code.fatal else Exit_code.ok
+  | _else_ -> failwith "TODO2"
 
 (*****************************************************************************)
 (* Entry point *)

--- a/src/osemgrep/cli_test/Test_subcommand.ml
+++ b/src/osemgrep/cli_test/Test_subcommand.ml
@@ -659,10 +659,12 @@ let run_conf (conf : Test_CLI.conf) : Exit_code.t =
 
   match conf.target with
   | Test_CLI.Dir (dir, None) ->
-      let fail_callback _num _msg = () in
-      let tests, total_mismatch =
-        Test_engine.make_tests ~fail_callback [ dir ]
+      (* coupling: similar to Test_engine.test_rules() *)
+      let total_mismatch = ref 0 in
+      let fail_callback num_errors _msg =
+        total_mismatch := !total_mismatch + num_errors
       in
+      let tests = Test_engine.make_tests ~fail_callback [ dir ] in
       tests |> List.iter (fun (test : Alcotest_ext.test) -> test.func ());
       Logs.app (fun m -> m "total mismatch: %d" !total_mismatch);
       if !total_mismatch > 0 then Exit_code.fatal else Exit_code.ok


### PR DESCRIPTION
Use ~fail_callback instead of vague ~unit_testing

Also connect osemgrep to it!

test plan:
```
./bin/osemgrep test tests/semgrep-rules/ocaml --debug
[00.00][DEBUG]: Logging setup for osemgrep
[00.00][DEBUG]: Executed as: ./bin/osemgrep test tests/semgrep-rules/ocaml --debug
[00.00][DEBUG]: conf = { Test_CLI.target = (Test_CLI.Dir (tests/semgrep-rules/ocaml, None));
  ignore_todo = false; json = false; optimizations = true; strict = false;
  common =
  { CLI_common.logging_level = (Some DEBUG); profile = false;
    maturity = Maturity.Default }
  }
[00.00][INFO]: processing rule file tests/semgrep-rules/ocaml/lang/best-practice/exception.yaml
[00.05][INFO]: processing rule file tests/semgrep-rules/ocaml/lang/best-practice/bool.yaml
[0.123  Warning    Main.Parse_rule      ] skipping unknown field: pattern-either
[0.123  Warning    Main.Parse_rule      ] skipping unknown field: pattern-either
[00.05][INFO]: processing rule file tests/semgrep-rules/ocaml/lang/best-practice/string.yaml
[0.124  Warning    Main.Parse_rule      ] skipping unknown field: pattern-either
[00.05][INFO]: processing rule file tests/semgrep-rules/ocaml/lang/best-practice/ref.yaml
[00.05][INFO]: processing rule file tests/semgrep-rules/ocaml/lang/best-practice/ifs.yaml
[00.05][INFO]: processing rule file tests/semgrep-rules/ocaml/lang/best-practice/list.yaml
[00.05][INFO]: processing rule file tests/semgrep-rules/ocaml/lang/best-practice/hashtbl.yaml
[0.130  Error      Main.Pfff_or_tree_sitter] exn (Parsing_error.Syntax_error (tests/semgrep-rules/ocaml/lang/best-practice/hashtbl.ml:20:3 "exception")) with Pfff parser
[00.05][INFO]: processing rule file tests/semgrep-rules/ocaml/lang/security/marshal.yaml
[0.131  Warning    Main.Parse_rule      ] skipping unknown field: pattern-either
[00.06][INFO]: processing rule file tests/semgrep-rules/ocaml/lang/security/unsafe.yaml
[0.132  Warning    Main.Parse_rule      ] skipping unknown field: pattern-either
[00.06][INFO]: processing rule file tests/semgrep-rules/ocaml/lang/security/filenameconcat.yaml
[00.06][INFO]: processing rule file tests/semgrep-rules/ocaml/lang/security/digest.yaml
[0.133  Warning    Main.Parse_rule      ] skipping unknown field: pattern-either
[00.06][INFO]: processing rule file tests/semgrep-rules/ocaml/lang/security/hashtable-dos.yaml
[00.06][INFO]: processing rule file tests/semgrep-rules/ocaml/lang/security/tempfile.yaml
[00.06][INFO]: processing rule file tests/semgrep-rules/ocaml/lang/security/exec.yaml
[00.06][INFO]: processing rule file tests/semgrep-rules/ocaml/lang/portability/slash-tmp.yaml
[00.06][INFO]: processing rule file tests/semgrep-rules/ocaml/lang/portability/crlf-support.yaml
[00.06][INFO]: processing rule file tests/semgrep-rules/ocaml/lang/compatibility/deprecated.yaml
[00.06][INFO]: processing rule file tests/semgrep-rules/ocaml/lang/correctness/useless-let.yaml
[00.06][INFO]: processing rule file tests/semgrep-rules/ocaml/lang/correctness/useless-compare.yaml
[00.06][INFO]: processing rule file tests/semgrep-rules/ocaml/lang/correctness/useless-if.yaml
[00.06][INFO]: processing rule file tests/semgrep-rules/ocaml/lang/correctness/useless-eq.yaml
[00.06][INFO]: processing rule file tests/semgrep-rules/ocaml/lang/correctness/physical-vs-structural.yaml
[00.06][INFO]: processing rule file tests/semgrep-rules/ocaml/lang/performance/list.yaml
[00.06]: total mismatch: 0
[00.06][DEBUG]: Metrics not enabled, skipping sending
```