### PR TITLE
strip semgrep-core for smaller binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,8 @@ core:
 	$(MAKE) minimal-build
 	# make executables easily accessible for manual testing:
 	ln -s semgrep-core bin/osemgrep
+	chmod +w _build/install/default/bin/semgrep-core
+	strip _build/install/default/bin/semgrep-core
 
 #history: was called the 'all' target in semgrep-core/Makefile before
 .PHONY: core-bc


### PR DESCRIPTION
I think `semgrep-core` size is enough to consider looking into how to reduce.

I'm not familiar (at all) with ocaml and I wasn't able to find any compilation flags that would be able to produce smaller binaries.

I'm not a UPX fan (size versus unpack CPU performance, plus many caveats),  `strip` however did yield some results.

Linux aarch64 from ~150 to ~112
OSX aarch64 from ~138 to ~122 🤒 

Googled a bit if there was any known impact of stripping ocaml binaries but couldn't find anything.

[This community thread](https://discuss.ocaml.org/t/stripping-binaries/2308/19) actually confirms many people use it.