### PR TITLE
fix Fmt_.with_buffer_to_string

### DIFF
--- a/libs/commons/Fmt_.ml
+++ b/libs/commons/Fmt_.ml
@@ -63,7 +63,13 @@ let with_buffer_to_string f =
   let buf = Buffer.create 100 in
   let (ppf : Format.formatter) = Format.formatter_of_buffer buf in
   f ppf;
+  Format.pp_print_flush ppf ();
   Buffer.contents buf
+
+let () =
+  Alcotest_ext.test "Fmt_.with_buffer_to_string" (fun () ->
+      assert (
+        with_buffer_to_string (fun fmt -> Format.fprintf fmt "foo") = "foo"))
 
 let pp_table (h1, heading) ppf entries =
   let lines = layout_table (h1, heading) entries in


### PR DESCRIPTION
As reported by amarin on slack, after
https://github.com/semgrep/semgrep/pull/9417
the trace matching debugging was not working anymore
because we switched OCaml.string_of_v to use
Fmt_.with_buffer_to_string which was buggy.

This PR fixes the regression

test plan:
unit test included
and also after setting Trace_mathing.on to true
```
$ ./bin/semgrep-core -l python -f tests/patterns/python/imports.{sgrep,py}
...
----- m_stmt -----
stmt pattern:
DirectiveStmt({d_attrs=[]; d=ImportAs(..., ..., ...); })
~~~~~
stmt target:
DirectiveStmt({d_attrs=[]; d=ImportFrom(..., ..., ...); })

...
```
works again