### PR TITLE
fix: do not convert primitive type `ConstructedObject` to `New` expression in C++

### DIFF
--- a/changelog.d/pa-3336.changed
+++ b/changelog.d/pa-3336.changed
@@ -1,0 +1,3 @@
+The primitive object construct expression will no longer match the new
+expression pattern. For example, the pattern `new $TYPE` will now only match
+`new int`, not `int()`.

--- a/tests/rules/prim_obj_init_cpp.cpp
+++ b/tests/rules/prim_obj_init_cpp.cpp
@@ -1,0 +1,16 @@
+void f()
+{
+  // ruleid: new-expr
+  new int;
+  // ruleid: new-expr
+  new int(0);
+
+  // ok: new-expr
+  int {};
+  // ok: new-expr
+  int {0};
+  // ok: new-expr
+  int ();
+  // ok: new-expr
+  int (0);
+}

--- a/tests/rules/prim_obj_init_cpp.yaml
+++ b/tests/rules/prim_obj_init_cpp.yaml
@@ -1,0 +1,12 @@
+rules:
+  - id: new-expr
+    pattern-either:
+      - pattern: |
+          new $TYPE
+      - pattern: |
+          new $CALL(...)
+    message: Semgrep found a match
+    languages:
+      - cpp
+    severity: WARNING
+


### PR DESCRIPTION
Test Plan: `make test`