### PR TITLE
feat: remove SEMGREP_REPO_NAME requirement for semgrep scan --config [SCRT-538]

### DIFF
--- a/cli/src/semgrep/config_resolver.py
+++ b/cli/src/semgrep/config_resolver.py
@@ -252,18 +252,11 @@ class ConfigLoader:
     def is_registry_url(self) -> bool:
         return self._origin == ConfigType.REGISTRY
 
-    def _project_metadata_for_standalone_scan(
-        self, require_repo_name: bool
-    ) -> out.ProjectMetadata:
+    def _project_metadata_for_standalone_scan(self) -> out.ProjectMetadata:
         repo_name = os.environ.get("SEMGREP_REPO_NAME")
 
         if repo_name is None:
-            if require_repo_name:
-                raise SemgrepError(
-                    f"Need to set env var SEMGREP_REPO_NAME to use `--config {self._config_path}`"
-                )
-            else:
-                repo_name = "unknown"
+            repo_name = "unknown"
 
         return out.ProjectMetadata(
             semgrep_version=out.Version(__VERSION__),
@@ -297,11 +290,6 @@ class ConfigLoader:
             for p in self._config_path.split(",")
         ]
 
-        # Require SEMGREP_REPO_NAME env var if SAST or Secrets are requested
-        require_repo_name = any(
-            p.value in [out.SAST(), out.Secrets()] for p in products
-        )
-
         request = out.ScanRequest(
             meta=out.RawJson({}),  # required for now, but we won't populate it
             scan_metadata=out.ScanMetadata(
@@ -310,9 +298,7 @@ class ConfigLoader:
                 requested_products=products,
                 dry_run=True,  # semgrep scan never submits findings, so always a dry run
             ),
-            project_metadata=self._project_metadata_for_standalone_scan(
-                require_repo_name
-            ),
+            project_metadata=self._project_metadata_for_standalone_scan(),
         )
 
         try:

--- a/cli/tests/unit/test_config_resolver.py
+++ b/cli/tests/unit/test_config_resolver.py
@@ -150,9 +150,7 @@ class TestConfigLoaderForProducts:
                 requested_products=products,
                 dry_run=True,
             ),
-            project_metadata=config_loader._project_metadata_for_standalone_scan(
-                require_repo_name=False
-            ),
+            project_metadata=config_loader._project_metadata_for_standalone_scan(),
         )
 
         return request
@@ -223,20 +221,9 @@ class TestConfigLoaderForProducts:
         self, config_loader: ConfigLoader, monkeypatch
     ):
         monkeypatch.setenv("SEMGREP_REPO_NAME", "test_repo")
-        metadata = config_loader._project_metadata_for_standalone_scan(
-            require_repo_name=True
-        )
+        metadata = config_loader._project_metadata_for_standalone_scan()
         assert isinstance(metadata, out.ProjectMetadata)
         assert metadata.repository == "test_repo"
-
-    @pytest.mark.quick
-    @pytest.mark.osemfail
-    def test__project_metadata_for_standalone_scan__no_repo_throws(
-        self, config_loader: ConfigLoader, monkeypatch
-    ):
-        monkeypatch.delenv("SEMGREP_REPO_NAME", raising=False)
-        with pytest.raises(SemgrepError):
-            config_loader._project_metadata_for_standalone_scan(require_repo_name=True)
 
     @pytest.mark.quick
     @pytest.mark.osemfail
@@ -244,9 +231,7 @@ class TestConfigLoaderForProducts:
         self, config_loader: ConfigLoader, monkeypatch
     ):
         monkeypatch.delenv("SEMGREP_REPO_NAME", raising=False)
-        metadata = config_loader._project_metadata_for_standalone_scan(
-            require_repo_name=False
-        )
+        metadata = config_loader._project_metadata_for_standalone_scan()
         assert metadata.repository == "unknown"
 
 


### PR DESCRIPTION
There has been plenty of feedback from internal users of semgrep that requiring the SEMGREP_REPO_NAME is a friction point. 

> i think for scan it makes sense to not be there.  the only thing i know we use this for is where to report findings in the cloud platform - but since we can't send findings up i think this is just friction as-is

This PR removes the requirement of passing in SEMGREP_REPO_NAME when calling `semgrep scan --config`. Since findings do not get uploaded with `scan`, it is fine we set repo as `unknown`.