### PR TITLE
js: bump emsdk image + disable fix-irreducible-control-flow-pass

### DIFF
--- a/.github/workflows/build-test-javascript.jsonnet
+++ b/.github/workflows/build-test-javascript.jsonnet
@@ -98,7 +98,7 @@ local build_job =
 
 local test_job = {
   'runs-on': 'ubuntu-latest-16-core',
-  container: 'emscripten/emsdk:3.1.46',
+  container: 'emscripten/emsdk:3.1.51',
   needs: [
     'build',
   ],

--- a/.github/workflows/build-test-javascript.yml
+++ b/.github/workflows/build-test-javascript.yml
@@ -46,7 +46,7 @@ jobs:
         name: semgrep-js-ocaml-build-${{ github.sha }}
   test:
     runs-on: ubuntu-latest-16-core
-    container: emscripten/emsdk:3.1.46
+    container: emscripten/emsdk:3.1.51
     needs:
     - build
     env:

--- a/js/languages/cpp/Makefile
+++ b/js/languages/cpp/Makefile
@@ -2,4 +2,6 @@ SEMGREP_LANG := cpp
 
 EMCC_TEST_OPTIMIZATION := -O1
 
+EMCC_OPTIMIZATION := -mllvm -wasm-disable-fix-irreducible-control-flow-pass
+
 include ../shared/Makefile.include

--- a/js/languages/cpp/Makefile
+++ b/js/languages/cpp/Makefile
@@ -2,6 +2,6 @@ SEMGREP_LANG := cpp
 
 EMCC_TEST_OPTIMIZATION := -O1
 
-EMCC_OPTIMIZATION := -mllvm -wasm-disable-fix-irreducible-control-flow-pass
+EMCC_OPTIMIZATION := -O1 -mllvm -wasm-disable-fix-irreducible-control-flow-pass
 
 include ../shared/Makefile.include

--- a/js/languages/julia/Makefile
+++ b/js/languages/julia/Makefile
@@ -2,4 +2,6 @@ SEMGREP_LANG := julia
 
 EMCC_TEST_OPTIMIZATION := -O1
 
+EMCC_OPTIMIZATION := -mllvm -wasm-disable-fix-irreducible-control-flow-pass
+
 include ../shared/Makefile.include

--- a/js/languages/julia/Makefile
+++ b/js/languages/julia/Makefile
@@ -2,6 +2,6 @@ SEMGREP_LANG := julia
 
 EMCC_TEST_OPTIMIZATION := -O1
 
-EMCC_OPTIMIZATION := -mllvm -wasm-disable-fix-irreducible-control-flow-pass
+EMCC_OPTIMIZATION := -O1 -mllvm -wasm-disable-fix-irreducible-control-flow-pass
 
 include ../shared/Makefile.include

--- a/js/languages/ruby/Makefile
+++ b/js/languages/ruby/Makefile
@@ -2,6 +2,6 @@ SEMGREP_LANG := ruby
 
 EMCC_TEST_OPTIMIZATION := -O1
 
-EMCC_OPTIMIZATION := -mllvm -wasm-disable-fix-irreducible-control-flow-pass
+EMCC_OPTIMIZATION := -O1 -mllvm -wasm-disable-fix-irreducible-control-flow-pass
 
 include ../shared/Makefile.include

--- a/js/languages/ruby/Makefile
+++ b/js/languages/ruby/Makefile
@@ -2,4 +2,6 @@ SEMGREP_LANG := ruby
 
 EMCC_TEST_OPTIMIZATION := -O1
 
+EMCC_OPTIMIZATION := -mllvm -wasm-disable-fix-irreducible-control-flow-pass
+
 include ../shared/Makefile.include

--- a/js/languages/swift/Makefile
+++ b/js/languages/swift/Makefile
@@ -1,5 +1,5 @@
 SEMGREP_LANG := swift
 
-EMCC_OPTIMIZATION := -mllvm -wasm-disable-fix-irreducible-control-flow-pass
+EMCC_OPTIMIZATION := -O1 -mllvm -wasm-disable-fix-irreducible-control-flow-pass
 
 include ../shared/Makefile.include

--- a/js/languages/swift/Makefile
+++ b/js/languages/swift/Makefile
@@ -1,3 +1,5 @@
 SEMGREP_LANG := swift
 
+EMCC_OPTIMIZATION := -mllvm -wasm-disable-fix-irreducible-control-flow-pass
+
 include ../shared/Makefile.include


### PR DESCRIPTION
`emscripten/emsdk:3.1.51` pulls in a new enough version of llvm which contains https://github.com/llvm/llvm-project/pull/67715. Let's start using it and save some time!

@ajbt200128 are there any languages I'm forgetting here? Or should we blanket apply `-wasm-disable-fix-irreducible-control-flow-pass` ?