### PR TITLE
devops: refactor containers in semgrep.libsonnet

### DIFF
--- a/.github/workflows/build-test-core-x86-ocaml5.jsonnet
+++ b/.github/workflows/build-test-core-x86-ocaml5.jsonnet
@@ -8,7 +8,7 @@ local core_x86 = import 'build-test-core-x86.jsonnet';
 // The job
 // ----------------------------------------------------------------------------
 local job = core_x86.export.job(
-  container=semgrep.ocaml5_alpine_container,
+  container=semgrep.containers.ocaml5_alpine,
   artifact='ocaml-build-artifacts-ocaml5-release',
   // TODO: some tests are currently failing with OCaml5! but at least
   // we can still check whether it builds

--- a/.github/workflows/build-test-core-x86.jsonnet
+++ b/.github/workflows/build-test-core-x86.jsonnet
@@ -13,7 +13,7 @@ local artifact_name = 'ocaml-build-artifacts-release';
 // ----------------------------------------------------------------------------
 // The job
 // ----------------------------------------------------------------------------
-local job(container=semgrep.ocaml_alpine_container, artifact=artifact_name, run_test=true) =
+local job(container=semgrep.containers.ocaml_alpine, artifact=artifact_name, run_test=true) =
 
   local test_steps =
     if run_test
@@ -27,7 +27,7 @@ local job(container=semgrep.ocaml_alpine_container, artifact=artifact_name, run_
   // already created, and a big set of packages already installed. Thus,
   // the 'make install-deps-ALPINE-for-semgrep-core' below is very fast and
   // almost a noop.
-  container
+  container.job
   {
     steps: [
       gha.speedy_checkout_step,

--- a/.github/workflows/build-test-javascript.jsonnet
+++ b/.github/workflows/build-test-javascript.jsonnet
@@ -60,7 +60,7 @@ local guard_cache_hit = {
 local build_artifact_name = 'semgrep-js-ocaml-build-${{ github.sha }}';
 
 local build_job =
-  semgrep.ocaml_alpine_container
+  semgrep.containers.ocaml_alpine.job
   {
     'runs-on': 'ubuntu-latest-16-core',
     steps: [

--- a/.github/workflows/tests.jsonnet
+++ b/.github/workflows/tests.jsonnet
@@ -92,7 +92,7 @@ local snapshot_update_pr_steps = [
 // but without the artifact creation and with more tests.
 // alt: we could factorize buy copy-paste is ok.
 local test_semgrep_core_job =
-  semgrep.ocaml_alpine_container
+  semgrep.containers.ocaml_alpine.job
   {
     steps: [
       gha.speedy_checkout_step,
@@ -142,7 +142,7 @@ local test_semgrep_core_job =
 
 // alt: could factorize with previous job
 local test_osemgrep_job =
-  semgrep.ocaml_alpine_container
+  semgrep.containers.ocaml_alpine.job
   {
     steps: [
       gha.speedy_checkout_step,


### PR DESCRIPTION
By putting also the opam_switch_info,  we could use it
for opam cache_key in futur PRs

test plan:
wait for green CI checks