### PR TITLE
Fix release.jsonnet docker-tags strings

### DIFF
--- a/.github/workflows/release.jsonnet
+++ b/.github/workflows/release.jsonnet
@@ -5,7 +5,6 @@
 //  - prepare and upload to PyPy a new semgrep package
 //  - make a PR for homebrew's formula to update to the latest semgrep
 
-// TODO: remove the \n
 // TODO: use semgrep.github_bot.token instead of ref to step each time
 // TODO: factorize more, use reference and local instead of duplicating strings
 // TODO: remove some useless name:
@@ -59,6 +58,17 @@ local inputs_job = {
 // Docker jobs
 // ----------------------------------------------------------------------------
 
+// TODO: those are comments for the docker-tags below. Not sure
+// why but if we put those comments directly in the ||| |||
+// then the job does not work.
+//
+// # tag image with "canary"
+// type=raw,value=canary
+// # tag image with full version (ex. "1.2.3")
+// type=semver,pattern={{version}}
+// # tag image with major.minor (ex. "1.2")
+// type=semver,pattern={{major}}.{{minor}}
+
 local build_test_docker_job = {
   uses: './.github/workflows/build-test-docker.yaml',
   secrets: 'inherit',
@@ -69,11 +79,8 @@ local build_test_docker_job = {
     // don't add a "latest" tag (we'll promote "canary" to "latest" after testing)
     'docker-flavor': 'latest=false',
     'docker-tags': |||
-      # tag image with "canary"
       type=raw,value=canary
-      # tag image with full version (ex. "1.2.3")
       type=semver,pattern={{version}}
-      # tag image with major.minor (ex. "1.2")
       type=semver,pattern={{major}}.{{minor}}
     |||,
     'repository-name': 'returntocorp/semgrep',
@@ -83,6 +90,18 @@ local build_test_docker_job = {
     'enable-tests': true,
   },
 };
+
+// # suffix all tags with "-nonroot"
+// suffix=-nonroot
+// # don't add a "latest-nonroot" tag (we'll promote "canary-nonroot" to "latest-nonroot" after testing)
+// latest=false
+
+// # tag image with "canary-nonroot"
+// type=raw,value=canary
+// # tag image with full version (ex. "1.2.3-nonroot")
+// type=semver,pattern={{version}}
+// # tag image with major.minor version (ex. "1.2-nonroot")
+// type=semver,pattern={{major}}.{{minor}}
 
 local build_test_docker_nonroot_job = {
   uses: './.github/workflows/build-test-docker.yaml',
@@ -96,17 +115,12 @@ local build_test_docker_nonroot_job = {
   ],
   with: {
     'docker-flavor': |||
-      # suffix all tags with "-nonroot"
       suffix=-nonroot
-      # don't add a "latest-nonroot" tag (we'll promote "canary-nonroot" to "latest-nonroot" after testing)
       latest=false
     |||,
     'docker-tags': |||
-      # tag image with "canary-nonroot"
       type=raw,value=canary
-      # tag image with full version (ex. "1.2.3-nonroot")
       type=semver,pattern={{version}}
-      # tag image with major.minor version (ex. "1.2-nonroot")
       type=semver,pattern={{major}}.{{minor}}
     |||,
     'repository-name': 'returntocorp/semgrep',

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,10 +78,8 @@ jobs:
     - inputs
     with:
       docker-flavor: latest=false
-      docker-tags: "\n      # tag image with \"canary\"\n      type=raw,value=canary\n
-        \     # tag image with full version (ex. \"1.2.3\")\n      type=semver,pattern={{version}}\n
-        \     # tag image with major.minor (ex. \"1.2\")\n      type=semver,pattern={{major}}.{{minor}}\n
-        \   "
+      docker-tags: "\n      type=raw,value=canary\n      type=semver,pattern={{version}}\n
+        \     type=semver,pattern={{major}}.{{minor}}\n    "
       repository-name: returntocorp/semgrep
       artifact-name: image-release
       file: Dockerfile
@@ -94,13 +92,9 @@ jobs:
     - inputs
     - build-test-docker
     with:
-      docker-flavor: "\n      # suffix all tags with \"-nonroot\"\n      suffix=-nonroot\n
-        \     # don't add a \"latest-nonroot\" tag (we'll promote \"canary-nonroot\"
-        to \"latest-nonroot\" after testing)\n      latest=false\n    "
-      docker-tags: "\n      # tag image with \"canary-nonroot\"\n      type=raw,value=canary\n
-        \     # tag image with full version (ex. \"1.2.3-nonroot\")\n      type=semver,pattern={{version}}\n
-        \     # tag image with major.minor version (ex. \"1.2-nonroot\")\n      type=semver,pattern={{major}}.{{minor}}\n
-        \   "
+      docker-flavor: "\n      suffix=-nonroot\n      latest=false\n    "
+      docker-tags: "\n      type=raw,value=canary\n      type=semver,pattern={{version}}\n
+        \     type=semver,pattern={{major}}.{{minor}}\n    "
       repository-name: returntocorp/semgrep
       artifact-name: image-release-nonroot
       file: Dockerfile


### PR DESCRIPTION
Removed the comments which seem to interfer with the execution.
See the failure in
https://github.com/semgrep/semgrep/actions/runs/7285106314/job/19851483716

test plan:
trigger the release manually from this branch in dry-run and check
whether build-test-docker now succeed