### PR TITLE
new semgrep-core -dump_lang_ast to dump lang-specific ASTs

### DIFF
--- a/src/core_cli/Core_CLI.ml
+++ b/src/core_cli/Core_CLI.ml
@@ -308,6 +308,12 @@ let all_actions (caps : Cap.all_caps) () =
         Arg_.mk_action_1_conv Fpath.v
           (dump_ast ~naming:false caps (Xlang.lang_of_opt_xlang_exn !lang))
           file );
+    ( "-dump_lang_ast",
+      " <file>",
+      fun file ->
+        Arg_.mk_action_1_conv Fpath.v
+          (Test_parsing.dump_lang_ast (Xlang.lang_of_opt_xlang_exn !lang))
+          file );
     ( "-dump_named_ast",
       " <file>",
       fun file ->
@@ -503,6 +509,7 @@ let options caps actions =
     ( "-tree_sitter_only",
       Arg.Set Flag.tree_sitter_only,
       " only use tree-sitter-based parsers" );
+    ("-pfff_only", Arg.Set Flag.pfff_only, " only use pfff-based parsers");
     ( "-timeout",
       Arg.Set_float timeout,
       " <float> maxinum time to spend running a rule on a single file (in \

--- a/src/parsing/tests/Test_parsing.ml
+++ b/src/parsing/tests/Test_parsing.ml
@@ -280,6 +280,24 @@ let test_parse_tree_sitter lang root_paths =
   ()
 
 (*****************************************************************************)
+(* AST specific dumpers *)
+(*****************************************************************************)
+(* used to be offered by the ./bin/pfff tool *)
+let dump_lang_ast (lang : Lang.t) (file : Fpath.t) : unit =
+  match lang with
+  | Lang.Ocaml ->
+      let (ast : AST_ocaml.program) =
+        if !Flag_semgrep.tree_sitter_only then
+          let res = Parse_ocaml_tree_sitter.parse !!file in
+          res.program |> List_.optlist_to_list
+        else Parse_ml.parse_program !!file
+      in
+      let s = AST_ocaml.show_program ast in
+      UCommon.pr2 s
+  | _else_ ->
+      failwith (spf "dumper not supported yet for lang: %s" (Lang.show lang))
+
+(*****************************************************************************)
 (* Pfff and tree-sitter parsing *)
 (*****************************************************************************)
 

--- a/src/parsing/tests/Test_parsing.mli
+++ b/src/parsing/tests/Test_parsing.mli
@@ -25,11 +25,11 @@ val test_parse_tree_sitter : Lang.t -> string (* filename *) list -> unit
  * the language and parser to use based on the filename extension). *)
 val dump_tree_sitter_cst : Lang.t -> string (* filename *) -> unit
 
-(* Dump the generic AST of the given file (it automatically detects
- * the language to use based on the filename extension) but only use
- * a pfff parser.
- *)
+(* Dump the generic AST of the given file but only use a pfff parser *)
 val dump_pfff_ast : Lang.t -> string (* filename *) -> unit
+
+(* Dump the lang-specific AST of the given file *)
+val dump_lang_ast : Lang.t -> Fpath.t -> unit
 
 (* For each file, parse the file using a pfff parser and
  * parse the file using a tree-sitter parser and output the differences


### PR DESCRIPTION
test plan:
./semgrep-core -l ocaml -dump_lang_ast ref.ml