### PR TITLE
devops: use cache opam for build-test-core-x86 too

### DIFF
--- a/.github/workflows/build-test-core-x86-ocaml5.yml
+++ b/.github/workflows/build-test-core-x86-ocaml5.yml
@@ -20,9 +20,18 @@ jobs:
         submodules: true
     - name: Configure git safedir properly
       run: git config --global --add safe.directory $(pwd)
-    - name: Build semgrep-core
+    - name: Cache ~/.opam
+      uses: actions/cache@v3
+      env:
+        SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
+      with:
+        path: ~/.opam
+        key: ${{ runner.os }}-${{ runner.arch }}-opam-deps-5.1.0-${{hashFiles('semgrep.opam')}}
+    - name: Install dependencies
       run: "\n          eval $(opam env)\n          make install-deps-ALPINE-for-semgrep-core\n
-        \         make install-deps-for-semgrep-core\n          make core\n        "
+        \         make install-deps-for-semgrep-core\n        "
+    - name: Build semgrep-core
+      run: opam exec -- make core
     - name: Make artifact
       run: "\n          mkdir -p ocaml-build-artifacts/bin\n          cp bin/semgrep-core
         ocaml-build-artifacts/bin/\n          tar czf ocaml-build-artifacts.tgz ocaml-build-artifacts\n

--- a/.github/workflows/build-test-core-x86-ocaml5.yml
+++ b/.github/workflows/build-test-core-x86-ocaml5.yml
@@ -20,7 +20,7 @@ jobs:
         submodules: true
     - name: Configure git safedir properly
       run: git config --global --add safe.directory $(pwd)
-    - name: Cache ~/.opam
+    - name: Set GHA cache for OPAM in ~/.opam
       uses: actions/cache@v3
       env:
         SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2

--- a/.github/workflows/build-test-core-x86.yml
+++ b/.github/workflows/build-test-core-x86.yml
@@ -17,7 +17,7 @@ jobs:
         submodules: true
     - name: Configure git safedir properly
       run: git config --global --add safe.directory $(pwd)
-    - name: Cache ~/.opam
+    - name: Set GHA cache for OPAM in ~/.opam
       uses: actions/cache@v3
       env:
         SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2

--- a/.github/workflows/build-test-core-x86.yml
+++ b/.github/workflows/build-test-core-x86.yml
@@ -17,9 +17,18 @@ jobs:
         submodules: true
     - name: Configure git safedir properly
       run: git config --global --add safe.directory $(pwd)
-    - name: Build semgrep-core
+    - name: Cache ~/.opam
+      uses: actions/cache@v3
+      env:
+        SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
+      with:
+        path: ~/.opam
+        key: ${{ runner.os }}-${{ runner.arch }}-opam-deps-4.14.0-${{hashFiles('semgrep.opam')}}
+    - name: Install dependencies
       run: "\n          eval $(opam env)\n          make install-deps-ALPINE-for-semgrep-core\n
-        \         make install-deps-for-semgrep-core\n          make core\n        "
+        \         make install-deps-for-semgrep-core\n        "
+    - name: Build semgrep-core
+      run: opam exec -- make core
     - name: Make artifact
       run: "\n          mkdir -p ocaml-build-artifacts/bin\n          cp bin/semgrep-core
         ocaml-build-artifacts/bin/\n          tar czf ocaml-build-artifacts.tgz ocaml-build-artifacts\n

--- a/.github/workflows/build-test-osx-arm64.yml
+++ b/.github/workflows/build-test-osx-arm64.yml
@@ -34,7 +34,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         submodules: true
-    - name: Cache ~/.opam
+    - name: Set GHA cache for OPAM in ~/.opam
       uses: actions/cache@v3
       env:
         SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2

--- a/.github/workflows/build-test-osx-x86.jsonnet
+++ b/.github/workflows/build-test-osx-x86.jsonnet
@@ -52,7 +52,6 @@ local wheel_name = 'osx-x86-wheel';
 
 local build_core_job = {
   'runs-on': runs_on,
-  //TODO: could pass it via an argument to cache_opam_step instead of env?
   steps: [
     actions.checkout_with_submodules(),
     // TODO: we should use opam.lock instead of semgrep.opam at some point

--- a/.github/workflows/build-test-osx-x86.yml
+++ b/.github/workflows/build-test-osx-x86.yml
@@ -24,7 +24,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         submodules: true
-    - name: Cache ~/.opam
+    - name: Set GHA cache for OPAM in ~/.opam
       uses: actions/cache@v3
       env:
         SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2

--- a/.github/workflows/build-test-windows-x86.jsonnet
+++ b/.github/workflows/build-test-windows-x86.jsonnet
@@ -39,7 +39,7 @@ local job = {
     // - without the opam switch cache we'd spend 8-9 minutes every build
     // running `opam install`
     semgrep.cache_opam.step(
-      key=semgrep.opam_switch + '${{ hashFiles("semgrep.opam") }}',
+      key=semgrep.opam_switch + "${{ hashFiles('semgrep.opam') }}",
       // ocaml/setup-ocaml creates the opam switch local to the repository
       // (vs. ~/.opam in our other workflows)
       path='_opam',

--- a/.github/workflows/build-test-windows-x86.jsonnet
+++ b/.github/workflows/build-test-windows-x86.jsonnet
@@ -39,7 +39,7 @@ local job = {
     // - without the opam switch cache we'd spend 8-9 minutes every build
     // running `opam install`
     semgrep.cache_opam.step(
-      key=semgrep.opam_switch + "${{ hashFiles('semgrep.opam') }}",
+      key=semgrep.opam_switch + "-${{ hashFiles('semgrep.opam') }}",
       // ocaml/setup-ocaml creates the opam switch local to the repository
       // (vs. ~/.opam in our other workflows)
       path='_opam',

--- a/.github/workflows/build-test-windows-x86.yml
+++ b/.github/workflows/build-test-windows-x86.yml
@@ -22,7 +22,7 @@ jobs:
         SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
       with:
         path: _opam
-        key: ${{ runner.os }}-${{ runner.arch }}-opam-deps-4.14.0${{ hashFiles('semgrep.opam')
+        key: ${{ runner.os }}-${{ runner.arch }}-opam-deps-4.14.0-${{ hashFiles('semgrep.opam')
           }}
     - uses: ocaml/setup-ocaml@v2
       with:

--- a/.github/workflows/build-test-windows-x86.yml
+++ b/.github/workflows/build-test-windows-x86.yml
@@ -16,14 +16,6 @@ jobs:
     - uses: actions/checkout@v3
       with:
         submodules: true
-    - name: Set GHA cache for OPAM in _opam
-      uses: actions/cache@v3
-      env:
-        SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
-      with:
-        path: _opam
-        key: ${{ runner.os }}-${{ runner.arch }}-opam-deps-4.14.0-${{ hashFiles('semgrep.opam')
-          }}
     - uses: ocaml/setup-ocaml@v2
       with:
         ocaml-compiler: "4.14"
@@ -35,6 +27,14 @@ jobs:
 
           '
         opam-local-packages: dont_install_local_packages.opam
+    - name: Set GHA cache for OPAM in _opam
+      uses: actions/cache@v3
+      env:
+        SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
+      with:
+        path: _opam
+        key: ${{ runner.os }}-${{ runner.arch }}-opam-deps-4.14.0-${{ hashFiles('semgrep.opam')
+          }}
     - name: Build tree-sitter
       env:
         CC: x86_64-w64-mingw32-gcc

--- a/.github/workflows/build-test-windows-x86.yml
+++ b/.github/workflows/build-test-windows-x86.yml
@@ -22,7 +22,7 @@ jobs:
         SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
       with:
         path: _opam
-        key: ${{ runner.os }}-${{ runner.arch }}-opam-deps-4.14.0${{ hashFiles("semgrep.opam")
+        key: ${{ runner.os }}-${{ runner.arch }}-opam-deps-4.14.0${{ hashFiles('semgrep.opam')
           }}
     - uses: ocaml/setup-ocaml@v2
       with:

--- a/.github/workflows/build-test-windows-x86.yml
+++ b/.github/workflows/build-test-windows-x86.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         submodules: true
-    - name: Cache ~/.opam
+    - name: Set GHA cache for OPAM in _opam
       uses: actions/cache@v3
       env:
         SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2

--- a/.github/workflows/build-test-windows-x86.yml
+++ b/.github/workflows/build-test-windows-x86.yml
@@ -16,6 +16,14 @@ jobs:
     - uses: actions/checkout@v3
       with:
         submodules: true
+    - name: Cache ~/.opam
+      uses: actions/cache@v3
+      env:
+        SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
+      with:
+        path: _opam
+        key: ${{ runner.os }}-${{ runner.arch }}-opam-deps-4.14.0${{ hashFiles("semgrep.opam")
+          }}
     - uses: ocaml/setup-ocaml@v2
       with:
         ocaml-compiler: "4.14"
@@ -34,11 +42,6 @@ jobs:
         --lazy\n        prefix=\"$(pwd)/tree-sitter\"\n        cd downloads/tree-sitter\n
         \       make PREFIX=\"$prefix\" CFLAGS=\"-O3 -Wall -Wextra\"\n        make
         PREFIX=\"$prefix\" install\n      "
-    - name: Cache opam switch
-      uses: actions/cache@v3
-      with:
-        key: opam-${{ runner.os }}-1.14-${{ hashFiles('semgrep.opam') }}
-        path: _opam
     - name: Install deps
       run: "\n        export PATH=\"${CYGWIN_ROOT_BIN}:${PATH}\"\n        opam depext
         conf-pkg-config conf-gmp conf-libpcre\n        opam install -y ./ ./libs/ocaml-tree-sitter-core

--- a/.github/workflows/check-semgrep-pro.jsonnet
+++ b/.github/workflows/check-semgrep-pro.jsonnet
@@ -31,9 +31,13 @@ local job = {
       name: 'Setup OCaml and opam',
       uses: 'ocaml/setup-ocaml@v2',
       with: {
-        'ocaml-compiler': '4.14.x',
+        'ocaml-compiler': semgrep.opam_switch,
       },
     },
+    semgrep.cache_opam.step(
+      key=semgrep.opam_switch + '-_opam-' + "${{ hashFiles('semgrep.opam') }}",
+      path="_opam",
+    ),
     // alt: call 'sudo make install-deps-UBUNTU-for-semgrep-core'
     // but looks like opam and setup-ocaml@ can automatically install
     // depext dependencies.

--- a/.github/workflows/check-semgrep-pro.yml
+++ b/.github/workflows/check-semgrep-pro.yml
@@ -30,7 +30,15 @@ jobs:
     - name: Setup OCaml and opam
       uses: ocaml/setup-ocaml@v2
       with:
-        ocaml-compiler: 4.14.x
+        ocaml-compiler: 4.14.0
+    - name: Cache ~/.opam
+      uses: actions/cache@v3
+      env:
+        SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
+      with:
+        path: _opam
+        key: ${{ runner.os }}-${{ runner.arch }}-opam-deps-4.14.0-_opam-${{ hashFiles('semgrep.opam')
+          }}
     - name: Install semgrep dependencies
       run: "\n        eval $(opam env)\n        make install-deps-for-semgrep-core\n
         \       make install-deps\n      "

--- a/.github/workflows/check-semgrep-pro.yml
+++ b/.github/workflows/check-semgrep-pro.yml
@@ -31,7 +31,7 @@ jobs:
       uses: ocaml/setup-ocaml@v2
       with:
         ocaml-compiler: 4.14.0
-    - name: Cache ~/.opam
+    - name: Set GHA cache for OPAM in _opam
       uses: actions/cache@v3
       env:
         SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2

--- a/.github/workflows/libs/semgrep.libsonnet
+++ b/.github/workflows/libs/semgrep.libsonnet
@@ -107,8 +107,8 @@ local github_bot = {
 //
 // See https://github.com/organizations/semgrep/settings/actions/caches
 // (requires admin access to github org) to see the GHA cache settings
-// and https://github.com/semgrep/semgrep/actions/caches
-// to see the actual cache files created.
+// and https://github.com/semgrep/semgrep/actions/caches?query=sort%3Asize-desc
+// to see the actual cache files created and used.
 
 local cache_opam = {
   step(key, path="~/.opam"): {

--- a/.github/workflows/libs/semgrep.libsonnet
+++ b/.github/workflows/libs/semgrep.libsonnet
@@ -112,7 +112,7 @@ local github_bot = {
 
 local cache_opam = {
   step(key, path="~/.opam"): {
-    name: 'Cache ~/.opam',
+    name: 'Set GHA cache for OPAM in ' + path,
     uses: 'actions/cache@v3',
     env: {
       SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2,

--- a/.github/workflows/tests.jsonnet
+++ b/.github/workflows/tests.jsonnet
@@ -90,7 +90,7 @@ local snapshot_update_pr_steps = [
 
 // This is mostly the same that in build-test-core-x86.jsonnet
 // but without the artifact creation and with more tests.
-// alt: we could factorize buy copy-paste is ok.
+// alt: we could factorize
 local test_semgrep_core_job =
   semgrep.containers.ocaml_alpine.job
   {
@@ -98,14 +98,21 @@ local test_semgrep_core_job =
       gha.speedy_checkout_step,
       actions.checkout_with_submodules(),
       gha.git_safedir,
+      semgrep.cache_opam.step(
+        key=semgrep.containers.ocaml_alpine.opam_switch +
+          "-${{hashFiles('semgrep.opam')}}"
+       ),
       {
-        name: 'Build semgrep-core',
+        name: 'Install dependencies',
         run: |||
           eval $(opam env)
           make install-deps-ALPINE-for-semgrep-core
           make install-deps-for-semgrep-core
-          make core
         |||,
+      },
+      {
+        name: 'Build semgrep-core',
+        run: 'opam exec -- make core',
       },
       {
         name: 'Test semgrep-core (and time it)',

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,9 +24,18 @@ jobs:
         submodules: true
     - name: Configure git safedir properly
       run: git config --global --add safe.directory $(pwd)
-    - name: Build semgrep-core
+    - name: Set GHA cache for OPAM in ~/.opam
+      uses: actions/cache@v3
+      env:
+        SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
+      with:
+        path: ~/.opam
+        key: ${{ runner.os }}-${{ runner.arch }}-opam-deps-4.14.0-${{hashFiles('semgrep.opam')}}
+    - name: Install dependencies
       run: "\n          eval $(opam env)\n          make install-deps-ALPINE-for-semgrep-core\n
-        \         make install-deps-for-semgrep-core\n          make core\n        "
+        \         make install-deps-for-semgrep-core\n        "
+    - name: Build semgrep-core
+      run: opam exec -- make core
     - name: Test semgrep-core (and time it)
       run: "\n          eval $(opam env)\n          START=`date +%s`\n\n          make
         core-test\n          make core-test-e2e\n\n          END=`date +%s`\n          TEST_RUN_TIME=$((END-START))\n


### PR DESCRIPTION
In theory we need it less because of our use of ocaml-layer,
but at some point we may want to get rid of ocaml-layer
so why not. Moreover if ocaml-layer is a bit lagging behind,
not installing the necessary packages, then at least
we got the opam cache

test plan:
hope for better time in CI and check if cache created in
https://github.com/semgrep/semgrep/actions/caches