### PR TITLE
Fix globbing bugs for gitignore/semgrepignore

### DIFF
--- a/changelog.d/gh-9544.fixed
+++ b/changelog.d/gh-9544.fixed
@@ -1,0 +1,1 @@
+Fixed bugs in gitignore/semgrepignore globbing implementation affecting `--experimental`.

--- a/cli/src/semgrep/run_scan.py
+++ b/cli/src/semgrep/run_scan.py
@@ -312,9 +312,9 @@ def run_rules(
 def list_targets_and_exit(target_manager: TargetManager, product: out.Product) -> None:
     targets = target_manager.get_files_for_language(None, product)
     for path in sorted(targets.kept):
-        print(f"SEL {path}")
+        print(f"selected {path}")
     for path, reason in target_manager.ignore_log.list_skipped_paths_with_reason():
-        print(f"IGN {path} [{reason}]")
+        print(f"ignored {path} [{reason}]")
     exit(0)
 
 

--- a/cli/src/semgrep/run_scan.py
+++ b/cli/src/semgrep/run_scan.py
@@ -312,9 +312,9 @@ def run_rules(
 def list_targets_and_exit(target_manager: TargetManager, product: out.Product) -> None:
     targets = target_manager.get_files_for_language(None, product)
     for path in sorted(targets.kept):
-        print(f"+ {path}")
+        print(f"SEL {path}")
     for path, reason in target_manager.ignore_log.list_skipped_paths_with_reason():
-        print(f"- [{reason}] {path}")
+        print(f"IGN {path} [{reason}]")
     exit(0)
 
 

--- a/cli/src/semgrep/test.py
+++ b/cli/src/semgrep/test.py
@@ -480,12 +480,17 @@ def generate_test_results(
     # in a test context, we don't want to honor the paths: (include/exclude)
     # directive since the test target file, which must have the same
     # basename than the rule, may not match the paths: of the rule
+    respect_rule_paths = False
+    no_git_ignore = True
+    no_rewrite_rule_ids = True
+    # COUPLING: the arguments are the same as the second semgrep-core
+    # invocation later in this file (except for one)!
     invoke_semgrep_fn = functools.partial(
         invoke_semgrep_multi,
         engine_type=engine_type,
-        no_git_ignore=True,
-        respect_rule_paths=False,
-        no_rewrite_rule_ids=True,
+        no_git_ignore=no_git_ignore,
+        respect_rule_paths=respect_rule_paths,
+        no_rewrite_rule_ids=no_rewrite_rule_ids,
         strict=strict,
         optimizations=optimizations,
     )
@@ -570,14 +575,16 @@ def generate_test_results(
     ]
 
     # This is the invocation of semgrep for testing autofix.
-    #
-    # TODO: should 'engine' be set to 'engine=engine' or always 'engine=EngineType.OSS'?
+    # COUPLING: except for autofix, the arguments are the same as above
     invoke_semgrep_with_autofix_fn = functools.partial(
         invoke_semgrep_multi,
-        no_git_ignore=True,
-        no_rewrite_rule_ids=True,
+        engine_type=engine_type,
+        no_git_ignore=no_git_ignore,
+        respect_rule_paths=respect_rule_paths,
+        no_rewrite_rule_ids=no_rewrite_rule_ids,
         strict=strict,
         optimizations=optimizations,
+        # only option that differs from the earlier call to semgrep-core:
         autofix=True,
     )
 

--- a/cli/src/semgrep/test.py
+++ b/cli/src/semgrep/test.py
@@ -18,6 +18,7 @@ import os
 import shutil
 import sys
 import tempfile
+import traceback
 import uuid
 from itertools import product
 from pathlib import Path
@@ -301,11 +302,11 @@ def invoke_semgrep_multi(
 ) -> Tuple[Path, Optional[str], Any]:
     try:
         output = semgrep.run_scan.run_scan_and_return_json(config, targets, **kwargs)
-    except Exception as error:
+    except Exception:
         # We must get the string of the error because the multiprocessing library
         # will fail the marshal the error and hang
         # See: https://bugs.python.org/issue39751
-        return (config, str(error), {})
+        return (config, traceback.format_exc(), {})
     else:
         return (config, None, output)
 

--- a/libs/alcotest_ext/core/Alcotest_ext.ml
+++ b/libs/alcotest_ext/core/Alcotest_ext.ml
@@ -180,6 +180,12 @@ let mask_pcre_pattern ?(mask = "<MASKED>") pat =
   let subst _matched = mask in
   fun subj -> Re.Pcre.substitute ~rex ~subst subj
 
+let mask_temp_paths ?(mask = "<TEMPORARY FILE PATH>") () =
+  let pat =
+    Re.Pcre.quote (Filename.get_temp_dir_name ()) ^ {|[/\\A-Za-z0-9_.-]*|}
+  in
+  mask_pcre_pattern ~mask pat
+
 (* Allow conversion from Lwt to synchronous function *)
 let update_func (test : 'a t) mona2 func : 'b t = { test with func; m = mona2 }
 let has_tag tag test = List.mem tag test.tags

--- a/libs/alcotest_ext/core/Alcotest_ext.ml
+++ b/libs/alcotest_ext/core/Alcotest_ext.ml
@@ -81,7 +81,7 @@ type 'unit_promise t = 'unit_promise T.test = {
   expected_outcome : expected_outcome;
   tags : Tag.t list;
   mask_output : (string -> string) list;
-  output_kind : output_kind;
+  checked_output : output_kind;
   skipped : bool;
   tolerate_chdir : bool;
   m : 'unit_promise Mona.t;
@@ -122,8 +122,8 @@ let update_id (test : _ t) =
   let id = String.sub md5_hex 0 12 in
   { test with id; internal_full_name }
 
-let create_gen ?(category = []) ?(expected_outcome = Should_succeed)
-    ?(mask_output = []) ?(output_kind = Ignore_output) ?(skipped = false)
+let create_gen ?(category = []) ?(checked_output = Ignore_output)
+    ?(expected_outcome = Should_succeed) ?(mask_output = []) ?(skipped = false)
     ?(tags = []) ?(tolerate_chdir = false) mona name func =
   {
     id = "";
@@ -134,21 +134,21 @@ let create_gen ?(category = []) ?(expected_outcome = Should_succeed)
     expected_outcome;
     tags;
     mask_output;
-    output_kind;
+    checked_output;
     skipped;
     tolerate_chdir;
     m = mona;
   }
   |> update_id
 
-let create ?category ?expected_outcome ?mask_output ?output_kind ?skipped ?tags
-    ?tolerate_chdir name func =
-  create_gen ?category ?expected_outcome ?mask_output ?output_kind ?skipped
+let create ?category ?checked_output ?expected_outcome ?mask_output ?skipped
+    ?tags ?tolerate_chdir name func =
+  create_gen ?category ?checked_output ?expected_outcome ?mask_output ?skipped
     ?tags ?tolerate_chdir Mona.sync name func
 
 let opt option default = Option.value option ~default
 
-let update ?category ?expected_outcome ?func ?mask_output ?name ?output_kind
+let update ?category ?checked_output ?expected_outcome ?func ?mask_output ?name
     ?skipped ?tags ?tolerate_chdir old =
   {
     id = "";
@@ -160,7 +160,7 @@ let update ?category ?expected_outcome ?func ?mask_output ?name ?output_kind
     expected_outcome = opt expected_outcome old.expected_outcome;
     tags = opt tags old.tags;
     mask_output = opt mask_output old.mask_output;
-    output_kind = opt output_kind old.output_kind;
+    checked_output = opt checked_output old.checked_output;
     skipped = opt skipped old.skipped;
     tolerate_chdir = opt tolerate_chdir old.tolerate_chdir;
     m = old.m;
@@ -215,9 +215,9 @@ let to_alcotest = Run.to_alcotest
 let registered_tests : test list ref = ref []
 let register x = registered_tests := x :: !registered_tests
 
-let test ?category ?expected_outcome ?mask_output ?output_kind ?skipped ?tags
+let test ?category ?checked_output ?expected_outcome ?mask_output ?skipped ?tags
     ?tolerate_chdir name func =
-  create ?category ?expected_outcome ?mask_output ?output_kind ?skipped ?tags
+  create ?category ?checked_output ?expected_outcome ?mask_output ?skipped ?tags
     ?tolerate_chdir name func
   |> register
 

--- a/libs/alcotest_ext/core/Alcotest_ext.mli
+++ b/libs/alcotest_ext/core/Alcotest_ext.mli
@@ -114,7 +114,7 @@ type 'unit_promise t = private {
   (* An optional function to rewrite any output data so as to mask the
      variable parts. *)
   mask_output : (string -> string) list;
-  output_kind : output_kind;
+  checked_output : output_kind;
   (* The 'skipped' property causes a test to be skipped by Alcotest but still
      shown as "[SKIP]" rather than being omitted. *)
   skipped : bool;
@@ -149,9 +149,9 @@ type simple_test = string * (unit -> unit)
 *)
 val create :
   ?category:string list ->
+  ?checked_output:output_kind ->
   ?expected_outcome:expected_outcome ->
   ?mask_output:(string -> string) list ->
-  ?output_kind:output_kind ->
   ?skipped:bool ->
   ?tags:Tag.t list ->
   ?tolerate_chdir:bool ->
@@ -165,9 +165,9 @@ val create :
 *)
 val create_gen :
   ?category:string list ->
+  ?checked_output:output_kind ->
   ?expected_outcome:expected_outcome ->
   ?mask_output:(string -> string) list ->
-  ?output_kind:output_kind ->
   ?skipped:bool ->
   ?tags:Tag.t list ->
   ?tolerate_chdir:bool ->
@@ -183,11 +183,11 @@ val create_gen :
 *)
 val update :
   ?category:string list ->
+  ?checked_output:output_kind ->
   ?expected_outcome:expected_outcome ->
   ?func:(unit -> 'unit_promise) ->
   ?mask_output:(string -> string) list ->
   ?name:string ->
-  ?output_kind:output_kind ->
   ?skipped:bool ->
   ?tags:Tag.t list ->
   ?tolerate_chdir:bool ->
@@ -246,9 +246,9 @@ val pack_tests : string -> simple_test list -> test list
 *)
 val test :
   ?category:string list ->
+  ?checked_output:output_kind ->
   ?expected_outcome:expected_outcome ->
   ?mask_output:(string -> string) list ->
-  ?output_kind:output_kind ->
   ?skipped:bool ->
   ?tags:Tag.t list ->
   ?tolerate_chdir:bool ->

--- a/libs/alcotest_ext/core/Alcotest_ext.mli
+++ b/libs/alcotest_ext/core/Alcotest_ext.mli
@@ -204,6 +204,16 @@ val mask_line :
 val mask_pcre_pattern : ?mask:string -> string -> string -> string
 
 (*
+   Mask strings that look like temporary file paths. This is useful in the
+   following cases:
+   - the temporary folder depends on the platform (Unix, Windows) or
+     on the environment (TMPDIR environment variable or equivalent);
+   - the files placed in the system's temporary folder are assigned
+     random names.
+*)
+val mask_temp_paths : ?mask:string -> unit -> string -> string
+
+(*
    Special case of the 'update' function that allows a different type
    for the new test function. This is useful for converting an Lwt test
    to a regular one.

--- a/libs/alcotest_ext/core/Store.mli
+++ b/libs/alcotest_ext/core/Store.mli
@@ -40,8 +40,10 @@ val get_output_file_pairs : 'a Types.test -> output_file_pair list
 (*
    Ordinary output that's not compared against expectations.
    This is what's left of stdout and stderr after redirections.
+
+   Return a pair (English description, data).
 *)
-val get_unchecked_output : 'a Types.test -> string option
+val get_unchecked_output : 'a Types.test -> (string * string) option
 
 (*
    These functions are available after the call to 'init'.

--- a/libs/alcotest_ext/core/Types.ml
+++ b/libs/alcotest_ext/core/Types.ml
@@ -102,7 +102,7 @@ type 'unit_promise test = {
   expected_outcome : expected_outcome;
   tags : Tag.t list;
   mask_output : (string -> string) list;
-  output_kind : output_kind;
+  checked_output : output_kind;
   skipped : bool;
   tolerate_chdir : bool;
   m : 'unit_promise Mona.t;

--- a/libs/alcotest_ext/lwt/Alcotest_ext_lwt.ml
+++ b/libs/alcotest_ext/lwt/Alcotest_ext_lwt.ml
@@ -13,9 +13,9 @@ let mona : unit Lwt.t Alcotest_ext.Mona.t =
   in
   { return = Lwt.return; bind = Lwt.bind; catch }
 
-let create ?category ?expected_outcome ?mask_output ?output_kind ?skipped ?tags
-    ?tolerate_chdir name func =
-  Alcotest_ext.create_gen ?category ?expected_outcome ?mask_output ?output_kind
-    ?skipped ?tags ?tolerate_chdir mona name func
+let create ?category ?checked_output ?expected_outcome ?mask_output ?skipped
+    ?tags ?tolerate_chdir name func =
+  Alcotest_ext.create_gen ?category ?checked_output ?expected_outcome
+    ?mask_output ?skipped ?tags ?tolerate_chdir mona name func
 
 let interpret_argv = Alcotest_ext.interpret_argv_gen ~mona

--- a/libs/alcotest_ext/lwt/Alcotest_ext_lwt.mli
+++ b/libs/alcotest_ext/lwt/Alcotest_ext_lwt.mli
@@ -15,9 +15,9 @@ val mona : unit Lwt.t Alcotest_ext.Mona.t
    See the documentation for Alcotest_ext.create. *)
 val create :
   ?category:string list ->
+  ?checked_output:Alcotest_ext.output_kind ->
   ?expected_outcome:Alcotest_ext.expected_outcome ->
   ?mask_output:(string -> string) list ->
-  ?output_kind:Alcotest_ext.output_kind ->
   ?skipped:bool ->
   ?tags:Alcotest_ext.Tag.t list ->
   ?tolerate_chdir:bool ->

--- a/libs/alcotest_ext/tests/Failing_test.ml
+++ b/libs/alcotest_ext/tests/Failing_test.ml
@@ -14,7 +14,7 @@ let tests =
     t "failing" failing_function;
     t "failing to fail" ~expected_outcome:(Should_fail "<reasons>") (fun () ->
         print_string "<something being printed by the test>");
-    t "output mismatch" ~output_kind:Stdout (fun () ->
+    t "output mismatch" ~checked_output:Stdout (fun () ->
         print_string
           {|
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
@@ -24,6 +24,8 @@ consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
 cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat
 non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 |});
+    t "missing snapshot" ~checked_output:Stdout (fun () ->
+        print_endline "hello");
   ]
 
 let () =

--- a/libs/alcotest_ext/tests/Failing_test.ml
+++ b/libs/alcotest_ext/tests/Failing_test.ml
@@ -24,8 +24,7 @@ consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
 cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat
 non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 |});
-    t "missing snapshot" ~checked_output:Stdout (fun () ->
-        print_endline "hello");
+    t "missing snapshot" ~checked_output:Stdout (fun () -> ());
   ]
 
 let () =

--- a/libs/alcotest_ext/tests/Meta_test.ml
+++ b/libs/alcotest_ext/tests/Meta_test.ml
@@ -101,7 +101,7 @@ let mask_alcotest_output =
 
 let tests =
   [
-    t ~output_kind:Merged_stdout_stderr ~mask_output:mask_alcotest_output
+    t ~checked_output:Merged_stdout_stderr ~mask_output:mask_alcotest_output
       "standard flow" test_standard_flow;
     t "failing flow run"
       ~expected_outcome:

--- a/libs/alcotest_ext/tests/Test.ml
+++ b/libs/alcotest_ext/tests/Test.ml
@@ -14,22 +14,23 @@ let tests =
     t "category" ~category:[ "category"; "subcategory" ] (fun () -> ());
     t "unchecked stdout" (fun () -> print_endline "hello\nworld");
     t "unchecked stderr" (fun () -> prerr_string "hello\n");
-    t "capture stdout" ~output_kind:Stdout (fun () -> print_string "hello\n");
-    t "capture stderr" ~output_kind:Stderr (fun () -> prerr_string "error\n");
-    t "capture stdxxx" ~output_kind:Merged_stdout_stderr (fun () ->
+    t "capture stdout" ~checked_output:Stdout (fun () -> print_string "hello\n");
+    t "capture stderr" ~checked_output:Stderr (fun () -> prerr_string "error\n");
+    t "capture stdxxx" ~checked_output:Merged_stdout_stderr (fun () ->
         print_string "hello\n";
         flush stdout;
         prerr_string "error\n";
         flush stderr;
         print_string "goodbye\n");
-    t "capture stdout and stderr" ~output_kind:Separate_stdout_stderr (fun () ->
+    t "capture stdout and stderr" ~checked_output:Separate_stdout_stderr
+      (fun () ->
         print_string "hello\n";
         prerr_string "error\n");
     t "xfail" ~expected_outcome:(Should_fail "raises exception on purpose")
       (fun () -> failwith "this exception is expected");
     t "skipped" ~skipped:true (fun () -> failwith "this shouldn't happen");
     t "chdir" ~tolerate_chdir:true (fun () -> Sys.chdir "/");
-    t ~output_kind:Stdout ~mask_output:[ String.lowercase_ascii ] "masked"
+    t ~checked_output:Stdout ~mask_output:[ String.lowercase_ascii ] "masked"
       (fun () -> print_endline "HELLO");
   ]
 

--- a/libs/alcotest_ext/tests/snapshots/alcotest_ext_meta_tests/fccf02a5c37e/stdxxx
+++ b/libs/alcotest_ext/tests/snapshots/alcotest_ext_meta_tests/fccf02a5c37e/stdxxx
@@ -16,102 +16,134 @@ Legend:
 
 [33m[MISS]  [0m8dbdda48fb87 [36msimple[0m
 [2m• [0m[31mMissing file containing the test output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/8dbdda48fb87/outcome[0m
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/8dbdda48fb87/log
 [33m[MISS]  [0md57ac4525684 ([1mtags[0m [1mtesting[0m) [36mtags[0m
 [2m• [0m[31mMissing file containing the test output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/d57ac4525684/outcome[0m
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/d57ac4525684/log
 [33m[MISS]  [0mbd1c5167dc34 [36mcategory[0m > [36msubcategory[0m > [36mcategory[0m
 [2m• [0m[31mMissing file containing the test output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/bd1c5167dc34/outcome[0m
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/bd1c5167dc34/log
 [33m[MISS]  [0m2c57c8917bfb [36munchecked stdout[0m
 [2m• [0m[31mMissing file containing the test output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/2c57c8917bfb/outcome[0m
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/2c57c8917bfb/log
 [33m[MISS]  [0m68358d78cb0b [36munchecked stderr[0m
 [2m• [0m[31mMissing file containing the test output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/68358d78cb0b/outcome[0m
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/68358d78cb0b/log
 [33m[MISS]  [0md1a055429711 [36mcapture stdout[0m
 [2m• [0mChecked output: stdout
 [2m• [0m[31mMissing file containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/d1a055429711/stdout[0m
+[2m• [0mPath to captured stdout: _build/alcotest_ext/status/alcotest_ext_dummy_tests/d1a055429711/stdout
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/d1a055429711/log
 [33m[MISS]  [0m72f48157b077 [36mcapture stderr[0m
 [2m• [0mChecked output: stderr
 [2m• [0m[31mMissing file containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/72f48157b077/stderr[0m
+[2m• [0mPath to captured stderr: _build/alcotest_ext/status/alcotest_ext_dummy_tests/72f48157b077/stderr
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/72f48157b077/log
 [33m[MISS]  [0m5deda5ac4212 [36mcapture stdxxx[0m
 [2m• [0mChecked output: merged stdout and stderr
 [2m• [0m[31mMissing file containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/5deda5ac4212/stdxxx[0m
+[2m• [0mPath to captured stdxxx: _build/alcotest_ext/status/alcotest_ext_dummy_tests/5deda5ac4212/stdxxx
 [33m[MISS]  [0m486ef3ce86ab [36mcapture stdout and stderr[0m
 [2m• [0mChecked output: separate stdout and stderr
 [2m• [0m[31mMissing files containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/486ef3ce86ab/stdout, tests/snapshots/alcotest_ext_dummy_tests/486ef3ce86ab/stderr[0m
+[2m• [0mPath to captured stdout: _build/alcotest_ext/status/alcotest_ext_dummy_tests/486ef3ce86ab/stdout
+[2m• [0mPath to captured stderr: _build/alcotest_ext/status/alcotest_ext_dummy_tests/486ef3ce86ab/stderr
 [33m[MISS]  [0m85349a4a9157 [36mxfail[0m
 [2m• [0mExpected to fail: raises exception on purpose
 [2m• [0m[31mMissing file containing the test output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/85349a4a9157/outcome[0m
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/85349a4a9157/log
 [33m[MISS]  [0me52e279299e9 [36mskipped[0m
 [2m• [0mAlways skipped
 [33m[MISS]  [0m91a3c9030236 [36mchdir[0m
 [2m• [0m[31mMissing file containing the test output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/91a3c9030236/outcome[0m
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/91a3c9030236/log
 [33m[MISS]  [0ma3e1a604f579 [36mmasked[0m
 [2m• [0mChecked output: stdout
 [2m• [0m[31mMissing file containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/a3e1a604f579/stdout[0m
+[2m• [0mPath to captured stdout: _build/alcotest_ext/status/alcotest_ext_dummy_tests/a3e1a604f579/stdout
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/a3e1a604f579/log
 
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[MISS]  [0m8dbdda48fb87 [36msimple[0m                                                  [2m│[0m
 [2m└──────────────────────────────────────────────────────────────────────────────┘
 [0m[2m• [0m[31mMissing file containing the test output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/8dbdda48fb87/outcome[0m
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/8dbdda48fb87/log
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[MISS]  [0md57ac4525684 ([1mtags[0m [1mtesting[0m) [36mtags[0m                                     [2m│[0m
 [2m└──────────────────────────────────────────────────────────────────────────────┘
 [0m[2m• [0m[31mMissing file containing the test output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/d57ac4525684/outcome[0m
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/d57ac4525684/log
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[MISS]  [0mbd1c5167dc34 [36mcategory[0m > [36msubcategory[0m > [36mcategory[0m                       [2m│[0m
 [2m└──────────────────────────────────────────────────────────────────────────────┘
 [0m[2m• [0m[31mMissing file containing the test output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/bd1c5167dc34/outcome[0m
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/bd1c5167dc34/log
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[MISS]  [0m2c57c8917bfb [36munchecked stdout[0m                                        [2m│[0m
 [2m└──────────────────────────────────────────────────────────────────────────────┘
 [0m[2m• [0m[31mMissing file containing the test output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/2c57c8917bfb/outcome[0m
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/2c57c8917bfb/log
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[MISS]  [0m68358d78cb0b [36munchecked stderr[0m                                        [2m│[0m
 [2m└──────────────────────────────────────────────────────────────────────────────┘
 [0m[2m• [0m[31mMissing file containing the test output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/68358d78cb0b/outcome[0m
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/68358d78cb0b/log
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[MISS]  [0md1a055429711 [36mcapture stdout[0m                                          [2m│[0m
 [2m└──────────────────────────────────────────────────────────────────────────────┘
 [0m[2m• [0mChecked output: stdout
 [2m• [0m[31mMissing file containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/d1a055429711/stdout[0m
+[2m• [0mPath to captured stdout: _build/alcotest_ext/status/alcotest_ext_dummy_tests/d1a055429711/stdout
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/d1a055429711/log
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[MISS]  [0m72f48157b077 [36mcapture stderr[0m                                          [2m│[0m
 [2m└──────────────────────────────────────────────────────────────────────────────┘
 [0m[2m• [0mChecked output: stderr
 [2m• [0m[31mMissing file containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/72f48157b077/stderr[0m
+[2m• [0mPath to captured stderr: _build/alcotest_ext/status/alcotest_ext_dummy_tests/72f48157b077/stderr
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/72f48157b077/log
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[MISS]  [0m5deda5ac4212 [36mcapture stdxxx[0m                                          [2m│[0m
 [2m└──────────────────────────────────────────────────────────────────────────────┘
 [0m[2m• [0mChecked output: merged stdout and stderr
 [2m• [0m[31mMissing file containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/5deda5ac4212/stdxxx[0m
+[2m• [0mPath to captured stdxxx: _build/alcotest_ext/status/alcotest_ext_dummy_tests/5deda5ac4212/stdxxx
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[MISS]  [0m486ef3ce86ab [36mcapture stdout and stderr[0m                               [2m│[0m
 [2m└──────────────────────────────────────────────────────────────────────────────┘
 [0m[2m• [0mChecked output: separate stdout and stderr
 [2m• [0m[31mMissing files containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/486ef3ce86ab/stdout, tests/snapshots/alcotest_ext_dummy_tests/486ef3ce86ab/stderr[0m
+[2m• [0mPath to captured stdout: _build/alcotest_ext/status/alcotest_ext_dummy_tests/486ef3ce86ab/stdout
+[2m• [0mPath to captured stderr: _build/alcotest_ext/status/alcotest_ext_dummy_tests/486ef3ce86ab/stderr
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[MISS]  [0m85349a4a9157 [36mxfail[0m                                                   [2m│[0m
 [2m└──────────────────────────────────────────────────────────────────────────────┘
 [0m[2m• [0mExpected to fail: raises exception on purpose
 [2m• [0m[31mMissing file containing the test output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/85349a4a9157/outcome[0m
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/85349a4a9157/log
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[MISS]  [0m91a3c9030236 [36mchdir[0m                                                   [2m│[0m
 [2m└──────────────────────────────────────────────────────────────────────────────┘
 [0m[2m• [0m[31mMissing file containing the test output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/91a3c9030236/outcome[0m
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/91a3c9030236/log
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[MISS]  [0ma3e1a604f579 [36mmasked[0m                                                  [2m│[0m
 [2m└──────────────────────────────────────────────────────────────────────────────┘
 [0m[2m• [0mChecked output: stdout
 [2m• [0m[31mMissing file containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/a3e1a604f579/stdout[0m
+[2m• [0mPath to captured stdout: _build/alcotest_ext/status/alcotest_ext_dummy_tests/a3e1a604f579/stdout
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/a3e1a604f579/log
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 13/13 selected tests:
   0 successful (0 pass, 0 xfail)
@@ -130,65 +162,83 @@ Legend:
   In this case, you should review the test output and run the 'approve'
   subcommand once you're satisfied with the output.
 [33m[RUN][0m   8dbdda48fb87 [36msimple[0m...[2K[32m[PASS]  [0m8dbdda48fb87 [36msimple[0m
-[2m• [0mPath to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/8dbdda48fb87/unchecked
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/8dbdda48fb87/log
 [33m[RUN][0m   d57ac4525684 ([1mtags[0m [1mtesting[0m) [36mtags[0m...[2K[32m[PASS]  [0md57ac4525684 ([1mtags[0m [1mtesting[0m) [36mtags[0m
-[2m• [0mPath to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/d57ac4525684/unchecked
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/d57ac4525684/log
 [33m[RUN][0m   bd1c5167dc34 [36mcategory[0m > [36msubcategory[0m > [36mcategory[0m...[2K[32m[PASS]  [0mbd1c5167dc34 [36mcategory[0m > [36msubcategory[0m > [36mcategory[0m
-[2m• [0mPath to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/bd1c5167dc34/unchecked
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/bd1c5167dc34/log
 [33m[RUN][0m   2c57c8917bfb [36munchecked stdout[0m...[2K[32m[PASS]  [0m2c57c8917bfb [36munchecked stdout[0m
-[2m• [0mPath to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/2c57c8917bfb/unchecked
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/2c57c8917bfb/log
 [33m[RUN][0m   68358d78cb0b [36munchecked stderr[0m...[2K[32m[PASS]  [0m68358d78cb0b [36munchecked stderr[0m
-[2m• [0mPath to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/68358d78cb0b/unchecked
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/68358d78cb0b/log
 [33m[RUN][0m   d1a055429711 [36mcapture stdout[0m...[2K[33m[PASS*] [0md1a055429711 [36mcapture stdout[0m
 [2m• [0mChecked output: stdout
 [2m• [0m[31mMissing file containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/d1a055429711/stdout[0m
+[2m• [0mPath to captured stdout: _build/alcotest_ext/status/alcotest_ext_dummy_tests/d1a055429711/stdout
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/d1a055429711/log
 [33m[RUN][0m   72f48157b077 [36mcapture stderr[0m...[2K[33m[PASS*] [0m72f48157b077 [36mcapture stderr[0m
 [2m• [0mChecked output: stderr
 [2m• [0m[31mMissing file containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/72f48157b077/stderr[0m
+[2m• [0mPath to captured stderr: _build/alcotest_ext/status/alcotest_ext_dummy_tests/72f48157b077/stderr
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/72f48157b077/log
 [33m[RUN][0m   5deda5ac4212 [36mcapture stdxxx[0m...[2K[33m[PASS*] [0m5deda5ac4212 [36mcapture stdxxx[0m
 [2m• [0mChecked output: merged stdout and stderr
 [2m• [0m[31mMissing file containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/5deda5ac4212/stdxxx[0m
+[2m• [0mPath to captured stdxxx: _build/alcotest_ext/status/alcotest_ext_dummy_tests/5deda5ac4212/stdxxx
 [33m[RUN][0m   486ef3ce86ab [36mcapture stdout and stderr[0m...[2K[33m[PASS*] [0m486ef3ce86ab [36mcapture stdout and stderr[0m
 [2m• [0mChecked output: separate stdout and stderr
 [2m• [0m[31mMissing files containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/486ef3ce86ab/stdout, tests/snapshots/alcotest_ext_dummy_tests/486ef3ce86ab/stderr[0m
+[2m• [0mPath to captured stdout: _build/alcotest_ext/status/alcotest_ext_dummy_tests/486ef3ce86ab/stdout
+[2m• [0mPath to captured stderr: _build/alcotest_ext/status/alcotest_ext_dummy_tests/486ef3ce86ab/stderr
 [33m[RUN][0m   85349a4a9157 [36mxfail[0m...[2K[32m[XFAIL] [0m85349a4a9157 [36mxfail[0m
 [2m• [0mExpected to fail: raises exception on purpose
-[2m• [0mPath to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/85349a4a9157/unchecked
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/85349a4a9157/log
 [33m[SKIP][0m  e52e279299e9 [36mskipped[0m
 [33m[RUN][0m   91a3c9030236 [36mchdir[0m...[2K[32m[PASS]  [0m91a3c9030236 [36mchdir[0m
-[2m• [0mPath to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/91a3c9030236/unchecked
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/91a3c9030236/log
 [33m[RUN][0m   a3e1a604f579 [36mmasked[0m...[2K[33m[PASS*] [0ma3e1a604f579 [36mmasked[0m
 [2m• [0mChecked output: stdout
 [2m• [0m[31mMissing file containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/a3e1a604f579/stdout[0m
+[2m• [0mPath to captured stdout: _build/alcotest_ext/status/alcotest_ext_dummy_tests/a3e1a604f579/stdout
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/a3e1a604f579/log
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[PASS*] [0md1a055429711 [36mcapture stdout[0m                                          [2m│[0m
 [2m└──────────────────────────────────────────────────────────────────────────────┘
 [0m[2m• [0mChecked output: stdout
 [2m• [0m[31mMissing file containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/d1a055429711/stdout[0m
+[2m• [0mPath to captured stdout: _build/alcotest_ext/status/alcotest_ext_dummy_tests/d1a055429711/stdout
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/d1a055429711/log
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[PASS*] [0m72f48157b077 [36mcapture stderr[0m                                          [2m│[0m
 [2m└──────────────────────────────────────────────────────────────────────────────┘
 [0m[2m• [0mChecked output: stderr
 [2m• [0m[31mMissing file containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/72f48157b077/stderr[0m
+[2m• [0mPath to captured stderr: _build/alcotest_ext/status/alcotest_ext_dummy_tests/72f48157b077/stderr
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/72f48157b077/log
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[PASS*] [0m5deda5ac4212 [36mcapture stdxxx[0m                                          [2m│[0m
 [2m└──────────────────────────────────────────────────────────────────────────────┘
 [0m[2m• [0mChecked output: merged stdout and stderr
 [2m• [0m[31mMissing file containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/5deda5ac4212/stdxxx[0m
+[2m• [0mPath to captured stdxxx: _build/alcotest_ext/status/alcotest_ext_dummy_tests/5deda5ac4212/stdxxx
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[PASS*] [0m486ef3ce86ab [36mcapture stdout and stderr[0m                               [2m│[0m
 [2m└──────────────────────────────────────────────────────────────────────────────┘
 [0m[2m• [0mChecked output: separate stdout and stderr
 [2m• [0m[31mMissing files containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/486ef3ce86ab/stdout, tests/snapshots/alcotest_ext_dummy_tests/486ef3ce86ab/stderr[0m
+[2m• [0mPath to captured stdout: _build/alcotest_ext/status/alcotest_ext_dummy_tests/486ef3ce86ab/stdout
+[2m• [0mPath to captured stderr: _build/alcotest_ext/status/alcotest_ext_dummy_tests/486ef3ce86ab/stderr
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[PASS*] [0ma3e1a604f579 [36mmasked[0m                                                  [2m│[0m
 [2m└──────────────────────────────────────────────────────────────────────────────┘
 [0m[2m• [0mChecked output: stdout
 [2m• [0m[31mMissing file containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/a3e1a604f579/stdout[0m
+[2m• [0mPath to captured stdout: _build/alcotest_ext/status/alcotest_ext_dummy_tests/a3e1a604f579/stdout
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/a3e1a604f579/log
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 13/13 selected tests:
   12 successful (11 pass, 1 xfail)
@@ -209,67 +259,85 @@ Legend:
   subcommand once you're satisfied with the output.
 
 [32m[PASS]  [0m8dbdda48fb87 [36msimple[0m
-[2m• [0mPath to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/8dbdda48fb87/unchecked
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/8dbdda48fb87/log
 [32m[PASS]  [0md57ac4525684 ([1mtags[0m [1mtesting[0m) [36mtags[0m
-[2m• [0mPath to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/d57ac4525684/unchecked
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/d57ac4525684/log
 [32m[PASS]  [0mbd1c5167dc34 [36mcategory[0m > [36msubcategory[0m > [36mcategory[0m
-[2m• [0mPath to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/bd1c5167dc34/unchecked
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/bd1c5167dc34/log
 [32m[PASS]  [0m2c57c8917bfb [36munchecked stdout[0m
-[2m• [0mPath to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/2c57c8917bfb/unchecked
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/2c57c8917bfb/log
 [32m[PASS]  [0m68358d78cb0b [36munchecked stderr[0m
-[2m• [0mPath to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/68358d78cb0b/unchecked
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/68358d78cb0b/log
 [33m[PASS*] [0md1a055429711 [36mcapture stdout[0m
 [2m• [0mChecked output: stdout
 [2m• [0m[31mMissing file containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/d1a055429711/stdout[0m
+[2m• [0mPath to captured stdout: _build/alcotest_ext/status/alcotest_ext_dummy_tests/d1a055429711/stdout
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/d1a055429711/log
 [33m[PASS*] [0m72f48157b077 [36mcapture stderr[0m
 [2m• [0mChecked output: stderr
 [2m• [0m[31mMissing file containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/72f48157b077/stderr[0m
+[2m• [0mPath to captured stderr: _build/alcotest_ext/status/alcotest_ext_dummy_tests/72f48157b077/stderr
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/72f48157b077/log
 [33m[PASS*] [0m5deda5ac4212 [36mcapture stdxxx[0m
 [2m• [0mChecked output: merged stdout and stderr
 [2m• [0m[31mMissing file containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/5deda5ac4212/stdxxx[0m
+[2m• [0mPath to captured stdxxx: _build/alcotest_ext/status/alcotest_ext_dummy_tests/5deda5ac4212/stdxxx
 [33m[PASS*] [0m486ef3ce86ab [36mcapture stdout and stderr[0m
 [2m• [0mChecked output: separate stdout and stderr
 [2m• [0m[31mMissing files containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/486ef3ce86ab/stdout, tests/snapshots/alcotest_ext_dummy_tests/486ef3ce86ab/stderr[0m
+[2m• [0mPath to captured stdout: _build/alcotest_ext/status/alcotest_ext_dummy_tests/486ef3ce86ab/stdout
+[2m• [0mPath to captured stderr: _build/alcotest_ext/status/alcotest_ext_dummy_tests/486ef3ce86ab/stderr
 [32m[XFAIL] [0m85349a4a9157 [36mxfail[0m
 [2m• [0mExpected to fail: raises exception on purpose
-[2m• [0mPath to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/85349a4a9157/unchecked
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/85349a4a9157/log
 [33m[MISS]  [0me52e279299e9 [36mskipped[0m
 [2m• [0mAlways skipped
 [32m[PASS]  [0m91a3c9030236 [36mchdir[0m
-[2m• [0mPath to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/91a3c9030236/unchecked
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/91a3c9030236/log
 [33m[PASS*] [0ma3e1a604f579 [36mmasked[0m
 [2m• [0mChecked output: stdout
 [2m• [0m[31mMissing file containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/a3e1a604f579/stdout[0m
+[2m• [0mPath to captured stdout: _build/alcotest_ext/status/alcotest_ext_dummy_tests/a3e1a604f579/stdout
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/a3e1a604f579/log
 
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[PASS*] [0md1a055429711 [36mcapture stdout[0m                                          [2m│[0m
 [2m└──────────────────────────────────────────────────────────────────────────────┘
 [0m[2m• [0mChecked output: stdout
 [2m• [0m[31mMissing file containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/d1a055429711/stdout[0m
+[2m• [0mPath to captured stdout: _build/alcotest_ext/status/alcotest_ext_dummy_tests/d1a055429711/stdout
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/d1a055429711/log
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[PASS*] [0m72f48157b077 [36mcapture stderr[0m                                          [2m│[0m
 [2m└──────────────────────────────────────────────────────────────────────────────┘
 [0m[2m• [0mChecked output: stderr
 [2m• [0m[31mMissing file containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/72f48157b077/stderr[0m
+[2m• [0mPath to captured stderr: _build/alcotest_ext/status/alcotest_ext_dummy_tests/72f48157b077/stderr
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/72f48157b077/log
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[PASS*] [0m5deda5ac4212 [36mcapture stdxxx[0m                                          [2m│[0m
 [2m└──────────────────────────────────────────────────────────────────────────────┘
 [0m[2m• [0mChecked output: merged stdout and stderr
 [2m• [0m[31mMissing file containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/5deda5ac4212/stdxxx[0m
+[2m• [0mPath to captured stdxxx: _build/alcotest_ext/status/alcotest_ext_dummy_tests/5deda5ac4212/stdxxx
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[PASS*] [0m486ef3ce86ab [36mcapture stdout and stderr[0m                               [2m│[0m
 [2m└──────────────────────────────────────────────────────────────────────────────┘
 [0m[2m• [0mChecked output: separate stdout and stderr
 [2m• [0m[31mMissing files containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/486ef3ce86ab/stdout, tests/snapshots/alcotest_ext_dummy_tests/486ef3ce86ab/stderr[0m
+[2m• [0mPath to captured stdout: _build/alcotest_ext/status/alcotest_ext_dummy_tests/486ef3ce86ab/stdout
+[2m• [0mPath to captured stderr: _build/alcotest_ext/status/alcotest_ext_dummy_tests/486ef3ce86ab/stderr
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[PASS*] [0ma3e1a604f579 [36mmasked[0m                                                  [2m│[0m
 [2m└──────────────────────────────────────────────────────────────────────────────┘
 [0m[2m• [0mChecked output: stdout
 [2m• [0m[31mMissing file containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/a3e1a604f579/stdout[0m
+[2m• [0mPath to captured stdout: _build/alcotest_ext/status/alcotest_ext_dummy_tests/a3e1a604f579/stdout
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/a3e1a604f579/log
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 13/13 selected tests:
   12 successful (11 pass, 1 xfail)
@@ -284,30 +352,39 @@ RUN ./test status --short
 [2m└──────────────────────────────────────────────────────────────────────────────┘
 [0m[2m• [0mChecked output: stdout
 [2m• [0m[31mMissing file containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/d1a055429711/stdout[0m
+[2m• [0mPath to captured stdout: _build/alcotest_ext/status/alcotest_ext_dummy_tests/d1a055429711/stdout
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/d1a055429711/log
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[PASS*] [0m72f48157b077 [36mcapture stderr[0m                                          [2m│[0m
 [2m└──────────────────────────────────────────────────────────────────────────────┘
 [0m[2m• [0mChecked output: stderr
 [2m• [0m[31mMissing file containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/72f48157b077/stderr[0m
+[2m• [0mPath to captured stderr: _build/alcotest_ext/status/alcotest_ext_dummy_tests/72f48157b077/stderr
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/72f48157b077/log
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[PASS*] [0m5deda5ac4212 [36mcapture stdxxx[0m                                          [2m│[0m
 [2m└──────────────────────────────────────────────────────────────────────────────┘
 [0m[2m• [0mChecked output: merged stdout and stderr
 [2m• [0m[31mMissing file containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/5deda5ac4212/stdxxx[0m
+[2m• [0mPath to captured stdxxx: _build/alcotest_ext/status/alcotest_ext_dummy_tests/5deda5ac4212/stdxxx
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[PASS*] [0m486ef3ce86ab [36mcapture stdout and stderr[0m                               [2m│[0m
 [2m└──────────────────────────────────────────────────────────────────────────────┘
 [0m[2m• [0mChecked output: separate stdout and stderr
 [2m• [0m[31mMissing files containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/486ef3ce86ab/stdout, tests/snapshots/alcotest_ext_dummy_tests/486ef3ce86ab/stderr[0m
+[2m• [0mPath to captured stdout: _build/alcotest_ext/status/alcotest_ext_dummy_tests/486ef3ce86ab/stdout
+[2m• [0mPath to captured stderr: _build/alcotest_ext/status/alcotest_ext_dummy_tests/486ef3ce86ab/stderr
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[PASS*] [0ma3e1a604f579 [36mmasked[0m                                                  [2m│[0m
 [2m└──────────────────────────────────────────────────────────────────────────────┘
 [0m[2m• [0mChecked output: stdout
 [2m• [0m[31mMissing file containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/a3e1a604f579/stdout[0m
+[2m• [0mPath to captured stdout: _build/alcotest_ext/status/alcotest_ext_dummy_tests/a3e1a604f579/stdout
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/a3e1a604f579/log
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 13/13 selected tests:
   12 successful (11 pass, 1 xfail)
@@ -330,47 +407,47 @@ Legend:
   subcommand once you're satisfied with the output.
 
 [32m[PASS]  [0m8dbdda48fb87 [36msimple[0m
-[2m• [0mPath to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/8dbdda48fb87/unchecked
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/8dbdda48fb87/log
 [32m[PASS]  [0md57ac4525684 ([1mtags[0m [1mtesting[0m) [36mtags[0m
-[2m• [0mPath to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/d57ac4525684/unchecked
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/d57ac4525684/log
 [32m[PASS]  [0mbd1c5167dc34 [36mcategory[0m > [36msubcategory[0m > [36mcategory[0m
-[2m• [0mPath to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/bd1c5167dc34/unchecked
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/bd1c5167dc34/log
 [32m[PASS]  [0m2c57c8917bfb [36munchecked stdout[0m
-[2m• [0mPath to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/2c57c8917bfb/unchecked
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/2c57c8917bfb/log
 [32m[PASS]  [0m68358d78cb0b [36munchecked stderr[0m
-[2m• [0mPath to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/68358d78cb0b/unchecked
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/68358d78cb0b/log
 [32m[PASS]  [0md1a055429711 [36mcapture stdout[0m
 [2m• [0mChecked output: stdout
 [2m• [0mPath to expected stdout: tests/snapshots/alcotest_ext_dummy_tests/d1a055429711/stdout
-[2m• [0mPath to latest stdout: _build/alcotest_ext/status/alcotest_ext_dummy_tests/d1a055429711/stdout
-[2m• [0mPath to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/d1a055429711/unchecked
+[2m• [0mPath to captured stdout: _build/alcotest_ext/status/alcotest_ext_dummy_tests/d1a055429711/stdout
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/d1a055429711/log
 [32m[PASS]  [0m72f48157b077 [36mcapture stderr[0m
 [2m• [0mChecked output: stderr
 [2m• [0mPath to expected stderr: tests/snapshots/alcotest_ext_dummy_tests/72f48157b077/stderr
-[2m• [0mPath to latest stderr: _build/alcotest_ext/status/alcotest_ext_dummy_tests/72f48157b077/stderr
-[2m• [0mPath to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/72f48157b077/unchecked
+[2m• [0mPath to captured stderr: _build/alcotest_ext/status/alcotest_ext_dummy_tests/72f48157b077/stderr
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/72f48157b077/log
 [32m[PASS]  [0m5deda5ac4212 [36mcapture stdxxx[0m
 [2m• [0mChecked output: merged stdout and stderr
 [2m• [0mPath to expected stdxxx: tests/snapshots/alcotest_ext_dummy_tests/5deda5ac4212/stdxxx
-[2m• [0mPath to latest stdxxx: _build/alcotest_ext/status/alcotest_ext_dummy_tests/5deda5ac4212/stdxxx
+[2m• [0mPath to captured stdxxx: _build/alcotest_ext/status/alcotest_ext_dummy_tests/5deda5ac4212/stdxxx
 [32m[PASS]  [0m486ef3ce86ab [36mcapture stdout and stderr[0m
 [2m• [0mChecked output: separate stdout and stderr
 [2m• [0mPath to expected stdout: tests/snapshots/alcotest_ext_dummy_tests/486ef3ce86ab/stdout
-[2m• [0mPath to latest stdout: _build/alcotest_ext/status/alcotest_ext_dummy_tests/486ef3ce86ab/stdout
+[2m• [0mPath to captured stdout: _build/alcotest_ext/status/alcotest_ext_dummy_tests/486ef3ce86ab/stdout
 [2m• [0mPath to expected stderr: tests/snapshots/alcotest_ext_dummy_tests/486ef3ce86ab/stderr
-[2m• [0mPath to latest stderr: _build/alcotest_ext/status/alcotest_ext_dummy_tests/486ef3ce86ab/stderr
+[2m• [0mPath to captured stderr: _build/alcotest_ext/status/alcotest_ext_dummy_tests/486ef3ce86ab/stderr
 [32m[XFAIL] [0m85349a4a9157 [36mxfail[0m
 [2m• [0mExpected to fail: raises exception on purpose
-[2m• [0mPath to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/85349a4a9157/unchecked
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/85349a4a9157/log
 [33m[MISS]  [0me52e279299e9 [36mskipped[0m
 [2m• [0mAlways skipped
 [32m[PASS]  [0m91a3c9030236 [36mchdir[0m
-[2m• [0mPath to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/91a3c9030236/unchecked
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/91a3c9030236/log
 [32m[PASS]  [0ma3e1a604f579 [36mmasked[0m
 [2m• [0mChecked output: stdout
 [2m• [0mPath to expected stdout: tests/snapshots/alcotest_ext_dummy_tests/a3e1a604f579/stdout
-[2m• [0mPath to latest stdout: _build/alcotest_ext/status/alcotest_ext_dummy_tests/a3e1a604f579/stdout
-[2m• [0mPath to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/a3e1a604f579/unchecked
+[2m• [0mPath to captured stdout: _build/alcotest_ext/status/alcotest_ext_dummy_tests/a3e1a604f579/stdout
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/a3e1a604f579/log
 
 13/13 selected tests:
   12 successful (11 pass, 1 xfail)
@@ -395,102 +472,134 @@ Legend:
 
 [33m[MISS]  [0m8dbdda48fb87 [36msimple[0m
 [2m• [0m[31mMissing file containing the test output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/8dbdda48fb87/outcome[0m
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/8dbdda48fb87/log
 [33m[MISS]  [0md57ac4525684 ([1mtags[0m [1mtesting[0m) [36mtags[0m
 [2m• [0m[31mMissing file containing the test output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/d57ac4525684/outcome[0m
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/d57ac4525684/log
 [33m[MISS]  [0mbd1c5167dc34 [36mcategory[0m > [36msubcategory[0m > [36mcategory[0m
 [2m• [0m[31mMissing file containing the test output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/bd1c5167dc34/outcome[0m
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/bd1c5167dc34/log
 [33m[MISS]  [0m2c57c8917bfb [36munchecked stdout[0m
 [2m• [0m[31mMissing file containing the test output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/2c57c8917bfb/outcome[0m
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/2c57c8917bfb/log
 [33m[MISS]  [0m68358d78cb0b [36munchecked stderr[0m
 [2m• [0m[31mMissing file containing the test output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/68358d78cb0b/outcome[0m
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/68358d78cb0b/log
 [33m[MISS]  [0md1a055429711 [36mcapture stdout[0m
 [2m• [0mChecked output: stdout
 [2m• [0m[31mMissing file containing the test output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/d1a055429711/outcome[0m
+[2m• [0mPath to captured stdout: _build/alcotest_ext/status/alcotest_ext_dummy_tests/d1a055429711/stdout
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/d1a055429711/log
 [33m[MISS]  [0m72f48157b077 [36mcapture stderr[0m
 [2m• [0mChecked output: stderr
 [2m• [0m[31mMissing file containing the test output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/72f48157b077/outcome[0m
+[2m• [0mPath to captured stderr: _build/alcotest_ext/status/alcotest_ext_dummy_tests/72f48157b077/stderr
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/72f48157b077/log
 [33m[MISS]  [0m5deda5ac4212 [36mcapture stdxxx[0m
 [2m• [0mChecked output: merged stdout and stderr
 [2m• [0m[31mMissing file containing the test output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/5deda5ac4212/outcome[0m
+[2m• [0mPath to captured stdxxx: _build/alcotest_ext/status/alcotest_ext_dummy_tests/5deda5ac4212/stdxxx
 [33m[MISS]  [0m486ef3ce86ab [36mcapture stdout and stderr[0m
 [2m• [0mChecked output: separate stdout and stderr
 [2m• [0m[31mMissing file containing the test output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/486ef3ce86ab/outcome[0m
+[2m• [0mPath to captured stdout: _build/alcotest_ext/status/alcotest_ext_dummy_tests/486ef3ce86ab/stdout
+[2m• [0mPath to captured stderr: _build/alcotest_ext/status/alcotest_ext_dummy_tests/486ef3ce86ab/stderr
 [33m[MISS]  [0m85349a4a9157 [36mxfail[0m
 [2m• [0mExpected to fail: raises exception on purpose
 [2m• [0m[31mMissing file containing the test output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/85349a4a9157/outcome[0m
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/85349a4a9157/log
 [33m[MISS]  [0me52e279299e9 [36mskipped[0m
 [2m• [0mAlways skipped
 [33m[MISS]  [0m91a3c9030236 [36mchdir[0m
 [2m• [0m[31mMissing file containing the test output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/91a3c9030236/outcome[0m
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/91a3c9030236/log
 [33m[MISS]  [0ma3e1a604f579 [36mmasked[0m
 [2m• [0mChecked output: stdout
 [2m• [0m[31mMissing file containing the test output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/a3e1a604f579/outcome[0m
+[2m• [0mPath to captured stdout: _build/alcotest_ext/status/alcotest_ext_dummy_tests/a3e1a604f579/stdout
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/a3e1a604f579/log
 
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[MISS]  [0m8dbdda48fb87 [36msimple[0m                                                  [2m│[0m
 [2m└──────────────────────────────────────────────────────────────────────────────┘
 [0m[2m• [0m[31mMissing file containing the test output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/8dbdda48fb87/outcome[0m
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/8dbdda48fb87/log
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[MISS]  [0md57ac4525684 ([1mtags[0m [1mtesting[0m) [36mtags[0m                                     [2m│[0m
 [2m└──────────────────────────────────────────────────────────────────────────────┘
 [0m[2m• [0m[31mMissing file containing the test output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/d57ac4525684/outcome[0m
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/d57ac4525684/log
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[MISS]  [0mbd1c5167dc34 [36mcategory[0m > [36msubcategory[0m > [36mcategory[0m                       [2m│[0m
 [2m└──────────────────────────────────────────────────────────────────────────────┘
 [0m[2m• [0m[31mMissing file containing the test output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/bd1c5167dc34/outcome[0m
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/bd1c5167dc34/log
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[MISS]  [0m2c57c8917bfb [36munchecked stdout[0m                                        [2m│[0m
 [2m└──────────────────────────────────────────────────────────────────────────────┘
 [0m[2m• [0m[31mMissing file containing the test output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/2c57c8917bfb/outcome[0m
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/2c57c8917bfb/log
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[MISS]  [0m68358d78cb0b [36munchecked stderr[0m                                        [2m│[0m
 [2m└──────────────────────────────────────────────────────────────────────────────┘
 [0m[2m• [0m[31mMissing file containing the test output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/68358d78cb0b/outcome[0m
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/68358d78cb0b/log
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[MISS]  [0md1a055429711 [36mcapture stdout[0m                                          [2m│[0m
 [2m└──────────────────────────────────────────────────────────────────────────────┘
 [0m[2m• [0mChecked output: stdout
 [2m• [0m[31mMissing file containing the test output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/d1a055429711/outcome[0m
+[2m• [0mPath to captured stdout: _build/alcotest_ext/status/alcotest_ext_dummy_tests/d1a055429711/stdout
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/d1a055429711/log
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[MISS]  [0m72f48157b077 [36mcapture stderr[0m                                          [2m│[0m
 [2m└──────────────────────────────────────────────────────────────────────────────┘
 [0m[2m• [0mChecked output: stderr
 [2m• [0m[31mMissing file containing the test output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/72f48157b077/outcome[0m
+[2m• [0mPath to captured stderr: _build/alcotest_ext/status/alcotest_ext_dummy_tests/72f48157b077/stderr
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/72f48157b077/log
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[MISS]  [0m5deda5ac4212 [36mcapture stdxxx[0m                                          [2m│[0m
 [2m└──────────────────────────────────────────────────────────────────────────────┘
 [0m[2m• [0mChecked output: merged stdout and stderr
 [2m• [0m[31mMissing file containing the test output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/5deda5ac4212/outcome[0m
+[2m• [0mPath to captured stdxxx: _build/alcotest_ext/status/alcotest_ext_dummy_tests/5deda5ac4212/stdxxx
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[MISS]  [0m486ef3ce86ab [36mcapture stdout and stderr[0m                               [2m│[0m
 [2m└──────────────────────────────────────────────────────────────────────────────┘
 [0m[2m• [0mChecked output: separate stdout and stderr
 [2m• [0m[31mMissing file containing the test output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/486ef3ce86ab/outcome[0m
+[2m• [0mPath to captured stdout: _build/alcotest_ext/status/alcotest_ext_dummy_tests/486ef3ce86ab/stdout
+[2m• [0mPath to captured stderr: _build/alcotest_ext/status/alcotest_ext_dummy_tests/486ef3ce86ab/stderr
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[MISS]  [0m85349a4a9157 [36mxfail[0m                                                   [2m│[0m
 [2m└──────────────────────────────────────────────────────────────────────────────┘
 [0m[2m• [0mExpected to fail: raises exception on purpose
 [2m• [0m[31mMissing file containing the test output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/85349a4a9157/outcome[0m
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/85349a4a9157/log
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[MISS]  [0m91a3c9030236 [36mchdir[0m                                                   [2m│[0m
 [2m└──────────────────────────────────────────────────────────────────────────────┘
 [0m[2m• [0m[31mMissing file containing the test output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/91a3c9030236/outcome[0m
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/91a3c9030236/log
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[MISS]  [0ma3e1a604f579 [36mmasked[0m                                                  [2m│[0m
 [2m└──────────────────────────────────────────────────────────────────────────────┘
 [0m[2m• [0mChecked output: stdout
 [2m• [0m[31mMissing file containing the test output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/a3e1a604f579/outcome[0m
+[2m• [0mPath to captured stdout: _build/alcotest_ext/status/alcotest_ext_dummy_tests/a3e1a604f579/stdout
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/a3e1a604f579/log
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 13/13 selected tests:
   0 successful (0 pass, 0 xfail)
@@ -509,46 +618,46 @@ Legend:
   In this case, you should review the test output and run the 'approve'
   subcommand once you're satisfied with the output.
 [33m[RUN][0m   8dbdda48fb87 [36msimple[0m...[2K[32m[PASS]  [0m8dbdda48fb87 [36msimple[0m
-[2m• [0mPath to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/8dbdda48fb87/unchecked
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/8dbdda48fb87/log
 [33m[RUN][0m   d57ac4525684 ([1mtags[0m [1mtesting[0m) [36mtags[0m...[2K[32m[PASS]  [0md57ac4525684 ([1mtags[0m [1mtesting[0m) [36mtags[0m
-[2m• [0mPath to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/d57ac4525684/unchecked
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/d57ac4525684/log
 [33m[RUN][0m   bd1c5167dc34 [36mcategory[0m > [36msubcategory[0m > [36mcategory[0m...[2K[32m[PASS]  [0mbd1c5167dc34 [36mcategory[0m > [36msubcategory[0m > [36mcategory[0m
-[2m• [0mPath to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/bd1c5167dc34/unchecked
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/bd1c5167dc34/log
 [33m[RUN][0m   2c57c8917bfb [36munchecked stdout[0m...[2K[32m[PASS]  [0m2c57c8917bfb [36munchecked stdout[0m
-[2m• [0mPath to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/2c57c8917bfb/unchecked
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/2c57c8917bfb/log
 [33m[RUN][0m   68358d78cb0b [36munchecked stderr[0m...[2K[32m[PASS]  [0m68358d78cb0b [36munchecked stderr[0m
-[2m• [0mPath to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/68358d78cb0b/unchecked
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/68358d78cb0b/log
 [33m[RUN][0m   d1a055429711 [36mcapture stdout[0m...[2K[32m[PASS]  [0md1a055429711 [36mcapture stdout[0m
 [2m• [0mChecked output: stdout
 [2m• [0mPath to expected stdout: tests/snapshots/alcotest_ext_dummy_tests/d1a055429711/stdout
-[2m• [0mPath to latest stdout: _build/alcotest_ext/status/alcotest_ext_dummy_tests/d1a055429711/stdout
-[2m• [0mPath to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/d1a055429711/unchecked
+[2m• [0mPath to captured stdout: _build/alcotest_ext/status/alcotest_ext_dummy_tests/d1a055429711/stdout
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/d1a055429711/log
 [33m[RUN][0m   72f48157b077 [36mcapture stderr[0m...[2K[32m[PASS]  [0m72f48157b077 [36mcapture stderr[0m
 [2m• [0mChecked output: stderr
 [2m• [0mPath to expected stderr: tests/snapshots/alcotest_ext_dummy_tests/72f48157b077/stderr
-[2m• [0mPath to latest stderr: _build/alcotest_ext/status/alcotest_ext_dummy_tests/72f48157b077/stderr
-[2m• [0mPath to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/72f48157b077/unchecked
+[2m• [0mPath to captured stderr: _build/alcotest_ext/status/alcotest_ext_dummy_tests/72f48157b077/stderr
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/72f48157b077/log
 [33m[RUN][0m   5deda5ac4212 [36mcapture stdxxx[0m...[2K[32m[PASS]  [0m5deda5ac4212 [36mcapture stdxxx[0m
 [2m• [0mChecked output: merged stdout and stderr
 [2m• [0mPath to expected stdxxx: tests/snapshots/alcotest_ext_dummy_tests/5deda5ac4212/stdxxx
-[2m• [0mPath to latest stdxxx: _build/alcotest_ext/status/alcotest_ext_dummy_tests/5deda5ac4212/stdxxx
+[2m• [0mPath to captured stdxxx: _build/alcotest_ext/status/alcotest_ext_dummy_tests/5deda5ac4212/stdxxx
 [33m[RUN][0m   486ef3ce86ab [36mcapture stdout and stderr[0m...[2K[32m[PASS]  [0m486ef3ce86ab [36mcapture stdout and stderr[0m
 [2m• [0mChecked output: separate stdout and stderr
 [2m• [0mPath to expected stdout: tests/snapshots/alcotest_ext_dummy_tests/486ef3ce86ab/stdout
-[2m• [0mPath to latest stdout: _build/alcotest_ext/status/alcotest_ext_dummy_tests/486ef3ce86ab/stdout
+[2m• [0mPath to captured stdout: _build/alcotest_ext/status/alcotest_ext_dummy_tests/486ef3ce86ab/stdout
 [2m• [0mPath to expected stderr: tests/snapshots/alcotest_ext_dummy_tests/486ef3ce86ab/stderr
-[2m• [0mPath to latest stderr: _build/alcotest_ext/status/alcotest_ext_dummy_tests/486ef3ce86ab/stderr
+[2m• [0mPath to captured stderr: _build/alcotest_ext/status/alcotest_ext_dummy_tests/486ef3ce86ab/stderr
 [33m[RUN][0m   85349a4a9157 [36mxfail[0m...[2K[32m[XFAIL] [0m85349a4a9157 [36mxfail[0m
 [2m• [0mExpected to fail: raises exception on purpose
-[2m• [0mPath to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/85349a4a9157/unchecked
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/85349a4a9157/log
 [33m[SKIP][0m  e52e279299e9 [36mskipped[0m
 [33m[RUN][0m   91a3c9030236 [36mchdir[0m...[2K[32m[PASS]  [0m91a3c9030236 [36mchdir[0m
-[2m• [0mPath to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/91a3c9030236/unchecked
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/91a3c9030236/log
 [33m[RUN][0m   a3e1a604f579 [36mmasked[0m...[2K[32m[PASS]  [0ma3e1a604f579 [36mmasked[0m
 [2m• [0mChecked output: stdout
 [2m• [0mPath to expected stdout: tests/snapshots/alcotest_ext_dummy_tests/a3e1a604f579/stdout
-[2m• [0mPath to latest stdout: _build/alcotest_ext/status/alcotest_ext_dummy_tests/a3e1a604f579/stdout
-[2m• [0mPath to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/a3e1a604f579/unchecked
+[2m• [0mPath to captured stdout: _build/alcotest_ext/status/alcotest_ext_dummy_tests/a3e1a604f579/stdout
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/a3e1a604f579/log
 13/13 selected tests:
   12 successful (11 pass, 1 xfail)
   0 unsuccessful (0 fail, 0 xpass)
@@ -571,67 +680,85 @@ Legend:
   subcommand once you're satisfied with the output.
 
 [32m[PASS]  [0m8dbdda48fb87 [36msimple[0m
-[2m• [0mPath to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/8dbdda48fb87/unchecked
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/8dbdda48fb87/log
 [32m[PASS]  [0md57ac4525684 ([1mtags[0m [1mtesting[0m) [36mtags[0m
-[2m• [0mPath to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/d57ac4525684/unchecked
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/d57ac4525684/log
 [32m[PASS]  [0mbd1c5167dc34 [36mcategory[0m > [36msubcategory[0m > [36mcategory[0m
-[2m• [0mPath to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/bd1c5167dc34/unchecked
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/bd1c5167dc34/log
 [32m[PASS]  [0m2c57c8917bfb [36munchecked stdout[0m
-[2m• [0mPath to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/2c57c8917bfb/unchecked
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/2c57c8917bfb/log
 [32m[PASS]  [0m68358d78cb0b [36munchecked stderr[0m
-[2m• [0mPath to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/68358d78cb0b/unchecked
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/68358d78cb0b/log
 [33m[PASS*] [0md1a055429711 [36mcapture stdout[0m
 [2m• [0mChecked output: stdout
 [2m• [0m[31mMissing file containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/d1a055429711/stdout[0m
+[2m• [0mPath to captured stdout: _build/alcotest_ext/status/alcotest_ext_dummy_tests/d1a055429711/stdout
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/d1a055429711/log
 [33m[PASS*] [0m72f48157b077 [36mcapture stderr[0m
 [2m• [0mChecked output: stderr
 [2m• [0m[31mMissing file containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/72f48157b077/stderr[0m
+[2m• [0mPath to captured stderr: _build/alcotest_ext/status/alcotest_ext_dummy_tests/72f48157b077/stderr
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/72f48157b077/log
 [33m[PASS*] [0m5deda5ac4212 [36mcapture stdxxx[0m
 [2m• [0mChecked output: merged stdout and stderr
 [2m• [0m[31mMissing file containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/5deda5ac4212/stdxxx[0m
+[2m• [0mPath to captured stdxxx: _build/alcotest_ext/status/alcotest_ext_dummy_tests/5deda5ac4212/stdxxx
 [33m[PASS*] [0m486ef3ce86ab [36mcapture stdout and stderr[0m
 [2m• [0mChecked output: separate stdout and stderr
 [2m• [0m[31mMissing files containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/486ef3ce86ab/stdout, tests/snapshots/alcotest_ext_dummy_tests/486ef3ce86ab/stderr[0m
+[2m• [0mPath to captured stdout: _build/alcotest_ext/status/alcotest_ext_dummy_tests/486ef3ce86ab/stdout
+[2m• [0mPath to captured stderr: _build/alcotest_ext/status/alcotest_ext_dummy_tests/486ef3ce86ab/stderr
 [32m[XFAIL] [0m85349a4a9157 [36mxfail[0m
 [2m• [0mExpected to fail: raises exception on purpose
-[2m• [0mPath to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/85349a4a9157/unchecked
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/85349a4a9157/log
 [33m[MISS]  [0me52e279299e9 [36mskipped[0m
 [2m• [0mAlways skipped
 [32m[PASS]  [0m91a3c9030236 [36mchdir[0m
-[2m• [0mPath to unchecked output: _build/alcotest_ext/status/alcotest_ext_dummy_tests/91a3c9030236/unchecked
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/91a3c9030236/log
 [33m[PASS*] [0ma3e1a604f579 [36mmasked[0m
 [2m• [0mChecked output: stdout
 [2m• [0m[31mMissing file containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/a3e1a604f579/stdout[0m
+[2m• [0mPath to captured stdout: _build/alcotest_ext/status/alcotest_ext_dummy_tests/a3e1a604f579/stdout
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/a3e1a604f579/log
 
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[PASS*] [0md1a055429711 [36mcapture stdout[0m                                          [2m│[0m
 [2m└──────────────────────────────────────────────────────────────────────────────┘
 [0m[2m• [0mChecked output: stdout
 [2m• [0m[31mMissing file containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/d1a055429711/stdout[0m
+[2m• [0mPath to captured stdout: _build/alcotest_ext/status/alcotest_ext_dummy_tests/d1a055429711/stdout
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/d1a055429711/log
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[PASS*] [0m72f48157b077 [36mcapture stderr[0m                                          [2m│[0m
 [2m└──────────────────────────────────────────────────────────────────────────────┘
 [0m[2m• [0mChecked output: stderr
 [2m• [0m[31mMissing file containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/72f48157b077/stderr[0m
+[2m• [0mPath to captured stderr: _build/alcotest_ext/status/alcotest_ext_dummy_tests/72f48157b077/stderr
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/72f48157b077/log
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[PASS*] [0m5deda5ac4212 [36mcapture stdxxx[0m                                          [2m│[0m
 [2m└──────────────────────────────────────────────────────────────────────────────┘
 [0m[2m• [0mChecked output: merged stdout and stderr
 [2m• [0m[31mMissing file containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/5deda5ac4212/stdxxx[0m
+[2m• [0mPath to captured stdxxx: _build/alcotest_ext/status/alcotest_ext_dummy_tests/5deda5ac4212/stdxxx
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[PASS*] [0m486ef3ce86ab [36mcapture stdout and stderr[0m                               [2m│[0m
 [2m└──────────────────────────────────────────────────────────────────────────────┘
 [0m[2m• [0mChecked output: separate stdout and stderr
 [2m• [0m[31mMissing files containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/486ef3ce86ab/stdout, tests/snapshots/alcotest_ext_dummy_tests/486ef3ce86ab/stderr[0m
+[2m• [0mPath to captured stdout: _build/alcotest_ext/status/alcotest_ext_dummy_tests/486ef3ce86ab/stdout
+[2m• [0mPath to captured stderr: _build/alcotest_ext/status/alcotest_ext_dummy_tests/486ef3ce86ab/stderr
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 [2m┌──────────────────────────────────────────────────────────────────────────────┐
 [0m[2m│[0m [33m[PASS*] [0ma3e1a604f579 [36mmasked[0m                                                  [2m│[0m
 [2m└──────────────────────────────────────────────────────────────────────────────┘
 [0m[2m• [0mChecked output: stdout
 [2m• [0m[31mMissing file containing the expected output: tests/snapshots/alcotest_ext_dummy_tests/a3e1a604f579/stdout[0m
+[2m• [0mPath to captured stdout: _build/alcotest_ext/status/alcotest_ext_dummy_tests/a3e1a604f579/stdout
+[2m• [0mPath to captured log: _build/alcotest_ext/status/alcotest_ext_dummy_tests/a3e1a604f579/log
 [2m────────────────────────────────────────────────────────────────────────────────[0m
 13/13 selected tests:
   12 successful (11 pass, 1 xfail)

--- a/libs/git_wrapper/Git_wrapper.ml
+++ b/libs/git_wrapper/Git_wrapper.ml
@@ -427,9 +427,9 @@ let init ?cwd ?(branch = "main") () =
   | Ok (`Exited 0) -> ()
   | _ -> raise (Error "Error running git init")
 
-let add ?cwd files =
+let add ?cwd ?(force = false) files =
   let files = List_.map Fpath.to_string files in
-  let cmd = (git, cd cwd @ [ "add" ] @ files) in
+  let cmd = (git, cd cwd @ [ "add" ] @ flag "--force" force @ files) in
   match UCmd.status_of_run cmd with
   | Ok (`Exited 0) -> ()
   | _ -> raise (Error "Error running git add")

--- a/libs/git_wrapper/Git_wrapper.mli
+++ b/libs/git_wrapper/Git_wrapper.mli
@@ -108,7 +108,7 @@ val init : ?cwd:Fpath.t -> ?branch:string -> unit -> unit
     on the git version.
 *)
 
-val add : ?cwd:Fpath.t -> Fpath.t list -> unit
+val add : ?cwd:Fpath.t -> ?force:bool -> Fpath.t list -> unit
 (** Add the given files to the git repo *)
 
 val commit : ?cwd:Fpath.t -> string -> unit

--- a/libs/git_wrapper/Git_wrapper.mli
+++ b/libs/git_wrapper/Git_wrapper.mli
@@ -34,7 +34,11 @@ type ls_files_kind =
    This returns a list of paths relative to cwd.
 *)
 val ls_files :
-  ?cwd:Fpath.t -> ?kinds:ls_files_kind list -> Fpath.t list -> Fpath.t list
+  ?cwd:Fpath.t ->
+  ?exclude_standard:bool ->
+  ?kinds:ls_files_kind list ->
+  Fpath.t list ->
+  Fpath.t list
 
 (* get merge base between arg and HEAD *)
 val get_merge_base : string -> string

--- a/libs/gitignore/Unit_gitignore.ml
+++ b/libs/gitignore/Unit_gitignore.ml
@@ -4,38 +4,39 @@
 
 open Printf
 module F = Testutil_files
-open Testutil_files (* file/dir/symlink *)
 
 (*****************************************************************************)
 (* Helpers *)
 (*****************************************************************************)
 
-(* ?? *)
-let test_list (files : t list) () =
+let concat_lines lines = String.concat "\n" lines ^ "\n"
+let gitignore lines : Testutil_files.t = File (".gitignore", concat_lines lines)
+
+(* Test that Testutil_files works as it should *)
+let test_list (files : F.t list) () =
   F.with_tempfiles_verbose files (fun root ->
-      let files2 = read root |> sort in
+      let files2 = F.read root |> F.sort in
       printf "Output files:\n";
-      print_files files2;
+      F.print_files files2;
       assert (files2 = files))
 
 (*
    In these tests, the file hierarchy must contain the
    .gitignore files but the target files are not needed.
 *)
-let test_filter (files : F.t list) selection () =
+let test_filter (files : F.t list) () =
   F.with_tempdir ~chdir:true (fun root ->
       let files = F.sort files in
       printf "--- All files ---\n";
-      print_files files;
+      F.print_files files;
       F.write root files;
       let files2 = F.read root |> F.sort in
       assert (files2 = files);
       printf "--- Filtered files ---\n";
       let filter = Gitignore_filter.create ~project_root:root () in
-      let error = ref false in
-      selection
-      |> List.iter (fun (path, should_be_selected) ->
-             let path = Ppath.of_string_for_tests path in
+      files |> F.flatten
+      |> List.iter (fun path ->
+             let path = Ppath.of_string_for_tests (Fpath.to_string path) in
              let status, selection_events =
                Common.save_excursion Glob.Match.debug true (fun () ->
                    let selection_events = [] in
@@ -44,87 +45,77 @@ let test_filter (files : F.t list) selection () =
              in
              printf "Selection events for path %s:\n" (Ppath.to_string path);
              print_string (Gitignore.show_selection_events selection_events);
-             if should_be_selected then (
-               match status with
-               | Not_ignored ->
-                   printf "[OK] %s: not ignored\n" (Ppath.to_string path)
-               | Ignored ->
-                   printf "[FAIL] %s: ignored\n" (Ppath.to_string path);
-                   error := true)
-             else
-               match status with
-               | Not_ignored ->
-                   printf "[FAIL] %s: not ignored\n" (Ppath.to_string path);
-                   error := true
-               | Ignored -> printf "[OK] %s: ignored\n" (Ppath.to_string path));
-      assert (not !error))
+             match status with
+             | Not_ignored -> printf "SEL %s\n" (Ppath.to_string path)
+             | Ignored -> printf "IGN %s\n" (Ppath.to_string path)))
 
 (*****************************************************************************)
 (* The tests *)
 (*****************************************************************************)
 
+let t =
+  Alcotest_ext.create ~checked_output:Stdout
+    ~mask_output:[ Alcotest_ext.mask_temp_paths () ]
+
 let tests =
-  Alcotest_ext.pack_tests "Gitignore"
+  let open F in
+  Alcotest_ext.pack_tests_pro "Gitignore"
     [
-      ("list one file", test_list [ file "a" ]);
-      ( "list hierarchy",
-        test_list
-          [
-            file "a";
-            file "b";
-            symlink "c" "a";
-            dir "dir" [ file "d"; symlink "e" "f"; dir "g" [] ];
-          ] );
-      ( "simple gitignore",
-        test_filter
-          [ File (".gitignore", "*.c"); file "hello.c"; file "hello.ml" ]
-          [ ("/hello.ml", true); ("/hello.c", false) ] );
-      ( "relative paths",
-        test_filter
-          [ File (".gitignore", "*.c"); file "hello.c"; file "hello.ml" ]
-          [ ("hello.ml", true); ("hello.c", false) ] );
-      ( "deep gitignore",
-        test_filter
-          [ dir "dir" [ File (".gitignore", "a"); file "a" ]; file "a" ]
-          [ ("/a", true); ("/dir/a", false) ] );
-      ( "ignore directories only",
-        test_filter
-          [
-            File (".gitignore", "a/");
-            dir "dir" [ file "a" ];
-            dir "a" [ file "b" ];
-          ]
-          [
-            ("/a/", false);
-            ("/a", true);
-            ("/dir/a", true);
-            ("/dir/a/", false);
-            ("/a/b", false);
-          ] );
-      ( "absolute patterns",
-        test_filter
-          [
-            (* [!] 'b/c' is treated as anchored just like '/b/c' because it
-               contains a slash in the middle, as per the gitignore spec. *)
-            File (".gitignore", "/a\nb/c");
-            dir "a" [ file "b" ];
-            dir "b" [ file "a"; file "c"; file "d"; dir "b" [ file "c" ] ];
-          ]
-          [
-            ("/a/b", false);
-            ("/b/a", true);
-            ("/b/c", false);
-            ("/b/d", true);
-            ("/b/b/c", true);
-          ] );
-      (* unanchored patterns should not match if the parent dir hasn't been matched, and the path is excluded *)
-      ( "excluded patterns",
-        test_filter
-          [
-            File (".gitignore", "a/\n!dir/a\n!a/b");
-            dir "dir" [ dir "a" [ file "b" ] ];
-            dir "a" [ file "b" ];
-          ]
-          [ ("/a/", false); ("/a", true); ("/dir/a/b", true); ("/a/b", false) ]
-      );
+      t "list one file" (test_list [ file "a" ]);
+      t "list hierarchy"
+        (test_list
+           [
+             file "a";
+             file "b";
+             symlink "c" "a";
+             dir "dir" [ file "d"; symlink "e" "f"; dir "g" [] ];
+           ]);
+      t "simple gitignore"
+        (test_filter [ gitignore [ "*.c" ]; file "hello.c"; file "hello.ml" ]);
+      t "relative paths"
+        (test_filter [ gitignore [ "*.c" ]; file "hello.c"; file "hello.ml" ]);
+      t "unanchored"
+        (test_filter [ gitignore [ "a" ]; dir "dir" [ file "a" ]; file "a" ]);
+      t "deep gitignore"
+        (test_filter [ dir "dir" [ gitignore [ "a" ]; file "a" ]; file "a" ]);
+      t "ignore directories only"
+        (test_filter
+           [ gitignore [ "a/" ]; dir "dir" [ file "a" ]; dir "a" [ file "b" ] ]);
+      t "absolute patterns"
+        (test_filter
+           [
+             (* [!] 'b/c' is treated as anchored just like '/b/c' because it
+                contains a slash in the middle, as per the gitignore spec. *)
+             gitignore [ "/a"; "b/c" ];
+             dir "a" [ file "b" ];
+             dir "b" [ file "a"; file "c"; file "d"; dir "b" [ file "c" ] ];
+           ]);
+      (* unanchored patterns should not match if the parent dir hasn't been
+         matched, and the path is excluded *)
+      t "excluded patterns"
+        (test_filter
+           [
+             (* 'a/' excludes any folder or subfolder named 'a' *)
+             gitignore [ "a/"; "!dir/a"; "!a/b" ];
+             (* '/dir/a' is not ignored because '!dir/a' overrides 'a/'
+                (therefore '/dir/a/b' is not ignored either) *)
+             dir "dir" [ dir "a" [ file "b" ] ];
+             (* /a/b is ignored because its parent is ignored;
+                '!a/b' can do nothing about it. *)
+             dir "a" [ file "b" ];
+           ]);
+      t "anchored with trailing wildcard"
+        (test_filter
+           [
+             gitignore [ "dir/*" ];
+             dir "dir" [ file "ignore-me" ];
+             (* The slash in 'dir/*' anchors the pattern *)
+             dir "sub" [ dir "dir" [ file "ignore-me-not" ] ];
+           ]);
+      t "ignore all but one"
+        (test_filter
+           [
+             gitignore [ "dir/*"; "!dir/ignore-me-not" ];
+             dir "dir" [ file "ignore-me"; file "ignore-me-not" ];
+           ]);
     ]

--- a/libs/glob/Lexer.mll
+++ b/libs/glob/Lexer.mll
@@ -11,7 +11,7 @@ let syntax_error msg =
 let neg = ['^' '!']
 
 rule token = parse
-| '/'      { SLASH }
+| '/'+     { SLASH }
 | "**"     { (* only special if it occupies a whole path segment. This
                 is dealt with later. *)
              STARSTAR }

--- a/libs/glob/Match.ml
+++ b/libs/glob/Match.ml
@@ -112,7 +112,7 @@ let rec translate buf pat =
       add buf "/+";
       translate buf pat
   | Any_subpath :: pat ->
-      add buf "(?:[^/]+/+)*";
+      add buf "/*(?:[^/]+/+)*";
       translate buf pat
   | [] -> add buf eos
 
@@ -141,7 +141,7 @@ let run matcher path =
   let res = Pcre_.pmatch_noerr ~rex:matcher.re path in
   if !debug then
     (* expensive string concatenation; may not be suitable for logger#debug *)
-    Printf.eprintf "** glob: %S  pcre: %s  path: %S  matches: %B\n"
+    Printf.eprintf "** glob: %S  pcre: %s  path: %S  matches: %B\n%!"
       matcher.source.line_contents matcher.re.pattern path res;
   res
 [@@profiling "Glob.Match.run"]

--- a/libs/glob/Match.ml
+++ b/libs/glob/Match.ml
@@ -135,12 +135,8 @@ let run matcher path =
   let res = Pcre_.pmatch_noerr ~rex:matcher.re path in
   if !debug then
     (* expensive string concatenation; may not be suitable for logger#debug *)
-    (*
     Printf.printf "** glob: %S  pcre: %s  path: %S  matches: %B\n"
-      matcher.source.line_contents matcher.pcre path res;
-*)
-    Printf.printf "** pattern: %S  path: %S  matches: %B\n"
-      matcher.source.line_contents path res;
+      matcher.source.line_contents matcher.re.pattern path res;
   res
 [@@profiling "Glob.Match.run"]
 

--- a/libs/glob/Match.ml
+++ b/libs/glob/Match.ml
@@ -141,7 +141,7 @@ let run matcher path =
   let res = Pcre_.pmatch_noerr ~rex:matcher.re path in
   if !debug then
     (* expensive string concatenation; may not be suitable for logger#debug *)
-    Printf.printf "** glob: %S  pcre: %s  path: %S  matches: %B\n"
+    Printf.eprintf "** glob: %S  pcre: %s  path: %S  matches: %B\n"
       matcher.source.line_contents matcher.re.pattern path res;
   res
 [@@profiling "Glob.Match.run"]

--- a/libs/glob/Match.ml
+++ b/libs/glob/Match.ml
@@ -43,47 +43,79 @@ type loc = {
 let show_loc x =
   Printf.sprintf "%s, line %i: %s" x.source_name x.line_number x.line_contents
 
-type compiled_pattern = { source : loc; re : Re.re }
+type compiled_pattern = { source : loc; re : Pcre_.t }
 
 let string_loc ?(source_name = "<pattern>") ~source_kind pat =
   { source_name; source_kind; line_number = 1; line_contents = pat }
 
 (*****************************************************************************)
-(* Compilation of a Glob_pattern.t to Re.t *)
+(* Compilation of a Glob_pattern.t to a PCRE pattern *)
 (*****************************************************************************)
+(*
+   We used to use ocaml-re ('Re' module) to build directly a tree but
+   unfortunately, it doesn't support lookhead assertions that we would
+   need to match a glob pattern correctly. The issue is that the pattern
+   'a/*b' matches 'a/b' but the pattern 'a/*' doesn't match 'a/'.
+*)
 
-let slash = Re.char '/'
-let not_slash = Re.compl [ slash ]
+let add = Buffer.add_string
+let addc = Buffer.add_char
+let quote_char buf c = add buf (Pcre.quote (String.make 1 c))
 
-let map_frag (frag : Pattern.segment_fragment) : Re.t =
+let translate_frag buf (frag : Pattern.segment_fragment) =
   match frag with
-  | Char c -> Re.char c
+  | Char c -> quote_char buf c
   | Char_class { complement; ranges } ->
-      let cset =
-        List_.map
-          (fun range ->
-            match range with
-            | Class_char c -> Re.char c
-            | Range (a, b) -> Re.rg a b)
-          ranges
-      in
-      if complement then Re.compl cset else Re.alt cset
-  | Question -> not_slash
-  | Star -> Re.rep not_slash
+      if complement then add buf "[^" else addc buf '[';
+      ranges
+      |> List.iter (fun range ->
+             match range with
+             | Class_char c -> quote_char buf c
+             | Range (a, b) ->
+                 quote_char buf a;
+                 addc buf '-';
+                 quote_char buf b);
+      addc buf ']'
+  | Question -> add buf "[^/]"
+  | Star -> add buf "[^/]*"
 
-let map_seg (seg : segment_fragment list) : Re.t =
-  Re.seq (List_.map map_frag seg)
+let translate_seg buf (seg : segment_fragment list) =
+  match seg with
+  | [] -> ()
+  | _nonempty_segment ->
+      (* lookahead assertion that checks that the path segment is not empty,
+         because pattern 'a/*' should not match path 'a/' which has an
+         empty trailing segment. *)
+      add buf "(?=[^/])";
+      List.iter (translate_frag buf) seg
 
-let rec map pat =
+(* beginning of string *)
+let bos = {|\A|}
+
+(* end of string *)
+let eos = {|\z|}
+
+let rec translate buf pat =
   match pat with
-  | [ Segment seg ] -> [ map_seg seg; Re.eos ]
-  | [ Any_subpath ] -> []
-  | Segment seg :: pat -> map_seg seg :: slash :: map pat
-  | Any_subpath :: pat -> Re.rep (Re.seq [ Re.rep not_slash; slash ]) :: map pat
-  | [] -> [ Re.eos ]
+  | [ Segment seg ] ->
+      translate_seg buf seg;
+      add buf eos
+  | [ Any_subpath ] -> ()
+  | Segment seg :: pat ->
+      translate_seg buf seg;
+      add buf "/+";
+      translate buf pat
+  | Any_subpath :: pat ->
+      add buf "(?:[^/]+/+)*";
+      translate buf pat
+  | [] -> add buf eos
 
 (* Create a pattern that's left-anchored and right-anchored *)
-let map_root pat = Re.seq (Re.bos :: map pat)
+let translate_root pat =
+  let buf = Buffer.create 128 in
+  add buf bos;
+  translate buf pat;
+  Buffer.contents buf
 
 (*****************************************************************************)
 (* Entry points *)
@@ -91,7 +123,8 @@ let map_root pat = Re.seq (Re.bos :: map pat)
 
 (* Compile a pattern into an ocaml-re regexp for fast matching *)
 let compile ~source pat =
-  let re = map_root pat |> Re.compile in
+  let pcre = translate_root pat in
+  let re = Pcre_.regexp pcre in
   { source; re }
 [@@profiling "Glob.Match.compile"]
 
@@ -99,9 +132,13 @@ let compile ~source pat =
 let debug = ref false
 
 let run matcher path =
-  let res = Re.execp matcher.re path in
+  let res = Pcre_.pmatch_noerr ~rex:matcher.re path in
   if !debug then
     (* expensive string concatenation; may not be suitable for logger#debug *)
+    (*
+    Printf.printf "** glob: %S  pcre: %s  path: %S  matches: %B\n"
+      matcher.source.line_contents matcher.pcre path res;
+*)
     Printf.printf "** pattern: %S  path: %S  matches: %B\n"
       matcher.source.line_contents path res;
   res
@@ -110,8 +147,4 @@ let run matcher path =
 let source matcher = matcher.source
 
 let show x =
-  let re_info =
-    Re.pp_re Format.str_formatter x.re;
-    Format.flush_str_formatter ()
-  in
-  Printf.sprintf "pattern at %s:\n%s" (show_loc x.source) re_info
+  Printf.sprintf "pattern at %s:\n%s" (show_loc x.source) x.re.pattern

--- a/libs/glob/Unit_glob.ml
+++ b/libs/glob/Unit_glob.ml
@@ -88,4 +88,7 @@ let tests =
       (* not matching either *)
       ("ellipsis 12", test "****" "a/b" false);
       ("double slash", test "//a//b//" "//a//b//" true);
+      ("double slash in pattern", test "//a//b//" "/a/b/" true);
+      ("double slash in path", test "/a/b/" "//a//b//" true);
+      ("empty segment", test "a/*" "a/" false);
     ]

--- a/libs/glob/Unit_glob.ml
+++ b/libs/glob/Unit_glob.ml
@@ -90,8 +90,13 @@ let tests =
        *)
       ("ellipsis 10", test "a**" "a/b" false);
       ("ellipsis 11", test "****" "a" true);
-      (* not matching either *)
       ("ellipsis 12", test "****" "a/b" false);
+      ("ellipsis 13", test "**/*b" "/a/b" true);
+      ("ellipsis 14", test "**/*b" "a/b" true);
+      ("ellipsis 15", test "**/*b" "//a/b" true);
+      ("ellipsis 16", test "a/**" "a/b/c" true);
+      ("ellipsis 17", test "a/**" "a/" true);
+      ("ellipsis 18", test "a/**" "a" false);
       ("double slash", test "//a//b//" "//a//b//" true);
       ("double slash in pattern", test "//a//b//" "/a/b/" true);
       ("double slash in path", test "/a/b/" "//a//b//" true);

--- a/libs/glob/Unit_glob.ml
+++ b/libs/glob/Unit_glob.ml
@@ -23,12 +23,17 @@ let test pattern path matches () =
      %s\n\
      %s\n"
     pattern path matches res (Pattern.show pat) (Match.show compiled_pat);
-  Alcotest.(check bool) "equal" matches res
+  Alcotest.(check bool) __LOC__ matches res
 
 (*****************************************************************************)
 (* Test data *)
 (*****************************************************************************)
 
+(*
+   These tests conform with the gitignore specification, falling back to
+   the official gitignore implementation in case some important behavior
+   is unspecified (e.g. '**' matches dot files but '*' doesn't).
+*)
 let tests =
   Alcotest_ext.pack_tests "Glob"
     [
@@ -90,5 +95,15 @@ let tests =
       ("double slash", test "//a//b//" "//a//b//" true);
       ("double slash in pattern", test "//a//b//" "/a/b/" true);
       ("double slash in path", test "/a/b/" "//a//b//" true);
-      ("empty segment", test "a/*" "a/" false);
+      ("empty trailing segment", test "a/*" "a/" false);
+      ("empty leading segment", test "*/a" "/a" false);
+      ("not a dot file", test "*a" "b.a" true);
+      ("don't match dot file with wildcard", test "*" ".a" false);
+      ("don't match dot file with wildcard 2", test "*a" ".a" false);
+      ("don't match dot file with wildcard 3", test "*" ".a" false);
+      ("match dot file with literal dot", test ".?b" ".ab" true);
+      ("don't match dot file with wildcard sequence", test "*?a" ".a" false);
+      ("don't match dot file with wildcard sequence 2", test "?*a" ".a" false);
+      ("match dot file with '**'", test "**" ".a" true);
+      ("match dot file with '**' 2", test "a/**/c" "a/.b/c" true);
     ]

--- a/libs/ojsonnet/Unit_jsonnet.ml
+++ b/libs/ojsonnet/Unit_jsonnet.ml
@@ -57,11 +57,13 @@ let mk_tests (subdir : string) (strategys : Conf.eval_strategy list) :
              |> List.iter (fun strategy ->
                     let str_strategy = Conf.show_eval_strategy strategy in
                     try
+                      let timeout = 0.5 in
                       let json_opt =
                         Common.save_excursion Conf.eval_strategy strategy
                           (fun () ->
                             Time_limit.set_timeout
-                              ~name:("ojsonnet-" ^ str_strategy) 0.5 (fun () ->
+                              ~name:("ojsonnet-" ^ str_strategy) timeout
+                              (fun () ->
                                 let value_ = Eval_jsonnet.eval_program core in
                                 JSON.to_yojson
                                   (Eval_jsonnet.manifest_value value_)))
@@ -69,7 +71,8 @@ let mk_tests (subdir : string) (strategys : Conf.eval_strategy list) :
                       match json_opt with
                       | None ->
                           failwith
-                            (spf "timeout on %s with %s" !!file str_strategy)
+                            (spf "%gs timeout on %s with %s" timeout !!file
+                               str_strategy)
                       | Some json ->
                           if not (Y.equal json expected) then
                             failwith

--- a/scripts/compare-target-selection
+++ b/scripts/compare-target-selection
@@ -10,12 +10,23 @@ osemgrep="osemgrep --experimental"
 
 echo "=== pysemgrep ==="
 time $pysemgrep --x-ls . > target-selection.pysemgrep
-grep -v '^-' target-selection.pysemgrep \
-| cut -c 3- \
+grep '^SEL' target-selection.pysemgrep \
+| cut -c 5- \
 | sort -u > targets.pysemgrep
+
+echo -n "number of selected targets: "
+wc -l targets.pysemgrep
 
 echo "=== osemgrep ==="
 time $osemgrep --x-ls . > target-selection.osemgrep
-grep -v '^-' target-selection.osemgrep \
-| cut -c 3- \
+grep '^SEL' target-selection.osemgrep \
+| cut -c 5- \
 | sort -u > targets.osemgrep
+
+echo -n "number of selected targets: "
+wc -l targets.osemgrep
+
+echo -n "number of differences in the set of selected targets: "
+diff -u targets.pysemgrep targets.osemgrep \
+| grep -P '^[+-]' \
+| wc -l

--- a/scripts/compare-target-selection
+++ b/scripts/compare-target-selection
@@ -10,7 +10,7 @@ osemgrep="osemgrep --experimental"
 
 echo "=== pysemgrep ==="
 time $pysemgrep --x-ls . > target-selection.pysemgrep
-grep '^SEL' target-selection.pysemgrep \
+grep '^selected' target-selection.pysemgrep \
 | cut -c 5- \
 | sort -u > targets.pysemgrep
 
@@ -19,7 +19,7 @@ wc -l targets.pysemgrep
 
 echo "=== osemgrep ==="
 time $osemgrep --x-ls . > target-selection.osemgrep
-grep '^SEL' target-selection.osemgrep \
+grep '^selected' target-selection.osemgrep \
 | cut -c 5- \
 | sort -u > targets.osemgrep
 

--- a/scripts/compare-target-selection
+++ b/scripts/compare-target-selection
@@ -1,0 +1,21 @@
+#! /usr/bin/env bash
+#
+# A script used by Martin to compare file targeting results between
+# pysemgrep and osemgrep.
+#
+set -eu
+
+pysemgrep="osemgrep"
+osemgrep="osemgrep --experimental"
+
+echo "=== pysemgrep ==="
+time $pysemgrep --x-ls . > target-selection.pysemgrep
+grep -v '^-' target-selection.pysemgrep \
+| cut -c 3- \
+| sort -u > targets.pysemgrep
+
+echo "=== osemgrep ==="
+time $osemgrep --x-ls . > target-selection.osemgrep
+grep -v '^-' target-selection.osemgrep \
+| cut -c 3- \
+| sort -u > targets.osemgrep

--- a/src/osemgrep/cli_scan/Ls_subcommand.ml
+++ b/src/osemgrep/cli_scan/Ls_subcommand.ml
@@ -10,13 +10,13 @@ let run ~target_roots ~targeting_conf:conf () =
   let selected, skipped = Find_targets.get_targets conf target_roots in
   selected |> List.sort Fppath.compare
   |> List.iter (fun (x : Fppath.t) ->
-         Out.put (spf "SEL %s" (Fpath.to_string x.fpath)));
+         Out.put (spf "selected %s" (Fpath.to_string x.fpath)));
   skipped
   |> List.sort (fun (a : OutJ.skipped_target) (b : OutJ.skipped_target) ->
          Fpath.compare a.path b.path)
   |> List.iter (fun (x : OutJ.skipped_target) ->
          Out.put
-           (spf "IGN %s [%s]" (Fpath.to_string x.path)
+           (spf "ignored %s [%s]" (Fpath.to_string x.path)
               (x.reason |> OutJ.string_of_skip_reason
              |> JSON.remove_enclosing_quotes_of_jstring)));
   Exit_code.ok

--- a/src/osemgrep/cli_scan/Ls_subcommand.ml
+++ b/src/osemgrep/cli_scan/Ls_subcommand.ml
@@ -10,14 +10,13 @@ let run ~target_roots ~targeting_conf:conf () =
   let selected, skipped = Find_targets.get_targets conf target_roots in
   selected |> List.sort Fppath.compare
   |> List.iter (fun (x : Fppath.t) ->
-         Out.put (spf "+ %s" (Fpath.to_string x.fpath)));
+         Out.put (spf "SEL %s" (Fpath.to_string x.fpath)));
   skipped
   |> List.sort (fun (a : OutJ.skipped_target) (b : OutJ.skipped_target) ->
          Fpath.compare a.path b.path)
   |> List.iter (fun (x : OutJ.skipped_target) ->
          Out.put
-           (spf "- [%s] %s"
+           (spf "IGN %s [%s]" (Fpath.to_string x.path)
               (x.reason |> OutJ.string_of_skip_reason
-             |> JSON.remove_enclosing_quotes_of_jstring)
-              (Fpath.to_string x.path)));
+             |> JSON.remove_enclosing_quotes_of_jstring)));
   Exit_code.ok

--- a/src/osemgrep/tests/Osemgrep_tests.ml
+++ b/src/osemgrep/tests/Osemgrep_tests.ml
@@ -4,4 +4,4 @@
 
 let tests caps =
   Alcotest_ext.pack_suites "OSemgrep end-to-end"
-    [ Test_osemgrep.tests caps; Test_target_selection.tests ]
+    [ Test_osemgrep.tests caps; Test_target_selection.tests caps ]

--- a/src/osemgrep/tests/Test_target_selection.ml
+++ b/src/osemgrep/tests/Test_target_selection.ml
@@ -9,7 +9,7 @@ let with_git_repo (files : Testutil_files.t list) func =
   Testutil_files.with_tempfiles_verbose files (fun path ->
       Testutil_files.with_chdir path (fun () ->
           Git_wrapper.init ();
-          Git_wrapper.add [ Fpath.v "." ];
+          Git_wrapper.add ~force:true [ Fpath.v "." ];
           Git_wrapper.commit "Add all the files";
           func ()))
 

--- a/src/osemgrep/tests/Test_target_selection.mli
+++ b/src/osemgrep/tests/Test_target_selection.mli
@@ -2,4 +2,4 @@
    Test Osemgrep's target selection on real git (or other) repos.
 *)
 
-val tests : Alcotest_ext.test list
+val tests : Cap.all_caps -> Alcotest_ext.test list

--- a/src/targeting/Filter_target.ml
+++ b/src/targeting/Filter_target.ml
@@ -35,17 +35,35 @@ let filter_target_for_xlang (xlang : Xlang.t) (path : Fpath.t) : bool =
   | LAliengrep ->
       true
 
-(* Used by Run_semgrep.semgrep_with_rules().
- * See also https://semgrep.dev/docs/writing-rules/rule-syntax/#paths
- * TODO: according to the doc,
- * "Paths [in include: and exclude: patterns] are relative to the root
- * directory of the scanned project" but it seems pysemgrep does not honor
- * this thing because adding an exclude such as "metachecking/*" will
- * filter code even in subdirs calls metachecking. The glob is not anchored,
- * even when it contains a '/'.
- * LESS: there used to be a time where semgrep-core was handling the
- * include/exclude too. Can we find back this code?
- *)
+(*
+   Tentative plan:
+
+   - write tests specifically to test paths.include and paths.exclude
+     in different contexts (absolute target paths, relative target paths,
+     git project, non-git project);
+   - make sure that the paths passed to the glob matcher are relative
+     to the project root;
+   - use the same rules as for gitignore (forget about Python's wcmatch
+     that we're not going to reimplement completely):
+     * a slash at the beginning or in the middle of the path makes it
+       anchored;
+     * reuse what we implemented for gitignore and semgrepignore.
+   - update the semgrep documentation accordingly i.e. mention that the
+     standard is gitignore/semgrepignore, not wcmatch anymore.
+
+   Details:
+
+   Used by Run_semgrep.semgrep_with_rules().
+   See also https://semgrep.dev/docs/writing-rules/rule-syntax/#paths
+   TODO: according to the doc,
+   "Paths [in include: and exclude: patterns] are relative to the root
+   directory of the scanned project" but it seems pysemgrep does not honor
+   this thing because adding an exclude such as "metachecking/*" will
+   filter code even in subdirs calls metachecking. The glob is not anchored,
+   even when it contains a '/'.
+   LESS: there used to be a time where semgrep-core was handling the
+   include/exclude too. Can we find back this code?
+*)
 let filter_paths (paths : Rule.paths) (path : Fpath.t) : bool =
   let match_glob (pat : Rule.glob) (path : Fpath.t) : bool =
     (* ugly: pysemgrep adds a leading **/ and a suffix /** to each pattern.

--- a/src/targeting/Find_targets.ml
+++ b/src/targeting/Find_targets.ml
@@ -434,10 +434,10 @@ let get_targets_for_project conf (project_roots : project_roots) =
   let selected_targets, skipped_targets =
     match (git_tracked, git_untracked) with
     | Some tracked, Some untracked ->
-        Printf.printf
-          "target file candidates from git: tracked: %i, untracked: %i\n%!"
-          (Fppath_set.cardinal tracked)
-          (Fppath_set.cardinal untracked);
+        Logs.debug (fun m ->
+            m "target file candidates from git: tracked: %i, untracked: %i"
+              (Fppath_set.cardinal tracked)
+              (Fppath_set.cardinal untracked));
         let all_files = Fppath_set.union tracked untracked in
         all_files |> Fppath_set.elements |> filter_targets conf project_roots
     | None, _

--- a/src/targeting/Find_targets.ml
+++ b/src/targeting/Find_targets.ml
@@ -246,7 +246,8 @@ let git_list_files (file_kinds : Git_wrapper.ls_files_kind list)
       Some
         (project_roots.scanning_roots
         |> List.concat_map (fun (sc_root : Fppath.t) ->
-               Git_wrapper.ls_files ~kinds:file_kinds [ sc_root.fpath ]
+               Git_wrapper.ls_files ~exclude_standard:true ~kinds:file_kinds
+                 [ sc_root.fpath ]
                |> List_.map (fun fpath ->
                       let fpath_relative_to_scan_root =
                         match Fpath.relativize ~root:sc_root.fpath fpath with
@@ -433,6 +434,10 @@ let get_targets_for_project conf (project_roots : project_roots) =
   let selected_targets, skipped_targets =
     match (git_tracked, git_untracked) with
     | Some tracked, Some untracked ->
+        Printf.printf
+          "target file candidates from git: tracked: %i, untracked: %i\n%!"
+          (Fppath_set.cardinal tracked)
+          (Fppath_set.cardinal untracked);
         let all_files = Fppath_set.union tracked untracked in
         all_files |> Fppath_set.elements |> filter_targets conf project_roots
     | None, _

--- a/tests/snapshots/semgrep-core/2e75b85cd1f4/stdout
+++ b/tests/snapshots/semgrep-core/2e75b85cd1f4/stdout
@@ -1,0 +1,18 @@
+--- All files ---
+.gitignore
+a
+dir/a
+--- Filtered files ---
+** pattern: "a"  path: "/.gitignore"  matches: false
+Selection events for path .gitignore:
+SEL .gitignore
+** pattern: "a"  path: "/a"  matches: true
+Selection events for path a:
+ignored at <TEMPORARY FILE PATH>, line 1: a
+IGN a
+** pattern: "a"  path: "/dir"  matches: false
+** pattern: "a"  path: "/dir/"  matches: false
+** pattern: "a"  path: "/dir/a"  matches: true
+Selection events for path dir/a:
+ignored at <TEMPORARY FILE PATH>, line 1: a
+IGN dir/a

--- a/tests/snapshots/semgrep-core/2e75b85cd1f4/stdout
+++ b/tests/snapshots/semgrep-core/2e75b85cd1f4/stdout
@@ -3,16 +3,16 @@
 a
 dir/a
 --- Filtered files ---
-** pattern: "a"  path: "/.gitignore"  matches: false
+** glob: "a"  pcre: \A/+(?:[^/]+/+)*(?=[^/])a\z  path: "/.gitignore"  matches: false
 Selection events for path .gitignore:
 SEL .gitignore
-** pattern: "a"  path: "/a"  matches: true
+** glob: "a"  pcre: \A/+(?:[^/]+/+)*(?=[^/])a\z  path: "/a"  matches: true
 Selection events for path a:
 ignored at <TEMPORARY FILE PATH>, line 1: a
 IGN a
-** pattern: "a"  path: "/dir"  matches: false
-** pattern: "a"  path: "/dir/"  matches: false
-** pattern: "a"  path: "/dir/a"  matches: true
+** glob: "a"  pcre: \A/+(?:[^/]+/+)*(?=[^/])a\z  path: "/dir"  matches: false
+** glob: "a"  pcre: \A/+(?:[^/]+/+)*(?=[^/])a\z  path: "/dir/"  matches: false
+** glob: "a"  pcre: \A/+(?:[^/]+/+)*(?=[^/])a\z  path: "/dir/a"  matches: true
 Selection events for path dir/a:
 ignored at <TEMPORARY FILE PATH>, line 1: a
 IGN dir/a

--- a/tests/snapshots/semgrep-core/2e75b85cd1f4/stdout
+++ b/tests/snapshots/semgrep-core/2e75b85cd1f4/stdout
@@ -3,16 +3,11 @@
 a
 dir/a
 --- Filtered files ---
-** glob: "a"  pcre: \A/+(?:[^/]+/+)*(?=[^/])a\z  path: "/.gitignore"  matches: false
 Selection events for path .gitignore:
 SEL .gitignore
-** glob: "a"  pcre: \A/+(?:[^/]+/+)*(?=[^/])a\z  path: "/a"  matches: true
 Selection events for path a:
 ignored at <TEMPORARY FILE PATH>, line 1: a
 IGN a
-** glob: "a"  pcre: \A/+(?:[^/]+/+)*(?=[^/])a\z  path: "/dir"  matches: false
-** glob: "a"  pcre: \A/+(?:[^/]+/+)*(?=[^/])a\z  path: "/dir/"  matches: false
-** glob: "a"  pcre: \A/+(?:[^/]+/+)*(?=[^/])a\z  path: "/dir/a"  matches: true
 Selection events for path dir/a:
 ignored at <TEMPORARY FILE PATH>, line 1: a
 IGN dir/a

--- a/tests/snapshots/semgrep-core/32f4d7e519a5/stdout
+++ b/tests/snapshots/semgrep-core/32f4d7e519a5/stdout
@@ -7,5 +7,5 @@ Input files:
 .gitignore
 a
 RUN semgrep scan --experimental --x-ls .
-SEL .gitignore
-IGN a [semgrepignore_patterns_match]
+selected .gitignore
+ignored a [semgrepignore_patterns_match]

--- a/tests/snapshots/semgrep-core/32f4d7e519a5/stdout
+++ b/tests/snapshots/semgrep-core/32f4d7e519a5/stdout
@@ -1,10 +1,11 @@
 Initialized empty Git repository in<MASKED>
 [main (root-commit) <MASKED>] Add all the files
- 1 file changed, 1 insertion(+)
+ 2 files changed, 1 insertion(+)
  create mode 100644 .gitignore
+ create mode 100644 a
 Input files:
 .gitignore
 a
 RUN semgrep scan --experimental --x-ls .
-+ .gitignore
-- [semgrepignore_patterns_match] a
+SEL .gitignore
+IGN a [semgrepignore_patterns_match]

--- a/tests/snapshots/semgrep-core/32f4d7e519a5/stdout
+++ b/tests/snapshots/semgrep-core/32f4d7e519a5/stdout
@@ -5,3 +5,6 @@ Initialized empty Git repository in<MASKED>
 Input files:
 .gitignore
 a
+RUN semgrep scan --experimental --x-ls .
++ .gitignore
+- [semgrepignore_patterns_match] a

--- a/tests/snapshots/semgrep-core/4148713a0e06/stdout
+++ b/tests/snapshots/semgrep-core/4148713a0e06/stdout
@@ -1,0 +1,12 @@
+Input files:
+a
+b
+c
+dir/d
+dir/e
+Output files:
+a
+b
+c
+dir/d
+dir/e

--- a/tests/snapshots/semgrep-core/4d29498cab9a/stdout
+++ b/tests/snapshots/semgrep-core/4d29498cab9a/stdout
@@ -1,8 +1,9 @@
 Initialized empty Git repository in<MASKED>
 [main (root-commit) <MASKED>] Add all the files
- 4 files changed, 2 insertions(+)
+ 5 files changed, 2 insertions(+)
  create mode 100644 .gitignore
  create mode 100644 .semgrepignore
+ create mode 100644 a
  create mode 100644 b
  create mode 100644 c
 Input files:
@@ -12,8 +13,8 @@ a
 b
 c
 RUN semgrep scan --experimental --x-ls .
-+ .gitignore
-+ .semgrepignore
-+ c
-- [semgrepignore_patterns_match] a
-- [semgrepignore_patterns_match] b
+SEL .gitignore
+SEL .semgrepignore
+SEL c
+IGN a [semgrepignore_patterns_match]
+IGN b [semgrepignore_patterns_match]

--- a/tests/snapshots/semgrep-core/4d29498cab9a/stdout
+++ b/tests/snapshots/semgrep-core/4d29498cab9a/stdout
@@ -13,8 +13,8 @@ a
 b
 c
 RUN semgrep scan --experimental --x-ls .
-SEL .gitignore
-SEL .semgrepignore
-SEL c
-IGN a [semgrepignore_patterns_match]
-IGN b [semgrepignore_patterns_match]
+selected .gitignore
+selected .semgrepignore
+selected c
+ignored a [semgrepignore_patterns_match]
+ignored b [semgrepignore_patterns_match]

--- a/tests/snapshots/semgrep-core/4d29498cab9a/stdout
+++ b/tests/snapshots/semgrep-core/4d29498cab9a/stdout
@@ -11,3 +11,9 @@ Input files:
 a
 b
 c
+RUN semgrep scan --experimental --x-ls .
++ .gitignore
++ .semgrepignore
++ c
+- [semgrepignore_patterns_match] a
+- [semgrepignore_patterns_match] b

--- a/tests/snapshots/semgrep-core/551857e0cb97/stdout
+++ b/tests/snapshots/semgrep-core/551857e0cb97/stdout
@@ -5,10 +5,8 @@ dir/a
 --- Filtered files ---
 Selection events for path a:
 SEL a
-** glob: "a"  pcre: \A/+(?=[^/])dir/+(?:[^/]+/+)*(?=[^/])a\z  path: "/dir/.gitignore"  matches: false
 Selection events for path dir/.gitignore:
 SEL dir/.gitignore
-** glob: "a"  pcre: \A/+(?=[^/])dir/+(?:[^/]+/+)*(?=[^/])a\z  path: "/dir/a"  matches: true
 Selection events for path dir/a:
 ignored at <TEMPORARY FILE PATH>, line 1: a
 IGN dir/a

--- a/tests/snapshots/semgrep-core/551857e0cb97/stdout
+++ b/tests/snapshots/semgrep-core/551857e0cb97/stdout
@@ -1,0 +1,14 @@
+--- All files ---
+a
+dir/.gitignore
+dir/a
+--- Filtered files ---
+Selection events for path a:
+SEL a
+** pattern: "a"  path: "/dir/.gitignore"  matches: false
+Selection events for path dir/.gitignore:
+SEL dir/.gitignore
+** pattern: "a"  path: "/dir/a"  matches: true
+Selection events for path dir/a:
+ignored at <TEMPORARY FILE PATH>, line 1: a
+IGN dir/a

--- a/tests/snapshots/semgrep-core/551857e0cb97/stdout
+++ b/tests/snapshots/semgrep-core/551857e0cb97/stdout
@@ -5,10 +5,10 @@ dir/a
 --- Filtered files ---
 Selection events for path a:
 SEL a
-** pattern: "a"  path: "/dir/.gitignore"  matches: false
+** glob: "a"  pcre: \A/+(?=[^/])dir/+(?:[^/]+/+)*(?=[^/])a\z  path: "/dir/.gitignore"  matches: false
 Selection events for path dir/.gitignore:
 SEL dir/.gitignore
-** pattern: "a"  path: "/dir/a"  matches: true
+** glob: "a"  pcre: \A/+(?=[^/])dir/+(?:[^/]+/+)*(?=[^/])a\z  path: "/dir/a"  matches: true
 Selection events for path dir/a:
 ignored at <TEMPORARY FILE PATH>, line 1: a
 IGN dir/a

--- a/tests/snapshots/semgrep-core/5722008e9775/stdout
+++ b/tests/snapshots/semgrep-core/5722008e9775/stdout
@@ -3,19 +3,19 @@
 dir/ignore-me
 sub/dir/ignore-me-not
 --- Filtered files ---
-** pattern: "dir/*"  path: "/.gitignore"  matches: false
+** glob: "dir/*"  pcre: \A/+(?=[^/])dir/+(?=[^/])[^/]*\z  path: "/.gitignore"  matches: false
 Selection events for path .gitignore:
 SEL .gitignore
-** pattern: "dir/*"  path: "/dir"  matches: false
-** pattern: "dir/*"  path: "/dir/"  matches: false
-** pattern: "dir/*"  path: "/dir/ignore-me"  matches: true
+** glob: "dir/*"  pcre: \A/+(?=[^/])dir/+(?=[^/])[^/]*\z  path: "/dir"  matches: false
+** glob: "dir/*"  pcre: \A/+(?=[^/])dir/+(?=[^/])[^/]*\z  path: "/dir/"  matches: false
+** glob: "dir/*"  pcre: \A/+(?=[^/])dir/+(?=[^/])[^/]*\z  path: "/dir/ignore-me"  matches: true
 Selection events for path dir/ignore-me:
 ignored at <TEMPORARY FILE PATH>, line 1: dir/*
 IGN dir/ignore-me
-** pattern: "dir/*"  path: "/sub"  matches: false
-** pattern: "dir/*"  path: "/sub/"  matches: false
-** pattern: "dir/*"  path: "/sub/dir"  matches: false
-** pattern: "dir/*"  path: "/sub/dir/"  matches: false
-** pattern: "dir/*"  path: "/sub/dir/ignore-me-not"  matches: false
+** glob: "dir/*"  pcre: \A/+(?=[^/])dir/+(?=[^/])[^/]*\z  path: "/sub"  matches: false
+** glob: "dir/*"  pcre: \A/+(?=[^/])dir/+(?=[^/])[^/]*\z  path: "/sub/"  matches: false
+** glob: "dir/*"  pcre: \A/+(?=[^/])dir/+(?=[^/])[^/]*\z  path: "/sub/dir"  matches: false
+** glob: "dir/*"  pcre: \A/+(?=[^/])dir/+(?=[^/])[^/]*\z  path: "/sub/dir/"  matches: false
+** glob: "dir/*"  pcre: \A/+(?=[^/])dir/+(?=[^/])[^/]*\z  path: "/sub/dir/ignore-me-not"  matches: false
 Selection events for path sub/dir/ignore-me-not:
 SEL sub/dir/ignore-me-not

--- a/tests/snapshots/semgrep-core/5722008e9775/stdout
+++ b/tests/snapshots/semgrep-core/5722008e9775/stdout
@@ -3,19 +3,10 @@
 dir/ignore-me
 sub/dir/ignore-me-not
 --- Filtered files ---
-** glob: "dir/*"  pcre: \A/+(?=[^/])dir/+(?=[^/])(?![.])[^/]*\z  path: "/.gitignore"  matches: false
 Selection events for path .gitignore:
 SEL .gitignore
-** glob: "dir/*"  pcre: \A/+(?=[^/])dir/+(?=[^/])(?![.])[^/]*\z  path: "/dir"  matches: false
-** glob: "dir/*"  pcre: \A/+(?=[^/])dir/+(?=[^/])(?![.])[^/]*\z  path: "/dir/"  matches: false
-** glob: "dir/*"  pcre: \A/+(?=[^/])dir/+(?=[^/])(?![.])[^/]*\z  path: "/dir/ignore-me"  matches: true
 Selection events for path dir/ignore-me:
 ignored at <TEMPORARY FILE PATH>, line 1: dir/*
 IGN dir/ignore-me
-** glob: "dir/*"  pcre: \A/+(?=[^/])dir/+(?=[^/])(?![.])[^/]*\z  path: "/sub"  matches: false
-** glob: "dir/*"  pcre: \A/+(?=[^/])dir/+(?=[^/])(?![.])[^/]*\z  path: "/sub/"  matches: false
-** glob: "dir/*"  pcre: \A/+(?=[^/])dir/+(?=[^/])(?![.])[^/]*\z  path: "/sub/dir"  matches: false
-** glob: "dir/*"  pcre: \A/+(?=[^/])dir/+(?=[^/])(?![.])[^/]*\z  path: "/sub/dir/"  matches: false
-** glob: "dir/*"  pcre: \A/+(?=[^/])dir/+(?=[^/])(?![.])[^/]*\z  path: "/sub/dir/ignore-me-not"  matches: false
 Selection events for path sub/dir/ignore-me-not:
 SEL sub/dir/ignore-me-not

--- a/tests/snapshots/semgrep-core/5722008e9775/stdout
+++ b/tests/snapshots/semgrep-core/5722008e9775/stdout
@@ -1,0 +1,21 @@
+--- All files ---
+.gitignore
+dir/ignore-me
+sub/dir/ignore-me-not
+--- Filtered files ---
+** pattern: "dir/*"  path: "/.gitignore"  matches: false
+Selection events for path .gitignore:
+SEL .gitignore
+** pattern: "dir/*"  path: "/dir"  matches: false
+** pattern: "dir/*"  path: "/dir/"  matches: false
+** pattern: "dir/*"  path: "/dir/ignore-me"  matches: true
+Selection events for path dir/ignore-me:
+ignored at <TEMPORARY FILE PATH>, line 1: dir/*
+IGN dir/ignore-me
+** pattern: "dir/*"  path: "/sub"  matches: false
+** pattern: "dir/*"  path: "/sub/"  matches: false
+** pattern: "dir/*"  path: "/sub/dir"  matches: false
+** pattern: "dir/*"  path: "/sub/dir/"  matches: false
+** pattern: "dir/*"  path: "/sub/dir/ignore-me-not"  matches: false
+Selection events for path sub/dir/ignore-me-not:
+SEL sub/dir/ignore-me-not

--- a/tests/snapshots/semgrep-core/5722008e9775/stdout
+++ b/tests/snapshots/semgrep-core/5722008e9775/stdout
@@ -3,19 +3,19 @@
 dir/ignore-me
 sub/dir/ignore-me-not
 --- Filtered files ---
-** glob: "dir/*"  pcre: \A/+(?=[^/])dir/+(?=[^/])[^/]*\z  path: "/.gitignore"  matches: false
+** glob: "dir/*"  pcre: \A/+(?=[^/])dir/+(?=[^/])(?![.])[^/]*\z  path: "/.gitignore"  matches: false
 Selection events for path .gitignore:
 SEL .gitignore
-** glob: "dir/*"  pcre: \A/+(?=[^/])dir/+(?=[^/])[^/]*\z  path: "/dir"  matches: false
-** glob: "dir/*"  pcre: \A/+(?=[^/])dir/+(?=[^/])[^/]*\z  path: "/dir/"  matches: false
-** glob: "dir/*"  pcre: \A/+(?=[^/])dir/+(?=[^/])[^/]*\z  path: "/dir/ignore-me"  matches: true
+** glob: "dir/*"  pcre: \A/+(?=[^/])dir/+(?=[^/])(?![.])[^/]*\z  path: "/dir"  matches: false
+** glob: "dir/*"  pcre: \A/+(?=[^/])dir/+(?=[^/])(?![.])[^/]*\z  path: "/dir/"  matches: false
+** glob: "dir/*"  pcre: \A/+(?=[^/])dir/+(?=[^/])(?![.])[^/]*\z  path: "/dir/ignore-me"  matches: true
 Selection events for path dir/ignore-me:
 ignored at <TEMPORARY FILE PATH>, line 1: dir/*
 IGN dir/ignore-me
-** glob: "dir/*"  pcre: \A/+(?=[^/])dir/+(?=[^/])[^/]*\z  path: "/sub"  matches: false
-** glob: "dir/*"  pcre: \A/+(?=[^/])dir/+(?=[^/])[^/]*\z  path: "/sub/"  matches: false
-** glob: "dir/*"  pcre: \A/+(?=[^/])dir/+(?=[^/])[^/]*\z  path: "/sub/dir"  matches: false
-** glob: "dir/*"  pcre: \A/+(?=[^/])dir/+(?=[^/])[^/]*\z  path: "/sub/dir/"  matches: false
-** glob: "dir/*"  pcre: \A/+(?=[^/])dir/+(?=[^/])[^/]*\z  path: "/sub/dir/ignore-me-not"  matches: false
+** glob: "dir/*"  pcre: \A/+(?=[^/])dir/+(?=[^/])(?![.])[^/]*\z  path: "/sub"  matches: false
+** glob: "dir/*"  pcre: \A/+(?=[^/])dir/+(?=[^/])(?![.])[^/]*\z  path: "/sub/"  matches: false
+** glob: "dir/*"  pcre: \A/+(?=[^/])dir/+(?=[^/])(?![.])[^/]*\z  path: "/sub/dir"  matches: false
+** glob: "dir/*"  pcre: \A/+(?=[^/])dir/+(?=[^/])(?![.])[^/]*\z  path: "/sub/dir/"  matches: false
+** glob: "dir/*"  pcre: \A/+(?=[^/])dir/+(?=[^/])(?![.])[^/]*\z  path: "/sub/dir/ignore-me-not"  matches: false
 Selection events for path sub/dir/ignore-me-not:
 SEL sub/dir/ignore-me-not

--- a/tests/snapshots/semgrep-core/68ddf7069d0b/stdout
+++ b/tests/snapshots/semgrep-core/68ddf7069d0b/stdout
@@ -1,0 +1,18 @@
+--- All files ---
+.gitignore
+a/b
+dir/a
+--- Filtered files ---
+** pattern: "a/"  path: "/.gitignore"  matches: false
+Selection events for path .gitignore:
+SEL .gitignore
+** pattern: "a/"  path: "/a"  matches: false
+** pattern: "a/"  path: "/a/"  matches: true
+Selection events for path a/b:
+ignored at <TEMPORARY FILE PATH>, line 1: a/
+IGN a/b
+** pattern: "a/"  path: "/dir"  matches: false
+** pattern: "a/"  path: "/dir/"  matches: false
+** pattern: "a/"  path: "/dir/a"  matches: false
+Selection events for path dir/a:
+SEL dir/a

--- a/tests/snapshots/semgrep-core/68ddf7069d0b/stdout
+++ b/tests/snapshots/semgrep-core/68ddf7069d0b/stdout
@@ -3,16 +3,10 @@
 a/b
 dir/a
 --- Filtered files ---
-** glob: "a/"  pcre: \A/+(?:[^/]+/+)*(?=[^/])a/+\z  path: "/.gitignore"  matches: false
 Selection events for path .gitignore:
 SEL .gitignore
-** glob: "a/"  pcre: \A/+(?:[^/]+/+)*(?=[^/])a/+\z  path: "/a"  matches: false
-** glob: "a/"  pcre: \A/+(?:[^/]+/+)*(?=[^/])a/+\z  path: "/a/"  matches: true
 Selection events for path a/b:
 ignored at <TEMPORARY FILE PATH>, line 1: a/
 IGN a/b
-** glob: "a/"  pcre: \A/+(?:[^/]+/+)*(?=[^/])a/+\z  path: "/dir"  matches: false
-** glob: "a/"  pcre: \A/+(?:[^/]+/+)*(?=[^/])a/+\z  path: "/dir/"  matches: false
-** glob: "a/"  pcre: \A/+(?:[^/]+/+)*(?=[^/])a/+\z  path: "/dir/a"  matches: false
 Selection events for path dir/a:
 SEL dir/a

--- a/tests/snapshots/semgrep-core/68ddf7069d0b/stdout
+++ b/tests/snapshots/semgrep-core/68ddf7069d0b/stdout
@@ -3,16 +3,16 @@
 a/b
 dir/a
 --- Filtered files ---
-** pattern: "a/"  path: "/.gitignore"  matches: false
+** glob: "a/"  pcre: \A/+(?:[^/]+/+)*(?=[^/])a/+\z  path: "/.gitignore"  matches: false
 Selection events for path .gitignore:
 SEL .gitignore
-** pattern: "a/"  path: "/a"  matches: false
-** pattern: "a/"  path: "/a/"  matches: true
+** glob: "a/"  pcre: \A/+(?:[^/]+/+)*(?=[^/])a/+\z  path: "/a"  matches: false
+** glob: "a/"  pcre: \A/+(?:[^/]+/+)*(?=[^/])a/+\z  path: "/a/"  matches: true
 Selection events for path a/b:
 ignored at <TEMPORARY FILE PATH>, line 1: a/
 IGN a/b
-** pattern: "a/"  path: "/dir"  matches: false
-** pattern: "a/"  path: "/dir/"  matches: false
-** pattern: "a/"  path: "/dir/a"  matches: false
+** glob: "a/"  pcre: \A/+(?:[^/]+/+)*(?=[^/])a/+\z  path: "/dir"  matches: false
+** glob: "a/"  pcre: \A/+(?:[^/]+/+)*(?=[^/])a/+\z  path: "/dir/"  matches: false
+** glob: "a/"  pcre: \A/+(?:[^/]+/+)*(?=[^/])a/+\z  path: "/dir/a"  matches: false
 Selection events for path dir/a:
 SEL dir/a

--- a/tests/snapshots/semgrep-core/917142b5cdf9/stdout
+++ b/tests/snapshots/semgrep-core/917142b5cdf9/stdout
@@ -3,13 +3,10 @@
 hello.c
 hello.ml
 --- Filtered files ---
-** glob: "*.c"  pcre: \A/+(?:[^/]+/+)*(?=[^/])(?![.])[^/]*\.c\z  path: "/.gitignore"  matches: false
 Selection events for path .gitignore:
 SEL .gitignore
-** glob: "*.c"  pcre: \A/+(?:[^/]+/+)*(?=[^/])(?![.])[^/]*\.c\z  path: "/hello.c"  matches: true
 Selection events for path hello.c:
 ignored at <TEMPORARY FILE PATH>, line 1: *.c
 IGN hello.c
-** glob: "*.c"  pcre: \A/+(?:[^/]+/+)*(?=[^/])(?![.])[^/]*\.c\z  path: "/hello.ml"  matches: false
 Selection events for path hello.ml:
 SEL hello.ml

--- a/tests/snapshots/semgrep-core/917142b5cdf9/stdout
+++ b/tests/snapshots/semgrep-core/917142b5cdf9/stdout
@@ -3,13 +3,13 @@
 hello.c
 hello.ml
 --- Filtered files ---
-** pattern: "*.c"  path: "/.gitignore"  matches: false
+** glob: "*.c"  pcre: \A/+(?:[^/]+/+)*(?=[^/])[^/]*\.c\z  path: "/.gitignore"  matches: false
 Selection events for path .gitignore:
 SEL .gitignore
-** pattern: "*.c"  path: "/hello.c"  matches: true
+** glob: "*.c"  pcre: \A/+(?:[^/]+/+)*(?=[^/])[^/]*\.c\z  path: "/hello.c"  matches: true
 Selection events for path hello.c:
 ignored at <TEMPORARY FILE PATH>, line 1: *.c
 IGN hello.c
-** pattern: "*.c"  path: "/hello.ml"  matches: false
+** glob: "*.c"  pcre: \A/+(?:[^/]+/+)*(?=[^/])[^/]*\.c\z  path: "/hello.ml"  matches: false
 Selection events for path hello.ml:
 SEL hello.ml

--- a/tests/snapshots/semgrep-core/917142b5cdf9/stdout
+++ b/tests/snapshots/semgrep-core/917142b5cdf9/stdout
@@ -3,13 +3,13 @@
 hello.c
 hello.ml
 --- Filtered files ---
-** glob: "*.c"  pcre: \A/+(?:[^/]+/+)*(?=[^/])[^/]*\.c\z  path: "/.gitignore"  matches: false
+** glob: "*.c"  pcre: \A/+(?:[^/]+/+)*(?=[^/])(?![.])[^/]*\.c\z  path: "/.gitignore"  matches: false
 Selection events for path .gitignore:
 SEL .gitignore
-** glob: "*.c"  pcre: \A/+(?:[^/]+/+)*(?=[^/])[^/]*\.c\z  path: "/hello.c"  matches: true
+** glob: "*.c"  pcre: \A/+(?:[^/]+/+)*(?=[^/])(?![.])[^/]*\.c\z  path: "/hello.c"  matches: true
 Selection events for path hello.c:
 ignored at <TEMPORARY FILE PATH>, line 1: *.c
 IGN hello.c
-** glob: "*.c"  pcre: \A/+(?:[^/]+/+)*(?=[^/])[^/]*\.c\z  path: "/hello.ml"  matches: false
+** glob: "*.c"  pcre: \A/+(?:[^/]+/+)*(?=[^/])(?![.])[^/]*\.c\z  path: "/hello.ml"  matches: false
 Selection events for path hello.ml:
 SEL hello.ml

--- a/tests/snapshots/semgrep-core/917142b5cdf9/stdout
+++ b/tests/snapshots/semgrep-core/917142b5cdf9/stdout
@@ -1,0 +1,15 @@
+--- All files ---
+.gitignore
+hello.c
+hello.ml
+--- Filtered files ---
+** pattern: "*.c"  path: "/.gitignore"  matches: false
+Selection events for path .gitignore:
+SEL .gitignore
+** pattern: "*.c"  path: "/hello.c"  matches: true
+Selection events for path hello.c:
+ignored at <TEMPORARY FILE PATH>, line 1: *.c
+IGN hello.c
+** pattern: "*.c"  path: "/hello.ml"  matches: false
+Selection events for path hello.ml:
+SEL hello.ml

--- a/tests/snapshots/semgrep-core/928cede2578e/stdout
+++ b/tests/snapshots/semgrep-core/928cede2578e/stdout
@@ -3,24 +3,24 @@
 dir/ignore-me
 dir/ignore-me-not
 --- Filtered files ---
-** glob: "dir/*"  pcre: \A/+(?=[^/])dir/+(?=[^/])[^/]*\z  path: "/.gitignore"  matches: false
+** glob: "dir/*"  pcre: \A/+(?=[^/])dir/+(?=[^/])(?![.])[^/]*\z  path: "/.gitignore"  matches: false
 ** glob: "!dir/ignore-me-not"  pcre: \A/+(?=[^/])dir/+(?=[^/])ignore-me-not\z  path: "/.gitignore"  matches: false
 Selection events for path .gitignore:
 SEL .gitignore
-** glob: "dir/*"  pcre: \A/+(?=[^/])dir/+(?=[^/])[^/]*\z  path: "/dir"  matches: false
+** glob: "dir/*"  pcre: \A/+(?=[^/])dir/+(?=[^/])(?![.])[^/]*\z  path: "/dir"  matches: false
 ** glob: "!dir/ignore-me-not"  pcre: \A/+(?=[^/])dir/+(?=[^/])ignore-me-not\z  path: "/dir"  matches: false
-** glob: "dir/*"  pcre: \A/+(?=[^/])dir/+(?=[^/])[^/]*\z  path: "/dir/"  matches: false
+** glob: "dir/*"  pcre: \A/+(?=[^/])dir/+(?=[^/])(?![.])[^/]*\z  path: "/dir/"  matches: false
 ** glob: "!dir/ignore-me-not"  pcre: \A/+(?=[^/])dir/+(?=[^/])ignore-me-not\z  path: "/dir/"  matches: false
-** glob: "dir/*"  pcre: \A/+(?=[^/])dir/+(?=[^/])[^/]*\z  path: "/dir/ignore-me"  matches: true
+** glob: "dir/*"  pcre: \A/+(?=[^/])dir/+(?=[^/])(?![.])[^/]*\z  path: "/dir/ignore-me"  matches: true
 ** glob: "!dir/ignore-me-not"  pcre: \A/+(?=[^/])dir/+(?=[^/])ignore-me-not\z  path: "/dir/ignore-me"  matches: false
 Selection events for path dir/ignore-me:
 ignored at <TEMPORARY FILE PATH>, line 1: dir/*
 IGN dir/ignore-me
-** glob: "dir/*"  pcre: \A/+(?=[^/])dir/+(?=[^/])[^/]*\z  path: "/dir"  matches: false
+** glob: "dir/*"  pcre: \A/+(?=[^/])dir/+(?=[^/])(?![.])[^/]*\z  path: "/dir"  matches: false
 ** glob: "!dir/ignore-me-not"  pcre: \A/+(?=[^/])dir/+(?=[^/])ignore-me-not\z  path: "/dir"  matches: false
-** glob: "dir/*"  pcre: \A/+(?=[^/])dir/+(?=[^/])[^/]*\z  path: "/dir/"  matches: false
+** glob: "dir/*"  pcre: \A/+(?=[^/])dir/+(?=[^/])(?![.])[^/]*\z  path: "/dir/"  matches: false
 ** glob: "!dir/ignore-me-not"  pcre: \A/+(?=[^/])dir/+(?=[^/])ignore-me-not\z  path: "/dir/"  matches: false
-** glob: "dir/*"  pcre: \A/+(?=[^/])dir/+(?=[^/])[^/]*\z  path: "/dir/ignore-me-not"  matches: true
+** glob: "dir/*"  pcre: \A/+(?=[^/])dir/+(?=[^/])(?![.])[^/]*\z  path: "/dir/ignore-me-not"  matches: true
 ** glob: "!dir/ignore-me-not"  pcre: \A/+(?=[^/])dir/+(?=[^/])ignore-me-not\z  path: "/dir/ignore-me-not"  matches: true
 Selection events for path dir/ignore-me-not:
 ignored at <TEMPORARY FILE PATH>, line 1: dir/*

--- a/tests/snapshots/semgrep-core/928cede2578e/stdout
+++ b/tests/snapshots/semgrep-core/928cede2578e/stdout
@@ -3,25 +3,25 @@
 dir/ignore-me
 dir/ignore-me-not
 --- Filtered files ---
-** pattern: "dir/*"  path: "/.gitignore"  matches: false
-** pattern: "!dir/ignore-me-not"  path: "/.gitignore"  matches: false
+** glob: "dir/*"  pcre: \A/+(?=[^/])dir/+(?=[^/])[^/]*\z  path: "/.gitignore"  matches: false
+** glob: "!dir/ignore-me-not"  pcre: \A/+(?=[^/])dir/+(?=[^/])ignore-me-not\z  path: "/.gitignore"  matches: false
 Selection events for path .gitignore:
 SEL .gitignore
-** pattern: "dir/*"  path: "/dir"  matches: false
-** pattern: "!dir/ignore-me-not"  path: "/dir"  matches: false
-** pattern: "dir/*"  path: "/dir/"  matches: false
-** pattern: "!dir/ignore-me-not"  path: "/dir/"  matches: false
-** pattern: "dir/*"  path: "/dir/ignore-me"  matches: true
-** pattern: "!dir/ignore-me-not"  path: "/dir/ignore-me"  matches: false
+** glob: "dir/*"  pcre: \A/+(?=[^/])dir/+(?=[^/])[^/]*\z  path: "/dir"  matches: false
+** glob: "!dir/ignore-me-not"  pcre: \A/+(?=[^/])dir/+(?=[^/])ignore-me-not\z  path: "/dir"  matches: false
+** glob: "dir/*"  pcre: \A/+(?=[^/])dir/+(?=[^/])[^/]*\z  path: "/dir/"  matches: false
+** glob: "!dir/ignore-me-not"  pcre: \A/+(?=[^/])dir/+(?=[^/])ignore-me-not\z  path: "/dir/"  matches: false
+** glob: "dir/*"  pcre: \A/+(?=[^/])dir/+(?=[^/])[^/]*\z  path: "/dir/ignore-me"  matches: true
+** glob: "!dir/ignore-me-not"  pcre: \A/+(?=[^/])dir/+(?=[^/])ignore-me-not\z  path: "/dir/ignore-me"  matches: false
 Selection events for path dir/ignore-me:
 ignored at <TEMPORARY FILE PATH>, line 1: dir/*
 IGN dir/ignore-me
-** pattern: "dir/*"  path: "/dir"  matches: false
-** pattern: "!dir/ignore-me-not"  path: "/dir"  matches: false
-** pattern: "dir/*"  path: "/dir/"  matches: false
-** pattern: "!dir/ignore-me-not"  path: "/dir/"  matches: false
-** pattern: "dir/*"  path: "/dir/ignore-me-not"  matches: true
-** pattern: "!dir/ignore-me-not"  path: "/dir/ignore-me-not"  matches: true
+** glob: "dir/*"  pcre: \A/+(?=[^/])dir/+(?=[^/])[^/]*\z  path: "/dir"  matches: false
+** glob: "!dir/ignore-me-not"  pcre: \A/+(?=[^/])dir/+(?=[^/])ignore-me-not\z  path: "/dir"  matches: false
+** glob: "dir/*"  pcre: \A/+(?=[^/])dir/+(?=[^/])[^/]*\z  path: "/dir/"  matches: false
+** glob: "!dir/ignore-me-not"  pcre: \A/+(?=[^/])dir/+(?=[^/])ignore-me-not\z  path: "/dir/"  matches: false
+** glob: "dir/*"  pcre: \A/+(?=[^/])dir/+(?=[^/])[^/]*\z  path: "/dir/ignore-me-not"  matches: true
+** glob: "!dir/ignore-me-not"  pcre: \A/+(?=[^/])dir/+(?=[^/])ignore-me-not\z  path: "/dir/ignore-me-not"  matches: true
 Selection events for path dir/ignore-me-not:
 ignored at <TEMPORARY FILE PATH>, line 1: dir/*
 de-ignored at <TEMPORARY FILE PATH>, line 2: !dir/ignore-me-not

--- a/tests/snapshots/semgrep-core/928cede2578e/stdout
+++ b/tests/snapshots/semgrep-core/928cede2578e/stdout
@@ -1,0 +1,28 @@
+--- All files ---
+.gitignore
+dir/ignore-me
+dir/ignore-me-not
+--- Filtered files ---
+** pattern: "dir/*"  path: "/.gitignore"  matches: false
+** pattern: "!dir/ignore-me-not"  path: "/.gitignore"  matches: false
+Selection events for path .gitignore:
+SEL .gitignore
+** pattern: "dir/*"  path: "/dir"  matches: false
+** pattern: "!dir/ignore-me-not"  path: "/dir"  matches: false
+** pattern: "dir/*"  path: "/dir/"  matches: false
+** pattern: "!dir/ignore-me-not"  path: "/dir/"  matches: false
+** pattern: "dir/*"  path: "/dir/ignore-me"  matches: true
+** pattern: "!dir/ignore-me-not"  path: "/dir/ignore-me"  matches: false
+Selection events for path dir/ignore-me:
+ignored at <TEMPORARY FILE PATH>, line 1: dir/*
+IGN dir/ignore-me
+** pattern: "dir/*"  path: "/dir"  matches: false
+** pattern: "!dir/ignore-me-not"  path: "/dir"  matches: false
+** pattern: "dir/*"  path: "/dir/"  matches: false
+** pattern: "!dir/ignore-me-not"  path: "/dir/"  matches: false
+** pattern: "dir/*"  path: "/dir/ignore-me-not"  matches: true
+** pattern: "!dir/ignore-me-not"  path: "/dir/ignore-me-not"  matches: true
+Selection events for path dir/ignore-me-not:
+ignored at <TEMPORARY FILE PATH>, line 1: dir/*
+de-ignored at <TEMPORARY FILE PATH>, line 2: !dir/ignore-me-not
+SEL dir/ignore-me-not

--- a/tests/snapshots/semgrep-core/928cede2578e/stdout
+++ b/tests/snapshots/semgrep-core/928cede2578e/stdout
@@ -3,25 +3,11 @@
 dir/ignore-me
 dir/ignore-me-not
 --- Filtered files ---
-** glob: "dir/*"  pcre: \A/+(?=[^/])dir/+(?=[^/])(?![.])[^/]*\z  path: "/.gitignore"  matches: false
-** glob: "!dir/ignore-me-not"  pcre: \A/+(?=[^/])dir/+(?=[^/])ignore-me-not\z  path: "/.gitignore"  matches: false
 Selection events for path .gitignore:
 SEL .gitignore
-** glob: "dir/*"  pcre: \A/+(?=[^/])dir/+(?=[^/])(?![.])[^/]*\z  path: "/dir"  matches: false
-** glob: "!dir/ignore-me-not"  pcre: \A/+(?=[^/])dir/+(?=[^/])ignore-me-not\z  path: "/dir"  matches: false
-** glob: "dir/*"  pcre: \A/+(?=[^/])dir/+(?=[^/])(?![.])[^/]*\z  path: "/dir/"  matches: false
-** glob: "!dir/ignore-me-not"  pcre: \A/+(?=[^/])dir/+(?=[^/])ignore-me-not\z  path: "/dir/"  matches: false
-** glob: "dir/*"  pcre: \A/+(?=[^/])dir/+(?=[^/])(?![.])[^/]*\z  path: "/dir/ignore-me"  matches: true
-** glob: "!dir/ignore-me-not"  pcre: \A/+(?=[^/])dir/+(?=[^/])ignore-me-not\z  path: "/dir/ignore-me"  matches: false
 Selection events for path dir/ignore-me:
 ignored at <TEMPORARY FILE PATH>, line 1: dir/*
 IGN dir/ignore-me
-** glob: "dir/*"  pcre: \A/+(?=[^/])dir/+(?=[^/])(?![.])[^/]*\z  path: "/dir"  matches: false
-** glob: "!dir/ignore-me-not"  pcre: \A/+(?=[^/])dir/+(?=[^/])ignore-me-not\z  path: "/dir"  matches: false
-** glob: "dir/*"  pcre: \A/+(?=[^/])dir/+(?=[^/])(?![.])[^/]*\z  path: "/dir/"  matches: false
-** glob: "!dir/ignore-me-not"  pcre: \A/+(?=[^/])dir/+(?=[^/])ignore-me-not\z  path: "/dir/"  matches: false
-** glob: "dir/*"  pcre: \A/+(?=[^/])dir/+(?=[^/])(?![.])[^/]*\z  path: "/dir/ignore-me-not"  matches: true
-** glob: "!dir/ignore-me-not"  pcre: \A/+(?=[^/])dir/+(?=[^/])ignore-me-not\z  path: "/dir/ignore-me-not"  matches: true
 Selection events for path dir/ignore-me-not:
 ignored at <TEMPORARY FILE PATH>, line 1: dir/*
 de-ignored at <TEMPORARY FILE PATH>, line 2: !dir/ignore-me-not

--- a/tests/snapshots/semgrep-core/9e1227b52fc9/stdout
+++ b/tests/snapshots/semgrep-core/9e1227b52fc9/stdout
@@ -1,13 +1,14 @@
 Initialized empty Git repository in<MASKED>
 [main (root-commit) <MASKED>] Add all the files
- 2 files changed, 2 insertions(+)
+ 3 files changed, 2 insertions(+)
  create mode 100644 .gitignore
+ create mode 100644 bin/ignore-me
  create mode 100644 bin/ignore-me-not
 Input files:
 .gitignore
 bin/ignore-me
 bin/ignore-me-not
 RUN semgrep scan --experimental --x-ls .
-+ .gitignore
-+ bin/ignore-me-not
-- [semgrepignore_patterns_match] bin/ignore-me
+SEL .gitignore
+SEL bin/ignore-me-not
+IGN bin/ignore-me [semgrepignore_patterns_match]

--- a/tests/snapshots/semgrep-core/9e1227b52fc9/stdout
+++ b/tests/snapshots/semgrep-core/9e1227b52fc9/stdout
@@ -1,0 +1,13 @@
+Initialized empty Git repository in<MASKED>
+[main (root-commit) <MASKED>] Add all the files
+ 2 files changed, 2 insertions(+)
+ create mode 100644 .gitignore
+ create mode 100644 bin/ignore-me-not
+Input files:
+.gitignore
+bin/ignore-me
+bin/ignore-me-not
+RUN semgrep scan --experimental --x-ls .
++ .gitignore
++ bin/ignore-me-not
+- [semgrepignore_patterns_match] bin/ignore-me

--- a/tests/snapshots/semgrep-core/9e1227b52fc9/stdout
+++ b/tests/snapshots/semgrep-core/9e1227b52fc9/stdout
@@ -9,6 +9,6 @@ Input files:
 bin/ignore-me
 bin/ignore-me-not
 RUN semgrep scan --experimental --x-ls .
-SEL .gitignore
-SEL bin/ignore-me-not
-IGN bin/ignore-me [semgrepignore_patterns_match]
+selected .gitignore
+selected bin/ignore-me-not
+ignored bin/ignore-me [semgrepignore_patterns_match]

--- a/tests/snapshots/semgrep-core/aaadc9ccf052/stdout
+++ b/tests/snapshots/semgrep-core/aaadc9ccf052/stdout
@@ -3,32 +3,32 @@
 a/b
 dir/a/b
 --- Filtered files ---
-** pattern: "a/"  path: "/.gitignore"  matches: false
-** pattern: "!dir/a"  path: "/.gitignore"  matches: false
-** pattern: "!a/b"  path: "/.gitignore"  matches: false
+** glob: "a/"  pcre: \A/+(?:[^/]+/+)*(?=[^/])a/+\z  path: "/.gitignore"  matches: false
+** glob: "!dir/a"  pcre: \A/+(?=[^/])dir/+(?=[^/])a\z  path: "/.gitignore"  matches: false
+** glob: "!a/b"  pcre: \A/+(?=[^/])a/+(?=[^/])b\z  path: "/.gitignore"  matches: false
 Selection events for path .gitignore:
 SEL .gitignore
-** pattern: "a/"  path: "/a"  matches: false
-** pattern: "!dir/a"  path: "/a"  matches: false
-** pattern: "!a/b"  path: "/a"  matches: false
-** pattern: "a/"  path: "/a/"  matches: true
-** pattern: "!dir/a"  path: "/a/"  matches: false
-** pattern: "!a/b"  path: "/a/"  matches: false
+** glob: "a/"  pcre: \A/+(?:[^/]+/+)*(?=[^/])a/+\z  path: "/a"  matches: false
+** glob: "!dir/a"  pcre: \A/+(?=[^/])dir/+(?=[^/])a\z  path: "/a"  matches: false
+** glob: "!a/b"  pcre: \A/+(?=[^/])a/+(?=[^/])b\z  path: "/a"  matches: false
+** glob: "a/"  pcre: \A/+(?:[^/]+/+)*(?=[^/])a/+\z  path: "/a/"  matches: true
+** glob: "!dir/a"  pcre: \A/+(?=[^/])dir/+(?=[^/])a\z  path: "/a/"  matches: false
+** glob: "!a/b"  pcre: \A/+(?=[^/])a/+(?=[^/])b\z  path: "/a/"  matches: false
 Selection events for path a/b:
 ignored at <TEMPORARY FILE PATH>, line 1: a/
 IGN a/b
-** pattern: "a/"  path: "/dir"  matches: false
-** pattern: "!dir/a"  path: "/dir"  matches: false
-** pattern: "!a/b"  path: "/dir"  matches: false
-** pattern: "a/"  path: "/dir/"  matches: false
-** pattern: "!dir/a"  path: "/dir/"  matches: false
-** pattern: "!a/b"  path: "/dir/"  matches: false
-** pattern: "a/"  path: "/dir/a"  matches: false
-** pattern: "!dir/a"  path: "/dir/a"  matches: true
-** pattern: "!a/b"  path: "/dir/a"  matches: false
-** pattern: "a/"  path: "/dir/a/b"  matches: false
-** pattern: "!dir/a"  path: "/dir/a/b"  matches: false
-** pattern: "!a/b"  path: "/dir/a/b"  matches: false
+** glob: "a/"  pcre: \A/+(?:[^/]+/+)*(?=[^/])a/+\z  path: "/dir"  matches: false
+** glob: "!dir/a"  pcre: \A/+(?=[^/])dir/+(?=[^/])a\z  path: "/dir"  matches: false
+** glob: "!a/b"  pcre: \A/+(?=[^/])a/+(?=[^/])b\z  path: "/dir"  matches: false
+** glob: "a/"  pcre: \A/+(?:[^/]+/+)*(?=[^/])a/+\z  path: "/dir/"  matches: false
+** glob: "!dir/a"  pcre: \A/+(?=[^/])dir/+(?=[^/])a\z  path: "/dir/"  matches: false
+** glob: "!a/b"  pcre: \A/+(?=[^/])a/+(?=[^/])b\z  path: "/dir/"  matches: false
+** glob: "a/"  pcre: \A/+(?:[^/]+/+)*(?=[^/])a/+\z  path: "/dir/a"  matches: false
+** glob: "!dir/a"  pcre: \A/+(?=[^/])dir/+(?=[^/])a\z  path: "/dir/a"  matches: true
+** glob: "!a/b"  pcre: \A/+(?=[^/])a/+(?=[^/])b\z  path: "/dir/a"  matches: false
+** glob: "a/"  pcre: \A/+(?:[^/]+/+)*(?=[^/])a/+\z  path: "/dir/a/b"  matches: false
+** glob: "!dir/a"  pcre: \A/+(?=[^/])dir/+(?=[^/])a\z  path: "/dir/a/b"  matches: false
+** glob: "!a/b"  pcre: \A/+(?=[^/])a/+(?=[^/])b\z  path: "/dir/a/b"  matches: false
 Selection events for path dir/a/b:
 de-ignored at <TEMPORARY FILE PATH>, line 2: !dir/a
 SEL dir/a/b

--- a/tests/snapshots/semgrep-core/aaadc9ccf052/stdout
+++ b/tests/snapshots/semgrep-core/aaadc9ccf052/stdout
@@ -1,0 +1,34 @@
+--- All files ---
+.gitignore
+a/b
+dir/a/b
+--- Filtered files ---
+** pattern: "a/"  path: "/.gitignore"  matches: false
+** pattern: "!dir/a"  path: "/.gitignore"  matches: false
+** pattern: "!a/b"  path: "/.gitignore"  matches: false
+Selection events for path .gitignore:
+SEL .gitignore
+** pattern: "a/"  path: "/a"  matches: false
+** pattern: "!dir/a"  path: "/a"  matches: false
+** pattern: "!a/b"  path: "/a"  matches: false
+** pattern: "a/"  path: "/a/"  matches: true
+** pattern: "!dir/a"  path: "/a/"  matches: false
+** pattern: "!a/b"  path: "/a/"  matches: false
+Selection events for path a/b:
+ignored at <TEMPORARY FILE PATH>, line 1: a/
+IGN a/b
+** pattern: "a/"  path: "/dir"  matches: false
+** pattern: "!dir/a"  path: "/dir"  matches: false
+** pattern: "!a/b"  path: "/dir"  matches: false
+** pattern: "a/"  path: "/dir/"  matches: false
+** pattern: "!dir/a"  path: "/dir/"  matches: false
+** pattern: "!a/b"  path: "/dir/"  matches: false
+** pattern: "a/"  path: "/dir/a"  matches: false
+** pattern: "!dir/a"  path: "/dir/a"  matches: true
+** pattern: "!a/b"  path: "/dir/a"  matches: false
+** pattern: "a/"  path: "/dir/a/b"  matches: false
+** pattern: "!dir/a"  path: "/dir/a/b"  matches: false
+** pattern: "!a/b"  path: "/dir/a/b"  matches: false
+Selection events for path dir/a/b:
+de-ignored at <TEMPORARY FILE PATH>, line 2: !dir/a
+SEL dir/a/b

--- a/tests/snapshots/semgrep-core/aaadc9ccf052/stdout
+++ b/tests/snapshots/semgrep-core/aaadc9ccf052/stdout
@@ -3,32 +3,11 @@
 a/b
 dir/a/b
 --- Filtered files ---
-** glob: "a/"  pcre: \A/+(?:[^/]+/+)*(?=[^/])a/+\z  path: "/.gitignore"  matches: false
-** glob: "!dir/a"  pcre: \A/+(?=[^/])dir/+(?=[^/])a\z  path: "/.gitignore"  matches: false
-** glob: "!a/b"  pcre: \A/+(?=[^/])a/+(?=[^/])b\z  path: "/.gitignore"  matches: false
 Selection events for path .gitignore:
 SEL .gitignore
-** glob: "a/"  pcre: \A/+(?:[^/]+/+)*(?=[^/])a/+\z  path: "/a"  matches: false
-** glob: "!dir/a"  pcre: \A/+(?=[^/])dir/+(?=[^/])a\z  path: "/a"  matches: false
-** glob: "!a/b"  pcre: \A/+(?=[^/])a/+(?=[^/])b\z  path: "/a"  matches: false
-** glob: "a/"  pcre: \A/+(?:[^/]+/+)*(?=[^/])a/+\z  path: "/a/"  matches: true
-** glob: "!dir/a"  pcre: \A/+(?=[^/])dir/+(?=[^/])a\z  path: "/a/"  matches: false
-** glob: "!a/b"  pcre: \A/+(?=[^/])a/+(?=[^/])b\z  path: "/a/"  matches: false
 Selection events for path a/b:
 ignored at <TEMPORARY FILE PATH>, line 1: a/
 IGN a/b
-** glob: "a/"  pcre: \A/+(?:[^/]+/+)*(?=[^/])a/+\z  path: "/dir"  matches: false
-** glob: "!dir/a"  pcre: \A/+(?=[^/])dir/+(?=[^/])a\z  path: "/dir"  matches: false
-** glob: "!a/b"  pcre: \A/+(?=[^/])a/+(?=[^/])b\z  path: "/dir"  matches: false
-** glob: "a/"  pcre: \A/+(?:[^/]+/+)*(?=[^/])a/+\z  path: "/dir/"  matches: false
-** glob: "!dir/a"  pcre: \A/+(?=[^/])dir/+(?=[^/])a\z  path: "/dir/"  matches: false
-** glob: "!a/b"  pcre: \A/+(?=[^/])a/+(?=[^/])b\z  path: "/dir/"  matches: false
-** glob: "a/"  pcre: \A/+(?:[^/]+/+)*(?=[^/])a/+\z  path: "/dir/a"  matches: false
-** glob: "!dir/a"  pcre: \A/+(?=[^/])dir/+(?=[^/])a\z  path: "/dir/a"  matches: true
-** glob: "!a/b"  pcre: \A/+(?=[^/])a/+(?=[^/])b\z  path: "/dir/a"  matches: false
-** glob: "a/"  pcre: \A/+(?:[^/]+/+)*(?=[^/])a/+\z  path: "/dir/a/b"  matches: false
-** glob: "!dir/a"  pcre: \A/+(?=[^/])dir/+(?=[^/])a\z  path: "/dir/a/b"  matches: false
-** glob: "!a/b"  pcre: \A/+(?=[^/])a/+(?=[^/])b\z  path: "/dir/a/b"  matches: false
 Selection events for path dir/a/b:
 de-ignored at <TEMPORARY FILE PATH>, line 2: !dir/a
 SEL dir/a/b

--- a/tests/snapshots/semgrep-core/d5c73b8c6b15/stdout
+++ b/tests/snapshots/semgrep-core/d5c73b8c6b15/stdout
@@ -1,0 +1,4 @@
+Input files:
+a
+Output files:
+a

--- a/tests/snapshots/semgrep-core/ec0b6d8d3aac/stdout
+++ b/tests/snapshots/semgrep-core/ec0b6d8d3aac/stdout
@@ -1,0 +1,54 @@
+--- All files ---
+.gitignore
+a/b
+b/a
+b/b/c
+b/c
+b/d
+--- Filtered files ---
+** pattern: "/a"  path: "/.gitignore"  matches: false
+** pattern: "b/c"  path: "/.gitignore"  matches: false
+Selection events for path .gitignore:
+SEL .gitignore
+** pattern: "/a"  path: "/a"  matches: true
+** pattern: "b/c"  path: "/a"  matches: false
+Selection events for path a/b:
+ignored at <TEMPORARY FILE PATH>, line 1: /a
+IGN a/b
+** pattern: "/a"  path: "/b"  matches: false
+** pattern: "b/c"  path: "/b"  matches: false
+** pattern: "/a"  path: "/b/"  matches: false
+** pattern: "b/c"  path: "/b/"  matches: false
+** pattern: "/a"  path: "/b/a"  matches: false
+** pattern: "b/c"  path: "/b/a"  matches: false
+Selection events for path b/a:
+SEL b/a
+** pattern: "/a"  path: "/b"  matches: false
+** pattern: "b/c"  path: "/b"  matches: false
+** pattern: "/a"  path: "/b/"  matches: false
+** pattern: "b/c"  path: "/b/"  matches: false
+** pattern: "/a"  path: "/b/b"  matches: false
+** pattern: "b/c"  path: "/b/b"  matches: false
+** pattern: "/a"  path: "/b/b/"  matches: false
+** pattern: "b/c"  path: "/b/b/"  matches: false
+** pattern: "/a"  path: "/b/b/c"  matches: false
+** pattern: "b/c"  path: "/b/b/c"  matches: false
+Selection events for path b/b/c:
+SEL b/b/c
+** pattern: "/a"  path: "/b"  matches: false
+** pattern: "b/c"  path: "/b"  matches: false
+** pattern: "/a"  path: "/b/"  matches: false
+** pattern: "b/c"  path: "/b/"  matches: false
+** pattern: "/a"  path: "/b/c"  matches: false
+** pattern: "b/c"  path: "/b/c"  matches: true
+Selection events for path b/c:
+ignored at <TEMPORARY FILE PATH>, line 2: b/c
+IGN b/c
+** pattern: "/a"  path: "/b"  matches: false
+** pattern: "b/c"  path: "/b"  matches: false
+** pattern: "/a"  path: "/b/"  matches: false
+** pattern: "b/c"  path: "/b/"  matches: false
+** pattern: "/a"  path: "/b/d"  matches: false
+** pattern: "b/c"  path: "/b/d"  matches: false
+Selection events for path b/d:
+SEL b/d

--- a/tests/snapshots/semgrep-core/ec0b6d8d3aac/stdout
+++ b/tests/snapshots/semgrep-core/ec0b6d8d3aac/stdout
@@ -6,49 +6,49 @@ b/b/c
 b/c
 b/d
 --- Filtered files ---
-** pattern: "/a"  path: "/.gitignore"  matches: false
-** pattern: "b/c"  path: "/.gitignore"  matches: false
+** glob: "/a"  pcre: \A/+(?=[^/])a\z  path: "/.gitignore"  matches: false
+** glob: "b/c"  pcre: \A/+(?=[^/])b/+(?=[^/])c\z  path: "/.gitignore"  matches: false
 Selection events for path .gitignore:
 SEL .gitignore
-** pattern: "/a"  path: "/a"  matches: true
-** pattern: "b/c"  path: "/a"  matches: false
+** glob: "/a"  pcre: \A/+(?=[^/])a\z  path: "/a"  matches: true
+** glob: "b/c"  pcre: \A/+(?=[^/])b/+(?=[^/])c\z  path: "/a"  matches: false
 Selection events for path a/b:
 ignored at <TEMPORARY FILE PATH>, line 1: /a
 IGN a/b
-** pattern: "/a"  path: "/b"  matches: false
-** pattern: "b/c"  path: "/b"  matches: false
-** pattern: "/a"  path: "/b/"  matches: false
-** pattern: "b/c"  path: "/b/"  matches: false
-** pattern: "/a"  path: "/b/a"  matches: false
-** pattern: "b/c"  path: "/b/a"  matches: false
+** glob: "/a"  pcre: \A/+(?=[^/])a\z  path: "/b"  matches: false
+** glob: "b/c"  pcre: \A/+(?=[^/])b/+(?=[^/])c\z  path: "/b"  matches: false
+** glob: "/a"  pcre: \A/+(?=[^/])a\z  path: "/b/"  matches: false
+** glob: "b/c"  pcre: \A/+(?=[^/])b/+(?=[^/])c\z  path: "/b/"  matches: false
+** glob: "/a"  pcre: \A/+(?=[^/])a\z  path: "/b/a"  matches: false
+** glob: "b/c"  pcre: \A/+(?=[^/])b/+(?=[^/])c\z  path: "/b/a"  matches: false
 Selection events for path b/a:
 SEL b/a
-** pattern: "/a"  path: "/b"  matches: false
-** pattern: "b/c"  path: "/b"  matches: false
-** pattern: "/a"  path: "/b/"  matches: false
-** pattern: "b/c"  path: "/b/"  matches: false
-** pattern: "/a"  path: "/b/b"  matches: false
-** pattern: "b/c"  path: "/b/b"  matches: false
-** pattern: "/a"  path: "/b/b/"  matches: false
-** pattern: "b/c"  path: "/b/b/"  matches: false
-** pattern: "/a"  path: "/b/b/c"  matches: false
-** pattern: "b/c"  path: "/b/b/c"  matches: false
+** glob: "/a"  pcre: \A/+(?=[^/])a\z  path: "/b"  matches: false
+** glob: "b/c"  pcre: \A/+(?=[^/])b/+(?=[^/])c\z  path: "/b"  matches: false
+** glob: "/a"  pcre: \A/+(?=[^/])a\z  path: "/b/"  matches: false
+** glob: "b/c"  pcre: \A/+(?=[^/])b/+(?=[^/])c\z  path: "/b/"  matches: false
+** glob: "/a"  pcre: \A/+(?=[^/])a\z  path: "/b/b"  matches: false
+** glob: "b/c"  pcre: \A/+(?=[^/])b/+(?=[^/])c\z  path: "/b/b"  matches: false
+** glob: "/a"  pcre: \A/+(?=[^/])a\z  path: "/b/b/"  matches: false
+** glob: "b/c"  pcre: \A/+(?=[^/])b/+(?=[^/])c\z  path: "/b/b/"  matches: false
+** glob: "/a"  pcre: \A/+(?=[^/])a\z  path: "/b/b/c"  matches: false
+** glob: "b/c"  pcre: \A/+(?=[^/])b/+(?=[^/])c\z  path: "/b/b/c"  matches: false
 Selection events for path b/b/c:
 SEL b/b/c
-** pattern: "/a"  path: "/b"  matches: false
-** pattern: "b/c"  path: "/b"  matches: false
-** pattern: "/a"  path: "/b/"  matches: false
-** pattern: "b/c"  path: "/b/"  matches: false
-** pattern: "/a"  path: "/b/c"  matches: false
-** pattern: "b/c"  path: "/b/c"  matches: true
+** glob: "/a"  pcre: \A/+(?=[^/])a\z  path: "/b"  matches: false
+** glob: "b/c"  pcre: \A/+(?=[^/])b/+(?=[^/])c\z  path: "/b"  matches: false
+** glob: "/a"  pcre: \A/+(?=[^/])a\z  path: "/b/"  matches: false
+** glob: "b/c"  pcre: \A/+(?=[^/])b/+(?=[^/])c\z  path: "/b/"  matches: false
+** glob: "/a"  pcre: \A/+(?=[^/])a\z  path: "/b/c"  matches: false
+** glob: "b/c"  pcre: \A/+(?=[^/])b/+(?=[^/])c\z  path: "/b/c"  matches: true
 Selection events for path b/c:
 ignored at <TEMPORARY FILE PATH>, line 2: b/c
 IGN b/c
-** pattern: "/a"  path: "/b"  matches: false
-** pattern: "b/c"  path: "/b"  matches: false
-** pattern: "/a"  path: "/b/"  matches: false
-** pattern: "b/c"  path: "/b/"  matches: false
-** pattern: "/a"  path: "/b/d"  matches: false
-** pattern: "b/c"  path: "/b/d"  matches: false
+** glob: "/a"  pcre: \A/+(?=[^/])a\z  path: "/b"  matches: false
+** glob: "b/c"  pcre: \A/+(?=[^/])b/+(?=[^/])c\z  path: "/b"  matches: false
+** glob: "/a"  pcre: \A/+(?=[^/])a\z  path: "/b/"  matches: false
+** glob: "b/c"  pcre: \A/+(?=[^/])b/+(?=[^/])c\z  path: "/b/"  matches: false
+** glob: "/a"  pcre: \A/+(?=[^/])a\z  path: "/b/d"  matches: false
+** glob: "b/c"  pcre: \A/+(?=[^/])b/+(?=[^/])c\z  path: "/b/d"  matches: false
 Selection events for path b/d:
 SEL b/d

--- a/tests/snapshots/semgrep-core/ec0b6d8d3aac/stdout
+++ b/tests/snapshots/semgrep-core/ec0b6d8d3aac/stdout
@@ -6,49 +6,17 @@ b/b/c
 b/c
 b/d
 --- Filtered files ---
-** glob: "/a"  pcre: \A/+(?=[^/])a\z  path: "/.gitignore"  matches: false
-** glob: "b/c"  pcre: \A/+(?=[^/])b/+(?=[^/])c\z  path: "/.gitignore"  matches: false
 Selection events for path .gitignore:
 SEL .gitignore
-** glob: "/a"  pcre: \A/+(?=[^/])a\z  path: "/a"  matches: true
-** glob: "b/c"  pcre: \A/+(?=[^/])b/+(?=[^/])c\z  path: "/a"  matches: false
 Selection events for path a/b:
 ignored at <TEMPORARY FILE PATH>, line 1: /a
 IGN a/b
-** glob: "/a"  pcre: \A/+(?=[^/])a\z  path: "/b"  matches: false
-** glob: "b/c"  pcre: \A/+(?=[^/])b/+(?=[^/])c\z  path: "/b"  matches: false
-** glob: "/a"  pcre: \A/+(?=[^/])a\z  path: "/b/"  matches: false
-** glob: "b/c"  pcre: \A/+(?=[^/])b/+(?=[^/])c\z  path: "/b/"  matches: false
-** glob: "/a"  pcre: \A/+(?=[^/])a\z  path: "/b/a"  matches: false
-** glob: "b/c"  pcre: \A/+(?=[^/])b/+(?=[^/])c\z  path: "/b/a"  matches: false
 Selection events for path b/a:
 SEL b/a
-** glob: "/a"  pcre: \A/+(?=[^/])a\z  path: "/b"  matches: false
-** glob: "b/c"  pcre: \A/+(?=[^/])b/+(?=[^/])c\z  path: "/b"  matches: false
-** glob: "/a"  pcre: \A/+(?=[^/])a\z  path: "/b/"  matches: false
-** glob: "b/c"  pcre: \A/+(?=[^/])b/+(?=[^/])c\z  path: "/b/"  matches: false
-** glob: "/a"  pcre: \A/+(?=[^/])a\z  path: "/b/b"  matches: false
-** glob: "b/c"  pcre: \A/+(?=[^/])b/+(?=[^/])c\z  path: "/b/b"  matches: false
-** glob: "/a"  pcre: \A/+(?=[^/])a\z  path: "/b/b/"  matches: false
-** glob: "b/c"  pcre: \A/+(?=[^/])b/+(?=[^/])c\z  path: "/b/b/"  matches: false
-** glob: "/a"  pcre: \A/+(?=[^/])a\z  path: "/b/b/c"  matches: false
-** glob: "b/c"  pcre: \A/+(?=[^/])b/+(?=[^/])c\z  path: "/b/b/c"  matches: false
 Selection events for path b/b/c:
 SEL b/b/c
-** glob: "/a"  pcre: \A/+(?=[^/])a\z  path: "/b"  matches: false
-** glob: "b/c"  pcre: \A/+(?=[^/])b/+(?=[^/])c\z  path: "/b"  matches: false
-** glob: "/a"  pcre: \A/+(?=[^/])a\z  path: "/b/"  matches: false
-** glob: "b/c"  pcre: \A/+(?=[^/])b/+(?=[^/])c\z  path: "/b/"  matches: false
-** glob: "/a"  pcre: \A/+(?=[^/])a\z  path: "/b/c"  matches: false
-** glob: "b/c"  pcre: \A/+(?=[^/])b/+(?=[^/])c\z  path: "/b/c"  matches: true
 Selection events for path b/c:
 ignored at <TEMPORARY FILE PATH>, line 2: b/c
 IGN b/c
-** glob: "/a"  pcre: \A/+(?=[^/])a\z  path: "/b"  matches: false
-** glob: "b/c"  pcre: \A/+(?=[^/])b/+(?=[^/])c\z  path: "/b"  matches: false
-** glob: "/a"  pcre: \A/+(?=[^/])a\z  path: "/b/"  matches: false
-** glob: "b/c"  pcre: \A/+(?=[^/])b/+(?=[^/])c\z  path: "/b/"  matches: false
-** glob: "/a"  pcre: \A/+(?=[^/])a\z  path: "/b/d"  matches: false
-** glob: "b/c"  pcre: \A/+(?=[^/])b/+(?=[^/])c\z  path: "/b/d"  matches: false
 Selection events for path b/d:
 SEL b/d

--- a/tests/snapshots/semgrep-core/fc0ccdecb184/stdout
+++ b/tests/snapshots/semgrep-core/fc0ccdecb184/stdout
@@ -3,13 +3,10 @@
 hello.c
 hello.ml
 --- Filtered files ---
-** glob: "*.c"  pcre: \A/+(?:[^/]+/+)*(?=[^/])(?![.])[^/]*\.c\z  path: "/.gitignore"  matches: false
 Selection events for path .gitignore:
 SEL .gitignore
-** glob: "*.c"  pcre: \A/+(?:[^/]+/+)*(?=[^/])(?![.])[^/]*\.c\z  path: "/hello.c"  matches: true
 Selection events for path hello.c:
 ignored at <TEMPORARY FILE PATH>, line 1: *.c
 IGN hello.c
-** glob: "*.c"  pcre: \A/+(?:[^/]+/+)*(?=[^/])(?![.])[^/]*\.c\z  path: "/hello.ml"  matches: false
 Selection events for path hello.ml:
 SEL hello.ml

--- a/tests/snapshots/semgrep-core/fc0ccdecb184/stdout
+++ b/tests/snapshots/semgrep-core/fc0ccdecb184/stdout
@@ -3,13 +3,13 @@
 hello.c
 hello.ml
 --- Filtered files ---
-** pattern: "*.c"  path: "/.gitignore"  matches: false
+** glob: "*.c"  pcre: \A/+(?:[^/]+/+)*(?=[^/])[^/]*\.c\z  path: "/.gitignore"  matches: false
 Selection events for path .gitignore:
 SEL .gitignore
-** pattern: "*.c"  path: "/hello.c"  matches: true
+** glob: "*.c"  pcre: \A/+(?:[^/]+/+)*(?=[^/])[^/]*\.c\z  path: "/hello.c"  matches: true
 Selection events for path hello.c:
 ignored at <TEMPORARY FILE PATH>, line 1: *.c
 IGN hello.c
-** pattern: "*.c"  path: "/hello.ml"  matches: false
+** glob: "*.c"  pcre: \A/+(?:[^/]+/+)*(?=[^/])[^/]*\.c\z  path: "/hello.ml"  matches: false
 Selection events for path hello.ml:
 SEL hello.ml

--- a/tests/snapshots/semgrep-core/fc0ccdecb184/stdout
+++ b/tests/snapshots/semgrep-core/fc0ccdecb184/stdout
@@ -3,13 +3,13 @@
 hello.c
 hello.ml
 --- Filtered files ---
-** glob: "*.c"  pcre: \A/+(?:[^/]+/+)*(?=[^/])[^/]*\.c\z  path: "/.gitignore"  matches: false
+** glob: "*.c"  pcre: \A/+(?:[^/]+/+)*(?=[^/])(?![.])[^/]*\.c\z  path: "/.gitignore"  matches: false
 Selection events for path .gitignore:
 SEL .gitignore
-** glob: "*.c"  pcre: \A/+(?:[^/]+/+)*(?=[^/])[^/]*\.c\z  path: "/hello.c"  matches: true
+** glob: "*.c"  pcre: \A/+(?:[^/]+/+)*(?=[^/])(?![.])[^/]*\.c\z  path: "/hello.c"  matches: true
 Selection events for path hello.c:
 ignored at <TEMPORARY FILE PATH>, line 1: *.c
 IGN hello.c
-** glob: "*.c"  pcre: \A/+(?:[^/]+/+)*(?=[^/])[^/]*\.c\z  path: "/hello.ml"  matches: false
+** glob: "*.c"  pcre: \A/+(?:[^/]+/+)*(?=[^/])(?![.])[^/]*\.c\z  path: "/hello.ml"  matches: false
 Selection events for path hello.ml:
 SEL hello.ml

--- a/tests/snapshots/semgrep-core/fc0ccdecb184/stdout
+++ b/tests/snapshots/semgrep-core/fc0ccdecb184/stdout
@@ -1,0 +1,15 @@
+--- All files ---
+.gitignore
+hello.c
+hello.ml
+--- Filtered files ---
+** pattern: "*.c"  path: "/.gitignore"  matches: false
+Selection events for path .gitignore:
+SEL .gitignore
+** pattern: "*.c"  path: "/hello.c"  matches: true
+Selection events for path hello.c:
+ignored at <TEMPORARY FILE PATH>, line 1: *.c
+IGN hello.c
+** pattern: "*.c"  path: "/hello.ml"  matches: false
+Selection events for path hello.ml:
+SEL hello.ml


### PR DESCRIPTION
The following globbing bugs were fixed, making semgrepignore behavior in osemgrep more correct:

* `a/*` should not match `a/`
* `*` should not match `.a`
* `a//b` should match `a/b` and vice-versa

Improvements made to the test framework along the way:

* Print the path(s) to the captured output when the expected output is missing (allows reviewing it before approval)
* Add a function `mask_temp_paths` to conveniently hide random file paths in test output for comparison against past runs

Edit: target selection over the semgrep repo has become 2x slower (now 3x slower than pysemgrep)! I'm looking into it. It's very interesting.

Performance update: I solved it by adding the option `--exclude-standard` to `git ls-files --others` that honors gitignore, just like pysemgrep. The downside is that we can't de-ignore git-ignored files using semgrepignore. I think it's fine since deignoring files in semgrepignore is a new feature anyway. Here's the kind of deignoring we can do in semgrepignore:
```
tests/*
!tests/*.py
```
but we can't have the first pattern in a `.gitignore` and the second pattern (deignoring) in a `.semgrepignore`.