### PR TITLE
Clarify wording on command when not logged in

### DIFF
--- a/changelog.d/gh-9485.fixed
+++ b/changelog.d/gh-9485.fixed
@@ -1,0 +1,1 @@
+Revise error message when running `semgrep ci` without being logged in to clarify that `--config` is used with `semgrep scan`.

--- a/cli/src/semgrep/commands/ci.py
+++ b/cli/src/semgrep/commands/ci.py
@@ -226,7 +226,7 @@ def ci(
     token = state.app_session.token
     if not token and not config:
         # Not logged in and no explicit config
-        logger.info("run `semgrep login` before using `semgrep ci` or set `--config`")
+        logger.info("run `semgrep login` before using `semgrep ci` or use `semgrep scan` and set `--config`")
         sys.exit(INVALID_API_KEY_EXIT_CODE)
     elif not token and config:
         # Not logged in but has explicit config

--- a/cli/src/semgrep/commands/ci.py
+++ b/cli/src/semgrep/commands/ci.py
@@ -226,7 +226,9 @@ def ci(
     token = state.app_session.token
     if not token and not config:
         # Not logged in and no explicit config
-        logger.info("run `semgrep login` before using `semgrep ci` or use `semgrep scan` and set `--config`")
+        logger.info(
+            "run `semgrep login` before using `semgrep ci` or use `semgrep scan` and set `--config`"
+        )
         sys.exit(INVALID_API_KEY_EXIT_CODE)
     elif not token and config:
         # Not logged in but has explicit config

--- a/src/osemgrep/cli_ci/Ci_subcommand.ml
+++ b/src/osemgrep/cli_ci/Ci_subcommand.ml
@@ -130,7 +130,9 @@ let deployment_config_opt caps (api_token : Auth.token option)
   match (api_token, empty_config) with
   | None, true ->
       Logs.app (fun m ->
-          m "run `semgrep login` before using `semgrep ci` or use `semgrep scan` and set `--config`");
+          m
+            "run `semgrep login` before using `semgrep ci` or use `semgrep \
+             scan` and set `--config`");
       Error.exit Exit_code.invalid_api_key
   | Some _, false ->
       Logs.app (fun m ->

--- a/src/osemgrep/cli_ci/Ci_subcommand.ml
+++ b/src/osemgrep/cli_ci/Ci_subcommand.ml
@@ -130,7 +130,7 @@ let deployment_config_opt caps (api_token : Auth.token option)
   match (api_token, empty_config) with
   | None, true ->
       Logs.app (fun m ->
-          m "run `semgrep login` before using `semgrep ci` or set `--config`");
+          m "run `semgrep login` before using `semgrep ci` or use `semgrep scan` and set `--config`");
       Error.exit Exit_code.invalid_api_key
   | Some _, false ->
       Logs.app (fun m ->


### PR DESCRIPTION
The wording suggesting how to resolve the issue with using `semgrep ci` when not logged in was a bit unclear. You can't combine `--config` with `semgrep ci`, so this update clarifies that you use `semgrep scan` instead in that case.

Test plan:

* Run `semgrep ci` while not logged in (locally in testing, `pipenv run semgrep ci` or run from the pipenv shell).
* Run `semgrep ci --experimental` while not logged in.