### PR TITLE
tainting: C/C++: Correctly check taint for ptr->fld l-values

### DIFF
--- a/changelog.d/pa-3328.fixed
+++ b/changelog.d/pa-3328.fixed
@@ -1,3 +1,3 @@
 taint-mode: C/C++: Sanitization by side-effect was not working correctly for
-`ptr->fld` l-values. In particular, if `x` is tainted, and then `ptr->fld` is
-sanitized, then now Semgrep will correctly consider `ptr->fld` as clean.
+`ptr->fld` l-values. In particular, if `ptr` is tainted, and then `ptr->fld` is
+sanitized, Semgrep will now correctly consider `ptr->fld` as clean.

--- a/changelog.d/pa-3328.fixed
+++ b/changelog.d/pa-3328.fixed
@@ -1,0 +1,3 @@
+taint-mode: C/C++: Sanitization by side-effect was not working correctly for
+`ptr->fld` l-values. In particular, if `x` is tainted, and then `ptr->fld` is
+sanitized, then now Semgrep will correctly consider `ptr->fld` as clean.

--- a/src/tainting/Dataflow_tainting.ml
+++ b/src/tainting/Dataflow_tainting.ml
@@ -1093,7 +1093,9 @@ and check_tainted_lval_base env base =
   | Var _
   | VarSpecial _ ->
       (Taints.empty, `None, env.lval_env)
-  | Mem { e = Fetch lval; _ } -> check_tainted_lval_aux env lval
+  | Mem { e = Fetch lval; _ } ->
+      (* i.e. `*ptr` *)
+      check_tainted_lval_aux env lval
   | Mem e ->
       let taints, lval_env = check_tainted_expr env e in
       (taints, `None, lval_env)

--- a/src/tainting/Dataflow_tainting.ml
+++ b/src/tainting/Dataflow_tainting.ml
@@ -1007,8 +1007,7 @@ and check_tainted_lval_aux env (lval : IL.lval) :
         match lval with
         | { base; rev_offset = [] } ->
             (* Base case, no offset. *)
-            let taints, lval_env = check_tainted_lval_base env base in
-            (taints, `None, lval_env)
+            check_tainted_lval_base env base
         | { base = _; rev_offset = _ :: rev_offset' } ->
             (* Recursive case, given `x.a.b` we must first check `x.a`. *)
             check_tainted_lval_aux env { lval with rev_offset = rev_offset' }
@@ -1093,10 +1092,11 @@ and check_tainted_lval_base env base =
   match base with
   | Var _
   | VarSpecial _ ->
-      (Taints.empty, env.lval_env)
+      (Taints.empty, `None, env.lval_env)
+  | Mem { e = Fetch lval; _ } -> check_tainted_lval_aux env lval
   | Mem e ->
       let taints, lval_env = check_tainted_expr env e in
-      (taints, lval_env)
+      (taints, `None, lval_env)
 
 and check_tainted_lval_offset env offset =
   match offset.o with

--- a/tests/rules/taint_cpp_ptr_field1.cpp
+++ b/tests/rules/taint_cpp_ptr_field1.cpp
@@ -1,0 +1,12 @@
+void ok() {
+  auto x = tainted();
+  clean(x->parameter);
+  // ok: test
+  sink(x->parameter);
+}
+
+void bad() {
+  auto x = tainted();
+  // ruleid: test
+  sink(x->parameter);
+}

--- a/tests/rules/taint_cpp_ptr_field1.yaml
+++ b/tests/rules/taint_cpp_ptr_field1.yaml
@@ -1,0 +1,19 @@
+rules:
+  - id: test
+    languages:
+      - cpp
+    message: Test
+    severity: ERROR
+    mode: taint
+    pattern-sources:
+      - pattern: tainted(...)
+    pattern-sanitizers:
+      - by-side-effect: true
+        patterns:
+          - patterns:
+              - pattern: clean($SRC)
+              - focus-metavariable: $SRC
+    pattern-sinks:
+      - patterns:
+          - pattern: sink($SINK)
+          - focus-metavariable: $SINK


### PR DESCRIPTION
We handle `ptr->fld` as `(*ptr).fld`, and we were not correctly checking the taint of an l-value when the base was of the form `*ptr`. If `ptr` was tainted, but `ptr->fld` had been cleaned, we still considered that the taint of `ptr` made `ptr->fld` tainted too, like if the taint in `ptr` came directly from a source match at the very same occurrence, rather than from the environment. (We used `check_tainted_expr` to check `ptr` which merges all taints, rather than `check_tainted_lval` which separates taints from new matches and taints from the environment.)

Follows: c57b8c07137 ("C/C++: tainting: Track `this->xyz` l-values (#8968)")
Closes PA-3328

test plan:
make test

