### PR TITLE
Forbid exec, part1, forbid just Sys.command

### DIFF
--- a/TCB/forbid_exec.jsonnet
+++ b/TCB/forbid_exec.jsonnet
@@ -1,0 +1,28 @@
+//TODO:
+// - Unix.open_process_in (and UUnix.open_process_in)
+// - Bos.OS.Cmd
+// - Feather library
+// - ...
+// - UCmd.cmd_to_list
+// - UCmd.xxx_of_run, UCmd.with_open_process_in
+
+{
+  rules: [
+    {
+      id: 'forbid-exec',
+      match: { any: [
+	'Sys.command ...',
+	'USys.command ...',
+      ] },
+      languages: ['ocaml'],
+      paths: {
+        exclude: ['tools/*', 'scripts/*', 'Test*.ml'],
+      },
+      severity: 'ERROR',
+      message: |||
+        Do not invoke directly external commands. Use the safer CapExec.ml module.
+      |||,
+    },
+  ],
+
+}

--- a/TCB/forbid_exit.jsonnet
+++ b/TCB/forbid_exit.jsonnet
@@ -2,7 +2,13 @@
   rules: [
     {
       id: 'forbid-exit',
-      match: { any: ['exit $N', 'Unix._exit $N', 'UStdlib.exit $N'] },
+      match: { any: [
+	'exit $N',
+        'Stdlib.exit $N',
+        'UStdlib.exit $N',
+	'Unix._exit $N',
+	'UUnix._exit $N'
+      ] },
       languages: ['ocaml'],
       paths: {
         exclude: ['tools/*', 'scripts/*', '*_main.ml', 'Main.ml', 'Test.ml', 'Tests.ml'],

--- a/TCB/forbid_network.jsonnet
+++ b/TCB/forbid_network.jsonnet
@@ -1,3 +1,4 @@
+// TODO: factorize those .get/.post and Unix/UUnix with list comprehensions
 {
   rules: [
     {
@@ -15,6 +16,13 @@
         'Unix.bind ...',
         'Unix.connect ...',
         'Unix.listen ...',
+	// UUnix
+        'UUnix.socket ...',
+        'UUnix.socketpair ...',
+        'UUnix.accept ...',
+        'UUnix.bind ...',
+        'UUnix.connect ...',
+        'UUnix.listen ...',
       ] },
       paths: {
         exclude: ['http_helpers.ml'],

--- a/languages/php/menhir/flag_parsing_php.ml
+++ b/languages/php/menhir/flag_parsing_php.ml
@@ -1,10 +1,7 @@
-(*s: flag_parsing_php.ml *)
+open Common.Operators
 
 let strict_lexer = ref false
-
-(*x: flag_parsing_php.ml *)
 let short_open_tag = ref true
-(*x: flag_parsing_php.ml *)
 
 (* PHP is case insensitive, which is I think a bad idea, so
  * by default let's have a case sensitive lexer.
@@ -13,31 +10,9 @@ let case_sensitive = ref true
 
 (* e.g. yield *)
 let facebook_lang_extensions = ref true
-let verbose_pp = ref false
-
-(* Alternative way to get xhp by calling xhpize as a preprocessor.
- * Slower than builtin_xhp and have some issues where the comments
- * are removed, unless you use the experimental_merge_tokens_xhp
- * but which has some issues itself.
- *)
-let pp_default = ref (None : string option)
-
-(*s: flag_parsing_php.ml pp related flags *)
-
-open Common
 
 (* coupling: copy paste of Php_vs_php *)
 let is_metavar_name s = s =~ "[A-Z]\\([0-9]?_[A-Z]*\\)?"
 
 let cmdline_flags_pp () =
-  [
-    ( "-pp",
-      Arg.String (fun s -> pp_default := Some s),
-      " <cmd> optional preprocessor (e.g. xhpize)" );
-    ("-verbose_pp", Arg.Set verbose_pp, " ");
-    (*s: other cmdline_flags_pp *)
-    ("-no_fb_ext", Arg.Clear facebook_lang_extensions, " ")
-    (*e: other cmdline_flags_pp *);
-  ]
-(*e: flag_parsing_php.ml pp related flags *)
-(*e: flag_parsing_php.ml *)
+  [ ("-no_fb_ext", Arg.Clear facebook_lang_extensions, " ") ]

--- a/languages/php/menhir/parse_php.mli
+++ b/languages/php/menhir/parse_php.mli
@@ -1,11 +1,8 @@
 (* This is the main function. raise Parse_error when not Flag.error_recovery.*)
 val parse :
-  ?pp:string option ->
-  string (* filename *) ->
-  (Cst_php.program, Parser_php.token) Parsing_result.t
+  string (* filename *) -> (Cst_php.program, Parser_php.token) Parsing_result.t
 
-val parse_program :
-  ?pp:string option -> string (* filename *) -> Cst_php.program
+val parse_program : string (* filename *) -> Cst_php.program
 
 (* for sgrep/spatch patterns *)
 val any_of_string : string -> Cst_php.any

--- a/libs/commons2/common2.ml
+++ b/libs/commons2/common2.ml
@@ -31,8 +31,6 @@ open Common
  * reference.
  *)
 
-exception UnixExit of int
-
 let rec (do_n : int -> (unit -> unit) -> unit) =
  fun i f ->
   if i =|= 0 then ()
@@ -783,33 +781,6 @@ let mk_str_func_of_assoc_conv xs =
 (* now at bottom of file
    let format_to_string f =
    ...
-*)
-
-(*****************************************************************************)
-(* Macro *)
-(*****************************************************************************)
-
-(* put your macro in macro.ml4, and you can test it interactivly as in lisp *)
-let macro_expand s =
-  let c = UStdlib.open_out_bin "/tmp/ttttt.ml" in
-  output_string c s;
-  close_out c;
-  USys.command
-    ("ocamlc -c -pp 'camlp4o pa_extend.cmo q_MLast.cmo -impl' "
-   ^ "-I +camlp4 -impl macro.ml4")
-  |> ignore;
-  USys.command "camlp4o ./macro.cmo pr_o.cmo /tmp/ttttt.ml" |> ignore;
-  USys.command "rm -f /tmp/ttttt.ml" |> ignore
-
-(*
-let t = macro_expand "{ x + y | (x,y) <- [(1,1);(2,2);(3,3)] and x>2 and y<3}"
-let x = { x + y | (x,y) <- [(1,1);(2,2);(3,3)] and x > 2 and y < 3}
-let t = macro_expand "{1 .. 10}"
-let x = {1 .. 10} +> List.map (fun i -> i)
-let t = macro_expand "[1;2] to append to [2;4]"
-let t = macro_expand "{x = 2; x = 3}"
-
-let t = macro_expand "type 'a bintree = Leaf of 'a | Branch of ('a bintree * 'a bintree)"
 *)
 
 (*****************************************************************************)
@@ -2476,10 +2447,6 @@ let cat_excerpts file lines =
       in
       aux [] lines 1 |> List.rev)
 
-let interpolate str =
-  USys.command ("printf \"%s\\n\" " ^ str ^ ">/tmp/caml") |> ignore;
-  cat "/tmp/caml"
-
 (* could do a print_string but printf dont like print_string *)
 let echo s =
   UPrintf.printf "%s" s;
@@ -2490,10 +2457,6 @@ let usleep s =
   for _i = 1 to s do
     ()
   done
-
-(* now in prelude:
- * let command2 s = ignore(USys.command s)
- *)
 
 let nblines_with_wc a = nblines_eff a
 
@@ -2526,42 +2489,6 @@ let y_or_no msg =
           aux ()
     in
     aux ()
-
-let command2_y_or_no cmd =
-  if !_batch_mode then (
-    USys.command cmd |> ignore;
-    true)
-  else (
-    pr2 (cmd ^ " [y/n] ?");
-    match UStdlib.read_line () with
-    | "y"
-    | "yes"
-    | "Y" ->
-        USys.command cmd |> ignore;
-        true
-    | "n"
-    | "no"
-    | "N" ->
-        false
-    | _ -> failwith "answer by yes or no")
-
-let command2_y_or_no_exit_if_no cmd =
-  let res = command2_y_or_no cmd in
-  if res then () else raise (UnixExit 1)
-
-let command_safe ?verbose:(_verbose = false) program args =
-  let pid = UUnix.fork () in
-  let cmd_str = program :: args |> join " " in
-  if pid =|= 0 then (
-    pr2 ("running: " ^ cmd_str);
-    UUnix.execv program (Array.of_list (program :: args)))
-  else
-    let _pid2, status = UUnix.waitpid [] pid in
-    match status with
-    | Unix.WEXITED retcode -> retcode
-    | Unix.WSIGNALED _
-    | Unix.WSTOPPED _ ->
-        failwith ("problem running: " ^ cmd_str)
 
 let mkdir ?(mode = 0o770) file = UUnix.mkdir file mode
 
@@ -2734,19 +2661,6 @@ let with_tmp_file ~(str : string) ~(ext : string) (f : string -> 'a) : 'a =
       UCommon.erase_this_temp_file tmpfile)
 
 let register_tmp_file_cleanup_hook f = Stack_.push f tmp_file_cleanup_hooks
-
-let with_tmp_dir f =
-  let tmp_dir =
-    UFilename.temp_file (spf "with-tmp-dir-%d" (UUnix.getpid ())) ""
-  in
-  UUnix.unlink tmp_dir;
-  (* who cares about race *)
-  UUnix.mkdir tmp_dir 0o755;
-  Common.finalize
-    (fun () -> f tmp_dir)
-    (fun () ->
-      USys.command (spf "rm -f %s/*" tmp_dir) |> ignore;
-      UUnix.rmdir tmp_dir)
 
 let uncat xs file =
   UCommon.with_open_outfile file (fun (pr, _chan) ->
@@ -4588,107 +4502,6 @@ let test_ppm1 () =
     "img.ppm"
 
 (*****************************************************************************)
-(* Diff (lfs) *)
-(*****************************************************************************)
-type diff = Match | BnotinA | AnotinB
-
-let (diff : (int -> int -> diff -> unit) -> string list * string list -> unit) =
- fun f (xs, ys) ->
-  let file1 = "/tmp/diff1-" ^ string_of_int (UUnix.getuid ()) in
-  let file2 = "/tmp/diff2-" ^ string_of_int (UUnix.getuid ()) in
-  let fileresult = "/tmp/diffresult-" ^ string_of_int (UUnix.getuid ()) in
-  UCommon.write_file file1 (unwords xs);
-  UCommon.write_file file2 (unwords ys);
-  USys.command
-    ("diff --side-by-side -W 1 " ^ file1 ^ " " ^ file2 ^ " > " ^ fileresult)
-  |> ignore;
-  let res = cat fileresult in
-  let a = ref 0 in
-  let b = ref 0 in
-  res
-  |> List.iter (fun s ->
-         match s with
-         | ""
-         | " " ->
-             f !a !b Match;
-             incr a;
-             incr b
-         | ">" ->
-             f !a !b BnotinA;
-             incr b
-         | "|"
-         | "/"
-         | "\\" ->
-             f !a !b BnotinA;
-             f !a !b AnotinB;
-             incr a;
-             incr b
-         | "<" ->
-             f !a !b AnotinB;
-             incr a
-         | _ -> raise Common.Impossible)
-(*
-let _ =
-  diff
-    ["0";"a";"b";"c";"d";    "f";"g";"h";"j";"q";            "z"]
-    [    "a";"b";"c";"d";"e";"f";"g";"i";"j";"k";"r";"x";"y";"z"]
-   (fun x y -> pr "match")
-   (fun x y -> pr "a_not_in_b")
-   (fun x y -> pr "b_not_in_a")
-*)
-
-let (diff2 : (int -> int -> diff -> unit) -> string * string -> unit) =
- fun f (xstr, ystr) ->
-  UCommon.write_file "/tmp/diff1" xstr;
-  UCommon.write_file "/tmp/diff2" ystr;
-  USys.command
-    ("diff --side-by-side --left-column -W 1 "
-   ^ "/tmp/diff1 /tmp/diff2 > /tmp/diffresult")
-  |> ignore;
-  let res = cat "/tmp/diffresult" in
-  let a = ref 0 in
-  let b = ref 0 in
-  res
-  |> List.iter (fun s ->
-         match s with
-         | "(" ->
-             f !a !b Match;
-             incr a;
-             incr b
-         | ">" ->
-             f !a !b BnotinA;
-             incr b
-         | "|" ->
-             f !a !b BnotinA;
-             f !a !b AnotinB;
-             incr a;
-             incr b
-         | "<" ->
-             f !a !b AnotinB;
-             incr a
-         | _ -> raise Common.Impossible)
-
-(*****************************************************************************)
-(* Grep *)
-(*****************************************************************************)
-
-(* src: coccinelle *)
-let contain_any_token_with_egrep tokens file =
-  let tokens =
-    tokens
-    |> List.map (fun s ->
-           match () with
-           | _ when s =~ "^[A-Za-z_][A-Za-z_0-9]*$" -> "\\b" ^ s ^ "\\b"
-           | _ when s =~ "^[A-Za-z_]" -> "\\b" ^ s
-           | _ when s =~ ".*[A-Za-z_]$" -> s ^ "\\b"
-           | _ -> s)
-  in
-  let cmd = spf "egrep -q '(%s)' %s" (join "|" tokens) file in
-  match USys.command cmd with
-  | 0 (* success *) -> true
-  | _ (* failure *) -> false (* no match, so not worth trying *)
-
-(*****************************************************************************)
 (* Parsers (aop-colcombet) *)
 (*****************************************************************************)
 
@@ -5141,32 +4954,6 @@ let with_pr2_to_string f =
   redirect_stdout_stderr file f;
   cat file
 
-(* julia: convert something printed using format to print into a string *)
-let format_to_string f =
-  let nm, o = UFilename.open_temp_file "format_to_s" ".out" in
-  (* to avoid interference with other code using Format.printf, e.g.
-   * Ounit.run_tt
-   *)
-  UFormat.print_flush ();
-  UFormat.set_formatter_out_channel o;
-  let _ = f () in
-  UFormat.print_newline ();
-  UFormat.print_flush ();
-  UFormat.set_formatter_out_channel UStdlib.stdout;
-  close_out o;
-  let i = UStdlib.open_in_bin nm in
-  let lines = ref [] in
-  let rec loop _ =
-    let cur = input_line i in
-    lines := cur :: !lines;
-    loop ()
-  in
-  (try loop () with
-  | End_of_file -> ());
-  close_in i;
-  USys.command ("rm -f " ^ nm) |> ignore;
-  String.concat "\n" (List.rev !lines)
-
 (*---------------------------------------------------------------------------*)
 (* Directories part 2 *)
 (*---------------------------------------------------------------------------*)
@@ -5325,45 +5112,3 @@ let _ =
      =*= "/home/pad/pfff"
     )
 *)
-
-(*****************************************************************************)
-(* Misc/test *)
-(*****************************************************************************)
-
-let (generic_print : 'a -> string -> string) =
- fun v typ ->
-  write_value v "/tmp/generic_print";
-  USys.command
-    ("printf 'let (v:" ^ typ ^ ")= Common.get_value \"/tmp/generic_print\" "
-   ^ " in v;;' " ^ " | calc.top > /tmp/result_generic_print")
-  |> ignore;
-  cat "/tmp/result_generic_print"
-  |> drop_while (fun e -> not (e =~ "^#.*"))
-  |> tail |> unlines
-  |> fun s ->
-  if s =~ ".*= \\(.+\\)" then matched1 s
-  else "error in generic_print, not good format:" ^ s
-
-(* let main () = pr (generic_print [1;2;3;4] "int list") *)
-
-class ['a] olist (ys : 'a list) =
-  object
-    val xs = ys
-    method view = xs
-
-    (*    method fold f a = List.fold_left f a xs *)
-    method fold : 'b. ('b -> 'a -> 'b) -> 'b -> 'b =
-      fun f accu -> List.fold_left f accu xs
-  end
-
-(* let _ = write_value ((new setb[])#add 1) "/tmp/test" *)
-(*
-let typing_sux_test () =
-  let x = UObj.magic [ 1; 2; 3 ] in
-  let f1 xs = List.iter print_int xs in
-  let f2 xs = List.iter print_string xs in
-  f1 x;
-  f2 x
-*)
-(* let (test: 'a osetb -> 'a ocollection) = fun o -> (o :> 'a ocollection) *)
-(* let _ = test (new osetb (Setb.empty)) *)

--- a/libs/commons2/common2.mli
+++ b/libs/commons2/common2.mli
@@ -17,17 +17,6 @@ val verbose_level : int ref
 (* cf poslude *)
 
 (*****************************************************************************)
-(* Misc/test *)
-(*****************************************************************************)
-val generic_print : 'a -> string -> string
-
-class ['a] olist : 'a list -> object
-  val xs : 'a list
-  method fold : ('b -> 'a -> 'b) -> 'b -> 'b
-  method view : 'a list
-end
-
-(*****************************************************************************)
 (* Module side effect *)
 (*****************************************************************************)
 (*
@@ -275,9 +264,6 @@ val pp_f_in_box : (unit -> 'a) -> 'a
 val pp_do_in_zero_box : (unit -> unit) -> unit
 val pp : string -> unit
 
-(* convert something printed using Format to print into a string *)
-val format_to_string : (unit -> unit) -> (* printer *) string
-
 (* works with _tab_level_print enabling to mix some calls to pp, pr2
  * and indent_do to sometimes use advanced indentation pretty printing
  * (with the pp* functions) and sometimes explicit and simple indendation
@@ -287,13 +273,6 @@ val adjust_pp_with_indent_and_header : string -> (unit -> unit) -> unit
 
 val mk_str_func_of_assoc_conv :
   ('a * string) list -> (string -> 'a) * ('a -> string)
-
-(*****************************************************************************)
-(* Macro *)
-(*****************************************************************************)
-
-(* was working with my macro.ml4 *)
-val macro_expand : string -> unit
 
 (*****************************************************************************)
 (* Composition/Control *)
@@ -780,17 +759,10 @@ val indent_string : int -> string -> string
 val cat_orig : filename -> string list
 val cat_excerpts : filename -> int list -> string list
 val uncat : string list -> filename -> unit
-val interpolate : string -> string list
 val echo : string -> string
 val usleep : int -> unit
 val _batch_mode : bool ref
-
-val command_safe :
-  ?verbose:bool -> filename (* executable *) -> string list (* args *) -> int
-
 val y_or_no : string -> bool
-val command2_y_or_no : string -> bool
-val command2_y_or_no_exit_if_no : string -> unit
 val mkdir : ?mode:Unix.file_perm -> string -> unit
 val nblines_file : filename -> int
 val unix_lstat_eff : filename -> Unix.stats
@@ -838,7 +810,6 @@ val with_tmp_file : str:string -> ext:string -> (filename -> 'a) -> 'a
 (* Runs just before a tmp file is deleted. Multiple hooks can be added, but the
  * order in which they are called is unspecified. *)
 val register_tmp_file_cleanup_hook : (string -> unit) -> unit
-val with_tmp_dir : (dirname -> 'a) -> 'a
 
 (*###########################################################################*)
 (* Collection-like types *)
@@ -1479,21 +1450,6 @@ type pixel = int * int * int
 
 val write_ppm : int -> int -> pixel list -> filename -> unit
 val test_ppm1 : unit -> unit
-(*x: common.mli misc *)
-(*****************************************************************************)
-(* Diff (LFS) *)
-(*****************************************************************************)
-
-type diff = Match | BnotinA | AnotinB
-
-val diff : (int -> int -> diff -> unit) -> string list * string list -> unit
-val diff2 : (int -> int -> diff -> unit) -> string * string -> unit
-
-(*****************************************************************************)
-(* Grep (coccinelle) *)
-(*****************************************************************************)
-
-val contain_any_token_with_egrep : string list -> filename -> bool
 
 (*****************************************************************************)
 (* Parsers (aop-colcombet)                                                 *)

--- a/semgrep.jsonnet
+++ b/semgrep.jsonnet
@@ -103,7 +103,7 @@ local todo_skipped_for_now = [
 ];
 
 local override_messages = {
-  // semgrep specific adjustments
+  // Semgrep specific adjustments
   'ocaml.lang.best-practice.exception.bad-reraise': |||
     You should not re-raise exceptions using 'raise' because it loses track
     of where the exception was raised originally. See commons/Exception.mli

--- a/src/osemgrep/reporting/Matches_report.ml
+++ b/src/osemgrep/reporting/Matches_report.ml
@@ -73,7 +73,7 @@ let ws_prefix s =
   let rec index_rec s lim i acc =
     if i >= lim then List.rev acc
     else
-      let c = String.unsafe_get s i in
+      let c = s.[i] in
       if c = ' ' then index_rec s lim (i + 1) (' ' :: acc)
       else if c = '\t' then index_rec s lim (i + 1) ('\t' :: acc)
       else List.rev acc


### PR DESCRIPTION
As part of this PR, I've removed the ability
 - to call a preprocessor for PHP (was needed back in
my Facebook days where we used an XHP preprocessor a la JSX),
 - to call jsonnet in Parse_rule.ml (we can rely on ojsonnet instead)
 - removed lots of functions in common2.ml that were not used
   anyway in semgrep

test plan:
make check