### PR TITLE
fix: revising string literal type to `char *` in C++

### DIFF
--- a/changelog.d/pa-3236.fixed
+++ b/changelog.d/pa-3236.fixed
@@ -1,0 +1,24 @@
+In C++, the string literal now has a type of `char *`. It won't match with the
+`string` type. For instance,
+
+```yaml
+- metavariable-type:
+    metavariable: $EXPR
+    type: string
+```
+
+will only match
+
+```cpp
+string f;
+// MATCH
+int x = f.length();
+```
+
+but not
+
+```cpp
+const char *s;
+// OK
+s = "foo";
+```

--- a/tests/rules/string_vs_char_ptr_cpp.cpp
+++ b/tests/rules/string_vs_char_ptr_cpp.cpp
@@ -1,0 +1,14 @@
+using namespace std;
+
+void f() {
+  // This is an `std::string`
+  string f;
+  // ruleid: string-type
+  int x = f.length();
+
+  // `s` has type `const char *`
+  const char *s;
+  // The string literal has type `char const [4]`
+  // ok: string-type
+  s = "foo";
+}

--- a/tests/rules/string_vs_char_ptr_cpp.yaml
+++ b/tests/rules/string_vs_char_ptr_cpp.yaml
@@ -1,0 +1,13 @@
+rules:
+  - patterns:
+      - pattern: |
+          $EXPR
+      - metavariable-type:
+          metavariable: $EXPR
+          type: string
+    id: string-type
+    message: string-type
+    languages:
+      - cpp
+    severity: WARNING
+


### PR DESCRIPTION
Test plan: `make core-test`