### PR TITLE
cleanup: Remove interactive tty requirement to apply severity icon and update test snapshots

### DIFF
--- a/cli/src/semgrep/formatter/text.py
+++ b/cli/src/semgrep/formatter/text.py
@@ -1,4 +1,3 @@
-import sys
 import textwrap
 from contextlib import contextmanager
 from itertools import groupby
@@ -64,25 +63,27 @@ GROUP_TITLES: Dict[Tuple[out.Product, str], str] = {
     ): "Secrets Validation Error",
 }
 
-SEVERITY_MAP = (
-    {
-        out.Error.to_json(): ("red", "❯❯❱"),
-        out.Warning.to_json(): ("magenta", " ❯❱"),
-        out.Info.to_json(): ("green", "  ❱"),
-    }
-    if sys.stderr.isatty()
-    else {
-        out.Error.to_json(): ("", "   "),
-        out.Warning.to_json(): ("", "   "),
-        out.Info.to_json(): ("", "   "),
-    }
-)
+SEVERITY_MAP_PLAIN = {
+    out.Error.to_json(): ("", "❯❯❱"),
+    out.Warning.to_json(): ("", " ❯❱"),
+    out.Info.to_json(): ("", "  ❱"),
+}
+
+SEVERITY_MAP_STYLED = {
+    out.Error.to_json(): ("red", "❯❯❱"),
+    out.Warning.to_json(): ("magenta", " ❯❱"),
+    out.Info.to_json(): ("green", "  ❱"),
+}
 
 
-def to_severity_indicator(rule_match: RuleMatch) -> Tuple[str, str]:
+def to_severity_indicator(
+    rule_match: RuleMatch,
+    color_output: bool = False,
+) -> Tuple[str, str]:
     """Return a color and severity icon."""
     severity = rule_match.severity.to_json()
-    return SEVERITY_MAP.get(severity, ("bright_white", "   "))
+    lookup = SEVERITY_MAP_STYLED if color_output else SEVERITY_MAP_PLAIN
+    return lookup.get(severity, ("", "   "))
 
 
 def format_finding_line(
@@ -615,7 +616,7 @@ def print_text_output(
                 initial_indent="",
                 subsequent_indent=RULE_INDENT * " ",
             )
-            sev_color, sev_icon = to_severity_indicator(rule_match)
+            sev_color, sev_icon = to_severity_indicator(rule_match, color_output)
             text = Text.assemble(
                 (RULE_INDENT - 4) * " ",
                 (sev_icon, sev_color),

--- a/cli/tests/e2e/snapshots/test_check/test_sort_text_findings/output.txt
+++ b/cli/tests/e2e/snapshots/test_check/test_sort_text_findings/output.txt
@@ -5,12 +5,12 @@
 └──────────────────┘
 
     targets/sort-findings/b.py
-       rules.sort-findings-2
+   ❯❯❱ rules.sort-findings-2
           found something (2)
 
             1┆ f()
 
-       rules.sort-findings-1
+   ❯❯❱ rules.sort-findings-1
           found something (1)
 
             1┆ f()
@@ -20,29 +20,29 @@
             2┆ f()
             3┆ f()
 
-       rules.sort-findings-2
+   ❯❯❱ rules.sort-findings-2
           found something (2)
 
             2┆ f()
 
-       rules.sort-findings-1
+   ❯❯❱ rules.sort-findings-1
           found something (1)
 
             2┆ f()
             3┆ f()
 
-       rules.sort-findings-2
+   ❯❯❱ rules.sort-findings-2
           found something (2)
 
             3┆ f()
 
     targets/sort-findings/c.py
-       rules.sort-findings-2
+   ❯❯❱ rules.sort-findings-2
           found something (2)
 
             1┆ f()
 
-       rules.sort-findings-1
+   ❯❯❱ rules.sort-findings-1
           found something (1)
 
             1┆ f()
@@ -52,35 +52,35 @@
             2┆ f()
             3┆ f()
 
-       rules.sort-findings-2
+   ❯❯❱ rules.sort-findings-2
           found something (2)
 
             2┆ f()
 
-       rules.sort-findings-1
+   ❯❯❱ rules.sort-findings-1
           found something (1)
 
             2┆ f()
             3┆ f()
 
-       rules.sort-findings-2
+   ❯❯❱ rules.sort-findings-2
           found something (2)
 
             3┆ f()
 
     targets/sort-findings/z/a.py
-       rules.sort-findings-2
+   ❯❯❱ rules.sort-findings-2
           found something (2)
 
             1┆ f()
 
-       rules.sort-findings-1
+   ❯❯❱ rules.sort-findings-1
           found something (1)
 
             1┆ f()
             2┆ f()
 
-       rules.sort-findings-2
+   ❯❯❱ rules.sort-findings-2
           found something (2)
 
             2┆ f()

--- a/cli/tests/e2e/snapshots/test_check/test_terminal_output/results.txt
+++ b/cli/tests/e2e/snapshots/test_check/test_terminal_output/results.txt
@@ -14,13 +14,13 @@ SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_FORCE_COLOR="true" FORCE_COLOR="1" SEMG
 └─────────────────┘
 
     targets/basic/stupid.js 
-       rules.javascript-basic-eqeq-bad
+   ❯❯❱ rules.javascript-basic-eqeq-bad
           useless comparison
 
             3┆ console.log(x == x)
 
     targets/basic/stupid.py 
-       rules.eqeq-is-bad
+   ❯❯❱ rules.eqeq-is-bad
           useless comparison operation `a + b == a + b` or `a + b != a + b`
           Details: https://sg.run/xyz1
 
@@ -68,13 +68,13 @@ Ran 4 rules on 14 files: 2 findings.
 └─────────────────┘
 
   [36m[22m[24m  targets/basic/stupid.js [0m
-       [1mrules.javascript-basic-eqeq-bad[0m
+   [31m❯❯❱[0m [1mrules.javascript-basic-eqeq-bad[0m
           useless comparison
 
             3┆ console.log([1mx == x[0m)
 
   [36m[22m[24m  targets/basic/stupid.py [0m
-       [1mrules.eqeq-is-bad[0m
+   [31m❯❯❱[0m [1mrules.eqeq-is-bad[0m
           useless comparison operation `a + b == a + b` or `a + b != a + b`
           Details: https://sg.run/xyz1
 

--- a/cli/tests/e2e/snapshots/test_check/test_terminal_output/results_second.txt
+++ b/cli/tests/e2e/snapshots/test_check/test_terminal_output/results_second.txt
@@ -14,13 +14,13 @@ SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_FORCE_COLOR="true" FORCE_COLOR="1" SEMG
 └─────────────────┘
 
     targets/basic/stupid.js 
-       rules.javascript-basic-eqeq-bad
+   ❯❯❱ rules.javascript-basic-eqeq-bad
           useless comparison
 
             3┆ console.log(x == x)
 
     targets/basic/stupid.py 
-       rules.eqeq-is-bad
+   ❯❯❱ rules.eqeq-is-bad
           useless comparison operation `a + b == a + b` or `a + b != a + b`
           Details: https://sg.run/xyz1
 
@@ -62,13 +62,13 @@ Ran 4 rules on 14 files: 2 findings.
 └─────────────────┘
 
   [36m[22m[24m  targets/basic/stupid.js [0m
-       [1mrules.javascript-basic-eqeq-bad[0m
+   [31m❯❯❱[0m [1mrules.javascript-basic-eqeq-bad[0m
           useless comparison
 
             3┆ console.log([1mx == x[0m)
 
   [36m[22m[24m  targets/basic/stupid.py [0m
-       [1mrules.eqeq-is-bad[0m
+   [31m❯❯❱[0m [1mrules.eqeq-is-bad[0m
           useless comparison operation `a + b == a + b` or `a + b != a + b`
           Details: https://sg.run/xyz1
 

--- a/cli/tests/e2e/snapshots/test_check/test_terminal_output_quiet/results.txt
+++ b/cli/tests/e2e/snapshots/test_check/test_terminal_output_quiet/results.txt
@@ -14,13 +14,13 @@ SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_FORCE_COLOR="true" FORCE_COLOR="1" SEMG
 └─────────────────┘
 
     targets/basic/stupid.js 
-       rules.javascript-basic-eqeq-bad
+   ❯❯❱ rules.javascript-basic-eqeq-bad
           useless comparison
 
             3┆ console.log(x == x)
 
     targets/basic/stupid.py 
-       rules.eqeq-is-bad
+   ❯❯❱ rules.eqeq-is-bad
           useless comparison operation `a + b == a + b` or `a + b != a + b`
           Details: https://sg.run/xyz1
 
@@ -41,13 +41,13 @@ SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_FORCE_COLOR="true" FORCE_COLOR="1" SEMG
 └─────────────────┘
 
   [36m[22m[24m  targets/basic/stupid.js [0m
-       [1mrules.javascript-basic-eqeq-bad[0m
+   [31m❯❯❱[0m [1mrules.javascript-basic-eqeq-bad[0m
           useless comparison
 
             3┆ console.log([1mx == x[0m)
 
   [36m[22m[24m  targets/basic/stupid.py [0m
-       [1mrules.eqeq-is-bad[0m
+   [31m❯❯❱[0m [1mrules.eqeq-is-bad[0m
           useless comparison operation `a + b == a + b` or `a + b != a + b`
           Details: https://sg.run/xyz1
 

--- a/cli/tests/e2e/snapshots/test_ci/test_config_run/autofix/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_config_run/autofix/results.txt
@@ -14,7 +14,7 @@ SEMGREP_APP_TOKEN="" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<
 └──────────────────────────┘
 
     foo.py
-       eqeq-bad
+   ❯❯❱ eqeq-bad
           useless comparison
 
             4┆ a == a
@@ -25,19 +25,19 @@ SEMGREP_APP_TOKEN="" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<
             ⋮┆----------------------------------------
            11┆ y == y
 
-       eqeq-four
+   ❯❯❱ eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
 
-       eqeq-bad
+   ❯❯❱ eqeq-bad
           useless comparison
 
            23┆ b == b # Triage ignored by syntactic_id
             ⋮┆----------------------------------------
            24┆ a == a # Triage ignored by match_based_id
 
-       taint-test
+    ❯❱ taint-test
           unsafe use of danger
 
            27┆ sink(d2)
@@ -48,7 +48,7 @@ SEMGREP_APP_TOKEN="" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<
 └──────────────────────────────────┘
 
     poetry.lock
-       supply-chain1
+   ❯❯❱ supply-chain1
           found a dependency
 
             2┆ name = "badlib"
@@ -59,7 +59,7 @@ SEMGREP_APP_TOKEN="" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<
 └─────────────────────────────┘
 
     foo.py
-       eqeq-five
+   ❯❯❱ eqeq-five
           useless comparison to 5
 
            ▶▶┆ Autofix ▶ (x == 2)

--- a/cli/tests/e2e/snapshots/test_ci/test_config_run/noautofix/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_config_run/noautofix/results.txt
@@ -14,7 +14,7 @@ SEMGREP_APP_TOKEN="" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<
 └──────────────────────────┘
 
     foo.py
-       eqeq-bad
+   ❯❯❱ eqeq-bad
           useless comparison
 
             4┆ a == a
@@ -25,19 +25,19 @@ SEMGREP_APP_TOKEN="" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<
             ⋮┆----------------------------------------
            11┆ y == y
 
-       eqeq-four
+   ❯❯❱ eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
 
-       eqeq-bad
+   ❯❯❱ eqeq-bad
           useless comparison
 
            23┆ b == b # Triage ignored by syntactic_id
             ⋮┆----------------------------------------
            24┆ a == a # Triage ignored by match_based_id
 
-       taint-test
+    ❯❱ taint-test
           unsafe use of danger
 
            27┆ sink(d2)
@@ -48,7 +48,7 @@ SEMGREP_APP_TOKEN="" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<
 └──────────────────────────────────┘
 
     poetry.lock
-       supply-chain1
+   ❯❯❱ supply-chain1
           found a dependency
 
             2┆ name = "badlib"
@@ -59,7 +59,7 @@ SEMGREP_APP_TOKEN="" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<
 └─────────────────────────────┘
 
     foo.py
-       eqeq-five
+   ❯❯❱ eqeq-five
           useless comparison to 5
 
            ▶▶┆ Autofix ▶ (x == 2)

--- a/cli/tests/e2e/snapshots/test_ci/test_dryrun/None/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_dryrun/None/results.txt
@@ -14,7 +14,7 @@ SEMGREP_APP_TOKEN="fake-key-from-tests" SEMGREP_USER_AGENT_APPEND="pytest" SEMGR
 └──────────────────────────┘
 
     foo.py
-       eqeq-bad
+   ❯❯❱ eqeq-bad
           useless comparison
 
             4┆ a == a
@@ -25,12 +25,12 @@ SEMGREP_APP_TOKEN="fake-key-from-tests" SEMGREP_USER_AGENT_APPEND="pytest" SEMGR
             ⋮┆----------------------------------------
            11┆ y == y
 
-       eqeq-four
+   ❯❯❱ eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
 
-       taint-test
+    ❯❱ taint-test
           unsafe use of danger
 
            27┆ sink(d2)
@@ -41,7 +41,7 @@ SEMGREP_APP_TOKEN="fake-key-from-tests" SEMGREP_USER_AGENT_APPEND="pytest" SEMGR
 └──────────────────────────────────┘
 
     poetry.lock
-       supply-chain1
+   ❯❯❱ supply-chain1
           found a dependency
 
             2┆ name = "badlib"
@@ -52,7 +52,7 @@ SEMGREP_APP_TOKEN="fake-key-from-tests" SEMGREP_USER_AGENT_APPEND="pytest" SEMGR
 └─────────────────────────────┘
 
     foo.py
-       eqeq-five
+   ❯❯❱ eqeq-five
           useless comparison to 5
 
            ▶▶┆ Autofix ▶ (x == 2)

--- a/cli/tests/e2e/snapshots/test_ci/test_existing_supply_chain_finding/config/base_output.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_existing_supply_chain_finding/config/base_output.txt
@@ -14,7 +14,7 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
 └──────────────────────────────────┘
 
     poetry.lock
-       supply-chain1
+   ❯❯❱ supply-chain1
           found a dependency
 
            18┆ name = "python-dateutil"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines-overwrite-autodetected-variables/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines-overwrite-autodetected-variables/results.txt
@@ -14,7 +14,7 @@ BUILD_BUILDID="some_id" SEMGREP_REPO_NAME="a/repo/name" SEMGREP_REPO_URL="https:
 └──────────────────────────┘
 
     foo.py
-       eqeq-bad
+   ❯❯❱ eqeq-bad
           useless comparison
 
             4┆ a == a
@@ -25,12 +25,12 @@ BUILD_BUILDID="some_id" SEMGREP_REPO_NAME="a/repo/name" SEMGREP_REPO_URL="https:
             ⋮┆----------------------------------------
            11┆ y == y
 
-       eqeq-four
+   ❯❯❱ eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
 
-       taint-test
+    ❯❱ taint-test
           unsafe use of danger
 
            27┆ sink(d2)
@@ -41,7 +41,7 @@ BUILD_BUILDID="some_id" SEMGREP_REPO_NAME="a/repo/name" SEMGREP_REPO_URL="https:
 └──────────────────────────────────┘
 
     poetry.lock
-       supply-chain1
+   ❯❯❱ supply-chain1
           found a dependency
 
             2┆ name = "badlib"
@@ -52,7 +52,7 @@ BUILD_BUILDID="some_id" SEMGREP_REPO_NAME="a/repo/name" SEMGREP_REPO_URL="https:
 └─────────────────────────────┘
 
     foo.py
-       eqeq-five
+   ❯❯❱ eqeq-five
           useless comparison to 5
 
            ▶▶┆ Autofix ▶ (x == 2)

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines/results.txt
@@ -14,7 +14,7 @@ BUILD_BUILDID="some_id" BUILD_REPOSITORY_URI="https://github.com/project_name/pr
 └──────────────────────────┘
 
     foo.py
-       eqeq-bad
+   ❯❯❱ eqeq-bad
           useless comparison
 
             4┆ a == a
@@ -25,12 +25,12 @@ BUILD_BUILDID="some_id" BUILD_REPOSITORY_URI="https://github.com/project_name/pr
             ⋮┆----------------------------------------
            11┆ y == y
 
-       eqeq-four
+   ❯❯❱ eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
 
-       taint-test
+    ❯❱ taint-test
           unsafe use of danger
 
            27┆ sink(d2)
@@ -41,7 +41,7 @@ BUILD_BUILDID="some_id" BUILD_REPOSITORY_URI="https://github.com/project_name/pr
 └──────────────────────────────────┘
 
     poetry.lock
-       supply-chain1
+   ❯❯❱ supply-chain1
           found a dependency
 
             2┆ name = "badlib"
@@ -52,7 +52,7 @@ BUILD_BUILDID="some_id" BUILD_REPOSITORY_URI="https://github.com/project_name/pr
 └─────────────────────────────┘
 
     foo.py
-       eqeq-five
+   ❯❯❱ eqeq-five
           useless comparison to 5
 
            ▶▶┆ Autofix ▶ (x == 2)

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket-overwrite-autodetected-variables/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket-overwrite-autodetected-variables/results.txt
@@ -14,7 +14,7 @@ CI="true" BITBUCKET_BUILD_NUMBER="hi" SEMGREP_REPO_NAME="a/repo/name" SEMGREP_RE
 └──────────────────────────┘
 
     foo.py
-       eqeq-bad
+   ❯❯❱ eqeq-bad
           useless comparison
 
             4┆ a == a
@@ -25,12 +25,12 @@ CI="true" BITBUCKET_BUILD_NUMBER="hi" SEMGREP_REPO_NAME="a/repo/name" SEMGREP_RE
             ⋮┆----------------------------------------
            11┆ y == y
 
-       eqeq-four
+   ❯❯❱ eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
 
-       taint-test
+    ❯❱ taint-test
           unsafe use of danger
 
            27┆ sink(d2)
@@ -41,7 +41,7 @@ CI="true" BITBUCKET_BUILD_NUMBER="hi" SEMGREP_REPO_NAME="a/repo/name" SEMGREP_RE
 └──────────────────────────────────┘
 
     poetry.lock
-       supply-chain1
+   ❯❯❱ supply-chain1
           found a dependency
 
             2┆ name = "badlib"
@@ -52,7 +52,7 @@ CI="true" BITBUCKET_BUILD_NUMBER="hi" SEMGREP_REPO_NAME="a/repo/name" SEMGREP_RE
 └─────────────────────────────┘
 
     foo.py
-       eqeq-five
+   ❯❯❱ eqeq-five
           useless comparison to 5
 
            ▶▶┆ Autofix ▶ (x == 2)

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket/results.txt
@@ -14,7 +14,7 @@ CI="true" BITBUCKET_BUILD_NUMBER="hi" BITBUCKET_REPO_FULL_NAME="project_name/pro
 └──────────────────────────┘
 
     foo.py
-       eqeq-bad
+   ❯❯❱ eqeq-bad
           useless comparison
 
             4┆ a == a
@@ -25,12 +25,12 @@ CI="true" BITBUCKET_BUILD_NUMBER="hi" BITBUCKET_REPO_FULL_NAME="project_name/pro
             ⋮┆----------------------------------------
            11┆ y == y
 
-       eqeq-four
+   ❯❯❱ eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
 
-       taint-test
+    ❯❱ taint-test
           unsafe use of danger
 
            27┆ sink(d2)
@@ -41,7 +41,7 @@ CI="true" BITBUCKET_BUILD_NUMBER="hi" BITBUCKET_REPO_FULL_NAME="project_name/pro
 └──────────────────────────────────┘
 
     poetry.lock
-       supply-chain1
+   ❯❯❱ supply-chain1
           found a dependency
 
             2┆ name = "badlib"
@@ -52,7 +52,7 @@ CI="true" BITBUCKET_BUILD_NUMBER="hi" BITBUCKET_REPO_FULL_NAME="project_name/pro
 └─────────────────────────────┘
 
     foo.py
-       eqeq-five
+   ❯❯❱ eqeq-five
           useless comparison to 5
 
            ▶▶┆ Autofix ▶ (x == 2)

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite-overwrite-autodetected-variables/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite-overwrite-autodetected-variables/results.txt
@@ -14,7 +14,7 @@ BUILDKITE="true" SEMGREP_REPO_NAME="a/repo/name" SEMGREP_REPO_URL="https://rando
 └──────────────────────────┘
 
     foo.py
-       eqeq-bad
+   ❯❯❱ eqeq-bad
           useless comparison
 
             4┆ a == a
@@ -25,12 +25,12 @@ BUILDKITE="true" SEMGREP_REPO_NAME="a/repo/name" SEMGREP_REPO_URL="https://rando
             ⋮┆----------------------------------------
            11┆ y == y
 
-       eqeq-four
+   ❯❯❱ eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
 
-       taint-test
+    ❯❱ taint-test
           unsafe use of danger
 
            27┆ sink(d2)
@@ -41,7 +41,7 @@ BUILDKITE="true" SEMGREP_REPO_NAME="a/repo/name" SEMGREP_REPO_URL="https://rando
 └──────────────────────────────────┘
 
     poetry.lock
-       supply-chain1
+   ❯❯❱ supply-chain1
           found a dependency
 
             2┆ name = "badlib"
@@ -52,7 +52,7 @@ BUILDKITE="true" SEMGREP_REPO_NAME="a/repo/name" SEMGREP_REPO_URL="https://rando
 └─────────────────────────────┘
 
     foo.py
-       eqeq-five
+   ❯❯❱ eqeq-five
           useless comparison to 5
 
            ▶▶┆ Autofix ▶ (x == 2)

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite/results.txt
@@ -14,7 +14,7 @@ BUILDKITE="true" BUILDKITE_REPO="git@github.com/project_name/project_name.git" B
 └──────────────────────────┘
 
     foo.py
-       eqeq-bad
+   ❯❯❱ eqeq-bad
           useless comparison
 
             4┆ a == a
@@ -25,12 +25,12 @@ BUILDKITE="true" BUILDKITE_REPO="git@github.com/project_name/project_name.git" B
             ⋮┆----------------------------------------
            11┆ y == y
 
-       eqeq-four
+   ❯❯❱ eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
 
-       taint-test
+    ❯❱ taint-test
           unsafe use of danger
 
            27┆ sink(d2)
@@ -41,7 +41,7 @@ BUILDKITE="true" BUILDKITE_REPO="git@github.com/project_name/project_name.git" B
 └──────────────────────────────────┘
 
     poetry.lock
-       supply-chain1
+   ❯❯❱ supply-chain1
           found a dependency
 
             2┆ name = "badlib"
@@ -52,7 +52,7 @@ BUILDKITE="true" BUILDKITE_REPO="git@github.com/project_name/project_name.git" B
 └─────────────────────────────┘
 
     foo.py
-       eqeq-five
+   ❯❯❱ eqeq-five
           useless comparison to 5
 
            ▶▶┆ Autofix ▶ (x == 2)

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci-overwrite-autodetected-variables/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci-overwrite-autodetected-variables/results.txt
@@ -14,7 +14,7 @@ CI="true" SEMGREP_REPO_NAME="a/repo/name" SEMGREP_REPO_URL="https://random.url.o
 └──────────────────────────┘
 
     foo.py
-       eqeq-bad
+   ❯❯❱ eqeq-bad
           useless comparison
 
             4┆ a == a
@@ -25,12 +25,12 @@ CI="true" SEMGREP_REPO_NAME="a/repo/name" SEMGREP_REPO_URL="https://random.url.o
             ⋮┆----------------------------------------
            11┆ y == y
 
-       eqeq-four
+   ❯❯❱ eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
 
-       taint-test
+    ❯❱ taint-test
           unsafe use of danger
 
            27┆ sink(d2)
@@ -41,7 +41,7 @@ CI="true" SEMGREP_REPO_NAME="a/repo/name" SEMGREP_REPO_URL="https://random.url.o
 └──────────────────────────────────┘
 
     poetry.lock
-       supply-chain1
+   ❯❯❱ supply-chain1
           found a dependency
 
             2┆ name = "badlib"
@@ -52,7 +52,7 @@ CI="true" SEMGREP_REPO_NAME="a/repo/name" SEMGREP_REPO_URL="https://random.url.o
 └─────────────────────────────┘
 
     foo.py
-       eqeq-five
+   ❯❯❱ eqeq-five
           useless comparison to 5
 
            ▶▶┆ Autofix ▶ (x == 2)

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci/results.txt
@@ -14,7 +14,7 @@ CI="true" CIRCLECI="true" CIRCLE_PROJECT_USERNAME="project_name" CIRCLE_PROJECT_
 └──────────────────────────┘
 
     foo.py
-       eqeq-bad
+   ❯❯❱ eqeq-bad
           useless comparison
 
             4┆ a == a
@@ -25,12 +25,12 @@ CI="true" CIRCLECI="true" CIRCLE_PROJECT_USERNAME="project_name" CIRCLE_PROJECT_
             ⋮┆----------------------------------------
            11┆ y == y
 
-       eqeq-four
+   ❯❯❱ eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
 
-       taint-test
+    ❯❱ taint-test
           unsafe use of danger
 
            27┆ sink(d2)
@@ -41,7 +41,7 @@ CI="true" CIRCLECI="true" CIRCLE_PROJECT_USERNAME="project_name" CIRCLE_PROJECT_
 └──────────────────────────────────┘
 
     poetry.lock
-       supply-chain1
+   ❯❯❱ supply-chain1
           found a dependency
 
             2┆ name = "badlib"
@@ -52,7 +52,7 @@ CI="true" CIRCLECI="true" CIRCLE_PROJECT_USERNAME="project_name" CIRCLE_PROJECT_
 └─────────────────────────────┘
 
     foo.py
-       eqeq-five
+   ❯❯❱ eqeq-five
           useless comparison to 5
 
            ▶▶┆ Autofix ▶ (x == 2)

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/results.txt
@@ -39,7 +39,7 @@ CI="true" GITHUB_ACTIONS="true" GITHUB_ACTOR="some_test_username" GITHUB_API_URL
 └──────────────────────────┘
 
     foo.py
-       eqeq-bad
+   ❯❯❱ eqeq-bad
           useless comparison
 
             4┆ a == a
@@ -50,12 +50,12 @@ CI="true" GITHUB_ACTIONS="true" GITHUB_ACTOR="some_test_username" GITHUB_API_URL
             ⋮┆----------------------------------------
            11┆ y == y
 
-       eqeq-four
+   ❯❯❱ eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
 
-       taint-test
+    ❯❱ taint-test
           unsafe use of danger
 
            27┆ sink(d2)
@@ -66,7 +66,7 @@ CI="true" GITHUB_ACTIONS="true" GITHUB_ACTOR="some_test_username" GITHUB_API_URL
 └──────────────────────────────────┘
 
     poetry.lock
-       supply-chain1
+   ❯❯❱ supply-chain1
           found a dependency
 
             2┆ name = "badlib"
@@ -77,7 +77,7 @@ CI="true" GITHUB_ACTIONS="true" GITHUB_ACTOR="some_test_username" GITHUB_API_URL
 └─────────────────────────────┘
 
     foo.py
-       eqeq-five
+   ❯❯❱ eqeq-five
           useless comparison to 5
 
            ▶▶┆ Autofix ▶ (x == 2)

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr-semgrepconfig/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr-semgrepconfig/results.txt
@@ -52,7 +52,7 @@ Creating git worktree from '<MASKED>' to scan baseline.
 └──────────────────────────┘
 
     foo.py
-       eqeq-bad
+   ❯❯❱ eqeq-bad
           useless comparison
 
             4┆ a == a
@@ -63,12 +63,12 @@ Creating git worktree from '<MASKED>' to scan baseline.
             ⋮┆----------------------------------------
            11┆ y == y
 
-       eqeq-four
+   ❯❯❱ eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
 
-       taint-test
+    ❯❱ taint-test
           unsafe use of danger
 
            27┆ sink(d2)
@@ -79,7 +79,7 @@ Creating git worktree from '<MASKED>' to scan baseline.
 └─────────────────────────────┘
 
     foo.py
-       eqeq-five
+   ❯❯❱ eqeq-five
           useless comparison to 5
 
            ▶▶┆ Autofix ▶ (x == 2)

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr/results.txt
@@ -49,7 +49,7 @@ Creating git worktree from '<MASKED>' to scan baseline.
 └──────────────────────────┘
 
     foo.py
-       eqeq-bad
+   ❯❯❱ eqeq-bad
           useless comparison
 
             4┆ a == a
@@ -60,12 +60,12 @@ Creating git worktree from '<MASKED>' to scan baseline.
             ⋮┆----------------------------------------
            11┆ y == y
 
-       eqeq-four
+   ❯❯❱ eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
 
-       taint-test
+    ❯❱ taint-test
           unsafe use of danger
 
            27┆ sink(d2)
@@ -76,7 +76,7 @@ Creating git worktree from '<MASKED>' to scan baseline.
 └─────────────────────────────┘
 
     foo.py
-       eqeq-five
+   ❯❯❱ eqeq-five
           useless comparison to 5
 
            ▶▶┆ Autofix ▶ (x == 2)

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push-special-env-vars/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push-special-env-vars/results.txt
@@ -39,7 +39,7 @@ CI="true" GITHUB_ACTIONS="true" GITHUB_ACTOR="some_test_username" GITHUB_API_URL
 └──────────────────────────┘
 
     foo.py
-       eqeq-bad
+   ❯❯❱ eqeq-bad
           useless comparison
 
             4┆ a == a
@@ -50,12 +50,12 @@ CI="true" GITHUB_ACTIONS="true" GITHUB_ACTOR="some_test_username" GITHUB_API_URL
             ⋮┆----------------------------------------
            11┆ y == y
 
-       eqeq-four
+   ❯❯❱ eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
 
-       taint-test
+    ❯❱ taint-test
           unsafe use of danger
 
            27┆ sink(d2)
@@ -66,7 +66,7 @@ CI="true" GITHUB_ACTIONS="true" GITHUB_ACTOR="some_test_username" GITHUB_API_URL
 └──────────────────────────────────┘
 
     poetry.lock
-       supply-chain1
+   ❯❯❱ supply-chain1
           found a dependency
 
             2┆ name = "badlib"
@@ -77,7 +77,7 @@ CI="true" GITHUB_ACTIONS="true" GITHUB_ACTOR="some_test_username" GITHUB_API_URL
 └─────────────────────────────┘
 
     foo.py
-       eqeq-five
+   ❯❯❱ eqeq-five
           useless comparison to 5
 
            ▶▶┆ Autofix ▶ (x == 2)

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/results.txt
@@ -39,7 +39,7 @@ CI="true" GITHUB_ACTIONS="true" GITHUB_ACTOR="some_test_username" GITHUB_API_URL
 └──────────────────────────┘
 
     foo.py
-       eqeq-bad
+   ❯❯❱ eqeq-bad
           useless comparison
 
             4┆ a == a
@@ -50,12 +50,12 @@ CI="true" GITHUB_ACTIONS="true" GITHUB_ACTOR="some_test_username" GITHUB_API_URL
             ⋮┆----------------------------------------
            11┆ y == y
 
-       eqeq-four
+   ❯❯❱ eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
 
-       taint-test
+    ❯❱ taint-test
           unsafe use of danger
 
            27┆ sink(d2)
@@ -66,7 +66,7 @@ CI="true" GITHUB_ACTIONS="true" GITHUB_ACTOR="some_test_username" GITHUB_API_URL
 └──────────────────────────────────┘
 
     poetry.lock
-       supply-chain1
+   ❯❯❱ supply-chain1
           found a dependency
 
             2┆ name = "badlib"
@@ -77,7 +77,7 @@ CI="true" GITHUB_ACTIONS="true" GITHUB_ACTOR="some_test_username" GITHUB_API_URL
 └─────────────────────────────┘
 
     foo.py
-       eqeq-five
+   ❯❯❱ eqeq-five
           useless comparison to 5
 
            ▶▶┆ Autofix ▶ (x == 2)

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-push/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-push/results.txt
@@ -14,7 +14,7 @@ CI="true" GITLAB_CI="true" CI_PROJECT_PATH="project_name/project_name" CI_PIPELI
 └──────────────────────────┘
 
     foo.py
-       eqeq-bad
+   ❯❯❱ eqeq-bad
           useless comparison
 
             4┆ a == a
@@ -25,12 +25,12 @@ CI="true" GITLAB_CI="true" CI_PROJECT_PATH="project_name/project_name" CI_PIPELI
             ⋮┆----------------------------------------
            11┆ y == y
 
-       eqeq-four
+   ❯❯❱ eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
 
-       taint-test
+    ❯❱ taint-test
           unsafe use of danger
 
            27┆ sink(d2)
@@ -41,7 +41,7 @@ CI="true" GITLAB_CI="true" CI_PROJECT_PATH="project_name/project_name" CI_PIPELI
 └──────────────────────────────────┘
 
     poetry.lock
-       supply-chain1
+   ❯❯❱ supply-chain1
           found a dependency
 
             2┆ name = "badlib"
@@ -52,7 +52,7 @@ CI="true" GITLAB_CI="true" CI_PROJECT_PATH="project_name/project_name" CI_PIPELI
 └─────────────────────────────┘
 
     foo.py
-       eqeq-five
+   ❯❯❱ eqeq-five
           useless comparison to 5
 
            ▶▶┆ Autofix ▶ (x == 2)

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-special-env-vars/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-special-env-vars/results.txt
@@ -14,7 +14,7 @@ CI="true" GITLAB_CI="true" SEMGREP_REPO_NAME="project_name/project_name" CI_PIPE
 └──────────────────────────┘
 
     foo.py
-       eqeq-bad
+   ❯❯❱ eqeq-bad
           useless comparison
 
             4┆ a == a
@@ -25,12 +25,12 @@ CI="true" GITLAB_CI="true" SEMGREP_REPO_NAME="project_name/project_name" CI_PIPE
             ⋮┆----------------------------------------
            11┆ y == y
 
-       eqeq-four
+   ❯❯❱ eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
 
-       taint-test
+    ❯❱ taint-test
           unsafe use of danger
 
            27┆ sink(d2)
@@ -41,7 +41,7 @@ CI="true" GITLAB_CI="true" SEMGREP_REPO_NAME="project_name/project_name" CI_PIPE
 └─────────────────────────────┘
 
     foo.py
-       eqeq-five
+   ❯❯❱ eqeq-five
           useless comparison to 5
 
            ▶▶┆ Autofix ▶ (x == 2)

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab/results.txt
@@ -14,7 +14,7 @@ CI="true" GITLAB_CI="true" CI_PROJECT_PATH="project_name/project_name" CI_PIPELI
 └──────────────────────────┘
 
     foo.py
-       eqeq-bad
+   ❯❯❱ eqeq-bad
           useless comparison
 
             4┆ a == a
@@ -25,12 +25,12 @@ CI="true" GITLAB_CI="true" CI_PROJECT_PATH="project_name/project_name" CI_PIPELI
             ⋮┆----------------------------------------
            11┆ y == y
 
-       eqeq-four
+   ❯❯❱ eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
 
-       taint-test
+    ❯❱ taint-test
           unsafe use of danger
 
            27┆ sink(d2)
@@ -41,7 +41,7 @@ CI="true" GITLAB_CI="true" CI_PROJECT_PATH="project_name/project_name" CI_PIPELI
 └─────────────────────────────┘
 
     foo.py
-       eqeq-five
+   ❯❯❱ eqeq-five
           useless comparison to 5
 
            ▶▶┆ Autofix ▶ (x == 2)

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/results.txt
@@ -14,7 +14,7 @@ JENKINS_URL="some_url" SEMGREP_REPO_URL="https://random.url.org/some/path" SEMGR
 └──────────────────────────┘
 
     foo.py
-       eqeq-bad
+   ❯❯❱ eqeq-bad
           useless comparison
 
             4┆ a == a
@@ -25,12 +25,12 @@ JENKINS_URL="some_url" SEMGREP_REPO_URL="https://random.url.org/some/path" SEMGR
             ⋮┆----------------------------------------
            11┆ y == y
 
-       eqeq-four
+   ❯❯❱ eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
 
-       taint-test
+    ❯❱ taint-test
           unsafe use of danger
 
            27┆ sink(d2)
@@ -41,7 +41,7 @@ JENKINS_URL="some_url" SEMGREP_REPO_URL="https://random.url.org/some/path" SEMGR
 └──────────────────────────────────┘
 
     poetry.lock
-       supply-chain1
+   ❯❯❱ supply-chain1
           found a dependency
 
             2┆ name = "badlib"
@@ -52,7 +52,7 @@ JENKINS_URL="some_url" SEMGREP_REPO_URL="https://random.url.org/some/path" SEMGR
 └─────────────────────────────┘
 
     foo.py
-       eqeq-five
+   ❯❯❱ eqeq-five
           useless comparison to 5
 
            ▶▶┆ Autofix ▶ (x == 2)

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-overwrite-autodetected-variables/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-overwrite-autodetected-variables/results.txt
@@ -14,7 +14,7 @@ JENKINS_URL="some_url" SEMGREP_REPO_NAME="a/repo/name" SEMGREP_REPO_URL="https:/
 └──────────────────────────┘
 
     foo.py
-       eqeq-bad
+   ❯❯❱ eqeq-bad
           useless comparison
 
             4┆ a == a
@@ -25,12 +25,12 @@ JENKINS_URL="some_url" SEMGREP_REPO_NAME="a/repo/name" SEMGREP_REPO_URL="https:/
             ⋮┆----------------------------------------
            11┆ y == y
 
-       eqeq-four
+   ❯❯❱ eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
 
-       taint-test
+    ❯❱ taint-test
           unsafe use of danger
 
            27┆ sink(d2)
@@ -41,7 +41,7 @@ JENKINS_URL="some_url" SEMGREP_REPO_NAME="a/repo/name" SEMGREP_REPO_URL="https:/
 └──────────────────────────────────┘
 
     poetry.lock
-       supply-chain1
+   ❯❯❱ supply-chain1
           found a dependency
 
             2┆ name = "badlib"
@@ -52,7 +52,7 @@ JENKINS_URL="some_url" SEMGREP_REPO_NAME="a/repo/name" SEMGREP_REPO_URL="https:/
 └─────────────────────────────┘
 
     foo.py
-       eqeq-five
+   ❯❯❱ eqeq-five
           useless comparison to 5
 
            ▶▶┆ Autofix ▶ (x == 2)

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins/results.txt
@@ -14,7 +14,7 @@ JENKINS_URL="some_url" GIT_URL="https://github.com/org/repo.git/" GIT_BRANCH="so
 └──────────────────────────┘
 
     foo.py
-       eqeq-bad
+   ❯❯❱ eqeq-bad
           useless comparison
 
             4┆ a == a
@@ -25,12 +25,12 @@ JENKINS_URL="some_url" GIT_URL="https://github.com/org/repo.git/" GIT_BRANCH="so
             ⋮┆----------------------------------------
            11┆ y == y
 
-       eqeq-four
+   ❯❯❱ eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
 
-       taint-test
+    ❯❱ taint-test
           unsafe use of danger
 
            27┆ sink(d2)
@@ -41,7 +41,7 @@ JENKINS_URL="some_url" GIT_URL="https://github.com/org/repo.git/" GIT_BRANCH="so
 └──────────────────────────────────┘
 
     poetry.lock
-       supply-chain1
+   ❯❯❱ supply-chain1
           found a dependency
 
             2┆ name = "badlib"
@@ -52,7 +52,7 @@ JENKINS_URL="some_url" GIT_URL="https://github.com/org/repo.git/" GIT_BRANCH="so
 └─────────────────────────────┘
 
     foo.py
-       eqeq-five
+   ❯❯❱ eqeq-five
           useless comparison to 5
 
            ▶▶┆ Autofix ▶ (x == 2)

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/results.txt
@@ -14,7 +14,7 @@ SEMGREP_APP_TOKEN="fake-key-from-tests" SEMGREP_REPO_URL="git@github.com:example
 └──────────────────────────┘
 
     foo.py
-       eqeq-bad
+   ❯❯❱ eqeq-bad
           useless comparison
 
             4┆ a == a
@@ -25,12 +25,12 @@ SEMGREP_APP_TOKEN="fake-key-from-tests" SEMGREP_REPO_URL="git@github.com:example
             ⋮┆----------------------------------------
            11┆ y == y
 
-       eqeq-four
+   ❯❯❱ eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
 
-       taint-test
+    ❯❱ taint-test
           unsafe use of danger
 
            27┆ sink(d2)
@@ -41,7 +41,7 @@ SEMGREP_APP_TOKEN="fake-key-from-tests" SEMGREP_REPO_URL="git@github.com:example
 └──────────────────────────────────┘
 
     poetry.lock
-       supply-chain1
+   ❯❯❱ supply-chain1
           found a dependency
 
             2┆ name = "badlib"
@@ -52,7 +52,7 @@ SEMGREP_APP_TOKEN="fake-key-from-tests" SEMGREP_REPO_URL="git@github.com:example
 └─────────────────────────────┘
 
     foo.py
-       eqeq-five
+   ❯❯❱ eqeq-five
           useless comparison to 5
 
            ▶▶┆ Autofix ▶ (x == 2)

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-self-hosted/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-self-hosted/results.txt
@@ -14,7 +14,7 @@ CI="true" SEMGREP_REPO_NAME="org_name/project_name/project_name" SEMGREP_REPO_UR
 └──────────────────────────┘
 
     foo.py
-       eqeq-bad
+   ❯❯❱ eqeq-bad
           useless comparison
 
             4┆ a == a
@@ -25,12 +25,12 @@ CI="true" SEMGREP_REPO_NAME="org_name/project_name/project_name" SEMGREP_REPO_UR
             ⋮┆----------------------------------------
            11┆ y == y
 
-       eqeq-four
+   ❯❯❱ eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
 
-       taint-test
+    ❯❱ taint-test
           unsafe use of danger
 
            27┆ sink(d2)
@@ -41,7 +41,7 @@ CI="true" SEMGREP_REPO_NAME="org_name/project_name/project_name" SEMGREP_REPO_UR
 └──────────────────────────────────┘
 
     poetry.lock
-       supply-chain1
+   ❯❯❱ supply-chain1
           found a dependency
 
             2┆ name = "badlib"
@@ -52,7 +52,7 @@ CI="true" SEMGREP_REPO_NAME="org_name/project_name/project_name" SEMGREP_REPO_UR
 └─────────────────────────────┘
 
     foo.py
-       eqeq-five
+   ❯❯❱ eqeq-five
           useless comparison to 5
 
            ▶▶┆ Autofix ▶ (x == 2)

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis-overwrite-autodetected-variables/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis-overwrite-autodetected-variables/results.txt
@@ -14,7 +14,7 @@ CI="true" TRAVIS="true" SEMGREP_REPO_NAME="a/repo/name" SEMGREP_REPO_URL="https:
 └──────────────────────────┘
 
     foo.py
-       eqeq-bad
+   ❯❯❱ eqeq-bad
           useless comparison
 
             4┆ a == a
@@ -25,12 +25,12 @@ CI="true" TRAVIS="true" SEMGREP_REPO_NAME="a/repo/name" SEMGREP_REPO_URL="https:
             ⋮┆----------------------------------------
            11┆ y == y
 
-       eqeq-four
+   ❯❯❱ eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
 
-       taint-test
+    ❯❱ taint-test
           unsafe use of danger
 
            27┆ sink(d2)
@@ -41,7 +41,7 @@ CI="true" TRAVIS="true" SEMGREP_REPO_NAME="a/repo/name" SEMGREP_REPO_URL="https:
 └──────────────────────────────────┘
 
     poetry.lock
-       supply-chain1
+   ❯❯❱ supply-chain1
           found a dependency
 
             2┆ name = "badlib"
@@ -52,7 +52,7 @@ CI="true" TRAVIS="true" SEMGREP_REPO_NAME="a/repo/name" SEMGREP_REPO_URL="https:
 └─────────────────────────────┘
 
     foo.py
-       eqeq-five
+   ❯❯❱ eqeq-five
           useless comparison to 5
 
            ▶▶┆ Autofix ▶ (x == 2)

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis/results.txt
@@ -14,7 +14,7 @@ CI="true" TRAVIS="true" TRAVIS_REPO_SLUG="project_name/project_name" TRAVIS_PULL
 └──────────────────────────┘
 
     foo.py
-       eqeq-bad
+   ❯❯❱ eqeq-bad
           useless comparison
 
             4┆ a == a
@@ -25,12 +25,12 @@ CI="true" TRAVIS="true" TRAVIS_REPO_SLUG="project_name/project_name" TRAVIS_PULL
             ⋮┆----------------------------------------
            11┆ y == y
 
-       eqeq-four
+   ❯❯❱ eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
 
-       taint-test
+    ❯❱ taint-test
           unsafe use of danger
 
            27┆ sink(d2)
@@ -41,7 +41,7 @@ CI="true" TRAVIS="true" TRAVIS_REPO_SLUG="project_name/project_name" TRAVIS_PULL
 └──────────────────────────────────┘
 
     poetry.lock
-       supply-chain1
+   ❯❯❱ supply-chain1
           found a dependency
 
             2┆ name = "badlib"
@@ -52,7 +52,7 @@ CI="true" TRAVIS="true" TRAVIS_REPO_SLUG="project_name/project_name" TRAVIS_PULL
 └─────────────────────────────┘
 
     foo.py
-       eqeq-five
+   ❯❯❱ eqeq-five
           useless comparison to 5
 
            ▶▶┆ Autofix ▶ (x == 2)

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-unparsable_url/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-unparsable_url/results.txt
@@ -14,7 +14,7 @@ CI="true" SEMGREP_REPO_NAME="org_name/project_name/project_name" SEMGREP_REPO_UR
 └──────────────────────────┘
 
     foo.py
-       eqeq-bad
+   ❯❯❱ eqeq-bad
           useless comparison
 
             4┆ a == a
@@ -25,12 +25,12 @@ CI="true" SEMGREP_REPO_NAME="org_name/project_name/project_name" SEMGREP_REPO_UR
             ⋮┆----------------------------------------
            11┆ y == y
 
-       eqeq-four
+   ❯❯❱ eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
 
-       taint-test
+    ❯❱ taint-test
           unsafe use of danger
 
            27┆ sink(d2)
@@ -41,7 +41,7 @@ CI="true" SEMGREP_REPO_NAME="org_name/project_name/project_name" SEMGREP_REPO_UR
 └──────────────────────────────────┘
 
     poetry.lock
-       supply-chain1
+   ❯❯❱ supply-chain1
           found a dependency
 
             2┆ name = "badlib"
@@ -52,7 +52,7 @@ CI="true" SEMGREP_REPO_NAME="org_name/project_name/project_name" SEMGREP_REPO_UR
 └─────────────────────────────┘
 
     foo.py
-       eqeq-five
+   ❯❯❱ eqeq-five
           useless comparison to 5
 
            ▶▶┆ Autofix ▶ (x == 2)

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines-overwrite-autodetected-variables/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines-overwrite-autodetected-variables/results.txt
@@ -14,7 +14,7 @@ BUILD_BUILDID="some_id" SEMGREP_REPO_NAME="a/repo/name" SEMGREP_REPO_URL="https:
 └──────────────────────────┘
 
     foo.py
-       eqeq-bad
+   ❯❯❱ eqeq-bad
           useless comparison
 
             4┆ a == a
@@ -25,12 +25,12 @@ BUILD_BUILDID="some_id" SEMGREP_REPO_NAME="a/repo/name" SEMGREP_REPO_URL="https:
             ⋮┆----------------------------------------
            11┆ y == y
 
-       eqeq-four
+   ❯❯❱ eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
 
-       taint-test
+    ❯❱ taint-test
           unsafe use of danger
 
            27┆ sink(d2)
@@ -41,7 +41,7 @@ BUILD_BUILDID="some_id" SEMGREP_REPO_NAME="a/repo/name" SEMGREP_REPO_URL="https:
 └──────────────────────────────────┘
 
     poetry.lock
-       supply-chain1
+   ❯❯❱ supply-chain1
           found a dependency
 
             2┆ name = "badlib"
@@ -52,7 +52,7 @@ BUILD_BUILDID="some_id" SEMGREP_REPO_NAME="a/repo/name" SEMGREP_REPO_URL="https:
 └─────────────────────────────┘
 
     foo.py
-       eqeq-five
+   ❯❯❱ eqeq-five
           useless comparison to 5
 
            ▶▶┆ Autofix ▶ (x == 2)

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines/results.txt
@@ -14,7 +14,7 @@ BUILD_BUILDID="some_id" BUILD_REPOSITORY_URI="https://github.com/project_name/pr
 └──────────────────────────┘
 
     foo.py
-       eqeq-bad
+   ❯❯❱ eqeq-bad
           useless comparison
 
             4┆ a == a
@@ -25,12 +25,12 @@ BUILD_BUILDID="some_id" BUILD_REPOSITORY_URI="https://github.com/project_name/pr
             ⋮┆----------------------------------------
            11┆ y == y
 
-       eqeq-four
+   ❯❯❱ eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
 
-       taint-test
+    ❯❱ taint-test
           unsafe use of danger
 
            27┆ sink(d2)
@@ -41,7 +41,7 @@ BUILD_BUILDID="some_id" BUILD_REPOSITORY_URI="https://github.com/project_name/pr
 └──────────────────────────────────┘
 
     poetry.lock
-       supply-chain1
+   ❯❯❱ supply-chain1
           found a dependency
 
             2┆ name = "badlib"
@@ -52,7 +52,7 @@ BUILD_BUILDID="some_id" BUILD_REPOSITORY_URI="https://github.com/project_name/pr
 └─────────────────────────────┘
 
     foo.py
-       eqeq-five
+   ❯❯❱ eqeq-five
           useless comparison to 5
 
            ▶▶┆ Autofix ▶ (x == 2)

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket-overwrite-autodetected-variables/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket-overwrite-autodetected-variables/results.txt
@@ -14,7 +14,7 @@ CI="true" BITBUCKET_BUILD_NUMBER="hi" SEMGREP_REPO_NAME="a/repo/name" SEMGREP_RE
 └──────────────────────────┘
 
     foo.py
-       eqeq-bad
+   ❯❯❱ eqeq-bad
           useless comparison
 
             4┆ a == a
@@ -25,12 +25,12 @@ CI="true" BITBUCKET_BUILD_NUMBER="hi" SEMGREP_REPO_NAME="a/repo/name" SEMGREP_RE
             ⋮┆----------------------------------------
            11┆ y == y
 
-       eqeq-four
+   ❯❯❱ eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
 
-       taint-test
+    ❯❱ taint-test
           unsafe use of danger
 
            27┆ sink(d2)
@@ -41,7 +41,7 @@ CI="true" BITBUCKET_BUILD_NUMBER="hi" SEMGREP_REPO_NAME="a/repo/name" SEMGREP_RE
 └──────────────────────────────────┘
 
     poetry.lock
-       supply-chain1
+   ❯❯❱ supply-chain1
           found a dependency
 
             2┆ name = "badlib"
@@ -52,7 +52,7 @@ CI="true" BITBUCKET_BUILD_NUMBER="hi" SEMGREP_REPO_NAME="a/repo/name" SEMGREP_RE
 └─────────────────────────────┘
 
     foo.py
-       eqeq-five
+   ❯❯❱ eqeq-five
           useless comparison to 5
 
            ▶▶┆ Autofix ▶ (x == 2)

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket/results.txt
@@ -14,7 +14,7 @@ CI="true" BITBUCKET_BUILD_NUMBER="hi" BITBUCKET_REPO_FULL_NAME="project_name/pro
 └──────────────────────────┘
 
     foo.py
-       eqeq-bad
+   ❯❯❱ eqeq-bad
           useless comparison
 
             4┆ a == a
@@ -25,12 +25,12 @@ CI="true" BITBUCKET_BUILD_NUMBER="hi" BITBUCKET_REPO_FULL_NAME="project_name/pro
             ⋮┆----------------------------------------
            11┆ y == y
 
-       eqeq-four
+   ❯❯❱ eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
 
-       taint-test
+    ❯❱ taint-test
           unsafe use of danger
 
            27┆ sink(d2)
@@ -41,7 +41,7 @@ CI="true" BITBUCKET_BUILD_NUMBER="hi" BITBUCKET_REPO_FULL_NAME="project_name/pro
 └──────────────────────────────────┘
 
     poetry.lock
-       supply-chain1
+   ❯❯❱ supply-chain1
           found a dependency
 
             2┆ name = "badlib"
@@ -52,7 +52,7 @@ CI="true" BITBUCKET_BUILD_NUMBER="hi" BITBUCKET_REPO_FULL_NAME="project_name/pro
 └─────────────────────────────┘
 
     foo.py
-       eqeq-five
+   ❯❯❱ eqeq-five
           useless comparison to 5
 
            ▶▶┆ Autofix ▶ (x == 2)

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite-overwrite-autodetected-variables/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite-overwrite-autodetected-variables/results.txt
@@ -14,7 +14,7 @@ BUILDKITE="true" SEMGREP_REPO_NAME="a/repo/name" SEMGREP_REPO_URL="https://rando
 └──────────────────────────┘
 
     foo.py
-       eqeq-bad
+   ❯❯❱ eqeq-bad
           useless comparison
 
             4┆ a == a
@@ -25,12 +25,12 @@ BUILDKITE="true" SEMGREP_REPO_NAME="a/repo/name" SEMGREP_REPO_URL="https://rando
             ⋮┆----------------------------------------
            11┆ y == y
 
-       eqeq-four
+   ❯❯❱ eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
 
-       taint-test
+    ❯❱ taint-test
           unsafe use of danger
 
            27┆ sink(d2)
@@ -41,7 +41,7 @@ BUILDKITE="true" SEMGREP_REPO_NAME="a/repo/name" SEMGREP_REPO_URL="https://rando
 └──────────────────────────────────┘
 
     poetry.lock
-       supply-chain1
+   ❯❯❱ supply-chain1
           found a dependency
 
             2┆ name = "badlib"
@@ -52,7 +52,7 @@ BUILDKITE="true" SEMGREP_REPO_NAME="a/repo/name" SEMGREP_REPO_URL="https://rando
 └─────────────────────────────┘
 
     foo.py
-       eqeq-five
+   ❯❯❱ eqeq-five
           useless comparison to 5
 
            ▶▶┆ Autofix ▶ (x == 2)

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite/results.txt
@@ -14,7 +14,7 @@ BUILDKITE="true" BUILDKITE_REPO="git@github.com/project_name/project_name.git" B
 └──────────────────────────┘
 
     foo.py
-       eqeq-bad
+   ❯❯❱ eqeq-bad
           useless comparison
 
             4┆ a == a
@@ -25,12 +25,12 @@ BUILDKITE="true" BUILDKITE_REPO="git@github.com/project_name/project_name.git" B
             ⋮┆----------------------------------------
            11┆ y == y
 
-       eqeq-four
+   ❯❯❱ eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
 
-       taint-test
+    ❯❱ taint-test
           unsafe use of danger
 
            27┆ sink(d2)
@@ -41,7 +41,7 @@ BUILDKITE="true" BUILDKITE_REPO="git@github.com/project_name/project_name.git" B
 └──────────────────────────────────┘
 
     poetry.lock
-       supply-chain1
+   ❯❯❱ supply-chain1
           found a dependency
 
             2┆ name = "badlib"
@@ -52,7 +52,7 @@ BUILDKITE="true" BUILDKITE_REPO="git@github.com/project_name/project_name.git" B
 └─────────────────────────────┘
 
     foo.py
-       eqeq-five
+   ❯❯❱ eqeq-five
           useless comparison to 5
 
            ▶▶┆ Autofix ▶ (x == 2)

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci-overwrite-autodetected-variables/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci-overwrite-autodetected-variables/results.txt
@@ -14,7 +14,7 @@ CI="true" SEMGREP_REPO_NAME="a/repo/name" SEMGREP_REPO_URL="https://random.url.o
 └──────────────────────────┘
 
     foo.py
-       eqeq-bad
+   ❯❯❱ eqeq-bad
           useless comparison
 
             4┆ a == a
@@ -25,12 +25,12 @@ CI="true" SEMGREP_REPO_NAME="a/repo/name" SEMGREP_REPO_URL="https://random.url.o
             ⋮┆----------------------------------------
            11┆ y == y
 
-       eqeq-four
+   ❯❯❱ eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
 
-       taint-test
+    ❯❱ taint-test
           unsafe use of danger
 
            27┆ sink(d2)
@@ -41,7 +41,7 @@ CI="true" SEMGREP_REPO_NAME="a/repo/name" SEMGREP_REPO_URL="https://random.url.o
 └──────────────────────────────────┘
 
     poetry.lock
-       supply-chain1
+   ❯❯❱ supply-chain1
           found a dependency
 
             2┆ name = "badlib"
@@ -52,7 +52,7 @@ CI="true" SEMGREP_REPO_NAME="a/repo/name" SEMGREP_REPO_URL="https://random.url.o
 └─────────────────────────────┘
 
     foo.py
-       eqeq-five
+   ❯❯❱ eqeq-five
           useless comparison to 5
 
            ▶▶┆ Autofix ▶ (x == 2)

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci/results.txt
@@ -14,7 +14,7 @@ CI="true" CIRCLECI="true" CIRCLE_PROJECT_USERNAME="project_name" CIRCLE_PROJECT_
 └──────────────────────────┘
 
     foo.py
-       eqeq-bad
+   ❯❯❱ eqeq-bad
           useless comparison
 
             4┆ a == a
@@ -25,12 +25,12 @@ CI="true" CIRCLECI="true" CIRCLE_PROJECT_USERNAME="project_name" CIRCLE_PROJECT_
             ⋮┆----------------------------------------
            11┆ y == y
 
-       eqeq-four
+   ❯❯❱ eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
 
-       taint-test
+    ❯❱ taint-test
           unsafe use of danger
 
            27┆ sink(d2)
@@ -41,7 +41,7 @@ CI="true" CIRCLECI="true" CIRCLE_PROJECT_USERNAME="project_name" CIRCLE_PROJECT_
 └──────────────────────────────────┘
 
     poetry.lock
-       supply-chain1
+   ❯❯❱ supply-chain1
           found a dependency
 
             2┆ name = "badlib"
@@ -52,7 +52,7 @@ CI="true" CIRCLECI="true" CIRCLE_PROJECT_USERNAME="project_name" CIRCLE_PROJECT_
 └─────────────────────────────┘
 
     foo.py
-       eqeq-five
+   ❯❯❱ eqeq-five
           useless comparison to 5
 
            ▶▶┆ Autofix ▶ (x == 2)

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/results.txt
@@ -39,7 +39,7 @@ CI="true" GITHUB_ACTIONS="true" GITHUB_ACTOR="some_test_username" GITHUB_API_URL
 └──────────────────────────┘
 
     foo.py
-       eqeq-bad
+   ❯❯❱ eqeq-bad
           useless comparison
 
             4┆ a == a
@@ -50,12 +50,12 @@ CI="true" GITHUB_ACTIONS="true" GITHUB_ACTOR="some_test_username" GITHUB_API_URL
             ⋮┆----------------------------------------
            11┆ y == y
 
-       eqeq-four
+   ❯❯❱ eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
 
-       taint-test
+    ❯❱ taint-test
           unsafe use of danger
 
            27┆ sink(d2)
@@ -66,7 +66,7 @@ CI="true" GITHUB_ACTIONS="true" GITHUB_ACTOR="some_test_username" GITHUB_API_URL
 └──────────────────────────────────┘
 
     poetry.lock
-       supply-chain1
+   ❯❯❱ supply-chain1
           found a dependency
 
             2┆ name = "badlib"
@@ -77,7 +77,7 @@ CI="true" GITHUB_ACTIONS="true" GITHUB_ACTOR="some_test_username" GITHUB_API_URL
 └─────────────────────────────┘
 
     foo.py
-       eqeq-five
+   ❯❯❱ eqeq-five
           useless comparison to 5
 
            ▶▶┆ Autofix ▶ (x == 2)

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr-semgrepconfig/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr-semgrepconfig/results.txt
@@ -52,7 +52,7 @@ Creating git worktree from '<MASKED>' to scan baseline.
 └──────────────────────────┘
 
     foo.py
-       eqeq-bad
+   ❯❯❱ eqeq-bad
           useless comparison
 
             4┆ a == a
@@ -63,12 +63,12 @@ Creating git worktree from '<MASKED>' to scan baseline.
             ⋮┆----------------------------------------
            11┆ y == y
 
-       eqeq-four
+   ❯❯❱ eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
 
-       taint-test
+    ❯❱ taint-test
           unsafe use of danger
 
            27┆ sink(d2)
@@ -79,7 +79,7 @@ Creating git worktree from '<MASKED>' to scan baseline.
 └─────────────────────────────┘
 
     foo.py
-       eqeq-five
+   ❯❯❱ eqeq-five
           useless comparison to 5
 
            ▶▶┆ Autofix ▶ (x == 2)

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr/results.txt
@@ -49,7 +49,7 @@ Creating git worktree from '<MASKED>' to scan baseline.
 └──────────────────────────┘
 
     foo.py
-       eqeq-bad
+   ❯❯❱ eqeq-bad
           useless comparison
 
             4┆ a == a
@@ -60,12 +60,12 @@ Creating git worktree from '<MASKED>' to scan baseline.
             ⋮┆----------------------------------------
            11┆ y == y
 
-       eqeq-four
+   ❯❯❱ eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
 
-       taint-test
+    ❯❱ taint-test
           unsafe use of danger
 
            27┆ sink(d2)
@@ -76,7 +76,7 @@ Creating git worktree from '<MASKED>' to scan baseline.
 └─────────────────────────────┘
 
     foo.py
-       eqeq-five
+   ❯❯❱ eqeq-five
           useless comparison to 5
 
            ▶▶┆ Autofix ▶ (x == 2)

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push-special-env-vars/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push-special-env-vars/results.txt
@@ -39,7 +39,7 @@ CI="true" GITHUB_ACTIONS="true" GITHUB_ACTOR="some_test_username" GITHUB_API_URL
 └──────────────────────────┘
 
     foo.py
-       eqeq-bad
+   ❯❯❱ eqeq-bad
           useless comparison
 
             4┆ a == a
@@ -50,12 +50,12 @@ CI="true" GITHUB_ACTIONS="true" GITHUB_ACTOR="some_test_username" GITHUB_API_URL
             ⋮┆----------------------------------------
            11┆ y == y
 
-       eqeq-four
+   ❯❯❱ eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
 
-       taint-test
+    ❯❱ taint-test
           unsafe use of danger
 
            27┆ sink(d2)
@@ -66,7 +66,7 @@ CI="true" GITHUB_ACTIONS="true" GITHUB_ACTOR="some_test_username" GITHUB_API_URL
 └──────────────────────────────────┘
 
     poetry.lock
-       supply-chain1
+   ❯❯❱ supply-chain1
           found a dependency
 
             2┆ name = "badlib"
@@ -77,7 +77,7 @@ CI="true" GITHUB_ACTIONS="true" GITHUB_ACTOR="some_test_username" GITHUB_API_URL
 └─────────────────────────────┘
 
     foo.py
-       eqeq-five
+   ❯❯❱ eqeq-five
           useless comparison to 5
 
            ▶▶┆ Autofix ▶ (x == 2)

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/results.txt
@@ -39,7 +39,7 @@ CI="true" GITHUB_ACTIONS="true" GITHUB_ACTOR="some_test_username" GITHUB_API_URL
 └──────────────────────────┘
 
     foo.py
-       eqeq-bad
+   ❯❯❱ eqeq-bad
           useless comparison
 
             4┆ a == a
@@ -50,12 +50,12 @@ CI="true" GITHUB_ACTIONS="true" GITHUB_ACTOR="some_test_username" GITHUB_API_URL
             ⋮┆----------------------------------------
            11┆ y == y
 
-       eqeq-four
+   ❯❯❱ eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
 
-       taint-test
+    ❯❱ taint-test
           unsafe use of danger
 
            27┆ sink(d2)
@@ -66,7 +66,7 @@ CI="true" GITHUB_ACTIONS="true" GITHUB_ACTOR="some_test_username" GITHUB_API_URL
 └──────────────────────────────────┘
 
     poetry.lock
-       supply-chain1
+   ❯❯❱ supply-chain1
           found a dependency
 
             2┆ name = "badlib"
@@ -77,7 +77,7 @@ CI="true" GITHUB_ACTIONS="true" GITHUB_ACTOR="some_test_username" GITHUB_API_URL
 └─────────────────────────────┘
 
     foo.py
-       eqeq-five
+   ❯❯❱ eqeq-five
           useless comparison to 5
 
            ▶▶┆ Autofix ▶ (x == 2)

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-push/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-push/results.txt
@@ -14,7 +14,7 @@ CI="true" GITLAB_CI="true" CI_PROJECT_PATH="project_name/project_name" CI_PIPELI
 └──────────────────────────┘
 
     foo.py
-       eqeq-bad
+   ❯❯❱ eqeq-bad
           useless comparison
 
             4┆ a == a
@@ -25,12 +25,12 @@ CI="true" GITLAB_CI="true" CI_PROJECT_PATH="project_name/project_name" CI_PIPELI
             ⋮┆----------------------------------------
            11┆ y == y
 
-       eqeq-four
+   ❯❯❱ eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
 
-       taint-test
+    ❯❱ taint-test
           unsafe use of danger
 
            27┆ sink(d2)
@@ -41,7 +41,7 @@ CI="true" GITLAB_CI="true" CI_PROJECT_PATH="project_name/project_name" CI_PIPELI
 └──────────────────────────────────┘
 
     poetry.lock
-       supply-chain1
+   ❯❯❱ supply-chain1
           found a dependency
 
             2┆ name = "badlib"
@@ -52,7 +52,7 @@ CI="true" GITLAB_CI="true" CI_PROJECT_PATH="project_name/project_name" CI_PIPELI
 └─────────────────────────────┘
 
     foo.py
-       eqeq-five
+   ❯❯❱ eqeq-five
           useless comparison to 5
 
            ▶▶┆ Autofix ▶ (x == 2)

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-special-env-vars/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-special-env-vars/results.txt
@@ -14,7 +14,7 @@ CI="true" GITLAB_CI="true" SEMGREP_REPO_NAME="project_name/project_name" CI_PIPE
 └──────────────────────────┘
 
     foo.py
-       eqeq-bad
+   ❯❯❱ eqeq-bad
           useless comparison
 
             4┆ a == a
@@ -25,12 +25,12 @@ CI="true" GITLAB_CI="true" SEMGREP_REPO_NAME="project_name/project_name" CI_PIPE
             ⋮┆----------------------------------------
            11┆ y == y
 
-       eqeq-four
+   ❯❯❱ eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
 
-       taint-test
+    ❯❱ taint-test
           unsafe use of danger
 
            27┆ sink(d2)
@@ -41,7 +41,7 @@ CI="true" GITLAB_CI="true" SEMGREP_REPO_NAME="project_name/project_name" CI_PIPE
 └─────────────────────────────┘
 
     foo.py
-       eqeq-five
+   ❯❯❱ eqeq-five
           useless comparison to 5
 
            ▶▶┆ Autofix ▶ (x == 2)

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab/results.txt
@@ -14,7 +14,7 @@ CI="true" GITLAB_CI="true" CI_PROJECT_PATH="project_name/project_name" CI_PIPELI
 └──────────────────────────┘
 
     foo.py
-       eqeq-bad
+   ❯❯❱ eqeq-bad
           useless comparison
 
             4┆ a == a
@@ -25,12 +25,12 @@ CI="true" GITLAB_CI="true" CI_PROJECT_PATH="project_name/project_name" CI_PIPELI
             ⋮┆----------------------------------------
            11┆ y == y
 
-       eqeq-four
+   ❯❯❱ eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
 
-       taint-test
+    ❯❱ taint-test
           unsafe use of danger
 
            27┆ sink(d2)
@@ -41,7 +41,7 @@ CI="true" GITLAB_CI="true" CI_PROJECT_PATH="project_name/project_name" CI_PIPELI
 └─────────────────────────────┘
 
     foo.py
-       eqeq-five
+   ❯❯❱ eqeq-five
           useless comparison to 5
 
            ▶▶┆ Autofix ▶ (x == 2)

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/results.txt
@@ -14,7 +14,7 @@ JENKINS_URL="some_url" SEMGREP_REPO_URL="https://random.url.org/some/path" SEMGR
 └──────────────────────────┘
 
     foo.py
-       eqeq-bad
+   ❯❯❱ eqeq-bad
           useless comparison
 
             4┆ a == a
@@ -25,12 +25,12 @@ JENKINS_URL="some_url" SEMGREP_REPO_URL="https://random.url.org/some/path" SEMGR
             ⋮┆----------------------------------------
            11┆ y == y
 
-       eqeq-four
+   ❯❯❱ eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
 
-       taint-test
+    ❯❱ taint-test
           unsafe use of danger
 
            27┆ sink(d2)
@@ -41,7 +41,7 @@ JENKINS_URL="some_url" SEMGREP_REPO_URL="https://random.url.org/some/path" SEMGR
 └──────────────────────────────────┘
 
     poetry.lock
-       supply-chain1
+   ❯❯❱ supply-chain1
           found a dependency
 
             2┆ name = "badlib"
@@ -52,7 +52,7 @@ JENKINS_URL="some_url" SEMGREP_REPO_URL="https://random.url.org/some/path" SEMGR
 └─────────────────────────────┘
 
     foo.py
-       eqeq-five
+   ❯❯❱ eqeq-five
           useless comparison to 5
 
            ▶▶┆ Autofix ▶ (x == 2)

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-overwrite-autodetected-variables/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-overwrite-autodetected-variables/results.txt
@@ -14,7 +14,7 @@ JENKINS_URL="some_url" SEMGREP_REPO_NAME="a/repo/name" SEMGREP_REPO_URL="https:/
 └──────────────────────────┘
 
     foo.py
-       eqeq-bad
+   ❯❯❱ eqeq-bad
           useless comparison
 
             4┆ a == a
@@ -25,12 +25,12 @@ JENKINS_URL="some_url" SEMGREP_REPO_NAME="a/repo/name" SEMGREP_REPO_URL="https:/
             ⋮┆----------------------------------------
            11┆ y == y
 
-       eqeq-four
+   ❯❯❱ eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
 
-       taint-test
+    ❯❱ taint-test
           unsafe use of danger
 
            27┆ sink(d2)
@@ -41,7 +41,7 @@ JENKINS_URL="some_url" SEMGREP_REPO_NAME="a/repo/name" SEMGREP_REPO_URL="https:/
 └──────────────────────────────────┘
 
     poetry.lock
-       supply-chain1
+   ❯❯❱ supply-chain1
           found a dependency
 
             2┆ name = "badlib"
@@ -52,7 +52,7 @@ JENKINS_URL="some_url" SEMGREP_REPO_NAME="a/repo/name" SEMGREP_REPO_URL="https:/
 └─────────────────────────────┘
 
     foo.py
-       eqeq-five
+   ❯❯❱ eqeq-five
           useless comparison to 5
 
            ▶▶┆ Autofix ▶ (x == 2)

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins/results.txt
@@ -14,7 +14,7 @@ JENKINS_URL="some_url" GIT_URL="https://github.com/org/repo.git/" GIT_BRANCH="so
 └──────────────────────────┘
 
     foo.py
-       eqeq-bad
+   ❯❯❱ eqeq-bad
           useless comparison
 
             4┆ a == a
@@ -25,12 +25,12 @@ JENKINS_URL="some_url" GIT_URL="https://github.com/org/repo.git/" GIT_BRANCH="so
             ⋮┆----------------------------------------
            11┆ y == y
 
-       eqeq-four
+   ❯❯❱ eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
 
-       taint-test
+    ❯❱ taint-test
           unsafe use of danger
 
            27┆ sink(d2)
@@ -41,7 +41,7 @@ JENKINS_URL="some_url" GIT_URL="https://github.com/org/repo.git/" GIT_BRANCH="so
 └──────────────────────────────────┘
 
     poetry.lock
-       supply-chain1
+   ❯❯❱ supply-chain1
           found a dependency
 
             2┆ name = "badlib"
@@ -52,7 +52,7 @@ JENKINS_URL="some_url" GIT_URL="https://github.com/org/repo.git/" GIT_BRANCH="so
 └─────────────────────────────┘
 
     foo.py
-       eqeq-five
+   ❯❯❱ eqeq-five
           useless comparison to 5
 
            ▶▶┆ Autofix ▶ (x == 2)

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/results.txt
@@ -14,7 +14,7 @@ SEMGREP_APP_TOKEN="fake-key-from-tests" SEMGREP_REPO_URL="git@github.com:example
 └──────────────────────────┘
 
     foo.py
-       eqeq-bad
+   ❯❯❱ eqeq-bad
           useless comparison
 
             4┆ a == a
@@ -25,12 +25,12 @@ SEMGREP_APP_TOKEN="fake-key-from-tests" SEMGREP_REPO_URL="git@github.com:example
             ⋮┆----------------------------------------
            11┆ y == y
 
-       eqeq-four
+   ❯❯❱ eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
 
-       taint-test
+    ❯❱ taint-test
           unsafe use of danger
 
            27┆ sink(d2)
@@ -41,7 +41,7 @@ SEMGREP_APP_TOKEN="fake-key-from-tests" SEMGREP_REPO_URL="git@github.com:example
 └──────────────────────────────────┘
 
     poetry.lock
-       supply-chain1
+   ❯❯❱ supply-chain1
           found a dependency
 
             2┆ name = "badlib"
@@ -52,7 +52,7 @@ SEMGREP_APP_TOKEN="fake-key-from-tests" SEMGREP_REPO_URL="git@github.com:example
 └─────────────────────────────┘
 
     foo.py
-       eqeq-five
+   ❯❯❱ eqeq-five
           useless comparison to 5
 
            ▶▶┆ Autofix ▶ (x == 2)

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-self-hosted/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-self-hosted/results.txt
@@ -14,7 +14,7 @@ CI="true" SEMGREP_REPO_NAME="org_name/project_name/project_name" SEMGREP_REPO_UR
 └──────────────────────────┘
 
     foo.py
-       eqeq-bad
+   ❯❯❱ eqeq-bad
           useless comparison
 
             4┆ a == a
@@ -25,12 +25,12 @@ CI="true" SEMGREP_REPO_NAME="org_name/project_name/project_name" SEMGREP_REPO_UR
             ⋮┆----------------------------------------
            11┆ y == y
 
-       eqeq-four
+   ❯❯❱ eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
 
-       taint-test
+    ❯❱ taint-test
           unsafe use of danger
 
            27┆ sink(d2)
@@ -41,7 +41,7 @@ CI="true" SEMGREP_REPO_NAME="org_name/project_name/project_name" SEMGREP_REPO_UR
 └──────────────────────────────────┘
 
     poetry.lock
-       supply-chain1
+   ❯❯❱ supply-chain1
           found a dependency
 
             2┆ name = "badlib"
@@ -52,7 +52,7 @@ CI="true" SEMGREP_REPO_NAME="org_name/project_name/project_name" SEMGREP_REPO_UR
 └─────────────────────────────┘
 
     foo.py
-       eqeq-five
+   ❯❯❱ eqeq-five
           useless comparison to 5
 
            ▶▶┆ Autofix ▶ (x == 2)

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis-overwrite-autodetected-variables/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis-overwrite-autodetected-variables/results.txt
@@ -14,7 +14,7 @@ CI="true" TRAVIS="true" SEMGREP_REPO_NAME="a/repo/name" SEMGREP_REPO_URL="https:
 └──────────────────────────┘
 
     foo.py
-       eqeq-bad
+   ❯❯❱ eqeq-bad
           useless comparison
 
             4┆ a == a
@@ -25,12 +25,12 @@ CI="true" TRAVIS="true" SEMGREP_REPO_NAME="a/repo/name" SEMGREP_REPO_URL="https:
             ⋮┆----------------------------------------
            11┆ y == y
 
-       eqeq-four
+   ❯❯❱ eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
 
-       taint-test
+    ❯❱ taint-test
           unsafe use of danger
 
            27┆ sink(d2)
@@ -41,7 +41,7 @@ CI="true" TRAVIS="true" SEMGREP_REPO_NAME="a/repo/name" SEMGREP_REPO_URL="https:
 └──────────────────────────────────┘
 
     poetry.lock
-       supply-chain1
+   ❯❯❱ supply-chain1
           found a dependency
 
             2┆ name = "badlib"
@@ -52,7 +52,7 @@ CI="true" TRAVIS="true" SEMGREP_REPO_NAME="a/repo/name" SEMGREP_REPO_URL="https:
 └─────────────────────────────┘
 
     foo.py
-       eqeq-five
+   ❯❯❱ eqeq-five
           useless comparison to 5
 
            ▶▶┆ Autofix ▶ (x == 2)

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis/results.txt
@@ -14,7 +14,7 @@ CI="true" TRAVIS="true" TRAVIS_REPO_SLUG="project_name/project_name" TRAVIS_PULL
 └──────────────────────────┘
 
     foo.py
-       eqeq-bad
+   ❯❯❱ eqeq-bad
           useless comparison
 
             4┆ a == a
@@ -25,12 +25,12 @@ CI="true" TRAVIS="true" TRAVIS_REPO_SLUG="project_name/project_name" TRAVIS_PULL
             ⋮┆----------------------------------------
            11┆ y == y
 
-       eqeq-four
+   ❯❯❱ eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
 
-       taint-test
+    ❯❱ taint-test
           unsafe use of danger
 
            27┆ sink(d2)
@@ -41,7 +41,7 @@ CI="true" TRAVIS="true" TRAVIS_REPO_SLUG="project_name/project_name" TRAVIS_PULL
 └──────────────────────────────────┘
 
     poetry.lock
-       supply-chain1
+   ❯❯❱ supply-chain1
           found a dependency
 
             2┆ name = "badlib"
@@ -52,7 +52,7 @@ CI="true" TRAVIS="true" TRAVIS_REPO_SLUG="project_name/project_name" TRAVIS_PULL
 └─────────────────────────────┘
 
     foo.py
-       eqeq-five
+   ❯❯❱ eqeq-five
           useless comparison to 5
 
            ▶▶┆ Autofix ▶ (x == 2)

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-unparsable_url/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-unparsable_url/results.txt
@@ -14,7 +14,7 @@ CI="true" SEMGREP_REPO_NAME="org_name/project_name/project_name" SEMGREP_REPO_UR
 └──────────────────────────┘
 
     foo.py
-       eqeq-bad
+   ❯❯❱ eqeq-bad
           useless comparison
 
             4┆ a == a
@@ -25,12 +25,12 @@ CI="true" SEMGREP_REPO_NAME="org_name/project_name/project_name" SEMGREP_REPO_UR
             ⋮┆----------------------------------------
            11┆ y == y
 
-       eqeq-four
+   ❯❯❱ eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
 
-       taint-test
+    ❯❱ taint-test
           unsafe use of danger
 
            27┆ sink(d2)
@@ -41,7 +41,7 @@ CI="true" SEMGREP_REPO_NAME="org_name/project_name/project_name" SEMGREP_REPO_UR
 └──────────────────────────────────┘
 
     poetry.lock
-       supply-chain1
+   ❯❯❱ supply-chain1
           found a dependency
 
             2┆ name = "badlib"
@@ -52,7 +52,7 @@ CI="true" SEMGREP_REPO_NAME="org_name/project_name/project_name" SEMGREP_REPO_UR
 └─────────────────────────────┘
 
     foo.py
-       eqeq-five
+   ❯❯❱ eqeq-five
           useless comparison to 5
 
            ▶▶┆ Autofix ▶ (x == 2)

--- a/cli/tests/e2e/snapshots/test_ci/test_lockfile_parse_failure_reporting/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_lockfile_parse_failure_reporting/results.txt
@@ -14,7 +14,7 @@ SEMGREP_APP_TOKEN="fake-key-from-tests" SEMGREP_USER_AGENT_APPEND="pytest" SEMGR
 └──────────────────────────┘
 
     foo.py
-       eqeq-bad
+   ❯❯❱ eqeq-bad
           useless comparison
 
             4┆ a == a
@@ -25,12 +25,12 @@ SEMGREP_APP_TOKEN="fake-key-from-tests" SEMGREP_USER_AGENT_APPEND="pytest" SEMGR
             ⋮┆----------------------------------------
            11┆ y == y
 
-       eqeq-four
+   ❯❯❱ eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
 
-       taint-test
+    ❯❱ taint-test
           unsafe use of danger
 
            27┆ sink(d2)
@@ -41,7 +41,7 @@ SEMGREP_APP_TOKEN="fake-key-from-tests" SEMGREP_USER_AGENT_APPEND="pytest" SEMGR
 └──────────────────────────────────┘
 
     poetry.lock
-       supply-chain1
+   ❯❯❱ supply-chain1
           found a dependency
 
             2┆ name = "badlib"
@@ -52,7 +52,7 @@ SEMGREP_APP_TOKEN="fake-key-from-tests" SEMGREP_USER_AGENT_APPEND="pytest" SEMGR
 └─────────────────────────────┘
 
     foo.py
-       eqeq-five
+   ❯❯❱ eqeq-five
           useless comparison to 5
 
            ▶▶┆ Autofix ▶ (x == 2)

--- a/cli/tests/e2e/snapshots/test_ci/test_nosem/autofix---disable-nosem/output.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_nosem/autofix---disable-nosem/output.txt
@@ -14,7 +14,7 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
 └───────────────────────────┘
 
     foo.py
-       eqeq-bad
+   ❯❯❱ eqeq-bad
           useless comparison
 
             4┆ a == a
@@ -31,14 +31,14 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
             ⋮┆----------------------------------------
            13┆ z == z  # nosemgrep
 
-       eqeq-four
+   ❯❯❱ eqeq-four
           useless comparison to 4
 
            18┆ baz == 4  # nosemgrep
             ⋮┆----------------------------------------
            19┆ baz == 4
 
-       taint-test
+    ❯❱ taint-test
           unsafe use of danger
 
            27┆ sink(d2)
@@ -49,7 +49,7 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
 └──────────────────────────────────┘
 
     poetry.lock
-       supply-chain1
+   ❯❯❱ supply-chain1
           found a dependency
 
             2┆ name = "badlib"
@@ -60,7 +60,7 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
 └──────────────────────────────┘
 
     foo.py
-       eqeq-five
+   ❯❯❱ eqeq-five
           useless comparison to 5
 
            ▶▶┆ Autofix ▶ (x == 2)

--- a/cli/tests/e2e/snapshots/test_ci/test_nosem/autofix---enable-nosem/output.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_nosem/autofix---enable-nosem/output.txt
@@ -14,7 +14,7 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
 └──────────────────────────┘
 
     foo.py
-       eqeq-bad
+   ❯❯❱ eqeq-bad
           useless comparison
 
             4┆ a == a
@@ -25,12 +25,12 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
             ⋮┆----------------------------------------
            11┆ y == y
 
-       eqeq-four
+   ❯❯❱ eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
 
-       taint-test
+    ❯❱ taint-test
           unsafe use of danger
 
            27┆ sink(d2)
@@ -41,7 +41,7 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
 └──────────────────────────────────┘
 
     poetry.lock
-       supply-chain1
+   ❯❯❱ supply-chain1
           found a dependency
 
             2┆ name = "badlib"
@@ -52,7 +52,7 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
 └─────────────────────────────┘
 
     foo.py
-       eqeq-five
+   ❯❯❱ eqeq-five
           useless comparison to 5
 
            ▶▶┆ Autofix ▶ (x == 2)

--- a/cli/tests/e2e/snapshots/test_ci/test_nosem/noautofix---disable-nosem/output.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_nosem/noautofix---disable-nosem/output.txt
@@ -14,7 +14,7 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
 └───────────────────────────┘
 
     foo.py
-       eqeq-bad
+   ❯❯❱ eqeq-bad
           useless comparison
 
             4┆ a == a
@@ -31,14 +31,14 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
             ⋮┆----------------------------------------
            13┆ z == z  # nosemgrep
 
-       eqeq-four
+   ❯❯❱ eqeq-four
           useless comparison to 4
 
            18┆ baz == 4  # nosemgrep
             ⋮┆----------------------------------------
            19┆ baz == 4
 
-       taint-test
+    ❯❱ taint-test
           unsafe use of danger
 
            27┆ sink(d2)
@@ -49,7 +49,7 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
 └──────────────────────────────────┘
 
     poetry.lock
-       supply-chain1
+   ❯❯❱ supply-chain1
           found a dependency
 
             2┆ name = "badlib"
@@ -60,7 +60,7 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
 └──────────────────────────────┘
 
     foo.py
-       eqeq-five
+   ❯❯❱ eqeq-five
           useless comparison to 5
 
            ▶▶┆ Autofix ▶ (x == 2)

--- a/cli/tests/e2e/snapshots/test_ci/test_nosem/noautofix---enable-nosem/output.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_nosem/noautofix---enable-nosem/output.txt
@@ -14,7 +14,7 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
 └──────────────────────────┘
 
     foo.py
-       eqeq-bad
+   ❯❯❱ eqeq-bad
           useless comparison
 
             4┆ a == a
@@ -25,12 +25,12 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
             ⋮┆----------------------------------------
            11┆ y == y
 
-       eqeq-four
+   ❯❯❱ eqeq-four
           useless comparison to 4
 
            19┆ baz == 4
 
-       taint-test
+    ❯❱ taint-test
           unsafe use of danger
 
            27┆ sink(d2)
@@ -41,7 +41,7 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
 └──────────────────────────────────┘
 
     poetry.lock
-       supply-chain1
+   ❯❯❱ supply-chain1
           found a dependency
 
             2┆ name = "badlib"
@@ -52,7 +52,7 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
 └─────────────────────────────┘
 
     foo.py
-       eqeq-five
+   ❯❯❱ eqeq-five
           useless comparison to 5
 
            ▶▶┆ Autofix ▶ (x == 2)

--- a/cli/tests/e2e/snapshots/test_ci/test_query_dependency/True-config/output.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_query_dependency/True-config/output.txt
@@ -14,7 +14,7 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
 └──────────────────────────┘
 
     foo.py
-       eqeq-bad
+   ❯❯❱ eqeq-bad
           useless comparison
 
             4┆ a == a
@@ -31,7 +31,7 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
 └──────────────────────────────────┘
 
     poetry.lock
-       supply-chain1
+   ❯❯❱ supply-chain1
           found a dependency
 
             2┆ name = "badlib"

--- a/cli/tests/e2e/snapshots/test_ci/test_shallow_wrong_merge_base/bad_results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_shallow_wrong_merge_base/bad_results.txt
@@ -50,14 +50,14 @@ Creating git worktree from 'b903231925961ac9d787ae53ee0bd15ec156e689' to scan ba
 └──────────────────────────────┘
 
     bar.py
-       eqeq-five
+   ❯❯❱ eqeq-five
           useless comparison to 5
 
            ▶▶┆ Autofix ▶ (bar == 2)
             1┆ bar == 5
 
     foo.py
-       eqeq-five
+   ❯❯❱ eqeq-five
           useless comparison to 5
 
            ▶▶┆ Autofix ▶ (foo == 2)

--- a/cli/tests/e2e/snapshots/test_ci/test_shallow_wrong_merge_base/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_shallow_wrong_merge_base/results.txt
@@ -39,7 +39,7 @@ Skipping baseline scan, because all current findings are in files that didn't ex
 └─────────────────────────────┘
 
     bar.py
-       eqeq-five
+   ❯❯❱ eqeq-five
           useless comparison to 5
 
            ▶▶┆ Autofix ▶ (bar == 2)

--- a/cli/tests/e2e/snapshots/test_cli_test/test_cli_test_match_rules_same_message/results.txt
+++ b/cli/tests/e2e/snapshots/test_cli_test/test_cli_test_match_rules_same_message/results.txt
@@ -5,12 +5,12 @@
 └─────────────────┘
 
   [36m[22m[24m  targets/cli_test/basic/basic.py [0m
-       [1mrules.cli_test.match_rules_same_message.rule1[0m
+   [31m❯❯❱[0m [1mrules.cli_test.match_rules_same_message.rule1[0m
           Same message as other rule.
 
             2┆ print([1m1 == 1[0m)
 
-       [1mrules.cli_test.match_rules_same_message.rule2[0m
+   [31m❯❯❱[0m [1mrules.cli_test.match_rules_same_message.rule2[0m
           Same message as other rule.
 
             2┆ print([1m1 == 1[0m)

--- a/cli/tests/e2e/snapshots/test_cli_test/test_cli_test_time/results.txt
+++ b/cli/tests/e2e/snapshots/test_cli_test/test_cli_test_time/results.txt
@@ -5,7 +5,7 @@
 └────────────────┘
 
   [36m[22m[24m  targets/cli_test/basic/basic.py [0m
-       [1mrules.cli_test.basic.basic-test[0m
+   [31m❯❯❱[0m [1mrules.cli_test.basic.basic-test[0m
           Basic test
 
             2┆ print([x.xxx == 1[0m)

--- a/cli/tests/e2e/snapshots/test_cli_test/test_cli_test_verbose/results.txt
+++ b/cli/tests/e2e/snapshots/test_cli_test/test_cli_test_verbose/results.txt
@@ -5,7 +5,7 @@
 └────────────────┘
 
   [36m[22m[24m  targets/cli_test/basic/basic.py [0m
-       [1mrules.cli_test.basic.basic-test[0m
+   [31m❯❯❱[0m [1mrules.cli_test.basic.basic-test[0m
           Basic test
 
             2┆ print([x.xxx == 1[0m)

--- a/cli/tests/e2e/snapshots/test_output/test_long_rule_id/results.out
+++ b/cli/tests/e2e/snapshots/test_output/test_long_rule_id/results.out
@@ -5,7 +5,7 @@
 └────────────────┘
 
     targets/cli_test/basic/basic.py
-       rules.cli_test.long_rule_id.this-is-a-very-long-rule-id-which-should-be-wrapped-in-the-cli-thank-you-very-much-
+    ❯❱ rules.cli_test.long_rule_id.this-is-a-very-long-rule-id-which-should-be-wrapped-in-the-cli-thank-you-very-much-
        supercalifragilisticexpialidocious
           This is the description of a very long rule id which should be wrapped in the cli thank you very
           much supercalifragilisticexpialidocious.

--- a/cli/tests/e2e/snapshots/test_output/test_long_rule_id_long_text/results.out
+++ b/cli/tests/e2e/snapshots/test_output/test_long_rule_id_long_text/results.out
@@ -5,7 +5,7 @@
 └────────────────┘
 
     targets/cli_test/long_text/long_text.py
-       rules.cli_test.long_rule_id.this-is-a-very-long-rule-id-which-should-be-wrapped-in-the-cli-thank-you-very-much-
+    ❯❱ rules.cli_test.long_rule_id.this-is-a-very-long-rule-id-which-should-be-wrapped-in-the-cli-thank-you-very-much-
        supercalifragilisticexpialidocious
           This is the description of a very long rule id which should be wrapped in the cli thank you very
           much supercalifragilisticexpialidocious.

--- a/cli/tests/e2e/snapshots/test_output/test_output_highlighting/results.txt
+++ b/cli/tests/e2e/snapshots/test_output/test_output_highlighting/results.txt
@@ -5,7 +5,7 @@
 └────────────────┘
 
   [36m[22m[24m  targets/cli_test/basic/basic.py [0m
-       [1mrules.cli_test.basic.basic-test[0m
+   [31m❯❯❱[0m [1mrules.cli_test.basic.basic-test[0m
           Basic test
 
             2┆ print([1m1 == 1[0m)

--- a/cli/tests/e2e/snapshots/test_output/test_output_highlighting__force_color_and_no_color/results.txt
+++ b/cli/tests/e2e/snapshots/test_output/test_output_highlighting__force_color_and_no_color/results.txt
@@ -5,7 +5,7 @@
 └────────────────┘
 
   [36m[22m[24m  targets/cli_test/basic/basic.py [0m
-       [1mrules.cli_test.basic.basic-test[0m
+   [31m❯❯❱[0m [1mrules.cli_test.basic.basic-test[0m
           Basic test
 
             2┆ print([1m1 == 1[0m)

--- a/cli/tests/e2e/snapshots/test_output/test_output_highlighting__no_color/results.txt
+++ b/cli/tests/e2e/snapshots/test_output/test_output_highlighting__no_color/results.txt
@@ -5,7 +5,7 @@
 └────────────────┘
 
     targets/cli_test/basic/basic.py
-       rules.cli_test.basic.basic-test
+   ❯❯❱ rules.cli_test.basic.basic-test
           Basic test
 
             2┆ print(1 == 1)

--- a/cli/tests/e2e/snapshots/test_output/test_promql_duration_captures/results.txt
+++ b/cli/tests/e2e/snapshots/test_output/test_promql_duration_captures/results.txt
@@ -5,17 +5,17 @@
 └─────────────────┘
 
     targets/promql/promql-duration-capture.yaml
-       rules.test-promql-duration-capture
+     ❱ rules.test-promql-duration-capture
           captured duration "5m"
 
             5┆ expr: sum_over_time(foo[5m])
             ⋮┆----------------------------------------
-       rules.test-promql-duration-capture
+     ❱ rules.test-promql-duration-capture
           captured duration "10m"
 
             7┆ expr: sum_over_time(sum(foobar)[10m:])
             ⋮┆----------------------------------------
-       rules.test-promql-duration-capture
+     ❱ rules.test-promql-duration-capture
           captured duration "15m"
 
             9┆ expr: sum_over_time(sum(foobarbaz)[15m:30s])

--- a/cli/tests/e2e/snapshots/test_output/test_yaml_capturing/results.txt
+++ b/cli/tests/e2e/snapshots/test_output/test_yaml_capturing/results.txt
@@ -5,7 +5,7 @@
 └─────────────────┘
 
     targets/yaml/yaml_capture.yaml
-       rules.foo
+   ❯❯❱ rules.foo
           example
 
             3┆ importantKey:

--- a/cli/tests/e2e/snapshots/test_sca/test_sca_lockfile_only_output/results.txt
+++ b/cli/tests/e2e/snapshots/test_sca/test_sca_lockfile_only_output/results.txt
@@ -5,7 +5,7 @@
 └─────────────────────────────────────┘
 
     targets/dependency_aware/unreachable_multiple_copies/yarn.lock
-       rules.dependency_aware.GHSA-p6mc-m468-83gw
+    ❯❱ rules.dependency_aware.GHSA-p6mc-m468-83gw
           Versions of lodash prior to 4.17.19 are vulnerable to Prototype Pollution. The function
           zipObjectDeep allows a malicious user to modify the prototype of Object if the property identifiers
           are user-supplied. Being affected by this issue requires zipping objects based on user-provided

--- a/cli/tests/e2e/snapshots/test_sca/test_sca_output/results.txt
+++ b/cli/tests/e2e/snapshots/test_sca/test_sca_output/results.txt
@@ -5,7 +5,7 @@
 └──────────────────────────────────┘
 
     targets/dependency_aware/monorepo/webapp1/app.js with lockfile targets/dependency_aware/monorepo/webapp1/yarn.lock
-       bad-lib - CVE-FOO-BAR
+    ❯❱ bad-lib - CVE-FOO-BAR
           Severity: HIGH
           oh no
 
@@ -18,7 +18,7 @@
 └────────────────────────────────────┘
 
     targets/dependency_aware/monorepo/webapp2/yarn.lock
-       bad-lib - CVE-FOO-BAR
+    ❯❱ bad-lib - CVE-FOO-BAR
           Severity: HIGH
           oh no
 
@@ -31,13 +31,13 @@
 └─────────────────┘
 
     targets/dependency_aware/monorepo/build.js
-       rules.dependency_aware.js-other
+    ❯❱ rules.dependency_aware.js-other
           this is always bad
 
             1┆ bad()
 
     targets/dependency_aware/monorepo/webapp1/app.js
-       rules.dependency_aware.js-other
+    ❯❱ rules.dependency_aware.js-other
           this is always bad
 
             1┆ bad()

--- a/cli/tests/e2e/snapshots/test_secret/test_cli_test_secret_rule/results.txt
+++ b/cli/tests/e2e/snapshots/test_secret/test_cli_test_secret_rule/results.txt
@@ -5,7 +5,7 @@
 └───────────────────────────────┘
 
   [36m[22m[24m  targets/cli_test/basic/basic.py [0m
-       [1mrules.basic-test.secret[0m
+   [31m❯❯❱[0m [1mrules.basic-test.secret[0m
           Basic test
 
             2┆ print([1m1*****[0m)
@@ -16,7 +16,7 @@
 └────────────────┘
 
   [36m[22m[24m  targets/cli_test/basic/basic.py [0m
-       [1mrules.basic-test.nonsecret[0m
+   [31m❯❯❱[0m [1mrules.basic-test.nonsecret[0m
           Basic test
 
             2┆ print([1m1 == 1[0m)

--- a/src/osemgrep/reporting/Matches_report.ml
+++ b/src/osemgrep/reporting/Matches_report.ml
@@ -286,35 +286,25 @@ let pp_text_outputs ~max_chars_per_line ~max_lines_per_finding ~color_output ppf
       | Some m -> m <> cur.extra.message
     in
     if print then (
-      (* NOTE: In a subsequent PR we should
-               (1) print the unicode arrows without color when color is disabled
-               (2) remove the in_test conditional
-      *)
       let no_color = !Semgrep_envvars.v.no_color in
-      let in_test =
-        !Semgrep_envvars.v.user_agent_append
-        |> Option.map (fun s -> String.equal s "pytest")
-        |> Option.value ~default:false
-      in
-      let pp_styled_severity =
-        if Fmt.style_renderer ppf = `Ansi_tty && (not no_color) && not in_test
-        then function
-          | `Error ->
-              Fmt.pf ppf "%s%a" rule_leading_indent
-                Fmt.(styled (`Fg `Red) string)
-                "❯❯❱"
-          (* No out-of-the-box support for Orange and we use here Magenta instead :/ *)
-          | `Warning ->
-              Fmt.pf ppf "%s%a" rule_leading_indent
-                Fmt.(styled (`Fg `Magenta) string)
-                " ❯❱"
-          | `Info ->
-              Fmt.pf ppf "%s%a" rule_leading_indent
-                Fmt.(styled (`Fg `Green) string)
-                "  ❱"
-          | _ -> Fmt.pf ppf "%s%s" rule_leading_indent "   "
-        else function
-          | _ -> Fmt.pf ppf "%s%s" rule_leading_indent "   "
+      let pp_styled_severity = function
+        | `Error ->
+            Fmt.pf ppf "%s%a" rule_leading_indent
+              (if no_color then Fmt.(styled `None string)
+               else Fmt.(styled (`Fg `Red) string))
+              "❯❯❱"
+        (* No out-of-the-box support for Orange and we use here Magenta instead :/ *)
+        | `Warning ->
+            Fmt.pf ppf "%s%a" rule_leading_indent
+              (if no_color then Fmt.(styled `None string)
+               else Fmt.(styled (`Fg `Magenta) string))
+              " ❯❱"
+        | `Info ->
+            Fmt.pf ppf "%s%a" rule_leading_indent
+              (if no_color then Fmt.(styled `None string)
+               else Fmt.(styled (`Fg `Green) string))
+              "  ❱"
+        | _ -> Fmt.pf ppf "%s%s" rule_leading_indent "   "
       in
       pp_styled_severity cur.extra.severity;
       let lines =


### PR DESCRIPTION
## Description
Shows the severity icon (e.g. ❯❯❱ ) irrespective of tty interactivity. 

This change reduces our code branching for whether to show our severity icon and applies it by default across interactive, ci, and test environments. 

Follow-up PR to #9575 

### Test Plan
- [x] Tests Pass