### PR TITLE
OCaml: use tree-sitter by default instead of menhir

### DIFF
--- a/changelog.d/ocaml.changed
+++ b/changelog.d/ocaml.changed
@@ -1,0 +1,3 @@
+OCaml: switch to using the tree-sitter based parser instead of
+the menhir parser, which has a more complete AST, especially
+for objects and classes.

--- a/languages/ocaml/ast/AST_ocaml.ml
+++ b/languages/ocaml/ast/AST_ocaml.ml
@@ -264,6 +264,11 @@ and let_def = {
   lparams : parameter list; (* can be empty *)
   lrettype : type_ option;
   lbody : expr;
+  (* each individual 'let' can have its own attributes,
+   * which forces to make let_def mutually recursive with attributes, which
+   * is itself mutually recursive with item.
+   *)
+  lattrs : attributes;
 }
 
 and parameter =
@@ -277,8 +282,12 @@ and parameter =
 (* Type declaration *)
 (* ------------------------------------------------------------------------- *)
 
+(* old: the type below used to be a clearly separate 'type ...' and not 'and',
+ * but with attributes in let_def, everything is now mutually recursive.
+ *)
+
 (* TODO: keyword attribute: private, constraints *)
-type type_declaration =
+and type_declaration =
   | TyDecl of type_declaration_classic
   (* TODO: Extension (+=) decl, .. *)
   | TyDeclTodo of todo_category
@@ -319,7 +328,10 @@ and mutable_opt = Tok.t option (* mutable *)
 (* Class (and object) *)
 (* ------------------------------------------------------------------------- *)
 
-type class_binding = {
+(* This also used to be separate 'type ...' but is now mutually recursive
+ * because of attributes in let_def.
+ *)
+and class_binding = {
   (* c_attrs: 'virtual' *)
   c_name : ident;
   c_tparams : type_parameter list;
@@ -347,7 +359,7 @@ and class_expr =
 (* ------------------------------------------------------------------------- *)
 (* Module *)
 (* ------------------------------------------------------------------------- *)
-type module_declaration = {
+and module_declaration = {
   mname : ident;
   (* TODO: mparams: for functors *)
   mbody : module_expr;
@@ -373,7 +385,10 @@ and dotted_ident = ident list
 (* Toplevel *)
 (*****************************************************************************)
 
-(* Signature/Structure items *)
+(* Signature/Structure items.
+ * Note that for Let, the attributes are actually in the nested
+ * let_binding, so iattrs will be empty.
+ *)
 and item = { i : item_kind; iattrs : attributes }
 
 (* could split in sig_item and struct_item but many constructions are

--- a/languages/ocaml/generic/ocaml_to_generic.ml
+++ b/languages/ocaml/generic/ocaml_to_generic.ml
@@ -70,8 +70,8 @@ let mk_var_or_func tlet params tret body =
 let defs_of_bindings tlet attrs xs =
   xs
   |> list (function
-       | Either.Left (ent, params, tret, body) ->
-           let ent = add_attrs ent attrs in
+       | Either.Left (ent, params, tret, body, lattrs) ->
+           let ent = add_attrs ent (attrs @ lattrs) in
            G.DefStmt (ent, mk_var_or_func tlet params tret body) |> G.s
        | Either.Right (pat, e) ->
            (* TODO no attrs *)
@@ -523,16 +523,17 @@ and let_binding = function
                *)
               idinfo.G.id_type := Some ty
           | _ -> raise Impossible);
-          Either.Left (ent, [], None, G.exprstmt v2)
+          Either.Left (ent, [], None, G.exprstmt v2, [])
       | _ -> Either.Right (v1, v2))
 
-and let_def { lname; lparams; lrettype; lbody } =
+and let_def { lname; lparams; lrettype; lbody; lattrs } =
   let v1 = ident lname in
   let v2 = list parameter lparams in
   let v3 = option type_ lrettype in
   let (v4 : G.stmt) = expr_body lbody in
+  let v5 = attributes lattrs in
   let ent = G.basic_entity v1 in
-  (ent, v2, v3, v4)
+  (ent, v2, v3, v4, v5)
 
 and parameter = function
   | Param v -> (

--- a/languages/ocaml/menhir/parser_ml.mly
+++ b/languages/ocaml/menhir/parser_ml.mly
@@ -1022,7 +1022,7 @@ type_variance:
 let_binding:
  | val_ident fun_binding
       { let (lparams, (lrettype, _teq, body)) = $2 in
-        LetClassic { lname = $1; lparams; lrettype; lbody = seq1 body; } }
+        LetClassic { lname = $1; lparams; lrettype; lbody = seq1 body; lattrs = [] } }
  | pattern "=" seq_expr
       { LetPattern ($1, seq1 $3) }
 

--- a/src/parsing_languages/Parse_target2.ml
+++ b/src/parsing_languages/Parse_target2.ml
@@ -116,8 +116,8 @@ let just_parse_with_lang lang file =
   | Lang.Ocaml ->
       run file
         [
-          Pfff (throw_tokens Parse_ml.parse);
           TreeSitter Parse_ocaml_tree_sitter.parse;
+          Pfff (throw_tokens Parse_ml.parse);
         ]
         Ocaml_to_generic.program
   | Lang.Php ->


### PR DESCRIPTION
The AST is more complete with tree-sitter, especially
for objects and classes which are not built in parser_ml.mly

test plan:
make test
```
~/yy/bin/semgrep-core -l ocaml -dump_ast ocaml/class.ml 
Pr(
  [DefStmt(
     ({
       name=EN(
              Id(("foo", ()),
                {id_info_id=1; id_flags=Ref(0); id_resolved=Ref(None); 
                 id_type=Ref(None); id_svalue=Ref(None); }));
       attrs=[]; tparams=[]; },
      ClassDef(
        {ckind=(Class, ()); cextends=[]; cimplements=[]; cmixins=[]; 
         cparams=[Param(
                    {pname=Some(("arg1", ())); pdefault=None; ptype=None; 
                     pattrs=[]; 
                     pinfo={id_info_id=3; id_flags=Ref(0); 
                            id_resolved=Ref(Some((Parameter, -1))); 
                            id_type=Ref(None); id_svalue=Ref(None); };
                     }); OtherParam(("Label", ()), []);
                  OtherParam(("Label", ()), []);
                  Param(
                    {pname=Some(("env", ())); pdefault=None; ptype=None; 
                     pattrs=[]; 
                     pinfo={id_info_id=5; id_flags=Ref(0); 
                            id_resolved=Ref(Some((Parameter, -1))); 
                            id_type=Ref(None); id_svalue=Ref(None); };
                     })];
         cbody=[F(
                  DefStmt(
                    ({
                      name=EN(
                             Id(("meth1", ()),
                               {id_info_id=6; id_flags=Ref(0); 
                                id_resolved=Ref(None); id_type=Ref(None); 
                                id_svalue=Ref(None); }));
                      attrs=[]; tparams=[]; },
                     FuncDef(
                       {fkind=(Method, ()); fparams=[]; 
                        frettype=Some({t_attrs=[]; 
                                       t=TyN(
                                           Id(("int", ()),
                                             {id_info_id=7; id_flags=Ref(
                                              0); id_resolved=Ref(None); 
                                              id_type=Ref(None); 
                                              id_svalue=Ref(None); }));
                                       });
                        fbody=FBExpr(L(Int((Some(1), ())))); }))));
                F(
                  DefStmt(
                    ({
                      name=EN(
                             Id(("meth2", ()),
                               {id_info_id=8; id_flags=Ref(0); 
                                id_resolved=Ref(None); id_type=Ref(None); 
                                id_svalue=Ref(None); }));
                      attrs=[]; tparams=[]; },
                     FuncDef(
                       {fkind=(Method, ()); fparams=[]; 
                        frettype=Some({t_attrs=[]; 
                                       t=TyN(
                                           Id(("int", ()),
                                             {id_info_id=9; id_flags=Ref(
                                              0); id_resolved=Ref(None); 
                                              id_type=Ref(None); 
                                              id_svalue=Ref(None); }));
                                       });
                        fbody=FBExpr(L(Int((Some(1), ())))); }))))];
         })))])
ocaml_tree_sitter_switch/home/pad/yy/tests/parsing $ 
```