### PR TITLE
Don't hardcode temporary folder as "/tmp"

### DIFF
--- a/changelog.d/gh-9534.fixed
+++ b/changelog.d/gh-9534.fixed
@@ -1,0 +1,3 @@
+Honor temporary folder specified via the TMPDIR environment variable (or
+equivalent on Windows) in some instances where it used to be hardcoded as
+`/tmp`.

--- a/cli/src/semgrep/core_runner.py
+++ b/cli/src/semgrep/core_runner.py
@@ -435,7 +435,7 @@ class StreamingSemgrepCore:
 
         Blocks til completion and returns exit code
         """
-        open_and_ignore("/tmp/core-runner-semgrep-BEGIN")
+        open_and_ignore(f"{tempfile.gettempdir()}/core-runner-semgrep-BEGIN")
 
         terminal = get_state().terminal
         with Progress(
@@ -460,7 +460,7 @@ class StreamingSemgrepCore:
 
             rc = asyncio.run(self._stream_exec_subprocess())
 
-        open_and_ignore("/tmp/core-runner-semgrep-END")
+        open_and_ignore(f"{tempfile.gettempdir()}/core-runner-semgrep-END")
         return rc
 
 


### PR DESCRIPTION
This affects two lock files, so it shouldn't solve any storage issues but it's cleaner.

See https://linear.app/semgrep/issue/PA-3329/semgrep-uses-tmp-even-with-tmpdir