### PR TITLE
devops: move opam caching stuff in semgrep.libsonnet

### DIFF
--- a/.github/workflows/.codemapignore
+++ b/.github/workflows/.codemapignore
@@ -7,6 +7,7 @@ build-test-osx-x86.yml
 build-test-osx-arm64.yml
 build-test-manylinux-x86.yml
 build-test-manylinux-aarch64.yml
+build-test-windows-x86.yml
 build-test-javascript.yml
 tests.yml
 test-e2e-semgrep-ci.yml

--- a/.github/workflows/build-test-javascript.jsonnet
+++ b/.github/workflows/build-test-javascript.jsonnet
@@ -189,16 +189,10 @@ local upload_job = {
   'if': '${{ inputs.upload-artifacts }}',
   permissions: gha.write_permissions,
   steps: [
-    {
-      name: 'Configure AWS credentials',
-      uses: 'aws-actions/configure-aws-credentials@v4',
-      with: {
-        'role-to-assume': 'arn:aws:iam::338683922796:role/semgrep-oss-js-artifacts-deploy-role',
-        'role-duration-seconds': 900,
-        'role-session-name': 'semgrep-s3-access',
-        'aws-region': 'us-west-2',
-      },
-    },
+    semgrep.aws_credentials_step(
+      role='semgrep-oss-js-artifacts-deploy-role',
+      session_name='semgrep-s3-access'
+      ),
     {
       uses: 'actions/download-artifact@v3',
       with: {

--- a/.github/workflows/build-test-javascript.yml
+++ b/.github/workflows/build-test-javascript.yml
@@ -112,7 +112,7 @@ jobs:
       id-token: write
       contents: write
     steps:
-    - name: Configure AWS credentials
+    - name: Configure AWS credentials for semgrep-oss-js-artifacts-deploy-role
       uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: arn:aws:iam::338683922796:role/semgrep-oss-js-artifacts-deploy-role

--- a/.github/workflows/build-test-osx-arm64.jsonnet
+++ b/.github/workflows/build-test-osx-arm64.jsonnet
@@ -55,7 +55,7 @@ local build_core_job = {
     actions.checkout_with_submodules(),
     // TODO: like for osx-x86, we should use opam.lock
     semgrep.cache_opam.step(
-       key=semgrep.opam_switch + "-${{hashFiles('semgrep.opam'}}")
+       key=semgrep.opam_switch + "-${{hashFiles('semgrep.opam')}}")
      + semgrep.cache_opam.if_cache_inputs,
     // exactly the same than in build-test-oxs-x86.jsonnet
     {

--- a/.github/workflows/build-test-osx-arm64.jsonnet
+++ b/.github/workflows/build-test-osx-arm64.jsonnet
@@ -53,8 +53,9 @@ local build_core_job = {
     setup_runner_step,
     setup_python_step,
     actions.checkout_with_submodules(),
-    // TODO: like for osx-x86, we should also encode opam.lock in key
-    semgrep.cache_opam.step(key=semgrep.opam_switch)
+    // TODO: like for osx-x86, we should use opam.lock
+    semgrep.cache_opam.step(
+       key=semgrep.opam_switch + "-${{hashFiles('semgrep.opam'}}")
      + semgrep.cache_opam.if_cache_inputs,
     // exactly the same than in build-test-oxs-x86.jsonnet
     {

--- a/.github/workflows/build-test-osx-arm64.jsonnet
+++ b/.github/workflows/build-test-osx-arm64.jsonnet
@@ -49,18 +49,17 @@ local wheel_name = 'osx-arm64-wheel';
 
 local build_core_job = {
   'runs-on': runs_on,
-  env: {
-    OPAM_SWITCH_NAME: semgrep.opam_switch,
-  },
   steps: [
     setup_runner_step,
     setup_python_step,
     actions.checkout_with_submodules(),
-    osx_x86.export.cache.cache_opam_step,
+    // TODO: like for osx-x86, we should also encode opam.lock in key
+    semgrep.cache_opam.step(key=semgrep.opam_switch)
+     + semgrep.cache_opam.if_cache_inputs,
     // exactly the same than in build-test-oxs-x86.jsonnet
     {
       name: 'Install dependencies',
-      run: './scripts/osx-setup-for-release.sh "${{ env.OPAM_SWITCH_NAME }}"',
+      run: './scripts/osx-setup-for-release.sh "%s"' % semgrep.opam_switch,
     },
     {
       name: 'Compile semgrep',
@@ -149,8 +148,8 @@ local test_wheels_job = {
 {
   name: 'build-test-osx-arm64',
   on: {
-    workflow_dispatch: osx_x86.export.cache.use_cache_inputs(required=true),
-    workflow_call: osx_x86.export.cache.use_cache_inputs(required=false),
+    workflow_dispatch: semgrep.cache_opam.inputs(required=true),
+    workflow_call: semgrep.cache_opam.inputs(required=false),
   },
   jobs: {
     'build-core': build_core_job,

--- a/.github/workflows/build-test-osx-arm64.yml
+++ b/.github/workflows/build-test-osx-arm64.yml
@@ -41,7 +41,7 @@ jobs:
       with:
         path: ~/.opam
         key: ${{ runner.os }}-${{ runner.arch }}-opam-deps-4.14.0
-      if: ${{ inputs.cache}}
+      if: ${{ inputs.use-cache}}
     - name: Install dependencies
       run: ./scripts/osx-setup-for-release.sh "4.14.0"
     - name: Compile semgrep

--- a/.github/workflows/build-test-osx-arm64.yml
+++ b/.github/workflows/build-test-osx-arm64.yml
@@ -34,7 +34,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         submodules: true
-    - name: Cache Opam
+    - name: Cache ~/.opam
       uses: actions/cache@v3
       env:
         SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2

--- a/.github/workflows/build-test-osx-arm64.yml
+++ b/.github/workflows/build-test-osx-arm64.yml
@@ -24,8 +24,6 @@ jobs:
     - macOS
     - ARM64
     - ghcr.io/cirruslabs/macos-monterey-xcode:latest
-    env:
-      OPAM_SWITCH_NAME: 4.14.0
     steps:
     - name: Setup runner directory
       run: "\n    sudo mkdir /Users/runner\n    sudo chown admin:staff /Users/runner\n
@@ -38,16 +36,14 @@ jobs:
         submodules: true
     - name: Cache Opam
       uses: actions/cache@v3
-      if: ${{ inputs.use-cache }}
       env:
         SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
       with:
         path: ~/.opam
-        key: ${{ runner.os }}-${{ runner.arch }}-${{ env.OPAM_SWITCH_NAME }}-opam-deps
-        restore-keys: ${{ runner.os }}-${{ runner.arch }}-${{ env.OPAM_SWITCH_NAME
-          }}-opam-deps
+        key: ${{ runner.os }}-${{ runner.arch }}-opam-deps-4.14.0
+      if: ${{ inputs.cache}}
     - name: Install dependencies
-      run: ./scripts/osx-setup-for-release.sh "${{ env.OPAM_SWITCH_NAME }}"
+      run: ./scripts/osx-setup-for-release.sh "4.14.0"
     - name: Compile semgrep
       run: opam exec -- make core
     - name: Make artifact

--- a/.github/workflows/build-test-osx-arm64.yml
+++ b/.github/workflows/build-test-osx-arm64.yml
@@ -40,7 +40,7 @@ jobs:
         SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
       with:
         path: ~/.opam
-        key: ${{ runner.os }}-${{ runner.arch }}-opam-deps-4.14.0-${{hashFiles('semgrep.opam'}}
+        key: ${{ runner.os }}-${{ runner.arch }}-opam-deps-4.14.0-${{hashFiles('semgrep.opam')}}
       if: ${{ inputs.use-cache}}
     - name: Install dependencies
       run: ./scripts/osx-setup-for-release.sh "4.14.0"

--- a/.github/workflows/build-test-osx-arm64.yml
+++ b/.github/workflows/build-test-osx-arm64.yml
@@ -40,7 +40,7 @@ jobs:
         SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
       with:
         path: ~/.opam
-        key: ${{ runner.os }}-${{ runner.arch }}-opam-deps-4.14.0
+        key: ${{ runner.os }}-${{ runner.arch }}-opam-deps-4.14.0-${{hashFiles('semgrep.opam'}}
       if: ${{ inputs.use-cache}}
     - name: Install dependencies
       run: ./scripts/osx-setup-for-release.sh "4.14.0"

--- a/.github/workflows/build-test-osx-x86.jsonnet
+++ b/.github/workflows/build-test-osx-x86.jsonnet
@@ -55,7 +55,9 @@ local build_core_job = {
   //TODO: could pass it via an argument to cache_opam_step instead of env?
   steps: [
     actions.checkout_with_submodules(),
-    // TODO: should use opam.lock instead of semgrep.opam at some point
+    // TODO: we should use opam.lock instead of semgrep.opam at some point
+    // so any update to our dependencies would automatically trigger a
+    // cache miss and generate a fresh ~/.opam.
     semgrep.cache_opam.step(
          key=semgrep.opam_switch + "-${{hashFiles('semgrep.opam'}}")
       + semgrep.cache_opam.if_cache_inputs,

--- a/.github/workflows/build-test-osx-x86.jsonnet
+++ b/.github/workflows/build-test-osx-x86.jsonnet
@@ -55,8 +55,9 @@ local build_core_job = {
   //TODO: could pass it via an argument to cache_opam_step instead of env?
   steps: [
     actions.checkout_with_submodules(),
-    // TODO: should also use opam.lock, or md5sum of semgrep.opam in key
-    semgrep.cache_opam.step(key=semgrep.opam_switch)
+    // TODO: should use opam.lock instead of semgrep.opam at some point
+    semgrep.cache_opam.step(
+         key=semgrep.opam_switch + "-${{hashFiles('semgrep.opam'}}")
       + semgrep.cache_opam.if_cache_inputs,
     {
       name: 'Install dependencies',

--- a/.github/workflows/build-test-osx-x86.jsonnet
+++ b/.github/workflows/build-test-osx-x86.jsonnet
@@ -44,91 +44,6 @@ local test_semgrep_steps = [
 ];
 
 // ----------------------------------------------------------------------------
-// OPAM caching (TODO: move in semgrep.libsonnet at some point)
-// ----------------------------------------------------------------------------
-
-// This workflow uses the actions/cache@v3 GHA extension to cache
-// the ~/.opam directory, which is different from what we do for our other
-// architecture's build processes.
-//
-// This workflow runs on GHA-hosted runners and without caching it would run
-// very slowly (like 35min instead of 10min with caching). The Linux build process
-// uses a special container (returntocorp/ocaml:alpine-xxx) to bring in the
-// required dependencies, which makes opam switch create unnecessary and opam
-// install almost a noop. The M1 build runs on fast self-hosted runners where
-// caching does not seem to be necessary.
-//
-// TODO? If this experiment goes well, we might want to use this ~/.opam caching
-// technique also for M1 for consistency, and maybe even get rid of our
-// returntocorp/ocaml:alpine-xxx container to simplify things.
-//
-// To update to a new version of OCaml, we can modify the `OPAM_SWITCH_NAME` var
-// below, which will update the cache key, and lead to a cache miss on the new builds.
-//
-// TODO? we might want to use opam.lock as a key so any update to our dependencies
-// would automatically trigger a cache miss and generate a fresh ~/.opam.
-//
-// alt:
-//  - use a self-hosted runner where we can save the content of ~/.opam between
-//    runs and do whatever we want. The problem is that the build is then
-//    not "hermetic", and we ran in many issues such as the disk of the self-hosted
-//    runner being full, or some stuff being left from other CI runs
-//    (such as a semgrep install) entering in conflicts with some of our build steps.
-//    This also requires some devops work to create and maintain those pools of
-//    self-hosted runners.
-//  - use a GHA-hosted runner which is nice because we don't have to do
-//    anything, and the build are guaranteed to be hermetic. The only problem originally
-//    was that it was slower, and for unknown reasons ocamlc was not working well
-//    on those macos-12 GHA runners, but caching the ~/.opam with actions/cache@v3
-//    seems to solve the speed issue (and maybe ocamlc works now well under macos-12).
-//  - use a technique similar to what we do for Linux with our special container, but
-//    can this be done for macos?
-//
-// See also https://www.notion.so/semgrep/Caching-the-Opam-Environment-5d7e594203884d289acdac53713fb39f for more information.
-
-// to be used with workflow_dispatch and workflow_call in the workflow
-local use_cache_inputs(required) = {
-  inputs: {
-    'use-cache': {
-      description: 'Use Opam Cache - uncheck the box to disable use of the opam cache, meaning a long-running but completely from-scratch build.',
-      required: required,
-      type: 'boolean',
-      default: true,
-    },
-  },
-};
-
-// Note that this actions does cache read and cache write.
-// See https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows for more information on GHA caching.
-//
-// Note that this works and speedup things because of the way OPAM works
-// and osx-setup-for-release.sh is written. Indeed, this script checks
-// if the opam switch is already created, and if a package is already
-// installed (in ~/.opam), then opam install on this package will do nothing.
-// If we use new packages in semgrep.opam, then we currently would still
-// hit the cache unfortunately, but we would spend time only for installing
-// those new packages (ideally we would want to regenerate the cache by
-// using an opam.pock in the cache key).
-//
-// PRE: the env.OPAM_SWITCH_NAME must be set in the caller
-local cache_opam_step = {
-  name: 'Cache Opam',
-  uses: 'actions/cache@v3',
-  // see use_cache_inputs() above
-  'if': '${{ inputs.use-cache }}',
-  env: {
-    SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2,
-  },
-  with: {
-    path: '~/.opam',
-    //TODO: we should add the md5sum of opam.lock as part of the key
-    key: '${{ runner.os }}-${{ runner.arch }}-${{ env.OPAM_SWITCH_NAME }}-opam-deps',
-    //TODO: what is restore-keys needed for?
-    'restore-keys': '${{ runner.os }}-${{ runner.arch }}-${{ env.OPAM_SWITCH_NAME }}-opam-deps',
-  },
-};
-
-// ----------------------------------------------------------------------------
 // The jobs
 // ----------------------------------------------------------------------------
 
@@ -138,18 +53,14 @@ local wheel_name = 'osx-x86-wheel';
 local build_core_job = {
   'runs-on': runs_on,
   //TODO: could pass it via an argument to cache_opam_step instead of env?
-  env: {
-    // This name is used in the cache key. If we update to a newer version of
-    // ocaml, we'll want to change the OPAM_SWITCH_NAME as well to avoid issues
-    // with caching.
-    OPAM_SWITCH_NAME: semgrep.opam_switch,
-  },
   steps: [
     actions.checkout_with_submodules(),
-    cache_opam_step,
+    // TODO: should also use opam.lock, or md5sum of semgrep.opam in key
+    semgrep.cache_opam.step(key=semgrep.opam_switch)
+      + semgrep.cache_opam.if_cache_inputs,
     {
       name: 'Install dependencies',
-      run: './scripts/osx-setup-for-release.sh "${{ env.OPAM_SWITCH_NAME }}"',
+      run: './scripts/osx-setup-for-release.sh "%s"' % semgrep.opam_switch,
     },
     {
       name: 'Compile semgrep',
@@ -232,8 +143,8 @@ local test_wheels_job = {
 {
   name: 'build-test-osx-x86',
   on: {
-    workflow_dispatch: use_cache_inputs(required=true),
-    workflow_call: use_cache_inputs(required=false),
+    workflow_dispatch: semgrep.cache_opam.inputs(required=true),
+    workflow_call: semgrep.cache_opam.inputs(required=false),
   },
   jobs: {
     'build-core': build_core_job,
@@ -242,10 +153,6 @@ local test_wheels_job = {
   },
   // to be used by other workflows (build-test-osx-arm64.jsonnet)
   export:: {
-    cache: {
-      use_cache_inputs: use_cache_inputs,
-      cache_opam_step: cache_opam_step,
-    },
     test_semgrep_steps: test_semgrep_steps,
   },
 }

--- a/.github/workflows/build-test-osx-x86.jsonnet
+++ b/.github/workflows/build-test-osx-x86.jsonnet
@@ -59,7 +59,7 @@ local build_core_job = {
     // so any update to our dependencies would automatically trigger a
     // cache miss and generate a fresh ~/.opam.
     semgrep.cache_opam.step(
-         key=semgrep.opam_switch + "-${{hashFiles('semgrep.opam'}}")
+         key=semgrep.opam_switch + "-${{hashFiles('semgrep.opam')}}")
       + semgrep.cache_opam.if_cache_inputs,
     {
       name: 'Install dependencies',

--- a/.github/workflows/build-test-osx-x86.yml
+++ b/.github/workflows/build-test-osx-x86.yml
@@ -24,7 +24,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         submodules: true
-    - name: Cache Opam
+    - name: Cache ~/.opam
       uses: actions/cache@v3
       env:
         SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2

--- a/.github/workflows/build-test-osx-x86.yml
+++ b/.github/workflows/build-test-osx-x86.yml
@@ -30,7 +30,7 @@ jobs:
         SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
       with:
         path: ~/.opam
-        key: ${{ runner.os }}-${{ runner.arch }}-opam-deps-4.14.0-${{hashFiles('semgrep.opam'}}
+        key: ${{ runner.os }}-${{ runner.arch }}-opam-deps-4.14.0-${{hashFiles('semgrep.opam')}}
       if: ${{ inputs.use-cache}}
     - name: Install dependencies
       run: ./scripts/osx-setup-for-release.sh "4.14.0"

--- a/.github/workflows/build-test-osx-x86.yml
+++ b/.github/workflows/build-test-osx-x86.yml
@@ -20,24 +20,20 @@ name: build-test-osx-x86
 jobs:
   build-core:
     runs-on: macos-12
-    env:
-      OPAM_SWITCH_NAME: 4.14.0
     steps:
     - uses: actions/checkout@v3
       with:
         submodules: true
     - name: Cache Opam
       uses: actions/cache@v3
-      if: ${{ inputs.use-cache }}
       env:
         SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
       with:
         path: ~/.opam
-        key: ${{ runner.os }}-${{ runner.arch }}-${{ env.OPAM_SWITCH_NAME }}-opam-deps
-        restore-keys: ${{ runner.os }}-${{ runner.arch }}-${{ env.OPAM_SWITCH_NAME
-          }}-opam-deps
+        key: ${{ runner.os }}-${{ runner.arch }}-opam-deps-4.14.0
+      if: ${{ inputs.cache}}
     - name: Install dependencies
-      run: ./scripts/osx-setup-for-release.sh "${{ env.OPAM_SWITCH_NAME }}"
+      run: ./scripts/osx-setup-for-release.sh "4.14.0"
     - name: Compile semgrep
       run: opam exec -- make core
     - name: Make artifact

--- a/.github/workflows/build-test-osx-x86.yml
+++ b/.github/workflows/build-test-osx-x86.yml
@@ -31,7 +31,7 @@ jobs:
       with:
         path: ~/.opam
         key: ${{ runner.os }}-${{ runner.arch }}-opam-deps-4.14.0
-      if: ${{ inputs.cache}}
+      if: ${{ inputs.use-cache}}
     - name: Install dependencies
       run: ./scripts/osx-setup-for-release.sh "4.14.0"
     - name: Compile semgrep

--- a/.github/workflows/build-test-osx-x86.yml
+++ b/.github/workflows/build-test-osx-x86.yml
@@ -30,7 +30,7 @@ jobs:
         SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
       with:
         path: ~/.opam
-        key: ${{ runner.os }}-${{ runner.arch }}-opam-deps-4.14.0
+        key: ${{ runner.os }}-${{ runner.arch }}-opam-deps-4.14.0-${{hashFiles('semgrep.opam'}}
       if: ${{ inputs.use-cache}}
     - name: Install dependencies
       run: ./scripts/osx-setup-for-release.sh "4.14.0"

--- a/.github/workflows/build-test-windows-x86.jsonnet
+++ b/.github/workflows/build-test-windows-x86.jsonnet
@@ -5,6 +5,13 @@
 // native support which will be faster and more convenient than what current
 // Semgrep users have to do which is to use Docker or the Window Subsystem
 // for Linux (WSL).
+//
+// Note that if you want to build semgrep yourself on a Windows machine,
+// you'll need to imitate some of the magic done by setup-ocaml@v2:
+//   c:\Windows\system32\fsutil.exe behavior query SymlinkEvaluation
+//   c:\Windows\system32\fsutil.exe behavior set SymlinkEvaluation R2L:1 R2R:1
+// otherwise the symlinks in semgrep used to link our .atd files would
+// confuse 'dune'
 
 local actions = import 'libs/actions.libsonnet';
 local gha = import 'libs/gha.libsonnet';

--- a/.github/workflows/check-semgrep-pro-version.jsonnet
+++ b/.github/workflows/check-semgrep-pro-version.jsonnet
@@ -1,5 +1,8 @@
-// workflow used to check the latest version of Semgrep Pro, ensuring the version
-// manifests are up to date before releasing.
+// workflow used to check the latest version of Semgrep Pro, ensuring the
+// version manifests are up to date before releasing.
+
+local semgrep = import 'libs/semgrep.libsonnet';
+local gha = import 'libs/gha.libsonnet';
 
 // ----------------------------------------------------------------------------
 // The inputs
@@ -34,22 +37,12 @@ local inputs = {
 // ----------------------------------------------------------------------------
 local job = {
   'runs-on': 'ubuntu-22.04',
-  name: 'Check Semgrep Pro Version Manifest',
-  permissions: {
-    'id-token': 'write',
-    contents: 'write',
-  },
+  permissions: gha.write_permissions,
   steps: [
-    {
-      name: 'Configure AWS credentials',
-      uses: 'aws-actions/configure-aws-credentials@v4',
-      with: {
-        'role-to-assume': 'arn:aws:iam::338683922796:role/returntocorp-semgrep-deploy-role',
-        'role-duration-seconds': 900,
-        'role-session-name': 'semgrep-s3-access',
-        'aws-region': 'us-west-2',
-      },
-    },
+    semgrep.aws_credentials_step(
+     role='returntocorp-semgrep-deploy-role',
+     session_name='semgrep-s3-access'
+    ),
     {
       name: 'Download binaries from S3',
       run: 'aws s3 cp "s3://${{ inputs.bucket-name }}/${{ inputs.manifest-key }}" versions-manifest.json',

--- a/.github/workflows/check-semgrep-pro-version.yml
+++ b/.github/workflows/check-semgrep-pro-version.yml
@@ -42,12 +42,11 @@ name: check-semgrep-pro-version
 jobs:
   job:
     runs-on: ubuntu-22.04
-    name: Check Semgrep Pro Version Manifest
     permissions:
       id-token: write
       contents: write
     steps:
-    - name: Configure AWS credentials
+    - name: Configure AWS credentials for returntocorp-semgrep-deploy-role
       uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: arn:aws:iam::338683922796:role/returntocorp-semgrep-deploy-role

--- a/.github/workflows/libs/semgrep.libsonnet
+++ b/.github/workflows/libs/semgrep.libsonnet
@@ -62,7 +62,7 @@ local github_bot = {
 // The step below uses the actions/cache@v3 GHA extension to cache
 // the ~/.opam directory which speedups a lot the "install opam dependencies"
 // step, especially in workflows where we can't use ocaml-layer.
-// See also gha.libsonnet for other caching helpers.
+// See also actions.libsonnet for other GHA caching helpers.
 //
 // For example, on GHA-hosted macos runners, without caching it would run
 // very slowly like 35min instead of 10min with caching.
@@ -103,6 +103,10 @@ local github_bot = {
 // if the opam switch is already created, and if a package is already
 // installed (in ~/.opam), then opam install on this package will do nothing.
 //
+// See https://github.com/organizations/semgrep/settings/actions/caches
+// (requires admin access to github org) to see the GHA cache settings
+// and https://github.com/semgrep/semgrep/actions/caches
+
 
 local cache_opam = {
   step(key): {
@@ -145,7 +149,7 @@ local cache_opam = {
   },
 
   aws_credentials_step(role, session_name): {
-      name: 'Configure AWS credentials',
+      name: 'Configure AWS credentials for %s' % role,
       uses: 'aws-actions/configure-aws-credentials@v4',
       with: {
         // This seems to be semgrep specific magic number

--- a/.github/workflows/libs/semgrep.libsonnet
+++ b/.github/workflows/libs/semgrep.libsonnet
@@ -143,6 +143,19 @@ local cache_opam = {
     // for e2e-semgrep-ci.jsonnet
     E2E_APP_TOKEN: '${{ secrets.SEMGREP_E2E_APP_TOKEN }}',
   },
+
+  aws_credentials_step(role, session_name): {
+      name: 'Configure AWS credentials',
+      uses: 'aws-actions/configure-aws-credentials@v4',
+      with: {
+        // This seems to be semgrep specific magic number
+        'role-to-assume': 'arn:aws:iam::338683922796:role/%s' % role,
+        'role-duration-seconds': 900,
+        'role-session-name': session_name,
+        'aws-region': 'us-west-2',
+      },
+    },
+
   // used in the build-test-osx-xxx jobs but ideally we should get rid
   // of it and rely on opam.lock for caching issues
   opam_switch: '4.14.0',

--- a/.github/workflows/libs/semgrep.libsonnet
+++ b/.github/workflows/libs/semgrep.libsonnet
@@ -63,6 +63,7 @@ local github_bot = {
 // the ~/.opam directory which speedups a lot the "install opam dependencies"
 // step, especially in workflows where we can't use ocaml-layer.
 // See also actions.libsonnet for other GHA caching helpers.
+// Note that actions/setup-ocaml@v2 is using a similar technique.
 //
 // For example, on GHA-hosted macos runners, without caching it would run
 // very slowly like 35min instead of 10min with caching.
@@ -72,7 +73,7 @@ local github_bot = {
 // bring in the required dependencies, which makes 'opam switch create'
 // and 'opam install deps' unnecessary and almost a noop.
 // Still, we could potentially get rid of ocaml-layer and replace it with
-// this more general caching mechanism.
+// this more general caching mechanism (or switch to setup-ocaml@v2).
 //
 // alt:
 //  - use a self-hosted runner where we can save the content of ~/.opam between
@@ -90,6 +91,7 @@ local github_bot = {
 //    works now well under macos-12).
 //  - use a technique similar to what we do for Linux with our special
 //    container, but can this be done for macos?
+//  - use setup-ocaml@v2 which internally uses a GHA cache too
 //
 // See also https://www.notion.so/semgrep/Caching-the-Opam-Environment-5d7e594203884d289acdac53713fb39f
 // for more information.
@@ -106,11 +108,11 @@ local github_bot = {
 // See https://github.com/organizations/semgrep/settings/actions/caches
 // (requires admin access to github org) to see the GHA cache settings
 // and https://github.com/semgrep/semgrep/actions/caches
-
+// to see the actual cache files created.
 
 local cache_opam = {
   step(key): {
-    name: 'Cache Opam',
+    name: 'Cache ~/.opam',
     uses: 'actions/cache@v3',
     env: {
       SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2,

--- a/.github/workflows/test-semgrep-pro.yml
+++ b/.github/workflows/test-semgrep-pro.yml
@@ -39,7 +39,6 @@ jobs:
         \         echo \"docker-tag=develop\" >> \"$GITHUB_OUTPUT\"\n          echo
         \"Setting dry-run to develop\"\n        fi\n      "
   test-semgrep-pro:
-    name: Test Semgrep Pro Engine
     runs-on: ubuntu-22.04
     permissions:
       id-token: write
@@ -48,12 +47,10 @@ jobs:
     env:
       SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
     steps:
-    - name: Checkout
-      uses: actions/checkout@v3
+    - uses: actions/checkout@v3
       with:
         submodules: true
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+    - uses: docker/setup-buildx-action@v2
     - name: Download artifact
       uses: actions/download-artifact@v3
       with:
@@ -61,7 +58,7 @@ jobs:
         path: /tmp
     - name: Load image
       run: docker load --input /tmp/image.tar
-    - name: Configure AWS credentials
+    - name: Configure AWS credentials for returntocorp-semgrep-deploy-role
       uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: arn:aws:iam::338683922796:role/returntocorp-semgrep-deploy-role


### PR DESCRIPTION
This will provides a path towards using the cache not only
for osx but other archs

test plan:
wait for green CI checks