### PR TITLE
feat(metrics): add findings by product breakdown

### DIFF
--- a/changelog.d/pa-3312.added
+++ b/changelog.d/pa-3312.added
@@ -1,0 +1,3 @@
+Added a new field that breaks down the number of findings per product
+in the metrics that are sent out by the CLI. This will help Semgrep
+understand users better.

--- a/cli/src/semgrep/constants.py
+++ b/cli/src/semgrep/constants.py
@@ -2,6 +2,8 @@ import re
 from enum import auto
 from enum import Enum
 
+import semgrep.semgrep_interfaces.semgrep_output_v1 as out
+
 RULES_KEY = "rules"
 MISSED_KEY = "missed"  # The number of Pro rules missed out on
 ID_KEY = "id"
@@ -127,3 +129,12 @@ class Colors(Enum):
     # these colors ignore user's terminal theme
     forced_black = 16  # #000
     forced_white = 231  # #FFF
+
+
+# Maps from product names used in our ATD files to product names
+# used in as command line options that users are more familiar with.
+USER_FRIENDLY_PRODUCT_NAMES = {
+    out.Product(out.SAST()): "code",
+    out.Product(out.SCA()): "supply-chain",
+    out.Product(out.Secrets()): "secrets",
+}

--- a/cli/src/semgrep/metrics.py
+++ b/cli/src/semgrep/metrics.py
@@ -27,6 +27,7 @@ from typing_extensions import LiteralString
 import semgrep.semgrep_interfaces.semgrep_metrics as met
 import semgrep.semgrep_interfaces.semgrep_output_v1 as out
 from semgrep import __VERSION__
+from semgrep.constants import USER_FRIENDLY_PRODUCT_NAMES
 from semgrep.error import error_type_string
 from semgrep.error import SemgrepError
 from semgrep.parsing_data import ParsingData
@@ -61,14 +62,6 @@ if TYPE_CHECKING:
 logger = getLogger(__name__)
 
 METRICS_ENDPOINT = "https://metrics.semgrep.dev"
-
-# Kept in sync with the command line options in ci.py, so that metrics
-# are reported in the same language that the user uses.
-USER_FRIENDLY_PRODUCT_NAMES = {
-    out.Product(out.SAST()): "code",
-    out.Product(out.SCA()): "supply-chain",
-    out.Product(out.Secrets()): "secrets",
-}
 
 
 class MetricsState(Enum):

--- a/cli/tests/e2e/snapshots/test_metrics/test_metrics_payload/pro_flag0/metrics-payload.json
+++ b/cli/tests/e2e/snapshots/test_metrics/test_metrics_payload/pro_flag0/metrics-payload.json
@@ -88,6 +88,9 @@
     ],
     "interfileLanguagesUsed": [],
     "numFindings": 1,
+    "numFindingsByProduct": {
+      "code": 1
+    },
     "numIgnored": 0,
     "ruleHashesWithFindings": {
       "7d0af7d79e44c9bafdba5c83bacbb44c5b663c3c3efe1eec1676df5158303eb4": 1

--- a/src/osemgrep/core/Metrics_.ml
+++ b/src/osemgrep/core/Metrics_.ml
@@ -160,6 +160,7 @@ let default_payload =
         features = [];
         proFeatures = None;
         numFindings = None;
+        numFindingsByProduct = None;
         numIgnored = None;
         ruleHashesWithFindings = None;
         engineRequested = "OSS";


### PR DESCRIPTION
Requires interface change: https://github.com/semgrep/semgrep-interfaces/pull/210

Closes PA-3312.

Breakdown findings by product. The product name in the metrics matches the product name in the CLI options.

Tested by running semgrep CI. Breakdown by products show up in Metabase.

Also updated a snapshot of a test to support this new field..

