### PR TITLE
Update precommit to use more recent semgrep

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -201,7 +201,7 @@ repos:
   # Dogfood! running semgrep in pre-commit!
   # ----------------------------------------------------------
   - repo: https://github.com/returntocorp/semgrep
-    rev: v1.51.0
+    rev: v1.54.0
     hooks:
       - id: semgrep
         name: Semgrep Jsonnet

--- a/TCB/forbid_everything.jsonnet
+++ b/TCB/forbid_everything.jsonnet
@@ -1,0 +1,12 @@
+// Rules to enforce the use of the TCB and forbid the use of the standard
+// library or any non-vetted external libraries.
+//
+// related work:
+//  - ppx_base_lint
+
+local forbid_exit = import 'forbid_exit.jsonnet';
+local forbid_network = import 'forbid_network.jsonnet';
+local forbid_exec = import 'forbid_exec.jsonnet';
+//TODO: forbid_fs, forbid_process, etc.
+
+{ rules: forbid_exit.rules + forbid_network.rules + forbid_exec.rules }

--- a/TCB/forbid_exec.jsonnet
+++ b/TCB/forbid_exec.jsonnet
@@ -1,25 +1,25 @@
+// helpers
+local unix_funcs = [
+  'system',
+  'execv',
+  'execve',
+  'execvp',
+  'execvpe',
+  'create_process',
+  'create_process_env',
+  'open_process_in',
+  'open_process_out',
+  'open_process',
+  'open_process_full',
+  'open_process_args_in',
+  'open_process_args_out',
+  'open_process_args',
+  'open_process_args_full',
+];
+
 // The rule
 {
   rules: [
-    // helpers
-    // TODO: move this at the toplevel, but ojsonnet bug!
-    local unix_funcs = [
-      'system',
-      'execv',
-      'execve',
-      'execvp',
-      'execvpe',
-      'create_process',
-      'create_process_env',
-      'open_process_in',
-      'open_process_out',
-      'open_process',
-      'open_process_full',
-      'open_process_args_in',
-      'open_process_args_out',
-      'open_process_args',
-      'open_process_args_full',
-    ];
     {
       id: 'forbid-exec',
       match: {
@@ -51,5 +51,4 @@
       |||,
     },
   ],
-
 }

--- a/TCB/forbid_network.jsonnet
+++ b/TCB/forbid_network.jsonnet
@@ -1,15 +1,15 @@
+local unix_funcs_network = [
+  'socket',
+  'socketpair',
+  'accept',
+  'bind',
+  'connect',
+  'listen',
+  'establish_server',
+];
+
 {
   rules: [
-    // TODO: move this at the toplevel, but ojsonnet bug!
-    local unix_funcs_network = [
-      'socket',
-      'socketpair',
-      'accept',
-      'bind',
-      'connect',
-      'listen',
-      'establish_server',
-    ];
     {
       id: 'forbid-network',
       match: {

--- a/TCB/semgrep_TCB.jsonnet
+++ b/TCB/semgrep_TCB.jsonnet
@@ -1,6 +1,0 @@
-// Rules to enforce the use of the TCB and forbid the use of the standard
-// library or any non-vetted external libraries
-// related work:
-//  - ppx_base_lint
-
-// TODO: a lot

--- a/semgrep.jsonnet
+++ b/semgrep.jsonnet
@@ -89,12 +89,7 @@ local semgrep_rules = [
 // ----------------------------------------------------------------------------
 // TCB rules
 // ----------------------------------------------------------------------------
-
-local forbid_exit = import 'TCB/forbid_exit.jsonnet';
-local forbid_network = import 'TCB/forbid_network.jsonnet';
-local forbid_exec = import 'TCB/forbid_exec.jsonnet';
-
-local tcb_rules = forbid_exit.rules + forbid_network.rules + forbid_exec.rules;
+local tcb = import "TCB/forbid_everything.jsonnet";
 
 // ----------------------------------------------------------------------------
 // Skip and last-minute override
@@ -129,7 +124,7 @@ local override_messages = {
 // Entry point
 // ----------------------------------------------------------------------------
 
-local all = yml.rules + semgrep_rules + ocaml_rules + tcb_rules;
+local all = yml.rules + semgrep_rules + ocaml_rules + tcb.rules;
 
 {
   rules:


### PR DESCRIPTION
We need at least 1.54.0 to get the recent improvements
in ojsonnet that don't raise lookup errors.

test plan:
pre-commit run -a