### PR TITLE
tainting: Check expressions occurring inside types

### DIFF
--- a/changelog.d/pa-3313.fixed
+++ b/changelog.d/pa-3313.fixed
@@ -1,0 +1,11 @@
+taint-mode: Semgrep was missing some sources occurring inside type expressions,
+for example:
+
+```cpp
+char *p = new char[source(x)];
+sink(x);
+```
+
+Now, if `x` is tainted by side-effect, Semgrep will check `x` inside the type
+expression `char[...]` and record it as tainting, and generate a finding for
+`sink(x)`.

--- a/src/il/Display_IL.ml
+++ b/src/il/Display_IL.ml
@@ -1,7 +1,7 @@
 open IL
 
-let string_of_type (ty : IL.type_) =
-  match ty.type_.t with
+let string_of_type (ty : G.type_) =
+  match ty.t with
   | TyN (Id (id, _)) -> fst id
   | __else__ -> "<TYPE>"
 

--- a/src/il/IL.ml
+++ b/src/il/IL.ml
@@ -252,22 +252,6 @@ and 'a argument = Unnamed of 'a | Named of ident * 'a
 [@@deriving show { with_path = false }]
 
 (*****************************************************************************)
-(* Types *)
-(*****************************************************************************)
-
-(* THINK: Types contain expressions that we want to check (see e.g. 'TyExpr'), but
- * right now we don't need/want to duplicate the type 'type_' just for this
- * (perhaps we could parameterize it?). *)
-type type_ = {
-  type_ : G.type_;
-  exps : exp list;
-      (* IL translation of the expressions in `type_`, we want to check them because
-       * these could be sinks! E.g. in PHP you can have `new $cons(args)` and the
-       * constructor $cons could be a sink. See 'tests/rules/misc_php_new_taint.php'. *)
-}
-[@@deriving show { with_path = false }]
-
-(*****************************************************************************)
 (* Instruction *)
 (*****************************************************************************)
 
@@ -282,7 +266,7 @@ and instr_kind =
   | AssignAnon of lval * anonymous_entity
   | Call of lval option * exp (* less: enforce lval? *) * exp argument list
   | CallSpecial of lval option * call_special wrap * exp argument list
-  | New of lval * type_ * exp option (* constructor *) * exp argument list
+  | New of lval * G.type_ * exp option (* constructor *) * exp argument list
   (* todo: PhiSSA! *)
   | FixmeInstr of fixme_kind * G.any
 

--- a/src/tainting/Dataflow_tainting.ml
+++ b/src/tainting/Dataflow_tainting.ml
@@ -1591,10 +1591,11 @@ let check_tainted_instr env instr : Taints.t * Lval_env.t =
         with
         | Some (call_taints, lval_env) -> (call_taints, lval_env)
         | None -> (all_args_taints, lval_env))
-    | New (_, ty, None, args) ->
+    | New (_lval, _ty, None, args) ->
         (* 'New' without reference to constructor *)
-        let exps = ty.exps @ (args |> List_.map IL_helpers.exp_of_arg) in
-        exps |> union_map_taints_and_vars env check_expr
+        args
+        |> List_.map IL_helpers.exp_of_arg
+        |> union_map_taints_and_vars env check_expr
     | CallSpecial (_, _, args) ->
         let _, taints, lval_env = check_function_call_arguments env args in
         let taints =

--- a/src/tainting/Taint_smatch.ml
+++ b/src/tainting/Taint_smatch.ml
@@ -149,11 +149,7 @@ let top_level_matches_in_nodes ~matches_of_orig flow =
                Seq.cons instr.iorig
                  (match instr.i with
                  | Call (_, c, args) -> Seq.cons c.eorig (origs_of_args args)
-                 | New (_, ty, _, args) ->
-                     let ty_origs =
-                       ty.exps |> List.to_seq |> Seq.map (fun e -> e.IL.eorig)
-                     in
-                     Seq.append ty_origs (origs_of_args args)
+                 | New (_, _, _, args) -> origs_of_args args
                  | CallSpecial (_, _, args) -> origs_of_args args
                  | Assign (_, e) -> List.to_seq [ e.eorig ]
                  | AssignAnon _

--- a/tests/rules/taint_expr_in_type.cpp
+++ b/tests/rules/taint_expr_in_type.cpp
@@ -1,0 +1,7 @@
+char* test() {
+  auto x;
+  char *p = new char[source(x)];
+  // ruleid: test
+  sink(x);
+  return p;
+}

--- a/tests/rules/taint_expr_in_type.yaml
+++ b/tests/rules/taint_expr_in_type.yaml
@@ -1,0 +1,20 @@
+rules:
+  - id: test
+    languages:
+      - cpp
+    message: Test
+    mode: taint
+    pattern-sources:
+      - by-side-effect: true
+        patterns:
+          - patterns:
+              - pattern: |
+                  source($SRC)
+              - focus-metavariable: $SRC
+    pattern-sinks:
+      - patterns:
+          - pattern: |
+              sink($SINK)
+          - focus-metavariable: $SINK
+    severity: ERROR
+

--- a/tests/rules/taint_expr_in_type_labels.cpp
+++ b/tests/rules/taint_expr_in_type_labels.cpp
@@ -1,0 +1,13 @@
+char* ok() {
+  auto ev = tainted();
+  char *p = new char[strlen(ev->parameter)];
+  // ok: test
+  sink(ev->parameter);
+  return p;
+}
+
+void bad() {
+  auto ev = tainted();
+  // ruleid: test
+  sink(ev->parameter);
+}

--- a/tests/rules/taint_expr_in_type_labels.yaml
+++ b/tests/rules/taint_expr_in_type_labels.yaml
@@ -1,0 +1,23 @@
+rules:
+  - id: test
+    languages:
+      - cpp
+    message: Test
+    mode: taint
+    pattern-sinks:
+      - patterns:
+          - pattern: |
+              sink($SINK)
+          - focus-metavariable: $SINK
+        requires: USER_CONTROLLED and not SANITIZED
+    pattern-sources:
+      - label: USER_CONTROLLED
+        pattern: |
+          tainted(...)
+      - by-side-effect: true
+        label: SANITIZED
+        patterns:
+          - pattern: |
+              strlen(..., $STR, ...)
+          - focus-metavariable: $STR
+    severity: ERROR


### PR DESCRIPTION
We were checking them in some cases but not in others, we now try to check them in virtually all cases.

Closes PA-3313

test plan:
make test # two new tests

