### PR TITLE
Alcotest_ext: capture and show unchecked test output

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,6 +60,7 @@ repos:
       - id: requirements-txt-fixer
       - id: trailing-whitespace
         args: [--markdown-linebreak-ext=md]
+        exclude: "snapshots"
 
   # ----------------------------------------------------------
   # Extra hooks with repositories defining their own hooks

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -26,6 +26,7 @@
 # a backslash, e.g. "\:foo".
 
 /tests
+# Test data
 /cli/tests/e2e/targets/
 /cli/tests/e2e/snapshots/
 /cli/tests/performance/targets/

--- a/libs/alcotest_ext/failing-test
+++ b/libs/alcotest_ext/failing-test
@@ -1,0 +1,1 @@
+../../_build/default/libs/alcotest_ext/tests/failing_test.exe

--- a/libs/alcotest_ext/lib/Alcotest_ext.ml
+++ b/libs/alcotest_ext/lib/Alcotest_ext.ml
@@ -38,12 +38,12 @@ type result = T.result = {
 
 type expectation = T.expectation = {
   expected_outcome : expected_outcome;
-  expected_output : (expected_output, string) Result.t;
+  expected_output : (expected_output, string list (* missing files *)) Result.t;
 }
 
 type status = T.status = {
   expectation : expectation;
-  result : (result, string) Result.t;
+  result : (result, string list) Result.t;
 }
 
 type status_class = T.status_class = PASS | FAIL | XFAIL | XPASS | MISS

--- a/libs/alcotest_ext/lib/Alcotest_ext.ml
+++ b/libs/alcotest_ext/lib/Alcotest_ext.ml
@@ -18,11 +18,18 @@ type expected_outcome = T.expected_outcome =
 type outcome = T.outcome = Succeeded | Failed
 
 type captured_output = T.captured_output =
-  | Ignored
-  | Captured_stdout of string
-  | Captured_stderr of string
+  | Ignored of string
+  | Captured_stdout of string * string
+  | Captured_stderr of string * string
   | Captured_stdout_stderr of string * string
   | Captured_merged of string
+
+type expected_output = T.expected_output =
+  | Ignored
+  | Expected_stdout of string
+  | Expected_stderr of string
+  | Expected_stdout_stderr of string * string (* stdout, stderr *)
+  | Expected_merged of string (* combined output *)
 
 type result = T.result = {
   outcome : outcome;
@@ -31,7 +38,7 @@ type result = T.result = {
 
 type expectation = T.expectation = {
   expected_outcome : expected_outcome;
-  expected_output : (captured_output, string) Result.t;
+  expected_output : (expected_output, string) Result.t;
 }
 
 type status = T.status = {

--- a/libs/alcotest_ext/lib/Alcotest_ext.ml
+++ b/libs/alcotest_ext/lib/Alcotest_ext.ml
@@ -72,7 +72,7 @@ type 'a t = 'a T.test = {
   expected_outcome : expected_outcome;
   tags : Tag.t list;
   speed_level : Alcotest.speed_level;
-  mask_output : (string -> string) option;
+  mask_output : (string -> string) list;
   output_kind : output_kind;
   skipped : bool;
   tolerate_chdir : bool;
@@ -106,9 +106,9 @@ let update_id (test : _ t) =
   let id = String.sub md5_hex 0 12 in
   { test with id; internal_full_name }
 
-let create ?(category = []) ?(expected_outcome = Should_succeed) ?mask_output
-    ?(output_kind = Ignore_output) ?(skipped = false) ?(speed_level = `Quick)
-    ?(tags = []) ?(tolerate_chdir = false) name func =
+let create ?(category = []) ?(expected_outcome = Should_succeed)
+    ?(mask_output = []) ?(output_kind = Ignore_output) ?(skipped = false)
+    ?(speed_level = `Quick) ?(tags = []) ?(tolerate_chdir = false) name func =
   {
     id = "";
     internal_full_name = "";

--- a/libs/alcotest_ext/lib/Alcotest_ext.mli
+++ b/libs/alcotest_ext/lib/Alcotest_ext.mli
@@ -43,10 +43,14 @@ type result = { outcome : outcome; captured_output : captured_output }
 
 type expectation = {
   expected_outcome : expected_outcome;
-  expected_output : (expected_output, string) Result.t;
+  expected_output : (expected_output, string list (* missing files *)) Result.t;
 }
 
-type status = { expectation : expectation; result : (result, string) Result.t }
+type status = {
+  expectation : expectation;
+  result : (result, string list) Result.t;
+}
+
 type status_class = PASS | FAIL | XFAIL | XPASS | MISS
 
 type status_summary = {

--- a/libs/alcotest_ext/lib/Alcotest_ext.mli
+++ b/libs/alcotest_ext/lib/Alcotest_ext.mli
@@ -103,7 +103,7 @@ type 'a t = private {
   speed_level : Alcotest.speed_level;
   (* An optional function to rewrite any output data so as to mask the
      variable parts. *)
-  mask_output : (string -> string) option;
+  mask_output : (string -> string) list;
   output_kind : output_kind;
   (* The 'skipped' property causes a test to be skipped by Alcotest but still
      shown as "[SKIP]" rather than being omitted. *)
@@ -143,7 +143,7 @@ type lwt_test = unit Lwt.t t
 val create :
   ?category:string list ->
   ?expected_outcome:expected_outcome ->
-  ?mask_output:(string -> string) ->
+  ?mask_output:(string -> string) list ->
   ?output_kind:output_kind ->
   ?skipped:bool ->
   ?speed_level:Alcotest.speed_level ->
@@ -162,7 +162,7 @@ val update :
   ?category:string list ->
   ?expected_outcome:expected_outcome ->
   ?func:(unit -> 'a) ->
-  ?mask_output:(string -> string) option ->
+  ?mask_output:(string -> string) list ->
   ?name:string ->
   ?output_kind:output_kind ->
   ?skipped:bool ->

--- a/libs/alcotest_ext/lib/Alcotest_ext.mli
+++ b/libs/alcotest_ext/lib/Alcotest_ext.mli
@@ -26,17 +26,24 @@ type expected_outcome =
 type outcome = Succeeded | Failed
 
 type captured_output =
+  | Ignored of string (* unchecked combined output *)
+  | Captured_stdout of string * string (* stdout, unchecked output *)
+  | Captured_stderr of string * string (* stderr, unchecked output *)
+  | Captured_stdout_stderr of string * string (* stdout, stderr *)
+  | Captured_merged of string (* combined output *)
+
+type expected_output =
   | Ignored
-  | Captured_stdout of string
-  | Captured_stderr of string
-  | Captured_stdout_stderr of string * string
-  | Captured_merged of string
+  | Expected_stdout of string
+  | Expected_stderr of string
+  | Expected_stdout_stderr of string * string (* stdout, stderr *)
+  | Expected_merged of string (* combined output *)
 
 type result = { outcome : outcome; captured_output : captured_output }
 
 type expectation = {
   expected_outcome : expected_outcome;
-  expected_output : (captured_output, string) Result.t;
+  expected_output : (expected_output, string) Result.t;
 }
 
 type status = { expectation : expectation; result : (result, string) Result.t }

--- a/libs/alcotest_ext/lib/Color.ml
+++ b/libs/alcotest_ext/lib/Color.ml
@@ -2,14 +2,14 @@
    Colorize the output
 *)
 
-(* TODO: allow combined styles like "bold red"? *)
-type style = Default | Red | Green | Yellow | Bold
+type style = Default | Red | Green | Yellow | Cyan | Bold
 
 let ansi_code_of_style = function
   | Default -> "0"
   | Red -> "31"
   | Green -> "32"
   | Yellow -> "33"
+  | Cyan -> "36"
   | Bold -> "1"
 
 let format style str =

--- a/libs/alcotest_ext/lib/Color.ml
+++ b/libs/alcotest_ext/lib/Color.ml
@@ -2,8 +2,6 @@
    Colorize the output
 *)
 
-type conf = Color | No_color
-
 (* TODO: allow combined styles like "bold red"? *)
 type style = Default | Red | Green | Yellow | Bold
 
@@ -14,9 +12,6 @@ let ansi_code_of_style = function
   | Yellow -> "33"
   | Bold -> "1"
 
-let format conf style str =
-  match conf with
-  | Color ->
-      Printf.sprintf "\027[%sm%s\027[%sm" (ansi_code_of_style style) str
-        (ansi_code_of_style Default)
-  | No_color -> str
+let format style str =
+  Printf.sprintf "\027[%sm%s\027[%sm" (ansi_code_of_style style) str
+    (ansi_code_of_style Default)

--- a/libs/alcotest_ext/lib/Color.mli
+++ b/libs/alcotest_ext/lib/Color.mli
@@ -1,10 +1,7 @@
 (*
    Colorize the output
-
-   (TODO: use an external library for this?)
 *)
 
-type conf = Color | No_color
 type style = Default | Red | Green | Yellow | Bold
 
-val format : conf -> style -> string -> string
+val format : style -> string -> string

--- a/libs/alcotest_ext/lib/Color.mli
+++ b/libs/alcotest_ext/lib/Color.mli
@@ -2,6 +2,6 @@
    Colorize the output
 *)
 
-type style = Default | Red | Green | Yellow | Bold
+type style = Default | Red | Green | Yellow | Cyan | Bold
 
 val format : style -> string -> string

--- a/libs/alcotest_ext/lib/Run.ml
+++ b/libs/alcotest_ext/lib/Run.ml
@@ -365,10 +365,12 @@ let is_important_status ((test : _ T.test), _status, (sum : T.status_summary)) =
 let show_diff (test : _ T.test) (output_kind : string) path_to_expected_output
     path_to_output =
   match
+    (* Warning: the implementation of 'diff' (which is it?) available on
+       BusyBox doesn't support '--color' option which is very sad.
+       TODO: find a way to show color diffs. *)
     (* nosemgrep: forbid-exec *)
     Sys.command
-      (sprintf "diff -u --color '%s' '%s'" path_to_expected_output
-         path_to_output)
+      (sprintf "diff -u '%s' '%s'" path_to_expected_output path_to_output)
   with
   | 0 -> ()
   | _nonzero ->

--- a/libs/alcotest_ext/lib/Run.ml
+++ b/libs/alcotest_ext/lib/Run.ml
@@ -18,7 +18,7 @@ type status_stats = {
   needs_approval : int ref;
 }
 
-type success = OK | OK_where_no_missing_data | Not_OK
+type success = OK | OK_but_new | Not_OK
 
 (*
    Check that no two tests have the same full name or the same ID.
@@ -59,15 +59,15 @@ let success_of_status_summary (sum : T.status_summary) =
   match sum.status_class with
   | PASS
   | XFAIL ->
-      if sum.has_expected_output then OK else OK_where_no_missing_data
+      if sum.has_expected_output then OK else OK_but_new
   | FAIL -> Not_OK
   | XPASS -> Not_OK
-  | MISS -> OK_where_no_missing_data
+  | MISS -> OK_but_new
 
 let style_of_status_summary (sum : T.status_summary) : Color.style =
   match success_of_status_summary sum with
   | OK -> Green
-  | OK_where_no_missing_data -> Yellow
+  | OK_but_new -> Yellow
   | Not_OK -> Red
 
 let brackets s = sprintf "[%s]" s
@@ -77,9 +77,7 @@ let format_status_summary (sum : T.status_summary) =
   let style = style_of_status_summary sum in
   let displayed_string = sum |> string_of_status_summary |> brackets in
   let padding = max 0 (7 - String.length displayed_string) in
-  sprintf "%s%s"
-    (Color.format Color style displayed_string)
-    (String.make padding ' ')
+  sprintf "%s%s" (Color.format style displayed_string) (String.make padding ' ')
 
 let stats_of_tests tests tests_with_status =
   let stats =
@@ -233,6 +231,34 @@ let to_alcotest_generic
          (suite_name, (test.name, test.speed_level, func)))
   |> group_by_key
 
+let print_exn (test : _ T.test) exn trace =
+  match test.expected_outcome with
+  | Should_succeed ->
+      prerr_string
+        (Color.format Red
+           (sprintf "FAIL: The test raised an exception: %s\n%s"
+              (Printexc.to_string exn)
+              (Printexc.raw_backtrace_to_string trace)))
+  | Should_fail _reason ->
+      prerr_string
+        (Color.format Green
+           (sprintf "XFAIL: As expected, the test raised an exception: %s\n%s"
+              (Printexc.to_string exn)
+              (Printexc.raw_backtrace_to_string trace)))
+
+let with_print_exn (test : _ T.test) func () =
+  try func () with
+  | exn ->
+      let trace = Printexc.get_raw_backtrace () in
+      print_exn test exn trace;
+      Printexc.raise_with_backtrace exn trace
+
+let with_print_exn_lwt (test : _ T.test) func () =
+  Lwt.catch func (fun exn ->
+      let trace = Printexc.get_raw_backtrace () in
+      print_exn test exn trace;
+      Printexc.raise_with_backtrace exn trace)
+
 let with_flip_xfail_outcome (test : _ T.test) func =
   match test.expected_outcome with
   | Should_succeed -> func
@@ -240,10 +266,10 @@ let with_flip_xfail_outcome (test : _ T.test) func =
       fun () ->
         try
           func ();
-          failwith "This test failed to raise an exception."
+          Alcotest.fail "XPASS: This test should have raised an exception."
         with
         | exn ->
-            eprintf "As expected, an exception was raised: %s\n"
+            eprintf "XFAIL: As expected, an exception was raised: %s\n"
               (Printexc.to_string exn))
 
 let with_flip_xfail_outcome_lwt (test : _ T.test) func =
@@ -254,9 +280,9 @@ let with_flip_xfail_outcome_lwt (test : _ T.test) func =
         Lwt.catch
           (fun () ->
             Lwt.bind (func ()) (fun () ->
-                failwith "This test failed to raise an exception"))
+                Alcotest.fail "XPASS: This test failed to raise an exception"))
           (fun exn ->
-            eprintf "As expected, an exception was raised: %s\n"
+            eprintf "XFAIL: As expected, an exception was raised: %s\n"
               (Printexc.to_string exn);
             Lwt.return ())
 
@@ -265,7 +291,7 @@ let conditional_wrap condition wrapper func =
 
 let to_alcotest_internal ~with_storage ~flip_xfail_outcome tests =
   let wrap_test_function test func =
-    func
+    func |> with_print_exn test
     |> conditional_wrap flip_xfail_outcome (with_flip_xfail_outcome test)
     |> protect_globals test
     |> conditional_wrap with_storage (Store.with_result_capture test)
@@ -274,7 +300,7 @@ let to_alcotest_internal ~with_storage ~flip_xfail_outcome tests =
 
 let to_alcotest_lwt_internal ~with_storage ~flip_xfail_outcome tests =
   let wrap_test_function test func =
-    func
+    func |> with_print_exn_lwt test
     |> conditional_wrap flip_xfail_outcome (with_flip_xfail_outcome_lwt test)
     |> protect_globals_lwt test
     |> conditional_wrap with_storage (Store.with_result_capture_lwt test)
@@ -319,8 +345,8 @@ let print_errors (xs : (_, string) Result.t list) : int =
   | xs ->
       let n_errors = List.length xs in
       let error_str =
-        if n_errors >= 2 then Color.format Color Red "Errors:\n"
-        else Color.format Color Red "Error: "
+        if n_errors >= 2 then Color.format Red "Errors:\n"
+        else Color.format Red "Error: "
       in
       let msg = String.concat "\n" error_messages in
       eprintf "%s%s\n%!" error_str msg;
@@ -332,12 +358,26 @@ let is_important_status ((test : _ T.test), _status, (sum : T.status_summary)) =
      ||
      match success_of_status_summary sum with
      | OK -> false
-     | OK_where_no_missing_data
+     | OK_but_new
      | Not_OK ->
          true)
 
-let show_output_paths ~with_diff (test : _ T.test)
+let show_diff (test : _ T.test) (output_kind : string) path_to_expected_output
+    path_to_output =
+  match
+    (* nosemgrep: forbid-exec *)
+    Sys.command
+      (sprintf "diff -u --color '%s' '%s'" path_to_expected_output
+         path_to_output)
+  with
+  | 0 -> ()
+  | _nonzero ->
+      printf "  Captured %s differs from expectation for test %s %s\n"
+        output_kind test.id test.internal_full_name
+
+let show_output (test : _ T.test) (sum : T.status_summary)
     (output_file_pairs : Store.output_file_pair list) =
+  let success = success_of_status_summary sum in
   output_file_pairs
   |> List.iter
        (fun
@@ -346,19 +386,23 @@ let show_output_paths ~with_diff (test : _ T.test)
        ->
          flush stdout;
          flush stderr;
-         (if with_diff then
-            match
-              (* nosemgrep: forbid-exec *)
-              Sys.command
-                (sprintf "diff -u --color '%s' '%s'" path_to_expected_output
-                   path_to_output)
-            with
-            | 0 -> ()
-            | _nonzero ->
-                printf "  Captured %s differs from expectation for test %s %s\n"
-                  short_name test.id test.internal_full_name);
-         printf "  Path to expected %s: %s\n" short_name path_to_expected_output;
-         printf "  Path to latest %s: %s\n" short_name path_to_output)
+         match path_to_expected_output with
+         | None -> printf "  Path to unchecked output: %s\n" path_to_output
+         | Some path_to_expected_output ->
+             (match success with
+             | OK
+             | OK_but_new ->
+                 ()
+             | Not_OK ->
+                 (* TODO: only show diff if this particular file differs *)
+                 show_diff test short_name path_to_expected_output
+                   path_to_output);
+             if success <> OK_but_new then
+               printf "  Path to expected %s: %s\n" short_name
+                 path_to_expected_output;
+             printf "  Path to latest %s: %s\n" short_name path_to_output)
+
+let print_error text = printf "  %s\n" (Color.format Red text)
 
 let print_status ?(output_style = Full)
     ((test : _ T.test), (status : T.status), sum) =
@@ -370,11 +414,11 @@ let print_status ?(output_style = Full)
   | Short -> ()
   | Full ->
       if (* Details about expectations *)
-         test.skipped then printf "  always skipped\n"
+         test.skipped then printf "  Always skipped\n"
       else (
         (match status.expectation.expected_outcome with
         | Should_succeed -> ()
-        | Should_fail reason -> printf "  expected to fail: %S\n" reason);
+        | Should_fail reason -> printf "  Expected to fail: %s\n" reason);
         (match test.output_kind with
         | Ignore_output -> ()
         | _ ->
@@ -386,19 +430,20 @@ let print_status ?(output_style = Full)
               | Merged_stdout_stderr -> "merged stdout and stderr"
               | Separate_stdout_stderr -> "separate stdout and stderr"
             in
-            printf "  checked output: %s\n" text);
+            printf "  Checked output: %s\n" text);
         (* Details about results *)
         match status.expectation.expected_output with
         | Error msg ->
-            printf "Missing file(s) containing the expected output: %s\n" msg
-        | Ok expected_output -> (
+            print_error
+              (sprintf "Missing file(s) containing the expected output: %s" msg)
+        | Ok _expected_output -> (
             match status.result with
             | Error msg ->
-                printf "Missing file(s) containing the test output: %s\n" msg
-            | Ok result ->
-                let with_diff = result.captured_output <> expected_output in
+                print_error
+                  (sprintf "Missing file(s) containing the test output: %s" msg)
+            | Ok _result ->
                 let output_file_pairs = Store.get_output_file_pairs test in
-                show_output_paths ~with_diff test output_file_pairs))
+                show_output test sum output_file_pairs))
 
 let print_statuses ~only_important ~output_style tests_with_status =
   let tests_with_status =
@@ -412,7 +457,7 @@ let is_overall_success statuses =
   |> List.for_all (fun (_test, _status, sum) ->
          match sum |> success_of_status_summary with
          | OK
-         | OK_where_no_missing_data ->
+         | OK_but_new ->
              true
          | Not_OK -> false)
 
@@ -444,11 +489,11 @@ Other states:
 |}
 
 let print_short_status tests_with_status =
-  print_endline (Color.format Color Bold "Short status");
+  print_endline (Color.format Bold "Short status");
   print_statuses ~only_important:true ~output_style:Short tests_with_status
 
 let print_long_status tests_with_status =
-  print_endline (Color.format Color Bold "Long status");
+  print_endline (Color.format Bold "Long status");
   print_statuses ~only_important:false ~output_style:Full tests_with_status
 
 let plural num = if num >= 2 then "s" else ""
@@ -470,8 +515,8 @@ let print_status_summary tests tests_with_status =
     !(stats.fail) !(stats.xpass) !(stats.miss) (plural !(stats.miss))
     !(stats.needs_approval)
     (plural !(stats.needs_approval))
-    (if overall_success then Color.format Color Green "success"
-     else Color.format Color Red "failure");
+    (if overall_success then Color.format Green "success"
+     else Color.format Red "failure");
   if overall_success then 0 else 1
 
 let print_full_status tests tests_with_status =
@@ -561,7 +606,7 @@ let before_run ?filter_by_substring ?(lazy_ = false) tests =
   (* It would probably be less confusing to report the 4-way outcome here
      (pass/fail/xfail/xpass) but we can't as long as we rely on Alcotest
      for running and printing test results. *)
-  print_endline (Color.format Color Bold "Test run");
+  print_endline (Color.format Bold "Test run");
   print_endline
     "In this section, tests are reported as either OK or FAIL without looking\n\
      at the expected outcome or expected output.";

--- a/libs/alcotest_ext/lib/Run.ml
+++ b/libs/alcotest_ext/lib/Run.ml
@@ -430,14 +430,22 @@ let print_status ((test : _ T.test), (status : T.status), sum) =
         printf "  Checked output: %s\n" text);
     (* Details about results *)
     (match status.expectation.expected_output with
-    | Error msg ->
+    | Error [ path ] ->
         print_error
-          (sprintf "Missing file(s) containing the expected output: %s" msg)
+          (sprintf "Missing file containing the expected output: %s" path)
+    | Error paths ->
+        print_error
+          (sprintf "Missing files containing the expected output: %s"
+             (String.concat ", " paths))
     | Ok _expected_output -> (
         match status.result with
-        | Error msg ->
+        | Error [ path ] ->
             print_error
-              (sprintf "Missing file(s) containing the test output: %s" msg)
+              (sprintf "Missing file containing the test output: %s" path)
+        | Error paths ->
+            print_error
+              (sprintf "Missing files containing the test output: %s"
+                 (String.concat ", " paths))
         | Ok _result ->
             let output_file_pairs = Store.get_output_file_pairs test in
             show_output test sum output_file_pairs));

--- a/libs/alcotest_ext/lib/Run.ml
+++ b/libs/alcotest_ext/lib/Run.ml
@@ -408,7 +408,8 @@ let print_status ?(output_style = Full)
     ((test : _ T.test), (status : T.status), sum) =
   printf "%s %s%s %s\n"
     (format_status_summary sum)
-    test.id (format_tags test) test.internal_full_name;
+    test.id (format_tags test)
+    (Color.format Cyan test.internal_full_name);
 
   match output_style with
   | Short -> ()

--- a/libs/alcotest_ext/lib/Run.ml
+++ b/libs/alcotest_ext/lib/Run.ml
@@ -358,8 +358,7 @@ let show_output_paths ~with_diff (test : _ T.test)
                 printf "  Captured %s differs from expectation for test %s %s\n"
                   short_name test.id test.internal_full_name);
          printf "  Path to expected %s: %s\n" short_name path_to_expected_output;
-         printf "  Path to latest %s: %s\n" short_name path_to_output);
-  print_newline ()
+         printf "  Path to latest %s: %s\n" short_name path_to_output)
 
 let print_status ?(output_style = Full)
     ((test : _ T.test), (status : T.status), sum) =

--- a/libs/alcotest_ext/lib/Run.mli
+++ b/libs/alcotest_ext/lib/Run.mli
@@ -8,14 +8,16 @@ val to_alcotest : unit Types.test list -> unit Alcotest.test list
 val to_alcotest_lwt : unit Lwt.t Types.test list -> unit Alcotest_lwt.test list
 
 val run_tests :
-  ?filter_by_substring:string ->
-  ?lazy_:bool ->
+  filter_by_substring:string option ->
+  lazy_:bool ->
+  show_output:bool ->
   unit Types.test list ->
   int * unit Types.test_with_status list
 
 val run_tests_lwt :
-  ?filter_by_substring:string ->
-  ?lazy_:bool ->
+  filter_by_substring:string option ->
+  lazy_:bool ->
+  show_output:bool ->
   unit Lwt.t Types.test list ->
   (int * unit Lwt.t Types.test_with_status list) Lwt.t
 
@@ -23,8 +25,9 @@ val run_tests_lwt :
    Return a non-zero exit status if any of the tests is not a success
    (PASS or XFAIL). *)
 val list_status :
-  ?filter_by_substring:string ->
-  ?output_style:status_output_style ->
+  filter_by_substring:string option ->
+  output_style:status_output_style ->
+  show_output:bool ->
   'a Types.test list ->
   int * 'a Types.test_with_status list
 

--- a/libs/alcotest_ext/lib/Store.ml
+++ b/libs/alcotest_ext/lib/Store.ml
@@ -192,6 +192,14 @@ let names_of_checked_output (output : T.output_kind) : string list =
   | Merged_stdout_stderr -> [ stdxxx_filename ]
   | Separate_stdout_stderr -> [ stdout_filename; stderr_filename ]
 
+let has_unchecked_output (output : T.output_kind) : bool =
+  match output with
+  | Ignore_output -> true
+  | Stdout -> true
+  | Stderr -> true
+  | Merged_stdout_stderr -> false
+  | Separate_stdout_stderr -> false
+
 let get_output_path (test : _ T.test) filename =
   get_status_workspace () // test.id // filename
 
@@ -209,6 +217,14 @@ let get_output (test : _ T.test) =
 
 let get_checked_output (test : _ T.test) =
   test |> get_checked_output_paths |> list_map read_file
+
+let get_unchecked_output (test : _ T.test) =
+  if has_unchecked_output test.output_kind then
+    let path = get_unchecked_output_path test in
+    match read_file path with
+    | Ok data -> Some data
+    | Error _cant_read_file -> None
+  else None
 
 let get_expected_output_path (test : _ T.test) filename =
   get_expectation_workspace () // test.id // filename

--- a/libs/alcotest_ext/lib/Store.ml
+++ b/libs/alcotest_ext/lib/Store.ml
@@ -287,13 +287,18 @@ let with_redirect_to_file from filename func () =
       Fun.protect ~finally:(fun () -> flush from) func)
     ()
 
+(* Apply functions to the data as a pipeline, from left to right. *)
+let compose_functions_left_to_right funcs x =
+  List.fold_left (fun x f -> f x) x funcs
+
 (* Iff the test is configured to rewrite its output so as to mask the
    unpredicable parts, we rewrite the standard output file and we make a
    backup of the original. *)
 let mask_output (test : unit T.test) =
   match test.mask_output with
-  | None -> ()
-  | Some rewrite_string ->
+  | [] -> ()
+  | mask_functions ->
+      let rewrite_string = compose_functions_left_to_right mask_functions in
       get_output_paths test
       |> List.iter (fun std_path ->
              let backup_path = std_path ^ orig_suffix in

--- a/libs/alcotest_ext/lib/Store.mli
+++ b/libs/alcotest_ext/lib/Store.mli
@@ -38,6 +38,12 @@ type output_file_pair = {
 val get_output_file_pairs : 'a Types.test -> output_file_pair list
 
 (*
+   Ordinary output that's not compared against expectations.
+   This is what's left of stdout and stderr after redirections.
+*)
+val get_unchecked_output : 'a Types.test -> string option
+
+(*
    These functions are available after the call to 'init'.
 *)
 val get_status_workspace : unit -> string

--- a/libs/alcotest_ext/lib/Store.mli
+++ b/libs/alcotest_ext/lib/Store.mli
@@ -22,9 +22,13 @@ val init_settings :
 *)
 val init_workspace : unit -> unit
 
+(*
+   For one kind of captured output, this is the corresponding pair of files.
+   Unchecked output doesn't have a file for expected output.
+*)
 type output_file_pair = {
   short_name : string;
-  path_to_expected_output : string;
+  path_to_expected_output : string option;
   path_to_output : string;
 }
 

--- a/libs/alcotest_ext/lib/Types.ml
+++ b/libs/alcotest_ext/lib/Types.ml
@@ -46,7 +46,7 @@ type expected_outcome =
 *)
 type expectation = {
   expected_outcome : expected_outcome;
-  expected_output : (expected_output, string) Result.t;
+  expected_output : (expected_output, string list (* missing files *)) Result.t;
 }
 
 (*
@@ -55,7 +55,10 @@ type expectation = {
    other statuses such as: missing expectation, missing result, xpass
    (success when expected outcome was Failed), ...
 *)
-type status = { expectation : expectation; result : (result, string) Result.t }
+type status = {
+  expectation : expectation;
+  result : (result, string list (* missing files *)) Result.t;
+}
 
 (* A summary of the 'status' object using the same language as pytest.
 

--- a/libs/alcotest_ext/lib/Types.ml
+++ b/libs/alcotest_ext/lib/Types.ml
@@ -96,7 +96,7 @@ type 'a test = {
   expected_outcome : expected_outcome;
   tags : Tag.t list;
   speed_level : Alcotest.speed_level;
-  mask_output : (string -> string) option;
+  mask_output : (string -> string) list;
   output_kind : output_kind;
   skipped : bool;
   tolerate_chdir : bool;

--- a/libs/alcotest_ext/tests/Failing_test.ml
+++ b/libs/alcotest_ext/tests/Failing_test.ml
@@ -1,0 +1,17 @@
+(*
+   Dummy suite that fails so we can check that failing tests are reported
+   nicely.
+*)
+
+let t = Alcotest_ext.create
+
+let tests =
+  [
+    t "failing" (fun () -> failwith "oh no, I'm failing");
+    t "failing to fail" ~expected_outcome:(Should_fail "<reasons>") (fun () ->
+        ());
+  ]
+
+let () =
+  Alcotest_ext.interpret_argv ~project_name:"alcotest_ext_dummy_failing_tests"
+    (fun () -> tests)

--- a/libs/alcotest_ext/tests/Failing_test.ml
+++ b/libs/alcotest_ext/tests/Failing_test.ml
@@ -7,9 +7,11 @@ let t = Alcotest_ext.create
 
 let tests =
   [
-    t "failing" (fun () -> failwith "oh no, I'm failing");
+    t "failing" (fun () ->
+        print_endline "<something being printed by the test>";
+        failwith "oh no, I'm failing");
     t "failing to fail" ~expected_outcome:(Should_fail "<reasons>") (fun () ->
-        ());
+        print_string "<something being printed by the test>");
   ]
 
 let () =

--- a/libs/alcotest_ext/tests/Meta_test.ml
+++ b/libs/alcotest_ext/tests/Meta_test.ml
@@ -58,18 +58,17 @@ let test_standard_flow () =
   test_subcommand "status";
   test_subcommand "approve"
 
-(* Function composition *)
-let ( @@@ ) f g x = f (g x)
-
 let tests =
   [
     t ~output_kind:Merged_stdout_stderr
       ~mask_output:
-        (T.mask_line ~mask:"<MASKED RUN ID>" ~after:"This run has ID `"
-           ~before:"'" ()
-        @@@ T.mask_pcre_pattern ~mask:"<MASKED DURATION>" {|in [0-9]+\.[0-9]+s|}
-        @@@ T.mask_line ~after:"Called from " ()
-        @@@ T.mask_line ~after:"Re-raised at " ())
+        [
+          T.mask_line ~mask:"<MASKED RUN ID>" ~after:"This run has ID `"
+            ~before:"'" ();
+          T.mask_pcre_pattern ~mask:"<MASKED DURATION>" {|in [0-9]+\.[0-9]+s|};
+          T.mask_line ~after:"Called from " ();
+          T.mask_line ~after:"Re-raised at " ();
+        ]
       "standard flow" test_standard_flow;
   ]
 

--- a/libs/alcotest_ext/tests/Test.ml
+++ b/libs/alcotest_ext/tests/Test.ml
@@ -8,6 +8,8 @@ let t = Alcotest_ext.create
 let tests =
   [
     t "simple" (fun () -> ());
+    t "unchecked stdout" (fun () -> print_endline "hello");
+    t "unchecked stderr" (fun () -> prerr_string "hello\n");
     t "capture stdout" ~output_kind:Stdout (fun () -> print_string "hello\n");
     t "capture stderr" ~output_kind:Stderr (fun () -> prerr_string "error\n");
     t "capture stdxxx" ~output_kind:Merged_stdout_stderr (fun () ->

--- a/libs/alcotest_ext/tests/Test.ml
+++ b/libs/alcotest_ext/tests/Test.ml
@@ -23,7 +23,7 @@ let tests =
       (fun () -> failwith "this exception is expected");
     t "skipped" ~skipped:true (fun () -> failwith "this shouldn't happen");
     t "chdir" ~tolerate_chdir:true (fun () -> Sys.chdir "/");
-    t ~output_kind:Stdout ~mask_output:String.lowercase_ascii "masked"
+    t ~output_kind:Stdout ~mask_output:[ String.lowercase_ascii ] "masked"
       (fun () -> print_endline "HELLO");
   ]
 

--- a/libs/alcotest_ext/tests/dune
+++ b/libs/alcotest_ext/tests/dune
@@ -7,7 +7,17 @@
  )
 )
 
-; The test suite that exercises the dummy test suite in various ways
+; Another dummy test suite. This one fails, allowing us to check the
+; quality of error reporting.
+(executable
+ (name failing_test)
+ (modules Failing_test)
+ (libraries
+    alcotest_ext
+ )
+)
+
+; The test suite that exercises the dummy test suites in various ways
 ; and checks that it outputs what it's supposed to.
 (executable
  (name meta_test)

--- a/libs/alcotest_ext/tests/snapshots/alcotest_ext_dummy_tests/5deda5ac4212/stdxxx
+++ b/libs/alcotest_ext/tests/snapshots/alcotest_ext_dummy_tests/5deda5ac4212/stdxxx
@@ -1,2 +1,3 @@
 hello
+error
 goodbye

--- a/libs/alcotest_ext/tests/snapshots/alcotest_ext_meta_tests/fccf02a5c37e/stdxxx
+++ b/libs/alcotest_ext/tests/snapshots/alcotest_ext_meta_tests/fccf02a5c37e/stdxxx
@@ -15,47 +15,63 @@ Other states:
   In this case, you should review the test output and run the 'approve'
   subcommand once you're satisfied with the output.
 
-[1mLong status[0m
-[33m[MISS][0m  8dbdda48fb87 simple
-  [31mMissing file(s) containing the test output: Missing file "_build/alcotest_ext/status/alcotest_ext_dummy_tests/8dbdda48fb87/outcome"[0m
-[33m[MISS][0m  2c57c8917bfb unchecked stdout
-  [31mMissing file(s) containing the test output: Missing file "_build/alcotest_ext/status/alcotest_ext_dummy_tests/2c57c8917bfb/outcome"[0m
-[33m[MISS][0m  68358d78cb0b unchecked stderr
-  [31mMissing file(s) containing the test output: Missing file "_build/alcotest_ext/status/alcotest_ext_dummy_tests/68358d78cb0b/outcome"[0m
-[33m[MISS][0m  d1a055429711 capture stdout
+[1mAll tests[0m
+[33m[MISS][0m  8dbdda48fb87 [36msimple[0m
+  [31mMissing file containing the test output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/8dbdda48fb87/outcome[0m
+[33m[MISS][0m  2c57c8917bfb [36munchecked stdout[0m
+  [31mMissing file containing the test output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/2c57c8917bfb/outcome[0m
+[33m[MISS][0m  68358d78cb0b [36munchecked stderr[0m
+  [31mMissing file containing the test output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/68358d78cb0b/outcome[0m
+[33m[MISS][0m  d1a055429711 [36mcapture stdout[0m
   Checked output: stdout
-  [31mMissing file(s) containing the expected output: Missing file "tests/snapshots/alcotest_ext_dummy_tests/d1a055429711/stdout"[0m
-[33m[MISS][0m  72f48157b077 capture stderr
+  [31mMissing file containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/d1a055429711/stdout[0m
+[33m[MISS][0m  72f48157b077 [36mcapture stderr[0m
   Checked output: stderr
-  [31mMissing file(s) containing the expected output: Missing file "tests/snapshots/alcotest_ext_dummy_tests/72f48157b077/stderr"[0m
-[33m[MISS][0m  5deda5ac4212 capture stdxxx
+  [31mMissing file containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/72f48157b077/stderr[0m
+[33m[MISS][0m  5deda5ac4212 [36mcapture stdxxx[0m
   Checked output: merged stdout and stderr
-  [31mMissing file(s) containing the expected output: Missing file "tests/snapshots/alcotest_ext_dummy_tests/5deda5ac4212/stdxxx"[0m
-[33m[MISS][0m  486ef3ce86ab capture stdout and stderr
+  [31mMissing file containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/5deda5ac4212/stdxxx[0m
+[33m[MISS][0m  486ef3ce86ab [36mcapture stdout and stderr[0m
   Checked output: separate stdout and stderr
-  [31mMissing file(s) containing the expected output: Missing file "tests/snapshots/alcotest_ext_dummy_tests/486ef3ce86ab/stdout"[0m
-[33m[MISS][0m  85349a4a9157 xfail
+  [31mMissing files containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/486ef3ce86ab/stdout, tests/snapshots/alcotest_ext_dummy_tests/486ef3ce86ab/stderr[0m
+[33m[MISS][0m  85349a4a9157 [36mxfail[0m
   Expected to fail: raises exception on purpose
-  [31mMissing file(s) containing the test output: Missing file "_build/alcotest_ext/status/alcotest_ext_dummy_tests/85349a4a9157/outcome"[0m
-[33m[MISS][0m  e52e279299e9 skipped
+  [31mMissing file containing the test output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/85349a4a9157/outcome[0m
+[33m[MISS][0m  e52e279299e9 [36mskipped[0m
   Always skipped
-[33m[MISS][0m  91a3c9030236 chdir
-  [31mMissing file(s) containing the test output: Missing file "_build/alcotest_ext/status/alcotest_ext_dummy_tests/91a3c9030236/outcome"[0m
-[33m[MISS][0m  a3e1a604f579 masked
+[33m[MISS][0m  91a3c9030236 [36mchdir[0m
+  [31mMissing file containing the test output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/91a3c9030236/outcome[0m
+[33m[MISS][0m  a3e1a604f579 [36mmasked[0m
   Checked output: stdout
-  [31mMissing file(s) containing the expected output: Missing file "tests/snapshots/alcotest_ext_dummy_tests/a3e1a604f579/stdout"[0m
+  [31mMissing file containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/a3e1a604f579/stdout[0m
 
-[1mShort status[0m
-[33m[MISS][0m  8dbdda48fb87 simple
-[33m[MISS][0m  2c57c8917bfb unchecked stdout
-[33m[MISS][0m  68358d78cb0b unchecked stderr
-[33m[MISS][0m  d1a055429711 capture stdout
-[33m[MISS][0m  72f48157b077 capture stderr
-[33m[MISS][0m  5deda5ac4212 capture stdxxx
-[33m[MISS][0m  486ef3ce86ab capture stdout and stderr
-[33m[MISS][0m  85349a4a9157 xfail
-[33m[MISS][0m  91a3c9030236 chdir
-[33m[MISS][0m  a3e1a604f579 masked
+[1mTests that need attention[0m
+[33m[MISS][0m  8dbdda48fb87 [36msimple[0m
+  [31mMissing file containing the test output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/8dbdda48fb87/outcome[0m
+[33m[MISS][0m  2c57c8917bfb [36munchecked stdout[0m
+  [31mMissing file containing the test output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/2c57c8917bfb/outcome[0m
+[33m[MISS][0m  68358d78cb0b [36munchecked stderr[0m
+  [31mMissing file containing the test output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/68358d78cb0b/outcome[0m
+[33m[MISS][0m  d1a055429711 [36mcapture stdout[0m
+  Checked output: stdout
+  [31mMissing file containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/d1a055429711/stdout[0m
+[33m[MISS][0m  72f48157b077 [36mcapture stderr[0m
+  Checked output: stderr
+  [31mMissing file containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/72f48157b077/stderr[0m
+[33m[MISS][0m  5deda5ac4212 [36mcapture stdxxx[0m
+  Checked output: merged stdout and stderr
+  [31mMissing file containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/5deda5ac4212/stdxxx[0m
+[33m[MISS][0m  486ef3ce86ab [36mcapture stdout and stderr[0m
+  Checked output: separate stdout and stderr
+  [31mMissing files containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/486ef3ce86ab/stdout, tests/snapshots/alcotest_ext_dummy_tests/486ef3ce86ab/stderr[0m
+[33m[MISS][0m  85349a4a9157 [36mxfail[0m
+  Expected to fail: raises exception on purpose
+  [31mMissing file containing the test output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/85349a4a9157/outcome[0m
+[33m[MISS][0m  91a3c9030236 [36mchdir[0m
+  [31mMissing file containing the test output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/91a3c9030236/outcome[0m
+[33m[MISS][0m  a3e1a604f579 [36mmasked[0m
+  Checked output: stdout
+  [31mMissing file containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/a3e1a604f579/stdout[0m
 11/11 selected tests:
   0 successful (0 pass, 0 xfail),
   0 unsuccessful (0 fail, 0 xpass),
@@ -139,42 +155,52 @@ Other states:
   In this case, you should review the test output and run the 'approve'
   subcommand once you're satisfied with the output.
 
-[1mLong status[0m
-[32m[PASS][0m  8dbdda48fb87 simple
+[1mAll tests[0m
+[32m[PASS][0m  8dbdda48fb87 [36msimple[0m
   Path to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/8dbdda48fb87/unchecked
-[32m[PASS][0m  2c57c8917bfb unchecked stdout
+[32m[PASS][0m  2c57c8917bfb [36munchecked stdout[0m
   Path to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/2c57c8917bfb/unchecked
-[32m[PASS][0m  68358d78cb0b unchecked stderr
+[32m[PASS][0m  68358d78cb0b [36munchecked stderr[0m
   Path to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/68358d78cb0b/unchecked
-[33m[PASS*][0m d1a055429711 capture stdout
+[33m[PASS*][0m d1a055429711 [36mcapture stdout[0m
   Checked output: stdout
-  [31mMissing file(s) containing the expected output: Missing file "tests/snapshots/alcotest_ext_dummy_tests/d1a055429711/stdout"[0m
-[33m[PASS*][0m 72f48157b077 capture stderr
+  [31mMissing file containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/d1a055429711/stdout[0m
+[33m[PASS*][0m 72f48157b077 [36mcapture stderr[0m
   Checked output: stderr
-  [31mMissing file(s) containing the expected output: Missing file "tests/snapshots/alcotest_ext_dummy_tests/72f48157b077/stderr"[0m
-[33m[PASS*][0m 5deda5ac4212 capture stdxxx
+  [31mMissing file containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/72f48157b077/stderr[0m
+[33m[PASS*][0m 5deda5ac4212 [36mcapture stdxxx[0m
   Checked output: merged stdout and stderr
-  [31mMissing file(s) containing the expected output: Missing file "tests/snapshots/alcotest_ext_dummy_tests/5deda5ac4212/stdxxx"[0m
-[33m[PASS*][0m 486ef3ce86ab capture stdout and stderr
+  [31mMissing file containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/5deda5ac4212/stdxxx[0m
+[33m[PASS*][0m 486ef3ce86ab [36mcapture stdout and stderr[0m
   Checked output: separate stdout and stderr
-  [31mMissing file(s) containing the expected output: Missing file "tests/snapshots/alcotest_ext_dummy_tests/486ef3ce86ab/stdout"[0m
-[32m[XFAIL][0m 85349a4a9157 xfail
+  [31mMissing files containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/486ef3ce86ab/stdout, tests/snapshots/alcotest_ext_dummy_tests/486ef3ce86ab/stderr[0m
+[32m[XFAIL][0m 85349a4a9157 [36mxfail[0m
   Expected to fail: raises exception on purpose
   Path to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/85349a4a9157/unchecked
-[33m[MISS][0m  e52e279299e9 skipped
+[33m[MISS][0m  e52e279299e9 [36mskipped[0m
   Always skipped
-[32m[PASS][0m  91a3c9030236 chdir
+[32m[PASS][0m  91a3c9030236 [36mchdir[0m
   Path to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/91a3c9030236/unchecked
-[33m[PASS*][0m a3e1a604f579 masked
+[33m[PASS*][0m a3e1a604f579 [36mmasked[0m
   Checked output: stdout
-  [31mMissing file(s) containing the expected output: Missing file "tests/snapshots/alcotest_ext_dummy_tests/a3e1a604f579/stdout"[0m
+  [31mMissing file containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/a3e1a604f579/stdout[0m
 
-[1mShort status[0m
-[33m[PASS*][0m d1a055429711 capture stdout
-[33m[PASS*][0m 72f48157b077 capture stderr
-[33m[PASS*][0m 5deda5ac4212 capture stdxxx
-[33m[PASS*][0m 486ef3ce86ab capture stdout and stderr
-[33m[PASS*][0m a3e1a604f579 masked
+[1mTests that need attention[0m
+[33m[PASS*][0m d1a055429711 [36mcapture stdout[0m
+  Checked output: stdout
+  [31mMissing file containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/d1a055429711/stdout[0m
+[33m[PASS*][0m 72f48157b077 [36mcapture stderr[0m
+  Checked output: stderr
+  [31mMissing file containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/72f48157b077/stderr[0m
+[33m[PASS*][0m 5deda5ac4212 [36mcapture stdxxx[0m
+  Checked output: merged stdout and stderr
+  [31mMissing file containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/5deda5ac4212/stdxxx[0m
+[33m[PASS*][0m 486ef3ce86ab [36mcapture stdout and stderr[0m
+  Checked output: separate stdout and stderr
+  [31mMissing files containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/486ef3ce86ab/stdout, tests/snapshots/alcotest_ext_dummy_tests/486ef3ce86ab/stderr[0m
+[33m[PASS*][0m a3e1a604f579 [36mmasked[0m
+  Checked output: stdout
+  [31mMissing file containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/a3e1a604f579/stdout[0m
 11/11 selected tests:
   10 successful (9 pass, 1 xfail),
   0 unsuccessful (0 fail, 0 xpass),
@@ -194,42 +220,52 @@ Other states:
   In this case, you should review the test output and run the 'approve'
   subcommand once you're satisfied with the output.
 
-[1mLong status[0m
-[32m[PASS][0m  8dbdda48fb87 simple
+[1mAll tests[0m
+[32m[PASS][0m  8dbdda48fb87 [36msimple[0m
   Path to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/8dbdda48fb87/unchecked
-[32m[PASS][0m  2c57c8917bfb unchecked stdout
+[32m[PASS][0m  2c57c8917bfb [36munchecked stdout[0m
   Path to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/2c57c8917bfb/unchecked
-[32m[PASS][0m  68358d78cb0b unchecked stderr
+[32m[PASS][0m  68358d78cb0b [36munchecked stderr[0m
   Path to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/68358d78cb0b/unchecked
-[33m[PASS*][0m d1a055429711 capture stdout
+[33m[PASS*][0m d1a055429711 [36mcapture stdout[0m
   Checked output: stdout
-  [31mMissing file(s) containing the expected output: Missing file "tests/snapshots/alcotest_ext_dummy_tests/d1a055429711/stdout"[0m
-[33m[PASS*][0m 72f48157b077 capture stderr
+  [31mMissing file containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/d1a055429711/stdout[0m
+[33m[PASS*][0m 72f48157b077 [36mcapture stderr[0m
   Checked output: stderr
-  [31mMissing file(s) containing the expected output: Missing file "tests/snapshots/alcotest_ext_dummy_tests/72f48157b077/stderr"[0m
-[33m[PASS*][0m 5deda5ac4212 capture stdxxx
+  [31mMissing file containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/72f48157b077/stderr[0m
+[33m[PASS*][0m 5deda5ac4212 [36mcapture stdxxx[0m
   Checked output: merged stdout and stderr
-  [31mMissing file(s) containing the expected output: Missing file "tests/snapshots/alcotest_ext_dummy_tests/5deda5ac4212/stdxxx"[0m
-[33m[PASS*][0m 486ef3ce86ab capture stdout and stderr
+  [31mMissing file containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/5deda5ac4212/stdxxx[0m
+[33m[PASS*][0m 486ef3ce86ab [36mcapture stdout and stderr[0m
   Checked output: separate stdout and stderr
-  [31mMissing file(s) containing the expected output: Missing file "tests/snapshots/alcotest_ext_dummy_tests/486ef3ce86ab/stdout"[0m
-[32m[XFAIL][0m 85349a4a9157 xfail
+  [31mMissing files containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/486ef3ce86ab/stdout, tests/snapshots/alcotest_ext_dummy_tests/486ef3ce86ab/stderr[0m
+[32m[XFAIL][0m 85349a4a9157 [36mxfail[0m
   Expected to fail: raises exception on purpose
   Path to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/85349a4a9157/unchecked
-[33m[MISS][0m  e52e279299e9 skipped
+[33m[MISS][0m  e52e279299e9 [36mskipped[0m
   Always skipped
-[32m[PASS][0m  91a3c9030236 chdir
+[32m[PASS][0m  91a3c9030236 [36mchdir[0m
   Path to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/91a3c9030236/unchecked
-[33m[PASS*][0m a3e1a604f579 masked
+[33m[PASS*][0m a3e1a604f579 [36mmasked[0m
   Checked output: stdout
-  [31mMissing file(s) containing the expected output: Missing file "tests/snapshots/alcotest_ext_dummy_tests/a3e1a604f579/stdout"[0m
+  [31mMissing file containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/a3e1a604f579/stdout[0m
 
-[1mShort status[0m
-[33m[PASS*][0m d1a055429711 capture stdout
-[33m[PASS*][0m 72f48157b077 capture stderr
-[33m[PASS*][0m 5deda5ac4212 capture stdxxx
-[33m[PASS*][0m 486ef3ce86ab capture stdout and stderr
-[33m[PASS*][0m a3e1a604f579 masked
+[1mTests that need attention[0m
+[33m[PASS*][0m d1a055429711 [36mcapture stdout[0m
+  Checked output: stdout
+  [31mMissing file containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/d1a055429711/stdout[0m
+[33m[PASS*][0m 72f48157b077 [36mcapture stderr[0m
+  Checked output: stderr
+  [31mMissing file containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/72f48157b077/stderr[0m
+[33m[PASS*][0m 5deda5ac4212 [36mcapture stdxxx[0m
+  Checked output: merged stdout and stderr
+  [31mMissing file containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/5deda5ac4212/stdxxx[0m
+[33m[PASS*][0m 486ef3ce86ab [36mcapture stdout and stderr[0m
+  Checked output: separate stdout and stderr
+  [31mMissing files containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/486ef3ce86ab/stdout, tests/snapshots/alcotest_ext_dummy_tests/486ef3ce86ab/stderr[0m
+[33m[PASS*][0m a3e1a604f579 [36mmasked[0m
+  Checked output: stdout
+  [31mMissing file containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/a3e1a604f579/stdout[0m
 11/11 selected tests:
   10 successful (9 pass, 1 xfail),
   0 unsuccessful (0 fail, 0 xpass),
@@ -238,12 +274,22 @@ Other states:
 overall status: [32msuccess[0m
 <handling result before exiting>
 RUN ./test status --short
-[1mShort status[0m
-[33m[PASS*][0m d1a055429711 capture stdout
-[33m[PASS*][0m 72f48157b077 capture stderr
-[33m[PASS*][0m 5deda5ac4212 capture stdxxx
-[33m[PASS*][0m 486ef3ce86ab capture stdout and stderr
-[33m[PASS*][0m a3e1a604f579 masked
+[1mTests that need attention[0m
+[33m[PASS*][0m d1a055429711 [36mcapture stdout[0m
+  Checked output: stdout
+  [31mMissing file containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/d1a055429711/stdout[0m
+[33m[PASS*][0m 72f48157b077 [36mcapture stderr[0m
+  Checked output: stderr
+  [31mMissing file containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/72f48157b077/stderr[0m
+[33m[PASS*][0m 5deda5ac4212 [36mcapture stdxxx[0m
+  Checked output: merged stdout and stderr
+  [31mMissing file containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/5deda5ac4212/stdxxx[0m
+[33m[PASS*][0m 486ef3ce86ab [36mcapture stdout and stderr[0m
+  Checked output: separate stdout and stderr
+  [31mMissing files containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/486ef3ce86ab/stdout, tests/snapshots/alcotest_ext_dummy_tests/486ef3ce86ab/stderr[0m
+[33m[PASS*][0m a3e1a604f579 [36mmasked[0m
+  Checked output: stdout
+  [31mMissing file containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/a3e1a604f579/stdout[0m
 11/11 selected tests:
   10 successful (9 pass, 1 xfail),
   0 unsuccessful (0 fail, 0 xpass),
@@ -265,47 +311,46 @@ Other states:
   In this case, you should review the test output and run the 'approve'
   subcommand once you're satisfied with the output.
 
-[1mLong status[0m
-[32m[PASS][0m  8dbdda48fb87 simple
+[1mAll tests[0m
+[32m[PASS][0m  8dbdda48fb87 [36msimple[0m
   Path to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/8dbdda48fb87/unchecked
-[32m[PASS][0m  2c57c8917bfb unchecked stdout
+[32m[PASS][0m  2c57c8917bfb [36munchecked stdout[0m
   Path to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/2c57c8917bfb/unchecked
-[32m[PASS][0m  68358d78cb0b unchecked stderr
+[32m[PASS][0m  68358d78cb0b [36munchecked stderr[0m
   Path to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/68358d78cb0b/unchecked
-[32m[PASS][0m  d1a055429711 capture stdout
+[32m[PASS][0m  d1a055429711 [36mcapture stdout[0m
   Checked output: stdout
   Path to expected stdout: tests/snapshots/alcotest_ext_dummy_tests/d1a055429711/stdout
   Path to latest stdout: _build/alcotest_ext/status/alcotest_ext_dummy_tests/d1a055429711/stdout
   Path to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/d1a055429711/unchecked
-[32m[PASS][0m  72f48157b077 capture stderr
+[32m[PASS][0m  72f48157b077 [36mcapture stderr[0m
   Checked output: stderr
   Path to expected stderr: tests/snapshots/alcotest_ext_dummy_tests/72f48157b077/stderr
   Path to latest stderr: _build/alcotest_ext/status/alcotest_ext_dummy_tests/72f48157b077/stderr
   Path to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/72f48157b077/unchecked
-[32m[PASS][0m  5deda5ac4212 capture stdxxx
+[32m[PASS][0m  5deda5ac4212 [36mcapture stdxxx[0m
   Checked output: merged stdout and stderr
   Path to expected stdxxx: tests/snapshots/alcotest_ext_dummy_tests/5deda5ac4212/stdxxx
   Path to latest stdxxx: _build/alcotest_ext/status/alcotest_ext_dummy_tests/5deda5ac4212/stdxxx
-[32m[PASS][0m  486ef3ce86ab capture stdout and stderr
+[32m[PASS][0m  486ef3ce86ab [36mcapture stdout and stderr[0m
   Checked output: separate stdout and stderr
   Path to expected stdout: tests/snapshots/alcotest_ext_dummy_tests/486ef3ce86ab/stdout
   Path to latest stdout: _build/alcotest_ext/status/alcotest_ext_dummy_tests/486ef3ce86ab/stdout
   Path to expected stderr: tests/snapshots/alcotest_ext_dummy_tests/486ef3ce86ab/stderr
   Path to latest stderr: _build/alcotest_ext/status/alcotest_ext_dummy_tests/486ef3ce86ab/stderr
-[32m[XFAIL][0m 85349a4a9157 xfail
+[32m[XFAIL][0m 85349a4a9157 [36mxfail[0m
   Expected to fail: raises exception on purpose
   Path to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/85349a4a9157/unchecked
-[33m[MISS][0m  e52e279299e9 skipped
+[33m[MISS][0m  e52e279299e9 [36mskipped[0m
   Always skipped
-[32m[PASS][0m  91a3c9030236 chdir
+[32m[PASS][0m  91a3c9030236 [36mchdir[0m
   Path to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/91a3c9030236/unchecked
-[32m[PASS][0m  a3e1a604f579 masked
+[32m[PASS][0m  a3e1a604f579 [36mmasked[0m
   Checked output: stdout
   Path to expected stdout: tests/snapshots/alcotest_ext_dummy_tests/a3e1a604f579/stdout
   Path to latest stdout: _build/alcotest_ext/status/alcotest_ext_dummy_tests/a3e1a604f579/stdout
   Path to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/a3e1a604f579/unchecked
 
-[1mShort status[0m
 11/11 selected tests:
   10 successful (9 pass, 1 xfail),
   0 unsuccessful (0 fail, 0 xpass),
@@ -329,47 +374,63 @@ Other states:
   In this case, you should review the test output and run the 'approve'
   subcommand once you're satisfied with the output.
 
-[1mLong status[0m
-[33m[MISS][0m  8dbdda48fb87 simple
-  [31mMissing file(s) containing the test output: Missing file "_build/alcotest_ext/status/alcotest_ext_dummy_tests/8dbdda48fb87/outcome"[0m
-[33m[MISS][0m  2c57c8917bfb unchecked stdout
-  [31mMissing file(s) containing the test output: Missing file "_build/alcotest_ext/status/alcotest_ext_dummy_tests/2c57c8917bfb/outcome"[0m
-[33m[MISS][0m  68358d78cb0b unchecked stderr
-  [31mMissing file(s) containing the test output: Missing file "_build/alcotest_ext/status/alcotest_ext_dummy_tests/68358d78cb0b/outcome"[0m
-[33m[MISS][0m  d1a055429711 capture stdout
+[1mAll tests[0m
+[33m[MISS][0m  8dbdda48fb87 [36msimple[0m
+  [31mMissing file containing the test output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/8dbdda48fb87/outcome[0m
+[33m[MISS][0m  2c57c8917bfb [36munchecked stdout[0m
+  [31mMissing file containing the test output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/2c57c8917bfb/outcome[0m
+[33m[MISS][0m  68358d78cb0b [36munchecked stderr[0m
+  [31mMissing file containing the test output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/68358d78cb0b/outcome[0m
+[33m[MISS][0m  d1a055429711 [36mcapture stdout[0m
   Checked output: stdout
-  [31mMissing file(s) containing the test output: Missing file "_build/alcotest_ext/status/alcotest_ext_dummy_tests/d1a055429711/outcome"[0m
-[33m[MISS][0m  72f48157b077 capture stderr
+  [31mMissing file containing the test output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/d1a055429711/outcome[0m
+[33m[MISS][0m  72f48157b077 [36mcapture stderr[0m
   Checked output: stderr
-  [31mMissing file(s) containing the test output: Missing file "_build/alcotest_ext/status/alcotest_ext_dummy_tests/72f48157b077/outcome"[0m
-[33m[MISS][0m  5deda5ac4212 capture stdxxx
+  [31mMissing file containing the test output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/72f48157b077/outcome[0m
+[33m[MISS][0m  5deda5ac4212 [36mcapture stdxxx[0m
   Checked output: merged stdout and stderr
-  [31mMissing file(s) containing the test output: Missing file "_build/alcotest_ext/status/alcotest_ext_dummy_tests/5deda5ac4212/outcome"[0m
-[33m[MISS][0m  486ef3ce86ab capture stdout and stderr
+  [31mMissing file containing the test output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/5deda5ac4212/outcome[0m
+[33m[MISS][0m  486ef3ce86ab [36mcapture stdout and stderr[0m
   Checked output: separate stdout and stderr
-  [31mMissing file(s) containing the test output: Missing file "_build/alcotest_ext/status/alcotest_ext_dummy_tests/486ef3ce86ab/outcome"[0m
-[33m[MISS][0m  85349a4a9157 xfail
+  [31mMissing file containing the test output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/486ef3ce86ab/outcome[0m
+[33m[MISS][0m  85349a4a9157 [36mxfail[0m
   Expected to fail: raises exception on purpose
-  [31mMissing file(s) containing the test output: Missing file "_build/alcotest_ext/status/alcotest_ext_dummy_tests/85349a4a9157/outcome"[0m
-[33m[MISS][0m  e52e279299e9 skipped
+  [31mMissing file containing the test output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/85349a4a9157/outcome[0m
+[33m[MISS][0m  e52e279299e9 [36mskipped[0m
   Always skipped
-[33m[MISS][0m  91a3c9030236 chdir
-  [31mMissing file(s) containing the test output: Missing file "_build/alcotest_ext/status/alcotest_ext_dummy_tests/91a3c9030236/outcome"[0m
-[33m[MISS][0m  a3e1a604f579 masked
+[33m[MISS][0m  91a3c9030236 [36mchdir[0m
+  [31mMissing file containing the test output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/91a3c9030236/outcome[0m
+[33m[MISS][0m  a3e1a604f579 [36mmasked[0m
   Checked output: stdout
-  [31mMissing file(s) containing the test output: Missing file "_build/alcotest_ext/status/alcotest_ext_dummy_tests/a3e1a604f579/outcome"[0m
+  [31mMissing file containing the test output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/a3e1a604f579/outcome[0m
 
-[1mShort status[0m
-[33m[MISS][0m  8dbdda48fb87 simple
-[33m[MISS][0m  2c57c8917bfb unchecked stdout
-[33m[MISS][0m  68358d78cb0b unchecked stderr
-[33m[MISS][0m  d1a055429711 capture stdout
-[33m[MISS][0m  72f48157b077 capture stderr
-[33m[MISS][0m  5deda5ac4212 capture stdxxx
-[33m[MISS][0m  486ef3ce86ab capture stdout and stderr
-[33m[MISS][0m  85349a4a9157 xfail
-[33m[MISS][0m  91a3c9030236 chdir
-[33m[MISS][0m  a3e1a604f579 masked
+[1mTests that need attention[0m
+[33m[MISS][0m  8dbdda48fb87 [36msimple[0m
+  [31mMissing file containing the test output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/8dbdda48fb87/outcome[0m
+[33m[MISS][0m  2c57c8917bfb [36munchecked stdout[0m
+  [31mMissing file containing the test output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/2c57c8917bfb/outcome[0m
+[33m[MISS][0m  68358d78cb0b [36munchecked stderr[0m
+  [31mMissing file containing the test output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/68358d78cb0b/outcome[0m
+[33m[MISS][0m  d1a055429711 [36mcapture stdout[0m
+  Checked output: stdout
+  [31mMissing file containing the test output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/d1a055429711/outcome[0m
+[33m[MISS][0m  72f48157b077 [36mcapture stderr[0m
+  Checked output: stderr
+  [31mMissing file containing the test output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/72f48157b077/outcome[0m
+[33m[MISS][0m  5deda5ac4212 [36mcapture stdxxx[0m
+  Checked output: merged stdout and stderr
+  [31mMissing file containing the test output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/5deda5ac4212/outcome[0m
+[33m[MISS][0m  486ef3ce86ab [36mcapture stdout and stderr[0m
+  Checked output: separate stdout and stderr
+  [31mMissing file containing the test output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/486ef3ce86ab/outcome[0m
+[33m[MISS][0m  85349a4a9157 [36mxfail[0m
+  Expected to fail: raises exception on purpose
+  [31mMissing file containing the test output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/85349a4a9157/outcome[0m
+[33m[MISS][0m  91a3c9030236 [36mchdir[0m
+  [31mMissing file containing the test output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/91a3c9030236/outcome[0m
+[33m[MISS][0m  a3e1a604f579 [36mmasked[0m
+  Checked output: stdout
+  [31mMissing file containing the test output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/a3e1a604f579/outcome[0m
 11/11 selected tests:
   0 successful (0 pass, 0 xfail),
   0 unsuccessful (0 fail, 0 xpass),
@@ -453,47 +514,46 @@ Other states:
   In this case, you should review the test output and run the 'approve'
   subcommand once you're satisfied with the output.
 
-[1mLong status[0m
-[32m[PASS][0m  8dbdda48fb87 simple
+[1mAll tests[0m
+[32m[PASS][0m  8dbdda48fb87 [36msimple[0m
   Path to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/8dbdda48fb87/unchecked
-[32m[PASS][0m  2c57c8917bfb unchecked stdout
+[32m[PASS][0m  2c57c8917bfb [36munchecked stdout[0m
   Path to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/2c57c8917bfb/unchecked
-[32m[PASS][0m  68358d78cb0b unchecked stderr
+[32m[PASS][0m  68358d78cb0b [36munchecked stderr[0m
   Path to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/68358d78cb0b/unchecked
-[32m[PASS][0m  d1a055429711 capture stdout
+[32m[PASS][0m  d1a055429711 [36mcapture stdout[0m
   Checked output: stdout
   Path to expected stdout: tests/snapshots/alcotest_ext_dummy_tests/d1a055429711/stdout
   Path to latest stdout: _build/alcotest_ext/status/alcotest_ext_dummy_tests/d1a055429711/stdout
   Path to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/d1a055429711/unchecked
-[32m[PASS][0m  72f48157b077 capture stderr
+[32m[PASS][0m  72f48157b077 [36mcapture stderr[0m
   Checked output: stderr
   Path to expected stderr: tests/snapshots/alcotest_ext_dummy_tests/72f48157b077/stderr
   Path to latest stderr: _build/alcotest_ext/status/alcotest_ext_dummy_tests/72f48157b077/stderr
   Path to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/72f48157b077/unchecked
-[32m[PASS][0m  5deda5ac4212 capture stdxxx
+[32m[PASS][0m  5deda5ac4212 [36mcapture stdxxx[0m
   Checked output: merged stdout and stderr
   Path to expected stdxxx: tests/snapshots/alcotest_ext_dummy_tests/5deda5ac4212/stdxxx
   Path to latest stdxxx: _build/alcotest_ext/status/alcotest_ext_dummy_tests/5deda5ac4212/stdxxx
-[32m[PASS][0m  486ef3ce86ab capture stdout and stderr
+[32m[PASS][0m  486ef3ce86ab [36mcapture stdout and stderr[0m
   Checked output: separate stdout and stderr
   Path to expected stdout: tests/snapshots/alcotest_ext_dummy_tests/486ef3ce86ab/stdout
   Path to latest stdout: _build/alcotest_ext/status/alcotest_ext_dummy_tests/486ef3ce86ab/stdout
   Path to expected stderr: tests/snapshots/alcotest_ext_dummy_tests/486ef3ce86ab/stderr
   Path to latest stderr: _build/alcotest_ext/status/alcotest_ext_dummy_tests/486ef3ce86ab/stderr
-[32m[XFAIL][0m 85349a4a9157 xfail
+[32m[XFAIL][0m 85349a4a9157 [36mxfail[0m
   Expected to fail: raises exception on purpose
   Path to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/85349a4a9157/unchecked
-[33m[MISS][0m  e52e279299e9 skipped
+[33m[MISS][0m  e52e279299e9 [36mskipped[0m
   Always skipped
-[32m[PASS][0m  91a3c9030236 chdir
+[32m[PASS][0m  91a3c9030236 [36mchdir[0m
   Path to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/91a3c9030236/unchecked
-[32m[PASS][0m  a3e1a604f579 masked
+[32m[PASS][0m  a3e1a604f579 [36mmasked[0m
   Checked output: stdout
   Path to expected stdout: tests/snapshots/alcotest_ext_dummy_tests/a3e1a604f579/stdout
   Path to latest stdout: _build/alcotest_ext/status/alcotest_ext_dummy_tests/a3e1a604f579/stdout
   Path to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/a3e1a604f579/unchecked
 
-[1mShort status[0m
 11/11 selected tests:
   10 successful (9 pass, 1 xfail),
   0 unsuccessful (0 fail, 0 xpass),
@@ -517,42 +577,52 @@ Other states:
   In this case, you should review the test output and run the 'approve'
   subcommand once you're satisfied with the output.
 
-[1mLong status[0m
-[32m[PASS][0m  8dbdda48fb87 simple
+[1mAll tests[0m
+[32m[PASS][0m  8dbdda48fb87 [36msimple[0m
   Path to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/8dbdda48fb87/unchecked
-[32m[PASS][0m  2c57c8917bfb unchecked stdout
+[32m[PASS][0m  2c57c8917bfb [36munchecked stdout[0m
   Path to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/2c57c8917bfb/unchecked
-[32m[PASS][0m  68358d78cb0b unchecked stderr
+[32m[PASS][0m  68358d78cb0b [36munchecked stderr[0m
   Path to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/68358d78cb0b/unchecked
-[33m[PASS*][0m d1a055429711 capture stdout
+[33m[PASS*][0m d1a055429711 [36mcapture stdout[0m
   Checked output: stdout
-  [31mMissing file(s) containing the expected output: Missing file "tests/snapshots/alcotest_ext_dummy_tests/d1a055429711/stdout"[0m
-[33m[PASS*][0m 72f48157b077 capture stderr
+  [31mMissing file containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/d1a055429711/stdout[0m
+[33m[PASS*][0m 72f48157b077 [36mcapture stderr[0m
   Checked output: stderr
-  [31mMissing file(s) containing the expected output: Missing file "tests/snapshots/alcotest_ext_dummy_tests/72f48157b077/stderr"[0m
-[33m[PASS*][0m 5deda5ac4212 capture stdxxx
+  [31mMissing file containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/72f48157b077/stderr[0m
+[33m[PASS*][0m 5deda5ac4212 [36mcapture stdxxx[0m
   Checked output: merged stdout and stderr
-  [31mMissing file(s) containing the expected output: Missing file "tests/snapshots/alcotest_ext_dummy_tests/5deda5ac4212/stdxxx"[0m
-[33m[PASS*][0m 486ef3ce86ab capture stdout and stderr
+  [31mMissing file containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/5deda5ac4212/stdxxx[0m
+[33m[PASS*][0m 486ef3ce86ab [36mcapture stdout and stderr[0m
   Checked output: separate stdout and stderr
-  [31mMissing file(s) containing the expected output: Missing file "tests/snapshots/alcotest_ext_dummy_tests/486ef3ce86ab/stdout"[0m
-[32m[XFAIL][0m 85349a4a9157 xfail
+  [31mMissing files containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/486ef3ce86ab/stdout, tests/snapshots/alcotest_ext_dummy_tests/486ef3ce86ab/stderr[0m
+[32m[XFAIL][0m 85349a4a9157 [36mxfail[0m
   Expected to fail: raises exception on purpose
   Path to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/85349a4a9157/unchecked
-[33m[MISS][0m  e52e279299e9 skipped
+[33m[MISS][0m  e52e279299e9 [36mskipped[0m
   Always skipped
-[32m[PASS][0m  91a3c9030236 chdir
+[32m[PASS][0m  91a3c9030236 [36mchdir[0m
   Path to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/91a3c9030236/unchecked
-[33m[PASS*][0m a3e1a604f579 masked
+[33m[PASS*][0m a3e1a604f579 [36mmasked[0m
   Checked output: stdout
-  [31mMissing file(s) containing the expected output: Missing file "tests/snapshots/alcotest_ext_dummy_tests/a3e1a604f579/stdout"[0m
+  [31mMissing file containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/a3e1a604f579/stdout[0m
 
-[1mShort status[0m
-[33m[PASS*][0m d1a055429711 capture stdout
-[33m[PASS*][0m 72f48157b077 capture stderr
-[33m[PASS*][0m 5deda5ac4212 capture stdxxx
-[33m[PASS*][0m 486ef3ce86ab capture stdout and stderr
-[33m[PASS*][0m a3e1a604f579 masked
+[1mTests that need attention[0m
+[33m[PASS*][0m d1a055429711 [36mcapture stdout[0m
+  Checked output: stdout
+  [31mMissing file containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/d1a055429711/stdout[0m
+[33m[PASS*][0m 72f48157b077 [36mcapture stderr[0m
+  Checked output: stderr
+  [31mMissing file containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/72f48157b077/stderr[0m
+[33m[PASS*][0m 5deda5ac4212 [36mcapture stdxxx[0m
+  Checked output: merged stdout and stderr
+  [31mMissing file containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/5deda5ac4212/stdxxx[0m
+[33m[PASS*][0m 486ef3ce86ab [36mcapture stdout and stderr[0m
+  Checked output: separate stdout and stderr
+  [31mMissing files containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/486ef3ce86ab/stdout, tests/snapshots/alcotest_ext_dummy_tests/486ef3ce86ab/stderr[0m
+[33m[PASS*][0m a3e1a604f579 [36mmasked[0m
+  Checked output: stdout
+  [31mMissing file containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/a3e1a604f579/stdout[0m
 11/11 selected tests:
   10 successful (9 pass, 1 xfail),
   0 unsuccessful (0 fail, 0 xpass),

--- a/libs/alcotest_ext/tests/snapshots/alcotest_ext_meta_tests/fccf02a5c37e/stdxxx
+++ b/libs/alcotest_ext/tests/snapshots/alcotest_ext_meta_tests/fccf02a5c37e/stdxxx
@@ -139,10 +139,10 @@ This run has ID `<MASKED RUN ID>'.
           Called from <MASKED>
           Called from <MASKED>
           
-Logs saved to `~/semgrep/libs/alcotest_ext/_build/_tests/test/85349a4a9157 U+005BxfailU+005D xfail.000.output'.
+Logs saved to <MASKED>
  ──────────────────────────────────────────────────────────────────────────────
 
-Full test results in `~/semgrep/libs/alcotest_ext/_build/_tests/test'.
+Full test results in <MASKED>
 1 failure! <MASKED DURATION>. 10 tests run.
 The status of completed tests is reported below as one of four kinds:
 - PASS: a successful test that was expected to succeed (good);
@@ -498,10 +498,10 @@ This run has ID `<MASKED RUN ID>'.
           Called from <MASKED>
           Called from <MASKED>
           
-Logs saved to `~/semgrep/libs/alcotest_ext/_build/_tests/test/85349a4a9157 U+005BxfailU+005D xfail.000.output'.
+Logs saved to <MASKED>
  ──────────────────────────────────────────────────────────────────────────────
 
-Full test results in `~/semgrep/libs/alcotest_ext/_build/_tests/test'.
+Full test results in <MASKED>
 1 failure! <MASKED DURATION>. 10 tests run.
 The status of completed tests is reported below as one of four kinds:
 - PASS: a successful test that was expected to succeed (good);

--- a/libs/alcotest_ext/tests/snapshots/alcotest_ext_meta_tests/fccf02a5c37e/stdxxx
+++ b/libs/alcotest_ext/tests/snapshots/alcotest_ext_meta_tests/fccf02a5c37e/stdxxx
@@ -231,12 +231,22 @@ Other states:
 [32m[PASS][0m  8dbdda48fb87 simple
 [32m[PASS][0m  d1a055429711 capture stdout
   checked output: stdout
+  Path to expected stdout: tests/snapshots/alcotest_ext_dummy_tests/d1a055429711/stdout
+  Path to latest stdout: _build/alcotest_ext/status/alcotest_ext_dummy_tests/d1a055429711/stdout
 [32m[PASS][0m  72f48157b077 capture stderr
   checked output: stderr
+  Path to expected stderr: tests/snapshots/alcotest_ext_dummy_tests/72f48157b077/stderr
+  Path to latest stderr: _build/alcotest_ext/status/alcotest_ext_dummy_tests/72f48157b077/stderr
 [32m[PASS][0m  5deda5ac4212 capture stdxxx
   checked output: merged stdout and stderr
+  Path to expected stdxxx: tests/snapshots/alcotest_ext_dummy_tests/5deda5ac4212/stdxxx
+  Path to latest stdxxx: _build/alcotest_ext/status/alcotest_ext_dummy_tests/5deda5ac4212/stdxxx
 [32m[PASS][0m  486ef3ce86ab capture stdout and stderr
   checked output: separate stdout and stderr
+  Path to expected stdout: tests/snapshots/alcotest_ext_dummy_tests/486ef3ce86ab/stdout
+  Path to latest stdout: _build/alcotest_ext/status/alcotest_ext_dummy_tests/486ef3ce86ab/stdout
+  Path to expected stderr: tests/snapshots/alcotest_ext_dummy_tests/486ef3ce86ab/stderr
+  Path to latest stderr: _build/alcotest_ext/status/alcotest_ext_dummy_tests/486ef3ce86ab/stderr
 [32m[XFAIL][0m 85349a4a9157 xfail
   expected to fail: "raises exception on purpose"
 [33m[MISS][0m  e52e279299e9 skipped
@@ -244,6 +254,8 @@ Other states:
 [32m[PASS][0m  91a3c9030236 chdir
 [32m[PASS][0m  a3e1a604f579 masked
   checked output: stdout
+  Path to expected stdout: tests/snapshots/alcotest_ext_dummy_tests/a3e1a604f579/stdout
+  Path to latest stdout: _build/alcotest_ext/status/alcotest_ext_dummy_tests/a3e1a604f579/stdout
 
 [1mShort status[0m
 9/9 selected tests:
@@ -373,12 +385,22 @@ Other states:
 [32m[PASS][0m  8dbdda48fb87 simple
 [32m[PASS][0m  d1a055429711 capture stdout
   checked output: stdout
+  Path to expected stdout: tests/snapshots/alcotest_ext_dummy_tests/d1a055429711/stdout
+  Path to latest stdout: _build/alcotest_ext/status/alcotest_ext_dummy_tests/d1a055429711/stdout
 [32m[PASS][0m  72f48157b077 capture stderr
   checked output: stderr
+  Path to expected stderr: tests/snapshots/alcotest_ext_dummy_tests/72f48157b077/stderr
+  Path to latest stderr: _build/alcotest_ext/status/alcotest_ext_dummy_tests/72f48157b077/stderr
 [32m[PASS][0m  5deda5ac4212 capture stdxxx
   checked output: merged stdout and stderr
+  Path to expected stdxxx: tests/snapshots/alcotest_ext_dummy_tests/5deda5ac4212/stdxxx
+  Path to latest stdxxx: _build/alcotest_ext/status/alcotest_ext_dummy_tests/5deda5ac4212/stdxxx
 [32m[PASS][0m  486ef3ce86ab capture stdout and stderr
   checked output: separate stdout and stderr
+  Path to expected stdout: tests/snapshots/alcotest_ext_dummy_tests/486ef3ce86ab/stdout
+  Path to latest stdout: _build/alcotest_ext/status/alcotest_ext_dummy_tests/486ef3ce86ab/stdout
+  Path to expected stderr: tests/snapshots/alcotest_ext_dummy_tests/486ef3ce86ab/stderr
+  Path to latest stderr: _build/alcotest_ext/status/alcotest_ext_dummy_tests/486ef3ce86ab/stderr
 [32m[XFAIL][0m 85349a4a9157 xfail
   expected to fail: "raises exception on purpose"
 [33m[MISS][0m  e52e279299e9 skipped
@@ -386,6 +408,8 @@ Other states:
 [32m[PASS][0m  91a3c9030236 chdir
 [32m[PASS][0m  a3e1a604f579 masked
   checked output: stdout
+  Path to expected stdout: tests/snapshots/alcotest_ext_dummy_tests/a3e1a604f579/stdout
+  Path to latest stdout: _build/alcotest_ext/status/alcotest_ext_dummy_tests/a3e1a604f579/stdout
 
 [1mShort status[0m
 9/9 selected tests:

--- a/libs/alcotest_ext/tests/snapshots/alcotest_ext_meta_tests/fccf02a5c37e/stdxxx
+++ b/libs/alcotest_ext/tests/snapshots/alcotest_ext_meta_tests/fccf02a5c37e/stdxxx
@@ -17,32 +17,38 @@ Other states:
 
 [1mLong status[0m
 [33m[MISS][0m  8dbdda48fb87 simple
-Missing file(s) containing the test output: Missing file "_build/alcotest_ext/status/alcotest_ext_dummy_tests/8dbdda48fb87/outcome"
+  [31mMissing file(s) containing the test output: Missing file "_build/alcotest_ext/status/alcotest_ext_dummy_tests/8dbdda48fb87/outcome"[0m
+[33m[MISS][0m  2c57c8917bfb unchecked stdout
+  [31mMissing file(s) containing the test output: Missing file "_build/alcotest_ext/status/alcotest_ext_dummy_tests/2c57c8917bfb/outcome"[0m
+[33m[MISS][0m  68358d78cb0b unchecked stderr
+  [31mMissing file(s) containing the test output: Missing file "_build/alcotest_ext/status/alcotest_ext_dummy_tests/68358d78cb0b/outcome"[0m
 [33m[MISS][0m  d1a055429711 capture stdout
-  checked output: stdout
-Missing file(s) containing the expected output: Missing file "tests/snapshots/alcotest_ext_dummy_tests/d1a055429711/stdout"
+  Checked output: stdout
+  [31mMissing file(s) containing the expected output: Missing file "tests/snapshots/alcotest_ext_dummy_tests/d1a055429711/stdout"[0m
 [33m[MISS][0m  72f48157b077 capture stderr
-  checked output: stderr
-Missing file(s) containing the expected output: Missing file "tests/snapshots/alcotest_ext_dummy_tests/72f48157b077/stderr"
+  Checked output: stderr
+  [31mMissing file(s) containing the expected output: Missing file "tests/snapshots/alcotest_ext_dummy_tests/72f48157b077/stderr"[0m
 [33m[MISS][0m  5deda5ac4212 capture stdxxx
-  checked output: merged stdout and stderr
-Missing file(s) containing the expected output: Missing file "tests/snapshots/alcotest_ext_dummy_tests/5deda5ac4212/stdxxx"
+  Checked output: merged stdout and stderr
+  [31mMissing file(s) containing the expected output: Missing file "tests/snapshots/alcotest_ext_dummy_tests/5deda5ac4212/stdxxx"[0m
 [33m[MISS][0m  486ef3ce86ab capture stdout and stderr
-  checked output: separate stdout and stderr
-Missing file(s) containing the expected output: Missing file "tests/snapshots/alcotest_ext_dummy_tests/486ef3ce86ab/stdout"
+  Checked output: separate stdout and stderr
+  [31mMissing file(s) containing the expected output: Missing file "tests/snapshots/alcotest_ext_dummy_tests/486ef3ce86ab/stdout"[0m
 [33m[MISS][0m  85349a4a9157 xfail
-  expected to fail: "raises exception on purpose"
-Missing file(s) containing the test output: Missing file "_build/alcotest_ext/status/alcotest_ext_dummy_tests/85349a4a9157/outcome"
+  Expected to fail: raises exception on purpose
+  [31mMissing file(s) containing the test output: Missing file "_build/alcotest_ext/status/alcotest_ext_dummy_tests/85349a4a9157/outcome"[0m
 [33m[MISS][0m  e52e279299e9 skipped
-  always skipped
+  Always skipped
 [33m[MISS][0m  91a3c9030236 chdir
-Missing file(s) containing the test output: Missing file "_build/alcotest_ext/status/alcotest_ext_dummy_tests/91a3c9030236/outcome"
+  [31mMissing file(s) containing the test output: Missing file "_build/alcotest_ext/status/alcotest_ext_dummy_tests/91a3c9030236/outcome"[0m
 [33m[MISS][0m  a3e1a604f579 masked
-  checked output: stdout
-Missing file(s) containing the expected output: Missing file "tests/snapshots/alcotest_ext_dummy_tests/a3e1a604f579/stdout"
+  Checked output: stdout
+  [31mMissing file(s) containing the expected output: Missing file "tests/snapshots/alcotest_ext_dummy_tests/a3e1a604f579/stdout"[0m
 
 [1mShort status[0m
 [33m[MISS][0m  8dbdda48fb87 simple
+[33m[MISS][0m  2c57c8917bfb unchecked stdout
+[33m[MISS][0m  68358d78cb0b unchecked stderr
 [33m[MISS][0m  d1a055429711 capture stdout
 [33m[MISS][0m  72f48157b077 capture stderr
 [33m[MISS][0m  5deda5ac4212 capture stdxxx
@@ -50,10 +56,10 @@ Missing file(s) containing the expected output: Missing file "tests/snapshots/al
 [33m[MISS][0m  85349a4a9157 xfail
 [33m[MISS][0m  91a3c9030236 chdir
 [33m[MISS][0m  a3e1a604f579 masked
-9/9 selected tests:
+11/11 selected tests:
   0 successful (0 pass, 0 xfail),
   0 unsuccessful (0 fail, 0 xpass),
-9 new tests
+11 new tests
 0 test whose output needs first-time approval
 overall status: [32msuccess[0m
 <handling result before exiting>
@@ -75,6 +81,8 @@ Testing `test'.
 This run has ID `<MASKED RUN ID>'.
 
   [OK]          8dbdda48fb87 simple                             0   simple.
+  [OK]          2c57c8917bfb unchecked stdout                   0   unchecked...
+  [OK]          68358d78cb0b unchecked stderr                   0   unchecked...
   [OK]          d1a055429711 capture stdout                     0   capture s...
   [OK]          72f48157b077 capture stderr                     0   capture s...
   [OK]          5deda5ac4212 capture stdxxx                     0   capture s...
@@ -94,6 +102,22 @@ This run has ID `<MASKED RUN ID>'.
           Called from <MASKED>
           Re-raised at <MASKED>
           Called from <MASKED>
+          Re-raised at <MASKED>
+          Called from <MASKED>
+          Re-raised at <MASKED>
+          Called from <MASKED>
+          Re-raised at <MASKED>
+          Called from <MASKED>
+          Re-raised at <MASKED>
+          Called from <MASKED>
+          Re-raised at <MASKED>
+          Called from <MASKED>
+          Re-raised at <MASKED>
+          Called from <MASKED>
+          Re-raised at <MASKED>
+          Called from <MASKED>
+          Re-raised at <MASKED>
+          Called from <MASKED>
           Called from <MASKED>
           Re-raised at <MASKED>
           Called from <MASKED>
@@ -103,7 +127,7 @@ Logs saved to `~/semgrep/libs/alcotest_ext/_build/_tests/test/85349a4a9157 U+005
  ──────────────────────────────────────────────────────────────────────────────
 
 Full test results in `~/semgrep/libs/alcotest_ext/_build/_tests/test'.
-1 failure! <MASKED DURATION>. 8 tests run.
+1 failure! <MASKED DURATION>. 10 tests run.
 The status of completed tests is reported below as one of four kinds:
 - PASS: a successful test that was expected to succeed (good);
 - FAIL: a failing test that was expected to succeed (needs fixing);
@@ -117,26 +141,33 @@ Other states:
 
 [1mLong status[0m
 [32m[PASS][0m  8dbdda48fb87 simple
+  Path to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/8dbdda48fb87/unchecked
+[32m[PASS][0m  2c57c8917bfb unchecked stdout
+  Path to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/2c57c8917bfb/unchecked
+[32m[PASS][0m  68358d78cb0b unchecked stderr
+  Path to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/68358d78cb0b/unchecked
 [33m[PASS*][0m d1a055429711 capture stdout
-  checked output: stdout
-Missing file(s) containing the expected output: Missing file "tests/snapshots/alcotest_ext_dummy_tests/d1a055429711/stdout"
+  Checked output: stdout
+  [31mMissing file(s) containing the expected output: Missing file "tests/snapshots/alcotest_ext_dummy_tests/d1a055429711/stdout"[0m
 [33m[PASS*][0m 72f48157b077 capture stderr
-  checked output: stderr
-Missing file(s) containing the expected output: Missing file "tests/snapshots/alcotest_ext_dummy_tests/72f48157b077/stderr"
+  Checked output: stderr
+  [31mMissing file(s) containing the expected output: Missing file "tests/snapshots/alcotest_ext_dummy_tests/72f48157b077/stderr"[0m
 [33m[PASS*][0m 5deda5ac4212 capture stdxxx
-  checked output: merged stdout and stderr
-Missing file(s) containing the expected output: Missing file "tests/snapshots/alcotest_ext_dummy_tests/5deda5ac4212/stdxxx"
+  Checked output: merged stdout and stderr
+  [31mMissing file(s) containing the expected output: Missing file "tests/snapshots/alcotest_ext_dummy_tests/5deda5ac4212/stdxxx"[0m
 [33m[PASS*][0m 486ef3ce86ab capture stdout and stderr
-  checked output: separate stdout and stderr
-Missing file(s) containing the expected output: Missing file "tests/snapshots/alcotest_ext_dummy_tests/486ef3ce86ab/stdout"
+  Checked output: separate stdout and stderr
+  [31mMissing file(s) containing the expected output: Missing file "tests/snapshots/alcotest_ext_dummy_tests/486ef3ce86ab/stdout"[0m
 [32m[XFAIL][0m 85349a4a9157 xfail
-  expected to fail: "raises exception on purpose"
+  Expected to fail: raises exception on purpose
+  Path to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/85349a4a9157/unchecked
 [33m[MISS][0m  e52e279299e9 skipped
-  always skipped
+  Always skipped
 [32m[PASS][0m  91a3c9030236 chdir
+  Path to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/91a3c9030236/unchecked
 [33m[PASS*][0m a3e1a604f579 masked
-  checked output: stdout
-Missing file(s) containing the expected output: Missing file "tests/snapshots/alcotest_ext_dummy_tests/a3e1a604f579/stdout"
+  Checked output: stdout
+  [31mMissing file(s) containing the expected output: Missing file "tests/snapshots/alcotest_ext_dummy_tests/a3e1a604f579/stdout"[0m
 
 [1mShort status[0m
 [33m[PASS*][0m d1a055429711 capture stdout
@@ -144,8 +175,8 @@ Missing file(s) containing the expected output: Missing file "tests/snapshots/al
 [33m[PASS*][0m 5deda5ac4212 capture stdxxx
 [33m[PASS*][0m 486ef3ce86ab capture stdout and stderr
 [33m[PASS*][0m a3e1a604f579 masked
-9/9 selected tests:
-  8 successful (7 pass, 1 xfail),
+11/11 selected tests:
+  10 successful (9 pass, 1 xfail),
   0 unsuccessful (0 fail, 0 xpass),
 1 new test
 5 tests whose output needs first-time approval
@@ -165,26 +196,33 @@ Other states:
 
 [1mLong status[0m
 [32m[PASS][0m  8dbdda48fb87 simple
+  Path to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/8dbdda48fb87/unchecked
+[32m[PASS][0m  2c57c8917bfb unchecked stdout
+  Path to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/2c57c8917bfb/unchecked
+[32m[PASS][0m  68358d78cb0b unchecked stderr
+  Path to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/68358d78cb0b/unchecked
 [33m[PASS*][0m d1a055429711 capture stdout
-  checked output: stdout
-Missing file(s) containing the expected output: Missing file "tests/snapshots/alcotest_ext_dummy_tests/d1a055429711/stdout"
+  Checked output: stdout
+  [31mMissing file(s) containing the expected output: Missing file "tests/snapshots/alcotest_ext_dummy_tests/d1a055429711/stdout"[0m
 [33m[PASS*][0m 72f48157b077 capture stderr
-  checked output: stderr
-Missing file(s) containing the expected output: Missing file "tests/snapshots/alcotest_ext_dummy_tests/72f48157b077/stderr"
+  Checked output: stderr
+  [31mMissing file(s) containing the expected output: Missing file "tests/snapshots/alcotest_ext_dummy_tests/72f48157b077/stderr"[0m
 [33m[PASS*][0m 5deda5ac4212 capture stdxxx
-  checked output: merged stdout and stderr
-Missing file(s) containing the expected output: Missing file "tests/snapshots/alcotest_ext_dummy_tests/5deda5ac4212/stdxxx"
+  Checked output: merged stdout and stderr
+  [31mMissing file(s) containing the expected output: Missing file "tests/snapshots/alcotest_ext_dummy_tests/5deda5ac4212/stdxxx"[0m
 [33m[PASS*][0m 486ef3ce86ab capture stdout and stderr
-  checked output: separate stdout and stderr
-Missing file(s) containing the expected output: Missing file "tests/snapshots/alcotest_ext_dummy_tests/486ef3ce86ab/stdout"
+  Checked output: separate stdout and stderr
+  [31mMissing file(s) containing the expected output: Missing file "tests/snapshots/alcotest_ext_dummy_tests/486ef3ce86ab/stdout"[0m
 [32m[XFAIL][0m 85349a4a9157 xfail
-  expected to fail: "raises exception on purpose"
+  Expected to fail: raises exception on purpose
+  Path to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/85349a4a9157/unchecked
 [33m[MISS][0m  e52e279299e9 skipped
-  always skipped
+  Always skipped
 [32m[PASS][0m  91a3c9030236 chdir
+  Path to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/91a3c9030236/unchecked
 [33m[PASS*][0m a3e1a604f579 masked
-  checked output: stdout
-Missing file(s) containing the expected output: Missing file "tests/snapshots/alcotest_ext_dummy_tests/a3e1a604f579/stdout"
+  Checked output: stdout
+  [31mMissing file(s) containing the expected output: Missing file "tests/snapshots/alcotest_ext_dummy_tests/a3e1a604f579/stdout"[0m
 
 [1mShort status[0m
 [33m[PASS*][0m d1a055429711 capture stdout
@@ -192,8 +230,8 @@ Missing file(s) containing the expected output: Missing file "tests/snapshots/al
 [33m[PASS*][0m 5deda5ac4212 capture stdxxx
 [33m[PASS*][0m 486ef3ce86ab capture stdout and stderr
 [33m[PASS*][0m a3e1a604f579 masked
-9/9 selected tests:
-  8 successful (7 pass, 1 xfail),
+11/11 selected tests:
+  10 successful (9 pass, 1 xfail),
   0 unsuccessful (0 fail, 0 xpass),
 1 new test
 5 tests whose output needs first-time approval
@@ -206,8 +244,8 @@ RUN ./test status --short
 [33m[PASS*][0m 5deda5ac4212 capture stdxxx
 [33m[PASS*][0m 486ef3ce86ab capture stdout and stderr
 [33m[PASS*][0m a3e1a604f579 masked
-9/9 selected tests:
-  8 successful (7 pass, 1 xfail),
+11/11 selected tests:
+  10 successful (9 pass, 1 xfail),
   0 unsuccessful (0 fail, 0 xpass),
 1 new test
 5 tests whose output needs first-time approval
@@ -229,37 +267,47 @@ Other states:
 
 [1mLong status[0m
 [32m[PASS][0m  8dbdda48fb87 simple
+  Path to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/8dbdda48fb87/unchecked
+[32m[PASS][0m  2c57c8917bfb unchecked stdout
+  Path to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/2c57c8917bfb/unchecked
+[32m[PASS][0m  68358d78cb0b unchecked stderr
+  Path to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/68358d78cb0b/unchecked
 [32m[PASS][0m  d1a055429711 capture stdout
-  checked output: stdout
+  Checked output: stdout
   Path to expected stdout: tests/snapshots/alcotest_ext_dummy_tests/d1a055429711/stdout
   Path to latest stdout: _build/alcotest_ext/status/alcotest_ext_dummy_tests/d1a055429711/stdout
+  Path to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/d1a055429711/unchecked
 [32m[PASS][0m  72f48157b077 capture stderr
-  checked output: stderr
+  Checked output: stderr
   Path to expected stderr: tests/snapshots/alcotest_ext_dummy_tests/72f48157b077/stderr
   Path to latest stderr: _build/alcotest_ext/status/alcotest_ext_dummy_tests/72f48157b077/stderr
+  Path to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/72f48157b077/unchecked
 [32m[PASS][0m  5deda5ac4212 capture stdxxx
-  checked output: merged stdout and stderr
+  Checked output: merged stdout and stderr
   Path to expected stdxxx: tests/snapshots/alcotest_ext_dummy_tests/5deda5ac4212/stdxxx
   Path to latest stdxxx: _build/alcotest_ext/status/alcotest_ext_dummy_tests/5deda5ac4212/stdxxx
 [32m[PASS][0m  486ef3ce86ab capture stdout and stderr
-  checked output: separate stdout and stderr
+  Checked output: separate stdout and stderr
   Path to expected stdout: tests/snapshots/alcotest_ext_dummy_tests/486ef3ce86ab/stdout
   Path to latest stdout: _build/alcotest_ext/status/alcotest_ext_dummy_tests/486ef3ce86ab/stdout
   Path to expected stderr: tests/snapshots/alcotest_ext_dummy_tests/486ef3ce86ab/stderr
   Path to latest stderr: _build/alcotest_ext/status/alcotest_ext_dummy_tests/486ef3ce86ab/stderr
 [32m[XFAIL][0m 85349a4a9157 xfail
-  expected to fail: "raises exception on purpose"
+  Expected to fail: raises exception on purpose
+  Path to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/85349a4a9157/unchecked
 [33m[MISS][0m  e52e279299e9 skipped
-  always skipped
+  Always skipped
 [32m[PASS][0m  91a3c9030236 chdir
+  Path to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/91a3c9030236/unchecked
 [32m[PASS][0m  a3e1a604f579 masked
-  checked output: stdout
+  Checked output: stdout
   Path to expected stdout: tests/snapshots/alcotest_ext_dummy_tests/a3e1a604f579/stdout
   Path to latest stdout: _build/alcotest_ext/status/alcotest_ext_dummy_tests/a3e1a604f579/stdout
+  Path to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/a3e1a604f579/unchecked
 
 [1mShort status[0m
-9/9 selected tests:
-  8 successful (7 pass, 1 xfail),
+11/11 selected tests:
+  10 successful (9 pass, 1 xfail),
   0 unsuccessful (0 fail, 0 xpass),
 1 new test
 0 test whose output needs first-time approval
@@ -283,32 +331,38 @@ Other states:
 
 [1mLong status[0m
 [33m[MISS][0m  8dbdda48fb87 simple
-Missing file(s) containing the test output: Missing file "_build/alcotest_ext/status/alcotest_ext_dummy_tests/8dbdda48fb87/outcome"
+  [31mMissing file(s) containing the test output: Missing file "_build/alcotest_ext/status/alcotest_ext_dummy_tests/8dbdda48fb87/outcome"[0m
+[33m[MISS][0m  2c57c8917bfb unchecked stdout
+  [31mMissing file(s) containing the test output: Missing file "_build/alcotest_ext/status/alcotest_ext_dummy_tests/2c57c8917bfb/outcome"[0m
+[33m[MISS][0m  68358d78cb0b unchecked stderr
+  [31mMissing file(s) containing the test output: Missing file "_build/alcotest_ext/status/alcotest_ext_dummy_tests/68358d78cb0b/outcome"[0m
 [33m[MISS][0m  d1a055429711 capture stdout
-  checked output: stdout
-Missing file(s) containing the test output: Missing file "_build/alcotest_ext/status/alcotest_ext_dummy_tests/d1a055429711/outcome"
+  Checked output: stdout
+  [31mMissing file(s) containing the test output: Missing file "_build/alcotest_ext/status/alcotest_ext_dummy_tests/d1a055429711/outcome"[0m
 [33m[MISS][0m  72f48157b077 capture stderr
-  checked output: stderr
-Missing file(s) containing the test output: Missing file "_build/alcotest_ext/status/alcotest_ext_dummy_tests/72f48157b077/outcome"
+  Checked output: stderr
+  [31mMissing file(s) containing the test output: Missing file "_build/alcotest_ext/status/alcotest_ext_dummy_tests/72f48157b077/outcome"[0m
 [33m[MISS][0m  5deda5ac4212 capture stdxxx
-  checked output: merged stdout and stderr
-Missing file(s) containing the test output: Missing file "_build/alcotest_ext/status/alcotest_ext_dummy_tests/5deda5ac4212/outcome"
+  Checked output: merged stdout and stderr
+  [31mMissing file(s) containing the test output: Missing file "_build/alcotest_ext/status/alcotest_ext_dummy_tests/5deda5ac4212/outcome"[0m
 [33m[MISS][0m  486ef3ce86ab capture stdout and stderr
-  checked output: separate stdout and stderr
-Missing file(s) containing the test output: Missing file "_build/alcotest_ext/status/alcotest_ext_dummy_tests/486ef3ce86ab/outcome"
+  Checked output: separate stdout and stderr
+  [31mMissing file(s) containing the test output: Missing file "_build/alcotest_ext/status/alcotest_ext_dummy_tests/486ef3ce86ab/outcome"[0m
 [33m[MISS][0m  85349a4a9157 xfail
-  expected to fail: "raises exception on purpose"
-Missing file(s) containing the test output: Missing file "_build/alcotest_ext/status/alcotest_ext_dummy_tests/85349a4a9157/outcome"
+  Expected to fail: raises exception on purpose
+  [31mMissing file(s) containing the test output: Missing file "_build/alcotest_ext/status/alcotest_ext_dummy_tests/85349a4a9157/outcome"[0m
 [33m[MISS][0m  e52e279299e9 skipped
-  always skipped
+  Always skipped
 [33m[MISS][0m  91a3c9030236 chdir
-Missing file(s) containing the test output: Missing file "_build/alcotest_ext/status/alcotest_ext_dummy_tests/91a3c9030236/outcome"
+  [31mMissing file(s) containing the test output: Missing file "_build/alcotest_ext/status/alcotest_ext_dummy_tests/91a3c9030236/outcome"[0m
 [33m[MISS][0m  a3e1a604f579 masked
-  checked output: stdout
-Missing file(s) containing the test output: Missing file "_build/alcotest_ext/status/alcotest_ext_dummy_tests/a3e1a604f579/outcome"
+  Checked output: stdout
+  [31mMissing file(s) containing the test output: Missing file "_build/alcotest_ext/status/alcotest_ext_dummy_tests/a3e1a604f579/outcome"[0m
 
 [1mShort status[0m
 [33m[MISS][0m  8dbdda48fb87 simple
+[33m[MISS][0m  2c57c8917bfb unchecked stdout
+[33m[MISS][0m  68358d78cb0b unchecked stderr
 [33m[MISS][0m  d1a055429711 capture stdout
 [33m[MISS][0m  72f48157b077 capture stderr
 [33m[MISS][0m  5deda5ac4212 capture stdxxx
@@ -316,10 +370,10 @@ Missing file(s) containing the test output: Missing file "_build/alcotest_ext/st
 [33m[MISS][0m  85349a4a9157 xfail
 [33m[MISS][0m  91a3c9030236 chdir
 [33m[MISS][0m  a3e1a604f579 masked
-9/9 selected tests:
+11/11 selected tests:
   0 successful (0 pass, 0 xfail),
   0 unsuccessful (0 fail, 0 xpass),
-9 new tests
+11 new tests
 0 test whose output needs first-time approval
 overall status: [32msuccess[0m
 <handling result before exiting>
@@ -341,6 +395,8 @@ Testing `test'.
 This run has ID `<MASKED RUN ID>'.
 
   [OK]          8dbdda48fb87 simple                             0   simple.
+  [OK]          2c57c8917bfb unchecked stdout                   0   unchecked...
+  [OK]          68358d78cb0b unchecked stderr                   0   unchecked...
   [OK]          d1a055429711 capture stdout                     0   capture s...
   [OK]          72f48157b077 capture stderr                     0   capture s...
   [OK]          5deda5ac4212 capture stdxxx                     0   capture s...
@@ -360,6 +416,22 @@ This run has ID `<MASKED RUN ID>'.
           Called from <MASKED>
           Re-raised at <MASKED>
           Called from <MASKED>
+          Re-raised at <MASKED>
+          Called from <MASKED>
+          Re-raised at <MASKED>
+          Called from <MASKED>
+          Re-raised at <MASKED>
+          Called from <MASKED>
+          Re-raised at <MASKED>
+          Called from <MASKED>
+          Re-raised at <MASKED>
+          Called from <MASKED>
+          Re-raised at <MASKED>
+          Called from <MASKED>
+          Re-raised at <MASKED>
+          Called from <MASKED>
+          Re-raised at <MASKED>
+          Called from <MASKED>
           Called from <MASKED>
           Re-raised at <MASKED>
           Called from <MASKED>
@@ -369,7 +441,7 @@ Logs saved to `~/semgrep/libs/alcotest_ext/_build/_tests/test/85349a4a9157 U+005
  ──────────────────────────────────────────────────────────────────────────────
 
 Full test results in `~/semgrep/libs/alcotest_ext/_build/_tests/test'.
-1 failure! <MASKED DURATION>. 8 tests run.
+1 failure! <MASKED DURATION>. 10 tests run.
 The status of completed tests is reported below as one of four kinds:
 - PASS: a successful test that was expected to succeed (good);
 - FAIL: a failing test that was expected to succeed (needs fixing);
@@ -383,37 +455,47 @@ Other states:
 
 [1mLong status[0m
 [32m[PASS][0m  8dbdda48fb87 simple
+  Path to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/8dbdda48fb87/unchecked
+[32m[PASS][0m  2c57c8917bfb unchecked stdout
+  Path to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/2c57c8917bfb/unchecked
+[32m[PASS][0m  68358d78cb0b unchecked stderr
+  Path to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/68358d78cb0b/unchecked
 [32m[PASS][0m  d1a055429711 capture stdout
-  checked output: stdout
+  Checked output: stdout
   Path to expected stdout: tests/snapshots/alcotest_ext_dummy_tests/d1a055429711/stdout
   Path to latest stdout: _build/alcotest_ext/status/alcotest_ext_dummy_tests/d1a055429711/stdout
+  Path to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/d1a055429711/unchecked
 [32m[PASS][0m  72f48157b077 capture stderr
-  checked output: stderr
+  Checked output: stderr
   Path to expected stderr: tests/snapshots/alcotest_ext_dummy_tests/72f48157b077/stderr
   Path to latest stderr: _build/alcotest_ext/status/alcotest_ext_dummy_tests/72f48157b077/stderr
+  Path to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/72f48157b077/unchecked
 [32m[PASS][0m  5deda5ac4212 capture stdxxx
-  checked output: merged stdout and stderr
+  Checked output: merged stdout and stderr
   Path to expected stdxxx: tests/snapshots/alcotest_ext_dummy_tests/5deda5ac4212/stdxxx
   Path to latest stdxxx: _build/alcotest_ext/status/alcotest_ext_dummy_tests/5deda5ac4212/stdxxx
 [32m[PASS][0m  486ef3ce86ab capture stdout and stderr
-  checked output: separate stdout and stderr
+  Checked output: separate stdout and stderr
   Path to expected stdout: tests/snapshots/alcotest_ext_dummy_tests/486ef3ce86ab/stdout
   Path to latest stdout: _build/alcotest_ext/status/alcotest_ext_dummy_tests/486ef3ce86ab/stdout
   Path to expected stderr: tests/snapshots/alcotest_ext_dummy_tests/486ef3ce86ab/stderr
   Path to latest stderr: _build/alcotest_ext/status/alcotest_ext_dummy_tests/486ef3ce86ab/stderr
 [32m[XFAIL][0m 85349a4a9157 xfail
-  expected to fail: "raises exception on purpose"
+  Expected to fail: raises exception on purpose
+  Path to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/85349a4a9157/unchecked
 [33m[MISS][0m  e52e279299e9 skipped
-  always skipped
+  Always skipped
 [32m[PASS][0m  91a3c9030236 chdir
+  Path to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/91a3c9030236/unchecked
 [32m[PASS][0m  a3e1a604f579 masked
-  checked output: stdout
+  Checked output: stdout
   Path to expected stdout: tests/snapshots/alcotest_ext_dummy_tests/a3e1a604f579/stdout
   Path to latest stdout: _build/alcotest_ext/status/alcotest_ext_dummy_tests/a3e1a604f579/stdout
+  Path to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/a3e1a604f579/unchecked
 
 [1mShort status[0m
-9/9 selected tests:
-  8 successful (7 pass, 1 xfail),
+11/11 selected tests:
+  10 successful (9 pass, 1 xfail),
   0 unsuccessful (0 fail, 0 xpass),
 1 new test
 0 test whose output needs first-time approval
@@ -437,26 +519,33 @@ Other states:
 
 [1mLong status[0m
 [32m[PASS][0m  8dbdda48fb87 simple
+  Path to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/8dbdda48fb87/unchecked
+[32m[PASS][0m  2c57c8917bfb unchecked stdout
+  Path to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/2c57c8917bfb/unchecked
+[32m[PASS][0m  68358d78cb0b unchecked stderr
+  Path to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/68358d78cb0b/unchecked
 [33m[PASS*][0m d1a055429711 capture stdout
-  checked output: stdout
-Missing file(s) containing the expected output: Missing file "tests/snapshots/alcotest_ext_dummy_tests/d1a055429711/stdout"
+  Checked output: stdout
+  [31mMissing file(s) containing the expected output: Missing file "tests/snapshots/alcotest_ext_dummy_tests/d1a055429711/stdout"[0m
 [33m[PASS*][0m 72f48157b077 capture stderr
-  checked output: stderr
-Missing file(s) containing the expected output: Missing file "tests/snapshots/alcotest_ext_dummy_tests/72f48157b077/stderr"
+  Checked output: stderr
+  [31mMissing file(s) containing the expected output: Missing file "tests/snapshots/alcotest_ext_dummy_tests/72f48157b077/stderr"[0m
 [33m[PASS*][0m 5deda5ac4212 capture stdxxx
-  checked output: merged stdout and stderr
-Missing file(s) containing the expected output: Missing file "tests/snapshots/alcotest_ext_dummy_tests/5deda5ac4212/stdxxx"
+  Checked output: merged stdout and stderr
+  [31mMissing file(s) containing the expected output: Missing file "tests/snapshots/alcotest_ext_dummy_tests/5deda5ac4212/stdxxx"[0m
 [33m[PASS*][0m 486ef3ce86ab capture stdout and stderr
-  checked output: separate stdout and stderr
-Missing file(s) containing the expected output: Missing file "tests/snapshots/alcotest_ext_dummy_tests/486ef3ce86ab/stdout"
+  Checked output: separate stdout and stderr
+  [31mMissing file(s) containing the expected output: Missing file "tests/snapshots/alcotest_ext_dummy_tests/486ef3ce86ab/stdout"[0m
 [32m[XFAIL][0m 85349a4a9157 xfail
-  expected to fail: "raises exception on purpose"
+  Expected to fail: raises exception on purpose
+  Path to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/85349a4a9157/unchecked
 [33m[MISS][0m  e52e279299e9 skipped
-  always skipped
+  Always skipped
 [32m[PASS][0m  91a3c9030236 chdir
+  Path to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/91a3c9030236/unchecked
 [33m[PASS*][0m a3e1a604f579 masked
-  checked output: stdout
-Missing file(s) containing the expected output: Missing file "tests/snapshots/alcotest_ext_dummy_tests/a3e1a604f579/stdout"
+  Checked output: stdout
+  [31mMissing file(s) containing the expected output: Missing file "tests/snapshots/alcotest_ext_dummy_tests/a3e1a604f579/stdout"[0m
 
 [1mShort status[0m
 [33m[PASS*][0m d1a055429711 capture stdout
@@ -464,8 +553,8 @@ Missing file(s) containing the expected output: Missing file "tests/snapshots/al
 [33m[PASS*][0m 5deda5ac4212 capture stdxxx
 [33m[PASS*][0m 486ef3ce86ab capture stdout and stderr
 [33m[PASS*][0m a3e1a604f579 masked
-9/9 selected tests:
-  8 successful (7 pass, 1 xfail),
+11/11 selected tests:
+  10 successful (9 pass, 1 xfail),
   0 unsuccessful (0 fail, 0 xpass),
 1 new test
 5 tests whose output needs first-time approval

--- a/libs/alcotest_ext/tests/snapshots/alcotest_ext_meta_tests/fccf02a5c37e/stdxxx
+++ b/libs/alcotest_ext/tests/snapshots/alcotest_ext_meta_tests/fccf02a5c37e/stdxxx
@@ -138,7 +138,7 @@ This run has ID `<MASKED RUN ID>'.
           Re-raised at <MASKED>
           Called from <MASKED>
           Called from <MASKED>
-
+          
 Logs saved to `~/semgrep/libs/alcotest_ext/_build/_tests/test/85349a4a9157 U+005BxfailU+005D xfail.000.output'.
  ──────────────────────────────────────────────────────────────────────────────
 
@@ -497,7 +497,7 @@ This run has ID `<MASKED RUN ID>'.
           Re-raised at <MASKED>
           Called from <MASKED>
           Called from <MASKED>
-
+          
 Logs saved to `~/semgrep/libs/alcotest_ext/_build/_tests/test/85349a4a9157 U+005BxfailU+005D xfail.000.output'.
  ──────────────────────────────────────────────────────────────────────────────
 

--- a/libs/commons/Testutil_files.ml
+++ b/libs/commons/Testutil_files.ml
@@ -207,8 +207,13 @@ let with_tempfiles_verbose (files : t list) func =
       print_files files;
       write root files;
       (* Nice listing of the real file tree.
-         Don't care if the 'tree' command is unavailable. *)
-      USys.command (Printf.sprintf "tree -a '%s'" !!root) |> ignore;
+            old: Don't care if the 'tree' command is unavailable.
+            new: Having the same output on all platform matters because we
+            now compare the output of tests against expectations. The version
+            of 'tree' in CI seems to be ignoring '-a'.
+            TODO: remove permanently or implement our own version of 'tree'.
+         USys.command (Printf.sprintf "tree -a '%s'" !!root) |> ignore;
+      *)
       func root)
 
 let () =

--- a/libs/git_wrapper/Git_wrapper.ml
+++ b/libs/git_wrapper/Git_wrapper.ml
@@ -108,6 +108,12 @@ let cd (opt_cwd : Fpath.t option) : Cmd.args =
   | None -> []
   | Some path -> [ "-C"; !!path ]
 
+(* Convert an option to a list. Used to inject optional arguments. *)
+let opt (o : string option) : string list =
+  match o with
+  | None -> []
+  | Some str -> [ str ]
+
 (** Given some git diff ranges (see above), extract the range info *)
 let range_of_git_diff lines =
   let range_of_substrings substrings =
@@ -249,22 +255,21 @@ let run_with_worktree ~commit ?(branch = None) f =
   | Ok _ -> raise (Error ("Could not create git worktree for " ^ commit))
   | Error (`Msg e) -> raise (Error e)
 
-let status ~cwd ~commit =
+let status ?cwd ?commit () =
   let cmd =
     ( git,
-      [
-        "-C";
-        !!cwd;
-        "diff";
-        "--cached";
-        "--name-status";
-        "--no-ext-diff";
-        "-z";
-        "--diff-filter=ACDMRTUXB";
-        "--ignore-submodules";
-        "--relative";
-        commit;
-      ] )
+      cd cwd
+      @ [
+          "diff";
+          "--cached";
+          "--name-status";
+          "--no-ext-diff";
+          "-z";
+          "--diff-filter=ACDMRTUXB";
+          "--ignore-submodules";
+          "--relative";
+        ]
+      @ opt commit )
   in
   let stats =
     match UCmd.string_of_run ~trim:true cmd with
@@ -335,23 +340,27 @@ let status ~cwd ~commit =
     renamed = !renamed;
   }
 
-let is_git_repo cwd =
-  let cmd = (git, [ "-C"; !!cwd; "rev-parse"; "--is-inside-work-tree" ]) in
+let is_git_repo ?cwd () =
+  let cmd = (git, cd cwd @ [ "rev-parse"; "--is-inside-work-tree" ]) in
   match UCmd.status_of_run ~quiet:true cmd with
   | Ok (`Exited 0) -> true
   | Ok _ -> false
   | Error (`Msg e) -> raise (Error e)
 
-let dirty_lines_of_file ?(git_ref = "HEAD") file =
-  let cwd = Fpath.parent file in
+let dirty_lines_of_file ?cwd ?(git_ref = "HEAD") file =
+  let cwd =
+    match cwd with
+    | None -> Some (Fpath.parent file)
+    | Some _ -> cwd
+  in
   let cmd =
     (* --error-unmatch Returns a non 0 exit code if a file is not tracked by git. This way further on in this function we don't try running git diff on untracked files, as this isn't allowed. *)
-    (git, [ "-C"; !!cwd; "ls-files"; "--error-unmatch"; !!file ])
+    (git, cd cwd @ [ "ls-files"; "--error-unmatch"; !!file ])
   in
   match (UCmd.status_of_run ~quiet:true cmd, git_ref = "HEAD") with
   | _, false
   | Ok (`Exited 0), _ ->
-      let cmd = (git, [ "-C"; !!cwd; "diff"; "-U0"; git_ref; !!file ]) in
+      let cmd = (git, cd cwd @ [ "diff"; "-U0"; git_ref; !!file ]) in
       let lines =
         match UCmd.string_of_run ~trim:true cmd with
         | Ok (lines, (_, `Exited 1))
@@ -364,17 +373,21 @@ let dirty_lines_of_file ?(git_ref = "HEAD") file =
   | Ok _, _ -> None
   | Error (`Msg e), _ -> raise (Error e)
 
-let is_tracked_by_git file =
-  let cwd = Fpath.parent file in
-  let cmd = (git, [ "-C"; !!cwd; "ls-files"; "--error-unmatch"; !!file ]) in
+let is_tracked_by_git ?cwd file =
+  let cwd =
+    match cwd with
+    | None -> Some (Fpath.parent file)
+    | Some _ -> cwd
+  in
+  let cmd = (git, cd cwd @ [ "ls-files"; "--error-unmatch"; !!file ]) in
   match UCmd.status_of_run ~quiet:true cmd with
   | Ok (`Exited 0) -> true
   | Ok _ -> false
   | Error (`Msg e) -> raise (Error e)
 
-let dirty_files cwd =
+let dirty_files ?cwd () =
   let cmd =
-    (git, [ "-C"; !!cwd; "status"; "--porcelain"; "--ignore-submodules" ])
+    (git, cd cwd @ [ "status"; "--porcelain"; "--ignore-submodules" ])
   in
   let lines =
     match UCmd.lines_of_run ~trim:false cmd with
@@ -386,22 +399,21 @@ let dirty_files cwd =
   let files = List_.map (fun l -> Fpath.v (Str.string_after l 3)) files in
   files
 
-let init cwd =
-  let cmd = (git, [ "-C"; !!cwd; "init" ]) in
+let init ?cwd () =
+  let cmd = (git, cd cwd @ [ "init" ]) in
   match UCmd.status_of_run cmd with
   | Ok (`Exited 0) -> ()
   | _ -> raise (Error "Error running git init")
 
-let add cwd files =
+let add ?cwd files =
   let files = List_.map Fpath.to_string files in
-  let files = String.concat " " files in
-  let cmd = (git, [ "-C"; !!cwd; "add"; files ]) in
+  let cmd = (git, cd cwd @ [ "add" ] @ files) in
   match UCmd.status_of_run cmd with
   | Ok (`Exited 0) -> ()
   | _ -> raise (Error "Error running git add")
 
-let commit cwd msg =
-  let cmd = (git, [ "-C"; !!cwd; "commit"; "-m"; msg ]) in
+let commit ?cwd msg =
+  let cmd = (git, cd cwd @ [ "commit"; "-m"; msg ]) in
   match UCmd.status_of_run cmd with
   | Ok (`Exited 0) -> ()
   | Ok (`Exited i) ->
@@ -412,8 +424,8 @@ let commit cwd msg =
       raise (Error (Common.spf "Error running git commit: %s" s))
 
 (* TODO: should return Uri.t option *)
-let get_project_url () : string option =
-  let cmd = (git, [ "ls-remote"; "--get-url" ]) in
+let get_project_url ?cwd () : string option =
+  let cmd = (git, cd cwd @ [ "ls-remote"; "--get-url" ]) in
   match UCmd.string_of_run ~trim:true cmd with
   | Ok (url, _) -> Some url
   | Error _ ->
@@ -438,13 +450,13 @@ let time_to_str (timestamp : float) : string =
   Printf.sprintf "%04d-%02d-%02d" year month day
 
 (* TODO: should really return a JSON.t list at least *)
-let get_git_logs ?(since = None) () : string list =
+let get_git_logs ?cwd ?(since = None) () : string list =
   let cmd : Cmd.t =
     match since with
-    | None -> (git, [ "log"; git_log_json_format ])
+    | None -> (git, cd cwd @ [ "log"; git_log_json_format ])
     | Some time ->
         let after = spf "--after=\"%s\"" (time_to_str time) in
-        (git, [ "log"; after; git_log_json_format ])
+        (git, cd cwd @ [ "log"; after; git_log_json_format ])
   in
   let lines =
     match UCmd.lines_of_run ~trim:true cmd with

--- a/libs/git_wrapper/Git_wrapper.ml
+++ b/libs/git_wrapper/Git_wrapper.ml
@@ -399,8 +399,8 @@ let dirty_files ?cwd () =
   let files = List_.map (fun l -> Fpath.v (Str.string_after l 3)) files in
   files
 
-let init ?cwd () =
-  let cmd = (git, cd cwd @ [ "init" ]) in
+let init ?cwd ?(branch = "main") () =
+  let cmd = (git, cd cwd @ [ "init"; "-b"; branch ]) in
   match UCmd.status_of_run cmd with
   | Ok (`Exited 0) -> ()
   | _ -> raise (Error "Error running git init")

--- a/libs/git_wrapper/Git_wrapper.mli
+++ b/libs/git_wrapper/Git_wrapper.mli
@@ -98,8 +98,11 @@ val is_tracked_by_git : ?cwd:Fpath.t -> Fpath.t -> bool
 val dirty_files : ?cwd:Fpath.t -> unit -> Fpath.t list
 (** Returns a list of files that are dirty in a git repo *)
 
-val init : ?cwd:Fpath.t -> unit -> unit
-(** Initialize a git repo in the given directory *)
+val init : ?cwd:Fpath.t -> ?branch:string -> unit -> unit
+(** Initialize a git repo in the given directory.
+    The branch is set by default to 'main' to avoid warnings that depend
+    on the git version.
+*)
 
 val add : ?cwd:Fpath.t -> Fpath.t list -> unit
 (** Add the given files to the git repo *)

--- a/libs/git_wrapper/Git_wrapper.mli
+++ b/libs/git_wrapper/Git_wrapper.mli
@@ -68,10 +68,10 @@ type status = {
 [@@deriving show]
 
 (* git status *)
-val status : cwd:Fpath.t -> commit:string -> status
+val status : ?cwd:Fpath.t -> ?commit:string -> unit -> status
 
 (* precondition: cwd must be a directory *)
-val is_git_repo : Fpath.t -> bool
+val is_git_repo : ?cwd:Fpath.t -> unit -> bool
 (** Returns true if passed directory a git repo*)
 
 (* Find the root of the repository containing 'cwd', if any.
@@ -83,37 +83,38 @@ val get_project_root : ?cwd:Fpath.t -> unit -> Fpath.t option
 val get_superproject_root : ?cwd:Fpath.t -> unit -> Fpath.t option
 
 (* precondition: cwd must be a directory *)
-val dirty_lines_of_file : ?git_ref:string -> Fpath.t -> (int * int) array option
+val dirty_lines_of_file :
+  ?cwd:Fpath.t -> ?git_ref:string -> Fpath.t -> (int * int) array option
 (** [dirty_lines_of_file path] will return an optional array of line ranges that indicate what
   * lines have been changed. An optional [git_ref] can be passed that will be used
   * to diff against. The default [git_ref] is ["HEAD"]
   *)
 
 (* precondition: cwd must be a directory *)
-val is_tracked_by_git : Fpath.t -> bool
+val is_tracked_by_git : ?cwd:Fpath.t -> Fpath.t -> bool
 (** [is_tracked_by_git path] Returns true if the file is tracked by git *)
 
 (* precondition: cwd must be a directory *)
-val dirty_files : Fpath.t -> Fpath.t list
+val dirty_files : ?cwd:Fpath.t -> unit -> Fpath.t list
 (** Returns a list of files that are dirty in a git repo *)
 
-val init : Fpath.t -> unit
+val init : ?cwd:Fpath.t -> unit -> unit
 (** Initialize a git repo in the given directory *)
 
-val add : Fpath.t -> Fpath.t list -> unit
+val add : ?cwd:Fpath.t -> Fpath.t list -> unit
 (** Add the given files to the git repo *)
 
-val commit : Fpath.t -> string -> unit
+val commit : ?cwd:Fpath.t -> string -> unit
 (** Commit the given files to the git repo with the given message *)
 
-val get_project_url : unit -> string option
+val get_project_url : ?cwd:Fpath.t -> unit -> string option
 (** [get_project_url ()] tries to get the URL of the project from
     [git ls-remote] or from the [.git/config] file. It returns [None] if it
     found nothing relevant.
     TODO: should maybe raise an exn instead if not run from a git repo.
 *)
 
-val get_git_logs : ?since:float option -> unit -> string list
+val get_git_logs : ?cwd:Fpath.t -> ?since:float option -> unit -> string list
 (** [get_git_logs()] will run 'git log' in the current directory
     and returns for each log a JSON string that fits the schema
     defined in semgrep_output_v1.atd contribution type.

--- a/scripts/run-core-test
+++ b/scripts/run-core-test
@@ -33,3 +33,7 @@ if ! dune runtest -f --no-buffer src/osemgrep; then
   echo -e "\n${RED}If expectation tests have failed, run \`dune promote\` to apply the corresponding diff.${NC}\n\n"
   exit 1
 fi
+
+# Alcotest_ext has its own test program because it's planned to become
+# a separate project.
+make -C libs/alcotest_ext test

--- a/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -515,7 +515,7 @@ let run_scan_files (_caps : < Cap.stdout >) (conf : Scan_CLI.conf)
           (* diff scan mode *)
           Metrics_.g.payload.environment.isDiffScan <- true;
           let commit = Git_wrapper.get_merge_base baseline_commit in
-          let status = Git_wrapper.status ~cwd:(Fpath.v ".") ~commit in
+          let status = Git_wrapper.status ~cwd:(Fpath.v ".") ~commit () in
           let diff_depth = Differential_scan_config.default_depth in
           let targets, diff_targets =
             let added_or_modified =

--- a/src/osemgrep/language_server/Unit_LS.ml
+++ b/src/osemgrep/language_server/Unit_LS.ml
@@ -15,7 +15,7 @@ let checked_command cmd =
   | _ -> failwith (Common.spf "Error running cmd: %s" (Bos.Cmd.to_string cmd))
 
 let setup_git workspace =
-  Git_wrapper.init workspace;
+  Git_wrapper.init ~cwd:workspace ();
   checked_command
     Bos.Cmd.(
       v "git" % "-C" % Fpath.to_string workspace % "config" % "user.email"
@@ -116,8 +116,8 @@ let add_file ?(git = false) ?(dirty = false)
   let oc = open_out_bin file in
   output_string oc content;
   close_out oc;
-  if git then Git_wrapper.add workspace [ Fpath.v file ];
-  if (not dirty) && git then Git_wrapper.commit workspace "test";
+  if git then Git_wrapper.add ~cwd:workspace [ Fpath.v file ];
+  if (not dirty) && git then Git_wrapper.commit ~cwd:workspace "test";
   file
 
 let with_mock_envvars f () =

--- a/src/osemgrep/language_server/scan_helpers/Processed_run.ml
+++ b/src/osemgrep/language_server/scan_helpers/Processed_run.ml
@@ -32,7 +32,8 @@ let filter_clean_lines git_ref matches =
     matches_by_file
     |> List.partition (fun (f, _) ->
            let parent = Fpath.parent f in
-           (Git_wrapper.is_tracked_by_git f && Git_wrapper.is_git_repo parent)
+           Git_wrapper.is_tracked_by_git f
+           && Git_wrapper.is_git_repo ~cwd:parent ()
            || Option.is_some git_ref)
     (* If the git_ref is set here, we might be comparing a tracked file
        with some sort of temporary file *)

--- a/src/osemgrep/language_server/server/Session.ml
+++ b/src/osemgrep/language_server/server/Session.ml
@@ -60,9 +60,9 @@ let create capabilities =
   }
 
 let dirty_files_of_folder folder =
-  let git_repo = Git_wrapper.is_git_repo folder in
+  let git_repo = Git_wrapper.is_git_repo ~cwd:folder () in
   if git_repo then
-    let dirty_files = Git_wrapper.dirty_files folder in
+    let dirty_files = Git_wrapper.dirty_files ~cwd:folder () in
     Some (List_.map (fun x -> folder // x) dirty_files)
   else None
 

--- a/src/osemgrep/tests/Osemgrep_tests.ml
+++ b/src/osemgrep/tests/Osemgrep_tests.ml
@@ -1,0 +1,7 @@
+(*
+   Osemgrep end-to-end tests.
+*)
+
+let tests caps =
+  Alcotest_ext.pack_suites "OSemgrep end-to-end"
+    [ Test_osemgrep.tests caps; Test_target_selection.tests ]

--- a/src/osemgrep/tests/Osemgrep_tests.mli
+++ b/src/osemgrep/tests/Osemgrep_tests.mli
@@ -1,0 +1,5 @@
+(*
+   Osemgrep end-to-end tests.
+*)
+
+val tests : Cap.all_caps -> Alcotest_ext.test list

--- a/src/osemgrep/tests/Test_osemgrep.ml
+++ b/src/osemgrep/tests/Test_osemgrep.ml
@@ -103,8 +103,9 @@ let test_scan_config_registry_with_invalid_token caps : Alcotest_ext.test =
 
 let tests caps =
   Alcotest_ext.pack_tests_pro "Osemgrep (e2e)"
-    [
-      test_scan_config_registry_no_token caps;
-      test_scan_config_registry_with_invalid_token
-        (caps :> < Cap.stdout ; Cap.network >);
-    ]
+    ([
+       test_scan_config_registry_no_token caps;
+       test_scan_config_registry_with_invalid_token
+         (caps :> < Cap.stdout ; Cap.network >);
+     ]
+    @ Test_target_selection.tests)

--- a/src/osemgrep/tests/Test_osemgrep.ml
+++ b/src/osemgrep/tests/Test_osemgrep.ml
@@ -103,9 +103,8 @@ let test_scan_config_registry_with_invalid_token caps : Alcotest_ext.test =
 
 let tests caps =
   Alcotest_ext.pack_tests_pro "Osemgrep (e2e)"
-    ([
-       test_scan_config_registry_no_token caps;
-       test_scan_config_registry_with_invalid_token
-         (caps :> < Cap.stdout ; Cap.network >);
-     ]
-    @ Test_target_selection.tests)
+    [
+      test_scan_config_registry_no_token caps;
+      test_scan_config_registry_with_invalid_token
+        (caps :> < Cap.stdout ; Cap.network >);
+    ]

--- a/src/osemgrep/tests/Test_target_selection.ml
+++ b/src/osemgrep/tests/Test_target_selection.ml
@@ -1,0 +1,46 @@
+(*
+   Test target selection on git repos with osemgrep.
+*)
+
+module T = Alcotest_ext
+
+let with_git_repo (files : Testutil_files.t list) func =
+  Testutil_files.with_tempfiles_verbose files (fun path ->
+      Testutil_files.with_chdir path (fun () ->
+          Git_wrapper.init ();
+          Git_wrapper.add [ Fpath.v "." ];
+          Git_wrapper.commit "Add all the files";
+          func ()))
+
+let osemgrep_ls () =
+  (* TODO: see/reuse what's being done in Test_osemgrep.ml *)
+  ()
+
+let repos : (string * Testutil_files.t list) list =
+  let open Testutil_files in
+  [
+    ( "simple-semgrepignore",
+      [
+        file "a";
+        file "b";
+        file "c";
+        File (".gitignore", "a\n");
+        File (".semgrepignore", "b\n");
+      ] );
+    ("no-semgrepignore", [ file "a"; File (".gitignore", "a\n") ]);
+  ]
+
+let tests =
+  repos
+  |> List_.map (fun (repo_name, (files : Testutil_files.t list)) ->
+         T.create
+           ~category:[ "target selection on real git repos" ]
+           ~output_kind:Stdout
+           ~mask_output:
+             [
+               T.mask_line ~after:"Initialized empty Git repository in" ();
+               T.mask_line ~after:"[main (root-commit) " ~before:"]" ();
+               T.mask_pcre_pattern "/test-[a-f0-9]+";
+             ]
+           repo_name
+           (fun () -> with_git_repo files osemgrep_ls))

--- a/src/osemgrep/tests/Test_target_selection.mli
+++ b/src/osemgrep/tests/Test_target_selection.mli
@@ -1,0 +1,5 @@
+(*
+   Test Osemgrep's target selection on real git (or other) repos.
+*)
+
+val tests : Alcotest_ext.test list

--- a/src/osemgrep/tests/dune
+++ b/src/osemgrep/tests/dune
@@ -1,7 +1,6 @@
 (library
   (public_name semgrep.osemgrep_tests)
   (name osemgrep_tests)
-  (wrapped false)
   (libraries
     commons
 

--- a/src/tests/Test.ml
+++ b/src/tests/Test.ml
@@ -69,7 +69,7 @@ let tests (caps : Cap.all_caps) =
       Unit_Fetching.tests (caps :> < Cap.network >);
       Test_login_subcommand.tests (caps :> < Cap.stdout ; Cap.network >);
       Test_publish_subcommand.tests (caps :> < Cap.stdout ; Cap.network >);
-      Test_osemgrep.tests caps;
+      Osemgrep_tests.tests caps;
       (* Networking tests disabled as they will get rate limited sometimes *)
       (* And the SSL issues they've been testing have been stable *)
       (*Unit_Networking.tests;*)

--- a/tests/snapshots/semgrep-core/32f4d7e519a5/stdout
+++ b/tests/snapshots/semgrep-core/32f4d7e519a5/stdout
@@ -1,0 +1,12 @@
+/tmp<MASKED>
+├── a
+└── .gitignore
+
+0 directories, 2 files
+Initialized empty Git repository in<MASKED>
+[main (root-commit) <MASKED>] Add all the files
+ 1 file changed, 1 insertion(+)
+ create mode 100644 .gitignore
+Input files:
+.gitignore
+a

--- a/tests/snapshots/semgrep-core/32f4d7e519a5/stdout
+++ b/tests/snapshots/semgrep-core/32f4d7e519a5/stdout
@@ -1,8 +1,3 @@
-/tmp<MASKED>
-├── a
-└── .gitignore
-
-0 directories, 2 files
 Initialized empty Git repository in<MASKED>
 [main (root-commit) <MASKED>] Add all the files
  1 file changed, 1 insertion(+)

--- a/tests/snapshots/semgrep-core/4d29498cab9a/stdout
+++ b/tests/snapshots/semgrep-core/4d29498cab9a/stdout
@@ -1,0 +1,21 @@
+/tmp<MASKED>
+├── a
+├── b
+├── c
+├── .gitignore
+└── .semgrepignore
+
+0 directories, 5 files
+Initialized empty Git repository in<MASKED>
+[main (root-commit) <MASKED>] Add all the files
+ 4 files changed, 2 insertions(+)
+ create mode 100644 .gitignore
+ create mode 100644 .semgrepignore
+ create mode 100644 b
+ create mode 100644 c
+Input files:
+.gitignore
+.semgrepignore
+a
+b
+c

--- a/tests/snapshots/semgrep-core/4d29498cab9a/stdout
+++ b/tests/snapshots/semgrep-core/4d29498cab9a/stdout
@@ -1,11 +1,3 @@
-/tmp<MASKED>
-├── a
-├── b
-├── c
-├── .gitignore
-└── .semgrepignore
-
-0 directories, 5 files
 Initialized empty Git repository in<MASKED>
 [main (root-commit) <MASKED>] Add all the files
  4 files changed, 2 insertions(+)


### PR DESCRIPTION
This branch adds several important improvements to alcotest_ext. This includes:
* show the output of failed tests at the end of the alcotest_ext output (`run` and `status` subcommands)
* optionally show the output of all tests (`run` and `status` subcommands)

I added a test suite that fails and whose output gets checked by the meta test suite. To preview the effect of failed tests, go to `libs/alcotest_ext`, run `make` and then run `./failing-test`. `make test` runs the meta test suite which is more complicated to interpret.
