### PR TITLE
feat: some `git` wrappers for `cat-file` and `ls-tree`

### DIFF
--- a/libs/git_wrapper/Git_wrapper.ml
+++ b/libs/git_wrapper/Git_wrapper.ml
@@ -483,8 +483,9 @@ let get_git_logs ?cwd ?(since = None) () : string list =
 let cat_file_batch_check_all_objects ?cwd () =
   let cmd =
     ( git,
-      ("cat-file" :: cd cwd)
+      cd cwd
       @ [
+          "cat-file";
           "--batch-all-objects";
           "--batch-check";
           "--unordered" (* List in pack order instead of hash; faster. *);
@@ -522,8 +523,8 @@ let cat_file_batch_check_all_objects ?cwd () =
   in
   Some objects
 
-let cat_file_blob sha =
-  let cmd = (git, [ "cat-file"; "blob"; sha ]) in
+let cat_file_blob ?cwd sha =
+  let cmd = (git, cd cwd @ [ "cat-file"; "blob"; sha ]) in
   match UCmd.string_of_run ~trim:false cmd with
   | Ok (s, (_, `Exited 0)) -> Ok s
   | Ok (s, _)
@@ -533,8 +534,8 @@ let cat_file_blob sha =
 let ls_tree ?cwd ?(recurse = false) sha : ls_tree_extra obj list option =
   let cmd =
     ( git,
-      ("ls-tree" :: cd cwd)
-      @ (if recurse then [ "-r" ] else [])
+      cd cwd
+      @ ("ls-tree" :: (if recurse then [ "-r" ] else []))
       @ [ "--full-tree"; "--format=%(objecttype) %(objectname) %(path)"; sha ]
     )
   in


### PR DESCRIPTION
Some additional functionality for interacting with `git` via `cat-file` and `ls-tree`. This is needed for anything which wants to interact with individual git objects (e.g., for working with git history on a per blob/commit/tree object basis).

Test plan: Manually tested on a git repo I have created for secrets testing; eventually this will be in pro and these will have some coverage via integration testing there. I didn't see anywhere for unit testing of our git wrappers. If this exists, could someone point me to it?