### PR TITLE
tests: pro: Facilitate running Pro intra-file tests

### DIFF
--- a/src/analyzing/Constant_propagation.ml
+++ b/src/analyzing/Constant_propagation.ml
@@ -646,8 +646,8 @@ type propagate_basic_visitor_funcs = {
     env * Iter_with_context.context -> AST_generic.definition -> unit;
 }
 
-let propagate_basic_visitor_hook : propagate_basic_visitor_funcs ref =
-  ref { visit_definition = (fun (_env, _ctx) _x -> ()) }
+let hook_propagate_basic_visitor : propagate_basic_visitor_funcs option ref =
+  ref None
 
 (* !Note that this assumes Naming_AST.resolve has been called before! *)
 let propagate_basic lang prog =
@@ -730,7 +730,8 @@ let propagate_basic lang prog =
               | None, _ -> ());
             super#visit_definition (env, ctx) x
         | _ ->
-            !propagate_basic_visitor_hook.visit_definition (env, ctx) x;
+            !hook_propagate_basic_visitor
+            |> Option.iter (fun v -> v.visit_definition (env, ctx) x);
             super#visit_definition (env, ctx) x
 
       (* the uses (and also defs for Python Assign) *)

--- a/src/analyzing/Constant_propagation.mli
+++ b/src/analyzing/Constant_propagation.mli
@@ -13,7 +13,7 @@ val add_constant_env :
   AST_generic.ident -> AST_generic.sid * AST_generic.svalue -> env -> unit
 
 (* used by pro engine *)
-val propagate_basic_visitor_hook : propagate_basic_visitor_funcs ref
+val hook_propagate_basic_visitor : propagate_basic_visitor_funcs option ref
 
 (* Works by side effect on the generic AST by modifying its refs.
  * We pass the lang because some constant propagation algorithm may be

--- a/src/engine/Globals.ml
+++ b/src/engine/Globals.ml
@@ -36,6 +36,17 @@
 (* Entry point *)
 (*****************************************************************************)
 
+let reset_pro_hooks () =
+  Generic_vs_generic.hook_find_possible_parents := None;
+  Constant_propagation.hook_propagate_basic_visitor := None;
+  Dataflow_svalue.hook_constness_of_function := None;
+  Dataflow_svalue.hook_transfer_of_assume := None;
+  Match_tainting_mode.hook_setup_hook_function_taint_signature := None;
+  Dataflow_tainting.hook_function_taint_signature := None;
+  Dataflow_tainting.hook_find_attribute_in_class := None;
+  (* TODO: more Pro hooks ? *)
+  ()
+
 (* Useful for defensive programming, especially in tests which may leave
  * bad state behind.
  * Note that it's currently unused, because we should prefer to fix our tests
@@ -47,10 +58,9 @@ let reset () =
   Core_profiling.mode := Core_profiling.MNo_info;
   AST_generic_equals.busy_with_equal := AST_generic_equals.Not_busy;
   Rule.last_matched_rule := None;
+  reset_pro_hooks ();
   (* TODO?
-   * - semgrep-pro hooks?
-   * - Match_patterns.last_matched_rule?
-   * - Http_helpers.client_ref?
+   * - Http_helpers.client_ref ?
    * - many more
    *)
   ()

--- a/src/engine/Test_engine.mli
+++ b/src/engine/Test_engine.mli
@@ -14,6 +14,12 @@ val make_tests :
   Fpath.t list ->
   Alcotest_ext.test list
 
+(* For Pro tests *)
+val collect_tests :
+  ?get_xlang:(Fpath.t -> Rule.rules -> Xlang.t) ->
+  Fpath.t list (* roots *) ->
+  (Fpath.t (* rule file *) * Fpath.t (* target file *) * Xlang.t) list
+
 (* helpers used in Test_subcommand.ml *)
 val find_target_of_yaml_file_opt : Fpath.t -> Fpath.t option
 val xlangs_of_rules : Rule.t list -> Xlang.t list


### PR DESCRIPTION
- Refactored and exposed `collect_tests` in Test_engine.
- Added `Globals.reset_pro_hooks()` to reset all (most?) of the Pro hooks to their non-Pro values.
- And fixed `propagate_basic_visitor_hook` to follow existing conventions.

test plan:
See semgrep/semgrep-proprietary#1170

