### PR TITLE
Fix release-homebrew.jsonnet

### DIFF
--- a/.github/workflows/.codemapignore
+++ b/.github/workflows/.codemapignore
@@ -15,4 +15,5 @@ check-semgrep-pro.yml
 test-pro-rules.yml
 start-release.yml
 release.yml
+release-homebrew.yml
 trigger-semgrep-comparison-argo.yml

--- a/.github/workflows/nightly.jsonnet
+++ b/.github/workflows/nightly.jsonnet
@@ -1,56 +1,26 @@
-// Cron to verify that the Homebrew Core Formula Works.
-// This formula is stored in https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/s/semgrep.rb
-// and "bumped" in release.yml by dawidd6/action-homebrew-bump-formula@v3
-//
-// This formula is created by our release process with the PR to homebrew/homebrew-core.
-// What this workflow does is uses the latest version of the formula at that repo, but
-// 'develop' branch source code from our PR. This serves two purposes:
-//  - verifies that our changes don't break Brew
-//  - gives us time before release to fix these issues and adjust our homebrew formula
-//    if needed.
+// Cron to verify that the release is still working (at least in dry-mode),
+// and that the Semgrep Homebrew formula still work.
+
+local release_homebrew = import 'release-homebrew.jsonnet';
 
 // ----------------------------------------------------------------------------
-// The main job
+// Helpers
 // ----------------------------------------------------------------------------
-
-local env = {
-  // We've had issues with this workflow in the past, and needed to ensure that
-  // homebrew wouldn't use the API.
-  // See: https://github.com/orgs/Homebrew/discussions/4150, and
-  // https://github.com/orgs/Homebrew/discussions/4136
-  // There's also much other discussion on this topic available on GH and in the
-  // brew discussions.
-  HOMEBREW_NO_INSTALL_FROM_API: 1,
-};
-
-local brew_build_job = {
-  name: 'Build Semgrep via Brew from `returntocorp/semgrep:develop`',
-  'runs-on': 'macos-12',
-  steps: [
-    {
-      run: 'brew update --debug --verbose',
-      env: env,
-    },
-    {
-      // See https://github.com/Homebrew/brew/issues/1742 for context on the brew link step.
-      run: 'brew install semgrep --HEAD --debug || brew link --overwrite semgrep',
-      env: env + {
-        NONINTERACTIVE: 1,
-      },
-    },
-    {
-      name: 'Check installed correctly',
-      run: 'brew test semgrep --HEAD',
-      env: env,
-    },
-  ],
-};
+// TODO: factorize with test-e2e-semgrep-ci.jsonnet using slack-github action
+local curl_notify() = |||
+        curl --request POST \
+        --url  ${{ secrets.HOMEBREW_NIGHTLY_NOTIFICATIONS_URL }} \
+        --header 'content-type: application/json' \
+        --data '{
+          "commit_sha": "${{ github.sha }}",
+          "workflow_url": "https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}"
+        }'
+|||;
 
 // ----------------------------------------------------------------------------
 // Failure notification
 // ----------------------------------------------------------------------------
 
-// TODO: factorize with test-e2e-semgrep-ci.jsonnet using slack-github action
 local notify_failure_job = {
   needs: [
     'brew-build',
@@ -61,16 +31,7 @@ local notify_failure_job = {
   'if': 'failure()',
   steps: [
     {
-      name: 'Notify Failure',
-      run: |||
-        curl --request POST \
-        --url  ${{ secrets.HOMEBREW_NIGHTLY_NOTIFICATIONS_URL }} \
-        --header 'content-type: application/json' \
-        --data '{
-          "commit_sha": "${{ github.sha }}",
-          "workflow_url": "https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}"
-        }'
-      |||,
+      run: curl_notify(),
     },
   ],
 };
@@ -78,7 +39,6 @@ local notify_failure_job = {
 // ----------------------------------------------------------------------------
 // The Workflow
 // ----------------------------------------------------------------------------
-
 {
   name: 'nightly',
   on: {
@@ -91,7 +51,7 @@ local notify_failure_job = {
     ],
   },
   jobs: {
-    'brew-build': brew_build_job,
+    'brew-build': release_homebrew.export.brew_build,
     'release-dry-run': {
       uses: './.github/workflows/release.yml',
       secrets: 'inherit',

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,7 +6,7 @@ name: nightly
   - cron: 26 9 * * *
 jobs:
   brew-build:
-    name: Build Semgrep via Brew from `returntocorp/semgrep:develop`
+    name: Build Semgrep via Brew from HEAD
     runs-on: macos-12
     steps:
     - run: brew update --debug --verbose
@@ -33,9 +33,8 @@ jobs:
     runs-on: ubuntu-20.04
     if: failure()
     steps:
-    - name: Notify Failure
-      run: "\n        curl --request POST \\\n        --url  ${{ secrets.HOMEBREW_NIGHTLY_NOTIFICATIONS_URL
+    - run: "\n        curl --request POST \\\n        --url  ${{ secrets.HOMEBREW_NIGHTLY_NOTIFICATIONS_URL
         }} \\\n        --header 'content-type: application/json' \\\n        --data
         '{\n          \"commit_sha\": \"${{ github.sha }}\",\n          \"workflow_url\":
         \"https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}\"\n
-        \       }'\n      "
+        \       }'\n"

--- a/.github/workflows/release-homebrew.jsonnet
+++ b/.github/workflows/release-homebrew.jsonnet
@@ -41,7 +41,7 @@ local homebrew_core_pr_job = {
       uses: 'actions/setup-python@v4',
       id: 'python-setup',
       with: {
-        'python-version': '3.10',
+        'python-version': '3.9',
       },
     },
     {
@@ -60,7 +60,7 @@ local homebrew_core_pr_job = {
       run: |||
         brew bump-formula-pr --force --no-audit --no-browse --write-only \
           --message="semgrep %s" \
-          --tag="%s" semgrep
+          --tag="%s" semgrep --debug
       ||| % [version, tag],
     } + unless_dry_run,
     {

--- a/.github/workflows/release-homebrew.jsonnet
+++ b/.github/workflows/release-homebrew.jsonnet
@@ -44,6 +44,10 @@ local homebrew_core_pr_job = {
     {
       run: 'find /usr/local/Cellar/python@3.11/'
     },
+    // ugly
+    {
+      run: 'cd /usr/local/Cellar/python@3.11; ln -s 3.11.6_1 3.11.7'
+    },
     {
       run: 'ls -al /usr/local/Cellar/python@3.11/3.11.7/libexec/bin/'
     },

--- a/.github/workflows/release-homebrew.jsonnet
+++ b/.github/workflows/release-homebrew.jsonnet
@@ -51,6 +51,8 @@ local homebrew_core_pr_job = {
       name: 'Open Brew PR',
       env: {
         HOMEBREW_GITHUB_API_TOKEN: '${{ secrets.SEMGREP_HOMEBREW_RELEASE_PAT }}',
+        HOMEBREW_NO_INSTALL_FROM_API: 1,
+
       },
       // Note that we use '--write-only' below so the command does not
       // open a new PR; it just modifies

--- a/.github/workflows/release-homebrew.jsonnet
+++ b/.github/workflows/release-homebrew.jsonnet
@@ -1,5 +1,5 @@
 // This file contains jobs to release Semgrep on Homebrew (https://brew.sh/).
-// Note that the Semgrep homebrew "recipe" is stored in
+// Note that the Semgrep homebrew "recipe" is not stored in this repo but at
 // https://github.com/Homebrew/homebrew-core/blob/master/Formula/s/semgrep.rb
 // The goal of the jobs below is to modify semgrep.rb after a new release
 // and to open a PR to the homebrew-core repo with the modified semgrep.rb
@@ -9,7 +9,7 @@
 // but it's also useful to have a separate workflow to trigger the
 // homebrew release manually as we often get issues with homebrew.
 //
-// You can also call 'brew bump-formula-pr ...' locally on your mac to
+// You can also call 'brew bump-formula-pr ...' locally on your Mac to
 // debug issues. However, you'll first need to run:
 //
 //    $ brew tap Homebrew/core --force
@@ -23,60 +23,64 @@
 // Input
 // ----------------------------------------------------------------------------
 
+local input = {
+  inputs: {
+    'dry-run': {
+      type: 'boolean',
+      description: |||
+        Check the box for a dry-run.
+        A dry-run will not push any external state.
+      |||,
+      default: false,
+      required: true,
+    },
+  },
+};
+
 // TODO: hardcoded for now
 local version = "1.55.1";
 local tag = "v1.55.1";
-local unless_dry_run = { };
+
+local unless_dry_run = {
+  'if': '${{ ! inputs.dry-run }}',
+};
 
 // ----------------------------------------------------------------------------
 // The jobs
 // ----------------------------------------------------------------------------
 
-// Note that this job needs to run after pypi released so brew bump-formula-pr
-// can update pypi dependency hashes in semgrep.rb
+// Note that this job needs to run after Semgrep has been released on Pypi so
+// brew bump-formula-pr below can update Pypi dependency hashes in semgrep.rb
 local homebrew_core_pr_job = {
   'runs-on': 'macos-12',
   steps: [
     {
       run: 'brew update',
     },
-    // This is run internally by bump-formula-pr
+    // ugly:  'brew bump-formula-pr' below internally calls
+    // /path/to/python -m pip install -q ... semgrep==1.xxx.yyy
+    // to fetch Semgrep python dependencies from Pypi but this path to python
+    // seems currently wrong hence this ugly fix below
     {
-      run: 'find /usr/local/Cellar/python@3.11/'
-    },
-    // ugly
-    {
+      name: 'ugly: fix the python path for brew bump-formula-pr',
       run: 'cd /usr/local/Cellar/python@3.11; ln -s 3.11.6_1 3.11.7'
     },
     {
-      run: 'ls -al /usr/local/Cellar/python@3.11/3.11.7/libexec/bin/'
-    },
-    {
-      run: 'python3 -m pip install -q --disable-pip-version-check --dry-run --ignore-installed --report=/dev/stdout semgrep==1.55.1'
-    },
-    {
-      name: 'Open Brew PR',
-      env: {
-        HOMEBREW_GITHUB_API_TOKEN: '${{ secrets.SEMGREP_HOMEBREW_RELEASE_PAT }}',
-        HOMEBREW_NO_INSTALL_FROM_API: 1,
-
-      },
+      name: 'Bump semgrep.rb',
       // Note that we use '--write-only' below so the command does not
-      // open a new PR; it just modifies
-      // /.../Library/Taps/homebrew/homebrew-core/Formula/s/semgrep.rb
+      // open a new PR; it just modifies .../Formula/s/semgrep.rb
       // The step below will make the commit, and the step further below
-      // will open the PR; We do things in 3 steps to help debug issues.
+      // will open the PR. We do things in 3 steps to help debug issues.
       run: |||
         brew bump-formula-pr --force --no-audit --no-browse --write-only \
           --message="semgrep %s" \
           --tag="%s" semgrep --debug
       ||| % [version, tag],
-    } + unless_dry_run,
+    },
     {
-      name: 'Prepare Branch',
+      name: 'Prepare commit',
       env: {
         GITHUB_TOKEN: '${{ secrets.SEMGREP_HOMEBREW_RELEASE_PAT }}',
-        R2C_HOMEBREW_CORE_FORK_HTTPS_URL: 'https://github.com/semgrep-release/homebrew-core.git',
       },
       run: |||
         cd "$(brew --repository)/Library/Taps/homebrew/homebrew-core"
@@ -85,14 +89,14 @@ local homebrew_core_pr_job = {
         git config user.name ${{ github.actor }}
         git config user.email ${{ github.actor }}@users.noreply.github.com
         gh auth setup-git
-        git remote add r2c "${R2C_HOMEBREW_CORE_FORK_HTTPS_URL}"
+        git remote add r2c https://github.com/semgrep-release/homebrew-core.git
         git checkout -b bump-semgrep-%s
         git add Formula/s/semgrep.rb
         git commit -m "semgrep %s"
       ||| % [version, version],
     },
     {
-      name: 'Push Branch to Fork',
+      name: 'Push commit to our fork of homebrew-core',
       env: {
         GITHUB_TOKEN: '${{ secrets.SEMGREP_HOMEBREW_RELEASE_PAT }}',
       },
@@ -102,14 +106,14 @@ local homebrew_core_pr_job = {
       ||| % version,
     } + unless_dry_run,
     {
-      name: 'Push to Fork',
+      name: 'Open PR to official homebrew-core repo',
       env: {
         GITHUB_TOKEN: '${{ secrets.SEMGREP_HOMEBREW_RELEASE_PAT }}',
-        R2C_HOMEBREW_CORE_OWNER: 'semgrep-release',
       },
+      // 'semgrep-release' below corresponds to r2c homebrew core owner
       run: |||
         gh pr create --repo homebrew/homebrew-core \
-          --base master --head "${R2C_HOMEBREW_CORE_OWNER}:bump-semgrep-%s" \
+          --base master --head "semgrep-release:bump-semgrep-%s" \
           --title="semgrep %s" \
           --body "Bump semgrep to version %s"
       ||| % [version, version, version],
@@ -123,7 +127,7 @@ local homebrew_core_pr_job = {
 {
   name: 'release-homebrew',
   on: {
-    workflow_dispatch: null,
+    workflow_dispatch: input,
   },
   jobs: {
     'homebrew-core-pr': homebrew_core_pr_job,

--- a/.github/workflows/release-homebrew.jsonnet
+++ b/.github/workflows/release-homebrew.jsonnet
@@ -132,7 +132,7 @@ local homebrew_core_pr_job(version, unless_dry_run) = {
   },
   jobs: {
     'homebrew-core-pr':
-      homebrew_core_pr_job('{{ inputs.version }}', unless_dry_run),
+      homebrew_core_pr_job('${{ inputs.version }}', unless_dry_run),
   },
   export:: {
    job: homebrew_core_pr_job,

--- a/.github/workflows/release-homebrew.jsonnet
+++ b/.github/workflows/release-homebrew.jsonnet
@@ -38,18 +38,11 @@ local homebrew_core_pr_job = {
   'runs-on': 'macos-12',
   steps: [
     {
-      uses: 'actions/setup-python@v4',
-      id: 'python-setup',
-      with: {
-        'python-version': '3.11',
-      },
-    },
-    {
       run: 'brew update',
     },
     // This is run internally by bump-formula-pr
     {
-      run: '/usr/local/Cellar/python@3.11/3.11.7/libexec/bin/python -m pip install -q --disable-pip-version-check --dry-run --ignore-installed --report=/dev/stdout semgrep==1.55.1'
+      run: 'python3 -m pip install -q --disable-pip-version-check --dry-run --ignore-installed --report=/dev/stdout semgrep==1.55.1'
     },
     {
       name: 'Open Brew PR',

--- a/.github/workflows/release-homebrew.jsonnet
+++ b/.github/workflows/release-homebrew.jsonnet
@@ -42,6 +42,12 @@ local homebrew_core_pr_job = {
     },
     // This is run internally by bump-formula-pr
     {
+      run: 'find /usr/local/Cellar/python@3.11/'
+    },
+    {
+      run: 'ls -al /usr/local/Cellar/python@3.11/3.11.7/libexec/bin/'
+    },
+    {
       run: 'python3 -m pip install -q --disable-pip-version-check --dry-run --ignore-installed --report=/dev/stdout semgrep==1.55.1'
     },
     {

--- a/.github/workflows/release-homebrew.jsonnet
+++ b/.github/workflows/release-homebrew.jsonnet
@@ -41,11 +41,15 @@ local homebrew_core_pr_job = {
       uses: 'actions/setup-python@v4',
       id: 'python-setup',
       with: {
-        'python-version': '3.9',
+        'python-version': '3.11',
       },
     },
     {
       run: 'brew update',
+    },
+    // This is run internally by bump-formula-pr
+    {
+      run: '/usr/local/Cellar/python@3.11/3.11.7/libexec/bin/python -m pip install -q --disable-pip-version-check --dry-run --ignore-installed --report=/dev/stdout semgrep==1.55.1'
     },
     {
       name: 'Open Brew PR',

--- a/.github/workflows/release-homebrew.jsonnet
+++ b/.github/workflows/release-homebrew.jsonnet
@@ -38,8 +38,8 @@ local input = {
 };
 
 // TODO: hardcoded for now
-local version = "1.55.1";
-local tag = "v1.55.1";
+local version = "1.55.2";
+local tag = "v1.55.2";
 
 local unless_dry_run = {
   'if': '${{ ! inputs.dry-run }}',

--- a/.github/workflows/release-homebrew.yml
+++ b/.github/workflows/release-homebrew.yml
@@ -7,6 +7,8 @@ jobs:
     runs-on: macos-12
     steps:
     - run: brew update
+    - run: find /usr/local/Cellar/python@3.11/
+    - run: ls -al /usr/local/Cellar/python@3.11/3.11.7/libexec/bin/
     - run: python3 -m pip install -q --disable-pip-version-check --dry-run --ignore-installed
         --report=/dev/stdout semgrep==1.55.1
     - name: Open Brew PR

--- a/.github/workflows/release-homebrew.yml
+++ b/.github/workflows/release-homebrew.yml
@@ -2,42 +2,43 @@
 name: release-homebrew
 "on":
   workflow_dispatch:
+    inputs:
+      dry-run:
+        type: boolean
+        description: "\n        Check the box for a dry-run.\n        A dry-run will
+          not push any external state.\n      "
+        default: false
+        required: true
 jobs:
   homebrew-core-pr:
     runs-on: macos-12
     steps:
     - run: brew update
-    - run: find /usr/local/Cellar/python@3.11/
-    - run: cd /usr/local/Cellar/python@3.11; ln -s 3.11.6_1 3.11.7
-    - run: ls -al /usr/local/Cellar/python@3.11/3.11.7/libexec/bin/
-    - run: python3 -m pip install -q --disable-pip-version-check --dry-run --ignore-installed
-        --report=/dev/stdout semgrep==1.55.1
-    - name: Open Brew PR
-      env:
-        HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.SEMGREP_HOMEBREW_RELEASE_PAT }}
-        HOMEBREW_NO_INSTALL_FROM_API: 1
+    - name: 'ugly: fix the python path for brew bump-formula-pr'
+      run: cd /usr/local/Cellar/python@3.11; ln -s 3.11.6_1 3.11.7
+    - name: Bump semgrep.rb
       run: "\n        brew bump-formula-pr --force --no-audit --no-browse --write-only
         \\\n          --message=\"semgrep 1.55.1\" \\\n          --tag=\"v1.55.1\"
         semgrep --debug\n      "
-    - name: Prepare Branch
+    - name: Prepare commit
       env:
         GITHUB_TOKEN: ${{ secrets.SEMGREP_HOMEBREW_RELEASE_PAT }}
-        R2C_HOMEBREW_CORE_FORK_HTTPS_URL: https://github.com/semgrep-release/homebrew-core.git
       run: "\n        cd \"$(brew --repository)/Library/Taps/homebrew/homebrew-core\"\n
         \       git status\n        git diff\n        git config user.name ${{ github.actor
         }}\n        git config user.email ${{ github.actor }}@users.noreply.github.com\n
-        \       gh auth setup-git\n        git remote add r2c \"${R2C_HOMEBREW_CORE_FORK_HTTPS_URL}\"\n
+        \       gh auth setup-git\n        git remote add r2c https://github.com/semgrep-release/homebrew-core.git\n
         \       git checkout -b bump-semgrep-1.55.1\n        git add Formula/s/semgrep.rb\n
         \       git commit -m \"semgrep 1.55.1\"\n      "
-    - name: Push Branch to Fork
+    - name: Push commit to our fork of homebrew-core
       env:
         GITHUB_TOKEN: ${{ secrets.SEMGREP_HOMEBREW_RELEASE_PAT }}
       run: "\n        cd \"$(brew --repository)/Library/Taps/homebrew/homebrew-core\"\n
         \       git push --set-upstream r2c --force \"bump-semgrep-1.55.1\"\n      "
-    - name: Push to Fork
+      if: ${{ ! inputs.dry-run }}
+    - name: Open PR to official homebrew-core repo
       env:
         GITHUB_TOKEN: ${{ secrets.SEMGREP_HOMEBREW_RELEASE_PAT }}
-        R2C_HOMEBREW_CORE_OWNER: semgrep-release
       run: "\n        gh pr create --repo homebrew/homebrew-core \\\n          --base
-        master --head \"${R2C_HOMEBREW_CORE_OWNER}:bump-semgrep-1.55.1\" \\\n          --title=\"semgrep
+        master --head \"semgrep-release:bump-semgrep-1.55.1\" \\\n          --title=\"semgrep
         1.55.1\" \\\n          --body \"Bump semgrep to version 1.55.1\"\n      "
+      if: ${{ ! inputs.dry-run }}

--- a/.github/workflows/release-homebrew.yml
+++ b/.github/workflows/release-homebrew.yml
@@ -9,8 +9,11 @@ jobs:
     - uses: actions/setup-python@v4
       id: python-setup
       with:
-        python-version: "3.9"
+        python-version: "3.11"
     - run: brew update
+    - run: /usr/local/Cellar/python@3.11/3.11.7/libexec/bin/python -m pip install
+        -q --disable-pip-version-check --dry-run --ignore-installed --report=/dev/stdout
+        semgrep==1.55.1
     - name: Open Brew PR
       env:
         HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.SEMGREP_HOMEBREW_RELEASE_PAT }}

--- a/.github/workflows/release-homebrew.yml
+++ b/.github/workflows/release-homebrew.yml
@@ -9,14 +9,14 @@ jobs:
     - uses: actions/setup-python@v4
       id: python-setup
       with:
-        python-version: "3.10"
+        python-version: "3.9"
     - run: brew update
     - name: Open Brew PR
       env:
         HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.SEMGREP_HOMEBREW_RELEASE_PAT }}
       run: "\n        brew bump-formula-pr --force --no-audit --no-browse --write-only
         \\\n          --message=\"semgrep 1.55.1\" \\\n          --tag=\"v1.55.1\"
-        semgrep\n      "
+        semgrep --debug\n      "
     - name: Prepare Branch
       env:
         GITHUB_TOKEN: ${{ secrets.SEMGREP_HOMEBREW_RELEASE_PAT }}

--- a/.github/workflows/release-homebrew.yml
+++ b/.github/workflows/release-homebrew.yml
@@ -5,7 +5,8 @@ name: release-homebrew
     inputs:
       version:
         type: string
-        description: The version of Semgrep to release on Homebrew (e.g., 1.55.2)
+        description: "\n        The version of Semgrep to release on Homebrew (e.g.,
+          1.55.2)\n      "
         required: true
       dry-run:
         type: boolean
@@ -49,3 +50,18 @@ jobs:
         \         --title=\"semgrep ${{ inputs.version }}\" \\\n          --body \"Bump
         semgrep to version ${{ inputs.version }}\"\n      "
       if: ${{ ! inputs.dry-run }}
+  brew-build:
+    name: Build Semgrep via Brew from HEAD
+    runs-on: macos-12
+    steps:
+    - run: brew update --debug --verbose
+      env:
+        HOMEBREW_NO_INSTALL_FROM_API: 1
+    - run: brew install semgrep --HEAD --debug || brew link --overwrite semgrep
+      env:
+        HOMEBREW_NO_INSTALL_FROM_API: 1
+        NONINTERACTIVE: 1
+    - name: Check installed correctly
+      run: brew test semgrep --HEAD
+      env:
+        HOMEBREW_NO_INSTALL_FROM_API: 1

--- a/.github/workflows/release-homebrew.yml
+++ b/.github/workflows/release-homebrew.yml
@@ -18,7 +18,7 @@ jobs:
       run: cd /usr/local/Cellar/python@3.11; ln -s 3.11.6_1 3.11.7
     - name: Bump semgrep.rb
       run: "\n        brew bump-formula-pr --force --no-audit --no-browse --write-only
-        \\\n          --message=\"semgrep 1.55.1\" \\\n          --tag=\"v1.55.1\"
+        \\\n          --message=\"semgrep 1.55.2\" \\\n          --tag=\"v1.55.2\"
         semgrep --debug\n      "
     - name: Prepare commit
       env:
@@ -27,18 +27,18 @@ jobs:
         \       git status\n        git diff\n        git config user.name ${{ github.actor
         }}\n        git config user.email ${{ github.actor }}@users.noreply.github.com\n
         \       gh auth setup-git\n        git remote add r2c https://github.com/semgrep-release/homebrew-core.git\n
-        \       git checkout -b bump-semgrep-1.55.1\n        git add Formula/s/semgrep.rb\n
-        \       git commit -m \"semgrep 1.55.1\"\n      "
+        \       git checkout -b bump-semgrep-1.55.2\n        git add Formula/s/semgrep.rb\n
+        \       git commit -m \"semgrep 1.55.2\"\n      "
     - name: Push commit to our fork of homebrew-core
       env:
         GITHUB_TOKEN: ${{ secrets.SEMGREP_HOMEBREW_RELEASE_PAT }}
       run: "\n        cd \"$(brew --repository)/Library/Taps/homebrew/homebrew-core\"\n
-        \       git push --set-upstream r2c --force \"bump-semgrep-1.55.1\"\n      "
+        \       git push --set-upstream r2c --force \"bump-semgrep-1.55.2\"\n      "
       if: ${{ ! inputs.dry-run }}
     - name: Open PR to official homebrew-core repo
       env:
         GITHUB_TOKEN: ${{ secrets.SEMGREP_HOMEBREW_RELEASE_PAT }}
       run: "\n        gh pr create --repo homebrew/homebrew-core \\\n          --base
-        master --head \"semgrep-release:bump-semgrep-1.55.1\" \\\n          --title=\"semgrep
-        1.55.1\" \\\n          --body \"Bump semgrep to version 1.55.1\"\n      "
+        master --head \"semgrep-release:bump-semgrep-1.55.2\" \\\n          --title=\"semgrep
+        1.55.2\" \\\n          --body \"Bump semgrep to version 1.55.2\"\n      "
       if: ${{ ! inputs.dry-run }}

--- a/.github/workflows/release-homebrew.yml
+++ b/.github/workflows/release-homebrew.yml
@@ -14,6 +14,7 @@ jobs:
     - name: Open Brew PR
       env:
         HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.SEMGREP_HOMEBREW_RELEASE_PAT }}
+        HOMEBREW_NO_INSTALL_FROM_API: 1
       run: "\n        brew bump-formula-pr --force --no-audit --no-browse --write-only
         \\\n          --message=\"semgrep 1.55.1\" \\\n          --tag=\"v1.55.1\"
         semgrep --debug\n      "

--- a/.github/workflows/release-homebrew.yml
+++ b/.github/workflows/release-homebrew.yml
@@ -6,14 +6,9 @@ jobs:
   homebrew-core-pr:
     runs-on: macos-12
     steps:
-    - uses: actions/setup-python@v4
-      id: python-setup
-      with:
-        python-version: "3.11"
     - run: brew update
-    - run: /usr/local/Cellar/python@3.11/3.11.7/libexec/bin/python -m pip install
-        -q --disable-pip-version-check --dry-run --ignore-installed --report=/dev/stdout
-        semgrep==1.55.1
+    - run: python3 -m pip install -q --disable-pip-version-check --dry-run --ignore-installed
+        --report=/dev/stdout semgrep==1.55.1
     - name: Open Brew PR
       env:
         HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.SEMGREP_HOMEBREW_RELEASE_PAT }}

--- a/.github/workflows/release-homebrew.yml
+++ b/.github/workflows/release-homebrew.yml
@@ -23,15 +23,16 @@ jobs:
       run: cd /usr/local/Cellar/python@3.11; ln -s 3.11.6_1 3.11.7
     - name: Bump semgrep.rb
       run: "\n        brew bump-formula-pr --force --no-audit --no-browse --write-only
-        \\\n          --message=\"semgrep ${{ inputs.version }}\" \\\n          --tag=\"v${{
-        inputs.version }}\" semgrep --debug\n      "
-    - name: Prepare commit
+        \\\n          --message=\"semgrep ${{ inputs.version }}\" --tag=\"v${{ inputs.version
+        }}\" semgrep --debug\n      "
+    - name: Make the commit
       env:
         GITHUB_TOKEN: ${{ secrets.SEMGREP_HOMEBREW_RELEASE_PAT }}
       run: "\n        cd \"$(brew --repository)/Library/Taps/homebrew/homebrew-core\"\n
         \       git status\n        git diff\n        git config user.name ${{ github.actor
         }}\n        git config user.email ${{ github.actor }}@users.noreply.github.com\n
-        \       gh auth setup-git\n        git remote add r2c https://github.com/semgrep-release/homebrew-core.git\n
+        \       gh auth setup-git\n        # TODO: we should move this repo in the
+        semgrep org\n        git remote add r2c https://github.com/semgrep-release/homebrew-core.git\n
         \       git checkout -b bump-semgrep-${{ inputs.version }}\n        git add
         Formula/s/semgrep.rb\n        git commit -m \"semgrep ${{ inputs.version }}\"\n
         \     "

--- a/.github/workflows/release-homebrew.yml
+++ b/.github/workflows/release-homebrew.yml
@@ -8,6 +8,7 @@ jobs:
     steps:
     - run: brew update
     - run: find /usr/local/Cellar/python@3.11/
+    - run: cd /usr/local/Cellar/python@3.11; ln -s 3.11.6_1 3.11.7
     - run: ls -al /usr/local/Cellar/python@3.11/3.11.7/libexec/bin/
     - run: python3 -m pip install -q --disable-pip-version-check --dry-run --ignore-installed
         --report=/dev/stdout semgrep==1.55.1

--- a/.github/workflows/release-homebrew.yml
+++ b/.github/workflows/release-homebrew.yml
@@ -3,6 +3,10 @@ name: release-homebrew
 "on":
   workflow_dispatch:
     inputs:
+      version:
+        type: string
+        description: The version of Semgrep to release on Homebrew (e.g., 1.55.2)
+        required: true
       dry-run:
         type: boolean
         description: "\n        Check the box for a dry-run.\n        A dry-run will
@@ -18,8 +22,8 @@ jobs:
       run: cd /usr/local/Cellar/python@3.11; ln -s 3.11.6_1 3.11.7
     - name: Bump semgrep.rb
       run: "\n        brew bump-formula-pr --force --no-audit --no-browse --write-only
-        \\\n          --message=\"semgrep 1.55.2\" \\\n          --tag=\"v1.55.2\"
-        semgrep --debug\n      "
+        \\\n          --message=\"semgrep {{ inputs.version }}\" \\\n          --tag=\"v{{
+        inputs.version }}\" semgrep --debug\n      "
     - name: Prepare commit
       env:
         GITHUB_TOKEN: ${{ secrets.SEMGREP_HOMEBREW_RELEASE_PAT }}
@@ -27,18 +31,21 @@ jobs:
         \       git status\n        git diff\n        git config user.name ${{ github.actor
         }}\n        git config user.email ${{ github.actor }}@users.noreply.github.com\n
         \       gh auth setup-git\n        git remote add r2c https://github.com/semgrep-release/homebrew-core.git\n
-        \       git checkout -b bump-semgrep-1.55.2\n        git add Formula/s/semgrep.rb\n
-        \       git commit -m \"semgrep 1.55.2\"\n      "
+        \       git checkout -b bump-semgrep-{{ inputs.version }}\n        git add
+        Formula/s/semgrep.rb\n        git commit -m \"semgrep {{ inputs.version }}\"\n
+        \     "
     - name: Push commit to our fork of homebrew-core
       env:
         GITHUB_TOKEN: ${{ secrets.SEMGREP_HOMEBREW_RELEASE_PAT }}
       run: "\n        cd \"$(brew --repository)/Library/Taps/homebrew/homebrew-core\"\n
-        \       git push --set-upstream r2c --force \"bump-semgrep-1.55.2\"\n      "
+        \       git push --set-upstream r2c --force \"bump-semgrep-{{ inputs.version
+        }}\"\n      "
       if: ${{ ! inputs.dry-run }}
     - name: Open PR to official homebrew-core repo
       env:
         GITHUB_TOKEN: ${{ secrets.SEMGREP_HOMEBREW_RELEASE_PAT }}
       run: "\n        gh pr create --repo homebrew/homebrew-core \\\n          --base
-        master --head \"semgrep-release:bump-semgrep-1.55.2\" \\\n          --title=\"semgrep
-        1.55.2\" \\\n          --body \"Bump semgrep to version 1.55.2\"\n      "
+        master --head \"semgrep-release:bump-semgrep-{{ inputs.version }}\" \\\n          --title=\"semgrep
+        {{ inputs.version }}\" \\\n          --body \"Bump semgrep to version {{ inputs.version
+        }}\"\n      "
       if: ${{ ! inputs.dry-run }}

--- a/.github/workflows/release-homebrew.yml
+++ b/.github/workflows/release-homebrew.yml
@@ -22,7 +22,7 @@ jobs:
       run: cd /usr/local/Cellar/python@3.11; ln -s 3.11.6_1 3.11.7
     - name: Bump semgrep.rb
       run: "\n        brew bump-formula-pr --force --no-audit --no-browse --write-only
-        \\\n          --message=\"semgrep {{ inputs.version }}\" \\\n          --tag=\"v{{
+        \\\n          --message=\"semgrep ${{ inputs.version }}\" \\\n          --tag=\"v${{
         inputs.version }}\" semgrep --debug\n      "
     - name: Prepare commit
       env:
@@ -31,21 +31,21 @@ jobs:
         \       git status\n        git diff\n        git config user.name ${{ github.actor
         }}\n        git config user.email ${{ github.actor }}@users.noreply.github.com\n
         \       gh auth setup-git\n        git remote add r2c https://github.com/semgrep-release/homebrew-core.git\n
-        \       git checkout -b bump-semgrep-{{ inputs.version }}\n        git add
-        Formula/s/semgrep.rb\n        git commit -m \"semgrep {{ inputs.version }}\"\n
+        \       git checkout -b bump-semgrep-${{ inputs.version }}\n        git add
+        Formula/s/semgrep.rb\n        git commit -m \"semgrep ${{ inputs.version }}\"\n
         \     "
     - name: Push commit to our fork of homebrew-core
       env:
         GITHUB_TOKEN: ${{ secrets.SEMGREP_HOMEBREW_RELEASE_PAT }}
       run: "\n        cd \"$(brew --repository)/Library/Taps/homebrew/homebrew-core\"\n
-        \       git push --set-upstream r2c --force \"bump-semgrep-{{ inputs.version
+        \       git push --set-upstream r2c --force \"bump-semgrep-${{ inputs.version
         }}\"\n      "
       if: ${{ ! inputs.dry-run }}
     - name: Open PR to official homebrew-core repo
       env:
         GITHUB_TOKEN: ${{ secrets.SEMGREP_HOMEBREW_RELEASE_PAT }}
       run: "\n        gh pr create --repo homebrew/homebrew-core \\\n          --base
-        master --head \"semgrep-release:bump-semgrep-{{ inputs.version }}\" \\\n          --title=\"semgrep
-        {{ inputs.version }}\" \\\n          --body \"Bump semgrep to version {{ inputs.version
-        }}\"\n      "
+        master --head \"semgrep-release:bump-semgrep-${{ inputs.version }}\" \\\n
+        \         --title=\"semgrep ${{ inputs.version }}\" \\\n          --body \"Bump
+        semgrep to version ${{ inputs.version }}\"\n      "
       if: ${{ ! inputs.dry-run }}

--- a/.github/workflows/release-homebrew.yml
+++ b/.github/workflows/release-homebrew.yml
@@ -4,7 +4,6 @@ name: release-homebrew
   workflow_dispatch:
 jobs:
   homebrew-core-pr:
-    name: Update on Homebrew-Core
     runs-on: macos-12
     steps:
     - uses: actions/setup-python@v4

--- a/.github/workflows/release.jsonnet
+++ b/.github/workflows/release.jsonnet
@@ -168,7 +168,6 @@ local push_docker_job(artifact_name) = {
 // ----------------------------------------------------------------------------
 
 local park_pypi_packages_job = {
-  name: 'Park PyPI package names',
   'runs-on': 'ubuntu-latest',
   needs: [
     'inputs',
@@ -298,7 +297,6 @@ local upload_wheels_job = {
 // ----------------------------------------------------------------------------
 
 local create_release_job = {
-  name: 'Create the Github Release',
   'runs-on': 'ubuntu-latest',
   needs: [
     'wait-for-build-test',
@@ -333,7 +331,6 @@ local create_release_job = {
 } + unless_dry_run;
 
 local create_release_interfaces_job = {
-  name: 'Create the Github Release on Semgrep Interfaces',
   'runs-on': 'ubuntu-latest',
   needs: [
     'wait-for-build-test',
@@ -375,7 +372,6 @@ local create_release_interfaces_job = {
 // see also nightly.jsonnet
 
 local sleep_before_homebrew_job = {
-  name: 'Sleep 10 min before releasing to homebrew',
   // Need to wait for pypi to propagate since pipgrip relies on it being published on pypi
   // TODO? comment still valid? do we still use pipgrip?
   needs: [
@@ -385,14 +381,12 @@ local sleep_before_homebrew_job = {
   'runs-on': 'ubuntu-latest',
   steps: [
     {
-      name: 'Sleep 10 min',
       run: 'sleep 10m',
     } + unless_dry_run,
   ],
 };
 
 local homebrew_core_pr_job = {
-  name: 'Update on Homebrew-Core',
   // Needs to run after pypi released so brew can update pypi dependency hashes
   needs: [
     'inputs',

--- a/.github/workflows/release.jsonnet
+++ b/.github/workflows/release.jsonnet
@@ -1,11 +1,15 @@
 // This workflow performs additional tasks on a PR when someone
-// (or start-release.jsonnet) push to a vXXX branch. Those tasks are to
-//  - push a new canary docker image
-//  - create release artifacts with the Linux and MacOS semgrep packages
-//  - prepare and upload to PyPy a new semgrep package
+// (or start-release.jsonnet) pushes to a vXXX branch. Those tasks are to
+//  - push a new :canary docker image. We used to push to :latest, but it
+//    is safer to first push to :canary and a few days later to promote
+//    :canary to :latest (see promote-canary-to-latest.yml)
+//  - create release artifacts on Github. We now just release the source
+//    of Semgrep in https://github.com/semgrep/semgrep/releases
+//    We used to release Linux and MacOS binaries, but we prefer now
+//    users to install Semgrep via docker, Pypi, or homebrew.
+//  - prepare and upload to PyPi a new semgrep package
+//    see https://pypi.org/project/semgrep/
 //  - make a PR for homebrew's formula to update to the latest semgrep
-
-// TODO: remove some useless name:
 
 local semgrep = import 'libs/semgrep.libsonnet';
 local actions = import 'libs/actions.libsonnet';

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -269,10 +269,10 @@ jobs:
       if: ${{ !contains(github.ref, '-test-release') && needs.inputs.outputs.dry-run
         != 'true' }}
   homebrew-core-pr:
+    runs-on: macos-12
     needs:
     - inputs
     - sleep-before-homebrew
-    runs-on: macos-12
     steps:
     - name: Get the version
       id: get-version
@@ -281,11 +281,6 @@ jobs:
         \"Using TAG=${TAG}\"\n        echo \"TAG=${TAG}\" >> $GITHUB_OUTPUT\n        echo
         \"Using VERSION=${TAG#v}\"\n        echo \"VERSION=${TAG#v}\" >> $GITHUB_OUTPUT\n
         \     "
-    - uses: actions/setup-python@v4
-      id: python-setup
-      with:
-        python-version: "3.10"
-    - run: brew update
     - name: Dry Run Brew PR
       env:
         HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.SEMGREP_HOMEBREW_RELEASE_PAT }}
@@ -294,26 +289,25 @@ jobs:
       run: "\n        brew bump-formula-pr --force --no-audit --no-browse --write-only
         \\\n          --message=\"semgrep 99.99.99\" \\\n          --tag=\"v99.99.99\"
         --revision=\"${GITHUB_SHA}\" semgrep --python-exclude-packages semgrep\n      "
-    - name: Open Brew PR
-      env:
-        HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.SEMGREP_HOMEBREW_RELEASE_PAT }}
+    - run: brew update
+    - name: 'ugly: fix the python path for brew bump-formula-pr'
+      run: cd /usr/local/Cellar/python@3.11; ln -s 3.11.6_1 3.11.7
+    - name: Bump semgrep.rb
       run: "\n        brew bump-formula-pr --force --no-audit --no-browse --write-only
         \\\n          --message=\"semgrep ${{ steps.get-version.outputs.VERSION }}\"
-        \\\n          --tag=\"${{ steps.get-version.outputs.TAG }}\" semgrep\n      "
-      if: ${{ !contains(github.ref, '-test-release') && needs.inputs.outputs.dry-run
-        != 'true' }}
-    - name: Prepare Branch
+        --tag=\"v${{ steps.get-version.outputs.VERSION }}\" semgrep --debug\n      "
+    - name: Make the commit
       env:
         GITHUB_TOKEN: ${{ secrets.SEMGREP_HOMEBREW_RELEASE_PAT }}
-        R2C_HOMEBREW_CORE_FORK_HTTPS_URL: https://github.com/semgrep-release/homebrew-core.git
       run: "\n        cd \"$(brew --repository)/Library/Taps/homebrew/homebrew-core\"\n
         \       git status\n        git diff\n        git config user.name ${{ github.actor
         }}\n        git config user.email ${{ github.actor }}@users.noreply.github.com\n
-        \       gh auth setup-git\n        git remote add r2c \"${R2C_HOMEBREW_CORE_FORK_HTTPS_URL}\"\n
+        \       gh auth setup-git\n        # TODO: we should move this repo in the
+        semgrep org\n        git remote add r2c https://github.com/semgrep-release/homebrew-core.git\n
         \       git checkout -b bump-semgrep-${{ steps.get-version.outputs.VERSION
         }}\n        git add Formula/s/semgrep.rb\n        git commit -m \"semgrep
         ${{ steps.get-version.outputs.VERSION }}\"\n      "
-    - name: Push Branch to Fork
+    - name: Push commit to our fork of homebrew-core
       env:
         GITHUB_TOKEN: ${{ secrets.SEMGREP_HOMEBREW_RELEASE_PAT }}
       run: "\n        cd \"$(brew --repository)/Library/Taps/homebrew/homebrew-core\"\n
@@ -321,12 +315,11 @@ jobs:
         }}\"\n      "
       if: ${{ !contains(github.ref, '-test-release') && needs.inputs.outputs.dry-run
         != 'true' }}
-    - name: Push to Fork
+    - name: Open PR to official homebrew-core repo
       env:
         GITHUB_TOKEN: ${{ secrets.SEMGREP_HOMEBREW_RELEASE_PAT }}
-        R2C_HOMEBREW_CORE_OWNER: semgrep-release
       run: "\n        gh pr create --repo homebrew/homebrew-core \\\n          --base
-        master --head \"${R2C_HOMEBREW_CORE_OWNER}:bump-semgrep-${{ steps.get-version.outputs.VERSION
+        master --head \"semgrep-release:bump-semgrep-${{ steps.get-version.outputs.VERSION
         }}\" \\\n          --title=\"semgrep ${{ steps.get-version.outputs.VERSION
         }}\" \\\n          --body \"Bump semgrep to version ${{ steps.get-version.outputs.VERSION
         }}\"\n      "

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,6 @@ jobs:
         >> $GITHUB_OUTPUT\n          echo \"Setting dry-run to FALSE\"\n        fi\n
         \     "
   park-pypi-packages:
-    name: Park PyPI package names
     runs-on: ubuntu-latest
     needs:
     - inputs
@@ -195,7 +194,6 @@ jobs:
       if: ${{ !contains(github.ref, '-test-release') && needs.inputs.outputs.dry-run
         != 'true' }}
   create-release:
-    name: Create the Github Release
     runs-on: ubuntu-latest
     needs:
     - wait-for-build-test
@@ -221,7 +219,6 @@ jobs:
     if: ${{ !contains(github.ref, '-test-release') && needs.inputs.outputs.dry-run
       != 'true' }}
   create-release-interfaces:
-    name: Create the Github Release on Semgrep Interfaces
     runs-on: ubuntu-latest
     needs:
     - wait-for-build-test
@@ -263,18 +260,15 @@ jobs:
     if: ${{ !contains(github.ref, '-test-release') && needs.inputs.outputs.dry-run
       != 'true' }}
   sleep-before-homebrew:
-    name: Sleep 10 min before releasing to homebrew
     needs:
     - inputs
     - upload-wheels
     runs-on: ubuntu-latest
     steps:
-    - name: Sleep 10 min
-      run: sleep 10m
+    - run: sleep 10m
       if: ${{ !contains(github.ref, '-test-release') && needs.inputs.outputs.dry-run
         != 'true' }}
   homebrew-core-pr:
-    name: Update on Homebrew-Core
     needs:
     - inputs
     - sleep-before-homebrew


### PR DESCRIPTION
See
https://semgrepinc.slack.com/archives/C066PJE9657/p1704395301068349
and
https://github.com/semgrep/semgrep/actions/runs/7413245405/job/20172979591?pr=9541
that was failing because brew bump-formula-pr not able
to grab the dependencies for semgrep 1.55.1 in GHA
(it's working fine locally on my mac)

test plan:
trigger the workflow manually from GHA dashboard and try to
find the right GHA settings to make it work