### PR TITLE
Forbid exec part3, forbid Bos.OS.Cmd

### DIFF
--- a/TCB/forbid_exec.jsonnet
+++ b/TCB/forbid_exec.jsonnet
@@ -30,7 +30,7 @@
           [('Unix.' + p) for p in unix_funcs] +
           [('UUnix.' + p) for p in unix_funcs] +
           // Bos
-          //   TODO Bos.OS.Cmd.xxx
+          ['Bos.OS.Cmd.$F'] +
           // Feather
           ['Feather.run'] +
           // UCmd
@@ -39,7 +39,11 @@
       },
       languages: ['ocaml'],
       paths: {
-        exclude: ['TCB/*', 'tools/*', 'scripts/*', 'stats/*', 'Test*.ml'],
+        exclude: [
+           'TCB/*',
+           'tools/*', 'scripts/*', 'stats/*',
+           'Test*.ml',  'Unit_*.ml',
+        ],
       },
       severity: 'ERROR',
       message: |||

--- a/TCB/forbid_exit.jsonnet
+++ b/TCB/forbid_exit.jsonnet
@@ -11,7 +11,12 @@
       ] },
       languages: ['ocaml'],
       paths: {
-        exclude: ['TCB/*', 'tools/*', 'scripts/*', '*_main.ml', 'Main.ml', 'Test.ml', 'Tests.ml'],
+        exclude: [
+           'TCB/*',
+           'tools/*', 'scripts/*',
+            '*_main.ml', 'Main.ml',
+            'Test*.ml',
+         ],
       },
       severity: 'ERROR',
       message: |||

--- a/libs/commons/UCmd.ml
+++ b/libs/commons/UCmd.ml
@@ -6,7 +6,7 @@ open Common
 (* Small wrapper around Bos.OS.Cmd
  *
  * A few functions contain a 'nosemgrep: forbid-exec' because anyway
- * those functions  will/are also blacklisted in forbid-exec.jsonnet.
+ * those functions will/are also blacklisted in forbid-exec.jsonnet.
  *)
 
 (*****************************************************************************)
@@ -46,13 +46,18 @@ let cmd_to_list ?verbose command =
 (*****************************************************************************)
 
 let string_of_run ~trim cmd =
+  (* nosemgrep: forbid-exec *)
   let out = Cmd.bos_apply Bos.OS.Cmd.run_out cmd in
+  (* nosemgrep: forbid-exec *)
   Bos.OS.Cmd.out_string ~trim out
 
 let lines_of_run ~trim cmd =
+  (* nosemgrep: forbid-exec *)
   let out = Cmd.bos_apply Bos.OS.Cmd.run_out cmd in
+  (* nosemgrep: forbid-exec *)
   Bos.OS.Cmd.out_lines ~trim out
 
+(* nosemgrep: forbid-exec *)
 let status_of_run ?quiet = Cmd.bos_apply (Bos.OS.Cmd.run_status ?quiet)
 
 (* TODO: switch to type Cmd.t for cmd *)

--- a/src/osemgrep/cli_install_semgrep_pro/Install_semgrep_pro_subcommand.ml
+++ b/src/osemgrep/cli_install_semgrep_pro/Install_semgrep_pro_subcommand.ml
@@ -174,13 +174,11 @@ let run_conf (caps : caps) (conf : Install_semgrep_pro_CLI.conf) : Exit_code.t =
 
         (* Get Pro version, it serves as a simple check that the binary works *)
         let version =
-          let cmd = Bos.Cmd.(v !!semgrep_pro_path_tmp % "-pro_version") in
+          let cmd = (Cmd.Name !!semgrep_pro_path_tmp, [ "-pro_version" ]) in
           let opt =
             Time_limit.set_timeout ~name:"check pro version" 10.0 (fun () ->
-                let path_r =
-                  Bos.OS.Cmd.run_out ~err:Bos.OS.Cmd.err_run_out cmd
-                in
-                let result = Bos.OS.Cmd.out_string ~trim:true path_r in
+                (* TODO?  Bos.OS.Cmd.run_out ~err:Bos.OS.Cmd.err_run_out *)
+                let result = UCmd.string_of_run ~trim:true cmd in
                 match result with
                 | Ok (output, _) -> Some output
                 | Error _ -> None)

--- a/src/osemgrep/cli_login/Login_subcommand.ml
+++ b/src/osemgrep/cli_login/Login_subcommand.ml
@@ -90,9 +90,8 @@ You can pass @{<cyan>`SEMGREP_APP_TOKEN`@} as an environment variable instead.|}
   else (
     print_preamble ();
     let session_id, url = Semgrep_login.make_login_url () in
-    let cmd = Bos.Cmd.(v "open" % Uri.to_string url) in
-    let res = Bos.OS.Cmd.run_out cmd |> Bos.OS.Cmd.to_string in
-    match res with
+    let cmd = (Cmd.Name "open", [ Uri.to_string url ]) in
+    match UCmd.status_of_run cmd with
     | Ok _ ->
         Logs.app (fun m -> m "Opening your sign-in link automatically...");
         let msg =


### PR DESCRIPTION
rewrite code to use UCmd, and so then the next PR
will have to rewrite all those UCmd in calls to CapExec

test plan:
make check