### PR TITLE
fix(metrics): compact ruleStats

### DIFF
--- a/cli/src/semgrep/metrics.py
+++ b/cli/src/semgrep/metrics.py
@@ -249,6 +249,10 @@ class Metrics:
                     bytesScanned=mock_int(_rule_bytes_scanned[rule.id2]),
                 )
                 for rule in rules
+                # We consider only rules with match times and bytes scanned
+                # greater than 0 to avoid making the metrics too bloated.
+                if _rule_match_times[rule.id2] > 0.0
+                and _rule_bytes_scanned[rule.id2] > 0
             ]
 
     @suppress_errors

--- a/cli/tests/e2e/snapshots/test_metrics/test_metrics_payload/pro_flag0/metrics-payload.json
+++ b/cli/tests/e2e/snapshots/test_metrics/test_metrics_payload/pro_flag0/metrics-payload.json
@@ -31,6 +31,30 @@
     }
   },
   "performance": {
+    "fileStats": [
+      {
+        "matchTime": 0.0,
+        "numTimesScanned": 0,
+        "parseTime": 0.0,
+        "runTime": 0.0,
+        "size": 782
+      },
+      {
+        "matchTime": 0.0,
+        "numTimesScanned": 0,
+        "parseTime": 0.0,
+        "runTime": 0.0,
+        "size": 710
+      },
+      {
+        "matchTime": 0.0,
+        "numTimesScanned": 0,
+        "parseTime": 0.0,
+        "runTime": 0.0,
+        "size": 300
+      }
+    ],
+    "maxMemoryBytes": 42336256,
     "numRules": 2,
     "numTargets": 3,
     "profilingTimes": {
@@ -39,6 +63,13 @@
       "ignores_time": 0.0,
       "total_time": 0.0
     },
+    "ruleStats": [
+      {
+        "bytesScanned": 0,
+        "matchTime": 0.0,
+        "ruleHash": "7d0af7d79e44c9bafdba5c83bacbb44c5b663c3c3efe1eec1676df5158303eb4"
+      }
+    ],
     "totalBytesScanned": 1792
   },
   "sent_at": "2017-03-03T00:00:00+09:00",
@@ -49,6 +80,7 @@
       "cli-flag/config",
       "cli-flag/metrics",
       "cli-flag/targets",
+      "cli-flag/time_flag",
       "config/local",
       "language/csharp",
       "language/java",

--- a/cli/tests/e2e/test_metrics.py
+++ b/cli/tests/e2e/test_metrics.py
@@ -221,7 +221,8 @@ def test_metrics_payload(tmp_path, snapshot, mocker, monkeypatch, pro_flag):
     runner.invoke(
         cli,
         subcommand="scan",
-        args=["--config=rule.yaml", "--metrics=on", "metrics_files"] + pro_flag,
+        args=["--config=rule.yaml", "--metrics=on", "metrics_files", "--time"]
+        + pro_flag,
     )
 
     payload = json.loads(mock_post.call_args.kwargs["data"])

--- a/src/osemgrep/core/Metrics_.ml
+++ b/src/osemgrep/core/Metrics_.ml
@@ -301,17 +301,13 @@ let add_rules_hashes_and_rules_profiling ?profiling:_TODO rules =
   in
   g.payload.environment.rulesHash <- Some (Digestif.SHA256.get rulesHash_value);
   g.payload.performance.numRules <- Some (List.length rules);
-  let ruleStats_value =
-    List_.mapi
-      (fun idx _rule ->
-        {
-          Semgrep_metrics_t.ruleHash = List.nth hashes idx;
-          bytesScanned = 0;
-          matchTime = None;
-        })
-      rules
-  in
-  g.payload.performance.ruleStats <- Some ruleStats_value
+  (* TODO: Properly populate g.payload.performance.ruleStats.
+   * Currently, when we have thousands of rules, they will bloat the
+   * metrics payload. Right now in metrics.py, we are only populating
+   * these stats when both matching time and bytes scanned are greater
+   * than 0.
+   *)
+  g.payload.performance.ruleStats <- None
 
 let add_max_memory_bytes (profiling_data : Core_profiling.t option) =
   Option.iter


### PR DESCRIPTION
Partially helps: PA-3321.

Follow up from https://github.com/semgrep/semgrep/pull/9477.

Tested with `make test` locally under cli to make sure there were no regressions. Some other tests were failing, but those tests were also failing on a fresh clone.

Also tested by checking semgrep scan results in metabase.
* For osemgrep, I ran with experiment and profile flags. 
* For pysemgrep, I hardcoded some examples to trigger the code that populates ruleStat (because I was unable to [make this condition be true](https://github.com/semgrep/semgrep/blob/2b36cd5b04b7b06741ab9cbed8475900ed226d03/cli/src/semgrep/metrics.py#L235-L252))

For both cases, the rules with bytes scanned and matching time greater than 0 showed up in the metrics when querying metabase.
