### PR TITLE
Enhance match_based_key generation for non-code-match SCA findings

### DIFF
--- a/changelog.d/sc-1195.fixed
+++ b/changelog.d/sc-1195.fixed
@@ -1,0 +1,1 @@
+Enhanced get_match_based_key in RuleMatch to uniquely identify non-code-match findings by including dependency package and version, ensuring distinct match_based_id generation for different package versions.

--- a/cli/src/semgrep/rule_match.py
+++ b/cli/src/semgrep/rule_match.py
@@ -353,6 +353,7 @@ class RuleMatch:
                 match_formula_str = match_formula_str.replace(
                     metavar, metavars[metavar]["abstract_content"]
                 )
+
         if self.from_transient_scan:
             # NOTE: We include the previous scan's rules in the config for consistent fixed status work.
             # For unique hashing/grouping, previous and current scan rules must have distinct check IDs.
@@ -365,6 +366,19 @@ class RuleMatch:
                 path,
                 self.annotated_rule_name,
             )
+
+        # Check if the match is non-code-match and reachable is False
+        if "sca_info" in self.extra and not self.extra["sca_info"].reachable:
+            # Include dependency package and version in the key
+            dependency = self.extra["sca_info"].dependency_match.found_dependency
+            return (
+                match_formula_str,
+                path,
+                self.rule_id,
+                dependency.package,
+                dependency.version,
+            )
+
         return (match_formula_str, path, self.rule_id)
 
     # This will supercede syntactic id, as currently that will change even if

--- a/cli/tests/e2e/snapshots/test_ci/test_dryrun/None/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_dryrun/None/results.txt
@@ -217,7 +217,7 @@ Would have sent findings and ignores blob: {
                 "sca-kind": "upgrade-only"
             },
             "is_blocking": false,
-            "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
+            "match_based_id": "31dd84080dabe6873b9bfc1f168b0a37b93c785e573c21e7133b812bf6b5cfd032d55befeb800ebc69dc8c1b0c4f7cdfad0ebfac575846ee3de74f665a08bdd5_0",
             "hashes": {
                 "start_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",
                 "end_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines-overwrite-autodetected-variables/findings_and_ignores.json
@@ -113,7 +113,7 @@
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
-      "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
+      "match_based_id": "31dd84080dabe6873b9bfc1f168b0a37b93c785e573c21e7133b812bf6b5cfd032d55befeb800ebc69dc8c1b0c4f7cdfad0ebfac575846ee3de74f665a08bdd5_0",
       "hashes": {
         "start_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",
         "end_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines/findings_and_ignores.json
@@ -113,7 +113,7 @@
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
-      "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
+      "match_based_id": "31dd84080dabe6873b9bfc1f168b0a37b93c785e573c21e7133b812bf6b5cfd032d55befeb800ebc69dc8c1b0c4f7cdfad0ebfac575846ee3de74f665a08bdd5_0",
       "hashes": {
         "start_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",
         "end_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket-overwrite-autodetected-variables/findings_and_ignores.json
@@ -113,7 +113,7 @@
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
-      "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
+      "match_based_id": "31dd84080dabe6873b9bfc1f168b0a37b93c785e573c21e7133b812bf6b5cfd032d55befeb800ebc69dc8c1b0c4f7cdfad0ebfac575846ee3de74f665a08bdd5_0",
       "hashes": {
         "start_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",
         "end_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket/findings_and_ignores.json
@@ -113,7 +113,7 @@
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
-      "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
+      "match_based_id": "31dd84080dabe6873b9bfc1f168b0a37b93c785e573c21e7133b812bf6b5cfd032d55befeb800ebc69dc8c1b0c4f7cdfad0ebfac575846ee3de74f665a08bdd5_0",
       "hashes": {
         "start_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",
         "end_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite-overwrite-autodetected-variables/findings_and_ignores.json
@@ -113,7 +113,7 @@
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
-      "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
+      "match_based_id": "31dd84080dabe6873b9bfc1f168b0a37b93c785e573c21e7133b812bf6b5cfd032d55befeb800ebc69dc8c1b0c4f7cdfad0ebfac575846ee3de74f665a08bdd5_0",
       "hashes": {
         "start_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",
         "end_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite/findings_and_ignores.json
@@ -113,7 +113,7 @@
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
-      "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
+      "match_based_id": "31dd84080dabe6873b9bfc1f168b0a37b93c785e573c21e7133b812bf6b5cfd032d55befeb800ebc69dc8c1b0c4f7cdfad0ebfac575846ee3de74f665a08bdd5_0",
       "hashes": {
         "start_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",
         "end_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci-overwrite-autodetected-variables/findings_and_ignores.json
@@ -113,7 +113,7 @@
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
-      "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
+      "match_based_id": "31dd84080dabe6873b9bfc1f168b0a37b93c785e573c21e7133b812bf6b5cfd032d55befeb800ebc69dc8c1b0c4f7cdfad0ebfac575846ee3de74f665a08bdd5_0",
       "hashes": {
         "start_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",
         "end_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci/findings_and_ignores.json
@@ -113,7 +113,7 @@
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
-      "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
+      "match_based_id": "31dd84080dabe6873b9bfc1f168b0a37b93c785e573c21e7133b812bf6b5cfd032d55befeb800ebc69dc8c1b0c4f7cdfad0ebfac575846ee3de74f665a08bdd5_0",
       "hashes": {
         "start_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",
         "end_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/findings_and_ignores.json
@@ -113,7 +113,7 @@
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
-      "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
+      "match_based_id": "31dd84080dabe6873b9bfc1f168b0a37b93c785e573c21e7133b812bf6b5cfd032d55befeb800ebc69dc8c1b0c4f7cdfad0ebfac575846ee3de74f665a08bdd5_0",
       "hashes": {
         "start_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",
         "end_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push-special-env-vars/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push-special-env-vars/findings_and_ignores.json
@@ -113,7 +113,7 @@
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
-      "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
+      "match_based_id": "31dd84080dabe6873b9bfc1f168b0a37b93c785e573c21e7133b812bf6b5cfd032d55befeb800ebc69dc8c1b0c4f7cdfad0ebfac575846ee3de74f665a08bdd5_0",
       "hashes": {
         "start_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",
         "end_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/findings_and_ignores.json
@@ -113,7 +113,7 @@
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
-      "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
+      "match_based_id": "31dd84080dabe6873b9bfc1f168b0a37b93c785e573c21e7133b812bf6b5cfd032d55befeb800ebc69dc8c1b0c4f7cdfad0ebfac575846ee3de74f665a08bdd5_0",
       "hashes": {
         "start_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",
         "end_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-push/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-push/findings_and_ignores.json
@@ -113,7 +113,7 @@
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
-      "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
+      "match_based_id": "31dd84080dabe6873b9bfc1f168b0a37b93c785e573c21e7133b812bf6b5cfd032d55befeb800ebc69dc8c1b0c4f7cdfad0ebfac575846ee3de74f665a08bdd5_0",
       "hashes": {
         "start_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",
         "end_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/findings_and_ignores.json
@@ -113,7 +113,7 @@
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
-      "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
+      "match_based_id": "31dd84080dabe6873b9bfc1f168b0a37b93c785e573c21e7133b812bf6b5cfd032d55befeb800ebc69dc8c1b0c4f7cdfad0ebfac575846ee3de74f665a08bdd5_0",
       "hashes": {
         "start_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",
         "end_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-overwrite-autodetected-variables/findings_and_ignores.json
@@ -113,7 +113,7 @@
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
-      "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
+      "match_based_id": "31dd84080dabe6873b9bfc1f168b0a37b93c785e573c21e7133b812bf6b5cfd032d55befeb800ebc69dc8c1b0c4f7cdfad0ebfac575846ee3de74f665a08bdd5_0",
       "hashes": {
         "start_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",
         "end_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins/findings_and_ignores.json
@@ -113,7 +113,7 @@
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
-      "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
+      "match_based_id": "31dd84080dabe6873b9bfc1f168b0a37b93c785e573c21e7133b812bf6b5cfd032d55befeb800ebc69dc8c1b0c4f7cdfad0ebfac575846ee3de74f665a08bdd5_0",
       "hashes": {
         "start_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",
         "end_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/findings_and_ignores.json
@@ -113,7 +113,7 @@
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
-      "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
+      "match_based_id": "31dd84080dabe6873b9bfc1f168b0a37b93c785e573c21e7133b812bf6b5cfd032d55befeb800ebc69dc8c1b0c4f7cdfad0ebfac575846ee3de74f665a08bdd5_0",
       "hashes": {
         "start_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",
         "end_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-self-hosted/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-self-hosted/findings_and_ignores.json
@@ -113,7 +113,7 @@
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
-      "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
+      "match_based_id": "31dd84080dabe6873b9bfc1f168b0a37b93c785e573c21e7133b812bf6b5cfd032d55befeb800ebc69dc8c1b0c4f7cdfad0ebfac575846ee3de74f665a08bdd5_0",
       "hashes": {
         "start_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",
         "end_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis-overwrite-autodetected-variables/findings_and_ignores.json
@@ -113,7 +113,7 @@
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
-      "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
+      "match_based_id": "31dd84080dabe6873b9bfc1f168b0a37b93c785e573c21e7133b812bf6b5cfd032d55befeb800ebc69dc8c1b0c4f7cdfad0ebfac575846ee3de74f665a08bdd5_0",
       "hashes": {
         "start_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",
         "end_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis/findings_and_ignores.json
@@ -113,7 +113,7 @@
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
-      "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
+      "match_based_id": "31dd84080dabe6873b9bfc1f168b0a37b93c785e573c21e7133b812bf6b5cfd032d55befeb800ebc69dc8c1b0c4f7cdfad0ebfac575846ee3de74f665a08bdd5_0",
       "hashes": {
         "start_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",
         "end_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-unparsable_url/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-unparsable_url/findings_and_ignores.json
@@ -113,7 +113,7 @@
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
-      "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
+      "match_based_id": "31dd84080dabe6873b9bfc1f168b0a37b93c785e573c21e7133b812bf6b5cfd032d55befeb800ebc69dc8c1b0c4f7cdfad0ebfac575846ee3de74f665a08bdd5_0",
       "hashes": {
         "start_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",
         "end_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines-overwrite-autodetected-variables/findings_and_ignores.json
@@ -113,7 +113,7 @@
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
-      "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
+      "match_based_id": "31dd84080dabe6873b9bfc1f168b0a37b93c785e573c21e7133b812bf6b5cfd032d55befeb800ebc69dc8c1b0c4f7cdfad0ebfac575846ee3de74f665a08bdd5_0",
       "hashes": {
         "start_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",
         "end_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines/findings_and_ignores.json
@@ -113,7 +113,7 @@
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
-      "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
+      "match_based_id": "31dd84080dabe6873b9bfc1f168b0a37b93c785e573c21e7133b812bf6b5cfd032d55befeb800ebc69dc8c1b0c4f7cdfad0ebfac575846ee3de74f665a08bdd5_0",
       "hashes": {
         "start_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",
         "end_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket-overwrite-autodetected-variables/findings_and_ignores.json
@@ -113,7 +113,7 @@
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
-      "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
+      "match_based_id": "31dd84080dabe6873b9bfc1f168b0a37b93c785e573c21e7133b812bf6b5cfd032d55befeb800ebc69dc8c1b0c4f7cdfad0ebfac575846ee3de74f665a08bdd5_0",
       "hashes": {
         "start_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",
         "end_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket/findings_and_ignores.json
@@ -113,7 +113,7 @@
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
-      "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
+      "match_based_id": "31dd84080dabe6873b9bfc1f168b0a37b93c785e573c21e7133b812bf6b5cfd032d55befeb800ebc69dc8c1b0c4f7cdfad0ebfac575846ee3de74f665a08bdd5_0",
       "hashes": {
         "start_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",
         "end_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite-overwrite-autodetected-variables/findings_and_ignores.json
@@ -113,7 +113,7 @@
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
-      "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
+      "match_based_id": "31dd84080dabe6873b9bfc1f168b0a37b93c785e573c21e7133b812bf6b5cfd032d55befeb800ebc69dc8c1b0c4f7cdfad0ebfac575846ee3de74f665a08bdd5_0",
       "hashes": {
         "start_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",
         "end_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite/findings_and_ignores.json
@@ -113,7 +113,7 @@
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
-      "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
+      "match_based_id": "31dd84080dabe6873b9bfc1f168b0a37b93c785e573c21e7133b812bf6b5cfd032d55befeb800ebc69dc8c1b0c4f7cdfad0ebfac575846ee3de74f665a08bdd5_0",
       "hashes": {
         "start_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",
         "end_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci-overwrite-autodetected-variables/findings_and_ignores.json
@@ -113,7 +113,7 @@
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
-      "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
+      "match_based_id": "31dd84080dabe6873b9bfc1f168b0a37b93c785e573c21e7133b812bf6b5cfd032d55befeb800ebc69dc8c1b0c4f7cdfad0ebfac575846ee3de74f665a08bdd5_0",
       "hashes": {
         "start_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",
         "end_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci/findings_and_ignores.json
@@ -113,7 +113,7 @@
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
-      "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
+      "match_based_id": "31dd84080dabe6873b9bfc1f168b0a37b93c785e573c21e7133b812bf6b5cfd032d55befeb800ebc69dc8c1b0c4f7cdfad0ebfac575846ee3de74f665a08bdd5_0",
       "hashes": {
         "start_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",
         "end_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/findings_and_ignores.json
@@ -113,7 +113,7 @@
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
-      "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
+      "match_based_id": "31dd84080dabe6873b9bfc1f168b0a37b93c785e573c21e7133b812bf6b5cfd032d55befeb800ebc69dc8c1b0c4f7cdfad0ebfac575846ee3de74f665a08bdd5_0",
       "hashes": {
         "start_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",
         "end_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push-special-env-vars/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push-special-env-vars/findings_and_ignores.json
@@ -113,7 +113,7 @@
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
-      "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
+      "match_based_id": "31dd84080dabe6873b9bfc1f168b0a37b93c785e573c21e7133b812bf6b5cfd032d55befeb800ebc69dc8c1b0c4f7cdfad0ebfac575846ee3de74f665a08bdd5_0",
       "hashes": {
         "start_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",
         "end_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/findings_and_ignores.json
@@ -113,7 +113,7 @@
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
-      "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
+      "match_based_id": "31dd84080dabe6873b9bfc1f168b0a37b93c785e573c21e7133b812bf6b5cfd032d55befeb800ebc69dc8c1b0c4f7cdfad0ebfac575846ee3de74f665a08bdd5_0",
       "hashes": {
         "start_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",
         "end_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-push/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-push/findings_and_ignores.json
@@ -113,7 +113,7 @@
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
-      "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
+      "match_based_id": "31dd84080dabe6873b9bfc1f168b0a37b93c785e573c21e7133b812bf6b5cfd032d55befeb800ebc69dc8c1b0c4f7cdfad0ebfac575846ee3de74f665a08bdd5_0",
       "hashes": {
         "start_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",
         "end_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/findings_and_ignores.json
@@ -113,7 +113,7 @@
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
-      "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
+      "match_based_id": "31dd84080dabe6873b9bfc1f168b0a37b93c785e573c21e7133b812bf6b5cfd032d55befeb800ebc69dc8c1b0c4f7cdfad0ebfac575846ee3de74f665a08bdd5_0",
       "hashes": {
         "start_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",
         "end_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-overwrite-autodetected-variables/findings_and_ignores.json
@@ -113,7 +113,7 @@
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
-      "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
+      "match_based_id": "31dd84080dabe6873b9bfc1f168b0a37b93c785e573c21e7133b812bf6b5cfd032d55befeb800ebc69dc8c1b0c4f7cdfad0ebfac575846ee3de74f665a08bdd5_0",
       "hashes": {
         "start_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",
         "end_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins/findings_and_ignores.json
@@ -113,7 +113,7 @@
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
-      "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
+      "match_based_id": "31dd84080dabe6873b9bfc1f168b0a37b93c785e573c21e7133b812bf6b5cfd032d55befeb800ebc69dc8c1b0c4f7cdfad0ebfac575846ee3de74f665a08bdd5_0",
       "hashes": {
         "start_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",
         "end_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/findings_and_ignores.json
@@ -113,7 +113,7 @@
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
-      "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
+      "match_based_id": "31dd84080dabe6873b9bfc1f168b0a37b93c785e573c21e7133b812bf6b5cfd032d55befeb800ebc69dc8c1b0c4f7cdfad0ebfac575846ee3de74f665a08bdd5_0",
       "hashes": {
         "start_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",
         "end_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-self-hosted/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-self-hosted/findings_and_ignores.json
@@ -113,7 +113,7 @@
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
-      "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
+      "match_based_id": "31dd84080dabe6873b9bfc1f168b0a37b93c785e573c21e7133b812bf6b5cfd032d55befeb800ebc69dc8c1b0c4f7cdfad0ebfac575846ee3de74f665a08bdd5_0",
       "hashes": {
         "start_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",
         "end_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis-overwrite-autodetected-variables/findings_and_ignores.json
@@ -113,7 +113,7 @@
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
-      "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
+      "match_based_id": "31dd84080dabe6873b9bfc1f168b0a37b93c785e573c21e7133b812bf6b5cfd032d55befeb800ebc69dc8c1b0c4f7cdfad0ebfac575846ee3de74f665a08bdd5_0",
       "hashes": {
         "start_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",
         "end_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis/findings_and_ignores.json
@@ -113,7 +113,7 @@
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
-      "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
+      "match_based_id": "31dd84080dabe6873b9bfc1f168b0a37b93c785e573c21e7133b812bf6b5cfd032d55befeb800ebc69dc8c1b0c4f7cdfad0ebfac575846ee3de74f665a08bdd5_0",
       "hashes": {
         "start_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",
         "end_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-unparsable_url/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-unparsable_url/findings_and_ignores.json
@@ -113,7 +113,7 @@
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
-      "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
+      "match_based_id": "31dd84080dabe6873b9bfc1f168b0a37b93c785e573c21e7133b812bf6b5cfd032d55befeb800ebc69dc8c1b0c4f7cdfad0ebfac575846ee3de74f665a08bdd5_0",
       "hashes": {
         "start_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",
         "end_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",

--- a/cli/tests/e2e/snapshots/test_ci/test_lockfile_parse_failure_reporting/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_lockfile_parse_failure_reporting/findings_and_ignores.json
@@ -113,7 +113,7 @@
         "sca-kind": "upgrade-only"
       },
       "is_blocking": false,
-      "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
+      "match_based_id": "31dd84080dabe6873b9bfc1f168b0a37b93c785e573c21e7133b812bf6b5cfd032d55befeb800ebc69dc8c1b0c4f7cdfad0ebfac575846ee3de74f665a08bdd5_0",
       "hashes": {
         "start_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",
         "end_line_hash": "13ed086097ee3dd997602b5df99fff011f3880f4fd53daca82db975bf8dd71dd",

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---sarif/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---sarif/results.txt
@@ -447,7 +447,7 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
         },
         {
           "fingerprints": {
-            "matchBasedId/v1": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0"
+            "matchBasedId/v1": "31dd84080dabe6873b9bfc1f168b0a37b93c785e573c21e7133b812bf6b5cfd032d55befeb800ebc69dc8c1b0c4f7cdfad0ebfac575846ee3de74f665a08bdd5_0"
           },
           "locations": [
             {

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---sarif/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---sarif/results.txt
@@ -393,7 +393,7 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
         },
         {
           "fingerprints": {
-            "matchBasedId/v1": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0"
+            "matchBasedId/v1": "31dd84080dabe6873b9bfc1f168b0a37b93c785e573c21e7133b812bf6b5cfd032d55befeb800ebc69dc8c1b0c4f7cdfad0ebfac575846ee3de74f665a08bdd5_0"
           },
           "locations": [
             {


### PR DESCRIPTION
This PR introduces an enhancement to the get_match_based_key method in the RuleMatch class to address an issue where non-code-match findings (specifically "always reachable" and unreachable matches) were generating non-unique match_based_id values for different versions of the same dependency package. By including dependency package and version information in the match_based_key for these types of findings, we ensure that each finding is uniquely identifiable.