### PR TITLE
Fix release.jsonnet after 1.55.0 failure

### DIFF
--- a/.github/workflows/release.jsonnet
+++ b/.github/workflows/release.jsonnet
@@ -15,6 +15,12 @@ local actions = import 'libs/actions.libsonnet';
 // ----------------------------------------------------------------------------
 local version = "${{ steps.get-version.outputs.VERSION }}";
 
+local get_version_step = {
+  name: 'Get the version',
+  id: 'get-version',
+  run: 'echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT',
+};
+
 // ----------------------------------------------------------------------------
 // Input
 // ----------------------------------------------------------------------------
@@ -299,12 +305,9 @@ local create_release_job = {
     'inputs',
   ],
   steps: [
-    {
-      name: 'Get the version',
-      id: 'get-version',
-      run: 'echo "VERSION=${GITHUB_REF/refs\\/tags\\//}" >> $GITHUB_OUTPUT',
-    },
-    // wait for the draft release since these may not be ready after the refactor of the start-release.
+    get_version_step,
+    // wait for the draft release since these may not be ready after the refactor
+    // of the start-release.
     {
       name: 'Wait for Draft Release if not Ready',
       id: 'wait-draft-release',
@@ -337,11 +340,7 @@ local create_release_interfaces_job = {
     'inputs',
   ],
   steps: [
-    {
-      name: 'Get the version',
-      id: 'get-version',
-      run: 'echo "VERSION=${GITHUB_REF/refs\\/tags\\//}" >> $GITHUB_OUTPUT',
-    },
+    get_version_step,
     semgrep.github_bot.get_jwt_step,
     semgrep.github_bot.get_token_step,
     {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,7 +203,7 @@ jobs:
     steps:
     - name: Get the version
       id: get-version
-      run: echo "VERSION=${GITHUB_REF/refs\\/tags\\//}" >> $GITHUB_OUTPUT
+      run: echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
     - name: Wait for Draft Release if not Ready
       id: wait-draft-release
       env:
@@ -229,7 +229,7 @@ jobs:
     steps:
     - name: Get the version
       id: get-version
-      run: echo "VERSION=${GITHUB_REF/refs\\/tags\\//}" >> $GITHUB_OUTPUT
+      run: echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
     - name: Get JWT for semgrep-ci GitHub App
       id: jwt
       uses: docker://public.ecr.aws/y9k7q4m1/devops/cicd:latest


### PR DESCRIPTION
During the translation to jsonnet, some additional \ got
inserted which prevents the version to be correctly extracted.
Compare the good run at
https://github.com/semgrep/semgrep/actions/runs/7106903050/job/19348085824

with
```
  echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
  ...

  while ! gh release --repo returntocorp/semgrep list -L 5 | grep -q
  "v1.52.0"; d
```

with the bad run at
https://github.com/semgrep/semgrep/actions/runs/7106903050/job/19348085824
with
```
echo "VERSION=${GITHUB_REF/refs\\/tags\\//}" >> $GITHUB_OUTPUT
...
Run while ! gh release --repo returntocorp/semgrep list -L 5 | grep -q "refs/tags/v1.55.0"; do
...
```

test plan:
trigger new release for 1.55.1 and hope it works