### PR TITLE
Cleanup Test_engine.ml part2

### DIFF
--- a/src/core/Extract.ml
+++ b/src/core/Extract.ml
@@ -81,6 +81,15 @@ let is_extract_rule (r : Rule.t) : bool =
   | `Steps _ ->
       false
 
+let partition_rules (rules : Rule.t list) : Rule.t list * Rule.extract_rule list
+    =
+  Either_.partition_either
+    (fun r ->
+      match r.Rule.mode with
+      | `Extract _ as e -> Right { r with mode = e }
+      | mode -> Left { r with mode })
+    rules
+
 (* this does not just filter, this also returns a better type *)
 let filter_extract_rules (rules : Rule.t list) : Rule.extract_rule list =
   rules

--- a/src/engine/Test_engine.mli
+++ b/src/engine/Test_engine.mli
@@ -7,7 +7,9 @@ val make_tests :
      int (* num errors *) ->
     string (* msg *) ->
     unit) ->
-  ?get_xlang:(Fpath.t -> Rule.rules -> Xlang.t) option ->
+  (* default to Test_engine.single_xlang_from_rules *)
+  ?get_xlang:(Fpath.t -> Rule.rules -> Xlang.t) ->
+  (* default to false *)
   ?prepend_lang:bool ->
   Fpath.t list ->
   Alcotest_ext.test list

--- a/src/engine/Test_engine.mli
+++ b/src/engine/Test_engine.mli
@@ -14,5 +14,6 @@ val make_tests :
 
 (* [test_rules dirs] run the tests discovered under [dirs]
  * and print a summary.
+ * This is what 'semgrep-core -test_rules' run.
  *)
 val test_rules : Fpath.t list -> unit

--- a/src/engine/Unit_engine.ml
+++ b/src/engine/Unit_engine.ml
@@ -655,7 +655,7 @@ let get_extract_source_lang file rules =
 let extract_tests () =
   let path = tests_path / "extract" in
   pack_tests_pro "extract mode"
-    (Test_engine.make_tests ~get_xlang:(Some get_extract_source_lang) [ path ])
+    (Test_engine.make_tests ~get_xlang:get_extract_source_lang [ path ])
 
 (*****************************************************************************)
 (* Tainting tests *)


### PR DESCRIPTION
The make_test_rule_file was gigantic, partly because of
the extract mode related code

test plan:
make test