### PR TITLE
osemgrep: omit details for skipped targets when testing

### DIFF
--- a/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -578,7 +578,20 @@ let run_scan_files (_caps : < Cap.stdout >) (conf : Scan_CLI.conf)
        * skipped above too?
        *)
       let skipped =
-        Some (skipped @ List_.optlist_to_list res.core.paths.skipped)
+        let skipped = skipped @ List_.optlist_to_list res.core.paths.skipped in
+        let in_test =
+          !Semgrep_envvars.v.user_agent_append
+          |> Option.map (fun s -> String.equal s "pytest")
+          |> Option.value ~default:false
+        in
+        let skipped =
+          if in_test then
+            List_.map
+              (fun (x : OutJ.skipped_target) -> { x with OutJ.details = None })
+              skipped
+          else skipped
+        in
+        Some skipped
       in
       (* Add the targets that were semgrepignored or errorneous *)
       {


### PR DESCRIPTION
pysemgrep does not output details for skipped targets, but osemgrep does. No new tests pass by this, but some now fail due to other reasons.

Joint work with @hannesm.