### PR TITLE
fix: tainting: `by-side-effect: only` applies only to l-values

### DIFF
--- a/changelog.d/pa-2980.fixed
+++ b/changelog.d/pa-2980.fixed
@@ -1,0 +1,17 @@
+taint-mode: Fixed recently added `by-side-effect: only` option for taint sources,
+so that it does not incorrectly taint expressions that are not l-values, e.g.
+given this taint source:
+
+```yaml
+pattern-sources:
+  - by-side-effect: only
+    patterns:
+      - pattern: delete $VAR;
+      - focus-metavariable: $VAR
+```
+
+The `get(*from)` expression should not become tainted since it's not an l-value:
+
+```cpp
+delete get(*from);
+```

--- a/tests/rules/taint_typestate4.cpp
+++ b/tests/rules/taint_typestate4.cpp
@@ -1,0 +1,11 @@
+void* delete_call(Data* from) {
+    // An example from `facebook/folly`. This is a low priority issue
+    // ok: double-delete
+    delete get(*from);
+}
+
+void delete_cast(Mutex *mutex) {
+    // This is logically the same as `delete_no_cast` above
+    // ok: double-delete
+    delete (CRITICAL_SECTION*)mutex;
+}

--- a/tests/rules/taint_typestate4.yaml
+++ b/tests/rules/taint_typestate4.yaml
@@ -1,0 +1,19 @@
+rules:
+  - id: double-delete
+    languages:
+      - cpp
+      - c
+    message: "`$SINK_VAR` has previously been deleted which will trigger a
+      double-free vulnerability. This may lead to memory corruption."
+    mode: taint
+    pattern-sinks:
+      - patterns:
+          - pattern: delete $SINK_VAR;
+          - focus-metavariable: $SINK_VAR
+    pattern-sources:
+      - by-side-effect: only
+        patterns:
+          - pattern: delete $VAR;
+          - focus-metavariable: $VAR
+    severity: ERROR
+


### PR DESCRIPTION
When requesting the taint sources of an arbitrary expression we should not take `by-side-effect: only` sources into consideration, otherwise we get FPs.

Helps PA-3298

Fixes: d00c6e67deb ("tainting: Add `by-side-effect: only` option to sources (#8414)")

test plan:
make test # new test

