### PR TITLE
fix(brew): remove pipgrip pinning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -334,19 +334,22 @@ jobs:
       - uses: actions/setup-python@v4
         id: python-setup
         with:
-          # Pin to python 3.9 for pipgrip issues: see https://github.com/returntocorp/semgrep/issues/4213
+          # Pin to python 3.9 for pipgrip issues:
+          # see https://github.com/returntocorp/semgrep/issues/4213
           python-version: "3.9.x"
       - name: Brew update
         run: brew update
-      # pipgrip tries to install python@3.11, and that has linking issues unless --overwrite is passed.
-      # we may be able to remove the python setup above.
-      - name: Brew install python@3.11
-        run: brew install --overwrite python@3.11
+      # pipgrip tries to install python@3.12, and that has linking issues unless
+      # --overwrite is passed. We may be able to remove the python setup above.
+      - name: Brew install python@3.12
+        run: brew install --overwrite python@3.12
       - name: Install pipgrip
         run: brew install --overwrite pipgrip
       - name: Dry Run Brew PR
-        # This step does some brew oddities (setting a fake version, and setting a revision) to allow the brew PR prep to succeed
-        # The `brew bump-formula-pr` does checks to ensure your PR is legit, but we want to do a phony PR (or at least prep it) for Dry Run only
+        # This step does some brew oddities (setting a fake version, and
+        # setting a revision)# to allow the brew PR prep to succeed.
+        # The `brew bump-formula-pr` does checks to ensure your PR is legit,
+        # but we want to do a phony PR (or at least prep it) for Dry Run only
         env:
           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.SEMGREP_HOMEBREW_RELEASE_PAT }}
         if: ${{ contains(github.ref, '-test-release') || needs.inputs.outputs.dry-run == 'true' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -334,20 +334,12 @@ jobs:
       - uses: actions/setup-python@v4
         id: python-setup
         with:
-          # Pin to python 3.9 for pipgrip issues:
-          # see https://github.com/returntocorp/semgrep/issues/4213
-          python-version: "3.9.x"
+          python-version: "3.10"
       - name: Brew update
         run: brew update
-      # pipgrip tries to install python@3.12, and that has linking issues unless
-      # --overwrite is passed. We may be able to remove the python setup above.
-      - name: Brew install python@3.12
-        run: brew install --overwrite python@3.12
-      - name: Install pipgrip
-        run: brew install --overwrite pipgrip
       - name: Dry Run Brew PR
         # This step does some brew oddities (setting a fake version, and
-        # setting a revision)# to allow the brew PR prep to succeed.
+        # setting a revision) to allow the brew PR prep to succeed.
         # The `brew bump-formula-pr` does checks to ensure your PR is legit,
         # but we want to do a phony PR (or at least prep it) for Dry Run only
         env:


### PR DESCRIPTION
See
https://github.com/semgrep/semgrep/actions/runs/7179417457/job/19550351926
and the nightly brew cron which failed with:
```
...
Pouring python@3.12--3.12.1.monterey.bottle.tar.gz
Error: The `brew link` step did not complete successfully
The formula built, but is not symlinked into /usr/local
Could not symlink bin/2to3-3.12
Target /usr/local/bin/2to3-3.12
already exists. You may want to remove it:
  rm '/usr/local/bin/2to3-3.12'

To force the link and overwrite all conflicting files:
  brew link --overwrite python@3.12

To list all files that would be deleted:
  brew link --overwrite --dry-run python@3.12
```

Hopefully this PR fixes it.

test plan:
run manually the release workflow with dry-run on