### PR TITLE
osemgrep: support always-skip

### DIFF
--- a/src/osemgrep/reporting/Skipped_report.mli
+++ b/src/osemgrep/reporting/Skipped_report.mli
@@ -5,6 +5,7 @@ type skipped_targets_grouped = {
   size : Semgrep_output_v1_t.skipped_target list;
   include_ : Semgrep_output_v1_t.skipped_target list;
   exclude : Semgrep_output_v1_t.skipped_target list;
+  always : Semgrep_output_v1_t.skipped_target list;
   other : Semgrep_output_v1_t.skipped_target list;
   (* targets skipped because there was parsing/matching
    * errors while running the engine on it

--- a/src/osemgrep/reporting/Summary_report.ml
+++ b/src/osemgrep/reporting/Summary_report.ml
@@ -22,6 +22,7 @@ let pp_summary ~respect_gitignore ~(maturity : Maturity.t) ~max_target_bytes
     include_ = include_ignored;
     exclude = exclude_ignored;
     size = file_size_ignored;
+    always = _always_ignored;
     other = other_ignored;
     errors;
   } =


### PR DESCRIPTION
This removes the TODO from skipped report (to display the targets that are always excluded). There's no direct test for this, but we encountered this inconsistency in some tests (that are still failing).

Joint work with @hannesm.