### PR TITLE
fix: dont show console spinner if running in window

### DIFF
--- a/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -278,7 +278,7 @@ let rules_from_rules_source ~token_opt ~rewrite_rule_ids ~registry_caching caps
     rules_source =
   (* Create the wait hook for our progress indicator *)
   let spinner_ls =
-    if !ANSITerminal.isatty Unix.stdout && not !Common.jsoo then
+    if Console_Spinner.should_show_spinner () then
       [ Console_Spinner.spinner_async () ]
     else []
   in

--- a/src/osemgrep/cli_ui/Console_Spinner.ml
+++ b/src/osemgrep/cli_ui/Console_Spinner.ml
@@ -4,18 +4,25 @@
 
 let spinner = [| "⠋"; "⠙"; "⠹"; "⠸"; "⠼"; "⠴"; "⠦"; "⠧"; "⠇"; "⠏" |]
 
+(* only show the console spinner if this is a non-JSOO Unix TTY *)
+let should_show_spinner () =
+  !ANSITerminal.isatty Unix.stdout && (not !Common.jsoo) && Sys.unix
+
 let show_spinner delay_ms : unit =
-  let print_frame ~frame_index:i : unit =
-    let spinner = spinner.(i mod Array.length spinner) in
-    ANSITerminal.set_cursor 1 (-1);
-    ANSITerminal.printf [ ANSITerminal.green ] "%s Waiting for sign in..."
-      spinner
-  in
-  for frame_index = 1 to 100 do
-    print_frame ~frame_index;
-    (* Note: sleep is measured in seconds *)
-    Unix.sleepf (Float.of_int delay_ms /. Float.of_int (1000 * 100))
-  done
+  if not (should_show_spinner ()) then
+    ANSITerminal.printf [ ANSITerminal.green ] "Waiting for sign in..."
+  else
+    let print_frame ~frame_index:i : unit =
+      let spinner = spinner.(i mod Array.length spinner) in
+      ANSITerminal.set_cursor 1 (-1);
+      ANSITerminal.printf [ ANSITerminal.green ] "%s Waiting for sign in..."
+        spinner
+    in
+    for frame_index = 1 to 100 do
+      print_frame ~frame_index;
+      (* Note: sleep is measured in seconds *)
+      Unix.sleepf (Float.of_int delay_ms /. Float.of_int (1000 * 100))
+    done
 
 let erase_spinner () : unit =
   ANSITerminal.set_cursor 1 (-1);

--- a/src/osemgrep/cli_ui/Console_Spinner.mli
+++ b/src/osemgrep/cli_ui/Console_Spinner.mli
@@ -1,3 +1,6 @@
+(* return whether or not we should show a spinner *)
+val should_show_spinner : unit -> bool
+
 (*
   Show a spinner while waiting for the user to sign in.
   delay_ms is the total delay across all frames, in milliseconds.


### PR DESCRIPTION
The console spinner doesn't seem to work in Windows -- let's disable it for now.