### PR TITLE
feat(LS): cache file targeting

### DIFF
--- a/changelog.d/pdx-148.added
+++ b/changelog.d/pdx-148.added
@@ -1,0 +1,1 @@
+Semgrep IDE integrations will now cache workspace targets, so a full traversal of a workspace is no longer needed on every scan

--- a/src/osemgrep/language_server/Test_LS_e2e.ml
+++ b/src/osemgrep/language_server/Test_LS_e2e.ml
@@ -818,6 +818,7 @@ let test_ls_specs () =
       (* nosem *)
       FileUtil.cp [ List.hd files |> Fpath.to_string ] (added |> Fpath.to_string);
 
+      (* Tests target caching *)
       let%lwt () = send_did_add info added in
       let%lwt () = send_did_open info added in
 

--- a/src/osemgrep/language_server/Unit_LS.ml
+++ b/src/osemgrep/language_server/Unit_LS.ml
@@ -34,7 +34,9 @@ let mock_session () =
   session
 
 let set_session_targets (session : Session.t) folders =
-  { session with workspace_folders = folders }
+  let session = { session with workspace_folders = folders } in
+  Session.cache_workspace_targets session;
+  session
 
 let mock_run_results (files : string list) : Core_runner.result =
   let pattern_string = "print(...)" in

--- a/src/osemgrep/language_server/notifications/Notification_handler.ml
+++ b/src/osemgrep/language_server/notifications/Notification_handler.ml
@@ -78,11 +78,18 @@ let on_notification notification (server : RPC_server.t) =
           let removed = Conv.workspace_folders_to_paths removed in
           Session.update_workspace_folders server.session ~added ~removed
         in
+        Session.cache_workspace_targets server.session;
         let server = { server with session } in
         Scan_helpers.scan_workspace server;
         server
+    (* If files are renamed or created, update our targets *)
+    | CN.DidRenameFiles _
+    | CN.DidCreateFiles _ ->
+        Session.cache_workspace_targets server.session;
+        server
     | CN.DidDeleteFiles { files; _ } ->
         (* This is lame, for whatever reason they chose to type uri as string here, not Uri.t *)
+        Session.cache_workspace_targets server.session;
         let files =
           List_.map
             (fun { FileDelete.uri } ->

--- a/src/osemgrep/language_server/requests/Initialize_request.ml
+++ b/src/osemgrep/language_server/requests/Initialize_request.ml
@@ -112,6 +112,7 @@ let initialize_server server
       state = State.Running;
     }
   in
+  Session.cache_workspace_targets server.session;
   Logs.debug (fun m ->
       m "Initialized server with session:\n%s" (Session.show server.session));
   server

--- a/src/osemgrep/language_server/scan_helpers/Scan_helpers.ml
+++ b/src/osemgrep/language_server/scan_helpers/Scan_helpers.ml
@@ -167,6 +167,16 @@ let scan_file server uri =
     let file = Fpath.v file_path in
     let targets = [ file ] in
     let session_targets = Session.targets server.session in
+    (* If the file opened isn't a target, try updating targets just in case *)
+    (* This feels fine since if it is an actual target, we need to do this, and if not *)
+    (* then the user won't see results either way. *)
+    if not (List.mem file session_targets) then (
+      Logs.warn (fun m ->
+          m
+            "File %a is not in the session targets recalculating targets just \
+             in case"
+            Fpath.pp file);
+      Session.cache_workspace_targets server.session);
     let targets = if List.mem file session_targets then targets else [] in
     let targets = Some targets in
     let results, _ = run_semgrep ~targets server in

--- a/src/osemgrep/language_server/server/Session.mli
+++ b/src/osemgrep/language_server/server/Session.mli
@@ -19,6 +19,7 @@ type session_cache = {
 type t = {
   capabilities : ServerCapabilities.t;
   workspace_folders : Fpath.t list;
+  cached_workspace_targets : (Fpath.t, Fpath.t list) Hashtbl.t;
   cached_scans : (Fpath.t, Semgrep_output_v1_t.cli_match list) Hashtbl.t;
   cached_session : session_cache;
   skipped_local_fingerprints : string list;
@@ -43,6 +44,11 @@ val cache_session : t -> unit Lwt.t
 (** [cache_session t] caches the rules and skipped fingerprints for the session. Fetches rules from any configured source
     as in [t.user_settings], and CI if an api token is available. This is an asynchronous operation,
     and so the rules are stored in a [session_cache] *)
+
+val cache_workspace_targets : t -> unit
+(** [cache_workspace_targets t] caches the targets for the session. This is a list of files in
+    workspace folders, with includes and excludes in [t.user_settings], and git
+    status taken into account if [t.user_settings.only_git_dirty] is set *)
 
 val targets : t -> Fpath.t list
 (** [targets t] returns the list of targets for the session. This is a list of files in


### PR DESCRIPTION
Currently we traverse the entire project on every scan, to determine if a file or files are valid targets (i.e. not gitignore'd etc.). This can be slow on large repos (like semgrep). This PR makes it so we cache the possible targets, and only update the cache when a user deletes/renames/creates a file, or updates what workspaces are being used.

## Test plan
I confirmed manually, and that in the LS e2e tests these code paths are flexed