### PR TITLE
AST_to_IL: C++: Better translation of `delete`

### DIFF
--- a/changelog.d/pa-3339.fixed
+++ b/changelog.d/pa-3339.fixed
@@ -1,0 +1,4 @@
+C++: Improve translation of `delete` expressions to the dataflow IL so that
+recently added (Pro-only) `at-exit: true` sinks work on them. Previously
+`delete` expression at "exit" positions were not being properly recognized
+as such.

--- a/languages/cpp/generic/cpp_to_generic.ml
+++ b/languages/cpp/generic/cpp_to_generic.ml
@@ -564,8 +564,10 @@ and map_expr env x : G.expr =
       and v4 = map_expr env v4 in
       match v3 with
       | None ->
+          (* delete <expr> *)
           G.OtherStmt (OS_Delete, [ G.Tk v2; G.E v4 ]) |> G.s |> G.stmt_to_expr
       | Some (l, (), r) ->
+          (* delete[] <expr>  *)
           (* THINK: Add a parameter to `OS_Delete` instead ? *)
           G.OtherStmt (OS_Delete, [ G.Tk v2; G.Tk l; G.Tk r; G.E v4 ])
           |> G.s |> G.stmt_to_expr)

--- a/languages/cpp/generic/cpp_to_generic.ml
+++ b/languages/cpp/generic/cpp_to_generic.ml
@@ -557,17 +557,18 @@ and map_expr env x : G.expr =
         | Some (l, args, r) -> (l, args, r)
       in
       G.New (v2, v4, G.empty_id_info (), (l, args, r)) |> G.e
-  | Delete (v1, v2, v3, v4) ->
+  | Delete (v1, v2, v3, v4) -> (
       let _topqualifierTODO = map_of_option (map_tok env) v1
       and v2 = map_tok env v2
       and v3 = map_of_option (map_bracket env map_of_unit) v3
       and v4 = map_expr env v4 in
-      let categ =
-        match v3 with
-        | None -> ("Delete", v2)
-        | Some (_l, (), _r) -> ("Delete[]", v2)
-      in
-      G.OtherExpr (categ, [ G.E v4 ]) |> G.e
+      match v3 with
+      | None ->
+          G.OtherStmt (OS_Delete, [ G.Tk v2; G.E v4 ]) |> G.s |> G.stmt_to_expr
+      | Some (l, (), r) ->
+          (* THINK: Add a parameter to `OS_Delete` instead ? *)
+          G.OtherStmt (OS_Delete, [ G.Tk v2; G.Tk l; G.Tk r; G.E v4 ])
+          |> G.s |> G.stmt_to_expr)
   | Throw (v1, v2) ->
       let v1 = map_tok env v1
       and v2 = expr_option v1 (map_of_option (map_expr env) v2) in

--- a/libs/ast_generic/AST_generic.ml
+++ b/libs/ast_generic/AST_generic.ml
@@ -1345,7 +1345,7 @@ and other_stmt_with_stmt_operator =
   | OSWS_Todo
 
 and other_stmt_operator =
-  (* Python *)
+  (* Python, C++ *)
   | OS_Delete
   (* todo: reduce? transpile? *)
   | OS_ForOrElse

--- a/src/analyzing/AST_to_IL.ml
+++ b/src/analyzing/AST_to_IL.ml
@@ -1063,6 +1063,16 @@ and stmt_expr env ?e_gen st =
         mk_s (Return (tok, e)) |> add_stmt env;
         expr_opt env None)
       else e
+  | G.OtherStmt
+      ( OS_Delete,
+        ( [ (G.Tk tok as atok); G.E eorig ]
+        | [ (G.Tk tok as atok); G.Tk _; G.Tk _; G.E eorig ] (* delete[] *) ) )
+    ->
+      let e = expr env eorig in
+      let special = (Delete, tok) in
+      add_instr env
+        (mk_i (CallSpecial (None, special, [ Unnamed e ])) (Related atok));
+      mk_unit tok (Related atok)
   | G.If (tok, cond, st1, opt_st2) ->
       (* if cond then e1 else e2
        * -->

--- a/src/il/IL.ml
+++ b/src/il/IL.ml
@@ -281,6 +281,8 @@ and call_special =
   | Spread
   | Yield
   | Await
+  (* C++ *)
+  | Delete
   (* was in stmt before, but with a new clean 'instr' type, better here *)
   | Assert
   (* was in expr before (only in C/PHP) *)


### PR DESCRIPTION
Instead of encoding `delete` as a string in Generic, we now prefer an `OtherStmt` + `OS_Delete`. We also added a proper constructor for `delete` in IL. Previously `delete` was encoded into IL as a `FixmeStmt`, but it worked in many cases because `AST_to_IL` looks into the `any list` and tries to translate the `any`s that correspond to expressions. But it did not work for `at-exit: true` sinks, where these `FixmeStmt`s are being ignored.

Helps PA-3339

test plan:
semgrep-core -lang cpp -dump_ast
See semgrep/semgrep-proprietary#1243