### PR TITLE
logging: Reduce noise in -debug's output

### DIFF
--- a/src/matching/Match_patterns.ml
+++ b/src/matching/Match_patterns.ml
@@ -307,7 +307,7 @@ let check ~hook ?(mvar_context = None) ?(range_filter = fun _ -> true)
           |> List.iter (fun (pattern, rule) ->
                  match AST_generic_helpers.range_of_any_opt (E x) with
                  | None ->
-                     logger#error "Skipping because we lack range info: %s"
+                     logger#debug "Skipping because we lack range info: %s"
                        (show_expr_kind x.e);
                      ()
                  | Some range_loc when range_filter range_loc ->


### PR DESCRIPTION
Lacking range info for an expression is pretty common unfortunately, due to the use of fake tokens. Logging these adds a lot of noise and it is unlikely to help us diagnosing any of the main issues that our customers typically complain about.

test plan:
`semgrep -c p/default-v2 path/to/repo --debug` is less noisy

