### PR TITLE
feat: Use function for tree sitter parser line,col -> bytepos conversion

### DIFF
--- a/languages/bash/tree-sitter/Parse_bash_tree_sitter.ml
+++ b/languages/bash/tree-sitter/Parse_bash_tree_sitter.ml
@@ -1483,6 +1483,8 @@ let parse_pattern str =
     (fun () -> Tree_sitter_bash.Parse.string str)
     (fun cst ->
       let file = "<pattern>" in
-      let env = { H.file; conv = Hashtbl.create 0; extra = AST_bash.Pattern } in
+      let env =
+        { H.file; conv = (fun _ -> raise Not_found); extra = AST_bash.Pattern }
+      in
       let tok = Tok.first_tok_of_file file in
       program env ~tok cst)

--- a/languages/cairo/generic/Parse_cairo_tree_sitter.ml
+++ b/languages/cairo/generic/Parse_cairo_tree_sitter.ml
@@ -995,5 +995,7 @@ let parse_pattern str =
     (fun () -> parse_expression_or_source_file str)
     (fun cst ->
       let file = "<pattern>" in
-      let env = { H.file; conv = Hashtbl.create 0; extra = Pattern } in
+      let env =
+        { H.file; conv = (fun _ -> raise Not_found); extra = Pattern }
+      in
       map_source_file env cst)

--- a/languages/cpp/tree-sitter/Parse_cpp_tree_sitter.ml
+++ b/languages/cpp/tree-sitter/Parse_cpp_tree_sitter.ml
@@ -4934,7 +4934,7 @@ let parse_pattern str =
     (fun () -> parse_expression_or_source_file str)
     (fun cst ->
       let file = "<pattern>" in
-      let env = { H.file; conv = Hashtbl.create 0; extra = () } in
+      let env = { H.file; conv = (fun _ -> raise Not_found); extra = () } in
       let x = map_program_or_expr env cst in
       match x with
       | Left [ s ] -> Toplevel s

--- a/languages/csharp/generic/Parse_csharp_tree_sitter.ml
+++ b/languages/csharp/generic/Parse_csharp_tree_sitter.ml
@@ -3396,5 +3396,5 @@ let parse_pattern str =
     (fun () -> parse_pattern_aux str)
     (fun cst ->
       let file = "<pattern>" in
-      let env = { H.file; conv = Hashtbl.create 0; extra = () } in
+      let env = { H.file; conv = (fun _ -> raise Not_found); extra = () } in
       compilation_unit env cst)

--- a/languages/dart/generic/Parse_dart_tree_sitter.ml
+++ b/languages/dart/generic/Parse_dart_tree_sitter.ml
@@ -3866,7 +3866,9 @@ let parse_pattern str =
     (fun () -> parse_expression_or_source_file str)
     (fun cst ->
       let file = "<pattern>" in
-      let env = { H.file; conv = Hashtbl.create 0; extra = Pattern } in
+      let env =
+        { H.file; conv = (fun _ -> raise Not_found); extra = Pattern }
+      in
       let any = map_program env cst in
       (* this will be simplified i:f needed in Parse_pattern.normalize_any *)
       any)

--- a/languages/dockerfile/tree-sitter/Parse_dockerfile_tree_sitter.ml
+++ b/languages/dockerfile/tree-sitter/Parse_dockerfile_tree_sitter.ml
@@ -1069,7 +1069,9 @@ let parse_pattern str =
       str |> ensure_trailing_newline |> Tree_sitter_dockerfile.Parse.string)
     (fun cst ->
       let file = "<pattern>" in
-      let env = { H.file; conv = Hashtbl.create 0; extra = (input_kind, Sh) } in
+      let env =
+        { H.file; conv = (fun _ -> raise Not_found); extra = (input_kind, Sh) }
+      in
       source_file env cst)
 
 (*

--- a/languages/html/generic/Parse_html_tree_sitter.ml
+++ b/languages/html/generic/Parse_html_tree_sitter.ml
@@ -277,7 +277,7 @@ let parse_pattern str =
     (fun () -> Tree_sitter_html.Parse.string str)
     (fun cst ->
       let file = "<pattern>" in
-      let env = { H.file; conv = Hashtbl.create 0; extra = () } in
+      let env = { H.file; conv = (fun _ -> raise Not_found); extra = () } in
 
       match map_fragment env cst with
       | Left xs -> (

--- a/languages/java/tree-sitter/Parse_java_tree_sitter.ml
+++ b/languages/java/tree-sitter/Parse_java_tree_sitter.ml
@@ -1944,5 +1944,5 @@ let parse_pattern str =
     (fun () -> Tree_sitter_java.Parse.string str)
     (fun cst ->
       let file = "<pattern>" in
-      let env = { H.file; conv = Hashtbl.create 0; extra = () } in
+      let env = { H.file; conv = (fun _ -> raise Not_found); extra = () } in
       program env file cst)

--- a/languages/jsonnet/tree-sitter/Parse_jsonnet_tree_sitter.ml
+++ b/languages/jsonnet/tree-sitter/Parse_jsonnet_tree_sitter.ml
@@ -703,6 +703,6 @@ let parse_pattern str =
     (fun () -> Tree_sitter_jsonnet.Parse.string str)
     (fun cst ->
       let file = "<pattern>" in
-      let env = { H.file; conv = Hashtbl.create 0; extra = () } in
+      let env = { H.file; conv = (fun _ -> raise Not_found); extra = () } in
       let e = map_document env cst in
       E e)

--- a/languages/julia/generic/Parse_julia_tree_sitter.ml
+++ b/languages/julia/generic/Parse_julia_tree_sitter.ml
@@ -2448,7 +2448,9 @@ let parse_pattern str =
     (fun () -> Tree_sitter_julia.Parse.string str)
     (fun cst ->
       let file = "<pattern>" in
-      let env = { H.file; conv = Hashtbl.create 0; extra = Pattern } in
+      let env =
+        { H.file; conv = (fun _ -> raise Not_found); extra = Pattern }
+      in
       match map_source_file env cst with
       | [ s ] -> (
           match s.G.s with

--- a/languages/kotlin/generic/Parse_kotlin_tree_sitter.ml
+++ b/languages/kotlin/generic/Parse_kotlin_tree_sitter.ml
@@ -2333,5 +2333,7 @@ let parse_pattern str =
     (fun () -> parse_expression_or_source_file str)
     (fun cst ->
       let file = "<pattern>" in
-      let env = { H.file; conv = Hashtbl.create 0; extra = Pattern } in
+      let env =
+        { H.file; conv = (fun _ -> raise Not_found); extra = Pattern }
+      in
       source_file env cst)

--- a/languages/lisp/tree-sitter/Parse_clojure_tree_sitter.ml
+++ b/languages/lisp/tree-sitter/Parse_clojure_tree_sitter.ml
@@ -325,7 +325,7 @@ let parse_pattern str =
     (fun () -> Tree_sitter_clojure.Parse.string str)
     (fun cst ->
       let file = "<pattern>" in
-      let env = { H.file; conv = Hashtbl.create 0; extra = () } in
+      let env = { H.file; conv = (fun _ -> raise Not_found); extra = () } in
       let e = map_source env cst in
       (* this will be simplified if needed in Parse_pattern.normalize_any *)
       Raw e)

--- a/languages/lua/generic/Parse_lua_tree_sitter.ml
+++ b/languages/lua/generic/Parse_lua_tree_sitter.ml
@@ -805,6 +805,6 @@ let parse_pattern str =
     (fun () -> Tree_sitter_lua.Parse.string str)
     (fun cst ->
       let file = "<pattern>" in
-      let env = { H.file; conv = Hashtbl.create 0; extra = () } in
+      let env = { H.file; conv = (fun _ -> raise Not_found); extra = () } in
       let xs = map_program env cst in
       G.Ss xs)

--- a/languages/promql/generic/Parse_promql_tree_sitter.ml
+++ b/languages/promql/generic/Parse_promql_tree_sitter.ml
@@ -406,6 +406,6 @@ let parse_pattern str =
     (fun () -> Tree_sitter_promql.Parse.string str)
     (fun cst ->
       let file = "<pattern>" in
-      let env = { H.file; conv = Hashtbl.create 0; extra = () } in
+      let env = { H.file; conv = (fun _ -> raise Not_found); extra = () } in
       let e = map_query env cst in
       G.E e)

--- a/languages/protobuf/generic/Parse_protobuf_tree_sitter.ml
+++ b/languages/protobuf/generic/Parse_protobuf_tree_sitter.ml
@@ -696,6 +696,6 @@ let parse_pattern str =
     (fun () -> Tree_sitter_proto.Parse.string str)
     (fun cst ->
       let file = "<pattern>" in
-      let env = { H.file; conv = Hashtbl.create 0; extra = () } in
+      let env = { H.file; conv = (fun _ -> raise Not_found); extra = () } in
       let xs = map_source_file env cst in
       G.Raw xs)

--- a/languages/python/tree-sitter/Parse_python_tree_sitter.ml
+++ b/languages/python/tree-sitter/Parse_python_tree_sitter.ml
@@ -1660,11 +1660,24 @@ let parse file =
       let env = { H.file; conv = H.line_col_to_pos file; extra = () } in
       map_module_ env cst)
 
+let parse_string ~file ~contents =
+  H.wrap_parser
+    (fun () -> Tree_sitter_python.Parse.string ~src_file:file contents)
+    (fun cst ->
+      let env =
+        {
+          H.file;
+          conv = (Pos.full_converters_str contents).linecol_to_bytepos_fun;
+          extra = ();
+        }
+      in
+      map_module_ env cst)
+
 (* Need return type to be "any"*)
 let parse_pattern str =
   H.wrap_parser
     (fun () -> Tree_sitter_python.Parse.string str)
     (fun cst ->
       let file = "<pattern>" in
-      let env = { H.file; conv = Hashtbl.create 0; extra = () } in
+      let env = { H.file; conv = (fun _ -> raise Not_found); extra = () } in
       Program (map_module_ env cst))

--- a/languages/python/tree-sitter/Parse_python_tree_sitter.mli
+++ b/languages/python/tree-sitter/Parse_python_tree_sitter.mli
@@ -1,4 +1,9 @@
 val parse :
   string (* filename *) -> AST_python.program Tree_sitter_run.Parsing_result.t
 
+val parse_string :
+  file:string (* filename *) ->
+  contents:string ->
+  AST_python.program Tree_sitter_run.Parsing_result.t
+
 val parse_pattern : string -> AST_python.any Tree_sitter_run.Parsing_result.t

--- a/languages/r/generic/Parse_r_tree_sitter.ml
+++ b/languages/r/generic/Parse_r_tree_sitter.ml
@@ -601,5 +601,5 @@ let parse_pattern str =
     (fun () -> Tree_sitter_r.Parse.string str)
     (fun cst ->
       let file = "<pattern>" in
-      let env = { H.file; conv = Hashtbl.create 0; extra = () } in
+      let env = { H.file; conv = (fun _ -> raise Not_found); extra = () } in
       G.Ss (map_program env cst))

--- a/languages/ruby/tree-sitter/Parse_ruby_tree_sitter.ml
+++ b/languages/ruby/tree-sitter/Parse_ruby_tree_sitter.ml
@@ -2439,6 +2439,8 @@ let parse_pattern string =
     (fun () -> Tree_sitter_ruby.Parse.string string)
     (fun cst ->
       let file = "<file>" in
-      let env = { H.file; conv = Hashtbl.create 0; extra = Pattern } in
+      let env =
+        { H.file; conv = (fun _ -> raise Not_found); extra = Pattern }
+      in
       if debug then Boilerplate.dump_tree cst;
       Ss (program env cst))

--- a/languages/rust/generic/Parse_rust_tree_sitter.ml
+++ b/languages/rust/generic/Parse_rust_tree_sitter.ml
@@ -3692,5 +3692,7 @@ let parse_pattern str =
     (fun () -> parse_expression_or_source_file str)
     (fun cst ->
       let file = "<pattern>" in
-      let env = { H.file; conv = Hashtbl.create 0; extra = Pattern } in
+      let env =
+        { H.file; conv = (fun _ -> raise Not_found); extra = Pattern }
+      in
       map_source_file env cst)

--- a/languages/solidity/generic/Parse_solidity_tree_sitter.ml
+++ b/languages/solidity/generic/Parse_solidity_tree_sitter.ml
@@ -2509,5 +2509,5 @@ let parse_pattern str =
     (fun () -> Tree_sitter_solidity.Parse.string str)
     (fun cst ->
       let file = "<pattern>" in
-      let env = { H.file; conv = Hashtbl.create 0; extra = () } in
+      let env = { H.file; conv = (fun _ -> raise Not_found); extra = () } in
       map_source_file env cst)

--- a/languages/swift/generic/Parse_swift_tree_sitter.ml
+++ b/languages/swift/generic/Parse_swift_tree_sitter.ml
@@ -3291,5 +3291,7 @@ let parse_pattern str =
     (fun () -> Tree_sitter_swift.Parse.string str)
     (fun cst ->
       let file = "<pattern>" in
-      let env = { H.file; conv = Hashtbl.create 0; extra = Pattern } in
+      let env =
+        { H.file; conv = (fun _ -> raise Not_found); extra = Pattern }
+      in
       map_source_file env cst)

--- a/languages/terraform/tree-sitter/Parse_terraform_tree_sitter.ml
+++ b/languages/terraform/tree-sitter/Parse_terraform_tree_sitter.ml
@@ -651,5 +651,5 @@ let parse_pattern str =
     (fun () -> parse_expression_or_source_file str)
     (fun cst ->
       let file = "<pattern>" in
-      let env = { H.file; conv = Hashtbl.create 0; extra = () } in
+      let env = { H.file; conv = (fun _ -> raise Not_found); extra = () } in
       map_config_file env cst)

--- a/languages/tree-sitter-to-generic/Parse_hack_tree_sitter.ml
+++ b/languages/tree-sitter-to-generic/Parse_hack_tree_sitter.ml
@@ -2981,7 +2981,7 @@ let parse_pattern str =
        * Imitate what we do in php_to_generic.ml?
        *)
       let extra = Pattern in
-      let env = { H.file; conv = Hashtbl.create 0; extra } in
+      let env = { H.file; conv = (fun _ -> raise Not_found); extra } in
       (* TODO: G.Ss (script env cst) but regressions *)
       match script env cst with
       | [ { G.s = G.ExprStmt (e, _); _ } ] -> G.E e

--- a/languages/tree-sitter-to-generic/Parse_vue_tree_sitter.ml
+++ b/languages/tree-sitter-to-generic/Parse_vue_tree_sitter.ml
@@ -50,18 +50,16 @@ let fb = Tok.unsafe_fake_bracket
  * https://github.com/returntocorp/ocaml-tree-sitter-core/issues/5
  * is fixed.
  *)
-let str_if_wrong_content_temporary_fix env (tok : Tree_sitter_run.Token.t) =
+let str_if_wrong_content_temporary_fix ({ file; conv; _ } : env)
+    (tok : Tree_sitter_run.Token.t) =
   let loc, _wrong_str = tok in
-
-  let file = env.H.file in
-  let h = env.H.conv in
 
   let bytepos, line, column =
     let pos = loc.Tree_sitter_run.Loc.start in
     (* Parse_info is 1-line based and 0-column based, like Emacs *)
     let line = pos.Tree_sitter_run.Loc.row + 1 in
     let column = pos.Tree_sitter_run.Loc.column in
-    try (Hashtbl.find h (line, column), line, column) with
+    try (conv (line, column), line, column) with
     | Not_found ->
         failwith (spf "could not find line:%d x col:%d in %s" line column file)
   in
@@ -70,7 +68,7 @@ let str_if_wrong_content_temporary_fix env (tok : Tree_sitter_run.Token.t) =
     (* Parse_info is 1-line based and 0-column based, like Emacs *)
     let line = pos.Tree_sitter_run.Loc.row + 1 in
     let column = pos.Tree_sitter_run.Loc.column in
-    try Hashtbl.find h (line, column) with
+    try conv (line, column) with
     | Not_found ->
         failwith (spf "could not find line:%d x col:%d in %s" line column file)
   in

--- a/languages/typescript/tree-sitter/Parse_typescript_tree_sitter.ml
+++ b/languages/typescript/tree-sitter/Parse_typescript_tree_sitter.ml
@@ -3229,7 +3229,7 @@ let parse_pattern str =
       (fun () -> (Tree_sitter_typescript.Parse.string str :> cst_result))
     (fun cst ->
       let file = "<pattern>" in
-      let env = { H.file; conv = Hashtbl.create 0; extra = () } in
+      let env = { H.file; conv = (fun _ -> raise Not_found); extra = () } in
       match program env cst with
       | Program ss -> Stmts ss
       | other -> other)

--- a/libs/lib_parsing/Pos.ml
+++ b/libs/lib_parsing/Pos.ml
@@ -121,8 +121,7 @@ let complete_position filename converters (x : t) =
    line_arr maps byte position to line.
    col_arr maps byte position to column.
 *)
-let converters_of_arrays ?(file = "<unknown>") line_arr col_arr :
-    bytepos_linecol_converters =
+let converters_of_arrays line_arr col_arr : bytepos_linecol_converters =
   let len1 = Bigarray.Array1.dim line_arr in
   let len2 = Bigarray.Array1.dim col_arr in
   (* len1 and len2 should be equal but we're playing it safe *)
@@ -159,9 +158,7 @@ let converters_of_arrays ?(file = "<unknown>") line_arr col_arr :
                       | Greater -> Greater)
              in
              match res with
-             | Error _idx ->
-                 failwith
-                   (Common.spf "invalid linecol %d:%d in file %s" line col file)
+             | Error _idx -> raise Not_found
              | Ok (bytepos, _) -> bytepos);
       }
 
@@ -220,7 +217,7 @@ let full_converters_large (file : string) : bytepos_linecol_converters =
             ()
       in
       full_charpos_to_pos_aux ());
-  converters_of_arrays ~file arr1 arr2
+  converters_of_arrays arr1 arr2
 [@@profiling]
 
 (* This is mostly a copy-paste of full_charpos_to_pos_large,

--- a/libs/lib_parsing/Pos.mli
+++ b/libs/lib_parsing/Pos.mli
@@ -43,7 +43,7 @@ val string_of_pos : t -> string
    in the range.
    Empty files admit at least one valid byte position.
 
-   If the (line, column) is out of range, a Failure exception will be raised.
+   If the (line, column) is out of range, a Not_found exception will be raised.
 *)
 type bytepos_linecol_converters = {
   bytepos_to_linecol_fun : int -> int * int;

--- a/libs/lib_parsing_tree_sitter/Parse_tree_sitter_helpers.ml
+++ b/libs/lib_parsing_tree_sitter/Parse_tree_sitter_helpers.ml
@@ -29,7 +29,7 @@ type 'a env = {
   (* TODO: use Fpath.t *)
   file : string; (* filename *)
   (* get the charpos (offset) in file given a line x col *)
-  conv : (int * int, int) Hashtbl.t;
+  conv : int * int -> int;
   extra : 'a;
 }
 
@@ -66,7 +66,7 @@ let line_col_to_pos file =
             ()
       in
       full_charpos_to_pos_aux ());
-  h
+  Hashtbl.find h
 
 let token env (tok : Tree_sitter_run.Token.t) =
   let loc, str = tok in
@@ -76,7 +76,7 @@ let token env (tok : Tree_sitter_run.Token.t) =
   let line = start.Tree_sitter_run.Loc.row + 1 in
   let column = start.Tree_sitter_run.Loc.column in
   let bytepos =
-    try Hashtbl.find h (line, column) with
+    try h (line, column) with
     | Not_found -> -1
     (* TODO? more strict? raise exn? *)
   in

--- a/libs/lib_parsing_tree_sitter/Parse_tree_sitter_helpers.mli
+++ b/libs/lib_parsing_tree_sitter/Parse_tree_sitter_helpers.mli
@@ -1,12 +1,12 @@
 type 'a env = {
   file : string;
-  (* get the charpos (offset) in file given a line x col *)
-  conv : (int * int, int) Hashtbl.t;
+  (* get the charpos (offset) in file given a (line, col) pair *)
+  conv : int * int -> int;
   extra : 'a;
 }
 
 (* to fill in conv *)
-val line_col_to_pos : string (* filename *) -> (int * int, int) Hashtbl.t
+val line_col_to_pos : string (* filename *) -> int * int -> int
 
 (* Tree_sitter_run tokens to Tok.t converters *)
 val token : 'a env -> Tree_sitter_run.Token.t -> Tok.t


### PR DESCRIPTION
Currently we require a hashtable to be used but this is more restrictive than
necessary, and we've converted some code which was formerly generating
hashtables to now generate functions which serve the same purpose. See, e.g.,
<https://github.com/semgrep/semgrep/pull/7596>, <https://github.com/semgrep/semgrep/pull/9223>, (eventually replacing `Parse_info.full_charpos_to_pos_large`
with `Pos.full_charpos_to_pos_large`). To be able to use those functions,
let's open this type up a bit. Existing places where we use a Hashtbl and find
are now replaced with a function which calls find on the relevant Hashtbl.
