### PR TITLE
fix: properly process `nosemgrep` with multiple ids

### DIFF
--- a/changelog.d/gh-9463.fixed
+++ b/changelog.d/gh-9463.fixed
@@ -1,0 +1,2 @@
+Nosemgrep: Fixed a bug where Semgrep would err upon reading a `nosemgrep`
+comment with multiple rule IDs.

--- a/cli/tests/e2e/rules/two_matches.yaml
+++ b/cli/tests/e2e/rules/two_matches.yaml
@@ -1,0 +1,13 @@
+rules:
+  - id: match-foo
+    pattern: |
+      foo(...)
+    message: "test regex message"
+    languages: [python]
+    severity: ERROR
+  - id: match-bar
+    pattern: |
+      bar(...)
+    message: "test regex message"
+    languages: [python]
+    severity: ERROR

--- a/cli/tests/e2e/targets/nosemgrep/multiple-nosemgrep.py
+++ b/cli/tests/e2e/targets/nosemgrep/multiple-nosemgrep.py
@@ -1,2 +1,2 @@
 def foo(a, b):
-    return a + b == a + b  # nosemgrep: rules.eqeq-is-bad, rules.assert-eqeq-is-ok
+    return foo(bar(1)) # nosemgrep: rules.match-foo, rules.match-bar

--- a/cli/tests/e2e/targets/nosemgrep/multiple-nosemgrep.py
+++ b/cli/tests/e2e/targets/nosemgrep/multiple-nosemgrep.py
@@ -1,0 +1,2 @@
+def foo(a, b):
+    return a + b == a + b  # nosemgrep: rules.eqeq-is-bad, rules.assert-eqeq-is-ok

--- a/cli/tests/e2e/test_nosemgrep.py
+++ b/cli/tests/e2e/test_nosemgrep.py
@@ -32,7 +32,7 @@ def test_nosem_rule__invalid_id(run_semgrep_in_tmp: RunSemgrep, snapshot):
 @pytest.mark.kinda_slow
 def test_nosem_with_multiple_ids(run_semgrep_in_tmp: RunSemgrep):
     run_semgrep_in_tmp(
-        "rules/eqeq.yaml",
+        "rules/two_matches.yaml",
         target_name="nosemgrep/multiple-nosemgrep.py",
         assert_exit_code=0,
     )

--- a/cli/tests/e2e/test_nosemgrep.py
+++ b/cli/tests/e2e/test_nosemgrep.py
@@ -30,6 +30,15 @@ def test_nosem_rule__invalid_id(run_semgrep_in_tmp: RunSemgrep, snapshot):
 
 
 @pytest.mark.kinda_slow
+def test_nosem_with_multiple_ids(run_semgrep_in_tmp: RunSemgrep):
+    run_semgrep_in_tmp(
+        "rules/eqeq.yaml",
+        target_name="nosemgrep/multiple-nosemgrep.py",
+        assert_exit_code=0,
+    )
+
+
+@pytest.mark.kinda_slow
 def test_nosem_rule__with_disable_nosem(run_semgrep_in_tmp: RunSemgrep, snapshot):
     snapshot.assert_match(
         run_semgrep_in_tmp("rules/nosem.yaml", options=["--disable-nosem"]).stdout,

--- a/src/reporting/Nosemgrep.ml
+++ b/src/reporting/Nosemgrep.ml
@@ -124,20 +124,12 @@ let rule_match_nosem (pm : Pattern_match.t) : bool * Core_error.t list =
     | None -> None
     | Some line -> recognise_and_collect ~rex:nosem_inline_re line
   in
-  UCommon.(
-    pr2
-      (Common.spf "ids line %s"
-         ([%show: (int * string * int) option list option] ids_line)));
   let ids_previous_line =
     match previous_line with
     | None -> None
     | Some previous_line ->
         recognise_and_collect ~rex:nosem_previous_line_re previous_line
   in
-  UCommon.(
-    pr2
-      (Common.spf "ids line %s"
-         ([%show: (int * string * int) option list option] ids_previous_line)));
 
   match
     ( Option.value ~default:[] ids_line,

--- a/src/reporting/Nosemgrep.ml
+++ b/src/reporting/Nosemgrep.ml
@@ -66,17 +66,29 @@ let nosem_previous_line_re =
    array IDs (["ids"]) collected during this recognition.
 *)
 let recognise_and_collect ~rex (line_num, line) =
-  Pcre_.exec_all ~rex line
-  |> Result.map
-       (Array.map (fun subst ->
-            match Pcre_.get_named_substring_and_ofs rex "ids" subst with
-            | Ok (Some (s, (begin_ofs, _end_ofs))) ->
-                Some (line_num, s, begin_ofs)
-            | Ok None
-            | Error _ ->
-                (* TODO: log something? *)
-                None))
-  |> Result.to_option
+  (* THINK: It is unclear to me why the following call should ever return more
+     than one match The above regex seems like it's recognizing a single instance
+     of "nosemgrep: <ids>", which shouldn't occur more than once in a single line?
+  *)
+  match Pcre_.exec_all ~rex line with
+  | Error _ -> None
+  | Ok arr ->
+      Array.to_list arr
+      |> List.concat_map (fun subst ->
+             match Pcre_.get_named_substring_and_ofs rex "ids" subst with
+             | Ok (Some (s, (begin_ofs, _end_ofs))) ->
+                 (* TODO: This will associate each ID with the range of the entire ID list.
+                    Fix later.
+                 *)
+                 String.split_on_char ',' s
+                 |> List_.map (fun id ->
+                        (line_num, Common2.strip ' ' id, begin_ofs))
+                 |> List_.map Option.some
+             | Ok None
+             | Error _ ->
+                 (* TODO: log something? *)
+                 [ None ])
+      |> Option.some
 
 (*
    Try to recognize a possible [nosem] tag into the given [match].
@@ -105,25 +117,33 @@ let rule_match_nosem (pm : Pattern_match.t) : bool * Core_error.t list =
     | [] (* XXX(dinosaure): is it possible? *) -> (None, None)
   in
 
-  let no_ids = Array.for_all Option.is_none in
+  let no_ids = List.for_all Option.is_none in
 
   let ids_line =
     match line with
     | None -> None
     | Some line -> recognise_and_collect ~rex:nosem_inline_re line
   in
+  UCommon.(
+    pr2
+      (Common.spf "ids line %s"
+         ([%show: (int * string * int) option list option] ids_line)));
   let ids_previous_line =
     match previous_line with
     | None -> None
     | Some previous_line ->
         recognise_and_collect ~rex:nosem_previous_line_re previous_line
   in
+  UCommon.(
+    pr2
+      (Common.spf "ids line %s"
+         ([%show: (int * string * int) option list option] ids_previous_line)));
 
   match
-    ( Option.value ~default:[||] ids_line,
-      Option.value ~default:[||] ids_previous_line )
+    ( Option.value ~default:[] ids_line,
+      Option.value ~default:[] ids_previous_line )
   with
-  | [||], [||] ->
+  | [], [] ->
       (* no lines or no [nosemgrep] occurrences found, keep the [rule_match]. *)
       (false, [])
   | ids_line, ids_previous_line when no_ids ids_line && no_ids ids_previous_line
@@ -131,9 +151,9 @@ let rule_match_nosem (pm : Pattern_match.t) : bool * Core_error.t list =
       (* [nosemgrep] occurrences found but no [ids]. *)
       (true, [])
   | ids_line, ids_previous_line ->
-      let ids = Array.append ids_line ids_previous_line in
+      let ids = ids_line @ ids_previous_line in
       let ids =
-        Array.to_list ids |> List_.map_filter Fun.id
+        ids |> List_.map_filter Fun.id
         |> List_.map (fun (line_num, s, col) ->
                (* [String.split_on_char] can **not** return an empty list. *)
                ( line_num,


### PR DESCRIPTION
**## What:
This PR makes it so that Semgrep doesn't err upon processing a `nosemgrep` with multiple IDs.

## Why:
This is intended behavior, and should work.

## How:
We were not properly splitting the the list of IDs obtained by a `nosemgrep` by comma, so this PR just re-introduces that behavior.

This causes a test to fail, due to some existing behavior of how `nosemgrep` works. Essentially, for every match that is produced, if there exists `#nosemgrep` comment for a rule which is not the same as the match's ID, Semgrep will complain.

In the case where there are multiple `# nosemgrep` IDs for a single line, this will always cause an error. This seems undesirable -- we would prefer to check that each ID that `# nosemgrep` ignores truly has a match it is ignoring. This would be considerably more work, however, so this PR just disables the warning when there are multiple IDs being ignored at once.

## Test plan:
Added a regression test.

Closes #9463 
Closes PA-3320**