### PR TITLE
style: Add Severity Indicators and Fix Rule, Autofix, and Finding Text Wrapping

### DIFF
--- a/changelog.d/grow-97.added
+++ b/changelog.d/grow-97.added
@@ -1,0 +1,2 @@
+Added a severity icon (e.g. "❯❯❱") and corresponding color to our CLI text output
+for findings of known severity.

--- a/changelog.d/grow-97.fixed
+++ b/changelog.d/grow-97.fixed
@@ -1,0 +1,3 @@
+Fixed rule IDs, descriptions, findings, and autofix text not wrapping as expected.
+Use newline instead of horiziontal separator for findings with a shared file
+but for different rules per design spec.

--- a/cli/src/semgrep/console.py
+++ b/cli/src/semgrep/console.py
@@ -101,4 +101,3 @@ class AutoIndentingConsole(Console):
 MAX_WIDTH = 120
 terminal_width = min(MAX_WIDTH, get_terminal_size((MAX_WIDTH, 1))[0])
 console = AutoIndentingConsole(highlighter=None, width=terminal_width)
-# console.width = min(console.width, MAX_WIDTH)

--- a/cli/src/semgrep/console.py
+++ b/cli/src/semgrep/console.py
@@ -9,6 +9,7 @@ See also the semgrep.terminal module which is an earlier attempt to
 standardize some output configuration, but is more low level and
 doesn't really offload logic to other libraries.
 """
+from shutil import get_terminal_size
 from typing import Any
 from typing import Optional
 
@@ -98,6 +99,6 @@ class AutoIndentingConsole(Console):
 
 
 MAX_WIDTH = 120
-
-console = AutoIndentingConsole(highlighter=None)
-console.width = min(console.width, MAX_WIDTH)
+terminal_width = min(MAX_WIDTH, get_terminal_size((MAX_WIDTH, 1))[0])
+console = AutoIndentingConsole(highlighter=None, width=terminal_width)
+# console.width = min(console.width, MAX_WIDTH)

--- a/cli/src/semgrep/console.py
+++ b/cli/src/semgrep/console.py
@@ -97,7 +97,7 @@ class AutoIndentingConsole(Console):
         super().print(Padding.indent(Group(*args), indent), **kwargs)
 
 
-MAX_WIDTH = 160
+MAX_WIDTH = 120
 
 console = AutoIndentingConsole(highlighter=None)
 console.width = min(console.width, MAX_WIDTH)

--- a/cli/src/semgrep/constants.py
+++ b/cli/src/semgrep/constants.py
@@ -125,7 +125,7 @@ class Colors(Enum):
     yellow = "yellow"  # TODO: benchmark timing output?
     red = "red"  # for errors
     bright_blue = "bright_blue"  # TODO: line numbers?
-
+    magenta = "magenta"
     # these colors ignore user's terminal theme
     forced_black = 16  # #000
     forced_white = 231  # #FFF

--- a/cli/src/semgrep/core_targets_plan.py
+++ b/cli/src/semgrep/core_targets_plan.py
@@ -21,6 +21,7 @@ from attr import field
 from attr import frozen
 from boltons.iterutils import get_path
 from rich import box
+from rich.style import Style
 from rich.table import Table
 
 import semgrep.semgrep_interfaces.semgrep_output_v1 as out
@@ -190,11 +191,17 @@ class Plan:
                     rule_nums.add(rule_num)
         return len(rule_nums)
 
-    def table_by_language(self, with_tables_for: Optional[out.Product] = None) -> Table:
+    def table_by_language(
+        self, with_tables_for: Optional[out.Product] = None, use_color: bool = True
+    ) -> Table:
         table = Table(box=box.SIMPLE_HEAD, show_edge=False)
-        table.add_column("Language")
-        table.add_column("Rules", justify="right")
-        table.add_column("Files", justify="right")
+        table.add_column("Language", header_style=Style(color=None, bold=use_color))
+        table.add_column(
+            "Rules", justify="right", header_style=Style(color=None, bold=use_color)
+        )
+        table.add_column(
+            "Files", justify="right", header_style=Style(color=None, bold=use_color)
+        )
 
         plans_by_language = sorted(
             self.split_by_lang_label_for_product(with_tables_for).items(),
@@ -238,10 +245,14 @@ class Plan:
 
         return table
 
-    def table_by_origin(self, with_tables_for: Optional[out.Product] = None) -> Table:
+    def table_by_origin(
+        self, with_tables_for: Optional[out.Product] = None, use_color: bool = True
+    ) -> Table:
         table = Table(box=box.SIMPLE_HEAD, show_edge=False)
-        table.add_column("Origin")
-        table.add_column("Rules", justify="right")
+        table.add_column("Origin", header_style=Style(color=None, bold=use_color))
+        table.add_column(
+            "Rules", justify="right", header_style=Style(color=None, bold=use_color)
+        )
 
         origin_counts = collections.Counter(
             get_path(rule.metadata, ("semgrep.dev", "rule", "origin"), default="custom")

--- a/cli/src/semgrep/formatter/text.py
+++ b/cli/src/semgrep/formatter/text.py
@@ -44,18 +44,13 @@ MAX_TEXT_WIDTH = 120
 
 RULE_INDENT = 8
 BASE_INDENT = 10
+FINDINGS_INDENT_DEPTH = 16
 
 terminal_size = get_terminal_size((MAX_TEXT_WIDTH, 1))[0]
 if terminal_size <= 0:
     terminal_size = MAX_TEXT_WIDTH
-width = min(MAX_TEXT_WIDTH, terminal_size)
-if width <= 110:
-    width = width - 5
-else:
-    width = width - (width - 100)
 
-FINDINGS_INDENT_DEPTH = 16
-
+base_width = min(MAX_TEXT_WIDTH, terminal_size)
 
 GROUP_TITLES: Dict[Tuple[out.Product, str], str] = {
     (out.Product(out.SCA()), "unreachable"): "Unreachable Supply Chain Finding",
@@ -619,7 +614,7 @@ def print_text_output(
             title_with_prefix = f"{4 * ' '}{pp_severity(rule_match)} {rule_title}"
             title_text = click.wrap_text(
                 title_with_prefix,
-                width=width + 12,
+                width=base_width + 4,
                 initial_indent="",
                 subsequent_indent=RULE_INDENT * " ",
                 preserve_paragraphs=False,
@@ -634,7 +629,7 @@ def print_text_output(
             )
             message_text = click.wrap_text(
                 f"{message}",
-                width,
+                width=base_width - BASE_INDENT * 2,
                 initial_indent=BASE_INDENT * " ",
                 subsequent_indent=BASE_INDENT * " ",
                 preserve_paragraphs=True,

--- a/cli/src/semgrep/formatter/text.py
+++ b/cli/src/semgrep/formatter/text.py
@@ -103,7 +103,9 @@ def format_finding_line(
     else:
         mid = line[start:end]
     # adjust for 1-indexed line number and add separator
-    line_number_str = f"{start + 1}┆ ".rjust(5)  # 3 digits + 1 separator + 1 space
+    line_number_str = f"{start + 1 if start > 0 else ''}┆ ".rjust(
+        5
+    )  # 3 digits + 1 separator + 1 space
     # use manual bold styling when color is enabled to ensure we wrap properly
     mid_styled = mid or "" if not color else f"\033[1m{mid}\033[0m"
     wrapped_text = textwrap.fill(
@@ -625,11 +627,25 @@ def print_text_output(
             shortlink_text = (BASE_INDENT * " " + shortlink + "\n") if shortlink else ""
             console.print(f"{severity}{message_text}\n{shortlink_text}")
 
-        autofix_tag = with_color(Colors.green, "         ▶▶┆ Autofix ▶")
         if fix is not None:
-            console.print(
-                f"{autofix_tag} {fix if fix else with_color(Colors.red, 'delete')}"
+            autofix_tag = "▶▶┆ Autofix ▶ "
+            wrapped_fix = (
+                textwrap.fill(
+                    fix,
+                    width=base_width
+                    - (RULE_INDENT + 20),  # 13 for autofix tag, 7 for indent
+                    initial_indent="",
+                    subsequent_indent=(RULE_INDENT + 7) * " ",
+                )
+                if fix
+                else ""
             )
+            fix_text = Text.assemble(
+                (11) * " ",
+                (autofix_tag, "green"),
+                wrapped_fix if wrapped_fix else ("delete", "red"),
+            )
+            console.print(fix_text)
         elif (
             "sca_info" in rule_match.extra
             and "sca-fix-versions" in rule_match.metadata

--- a/cli/src/semgrep/formatter/text.py
+++ b/cli/src/semgrep/formatter/text.py
@@ -192,14 +192,14 @@ def format_lines(
         stripped_str = (
             f"[shortened a long line from output, adjust with {MAX_CHARS_FLAG_NAME}]"
         )
-        yield " " * FINDINGS_INDENT_DEPTH + stripped_str
+        yield " " * (FINDINGS_INDENT_DEPTH - 4) + stripped_str
 
     if per_finding_max_lines_limit != 1:
         if trimmed > 0:
             trimmed_str = (
                 f" [hid {trimmed} additional lines, adjust with {MAX_LINES_FLAG_NAME}] "
             )
-            yield " " * FINDINGS_INDENT_DEPTH + trimmed_str
+            yield " " * (FINDINGS_INDENT_DEPTH - 4) + trimmed_str
         elif lines and show_separator:
             yield f" " * (FINDINGS_INDENT_DEPTH - 4) + f"⋮┆" + f"-" * 40
 
@@ -612,13 +612,17 @@ def print_text_output(
             rule_title = with_color(Colors.foreground, rule_match.title, bold=True)
             wrapped_text = textwrap.fill(  # should be equivalent to textwrap.fill
                 rule_title,
-                width=base_width - RULE_INDENT * 2,
+                width=base_width - max(16, RULE_INDENT * 2),
                 initial_indent=RULE_INDENT * " ",
                 subsequent_indent=RULE_INDENT * " ",
             )
             # Wrapping text seems to bug out with color codes, so we add them post-wrap
             severity_icon = pp_severity(rule_match)
-            title_text = 4 * " " + f"{severity_icon} " + wrapped_text[RULE_INDENT:]
+            title_text = (
+                (RULE_INDENT - 4) * " "
+                + f"{severity_icon} "
+                + wrapped_text[RULE_INDENT:]
+            )
 
             severity = (
                 (

--- a/cli/src/semgrep/formatter/text.py
+++ b/cli/src/semgrep/formatter/text.py
@@ -619,7 +619,8 @@ def print_text_output(
             text = Text.assemble(
                 (RULE_INDENT - 4) * " ",
                 (sev_icon, sev_color),
-                (f" {wrapped_text}", "bold"),
+                " ",
+                (f"{wrapped_text}", "bold"),
             )
             if (
                 last_file == current_file
@@ -830,11 +831,9 @@ class TextFormatter(BaseFormatter):
                     continue
                 console.print(Title(unit_str(len(matches), GROUP_TITLES[group])))
 
-                color_output = extra.get("color_output", False)
-
                 print_text_output(
                     matches,
-                    color_output,
+                    extra.get("color_output", False),
                     extra["per_finding_max_lines_limit"],
                     extra["per_line_max_chars_limit"],
                     extra["dataflow_traces"],

--- a/cli/src/semgrep/formatter/text.py
+++ b/cli/src/semgrep/formatter/text.py
@@ -631,7 +631,7 @@ def print_text_output(
 
             severity = (
                 (
-                    f"{RULE_INDENT * ' '}Severity: {with_color(Colors.foreground, rule_match.metadata['sca-severity'], bold=True)}\n"
+                    f"{BASE_INDENT * ' '}Severity: {with_color(Colors.foreground, rule_match.metadata['sca-severity'], bold=True)}\n"
                 )
                 if "sca_info" in rule_match.extra
                 and "sca-severity" in rule_match.metadata

--- a/cli/src/semgrep/formatter/text.py
+++ b/cli/src/semgrep/formatter/text.py
@@ -622,12 +622,7 @@ def print_text_output(
                 " ",
                 (f"{wrapped_text}", "bold"),
             )
-            if (
-                last_file == current_file
-                and last_rule_id != rule_match.rule_id
-                and sys.stderr.isatty()
-            ):
-                # Keep legacy behavior for non-tty (for now)
+            if last_file == current_file and last_rule_id != rule_match.rule_id:
                 console.print(
                     " "
                 )  # add a blank line between different rules in the same file
@@ -722,9 +717,7 @@ def print_text_output(
         )
         show_separator = (
             is_same_file
-            and (
-                is_same_rule or not sys.stderr.isatty()
-            )  # Keep legacy behavior for non-tty (for now)
+            and is_same_rule
             and not (dataflow_traces and rule_match.dataflow_trace)
         )
         for line in finding_to_line(

--- a/cli/src/semgrep/formatter/text.py
+++ b/cli/src/semgrep/formatter/text.py
@@ -103,9 +103,7 @@ def format_finding_line(
     else:
         mid = line[start:end]
     # adjust for 1-indexed line number and add separator
-    line_number_str = f"{start + 1 if start > 0 else ''}┆ ".rjust(
-        5
-    )  # 3 digits + 1 separator + 1 space
+    line_number_str = f"{line_number}┆ ".rjust(5)  # 3 digits + 1 separator + 1 space
     # use manual bold styling when color is enabled to ensure we wrap properly
     mid_styled = mid or "" if not color else f"\033[1m{mid}\033[0m"
     wrapped_text = textwrap.fill(
@@ -631,14 +629,16 @@ def print_text_output(
             autofix_tag = "▶▶┆ Autofix ▶ "
             wrapped_fix = (
                 textwrap.fill(
-                    fix,
+                    textwrap.dedent(
+                        "".join(l.strip() for l in fix.splitlines(keepends=True))
+                    ),
                     width=base_width
                     - (RULE_INDENT + 20),  # 13 for autofix tag, 7 for indent
                     initial_indent="",
                     subsequent_indent=(RULE_INDENT + 7) * " ",
                 )
                 if fix
-                else ""
+                else ""  # keep as empty string if fix is empty string
             )
             fix_text = Text.assemble(
                 (11) * " ",

--- a/cli/src/semgrep/formatter/text.py
+++ b/cli/src/semgrep/formatter/text.py
@@ -136,8 +136,8 @@ def format_lines(
         lines = lines[:per_finding_max_lines_limit]
 
     per_line_max_chars_limit = min(
-        per_line_max_chars_limit or base_width - FINDINGS_INDENT_DEPTH,
-        base_width - FINDINGS_INDENT_DEPTH,
+        per_line_max_chars_limit or base_width - FINDINGS_INDENT_DEPTH - 3,
+        base_width - FINDINGS_INDENT_DEPTH - 3,
     )
     # we remove indentation at the start of the snippet to avoid wasting space
     dedented_lines = textwrap.dedent("".join(lines)).splitlines()

--- a/cli/src/semgrep/output.py
+++ b/cli/src/semgrep/output.py
@@ -1,4 +1,5 @@
 import dataclasses
+import os
 import pathlib
 import sys
 from collections import defaultdict
@@ -465,8 +466,9 @@ class OutputHandler:
             extra["verbose_errors"] = True
         if self.settings.output_format == OutputFormat.TEXT:
             extra["color_output"] = (
-                self.settings.output_destination is None and sys.stdout.isatty(),
-            )
+                (self.settings.output_destination is None and sys.stdout.isatty())
+                or os.environ.get("SEMGREP_FORCE_COLOR")
+            ) and not os.environ.get("NO_COLOR")
             extra[
                 "per_finding_max_lines_limit"
             ] = self.settings.output_per_finding_max_lines_limit

--- a/cli/src/semgrep/scan_report.py
+++ b/cli/src/semgrep/scan_report.py
@@ -2,6 +2,7 @@
 # Prelude
 ##############################################################################
 # Helpers to run_scan.py to report scan status
+import sys
 from textwrap import wrap
 from typing import List
 from typing import Sequence
@@ -190,10 +191,14 @@ def _print_sast_table(
         )
         return
 
+    use_color = sys.stderr.isatty()
+    # NOTE: osemgrep lacks support for bold table headers
+    # Given that this is only printed in legacy and compatability
+    # runs, the output doesn't really matter
     _print_tables(
         [
-            sast_plan.table_by_language(with_tables_for=product),
-            sast_plan.table_by_origin(with_tables_for=product),
+            sast_plan.table_by_language(with_tables_for=product, use_color=use_color),
+            sast_plan.table_by_origin(with_tables_for=product, use_color=use_color),
         ]
     )
 

--- a/cli/src/semgrep/scan_report.py
+++ b/cli/src/semgrep/scan_report.py
@@ -211,12 +211,9 @@ def _print_sca_table(sca_plan: Plan, rule_count: int) -> None:
         _print_degenerate_table(sca_plan, rule_count=rule_count)
         return
 
-    _print_tables(
-        [
-            sca_plan.table_by_ecosystem(),
-            sca_plan.table_by_sca_analysis(),
-        ]
-    )
+    _print_tables([sca_plan.table_by_ecosystem()])
+    console.print("\n")  # space intentional to force second table to be on its own line
+    _print_tables([sca_plan.table_by_sca_analysis()])
 
 
 def _print_detailed_sca_table(

--- a/cli/src/semgrep/target_manager.py
+++ b/cli/src/semgrep/target_manager.py
@@ -276,7 +276,7 @@ class FileTargetingLog:
             yield 2, "<none>"
 
         yield 1, "Skipped by .semgrepignore:"
-        yield 1, "(See: https://semgrep.dev/docs/ignoring-files-folders-code/#understanding-semgrep-defaults)"
+        yield 1, "- https://semgrep.dev/docs/ignoring-files-folders-code/#understanding-semgrep-defaults"
         if self.semgrepignored:
             for path in sorted(self.semgrepignored):
                 yield 2, with_color(Colors.cyan, str(path))

--- a/cli/src/semgrep/target_manager.py
+++ b/cli/src/semgrep/target_manager.py
@@ -43,7 +43,7 @@ from boltons.iterutils import partition
 
 from semgrep.constants import Colors, UNSUPPORTED_EXT_IGNORE_LANGS
 from semgrep.error import FilesNotFoundError
-from semgrep.formatter.text import width
+from semgrep.formatter.text import base_width as width
 from semgrep.ignores import FileIgnore
 from semgrep.semgrep_types import FileExtension
 from semgrep.semgrep_types import LANGUAGE

--- a/cli/src/semgrep/target_manager.py
+++ b/cli/src/semgrep/target_manager.py
@@ -43,7 +43,7 @@ from boltons.iterutils import partition
 
 from semgrep.constants import Colors, UNSUPPORTED_EXT_IGNORE_LANGS
 from semgrep.error import FilesNotFoundError
-from semgrep.formatter.text import base_width as width
+from semgrep.formatter.text import BASE_WIDTH as width
 from semgrep.ignores import FileIgnore
 from semgrep.semgrep_types import FileExtension
 from semgrep.semgrep_types import LANGUAGE

--- a/cli/tests/conftest.py
+++ b/cli/tests/conftest.py
@@ -351,6 +351,10 @@ def _run_semgrep(
 
     if force_color:
         env["SEMGREP_FORCE_COLOR"] = "true"
+        # NOTE: We should also apply the known color flags to the env
+        env["FORCE_COLOR"] = "1"
+        if "NO_COLOR" in env:
+            del env["NO_COLOR"]
 
     if "SEMGREP_USER_AGENT_APPEND" not in env:
         env["SEMGREP_USER_AGENT_APPEND"] = "pytest"

--- a/cli/tests/e2e/rules/cli_test/long_rule_id/long_rule_id.yaml
+++ b/cli/tests/e2e/rules/cli_test/long_rule_id/long_rule_id.yaml
@@ -1,0 +1,6 @@
+rules:
+  - id: this-is-a-very-long-rule-id-which-should-be-wrapped-in-the-cli-thank-you-very-much-supercalifragilisticexpialidocious
+    pattern: $X == $X
+    message: This is the description of a very long rule id which should be wrapped in the cli thank you very much supercalifragilisticexpialidocious.
+    severity: WARNING
+    languages: [python]

--- a/cli/tests/e2e/snapshots/test_check/test_max_memory/error.txt
+++ b/cli/tests/e2e/snapshots/test_check/test_max_memory/error.txt
@@ -24,7 +24,7 @@ Files skipped:
    • <all files not listed by `git ls-files` were skipped>
 
   Skipped by .semgrepignore:
-  (See: https://semgrep.dev/docs/ignoring-files-folders-code/#understanding-semgrep-defaults)
+  - https://semgrep.dev/docs/ignoring-files-folders-code/#understanding-semgrep-defaults
 
    • <none>
 

--- a/cli/tests/e2e/snapshots/test_check/test_sort_text_findings/output.txt
+++ b/cli/tests/e2e/snapshots/test_check/test_sort_text_findings/output.txt
@@ -9,7 +9,7 @@
           found something (2)
 
             1┆ f()
-            ⋮┆----------------------------------------
+
        rules.sort-findings-1
           found something (1)
 
@@ -19,18 +19,18 @@
             1┆ f()
             2┆ f()
             3┆ f()
-            ⋮┆----------------------------------------
+
        rules.sort-findings-2
           found something (2)
 
             2┆ f()
-            ⋮┆----------------------------------------
+
        rules.sort-findings-1
           found something (1)
 
             2┆ f()
             3┆ f()
-            ⋮┆----------------------------------------
+
        rules.sort-findings-2
           found something (2)
 
@@ -41,7 +41,7 @@
           found something (2)
 
             1┆ f()
-            ⋮┆----------------------------------------
+
        rules.sort-findings-1
           found something (1)
 
@@ -51,18 +51,18 @@
             1┆ f()
             2┆ f()
             3┆ f()
-            ⋮┆----------------------------------------
+
        rules.sort-findings-2
           found something (2)
 
             2┆ f()
-            ⋮┆----------------------------------------
+
        rules.sort-findings-1
           found something (1)
 
             2┆ f()
             3┆ f()
-            ⋮┆----------------------------------------
+
        rules.sort-findings-2
           found something (2)
 
@@ -73,13 +73,13 @@
           found something (2)
 
             1┆ f()
-            ⋮┆----------------------------------------
+
        rules.sort-findings-1
           found something (1)
 
             1┆ f()
             2┆ f()
-            ⋮┆----------------------------------------
+
        rules.sort-findings-2
           found something (2)
 

--- a/cli/tests/e2e/snapshots/test_check/test_terminal_output/results.txt
+++ b/cli/tests/e2e/snapshots/test_check/test_terminal_output/results.txt
@@ -1,5 +1,5 @@
 === command
-SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_FORCE_COLOR="true" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_VERSION_CACHE_PATH="<MASKED>" SEMGREP_ENABLE_VERSION_CHECK="0" SEMGREP_SEND_METRICS="off" semgrep --strict --config rules/eqeq.yaml targets/basic
+SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_FORCE_COLOR="true" FORCE_COLOR="1" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_VERSION_CACHE_PATH="<MASKED>" SEMGREP_ENABLE_VERSION_CHECK="0" SEMGREP_SEND_METRICS="off" semgrep --strict --config rules/eqeq.yaml targets/basic
 === end of command
 
 === exit code
@@ -68,17 +68,17 @@ Ran 4 rules on 14 files: 2 findings.
 └─────────────────┘
 
   [36m[22m[24m  targets/basic/stupid.js [0m
-       [1m[24mrules.javascript-basic-eqeq-bad[0m
+       [1mrules.javascript-basic-eqeq-bad[0m
           useless comparison
 
-            3┆ console.log([1m[24mx == x[0m)
+            3┆ console.log([1mx == x[0m)
 
   [36m[22m[24m  targets/basic/stupid.py [0m
-       [1m[24mrules.eqeq-is-bad[0m
+       [1mrules.eqeq-is-bad[0m
           useless comparison operation `a + b == a + b` or `a + b != a + b`
           Details: https://sg.run/xyz1
 
-            3┆ return [1m[24ma + b == a + b[0m
+            3┆ return [1ma + b == a + b[0m
 
 
 === end of stdout - color

--- a/cli/tests/e2e/snapshots/test_check/test_terminal_output/results_second.txt
+++ b/cli/tests/e2e/snapshots/test_check/test_terminal_output/results_second.txt
@@ -1,5 +1,5 @@
 === command
-SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_FORCE_COLOR="true" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_VERSION_CACHE_PATH="<MASKED>" SEMGREP_ENABLE_VERSION_CHECK="0" SEMGREP_SEND_METRICS="off" semgrep --strict --config rules/eqeq.yaml targets/basic
+SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_FORCE_COLOR="true" FORCE_COLOR="1" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_VERSION_CACHE_PATH="<MASKED>" SEMGREP_ENABLE_VERSION_CHECK="0" SEMGREP_SEND_METRICS="off" semgrep --strict --config rules/eqeq.yaml targets/basic
 === end of command
 
 === exit code
@@ -62,17 +62,17 @@ Ran 4 rules on 14 files: 2 findings.
 └─────────────────┘
 
   [36m[22m[24m  targets/basic/stupid.js [0m
-       [1m[24mrules.javascript-basic-eqeq-bad[0m
+       [1mrules.javascript-basic-eqeq-bad[0m
           useless comparison
 
-            3┆ console.log([1m[24mx == x[0m)
+            3┆ console.log([1mx == x[0m)
 
   [36m[22m[24m  targets/basic/stupid.py [0m
-       [1m[24mrules.eqeq-is-bad[0m
+       [1mrules.eqeq-is-bad[0m
           useless comparison operation `a + b == a + b` or `a + b != a + b`
           Details: https://sg.run/xyz1
 
-            3┆ return [1m[24ma + b == a + b[0m
+            3┆ return [1ma + b == a + b[0m
 
 
 === end of stdout - color

--- a/cli/tests/e2e/snapshots/test_check/test_terminal_output_quiet/results.txt
+++ b/cli/tests/e2e/snapshots/test_check/test_terminal_output_quiet/results.txt
@@ -1,5 +1,5 @@
 === command
-SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_FORCE_COLOR="true" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_VERSION_CACHE_PATH="<MASKED>" SEMGREP_ENABLE_VERSION_CHECK="0" SEMGREP_SEND_METRICS="off" semgrep --strict --quiet --config rules/eqeq.yaml targets/basic
+SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_FORCE_COLOR="true" FORCE_COLOR="1" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_VERSION_CACHE_PATH="<MASKED>" SEMGREP_ENABLE_VERSION_CHECK="0" SEMGREP_SEND_METRICS="off" semgrep --strict --quiet --config rules/eqeq.yaml targets/basic
 === end of command
 
 === exit code
@@ -41,17 +41,17 @@ SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_FORCE_COLOR="true" SEMGREP_USER_AGENT_A
 └─────────────────┘
 
   [36m[22m[24m  targets/basic/stupid.js [0m
-       [1m[24mrules.javascript-basic-eqeq-bad[0m
+       [1mrules.javascript-basic-eqeq-bad[0m
           useless comparison
 
-            3┆ console.log([1m[24mx == x[0m)
+            3┆ console.log([1mx == x[0m)
 
   [36m[22m[24m  targets/basic/stupid.py [0m
-       [1m[24mrules.eqeq-is-bad[0m
+       [1mrules.eqeq-is-bad[0m
           useless comparison operation `a + b == a + b` or `a + b != a + b`
           Details: https://sg.run/xyz1
 
-            3┆ return [1m[24ma + b == a + b[0m
+            3┆ return [1ma + b == a + b[0m
 
 
 === end of stdout - color

--- a/cli/tests/e2e/snapshots/test_check/test_timeout_threshold/error.txt
+++ b/cli/tests/e2e/snapshots/test_check/test_timeout_threshold/error.txt
@@ -30,8 +30,7 @@ Files skipped:
    • <all files not listed by `git ls-files` were skipped>
 
   [1m[24mSkipped by .semgrepignore:[0m
-  [1m[24m(See: https://semgrep.dev/docs/ignoring-files-folders-code/#understanding-semgrep-
-  defaults)[0m
+  [1m[24m- https://semgrep.dev/docs/ignoring-files-folders-code/#understanding-semgrep-defaults[0m
 
    • <none>
 

--- a/cli/tests/e2e/snapshots/test_check/test_timeout_threshold/error_2.txt
+++ b/cli/tests/e2e/snapshots/test_check/test_timeout_threshold/error_2.txt
@@ -30,8 +30,7 @@ Files skipped:
    • <all files not listed by `git ls-files` were skipped>
 
   [1m[24mSkipped by .semgrepignore:[0m
-  [1m[24m(See: https://semgrep.dev/docs/ignoring-files-folders-code/#understanding-semgrep-
-  defaults)[0m
+  [1m[24m- https://semgrep.dev/docs/ignoring-files-folders-code/#understanding-semgrep-defaults[0m
 
    • <none>
 

--- a/cli/tests/e2e/snapshots/test_ci/test_config_run/autofix/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_config_run/autofix/results.txt
@@ -24,19 +24,19 @@ SEMGREP_APP_TOKEN="" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<
             7┆ a == a
             ⋮┆----------------------------------------
            11┆ y == y
-            ⋮┆----------------------------------------
+
        eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
-            ⋮┆----------------------------------------
+
        eqeq-bad
           useless comparison
 
            23┆ b == b # Triage ignored by syntactic_id
             ⋮┆----------------------------------------
            24┆ a == a # Triage ignored by match_based_id
-            ⋮┆----------------------------------------
+
        taint-test
           unsafe use of danger
 

--- a/cli/tests/e2e/snapshots/test_ci/test_config_run/noautofix/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_config_run/noautofix/results.txt
@@ -24,19 +24,19 @@ SEMGREP_APP_TOKEN="" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<
             7┆ a == a
             ⋮┆----------------------------------------
            11┆ y == y
-            ⋮┆----------------------------------------
+
        eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
-            ⋮┆----------------------------------------
+
        eqeq-bad
           useless comparison
 
            23┆ b == b # Triage ignored by syntactic_id
             ⋮┆----------------------------------------
            24┆ a == a # Triage ignored by match_based_id
-            ⋮┆----------------------------------------
+
        taint-test
           unsafe use of danger
 

--- a/cli/tests/e2e/snapshots/test_ci/test_dryrun/None/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_dryrun/None/results.txt
@@ -24,12 +24,12 @@ SEMGREP_APP_TOKEN="fake-key-from-tests" SEMGREP_USER_AGENT_APPEND="pytest" SEMGR
             7┆ a == a
             ⋮┆----------------------------------------
            11┆ y == y
-            ⋮┆----------------------------------------
+
        eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
-            ⋮┆----------------------------------------
+
        taint-test
           unsafe use of danger
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines-overwrite-autodetected-variables/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines-overwrite-autodetected-variables/results.txt
@@ -24,12 +24,12 @@ BUILD_BUILDID="some_id" SEMGREP_REPO_NAME="a/repo/name" SEMGREP_REPO_URL="https:
             7┆ a == a
             ⋮┆----------------------------------------
            11┆ y == y
-            ⋮┆----------------------------------------
+
        eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
-            ⋮┆----------------------------------------
+
        taint-test
           unsafe use of danger
 
@@ -75,8 +75,7 @@ BUILD_BUILDID="some_id" SEMGREP_REPO_NAME="a/repo/name" SEMGREP_REPO_URL="https:
 
   SCAN ENVIRONMENT
   versions    - semgrep <MASKED> on python <MASKED>
-  environment - running in environment azure-pipelines, triggering event is
-                pull_request
+  environment - running in environment azure-pipelines, triggering event is pull_request
 
   CONNECTION
   Initializing scan (deployment=org_name, scan_id=12345)

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines/results.txt
@@ -24,12 +24,12 @@ BUILD_BUILDID="some_id" BUILD_REPOSITORY_URI="https://github.com/project_name/pr
             7┆ a == a
             ⋮┆----------------------------------------
            11┆ y == y
-            ⋮┆----------------------------------------
+
        eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
-            ⋮┆----------------------------------------
+
        taint-test
           unsafe use of danger
 
@@ -75,8 +75,7 @@ BUILD_BUILDID="some_id" BUILD_REPOSITORY_URI="https://github.com/project_name/pr
 
   SCAN ENVIRONMENT
   versions    - semgrep <MASKED> on python <MASKED>
-  environment - running in environment azure-pipelines, triggering event is
-                pull_request
+  environment - running in environment azure-pipelines, triggering event is pull_request
 
   CONNECTION
   Initializing scan (deployment=org_name, scan_id=12345)

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket-overwrite-autodetected-variables/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket-overwrite-autodetected-variables/results.txt
@@ -24,12 +24,12 @@ CI="true" BITBUCKET_BUILD_NUMBER="hi" SEMGREP_REPO_NAME="a/repo/name" SEMGREP_RE
             7┆ a == a
             ⋮┆----------------------------------------
            11┆ y == y
-            ⋮┆----------------------------------------
+
        eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
-            ⋮┆----------------------------------------
+
        taint-test
           unsafe use of danger
 
@@ -75,8 +75,7 @@ CI="true" BITBUCKET_BUILD_NUMBER="hi" SEMGREP_REPO_NAME="a/repo/name" SEMGREP_RE
 
   SCAN ENVIRONMENT
   versions    - semgrep <MASKED> on python <MASKED>
-  environment - running in environment bitbucket, triggering event is
-                pull_request
+  environment - running in environment bitbucket, triggering event is pull_request
 
   CONNECTION
   Initializing scan (deployment=org_name, scan_id=12345)

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket/results.txt
@@ -24,12 +24,12 @@ CI="true" BITBUCKET_BUILD_NUMBER="hi" BITBUCKET_REPO_FULL_NAME="project_name/pro
             7┆ a == a
             ⋮┆----------------------------------------
            11┆ y == y
-            ⋮┆----------------------------------------
+
        eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
-            ⋮┆----------------------------------------
+
        taint-test
           unsafe use of danger
 
@@ -75,8 +75,7 @@ CI="true" BITBUCKET_BUILD_NUMBER="hi" BITBUCKET_REPO_FULL_NAME="project_name/pro
 
   SCAN ENVIRONMENT
   versions    - semgrep <MASKED> on python <MASKED>
-  environment - running in environment bitbucket, triggering event is
-                pull_request
+  environment - running in environment bitbucket, triggering event is pull_request
 
   CONNECTION
   Initializing scan (deployment=org_name, scan_id=12345)

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite-overwrite-autodetected-variables/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite-overwrite-autodetected-variables/results.txt
@@ -24,12 +24,12 @@ BUILDKITE="true" SEMGREP_REPO_NAME="a/repo/name" SEMGREP_REPO_URL="https://rando
             7┆ a == a
             ⋮┆----------------------------------------
            11┆ y == y
-            ⋮┆----------------------------------------
+
        eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
-            ⋮┆----------------------------------------
+
        taint-test
           unsafe use of danger
 
@@ -75,8 +75,7 @@ BUILDKITE="true" SEMGREP_REPO_NAME="a/repo/name" SEMGREP_REPO_URL="https://rando
 
   SCAN ENVIRONMENT
   versions    - semgrep <MASKED> on python <MASKED>
-  environment - running in environment buildkite, triggering event is
-                pull_request
+  environment - running in environment buildkite, triggering event is pull_request
 
   CONNECTION
   Initializing scan (deployment=org_name, scan_id=12345)

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite/results.txt
@@ -24,12 +24,12 @@ BUILDKITE="true" BUILDKITE_REPO="git@github.com/project_name/project_name.git" B
             7┆ a == a
             ⋮┆----------------------------------------
            11┆ y == y
-            ⋮┆----------------------------------------
+
        eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
-            ⋮┆----------------------------------------
+
        taint-test
           unsafe use of danger
 
@@ -75,8 +75,7 @@ BUILDKITE="true" BUILDKITE_REPO="git@github.com/project_name/project_name.git" B
 
   SCAN ENVIRONMENT
   versions    - semgrep <MASKED> on python <MASKED>
-  environment - running in environment buildkite, triggering event is
-                pull_request
+  environment - running in environment buildkite, triggering event is pull_request
 
   CONNECTION
   Initializing scan (deployment=org_name, scan_id=12345)

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci-overwrite-autodetected-variables/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci-overwrite-autodetected-variables/results.txt
@@ -24,12 +24,12 @@ CI="true" SEMGREP_REPO_NAME="a/repo/name" SEMGREP_REPO_URL="https://random.url.o
             7┆ a == a
             ⋮┆----------------------------------------
            11┆ y == y
-            ⋮┆----------------------------------------
+
        eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
-            ⋮┆----------------------------------------
+
        taint-test
           unsafe use of danger
 
@@ -75,8 +75,7 @@ CI="true" SEMGREP_REPO_NAME="a/repo/name" SEMGREP_REPO_URL="https://random.url.o
 
   SCAN ENVIRONMENT
   versions    - semgrep <MASKED> on python <MASKED>
-  environment - running in environment circleci, triggering event is
-                pull_request
+  environment - running in environment circleci, triggering event is pull_request
 
   CONNECTION
   Initializing scan (deployment=org_name, scan_id=12345)

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci/results.txt
@@ -24,12 +24,12 @@ CI="true" CIRCLECI="true" CIRCLE_PROJECT_USERNAME="project_name" CIRCLE_PROJECT_
             7┆ a == a
             ⋮┆----------------------------------------
            11┆ y == y
-            ⋮┆----------------------------------------
+
        eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
-            ⋮┆----------------------------------------
+
        taint-test
           unsafe use of danger
 
@@ -75,8 +75,7 @@ CI="true" CIRCLECI="true" CIRCLE_PROJECT_USERNAME="project_name" CIRCLE_PROJECT_
 
   SCAN ENVIRONMENT
   versions    - semgrep <MASKED> on python <MASKED>
-  environment - running in environment circleci, triggering event is
-                pull_request
+  environment - running in environment circleci, triggering event is pull_request
 
   CONNECTION
   Initializing scan (deployment=org_name, scan_id=12345)

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/results.txt
@@ -49,12 +49,12 @@ CI="true" GITHUB_ACTIONS="true" GITHUB_ACTOR="some_test_username" GITHUB_API_URL
             7┆ a == a
             ⋮┆----------------------------------------
            11┆ y == y
-            ⋮┆----------------------------------------
+
        eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
-            ⋮┆----------------------------------------
+
        taint-test
           unsafe use of danger
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr-semgrepconfig/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr-semgrepconfig/results.txt
@@ -18,8 +18,7 @@ CI="true" GITHUB_ACTIONS="true" GITHUB_ACTOR="some_test_username" GITHUB_API_URL
 
   SCAN ENVIRONMENT
   versions    - semgrep <MASKED> on python <MASKED>
-  environment - running in environment github-actions, triggering event is
-                pull_request
+  environment - running in environment github-actions, triggering event is pull_request
 Fixing git state for github action pull request
 Not on head ref: <MASKED>; checking that out now.
 
@@ -63,12 +62,12 @@ Creating git worktree from '<MASKED>' to scan baseline.
             7┆ a == a
             ⋮┆----------------------------------------
            11┆ y == y
-            ⋮┆----------------------------------------
+
        eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
-            ⋮┆----------------------------------------
+
        taint-test
           unsafe use of danger
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr/results.txt
@@ -15,8 +15,7 @@ CI="true" GITHUB_ACTIONS="true" GITHUB_ACTOR="some_test_username" GITHUB_API_URL
 
   SCAN ENVIRONMENT
   versions    - semgrep <MASKED> on python <MASKED>
-  environment - running in environment github-actions, triggering event is
-                pull_request
+  environment - running in environment github-actions, triggering event is pull_request
 Fixing git state for github action pull request
 Not on head ref: <MASKED>; checking that out now.
 
@@ -60,12 +59,12 @@ Creating git worktree from '<MASKED>' to scan baseline.
             7┆ a == a
             ⋮┆----------------------------------------
            11┆ y == y
-            ⋮┆----------------------------------------
+
        eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
-            ⋮┆----------------------------------------
+
        taint-test
           unsafe use of danger
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push-special-env-vars/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push-special-env-vars/results.txt
@@ -49,12 +49,12 @@ CI="true" GITHUB_ACTIONS="true" GITHUB_ACTOR="some_test_username" GITHUB_API_URL
             7┆ a == a
             ⋮┆----------------------------------------
            11┆ y == y
-            ⋮┆----------------------------------------
+
        eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
-            ⋮┆----------------------------------------
+
        taint-test
           unsafe use of danger
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/results.txt
@@ -49,12 +49,12 @@ CI="true" GITHUB_ACTIONS="true" GITHUB_ACTOR="some_test_username" GITHUB_API_URL
             7┆ a == a
             ⋮┆----------------------------------------
            11┆ y == y
-            ⋮┆----------------------------------------
+
        eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
-            ⋮┆----------------------------------------
+
        taint-test
           unsafe use of danger
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-push/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-push/results.txt
@@ -24,12 +24,12 @@ CI="true" GITLAB_CI="true" CI_PROJECT_PATH="project_name/project_name" CI_PIPELI
             7┆ a == a
             ⋮┆----------------------------------------
            11┆ y == y
-            ⋮┆----------------------------------------
+
        eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
-            ⋮┆----------------------------------------
+
        taint-test
           unsafe use of danger
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-special-env-vars/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-special-env-vars/results.txt
@@ -24,12 +24,12 @@ CI="true" GITLAB_CI="true" SEMGREP_REPO_NAME="project_name/project_name" CI_PIPE
             7┆ a == a
             ⋮┆----------------------------------------
            11┆ y == y
-            ⋮┆----------------------------------------
+
        eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
-            ⋮┆----------------------------------------
+
        taint-test
           unsafe use of danger
 
@@ -64,8 +64,7 @@ CI="true" GITLAB_CI="true" SEMGREP_REPO_NAME="project_name/project_name" CI_PIPE
 
   SCAN ENVIRONMENT
   versions    - semgrep <MASKED> on python <MASKED>
-  environment - running in environment gitlab-ci, triggering event is
-                pull_request
+  environment - running in environment gitlab-ci, triggering event is pull_request
 
   CONNECTION
   Initializing scan (deployment=org_name, scan_id=12345)

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab/results.txt
@@ -24,12 +24,12 @@ CI="true" GITLAB_CI="true" CI_PROJECT_PATH="project_name/project_name" CI_PIPELI
             7┆ a == a
             ⋮┆----------------------------------------
            11┆ y == y
-            ⋮┆----------------------------------------
+
        eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
-            ⋮┆----------------------------------------
+
        taint-test
           unsafe use of danger
 
@@ -64,8 +64,7 @@ CI="true" GITLAB_CI="true" CI_PROJECT_PATH="project_name/project_name" CI_PIPELI
 
   SCAN ENVIRONMENT
   versions    - semgrep <MASKED> on python <MASKED>
-  environment - running in environment gitlab-ci, triggering event is
-                pull_request
+  environment - running in environment gitlab-ci, triggering event is pull_request
 
   CONNECTION
   Initializing scan (deployment=org_name, scan_id=12345)

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/results.txt
@@ -24,12 +24,12 @@ JENKINS_URL="some_url" SEMGREP_REPO_URL="https://random.url.org/some/path" SEMGR
             7┆ a == a
             ⋮┆----------------------------------------
            11┆ y == y
-            ⋮┆----------------------------------------
+
        eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
-            ⋮┆----------------------------------------
+
        taint-test
           unsafe use of danger
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-overwrite-autodetected-variables/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-overwrite-autodetected-variables/results.txt
@@ -24,12 +24,12 @@ JENKINS_URL="some_url" SEMGREP_REPO_NAME="a/repo/name" SEMGREP_REPO_URL="https:/
             7┆ a == a
             ⋮┆----------------------------------------
            11┆ y == y
-            ⋮┆----------------------------------------
+
        eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
-            ⋮┆----------------------------------------
+
        taint-test
           unsafe use of danger
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins/results.txt
@@ -24,12 +24,12 @@ JENKINS_URL="some_url" GIT_URL="https://github.com/org/repo.git/" GIT_BRANCH="so
             7┆ a == a
             ⋮┆----------------------------------------
            11┆ y == y
-            ⋮┆----------------------------------------
+
        eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
-            ⋮┆----------------------------------------
+
        taint-test
           unsafe use of danger
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/results.txt
@@ -24,12 +24,12 @@ SEMGREP_APP_TOKEN="fake-key-from-tests" SEMGREP_REPO_URL="git@github.com:example
             7┆ a == a
             ⋮┆----------------------------------------
            11┆ y == y
-            ⋮┆----------------------------------------
+
        eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
-            ⋮┆----------------------------------------
+
        taint-test
           unsafe use of danger
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-self-hosted/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-self-hosted/results.txt
@@ -24,12 +24,12 @@ CI="true" SEMGREP_REPO_NAME="org_name/project_name/project_name" SEMGREP_REPO_UR
             7┆ a == a
             ⋮┆----------------------------------------
            11┆ y == y
-            ⋮┆----------------------------------------
+
        eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
-            ⋮┆----------------------------------------
+
        taint-test
           unsafe use of danger
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis-overwrite-autodetected-variables/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis-overwrite-autodetected-variables/results.txt
@@ -24,12 +24,12 @@ CI="true" TRAVIS="true" SEMGREP_REPO_NAME="a/repo/name" SEMGREP_REPO_URL="https:
             7┆ a == a
             ⋮┆----------------------------------------
            11┆ y == y
-            ⋮┆----------------------------------------
+
        eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
-            ⋮┆----------------------------------------
+
        taint-test
           unsafe use of danger
 
@@ -75,8 +75,7 @@ CI="true" TRAVIS="true" SEMGREP_REPO_NAME="a/repo/name" SEMGREP_REPO_URL="https:
 
   SCAN ENVIRONMENT
   versions    - semgrep <MASKED> on python <MASKED>
-  environment - running in environment travis-ci, triggering event is
-                pull_request
+  environment - running in environment travis-ci, triggering event is pull_request
 
   CONNECTION
   Initializing scan (deployment=org_name, scan_id=12345)

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis/results.txt
@@ -24,12 +24,12 @@ CI="true" TRAVIS="true" TRAVIS_REPO_SLUG="project_name/project_name" TRAVIS_PULL
             7┆ a == a
             ⋮┆----------------------------------------
            11┆ y == y
-            ⋮┆----------------------------------------
+
        eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
-            ⋮┆----------------------------------------
+
        taint-test
           unsafe use of danger
 
@@ -75,8 +75,7 @@ CI="true" TRAVIS="true" TRAVIS_REPO_SLUG="project_name/project_name" TRAVIS_PULL
 
   SCAN ENVIRONMENT
   versions    - semgrep <MASKED> on python <MASKED>
-  environment - running in environment travis-ci, triggering event is
-                pull_request
+  environment - running in environment travis-ci, triggering event is pull_request
 
   CONNECTION
   Initializing scan (deployment=org_name, scan_id=12345)

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-unparsable_url/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-unparsable_url/results.txt
@@ -24,12 +24,12 @@ CI="true" SEMGREP_REPO_NAME="org_name/project_name/project_name" SEMGREP_REPO_UR
             7┆ a == a
             ⋮┆----------------------------------------
            11┆ y == y
-            ⋮┆----------------------------------------
+
        eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
-            ⋮┆----------------------------------------
+
        taint-test
           unsafe use of danger
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines-overwrite-autodetected-variables/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines-overwrite-autodetected-variables/results.txt
@@ -24,12 +24,12 @@ BUILD_BUILDID="some_id" SEMGREP_REPO_NAME="a/repo/name" SEMGREP_REPO_URL="https:
             7┆ a == a
             ⋮┆----------------------------------------
            11┆ y == y
-            ⋮┆----------------------------------------
+
        eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
-            ⋮┆----------------------------------------
+
        taint-test
           unsafe use of danger
 
@@ -75,8 +75,7 @@ BUILD_BUILDID="some_id" SEMGREP_REPO_NAME="a/repo/name" SEMGREP_REPO_URL="https:
 
   SCAN ENVIRONMENT
   versions    - semgrep <MASKED> on python <MASKED>
-  environment - running in environment azure-pipelines, triggering event is
-                pull_request
+  environment - running in environment azure-pipelines, triggering event is pull_request
 
   CONNECTION
   Initializing scan (deployment=org_name, scan_id=12345)

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines/results.txt
@@ -24,12 +24,12 @@ BUILD_BUILDID="some_id" BUILD_REPOSITORY_URI="https://github.com/project_name/pr
             7┆ a == a
             ⋮┆----------------------------------------
            11┆ y == y
-            ⋮┆----------------------------------------
+
        eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
-            ⋮┆----------------------------------------
+
        taint-test
           unsafe use of danger
 
@@ -75,8 +75,7 @@ BUILD_BUILDID="some_id" BUILD_REPOSITORY_URI="https://github.com/project_name/pr
 
   SCAN ENVIRONMENT
   versions    - semgrep <MASKED> on python <MASKED>
-  environment - running in environment azure-pipelines, triggering event is
-                pull_request
+  environment - running in environment azure-pipelines, triggering event is pull_request
 
   CONNECTION
   Initializing scan (deployment=org_name, scan_id=12345)

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket-overwrite-autodetected-variables/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket-overwrite-autodetected-variables/results.txt
@@ -24,12 +24,12 @@ CI="true" BITBUCKET_BUILD_NUMBER="hi" SEMGREP_REPO_NAME="a/repo/name" SEMGREP_RE
             7┆ a == a
             ⋮┆----------------------------------------
            11┆ y == y
-            ⋮┆----------------------------------------
+
        eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
-            ⋮┆----------------------------------------
+
        taint-test
           unsafe use of danger
 
@@ -75,8 +75,7 @@ CI="true" BITBUCKET_BUILD_NUMBER="hi" SEMGREP_REPO_NAME="a/repo/name" SEMGREP_RE
 
   SCAN ENVIRONMENT
   versions    - semgrep <MASKED> on python <MASKED>
-  environment - running in environment bitbucket, triggering event is
-                pull_request
+  environment - running in environment bitbucket, triggering event is pull_request
 
   CONNECTION
   Initializing scan (deployment=org_name, scan_id=12345)

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket/results.txt
@@ -24,12 +24,12 @@ CI="true" BITBUCKET_BUILD_NUMBER="hi" BITBUCKET_REPO_FULL_NAME="project_name/pro
             7┆ a == a
             ⋮┆----------------------------------------
            11┆ y == y
-            ⋮┆----------------------------------------
+
        eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
-            ⋮┆----------------------------------------
+
        taint-test
           unsafe use of danger
 
@@ -75,8 +75,7 @@ CI="true" BITBUCKET_BUILD_NUMBER="hi" BITBUCKET_REPO_FULL_NAME="project_name/pro
 
   SCAN ENVIRONMENT
   versions    - semgrep <MASKED> on python <MASKED>
-  environment - running in environment bitbucket, triggering event is
-                pull_request
+  environment - running in environment bitbucket, triggering event is pull_request
 
   CONNECTION
   Initializing scan (deployment=org_name, scan_id=12345)

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite-overwrite-autodetected-variables/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite-overwrite-autodetected-variables/results.txt
@@ -24,12 +24,12 @@ BUILDKITE="true" SEMGREP_REPO_NAME="a/repo/name" SEMGREP_REPO_URL="https://rando
             7┆ a == a
             ⋮┆----------------------------------------
            11┆ y == y
-            ⋮┆----------------------------------------
+
        eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
-            ⋮┆----------------------------------------
+
        taint-test
           unsafe use of danger
 
@@ -75,8 +75,7 @@ BUILDKITE="true" SEMGREP_REPO_NAME="a/repo/name" SEMGREP_REPO_URL="https://rando
 
   SCAN ENVIRONMENT
   versions    - semgrep <MASKED> on python <MASKED>
-  environment - running in environment buildkite, triggering event is
-                pull_request
+  environment - running in environment buildkite, triggering event is pull_request
 
   CONNECTION
   Initializing scan (deployment=org_name, scan_id=12345)

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite/results.txt
@@ -24,12 +24,12 @@ BUILDKITE="true" BUILDKITE_REPO="git@github.com/project_name/project_name.git" B
             7┆ a == a
             ⋮┆----------------------------------------
            11┆ y == y
-            ⋮┆----------------------------------------
+
        eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
-            ⋮┆----------------------------------------
+
        taint-test
           unsafe use of danger
 
@@ -75,8 +75,7 @@ BUILDKITE="true" BUILDKITE_REPO="git@github.com/project_name/project_name.git" B
 
   SCAN ENVIRONMENT
   versions    - semgrep <MASKED> on python <MASKED>
-  environment - running in environment buildkite, triggering event is
-                pull_request
+  environment - running in environment buildkite, triggering event is pull_request
 
   CONNECTION
   Initializing scan (deployment=org_name, scan_id=12345)

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci-overwrite-autodetected-variables/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci-overwrite-autodetected-variables/results.txt
@@ -24,12 +24,12 @@ CI="true" SEMGREP_REPO_NAME="a/repo/name" SEMGREP_REPO_URL="https://random.url.o
             7┆ a == a
             ⋮┆----------------------------------------
            11┆ y == y
-            ⋮┆----------------------------------------
+
        eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
-            ⋮┆----------------------------------------
+
        taint-test
           unsafe use of danger
 
@@ -75,8 +75,7 @@ CI="true" SEMGREP_REPO_NAME="a/repo/name" SEMGREP_REPO_URL="https://random.url.o
 
   SCAN ENVIRONMENT
   versions    - semgrep <MASKED> on python <MASKED>
-  environment - running in environment circleci, triggering event is
-                pull_request
+  environment - running in environment circleci, triggering event is pull_request
 
   CONNECTION
   Initializing scan (deployment=org_name, scan_id=12345)

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci/results.txt
@@ -24,12 +24,12 @@ CI="true" CIRCLECI="true" CIRCLE_PROJECT_USERNAME="project_name" CIRCLE_PROJECT_
             7┆ a == a
             ⋮┆----------------------------------------
            11┆ y == y
-            ⋮┆----------------------------------------
+
        eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
-            ⋮┆----------------------------------------
+
        taint-test
           unsafe use of danger
 
@@ -75,8 +75,7 @@ CI="true" CIRCLECI="true" CIRCLE_PROJECT_USERNAME="project_name" CIRCLE_PROJECT_
 
   SCAN ENVIRONMENT
   versions    - semgrep <MASKED> on python <MASKED>
-  environment - running in environment circleci, triggering event is
-                pull_request
+  environment - running in environment circleci, triggering event is pull_request
 
   CONNECTION
   Initializing scan (deployment=org_name, scan_id=12345)

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/results.txt
@@ -49,12 +49,12 @@ CI="true" GITHUB_ACTIONS="true" GITHUB_ACTOR="some_test_username" GITHUB_API_URL
             7┆ a == a
             ⋮┆----------------------------------------
            11┆ y == y
-            ⋮┆----------------------------------------
+
        eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
-            ⋮┆----------------------------------------
+
        taint-test
           unsafe use of danger
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr-semgrepconfig/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr-semgrepconfig/results.txt
@@ -18,8 +18,7 @@ CI="true" GITHUB_ACTIONS="true" GITHUB_ACTOR="some_test_username" GITHUB_API_URL
 
   SCAN ENVIRONMENT
   versions    - semgrep <MASKED> on python <MASKED>
-  environment - running in environment github-actions, triggering event is
-                pull_request
+  environment - running in environment github-actions, triggering event is pull_request
 Fixing git state for github action pull request
 Not on head ref: <MASKED>; checking that out now.
 
@@ -63,12 +62,12 @@ Creating git worktree from '<MASKED>' to scan baseline.
             7┆ a == a
             ⋮┆----------------------------------------
            11┆ y == y
-            ⋮┆----------------------------------------
+
        eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
-            ⋮┆----------------------------------------
+
        taint-test
           unsafe use of danger
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr/results.txt
@@ -15,8 +15,7 @@ CI="true" GITHUB_ACTIONS="true" GITHUB_ACTOR="some_test_username" GITHUB_API_URL
 
   SCAN ENVIRONMENT
   versions    - semgrep <MASKED> on python <MASKED>
-  environment - running in environment github-actions, triggering event is
-                pull_request
+  environment - running in environment github-actions, triggering event is pull_request
 Fixing git state for github action pull request
 Not on head ref: <MASKED>; checking that out now.
 
@@ -60,12 +59,12 @@ Creating git worktree from '<MASKED>' to scan baseline.
             7┆ a == a
             ⋮┆----------------------------------------
            11┆ y == y
-            ⋮┆----------------------------------------
+
        eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
-            ⋮┆----------------------------------------
+
        taint-test
           unsafe use of danger
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push-special-env-vars/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push-special-env-vars/results.txt
@@ -49,12 +49,12 @@ CI="true" GITHUB_ACTIONS="true" GITHUB_ACTOR="some_test_username" GITHUB_API_URL
             7┆ a == a
             ⋮┆----------------------------------------
            11┆ y == y
-            ⋮┆----------------------------------------
+
        eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
-            ⋮┆----------------------------------------
+
        taint-test
           unsafe use of danger
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/results.txt
@@ -49,12 +49,12 @@ CI="true" GITHUB_ACTIONS="true" GITHUB_ACTOR="some_test_username" GITHUB_API_URL
             7┆ a == a
             ⋮┆----------------------------------------
            11┆ y == y
-            ⋮┆----------------------------------------
+
        eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
-            ⋮┆----------------------------------------
+
        taint-test
           unsafe use of danger
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-push/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-push/results.txt
@@ -24,12 +24,12 @@ CI="true" GITLAB_CI="true" CI_PROJECT_PATH="project_name/project_name" CI_PIPELI
             7┆ a == a
             ⋮┆----------------------------------------
            11┆ y == y
-            ⋮┆----------------------------------------
+
        eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
-            ⋮┆----------------------------------------
+
        taint-test
           unsafe use of danger
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-special-env-vars/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-special-env-vars/results.txt
@@ -24,12 +24,12 @@ CI="true" GITLAB_CI="true" SEMGREP_REPO_NAME="project_name/project_name" CI_PIPE
             7┆ a == a
             ⋮┆----------------------------------------
            11┆ y == y
-            ⋮┆----------------------------------------
+
        eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
-            ⋮┆----------------------------------------
+
        taint-test
           unsafe use of danger
 
@@ -64,8 +64,7 @@ CI="true" GITLAB_CI="true" SEMGREP_REPO_NAME="project_name/project_name" CI_PIPE
 
   SCAN ENVIRONMENT
   versions    - semgrep <MASKED> on python <MASKED>
-  environment - running in environment gitlab-ci, triggering event is
-                pull_request
+  environment - running in environment gitlab-ci, triggering event is pull_request
 
   CONNECTION
   Initializing scan (deployment=org_name, scan_id=12345)

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab/results.txt
@@ -24,12 +24,12 @@ CI="true" GITLAB_CI="true" CI_PROJECT_PATH="project_name/project_name" CI_PIPELI
             7┆ a == a
             ⋮┆----------------------------------------
            11┆ y == y
-            ⋮┆----------------------------------------
+
        eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
-            ⋮┆----------------------------------------
+
        taint-test
           unsafe use of danger
 
@@ -64,8 +64,7 @@ CI="true" GITLAB_CI="true" CI_PROJECT_PATH="project_name/project_name" CI_PIPELI
 
   SCAN ENVIRONMENT
   versions    - semgrep <MASKED> on python <MASKED>
-  environment - running in environment gitlab-ci, triggering event is
-                pull_request
+  environment - running in environment gitlab-ci, triggering event is pull_request
 
   CONNECTION
   Initializing scan (deployment=org_name, scan_id=12345)

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/results.txt
@@ -24,12 +24,12 @@ JENKINS_URL="some_url" SEMGREP_REPO_URL="https://random.url.org/some/path" SEMGR
             7┆ a == a
             ⋮┆----------------------------------------
            11┆ y == y
-            ⋮┆----------------------------------------
+
        eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
-            ⋮┆----------------------------------------
+
        taint-test
           unsafe use of danger
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-overwrite-autodetected-variables/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-overwrite-autodetected-variables/results.txt
@@ -24,12 +24,12 @@ JENKINS_URL="some_url" SEMGREP_REPO_NAME="a/repo/name" SEMGREP_REPO_URL="https:/
             7┆ a == a
             ⋮┆----------------------------------------
            11┆ y == y
-            ⋮┆----------------------------------------
+
        eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
-            ⋮┆----------------------------------------
+
        taint-test
           unsafe use of danger
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins/results.txt
@@ -24,12 +24,12 @@ JENKINS_URL="some_url" GIT_URL="https://github.com/org/repo.git/" GIT_BRANCH="so
             7┆ a == a
             ⋮┆----------------------------------------
            11┆ y == y
-            ⋮┆----------------------------------------
+
        eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
-            ⋮┆----------------------------------------
+
        taint-test
           unsafe use of danger
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/results.txt
@@ -24,12 +24,12 @@ SEMGREP_APP_TOKEN="fake-key-from-tests" SEMGREP_REPO_URL="git@github.com:example
             7┆ a == a
             ⋮┆----------------------------------------
            11┆ y == y
-            ⋮┆----------------------------------------
+
        eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
-            ⋮┆----------------------------------------
+
        taint-test
           unsafe use of danger
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-self-hosted/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-self-hosted/results.txt
@@ -24,12 +24,12 @@ CI="true" SEMGREP_REPO_NAME="org_name/project_name/project_name" SEMGREP_REPO_UR
             7┆ a == a
             ⋮┆----------------------------------------
            11┆ y == y
-            ⋮┆----------------------------------------
+
        eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
-            ⋮┆----------------------------------------
+
        taint-test
           unsafe use of danger
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis-overwrite-autodetected-variables/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis-overwrite-autodetected-variables/results.txt
@@ -24,12 +24,12 @@ CI="true" TRAVIS="true" SEMGREP_REPO_NAME="a/repo/name" SEMGREP_REPO_URL="https:
             7┆ a == a
             ⋮┆----------------------------------------
            11┆ y == y
-            ⋮┆----------------------------------------
+
        eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
-            ⋮┆----------------------------------------
+
        taint-test
           unsafe use of danger
 
@@ -75,8 +75,7 @@ CI="true" TRAVIS="true" SEMGREP_REPO_NAME="a/repo/name" SEMGREP_REPO_URL="https:
 
   SCAN ENVIRONMENT
   versions    - semgrep <MASKED> on python <MASKED>
-  environment - running in environment travis-ci, triggering event is
-                pull_request
+  environment - running in environment travis-ci, triggering event is pull_request
 
   CONNECTION
   Initializing scan (deployment=org_name, scan_id=12345)

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis/results.txt
@@ -24,12 +24,12 @@ CI="true" TRAVIS="true" TRAVIS_REPO_SLUG="project_name/project_name" TRAVIS_PULL
             7┆ a == a
             ⋮┆----------------------------------------
            11┆ y == y
-            ⋮┆----------------------------------------
+
        eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
-            ⋮┆----------------------------------------
+
        taint-test
           unsafe use of danger
 
@@ -75,8 +75,7 @@ CI="true" TRAVIS="true" TRAVIS_REPO_SLUG="project_name/project_name" TRAVIS_PULL
 
   SCAN ENVIRONMENT
   versions    - semgrep <MASKED> on python <MASKED>
-  environment - running in environment travis-ci, triggering event is
-                pull_request
+  environment - running in environment travis-ci, triggering event is pull_request
 
   CONNECTION
   Initializing scan (deployment=org_name, scan_id=12345)

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-unparsable_url/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-unparsable_url/results.txt
@@ -24,12 +24,12 @@ CI="true" SEMGREP_REPO_NAME="org_name/project_name/project_name" SEMGREP_REPO_UR
             7┆ a == a
             ⋮┆----------------------------------------
            11┆ y == y
-            ⋮┆----------------------------------------
+
        eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
-            ⋮┆----------------------------------------
+
        taint-test
           unsafe use of danger
 

--- a/cli/tests/e2e/snapshots/test_ci/test_lockfile_parse_failure_reporting/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_lockfile_parse_failure_reporting/results.txt
@@ -24,12 +24,12 @@ SEMGREP_APP_TOKEN="fake-key-from-tests" SEMGREP_USER_AGENT_APPEND="pytest" SEMGR
             7┆ a == a
             ⋮┆----------------------------------------
            11┆ y == y
-            ⋮┆----------------------------------------
+
        eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
-            ⋮┆----------------------------------------
+
        taint-test
           unsafe use of danger
 
@@ -92,9 +92,8 @@ SEMGREP_APP_TOKEN="fake-key-from-tests" SEMGREP_USER_AGENT_APPEND="pytest" SEMGR
 
   SUPPLY CHAIN RULES
   Scanning 1 file.
-  Failed to parse [bold]Pipfile.lock[/bold] at [bold]2:1[/bold] - expected one
-  of ['"', '-?(0|[1-9][0-9]*)([.][0-9]+)?([eE][+-]?[0-9]+)?', '[', 'false',
-  'null', 'true', '{']
+  Failed to parse [bold]Pipfile.lock[/bold] at [bold]2:1[/bold] - expected one of ['"',
+  '-?(0|[1-9][0-9]*)([.][0-9]+)?([eE][+-]?[0-9]+)?', '[', 'false', 'null', 'true', '{']
   2 | invalid
       ^
 

--- a/cli/tests/e2e/snapshots/test_ci/test_nosem/autofix---disable-nosem/output.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_nosem/autofix---disable-nosem/output.txt
@@ -30,14 +30,14 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
            11┆ y == y
             ⋮┆----------------------------------------
            13┆ z == z  # nosemgrep
-            ⋮┆----------------------------------------
+
        eqeq-four
           useless comparison to 4
 
            18┆ baz == 4  # nosemgrep
             ⋮┆----------------------------------------
            19┆ baz == 4
-            ⋮┆----------------------------------------
+
        taint-test
           unsafe use of danger
 

--- a/cli/tests/e2e/snapshots/test_ci/test_nosem/autofix---enable-nosem/output.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_nosem/autofix---enable-nosem/output.txt
@@ -24,12 +24,12 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
             7┆ a == a
             ⋮┆----------------------------------------
            11┆ y == y
-            ⋮┆----------------------------------------
+
        eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
-            ⋮┆----------------------------------------
+
        taint-test
           unsafe use of danger
 

--- a/cli/tests/e2e/snapshots/test_ci/test_nosem/noautofix---disable-nosem/output.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_nosem/noautofix---disable-nosem/output.txt
@@ -30,14 +30,14 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
            11┆ y == y
             ⋮┆----------------------------------------
            13┆ z == z  # nosemgrep
-            ⋮┆----------------------------------------
+
        eqeq-four
           useless comparison to 4
 
            18┆ baz == 4  # nosemgrep
             ⋮┆----------------------------------------
            19┆ baz == 4
-            ⋮┆----------------------------------------
+
        taint-test
           unsafe use of danger
 

--- a/cli/tests/e2e/snapshots/test_ci/test_nosem/noautofix---enable-nosem/output.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_nosem/noautofix---enable-nosem/output.txt
@@ -24,12 +24,12 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
             7┆ a == a
             ⋮┆----------------------------------------
            11┆ y == y
-            ⋮┆----------------------------------------
+
        eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
-            ⋮┆----------------------------------------
+
        taint-test
           unsafe use of danger
 

--- a/cli/tests/e2e/snapshots/test_ci/test_shallow_wrong_merge_base/bad_results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_shallow_wrong_merge_base/bad_results.txt
@@ -15,8 +15,7 @@ CI="true" GITHUB_ACTIONS="true" GITHUB_EVENT_NAME="pull_request" GITHUB_REPOSITO
 
   SCAN ENVIRONMENT
   versions    - semgrep <MASKED> on python <MASKED>
-  environment - running in environment github-actions, triggering event is
-                pull_request
+  environment - running in environment github-actions, triggering event is pull_request
 Fixing git state for github action pull request
 Not on head ref: 7b5cda417c780f1f96c888e1d7bd062f46df236e; checking that out now.
 

--- a/cli/tests/e2e/snapshots/test_ci/test_shallow_wrong_merge_base/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_shallow_wrong_merge_base/results.txt
@@ -15,8 +15,7 @@ CI="true" GITHUB_ACTIONS="true" GITHUB_EVENT_NAME="pull_request" GITHUB_REPOSITO
 
   SCAN ENVIRONMENT
   versions    - semgrep <MASKED> on python <MASKED>
-  environment - running in environment github-actions, triggering event is
-                pull_request
+  environment - running in environment github-actions, triggering event is pull_request
 Fixing git state for github action pull request
 Not on head ref: 7b5cda417c780f1f96c888e1d7bd062f46df236e; checking that out now.
 

--- a/cli/tests/e2e/snapshots/test_cli_test/test_cli_test_match_rules_same_message/results.txt
+++ b/cli/tests/e2e/snapshots/test_cli_test/test_cli_test_match_rules_same_message/results.txt
@@ -5,12 +5,12 @@
 └─────────────────┘
 
   [36m[22m[24m  targets/cli_test/basic/basic.py [0m
-      [1m rules.cli_test.match_rules_same_message.rule1[0m
+       [1mrules.cli_test.match_rules_same_message.rule1[0m
           Same message as other rule.
 
             2┆ print([1m1 == 1[0m)
-            ⋮┆----------------------------------------
-      [1m rules.cli_test.match_rules_same_message.rule2[0m
+
+       [1mrules.cli_test.match_rules_same_message.rule2[0m
           Same message as other rule.
 
             2┆ print([1m1 == 1[0m)

--- a/cli/tests/e2e/snapshots/test_cli_test/test_cli_test_match_rules_same_message/results.txt
+++ b/cli/tests/e2e/snapshots/test_cli_test/test_cli_test_match_rules_same_message/results.txt
@@ -5,13 +5,13 @@
 └─────────────────┘
 
   [36m[22m[24m  targets/cli_test/basic/basic.py [0m
-       [1m[24mrules.cli_test.match_rules_same_message.rule1[0m
+      [1m rules.cli_test.match_rules_same_message.rule1[0m
           Same message as other rule.
 
-            2┆ print([1m[24m1 == 1[0m)
+            2┆ print([1m1 == 1[0m)
             ⋮┆----------------------------------------
-       [1m[24mrules.cli_test.match_rules_same_message.rule2[0m
+      [1m rules.cli_test.match_rules_same_message.rule2[0m
           Same message as other rule.
 
-            2┆ print([1m[24m1 == 1[0m)
+            2┆ print([1m1 == 1[0m)
 

--- a/cli/tests/e2e/snapshots/test_cli_test/test_cli_test_time/results.txt
+++ b/cli/tests/e2e/snapshots/test_cli_test/test_cli_test_time/results.txt
@@ -5,23 +5,20 @@
 └────────────────┘
 
   [36m[22m[24m  targets/cli_test/basic/basic.py [0m
-       [1m[24mrules.cli_test.basic.basic-test[0m
+      [1m rules.cli_test.basic.basic-test[0m
           Basic test
 
-            2┆ print([1m[x.xxx == 1[0m)
+            2┆ print([x.xxx == 1[0m)
 
   ============================[ summary ]============================
   Total time: x.xxxs Config time: x.xxxs Core time: x.xxxs
 
   Semgrep-core time:
-  Total CPU time: x.xxxs  File parse time: x.xxxs  Rule parse time: x.xxxs
-  Match time: x.xxxs
+  Total CPU time: x.xxxs  File parse time: x.xxxs  Rule parse time: x.xxxs  Match time: x.xxxs
   Slowest x.xxx files
-  [32m[22m[24mtargets/cli_test/basic/basic.py                   [0m ( 35B):
-  x.xxxs (x.xxxs to parse)
+  [32m[22m[24mtargets/cli_test/basic/basic.py                   [0m ( 35B):  x.xxxs (x.xxxs to parse)
   Slowest 5 rules to match
-  [33m[22m[24mrules.cli_test.basic.basic-test:                           [0m
-  x.xxxs
+  [33m[22m[24mrules.cli_test.basic.basic-test:                           [0m x.xxxs
   Analyzed: 1 python files ( 35B in x.xxx seconds)
   Errors:   0 files with errors
 

--- a/cli/tests/e2e/snapshots/test_cli_test/test_cli_test_time/results.txt
+++ b/cli/tests/e2e/snapshots/test_cli_test/test_cli_test_time/results.txt
@@ -5,7 +5,7 @@
 └────────────────┘
 
   [36m[22m[24m  targets/cli_test/basic/basic.py [0m
-      [1m rules.cli_test.basic.basic-test[0m
+       [1mrules.cli_test.basic.basic-test[0m
           Basic test
 
             2┆ print([x.xxx == 1[0m)

--- a/cli/tests/e2e/snapshots/test_cli_test/test_cli_test_verbose/results.txt
+++ b/cli/tests/e2e/snapshots/test_cli_test/test_cli_test_verbose/results.txt
@@ -5,7 +5,7 @@
 └────────────────┘
 
   [36m[22m[24m  targets/cli_test/basic/basic.py [0m
-      [1m rules.cli_test.basic.basic-test[0m
+       [1mrules.cli_test.basic.basic-test[0m
           Basic test
 
             2┆ print([x.xxx == 1[0m)

--- a/cli/tests/e2e/snapshots/test_cli_test/test_cli_test_verbose/results.txt
+++ b/cli/tests/e2e/snapshots/test_cli_test/test_cli_test_verbose/results.txt
@@ -5,8 +5,8 @@
 └────────────────┘
 
   [36m[22m[24m  targets/cli_test/basic/basic.py [0m
-       [1m[24mrules.cli_test.basic.basic-test[0m
+      [1m rules.cli_test.basic.basic-test[0m
           Basic test
 
-            2┆ print([1m[x.xxx == 1[0m)
+            2┆ print([x.xxx == 1[0m)
 

--- a/cli/tests/e2e/snapshots/test_cli_test/test_parse_errors/errors.txt
+++ b/cli/tests/e2e/snapshots/test_cli_test/test_parse_errors/errors.txt
@@ -27,8 +27,7 @@ Files skipped:
    • <all files not listed by `git ls-files` were skipped>
 
   [1m[24mSkipped by .semgrepignore:[0m
-  [1m[24m(See: https://semgrep.dev/docs/ignoring-files-folders-code/#understanding-semgrep-
-  defaults)[0m
+  [1m[24m(See: https://semgrep.dev/docs/ignoring-files-folders-code/#understanding-semgrep-defaults)[0m
 
    • <none>
 

--- a/cli/tests/e2e/snapshots/test_cli_test/test_parse_errors/errors.txt
+++ b/cli/tests/e2e/snapshots/test_cli_test/test_parse_errors/errors.txt
@@ -27,7 +27,7 @@ Files skipped:
    • <all files not listed by `git ls-files` were skipped>
 
   [1m[24mSkipped by .semgrepignore:[0m
-  [1m[24m(See: https://semgrep.dev/docs/ignoring-files-folders-code/#understanding-semgrep-defaults)[0m
+  [1m[24m- https://semgrep.dev/docs/ignoring-files-folders-code/#understanding-semgrep-defaults[0m
 
    • <none>
 

--- a/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awareawscli_vuln.yaml-dependency_awareawscli-with-manifest/results.txt
+++ b/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awareawscli_vuln.yaml-dependency_awareawscli-with-manifest/results.txt
@@ -444,8 +444,9 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
   SUPPLY CHAIN RULES
 
   Ecosystem   Rules   Files   Lockfiles
- ───────────────────────────────────────────────────────────────────────────────
-  Pypi            6       1   targets/dependency_aware/awscli-with-manifest/Pi…
+ ────────────────────────────────────────────────────────────────────────────────────────
+  Pypi            6       1   targets/dependency_aware/awscli-with-manifest/Pipfile.lock
+
 
   Analysis   Rules
  ──────────────────

--- a/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awareawscli_vuln.yaml-dependency_awareawscli/results.txt
+++ b/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awareawscli_vuln.yaml-dependency_awareawscli/results.txt
@@ -447,6 +447,7 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
  ──────────────────────────────────────────────────────────────────────────
   Pypi            6       1   targets/dependency_aware/awscli/Pipfile.lock
 
+
   Analysis   Rules
  ──────────────────
   Unknown        6

--- a/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awarejs-pnpm-sca.yaml-dependency_awarepnpm-workspaces/results.txt
+++ b/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awarejs-pnpm-sca.yaml-dependency_awarepnpm-workspaces/results.txt
@@ -129,8 +129,9 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
   SUPPLY CHAIN RULES
 
   Ecosystem   Rules   Files   Lockfiles
- ───────────────────────────────────────────────────────────────────────────────
-  Npm             2       1   targets/dependency_aware/pnpm-workspaces/pnpm-lo…
+ ─────────────────────────────────────────────────────────────────────────────────────
+  Npm             2       1   targets/dependency_aware/pnpm-workspaces/pnpm-lock.yaml
+
 
   Analysis   Rules
  ──────────────────

--- a/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awarejs-pnpm-sca.yaml-dependency_awarepnpm/results.txt
+++ b/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awarejs-pnpm-sca.yaml-dependency_awarepnpm/results.txt
@@ -87,6 +87,7 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
  ──────────────────────────────────────────────────────────────────────────
   Npm             2       1   targets/dependency_aware/pnpm/pnpm-lock.yaml
 
+
   Analysis   Rules
  ──────────────────
   Unknown        2

--- a/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awarepython-poetry-sca.yaml-dependency_awaremanifest_parse_error/results.txt
+++ b/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awarepython-poetry-sca.yaml-dependency_awaremanifest_parse_error/results.txt
@@ -81,11 +81,8 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
 
   SUPPLY CHAIN RULES
   Nothing to scan.
-  Failed to parse
-  [bold]targets/dependency_aware/manifest_parse_error/pyproject.toml[/bold] at
-  [bold]3:1[/bold] - expected one of ['\n', '\n+',
-  '("[^"]*"|[^\\s=]+)\\s*=\\s*', 'EOF', '[', '[[',
-  '[tool.poetry.dependencies]\n']
+  Failed to parse [bold]targets/dependency_aware/manifest_parse_error/pyproject.toml[/bold] at [bold]3:1[/bold] -
+  expected one of ['\n', '\n+', '("[^"]*"|[^\\s=]+)\\s*=\\s*', 'EOF', '[', '[[', '[tool.poetry.dependencies]\n']
   3 | name ~ "test"
       ^
 

--- a/cli/tests/e2e/snapshots/test_exclude_include/test_exclude_include_verbose_sorted_1/results.err
+++ b/cli/tests/e2e/snapshots/test_exclude_include/test_exclude_include_verbose_sorted_1/results.err
@@ -27,7 +27,7 @@ Files skipped:
    • <all files not listed by `git ls-files` were skipped>
 
   Skipped by .semgrepignore:
-  (See: https://semgrep.dev/docs/ignoring-files-folders-code/#understanding-semgrep-defaults)
+  - https://semgrep.dev/docs/ignoring-files-folders-code/#understanding-semgrep-defaults
 
    • <none>
 

--- a/cli/tests/e2e/snapshots/test_exclude_include/test_exclude_include_verbose_sorted_2/results.err
+++ b/cli/tests/e2e/snapshots/test_exclude_include/test_exclude_include_verbose_sorted_2/results.err
@@ -24,7 +24,7 @@ Files skipped:
    • <all files not listed by `git ls-files` were skipped>
 
   Skipped by .semgrepignore:
-  (See: https://semgrep.dev/docs/ignoring-files-folders-code/#understanding-semgrep-defaults)
+  - https://semgrep.dev/docs/ignoring-files-folders-code/#understanding-semgrep-defaults
 
    • <none>
 

--- a/cli/tests/e2e/snapshots/test_output/test_debug_experimental_rule/results.txt
+++ b/cli/tests/e2e/snapshots/test_output/test_debug_experimental_rule/results.txt
@@ -64,7 +64,7 @@ Files skipped:
    • <all files not listed by `git ls-files` were skipped>
 
   Skipped by .semgrepignore:
-  (See: https://semgrep.dev<MASKED>
+  - https://semgrep.dev<MASKED>
 
    • <none>
 

--- a/cli/tests/e2e/snapshots/test_output/test_long_rule_id/results.out
+++ b/cli/tests/e2e/snapshots/test_output/test_long_rule_id/results.out
@@ -1,0 +1,14 @@
+
+
+┌────────────────┐
+│ 1 Code Finding │
+└────────────────┘
+
+    targets/cli_test/basic/basic.py
+       rules.cli_test.long_rule_id.this-is-a-very-long-rule-id-which-should-be-wrapped-in-the-cli-thank-you-very-much-
+       supercalifragilisticexpialidocious
+          This is the description of a very long rule id which should be wrapped in the cli thank you very
+          much supercalifragilisticexpialidocious.
+
+            2┆ print(1 == 1)
+

--- a/cli/tests/e2e/snapshots/test_output/test_long_rule_id_long_text/results.out
+++ b/cli/tests/e2e/snapshots/test_output/test_long_rule_id_long_text/results.out
@@ -1,0 +1,17 @@
+
+
+┌────────────────┐
+│ 1 Code Finding │
+└────────────────┘
+
+    targets/cli_test/long_text/long_text.py
+       rules.cli_test.long_rule_id.this-is-a-very-long-rule-id-which-should-be-wrapped-in-the-cli-thank-you-very-much-
+       supercalifragilisticexpialidocious
+          This is the description of a very long rule id which should be wrapped in the cli thank you very
+          much supercalifragilisticexpialidocious.
+
+            2┆ print("SELECT * FROM users WHERE id = 1 AND
+               very_long_variable_supercalifragilisticexpialidocious = TRUE"
+            3┆       == "SELECT * FROM users WHERE id = 1 AND
+               very_long_variable_supercalifragilisticexpialidocious = TRUE"
+

--- a/cli/tests/e2e/snapshots/test_output/test_output_highlighting/results.txt
+++ b/cli/tests/e2e/snapshots/test_output/test_output_highlighting/results.txt
@@ -5,8 +5,8 @@
 └────────────────┘
 
   [36m[22m[24m  targets/cli_test/basic/basic.py [0m
-       [1m[24mrules.cli_test.basic.basic-test[0m
+      [1m rules.cli_test.basic.basic-test[0m
           Basic test
 
-            2┆ print([1m[24m1 == 1[0m)
+            2┆ print([1m1 == 1[0m)
 

--- a/cli/tests/e2e/snapshots/test_output/test_output_highlighting/results.txt
+++ b/cli/tests/e2e/snapshots/test_output/test_output_highlighting/results.txt
@@ -5,7 +5,7 @@
 └────────────────┘
 
   [36m[22m[24m  targets/cli_test/basic/basic.py [0m
-      [1m rules.cli_test.basic.basic-test[0m
+       [1mrules.cli_test.basic.basic-test[0m
           Basic test
 
             2┆ print([1m1 == 1[0m)

--- a/cli/tests/e2e/snapshots/test_output/test_output_highlighting__force_color_and_no_color/results.txt
+++ b/cli/tests/e2e/snapshots/test_output/test_output_highlighting__force_color_and_no_color/results.txt
@@ -5,8 +5,8 @@
 └────────────────┘
 
   [36m[22m[24m  targets/cli_test/basic/basic.py [0m
-       [1m[24mrules.cli_test.basic.basic-test[0m
+      [1m rules.cli_test.basic.basic-test[0m
           Basic test
 
-            2┆ print([1m[24m1 == 1[0m)
+            2┆ print([1m1 == 1[0m)
 

--- a/cli/tests/e2e/snapshots/test_output/test_output_highlighting__force_color_and_no_color/results.txt
+++ b/cli/tests/e2e/snapshots/test_output/test_output_highlighting__force_color_and_no_color/results.txt
@@ -5,7 +5,7 @@
 └────────────────┘
 
   [36m[22m[24m  targets/cli_test/basic/basic.py [0m
-      [1m rules.cli_test.basic.basic-test[0m
+       [1mrules.cli_test.basic.basic-test[0m
           Basic test
 
             2┆ print([1m1 == 1[0m)

--- a/cli/tests/e2e/snapshots/test_sca/test_sca_lockfile_only_output/results.txt
+++ b/cli/tests/e2e/snapshots/test_sca/test_sca_lockfile_only_output/results.txt
@@ -6,19 +6,13 @@
 
     targets/dependency_aware/unreachable_multiple_copies/yarn.lock
        rules.dependency_aware.GHSA-p6mc-m468-83gw
-          Versions of lodash prior to 4.17.19 are vulnerable to Prototype
-  Pollution. The function
-          zipObjectDeep allows a malicious user to modify the prototype of
-  Object if the property
-          identifiers are user-supplied. Being affected by this issue requires
-  zipping objects based
-          on user-provided property arrays.
+          Versions of lodash prior to 4.17.19 are vulnerable to Prototype Pollution. The function
+          zipObjectDeep allows a malicious user to modify the prototype of Object if the property identifiers
+          are user-supplied. Being affected by this issue requires zipping objects based on user-provided
+          property arrays.
 
-          This vulnerability causes the addition or modification of an existing
-  property that will
-          exist on all objects and may lead to Denial of Service or Code
-  Execution under specific
-          circumstances.
+          This vulnerability causes the addition or modification of an existing property that will exist on
+          all objects and may lead to Denial of Service or Code Execution under specific circumstances.
 
             5┆ lodash@^1.0.0:
             ⋮┆----------------------------------------

--- a/cli/tests/e2e/snapshots/test_sca/test_sca_output/results.txt
+++ b/cli/tests/e2e/snapshots/test_sca/test_sca_output/results.txt
@@ -4,8 +4,7 @@
 │ 1 Reachable Supply Chain Finding │
 └──────────────────────────────────┘
 
-    targets/dependency_aware/monorepo/webapp1/app.js with lockfile
-  targets/dependency_aware/monorepo/webapp1/yarn.lock
+    targets/dependency_aware/monorepo/webapp1/app.js with lockfile targets/dependency_aware/monorepo/webapp1/yarn.lock
        bad-lib - CVE-FOO-BAR
           Severity: HIGH
           oh no

--- a/cli/tests/e2e/snapshots/test_secret/test_cli_test_secret_rule/results.txt
+++ b/cli/tests/e2e/snapshots/test_secret/test_cli_test_secret_rule/results.txt
@@ -5,10 +5,10 @@
 └───────────────────────────────┘
 
   [36m[22m[24m  targets/cli_test/basic/basic.py [0m
-       [1m[24mrules.basic-test.secret[0m
+       [1mrules.basic-test.secret[0m
           Basic test
 
-            2┆ print([1m[24m1*****[0m)
+            2┆ print([1m1*****[0m)
 
 
 ┌────────────────┐
@@ -16,8 +16,8 @@
 └────────────────┘
 
   [36m[22m[24m  targets/cli_test/basic/basic.py [0m
-       [1m[24mrules.basic-test.nonsecret[0m
+       [1mrules.basic-test.nonsecret[0m
           Basic test
 
-            2┆ print([1m[24m1 == 1[0m)
+            2┆ print([1m1 == 1[0m)
 

--- a/cli/tests/e2e/snapshots/test_semgrep_core_parse_error/test_file_parser__failure__error_messages/settings0/error.txt
+++ b/cli/tests/e2e/snapshots/test_semgrep_core_parse_error/test_file_parser__failure__error_messages/settings0/error.txt
@@ -24,8 +24,7 @@ Files skipped:
    • <all files not listed by `git ls-files` were skipped>
 
   [1m[24mSkipped by .semgrepignore:[0m
-  [1m[24m(See: https://semgrep.dev/docs/ignoring-files-folders-code/#understanding-semgrep-
-  defaults)[0m
+  [1m[24m- https://semgrep.dev/docs/ignoring-files-folders-code/#understanding-semgrep-defaults[0m
 
    • <none>
 

--- a/cli/tests/e2e/snapshots/test_semgrep_core_parse_error/test_file_parser__failure__error_messages/settings1/error.txt
+++ b/cli/tests/e2e/snapshots/test_semgrep_core_parse_error/test_file_parser__failure__error_messages/settings1/error.txt
@@ -25,8 +25,7 @@ Files skipped:
    • <all files not listed by `git ls-files` were skipped>
 
   [1m[24mSkipped by .semgrepignore:[0m
-  [1m[24m(See: https://semgrep.dev/docs/ignoring-files-folders-code/#understanding-semgrep-
-  defaults)[0m
+  [1m[24m- https://semgrep.dev/docs/ignoring-files-folders-code/#understanding-semgrep-defaults[0m
 
    • <none>
 

--- a/cli/tests/e2e/targets/cli_test/long_text/long_text.py
+++ b/cli/tests/e2e/targets/cli_test/long_text/long_text.py
@@ -1,0 +1,4 @@
+# ruleid: this-is-a-very-long-rule-id-which-should-be-wrapped-in-the-cli-thank-you-very-much-supercalifragilisticexpialidocious
+print("SELECT * FROM users WHERE id = 1 AND very_long_variable_supercalifragilisticexpialidocious = TRUE"
+      == "SELECT * FROM users WHERE id = 1 AND very_long_variable_supercalifragilisticexpialidocious = TRUE"
+)

--- a/cli/tests/e2e/test_output.py
+++ b/cli/tests/e2e/test_output.py
@@ -44,6 +44,7 @@ def _etree_to_dict(t):
 
 
 @pytest.mark.kinda_slow
+@pytest.mark.osempass
 def test_output_highlighting(run_semgrep_in_tmp: RunSemgrep, snapshot):
     results, _errors = run_semgrep_in_tmp(
         "rules/cli_test/basic/",
@@ -59,6 +60,7 @@ def test_output_highlighting(run_semgrep_in_tmp: RunSemgrep, snapshot):
 
 
 @pytest.mark.kinda_slow
+@pytest.mark.osempass
 def test_output_highlighting__no_color(run_semgrep_in_tmp: RunSemgrep, snapshot):
     results, _errors = run_semgrep_in_tmp(
         "rules/cli_test/basic/",
@@ -74,6 +76,7 @@ def test_output_highlighting__no_color(run_semgrep_in_tmp: RunSemgrep, snapshot)
 
 
 @pytest.mark.kinda_slow
+@pytest.mark.osempass
 def test_output_highlighting__force_color_and_no_color(
     run_semgrep_in_tmp: RunSemgrep, snapshot
 ):

--- a/cli/tests/e2e/test_output.py
+++ b/cli/tests/e2e/test_output.py
@@ -200,6 +200,28 @@ def test_output_format_osemfail(run_semgrep_in_tmp: RunSemgrep, snapshot, format
 
 
 @pytest.mark.kinda_slow
+@pytest.mark.osempass
+def test_long_rule_id(run_semgrep_in_tmp: RunSemgrep, snapshot):
+    stdout, _ = run_semgrep_in_tmp(
+        "rules/cli_test/long_rule_id/long_rule_id.yaml",
+        target_name="cli_test/basic",
+        output_format=OutputFormat.TEXT,
+    )
+    snapshot.assert_match(stdout, "results.out")
+
+
+@pytest.mark.kinda_slow
+@pytest.mark.osemfail  # TODO: fix text wrapping of findings
+def test_long_rule_id_long_text(run_semgrep_in_tmp: RunSemgrep, snapshot):
+    stdout, _ = run_semgrep_in_tmp(
+        "rules/cli_test/long_rule_id/long_rule_id.yaml",
+        target_name="cli_test/long_text",
+        output_format=OutputFormat.TEXT,
+    )
+    snapshot.assert_match(stdout, "results.out")
+
+
+@pytest.mark.kinda_slow
 @pytest.mark.osemfail
 def test_omit_inventory(run_semgrep_in_tmp: RunSemgrep, snapshot):
     stdout, _ = run_semgrep_in_tmp(

--- a/src/osemgrep/configuring/Semgrep_envvars.ml
+++ b/src/osemgrep/configuring/Semgrep_envvars.ml
@@ -48,6 +48,15 @@ let env_or conv var default =
 
 let in_env var = env_opt var <> None
 
+let env_truthy var =
+  env_opt var |> Option.value ~default:"" |> String.lowercase_ascii |> function
+  | "true"
+  | "1"
+  | "yes"
+  | "y" ->
+      true
+  | _ -> false
+
 (*****************************************************************************)
 (* Types and constants *)
 (*****************************************************************************)
@@ -71,6 +80,7 @@ type t = {
   user_dot_semgrep_dir : Fpath.t;
   user_log_file : Fpath.t;
   user_settings_file : Fpath.t;
+  no_color : bool;
   is_ci : bool;
   in_docker : bool;
   in_gh_action : bool;
@@ -133,6 +143,7 @@ let of_current_sys_env () : t =
     user_settings_file =
       env_or Fpath.v "SEMGREP_SETTINGS_FILE"
         (user_dot_semgrep_dir / settings_filename);
+    no_color = env_truthy "NO_COLOR" || env_truthy "SEMGREP_COLOR_NO_COLOR";
     is_ci = in_env "CI";
     in_docker = in_env "SEMGREP_IN_DOCKER";
     in_gh_action = in_env "GITHUB_WORKSPACE";

--- a/src/osemgrep/configuring/Semgrep_envvars.mli
+++ b/src/osemgrep/configuring/Semgrep_envvars.mli
@@ -36,6 +36,9 @@ type t = {
   user_log_file : Fpath.t;
   (* $SEMGREP_SETTINGS_FILE ~/.semgrep/settings.yml *)
   user_settings_file : Fpath.t;
+  (* TODO: Reconcile $SEMGREP_FORCE_COLOR via o_force_color *)
+  (* ($NO_COLOR | $SEMGREP_COLOR_NO_COLOR) *)
+  no_color : bool;
   is_ci : bool;
   in_docker : bool;
   (* $GITHUB_WORKSPACE *)

--- a/src/osemgrep/reporting/Matches_report.ml
+++ b/src/osemgrep/reporting/Matches_report.ml
@@ -311,7 +311,8 @@ let pp_text_outputs ~max_chars_per_line ~max_lines_per_finding ~color_output ppf
       in
       pp_styled_severity cur.extra.severity;
       let lines =
-        wrap ~indent:base_indent_size ~width:text_width
+        wrap ~indent:base_indent_size
+          ~width:(text_width - ((2 + base_indent_size) * 2))
           (Rule_ID.to_string cur.check_id)
       in
       match lines with
@@ -326,7 +327,7 @@ let pp_text_outputs ~max_chars_per_line ~max_lines_per_finding ~color_output ppf
           List.iter
             (fun (sp, l) -> Fmt.pf ppf "%s%s@." sp l)
             (wrap ~indent:detail_indent_size
-               ~width:(text_width - (base_indent_size * 2))
+               ~width:(text_width - (detail_indent_size * 2))
                cur.extra.message);
           (match Yojson.Basic.Util.member "shortlink" cur.extra.metadata with
           | `String s -> Fmt.pf ppf "%sDetails: %s@." detail_indent s

--- a/src/osemgrep/reporting/Matches_report.ml
+++ b/src/osemgrep/reporting/Matches_report.ml
@@ -310,7 +310,7 @@ let pp_text_outputs ~max_chars_per_line ~max_lines_per_finding ~color_output ppf
       in
       pp_styled_severity cur.extra.severity;
       let lines =
-        wrap ~indent:rule_indent_size ~width:(text_width - 4)
+        wrap ~indent:rule_indent_size ~width:text_width
           (Rule_ID.to_string cur.check_id)
       in
       match lines with

--- a/src/osemgrep/reporting/Matches_report.ml
+++ b/src/osemgrep/reporting/Matches_report.ml
@@ -286,11 +286,19 @@ let pp_text_outputs ~max_chars_per_line ~max_lines_per_finding ~color_output ppf
       | Some m -> m <> cur.extra.message
     in
     if print then (
-      let sev_icon_enablement = false in
-      (* Enable in a separate PR post-test updates *)
+      (* NOTE: In a subsequent PR we should
+               (1) print the unicode arrows without color when color is disabled
+               (2) remove the in_test conditional
+      *)
+      let no_color = !Semgrep_envvars.v.no_color in
+      let in_test =
+        !Semgrep_envvars.v.user_agent_append
+        |> Option.map (fun s -> String.equal s "pytest")
+        |> Option.value ~default:false
+      in
       let pp_styled_severity =
-        if Fmt.style_renderer ppf = `Ansi_tty && sev_icon_enablement then
-          function
+        if Fmt.style_renderer ppf = `Ansi_tty && (not no_color) && not in_test
+        then function
           | `Error ->
               Fmt.pf ppf "%s%a" rule_leading_indent
                 Fmt.(styled (`Fg `Red) string)

--- a/src/osemgrep/reporting/Matches_report.ml
+++ b/src/osemgrep/reporting/Matches_report.ml
@@ -24,8 +24,7 @@ let findings_indent = String.make findings_indent_size ' '
 let text_width =
   let max_text_width = 120 in
   let w = Option.value ~default:max_text_width (Terminal_size.get_columns ()) in
-  (* TODO: what is this w - (w - 100) ? What if w <= 5? *)
-  if w <= 110 then w - 5 else w - (w - 100)
+  min w max_text_width
 
 type report_group =
   [ OutJ.validation_state
@@ -326,7 +325,9 @@ let pp_text_outputs ~max_chars_per_line ~max_lines_per_finding ~color_output ppf
             rest;
           List.iter
             (fun (sp, l) -> Fmt.pf ppf "%s%s@." sp l)
-            (wrap ~indent:detail_indent_size ~width:text_width cur.extra.message);
+            (wrap ~indent:detail_indent_size
+               ~width:(text_width - (base_indent_size * 2))
+               cur.extra.message);
           (match Yojson.Basic.Util.member "shortlink" cur.extra.metadata with
           | `String s -> Fmt.pf ppf "%sDetails: %s@." detail_indent s
           | _else -> ());

--- a/src/osemgrep/reporting/Matches_report.ml
+++ b/src/osemgrep/reporting/Matches_report.ml
@@ -311,8 +311,7 @@ let pp_text_outputs ~max_chars_per_line ~max_lines_per_finding ~color_output ppf
       in
       pp_styled_severity cur.extra.severity;
       let lines =
-        wrap ~indent:base_indent_size
-          ~width:(text_width - ((2 + base_indent_size) * 2))
+        wrap ~indent:base_indent_size ~width:(text_width - 4)
           (Rule_ID.to_string cur.check_id)
       in
       match lines with
@@ -327,7 +326,7 @@ let pp_text_outputs ~max_chars_per_line ~max_lines_per_finding ~color_output ppf
           List.iter
             (fun (sp, l) -> Fmt.pf ppf "%s%s@." sp l)
             (wrap ~indent:detail_indent_size
-               ~width:(text_width - (detail_indent_size * 2))
+               ~width:(text_width - detail_indent_size)
                cur.extra.message);
           (match Yojson.Basic.Util.member "shortlink" cur.extra.metadata with
           | `String s -> Fmt.pf ppf "%sDetails: %s@." detail_indent s

--- a/src/osemgrep/reporting/Matches_report.ml
+++ b/src/osemgrep/reporting/Matches_report.ml
@@ -13,8 +13,13 @@ open Fpath_.Operators
 (*****************************************************************************)
 
 let ellipsis_string = " ... "
-let base_indent = String.make 10 ' '
-let findings_indent_depth = String.make 12 ' '
+let rule_leading_indent_size = 6
+let base_indent_size = 10
+let detail_indent_size = 12
+let findings_indent_size = 14
+let rule_leading_indent = String.make rule_leading_indent_size ' '
+let detail_indent = String.make detail_indent_size ' '
+let findings_indent = String.make findings_indent_size ' '
 
 let text_width =
   let max_text_width = 120 in
@@ -197,7 +202,11 @@ let pp_finding ~max_chars_per_line ~max_lines_per_finding ~color_output
              else (line, 0, false)
            in
            let line_number_str = string_of_int line_number in
-           let pad = String.make (13 - String.length line_number_str) ' ' in
+           let pad =
+             String.make
+               (findings_indent_size + 1 - String.length line_number_str)
+               ' '
+           in
            let col c = max 0 (c - 1 - dedented - line_off) in
            let ellipsis_len p =
              if stripped' && p then String.length ellipsis_string else 0
@@ -233,15 +242,15 @@ let pp_finding ~max_chars_per_line ~max_lines_per_finding ~color_output
     Fmt.pf ppf
       "%s[shortened a long line from output, adjust with \
        --max-chars-per-line]@."
-      findings_indent_depth;
+      findings_indent;
   match trimmed with
   | Some num ->
       Fmt.pf ppf
         "%s [hid %d additional lines, adjust with --max-lines-per-finding]@."
-        findings_indent_depth num
+        findings_indent num
   | None ->
       if show_separator then
-        Fmt.pf ppf "%s⋮┆%s" findings_indent_depth (String.make 40 '-')
+        Fmt.pf ppf "%s⋮┆%s" findings_indent (String.make 40 '-')
 
 let pp_text_outputs ~max_chars_per_line ~max_lines_per_finding ~color_output ppf
     (matches : OutJ.cli_match list) =
@@ -282,17 +291,46 @@ let pp_text_outputs ~max_chars_per_line ~max_lines_per_finding ~color_output ppf
         if Fmt.style_renderer ppf = `Ansi_tty then Fmt.any "\027[24m"
         else Fmt.any ""
       in
-      List.iter
-        (fun (sp, l) ->
-          Fmt.pf ppf "%s%a@." sp Fmt.(styled `Bold (esc ++ string)) l)
-        (wrap ~indent:7 ~width:text_width (Rule_ID.to_string cur.check_id));
-      List.iter
-        (fun (sp, l) -> Fmt.pf ppf "%s%s@." sp l)
-        (wrap ~indent:10 ~width:text_width cur.extra.message);
-      (match Yojson.Basic.Util.member "shortlink" cur.extra.metadata with
-      | `String s -> Fmt.pf ppf "%sDetails: %s@." base_indent s
-      | _else -> ());
-      Fmt.pf ppf "@.");
+      let pp_styled_severity =
+        if Fmt.style_renderer ppf = `Ansi_tty then function
+          | `Error ->
+              Fmt.pf ppf "%s%a" rule_leading_indent
+                Fmt.(styled (`Fg `Red) string)
+                "❯❯❱"
+          (* No out-of-the-box support for Orange and we use here Magenta instead :/ *)
+          | `Warning ->
+              Fmt.pf ppf "%s%a" rule_leading_indent
+                Fmt.(styled (`Fg `Magenta) string)
+                " ❯❱"
+          | `Info ->
+              Fmt.pf ppf "%s%a" rule_leading_indent
+                Fmt.(styled (`Fg `Green) string)
+                "  ❱"
+          | _ -> Fmt.pf ppf "   "
+        else function
+          | _ -> Fmt.pf ppf "   "
+      in
+      pp_styled_severity cur.extra.severity;
+      let lines =
+        wrap ~indent:base_indent_size ~width:text_width
+          (Rule_ID.to_string cur.check_id)
+      in
+      match lines with
+      | [] -> ()
+      | (_, l) :: rest ->
+          (* Rule indent of size 10 == 6 leading + 3 chars for severity + 1 leading space *)
+          Fmt.pf ppf " %a@." Fmt.(styled `Bold (esc ++ string)) l;
+          List.iter
+            (fun (sp, l) ->
+              Fmt.pf ppf "%s%a@." sp Fmt.(styled `Bold (esc ++ string)) l)
+            rest;
+          List.iter
+            (fun (sp, l) -> Fmt.pf ppf "%s%s@." sp l)
+            (wrap ~indent:detail_indent_size ~width:text_width cur.extra.message);
+          (match Yojson.Basic.Util.member "shortlink" cur.extra.metadata with
+          | `String s -> Fmt.pf ppf "%sDetails: %s@." detail_indent s
+          | _else -> ());
+          Fmt.pf ppf "@.");
     (* TODO autofix *)
     let same_file =
       match next with

--- a/src/osemgrep/reporting/Matches_report.ml
+++ b/src/osemgrep/reporting/Matches_report.ml
@@ -26,6 +26,8 @@ let text_width =
   let w = Option.value ~default:max_text_width (Terminal_size.get_columns ()) in
   min w max_text_width
 
+let fill_count = text_width - findings_indent_size - 8
+
 type report_group =
   [ OutJ.validation_state
   | `Unreachable
@@ -249,7 +251,7 @@ let pp_finding ~max_chars_per_line ~max_lines_per_finding ~color_output
         findings_indent num
   | None ->
       if show_separator then
-        Fmt.pf ppf "%s⋮┆%s" findings_indent (String.make 40 '-')
+        Fmt.pf ppf "%s⋮┆%s" findings_indent (String.make fill_count '-')
 
 let pp_text_outputs ~max_chars_per_line ~max_lines_per_finding ~color_output ppf
     (matches : OutJ.cli_match list) =
@@ -338,8 +340,13 @@ let pp_text_outputs ~max_chars_per_line ~max_lines_per_finding ~color_output ppf
       | None -> false
       | Some m -> m.path = cur.path
     in
+    let same_rule =
+      match next with
+      | None -> false
+      | Some m -> m.check_id = cur.check_id
+    in
     pp_finding ~max_chars_per_line ~max_lines_per_finding ~color_output
-      ~show_separator:same_file ppf cur;
+      ~show_separator:(same_file && same_rule) ppf cur;
     Fmt.pf ppf "@."
   in
   let last, cur =

--- a/src/osemgrep/reporting/dune
+++ b/src/osemgrep/reporting/dune
@@ -9,6 +9,7 @@
    terminal_size
    digestif
 
+  osemgrep_configuring
    osemgrep_core
    osemgrep_core_runner
    semgrep.reporting


### PR DESCRIPTION
## Description

This PR adds support for colored severity in the textual display and fixes a few design bugs as noted below.

### Addresses
- #9568
- #9556 
- #9557 

## Demo

| Before | After | 
| - | - |
| <img width="1914" alt="Old SG CLI exhibit a" src="https://github.com/semgrep/semgrep/assets/5779832/e14747ff-459e-4d13-b007-b707faff5c88"> | <img width="1920" alt="New SG CLI exhibit a" src="https://github.com/semgrep/semgrep/assets/5779832/c94ab7c7-c837-4be4-8ed0-564d417a4e4f"> |

| Before | After | 
| - | - |
| <img width="1920" alt="Old SG CLI exhibit b" src="https://github.com/semgrep/semgrep/assets/5779832/63e2cea2-e632-495f-909f-dd6dc0f0f814"> | <img width="1919" alt="New SG CLI exhibit b" src="https://github.com/semgrep/semgrep/assets/5779832/7420c00d-9ebc-4aa6-86a1-909daba47a30"> |

| Before | After | 
| - | - |
| <img width="1227" alt="Old SG cli exhibit c" src="https://github.com/semgrep/semgrep/assets/5779832/3656cd22-25bd-4f6d-aa72-44c868b73416"> | <img width="1328" alt="New SG cli exhibit c" src="https://github.com/semgrep/semgrep/assets/5779832/b45e70a0-f03b-4033-b5b3-efbeaf9b6ff2"> |

### Changes

#### Adds
- Severity icon w/ corresponding color for interactive terminals

### Fixes
- Rule ID taking up extra lines for narrow terminal displays
- Auto-fix indentation not wrapping properly
- Finding indentation not wrapping properly
- Newline instead of horizontal separator between different rules across same file
- Ensures ANSI color codes for rules and findings are not printed when piped to a file

#### Modifies
- Behavior of character truncation flag where we wrap instead of truncate
- Behavior of color enablement (i.e. `NO_COLOR` takes precedence over custom flags)

### Test Plan
- [x] existing tests pass
- [x] new `test_long_rule_id` test passes  (`osempass`)
- [x] new `test_long_rule_id_long_text` test passes (`osemfail`)

#### Implementer Notes
- severity icons are hidden for non-interactive stderr (e.g. in test-mode for `pysemgrep` and `osemgrep`)
- `osemgrep` still needs to properly wrap findings (and port autofix) for parity

#### Downscoping
- Leading indentation for rule titles are unchanged and should be updated per spec in a fast-follow PR
- Lines that wrap have the correct spacing but do not yet have the vertical line separator `┆` 
- The Medium severity color substitutes Orange for Magenta to pick from the 8-color ANSI Color Palette 
