### PR TITLE
Raises the list of rule-ids that cause a particular file timeout.

### DIFF
--- a/cli/tests/e2e/snapshots/test_check/test_timeout_threshold/error_2.txt
+++ b/cli/tests/e2e/snapshots/test_check/test_timeout_threshold/error_2.txt
@@ -11,8 +11,10 @@ Rules:
 └─────────────┘
   Scanning 1 file tracked by git with 3 Code rules:
   Scanning 1 file with 3 python rules.
-[31m[22m[24mWarning: 1 timeout error(s) in targets/equivalence/open_redirect.py when running the following rules:
-[rules.forcetimeout2][0m
+[31m[22m[24mWarning: 2 timeout error(s) in targets/equivalence/open_redirect.py when running the following rules:
+[rules.forcetimeout, rules.forcetimeout2]
+Semgrep stopped running rules on targets/equivalence/open_redirect.py after 2 timeout error(s). See `--timeout-
+threshold` for more info.[0m
 
 ========================================
 Files skipped:
@@ -48,7 +50,7 @@ Files skipped:
 
   [1m[24mPartially analyzed due to parsing or internal Semgrep errors[0m
 
-   • [36m[22m[24mtargets/equivalence/open_redirect.py with rule rules.forcetimeout2[0m
+   • [36m[22m[24mtargets/equivalence/open_redirect.py with 2 rules (e.g. rules.forcetimeout)[0m
 
 
 

--- a/src/core_scan/Core_scan.ml
+++ b/src/core_scan/Core_scan.ml
@@ -593,10 +593,15 @@ let iter_targets_and_get_matches_and_exn_to_errors (config : Core_scan_config.t)
                          match exn with
                          | Match_rules.File_timeout rule_ids ->
                              logger#info "Timeout on %s" !!file;
-                             (* TODO really several rules contributed
-                                to this file timeout. Once we get rid
-                                of the python wrapper we should send
-                                all the rule ids through. *)
+                             (* TODO what happened here is several rules
+                                timed out while trying to scan a file.
+                                Which heuristically indicates that the
+                                file is probably the problem. Once we
+                                get rid of the wrapper we should send
+                                all the rules we tried and also improve
+                                the error message displayed to clearly
+                                state that someone investigating should
+                                assume the timeout is due to the file *)
                              (OutJ.Timeout, Common2.hd_opt rule_ids)
                          | Out_of_memory ->
                              logger#info "OutOfMemory on %s" !!file;

--- a/src/core_scan/Core_scan.ml
+++ b/src/core_scan/Core_scan.ml
@@ -589,18 +589,19 @@ let iter_targets_and_get_matches_and_exn_to_errors (config : Core_scan_config.t)
                            rule.MR.pattern_string);
                      let loc = Tok.first_loc_of_file !!file in
                      let errors =
-                       let (error_ty, rule_id) = (match exn with
-                           | Match_rules.File_timeout rule_ids ->
+                       let error_ty, rule_id =
+                         match exn with
+                         | Match_rules.File_timeout rule_ids ->
                              logger#info "Timeout on %s" !!file;
                              (* TODO really several rules contributed
                                 to this file timeout. Once we get rid
                                 of the python wrapper we should send
                                 all the rule ids through. *)
                              (OutJ.Timeout, Common2.hd_opt rule_ids)
-                           | Out_of_memory ->
+                         | Out_of_memory ->
                              logger#info "OutOfMemory on %s" !!file;
                              (OutJ.OutOfMemory, !Rule.last_matched_rule)
-                           | _ -> raise Impossible)
+                         | _ -> raise Impossible
                        in
                        Core_error.ErrorSet.singleton
                          (E.mk_error rule_id loc "" error_ty)

--- a/src/engine/Match_rules.ml
+++ b/src/engine/Match_rules.ml
@@ -162,7 +162,7 @@ let per_rule_boilerplate_fn ~timeout ~timeout_threshold =
     | Some res -> res
     | None ->
         incr cnt_timeout;
-        rule_timeouts := rule_id :: !rule_timeouts;
+        Stack_.push rule_id rule_timeouts;
         if timeout_threshold > 0 && !cnt_timeout >= timeout_threshold then
           raise (File_timeout !rule_timeouts);
         let loc = Tok.first_loc_of_file file in

--- a/src/engine/Match_rules.ml
+++ b/src/engine/Match_rules.ml
@@ -32,7 +32,7 @@ let logger = Logging.get_logger [ __MODULE__ ]
 (* Types *)
 (*****************************************************************************)
 (* This can be captured in Run_semgrep.ml *)
-exception File_timeout of (Rule_ID.t list)
+exception File_timeout of Rule_ID.t list
 
 (* TODO make this one of the Semgrep_error_code exceptions *)
 exception Multistep_rules_not_available
@@ -161,16 +161,16 @@ let per_rule_boilerplate_fn ~timeout ~timeout_threshold =
     match res_opt with
     | Some res -> res
     | None ->
-      incr cnt_timeout;
-      rule_timeouts := rule_id :: !rule_timeouts;
-      if timeout_threshold > 0 && !cnt_timeout >= timeout_threshold then
-        raise (File_timeout !rule_timeouts);
-      let loc = Tok.first_loc_of_file file in
-      let error = E.mk_error (Some rule_id) loc "" OutJ.Timeout in
-      RP.make_match_result []
-        (Core_error.ErrorSet.singleton error)
-        (Core_profiling.empty_rule_profiling rule)
-        
+        incr cnt_timeout;
+        rule_timeouts := rule_id :: !rule_timeouts;
+        if timeout_threshold > 0 && !cnt_timeout >= timeout_threshold then
+          raise (File_timeout !rule_timeouts);
+        let loc = Tok.first_loc_of_file file in
+        let error = E.mk_error (Some rule_id) loc "" OutJ.Timeout in
+        RP.make_match_result []
+          (Core_error.ErrorSet.singleton error)
+          (Core_profiling.empty_rule_profiling rule)
+
 (*****************************************************************************)
 (* Entry point *)
 (*****************************************************************************)

--- a/src/engine/Match_rules.mli
+++ b/src/engine/Match_rules.mli
@@ -1,5 +1,5 @@
 (* this can be raised when timeout_threshold is set *)
-exception File_timeout
+exception File_timeout of Rule_ID.t list
 
 (* Matches many rules against one target. This function is called from
  * Test_engine.ml, Test_subcommand.ml, and of course Core_scan.ml


### PR DESCRIPTION
Adds a list of rule_ids instead of a single rule id that causes a File_timeout, but only selects the most recent rule when returning the core output since that is what is expected by the CLI.

Corresponding [PR in Semgrep-PRO](https://github.com/semgrep/semgrep-proprietary/pull/1164)

Test plan: Running CI tests.