### PR TITLE
simplify release.jsonnet, remove useless intermediate inputs job

### DIFF
--- a/.github/workflows/release-homebrew.jsonnet
+++ b/.github/workflows/release-homebrew.jsonnet
@@ -39,7 +39,6 @@ local input = {
         Check the box for a dry-run.
         A dry-run will not push any external state.
       |||,
-      default: false,
       required: true,
     },
   },

--- a/.github/workflows/release-homebrew.jsonnet
+++ b/.github/workflows/release-homebrew.jsonnet
@@ -44,9 +44,7 @@ local input = {
   },
 };
 
-//TODO: if remove the _here, then get bad scope when generating
-// release.yml from release.jsonnet
-local unless_dry_run_here = {
+local unless_dry_run = {
   'if': '${{ ! inputs.dry-run }}',
 };
 
@@ -57,7 +55,8 @@ local unless_dry_run_here = {
 // This is also called from release.jsonnet.
 // Note that this job needs to run after Semgrep has been released on Pypi so
 // brew bump-formula-pr below can update Pypi dependency hashes in semgrep.rb
-local homebrew_core_pr_job(version, unless_dry_run) = {
+// This job assumes the presence of a workflow with a 'inputs.dry-mode'
+local homebrew_core_pr_job(version) = {
   'runs-on': 'macos-12',
   steps: [
     {
@@ -72,6 +71,23 @@ local homebrew_core_pr_job(version, unless_dry_run) = {
       run: 'cd /usr/local/Cellar/python@3.11; ln -s 3.11.6_1 3.11.7'
     },
     {
+      name: 'Dry Run bump semgrep.rb',
+      // This step does some brew oddities (setting a fake version, and
+      // setting a revision) to allow the brew PR prep to succeed.
+      // The `brew bump-formula-pr` does checks to ensure your PR is legit,
+      // but we want to do a phony PR (or at least prep it) for Dry Run only
+      env: {
+        HOMEBREW_GITHUB_API_TOKEN: '${{ secrets.SEMGREP_HOMEBREW_RELEASE_PAT }}',
+      },
+      // this is run only in dry-mode
+      if: "${{ inputs.dry-run }}",
+      run: |||
+        brew bump-formula-pr --force --no-audit --no-browse --write-only \
+          --message="semgrep 99.99.99" \
+          --tag="v99.99.99" --revision="${GITHUB_SHA}" semgrep --python-exclude-packages semgrep
+      |||,
+    },
+    {
       name: 'Bump semgrep.rb',
       // Note that we use '--write-only' below so the command does not open a
       // new PR; it just modifies /usr/local/.../homebrew-core/.../s/semgrep.rb
@@ -83,7 +99,7 @@ local homebrew_core_pr_job(version, unless_dry_run) = {
         brew bump-formula-pr --force --no-audit --no-browse --write-only \
           --message="semgrep %s" --tag="v%s" semgrep --debug
       ||| % [version, version],
-    },
+    } + unless_dry_run,
     {
       name: 'Make the commit',
       env: {
@@ -183,7 +199,7 @@ local brew_build_job = {
   },
   jobs: {
     'homebrew-core-pr':
-       homebrew_core_pr_job('${{ inputs.version }}', unless_dry_run_here),
+       homebrew_core_pr_job('${{ inputs.version }}'),
     'brew-build': brew_build_job,
   },
   export:: {

--- a/.github/workflows/release-homebrew.yml
+++ b/.github/workflows/release-homebrew.yml
@@ -12,7 +12,6 @@ name: release-homebrew
         type: boolean
         description: "\n        Check the box for a dry-run.\n        A dry-run will
           not push any external state.\n      "
-        default: false
         required: true
 jobs:
   homebrew-core-pr:

--- a/.github/workflows/release-homebrew.yml
+++ b/.github/workflows/release-homebrew.yml
@@ -20,10 +20,18 @@ jobs:
     - run: brew update
     - name: 'ugly: fix the python path for brew bump-formula-pr'
       run: cd /usr/local/Cellar/python@3.11; ln -s 3.11.6_1 3.11.7
+    - name: Dry Run bump semgrep.rb
+      env:
+        HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.SEMGREP_HOMEBREW_RELEASE_PAT }}
+      if: ${{ inputs.dry-run }}
+      run: "\n        brew bump-formula-pr --force --no-audit --no-browse --write-only
+        \\\n          --message=\"semgrep 99.99.99\" \\\n          --tag=\"v99.99.99\"
+        --revision=\"${GITHUB_SHA}\" semgrep --python-exclude-packages semgrep\n      "
     - name: Bump semgrep.rb
       run: "\n        brew bump-formula-pr --force --no-audit --no-browse --write-only
         \\\n          --message=\"semgrep ${{ inputs.version }}\" --tag=\"v${{ inputs.version
         }}\" semgrep --debug\n      "
+      if: ${{ ! inputs.dry-run }}
     - name: Make the commit
       env:
         GITHUB_TOKEN: ${{ secrets.SEMGREP_HOMEBREW_RELEASE_PAT }}

--- a/.github/workflows/release.jsonnet
+++ b/.github/workflows/release.jsonnet
@@ -321,7 +321,7 @@ local sleep_before_homebrew_job = {
 };
 
 local homebrew_core_pr_job_base =
-  release_homebrew.export.homebrew_core_pr(version, unless_dry_run);
+  release_homebrew.export.homebrew_core_pr(version);
 
 local homebrew_core_pr_job =
  homebrew_core_pr_job_base + {
@@ -339,23 +339,6 @@ local homebrew_core_pr_job =
           TAG=v99.99.99
         fi
         echo "VERSION=${TAG#v}" >> $GITHUB_OUTPUT
-      |||,
-    },
-    {
-      name: 'Dry Run Brew PR',
-      // This step does some brew oddities (setting a fake version, and
-      // setting a revision) to allow the brew PR prep to succeed.
-      // The `brew bump-formula-pr` does checks to ensure your PR is legit,
-      // but we want to do a phony PR (or at least prep it) for Dry Run only
-      env: {
-        HOMEBREW_GITHUB_API_TOKEN: '${{ secrets.SEMGREP_HOMEBREW_RELEASE_PAT }}',
-      },
-      // this is run only in dry-mode
-      if: "${{ inputs.dry-run == 'true' }}",
-      run: |||
-        brew bump-formula-pr --force --no-audit --no-browse --write-only \
-          --message="semgrep 99.99.99" \
-          --tag="v99.99.99" --revision="${GITHUB_SHA}" semgrep --python-exclude-packages semgrep
       |||,
     },
   ] + homebrew_core_pr_job_base.steps,

--- a/.github/workflows/release.jsonnet
+++ b/.github/workflows/release.jsonnet
@@ -187,6 +187,15 @@ local park_pypi_packages_job = {
   ],
 } + unless_dry_run;
 
+local download_step(name) = {
+  name: 'Download %s' % name,
+  uses: 'actions/download-artifact@v3',
+  with: {
+    name: name,
+    path: name,
+  },
+};
+
 local upload_wheels_job = {
   name: 'Upload Wheels to PyPI',
   'runs-on': 'ubuntu-latest',
@@ -194,56 +203,17 @@ local upload_wheels_job = {
     'wait-for-build-test',
   ],
   steps: [
+    download_step('manylinux-x86-wheel'),
+    download_step('manylinux-aarch64-wheel'),
+    download_step('osx-x86-wheel'),
+    download_step('osx-arm64-wheel'),
     {
-      name: 'Download Artifact',
-      uses: 'actions/download-artifact@v3',
-      with: {
-        name: 'manylinux-x86-wheel',
-        path: 'manylinux-x86-wheel',
-      },
-    },
-    {
-      name: 'Download aarch64 Artifact',
-      uses: 'actions/download-artifact@v3',
-      with: {
-        name: 'manylinux-aarch64-wheel',
-        path: 'manylinux-aarch64-wheel',
-      },
-    },
-    {
-      name: 'Download OSX x86 Artifact',
-      uses: 'actions/download-artifact@v3',
-      with: {
-        name: 'osx-x86-wheel',
-        path: 'osx-x86-wheel',
-      },
-    },
-    {
-      name: 'Download OSX ARM64 Artifact',
-      uses: 'actions/download-artifact@v3',
-      with: {
-        name: 'osx-arm64-wheel',
-        path: 'osx-arm64-wheel',
-      },
-    },
-    {
-      name: 'Unzip x86_64 Wheel',
-      run: 'unzip ./manylinux-x86-wheel/dist.zip',
-    },
-    {
-      name: 'Unzip aarch64 Wheel',
-      // Don't unzip tar.gz because it already exists from ./manylinux-x86-wheel/dist.zip.
-      run: 'unzip ./manylinux-aarch64-wheel/dist.zip "*.whl"',
-    },
-    {
-      name: 'Unzip OSX x86 Wheel',
-      // Don't unzip tar.gz because it already exists from ./manylinux-x86-wheel/dist.zip.
-      run: 'unzip ./osx-x86-wheel/dist.zip "*.whl"',
-    },
-    {
-      name: 'Unzip OSX ARM64 Wheel',
-      // Don't unzip tar.gz because it already exists from ./manylinux-x86-wheel/dist.zip.
-      run: 'unzip ./osx-arm64-wheel/dist.zip "*.whl"',
+      run: |||
+       unzip ./manylinux-x86-wheel/dist.zip
+       unzip ./manylinux-aarch64-wheel/dist.zip "*.whl"
+       unzip ./osx-x86-wheel/dist.zip "*.whl"
+       unzip ./osx-arm64-wheel/dist.zip "*.whl"
+     |||,
     },
     {
       name: 'Publish to Pypi',

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -241,20 +241,21 @@ jobs:
       run: "\n        TAG=${GITHUB_REF/refs\\/tags\\//}\n        if [ \"${{ inputs.dry-run
         }}\" = \"true\" ]; then\n          TAG=v99.99.99\n        fi\n        echo
         \"VERSION=${TAG#v}\" >> $GITHUB_OUTPUT\n      "
-    - name: Dry Run Brew PR
-      env:
-        HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.SEMGREP_HOMEBREW_RELEASE_PAT }}
-      if: ${{ inputs.dry-run == 'true' }}
-      run: "\n        brew bump-formula-pr --force --no-audit --no-browse --write-only
-        \\\n          --message=\"semgrep 99.99.99\" \\\n          --tag=\"v99.99.99\"
-        --revision=\"${GITHUB_SHA}\" semgrep --python-exclude-packages semgrep\n      "
     - run: brew update
     - name: 'ugly: fix the python path for brew bump-formula-pr'
       run: cd /usr/local/Cellar/python@3.11; ln -s 3.11.6_1 3.11.7
+    - name: Dry Run bump semgrep.rb
+      env:
+        HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.SEMGREP_HOMEBREW_RELEASE_PAT }}
+      if: ${{ inputs.dry-run }}
+      run: "\n        brew bump-formula-pr --force --no-audit --no-browse --write-only
+        \\\n          --message=\"semgrep 99.99.99\" \\\n          --tag=\"v99.99.99\"
+        --revision=\"${GITHUB_SHA}\" semgrep --python-exclude-packages semgrep\n      "
     - name: Bump semgrep.rb
       run: "\n        brew bump-formula-pr --force --no-audit --no-browse --write-only
         \\\n          --message=\"semgrep ${{ steps.get-version.outputs.VERSION }}\"
         --tag=\"v${{ steps.get-version.outputs.VERSION }}\" semgrep --debug\n      "
+      if: ${{ ! inputs.dry-run }}
     - name: Make the commit
       env:
         GITHUB_TOKEN: ${{ secrets.SEMGREP_HOMEBREW_RELEASE_PAT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,34 +132,29 @@ jobs:
     needs:
     - wait-for-build-test
     steps:
-    - name: Download Artifact
+    - name: Download manylinux-x86-wheel
       uses: actions/download-artifact@v3
       with:
         name: manylinux-x86-wheel
         path: manylinux-x86-wheel
-    - name: Download aarch64 Artifact
+    - name: Download manylinux-aarch64-wheel
       uses: actions/download-artifact@v3
       with:
         name: manylinux-aarch64-wheel
         path: manylinux-aarch64-wheel
-    - name: Download OSX x86 Artifact
+    - name: Download osx-x86-wheel
       uses: actions/download-artifact@v3
       with:
         name: osx-x86-wheel
         path: osx-x86-wheel
-    - name: Download OSX ARM64 Artifact
+    - name: Download osx-arm64-wheel
       uses: actions/download-artifact@v3
       with:
         name: osx-arm64-wheel
         path: osx-arm64-wheel
-    - name: Unzip x86_64 Wheel
-      run: unzip ./manylinux-x86-wheel/dist.zip
-    - name: Unzip aarch64 Wheel
-      run: unzip ./manylinux-aarch64-wheel/dist.zip "*.whl"
-    - name: Unzip OSX x86 Wheel
-      run: unzip ./osx-x86-wheel/dist.zip "*.whl"
-    - name: Unzip OSX ARM64 Wheel
-      run: unzip ./osx-arm64-wheel/dist.zip "*.whl"
+    - run: "\n       unzip ./manylinux-x86-wheel/dist.zip\n       unzip ./manylinux-aarch64-wheel/dist.zip
+        \"*.whl\"\n       unzip ./osx-x86-wheel/dist.zip \"*.whl\"\n       unzip ./osx-arm64-wheel/dist.zip
+        \"*.whl\"\n     "
     - name: Publish to Pypi
       uses: pypa/gh-action-pypi-publish@release/v1
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,39 +4,23 @@ name: release
   workflow_dispatch:
     inputs:
       dry-run:
-        description: "\n        Run the release in dry-run mode, e.g., without changing
-          external\n        state (like pushing to PyPI/Docker)\n      "
-        required: true
         type: boolean
+        description: "\n        Run the release in dry-run mode, e.g., without changing
+          external\n        state (like pushing to PyPI/Docker/Homebrew)\n      "
+        required: true
   workflow_call:
     inputs:
       dry-run:
-        description: "\n        Run the release in dry-run mode, e.g., without changing
-          external\n        state (like pushing to PyPI/Docker)\n      "
-        required: true
         type: boolean
+        description: "\n        Run the release in dry-run mode, e.g., without changing
+          external\n        state (like pushing to PyPI/Docker/Homebrew)\n      "
+        required: true
   push:
-    branches:
-    - '**-test-release'
     tags:
     - v*
 jobs:
-  inputs:
-    runs-on: ubuntu-22.04
-    outputs:
-      dry-run: ${{steps.dry-run.outputs.dry-run}}
-    steps:
-    - name: Evaluate Dry Run
-      id: dry-run
-      run: "\n        if [[ \"${{ inputs.dry-run }}\" == \"true\" ]] || [[ \"${{ github.ref_name
-        }}\" == *test* ]]; then\n          echo \"dry-run=true\" >> $GITHUB_OUTPUT\n
-        \         echo \"Setting dry-run to TRUE\"\n        else\n          echo \"dry-run=false\"
-        >> $GITHUB_OUTPUT\n          echo \"Setting dry-run to FALSE\"\n        fi\n
-        \     "
   park-pypi-packages:
     runs-on: ubuntu-latest
-    needs:
-    - inputs
     defaults:
       run:
         working-directory: cli/
@@ -52,7 +36,6 @@ jobs:
       run: pipenv run python setup.py park
     - name: Publish to Pypi
       uses: pypa/gh-action-pypi-publish@release/v1
-      if: ${{ !contains(github.ref,'-test-release') }}
       with:
         user: __token__
         password: ${{ secrets.pypi_upload_token }}
@@ -60,20 +43,16 @@ jobs:
         packages_dir: cli/dist/
     - name: Publish to test Pypi
       uses: pypa/gh-action-pypi-publish@release/v1
-      if: ${{ contains(github.ref,'-test-release') }}
       with:
         repository_url: https://test.pypi.org/legacy/
         user: __token__
         password: ${{ secrets.test_pypi_upload_token }}
         skip_existing: true
         packages_dir: cli/dist/
-    if: ${{ !contains(github.ref, '-test-release') && needs.inputs.outputs.dry-run
-      != 'true' }}
+    if: ${{ ! inputs.dry-run }}
   build-test-docker:
     uses: ./.github/workflows/build-test-docker.yaml
     secrets: inherit
-    needs:
-    - inputs
     with:
       docker-flavor: latest=false
       docker-tags: "\n      type=raw,value=canary\n      type=semver,pattern={{version}}\n
@@ -87,7 +66,6 @@ jobs:
     uses: ./.github/workflows/build-test-docker.yaml
     secrets: inherit
     needs:
-    - inputs
     - build-test-docker
     with:
       docker-flavor: "\n      suffix=-nonroot\n      latest=false\n    "
@@ -133,29 +111,26 @@ jobs:
   push-docker:
     needs:
     - wait-for-build-test
-    - inputs
     uses: ./.github/workflows/push-docker.yaml
     secrets: inherit
     with:
       artifact-name: image-release
       repository-name: returntocorp/semgrep
-      dry-run: ${{ needs.inputs.outputs.dry-run == 'true' }}
+      dry-run: ${{ inputs.dry-run == 'true' }}
   push-docker-nonroot:
     needs:
     - wait-for-build-test
-    - inputs
     uses: ./.github/workflows/push-docker.yaml
     secrets: inherit
     with:
       artifact-name: image-release-nonroot
       repository-name: returntocorp/semgrep
-      dry-run: ${{ needs.inputs.outputs.dry-run == 'true' }}
+      dry-run: ${{ inputs.dry-run == 'true' }}
   upload-wheels:
     name: Upload Wheels to PyPI
     runs-on: ubuntu-latest
     needs:
     - wait-for-build-test
-    - inputs
     steps:
     - name: Download Artifact
       uses: actions/download-artifact@v3
@@ -191,13 +166,11 @@ jobs:
         user: __token__
         password: ${{ secrets.pypi_upload_token }}
         skip_existing: true
-      if: ${{ !contains(github.ref, '-test-release') && needs.inputs.outputs.dry-run
-        != 'true' }}
+      if: ${{ ! inputs.dry-run }}
   create-release:
     runs-on: ubuntu-latest
     needs:
     - wait-for-build-test
-    - inputs
     steps:
     - name: Get the version
       id: get-version
@@ -216,13 +189,11 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: gh release --repo returntocorp/semgrep edit ${{ steps.get-version.outputs.VERSION
         }} --draft=false
-    if: ${{ !contains(github.ref, '-test-release') && needs.inputs.outputs.dry-run
-      != 'true' }}
+    if: ${{ ! inputs.dry-run }}
   create-release-interfaces:
     runs-on: ubuntu-latest
     needs:
     - wait-for-build-test
-    - inputs
     steps:
     - name: Get the version
       id: get-version
@@ -257,35 +228,28 @@ jobs:
         GITHUB_TOKEN: ${{ steps.token.outputs.token }}
       run: gh release --repo returntocorp/semgrep-interfaces edit ${{ steps.get-version.outputs.VERSION
         }} --draft=false
-    if: ${{ !contains(github.ref, '-test-release') && needs.inputs.outputs.dry-run
-      != 'true' }}
+    if: ${{ ! inputs.dry-run }}
   sleep-before-homebrew:
     needs:
-    - inputs
     - upload-wheels
     runs-on: ubuntu-latest
     steps:
     - run: sleep 10m
-      if: ${{ !contains(github.ref, '-test-release') && needs.inputs.outputs.dry-run
-        != 'true' }}
+      if: ${{ ! inputs.dry-run }}
   homebrew-core-pr:
     runs-on: macos-12
     needs:
-    - inputs
     - sleep-before-homebrew
     steps:
     - name: Get the version
       id: get-version
-      run: "\n        TAG=${GITHUB_REF/refs\\/tags\\//}\n        if [ \"${{ needs.inputs.outputs.dry-run
+      run: "\n        TAG=${GITHUB_REF/refs\\/tags\\//}\n        if [ \"${{ inputs.dry-run
         }}\" = \"true\" ]; then\n          TAG=v99.99.99\n        fi\n        echo
-        \"Using TAG=${TAG}\"\n        echo \"TAG=${TAG}\" >> $GITHUB_OUTPUT\n        echo
-        \"Using VERSION=${TAG#v}\"\n        echo \"VERSION=${TAG#v}\" >> $GITHUB_OUTPUT\n
-        \     "
+        \"VERSION=${TAG#v}\" >> $GITHUB_OUTPUT\n      "
     - name: Dry Run Brew PR
       env:
         HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.SEMGREP_HOMEBREW_RELEASE_PAT }}
-      if: ${{ contains(github.ref, '-test-release') || needs.inputs.outputs.dry-run
-        == 'true' }}
+      if: ${{ inputs.dry-run == 'true' }}
       run: "\n        brew bump-formula-pr --force --no-audit --no-browse --write-only
         \\\n          --message=\"semgrep 99.99.99\" \\\n          --tag=\"v99.99.99\"
         --revision=\"${GITHUB_SHA}\" semgrep --python-exclude-packages semgrep\n      "
@@ -313,8 +277,7 @@ jobs:
       run: "\n        cd \"$(brew --repository)/Library/Taps/homebrew/homebrew-core\"\n
         \       git push --set-upstream r2c --force \"bump-semgrep-${{ steps.get-version.outputs.VERSION
         }}\"\n      "
-      if: ${{ !contains(github.ref, '-test-release') && needs.inputs.outputs.dry-run
-        != 'true' }}
+      if: ${{ ! inputs.dry-run }}
     - name: Open PR to official homebrew-core repo
       env:
         GITHUB_TOKEN: ${{ secrets.SEMGREP_HOMEBREW_RELEASE_PAT }}
@@ -323,5 +286,4 @@ jobs:
         }}\" \\\n          --title=\"semgrep ${{ steps.get-version.outputs.VERSION
         }}\" \\\n          --body \"Bump semgrep to version ${{ steps.get-version.outputs.VERSION
         }}\"\n      "
-      if: ${{ !contains(github.ref, '-test-release') && needs.inputs.outputs.dry-run
-        != 'true' }}
+      if: ${{ ! inputs.dry-run }}


### PR DESCRIPTION
test plan:
trigger manually the release from GHA dashboard in dry-mode