### PR TITLE
experiment: add trace as a library

### DIFF
--- a/src/core_scan/Core_scan.ml
+++ b/src/core_scan/Core_scan.ml
@@ -1004,11 +1004,16 @@ let scan ?match_hook config ((valid_rules, invalid_rules), rules_parse_time) :
 (* Entry point *)
 (*****************************************************************************)
 
+let get_rules config =
+  Trace.with_span ~__FILE__ ~__LINE__ "get_rules" @@ fun _sp ->
+  Common.with_time (fun () -> rules_from_rule_source config)
+
 let scan_with_exn_handler (config : Core_scan_config.t) :
     Core_result.result_or_exn =
   try
     let timed_rules =
-      Common.with_time (fun () -> rules_from_rule_source config)
+      Trace_tef.with_setup ~out:(`File "trace.json") () @@ fun () ->
+      get_rules config
     in
     (* The pre and post processors hook here is currently just used
        for the secrets post processor, but it should now be trivial to

--- a/src/core_scan/dune
+++ b/src/core_scan/dune
@@ -4,6 +4,8 @@
  (wrapped false)
  (libraries
     parmap
+    trace
+    trace-tef
 
     commons
 


### PR DESCRIPTION
I am experimenting with using trace for observability (e.g. to replace the current profiling times scheme).

Test plan: `make`

