### PR TITLE
perf: add profiling annot in Scan_subcommand

### DIFF
--- a/libs/gitignore/Gitignore_filter.ml
+++ b/libs/gitignore/Gitignore_filter.ml
@@ -52,6 +52,7 @@ let select_one acc levels path : Gitignore.selection_event list =
           | None -> acc)
         acc level.patterns)
     acc levels
+[@@profiling]
 
 let select_path opt_gitignore_file_cache sel_events levels relative_segments =
   let rec loop sel_events levels parent_path segments =


### PR DESCRIPTION
test plan:
```
$ ./bin/osemgrep --experimental --config semgrep.jsonnet --error --exclude tests --profile
---------------------
profiling result
---------------------
CLI.dispatch_subcommand                  :      6.102 sec          1 count
Find_targets.get_targets                 :      4.734 sec          1 count
Semgrepignore.select                     :      4.346 sec      76145 count
Gitignore_filter.select                  :      4.336 sec      76145 count
Gitignore_filter.select_one              :      4.275 sec     171595 count
Glob.Match.run                           :      2.654 sec   24076255 count
Scan_subcommand.rules_from_rules_source  :      1.296 sec          1 count
Desugar_jsonnet.desugar_expr_profiled    :      1.235 sec          1 count
Rule_fetching.mk_import_callback         :      1.230 sec          7 count
Rule_fetching.fetch_content_from_registry_url :      1.224 sec          1 count

```
so we now can see the part related to downloading the rules
(the rules_from_rules_source and fetch_content_from_registry_url lines)