### PR TITLE
fix(metrics): compact ruleHashesWithFindings

### DIFF
--- a/cli/src/semgrep/metrics.py
+++ b/cli/src/semgrep/metrics.py
@@ -258,8 +258,13 @@ class Metrics:
 
     @suppress_errors
     def add_findings(self, findings: FilteredMatches) -> None:
+        # Rules with 0 findings don't carry a lot of information
+        # compared to rules that actually have findings. Rules with 0
+        # findings also increase the size of the metrics quite
+        # significantly, e.g., when the number of rules grows up to
+        # magnitudes of 10k. So we filter them out in the metrics.
         self.payload.value.ruleHashesWithFindings = [
-            (r.full_hash, len(f)) for r, f in findings.kept.items()
+            (r.full_hash, len(f)) for r, f in findings.kept.items() if len(f) > 0
         ]
         self.payload.value.numFindings = sum(len(v) for v in findings.kept.values())
         self.payload.value.numIgnored = sum(len(v) for v in findings.removed.values())

--- a/cli/tests/e2e/snapshots/test_metrics/test_metrics_payload/pro_flag0/metrics-payload.json
+++ b/cli/tests/e2e/snapshots/test_metrics/test_metrics_payload/pro_flag0/metrics-payload.json
@@ -58,8 +58,7 @@
     "numFindings": 1,
     "numIgnored": 0,
     "ruleHashesWithFindings": {
-      "7d0af7d79e44c9bafdba5c83bacbb44c5b663c3c3efe1eec1676df5158303eb4": 1,
-      "d9b9091bec0a312e3cbf9735b69e80411a0131779938f802de3899fec6354aa7": 0
+      "7d0af7d79e44c9bafdba5c83bacbb44c5b663c3c3efe1eec1676df5158303eb4": 1
     }
   }
 }


### PR DESCRIPTION
Partially helps: PA-3321.

Tested with `make test` locally under `cli`. And made the metrics payload test pass.

Some other tests were failing, but those tests were also failing on a fresh clone.

Verified in metabase that the runs with lots of rules show up in metabase.

There are more places that the team needs to talk about. For example, `osemgrep` always [populates `ruleStats`](https://github.com/semgrep/semgrep/blob/2b36cd5b04b7b06741ab9cbed8475900ed226d03/src/osemgrep/core/Metrics_.ml#L304-L313). But I think this PR is still a good first step.

Did not add a changelog. It didn't feel exactly like a user facing feature. These metrics is for the team.