### PR TITLE
new TCB/forbid_network.jsonnet

### DIFF
--- a/TCB/forbid_exit.jsonnet
+++ b/TCB/forbid_exit.jsonnet
@@ -4,6 +4,7 @@
       id: 'forbid-exit',
       match: { any: ['exit $N', 'Unix._exit $N', 'UStdlib.exit $N'] },
       languages: ['ocaml'],
+      paths: { exclude: ['tools/*', 'scripts/*', '*_main.ml'] },
       severity: 'ERROR',
       message: |||
         Do not use directly exit(). Either raise Common.UnixExit or use the

--- a/TCB/forbid_exit.jsonnet
+++ b/TCB/forbid_exit.jsonnet
@@ -4,7 +4,9 @@
       id: 'forbid-exit',
       match: { any: ['exit $N', 'Unix._exit $N', 'UStdlib.exit $N'] },
       languages: ['ocaml'],
-      paths: { exclude: ['tools/*', 'scripts/*', '*_main.ml'] },
+      paths: {
+        exclude: ['tools/*', 'scripts/*', '*_main.ml', 'Main.ml', 'Test.ml', 'Tests.ml'],
+      },
       severity: 'ERROR',
       message: |||
         Do not use directly exit(). Either raise Common.UnixExit or use the

--- a/TCB/forbid_network.jsonnet
+++ b/TCB/forbid_network.jsonnet
@@ -3,10 +3,12 @@
     {
       id: 'forbid-network',
       match: { any: [
+	// Cohttp
         'Client.get ...',
         'Client.post ...',
         'Cohttp_lwt_unix.get ...',
         'Cohttp_lwt_unix.post ...',
+	// Unix
         'Unix.socket ...',
         'Unix.socketpair ...',
         'Unix.accept ...',
@@ -24,5 +26,4 @@
       |||,
     },
   ],
-
 }

--- a/TCB/forbid_network.jsonnet
+++ b/TCB/forbid_network.jsonnet
@@ -1,0 +1,28 @@
+{
+  rules: [
+    {
+      id: 'forbid-network',
+      match: { any: [
+        'Client.get ...',
+        'Client.post ...',
+        'Cohttp_lwt_unix.get ...',
+        'Cohttp_lwt_unix.post ...',
+        'Unix.socket ...',
+        'Unix.socketpair ...',
+        'Unix.accept ...',
+        'Unix.bind ...',
+        'Unix.connect ...',
+        'Unix.listen ...',
+      ] },
+      paths: {
+        exclude: ['http_helpers.ml'],
+      },
+      languages: ['ocaml'],
+      severity: 'ERROR',
+      message: |||
+        Do not use directly the network. Use Http_helpers.ml instead.
+      |||,
+    },
+  ],
+
+}

--- a/semgrep.jsonnet
+++ b/semgrep.jsonnet
@@ -73,11 +73,12 @@ local semgrep_rules = [
 // ----------------------------------------------------------------------------
 
 local exit_rules = import 'TCB/forbid_exit.jsonnet';
+local network_rules = import 'TCB/forbid_network.jsonnet';
 
 local tcb_rules =
   [
     r { paths: { exclude: ['tools/*', 'scripts/*', '*_main.ml'] } }
-    for r in exit_rules.rules
+    for r in exit_rules.rules + network_rules.rules
   ];
 
 // ----------------------------------------------------------------------------

--- a/semgrep.jsonnet
+++ b/semgrep.jsonnet
@@ -75,11 +75,7 @@ local semgrep_rules = [
 local exit_rules = import 'TCB/forbid_exit.jsonnet';
 local network_rules = import 'TCB/forbid_network.jsonnet';
 
-local tcb_rules =
-  [
-    r { paths: { exclude: ['tools/*', 'scripts/*', '*_main.ml'] } }
-    for r in exit_rules.rules + network_rules.rules
-  ];
+local tcb_rules = exit_rules.rules + network_rules.rules;
 
 // ----------------------------------------------------------------------------
 // Skip and last-minute override


### PR DESCRIPTION
Now that we use capabilities in http_helpers.ml, we can forbid
any other form of network access

test plan:
make check