### PR TITLE
chore: regenerate rule snapshot

### DIFF
--- a/cli/tests/e2e/rules/duplicate-rule.yaml
+++ b/cli/tests/e2e/rules/duplicate-rule.yaml
@@ -25,6 +25,7 @@ rules:
         slug: rule-board-block
       semgrep.url: https://semgrep.dev/r/javascript.jsonwebtoken.security.jwt-hardcode.hardcoded-jwt-secret
       semgrep.ruleset: ci
+      semgrep.ruleset_id: 735
   - id: duplicate-eq
     pattern: $X == $X
     message: Found redundant comparison
@@ -51,3 +52,4 @@ rules:
         slug: rule-board-block
       semgrep.url: https://semgrep.dev/r/javascript.jsonwebtoken.security.jwt-hardcode.hardcoded-jwt-secret
       semgrep.ruleset: other
+      semgrep.ruleset_id: 1234

--- a/cli/tests/e2e/snapshots/test_check/test_deduplication/results.json
+++ b/cli/tests/e2e/snapshots/test_check/test_deduplication/results.json
@@ -37,6 +37,7 @@
             "slug": "rule-board-block"
           },
           "semgrep.ruleset": "other",
+          "semgrep.ruleset_id": 1234,
           "semgrep.url": "https://semgrep.dev/r/javascript.jsonwebtoken.security.jwt-hardcode.hardcoded-jwt-secret",
           "shortlink": "https://sg.run/4xN9",
           "source": "https://semgrep.dev/r/javascript.jsonwebtoken.security.jwt-hardcode.hardcoded-jwt-secret",
@@ -100,6 +101,7 @@
             "slug": "rule-board-block"
           },
           "semgrep.ruleset": "other",
+          "semgrep.ruleset_id": 1234,
           "semgrep.url": "https://semgrep.dev/r/javascript.jsonwebtoken.security.jwt-hardcode.hardcoded-jwt-secret",
           "shortlink": "https://sg.run/4xN9",
           "source": "https://semgrep.dev/r/javascript.jsonwebtoken.security.jwt-hardcode.hardcoded-jwt-secret",
@@ -163,6 +165,7 @@
             "slug": "rule-board-block"
           },
           "semgrep.ruleset": "other",
+          "semgrep.ruleset_id": 1234,
           "semgrep.url": "https://semgrep.dev/r/javascript.jsonwebtoken.security.jwt-hardcode.hardcoded-jwt-secret",
           "shortlink": "https://sg.run/4xN9",
           "source": "https://semgrep.dev/r/javascript.jsonwebtoken.security.jwt-hardcode.hardcoded-jwt-secret",


### PR DESCRIPTION
We recently made a change on `semgrep-app` to now include `semgrep.ruleset_id` as part of the rule metadata sent to the CLI. So that we keep the rule metadata snapshot as up-to-date as possible, this PR is just to update the rule metadata and their corresponding snapshots so that they are up to date to what the app is sending.

Closes FIND-1459