### PR TITLE
fix: cross-platform tweaks

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -466,7 +466,7 @@ For more information see https://semgrep.dev
     ocolor
     ANSITerminal
     terminal_size
-    notty
+    (notty (<> :os win32))
     ; logging
     (easy_logging ( = 0.8.1 ))
     (easy_logging_yojson ( = 0.8.1 ))
@@ -507,7 +507,7 @@ For more information see https://semgrep.dev
     ; concurrency
     lwt
     lwt_ppx
-    conf-libev ; for lwt, to get better FD perf
+    (conf-libev (<> :os win32)) ; for lwt, to get better FD perf
     ; jsoo
     (js_of_ocaml (= 5.4.0))
     (js_of_ocaml-compiler (= 5.4.0))

--- a/dune-project
+++ b/dune-project
@@ -466,7 +466,7 @@ For more information see https://semgrep.dev
     ocolor
     ANSITerminal
     terminal_size
-    (notty (<> :os win32))  ; todo: figure out how to placate the osemgrep_cli_interactive win32 build
+    (notty (<> :os win32))  ; todo: this can go away once we move interactive to pro
     ; logging
     (easy_logging ( = 0.8.1 ))
     (easy_logging_yojson ( = 0.8.1 ))

--- a/dune-project
+++ b/dune-project
@@ -466,7 +466,7 @@ For more information see https://semgrep.dev
     ocolor
     ANSITerminal
     terminal_size
-    (notty (<> :os win32))
+    (notty (<> :os win32))  ; todo: figure out how to placate the osemgrep_cli_interactive win32 build
     ; logging
     (easy_logging ( = 0.8.1 ))
     (easy_logging_yojson ( = 0.8.1 ))

--- a/libs/lwt_platform/unix/Lwt_platform.ml
+++ b/libs/lwt_platform/unix/Lwt_platform.ml
@@ -26,5 +26,9 @@
 let run = Lwt_main.run
 let detach = Lwt_preemptive.detach
 let init_preemptive = Lwt_preemptive.init
-let set_engine () = Lwt_engine.set (new Lwt_engine.libev ())
+
+let set_engine () =
+  if Sys.unix then Lwt_engine.set (new Lwt_engine.libev ())
+  else Lwt_engine.set (new Lwt_engine.select)
+
 let sleep = Lwt_unix.sleep

--- a/semgrep.opam
+++ b/semgrep.opam
@@ -28,7 +28,7 @@ depends: [
   "ocolor"
   "ANSITerminal"
   "terminal_size"
-  "notty"
+  "notty" {os != "win32"}
   "easy_logging" {= "0.8.1"}
   "easy_logging_yojson" {= "0.8.1"}
   "logs"
@@ -61,7 +61,7 @@ depends: [
   "digestif" {>= "1.0.0"}
   "lwt"
   "lwt_ppx"
-  "conf-libev"
+  "conf-libev" {os != "win32"}
   "js_of_ocaml" {= "5.4.0"}
   "js_of_ocaml-compiler" {= "5.4.0"}
   "js_of_ocaml-ppx" {= "5.4.0"}

--- a/src/core_cli/Core_CLI.ml
+++ b/src/core_cli/Core_CLI.ml
@@ -640,7 +640,7 @@ let main_no_exn_handler (caps : Cap.all_caps) (sys_argv : string array) : unit =
    * > ignoring SIGXFSZ, continued attempts to increase the size of a file
    * > beyond the limit will fail with errno set to EFBIG.
    *)
-  Sys.set_signal Sys.sigxfsz Sys.Signal_ignore;
+  if Sys.unix then Sys.set_signal Sys.sigxfsz Sys.Signal_ignore;
 
   let usage_msg =
     spf

--- a/src/osemgrep/cli/CLI.ml
+++ b/src/osemgrep/cli/CLI.ml
@@ -282,7 +282,7 @@ let main (caps : Cap.all_caps) (argv : string array) : Exit_code.t =
    * > ignoring SIGXFSZ, continued attempts to increase the size of a file
    * > beyond the limit will fail with errno set to EFBIG.
    *)
-  CapSys.set_signal caps#signal Sys.sigxfsz Sys.Signal_ignore;
+  if Sys.unix then CapSys.set_signal caps#signal Sys.sigxfsz Sys.Signal_ignore;
 
   (* TODO? We used to tune the garbage collector but from profiling
      we found that the effect was small. Meanwhile, the memory

--- a/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -94,9 +94,11 @@ let default : conf =
     core_runner_conf =
       {
         (* Maxing out number of cores used to 16 if more not requested to
-         * not overload on large machines
+         * not overload on large machines.
+         * Also, hardcode num_jobs to 1 for non-unix environments.
          *)
-        Core_runner.num_jobs = min 16 (Parmap_helpers.get_cpu_count ());
+        Core_runner.num_jobs =
+          min 16 (if Sys.unix then Parmap_helpers.get_cpu_count () else 1);
         timeout = 5.0;
         (* ^ seconds, keep up-to-date with User_settings.ml and constants.py *)
         timeout_threshold = 3;

--- a/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -97,6 +97,7 @@ let default : conf =
          * not overload on large machines.
          * Also, hardcode num_jobs to 1 for non-unix (i.e. Windows) because
          * we don't believe that Parmap works in those environments
+         * TODO: figure out a solution for Windows multi-processing (OCaml 5 in the worst case)
          *)
         Core_runner.num_jobs =
           min 16 (if Sys.unix then Parmap_helpers.get_cpu_count () else 1);

--- a/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -95,7 +95,8 @@ let default : conf =
       {
         (* Maxing out number of cores used to 16 if more not requested to
          * not overload on large machines.
-         * Also, hardcode num_jobs to 1 for non-unix environments.
+         * Also, hardcode num_jobs to 1 for non-unix (i.e. Windows) because
+         * we don't believe that Parmap works in those environments
          *)
         Core_runner.num_jobs =
           min 16 (if Sys.unix then Parmap_helpers.get_cpu_count () else 1);


### PR DESCRIPTION
A couple minor tweaks to make the Semgrep build cross-platform. I'll add a GHA workflow in a separate PR.

With these changes, everything but `osemgrep_cli_interactive` should build in Windows -- it'd be good to figure out a workaround here (break interactive mode into its own executable? virtual library? something else?)