### PR TITLE
AST_to_IL: Keep track of orig for `return;` statements

### DIFF
--- a/changelog.d/pa-3337.fixed
+++ b/changelog.d/pa-3337.fixed
@@ -1,0 +1,2 @@
+Keep track of the origin of `return;` statements in the dataflow IL so that
+recently added (Pro-only) `at-exit: true` sinks work properly on them.

--- a/src/analyzing/AST_to_IL.ml
+++ b/src/analyzing/AST_to_IL.ml
@@ -850,10 +850,10 @@ and expr env ?void e_gen =
   try expr_aux env ?void e_gen with
   | Fixme (kind, any_generic) -> fixme_exp kind any_generic (related_exp e_gen)
 
-and expr_opt env = function
+and expr_opt env tok = function
   | None ->
-      let void = G.Unit (G.fake "void") in
-      mk_e (Literal void) NoOrig
+      let void = G.Unit tok in
+      mk_e (Literal void) (related_tok tok)
   | Some e -> expr env e
 
 and expr_lazy_op env op tok arg0 args eorig =
@@ -1061,7 +1061,7 @@ and stmt_expr env ?e_gen st =
       let e = expr env eorig in
       if eorig.is_implicit_return then (
         mk_s (Return (tok, e)) |> add_stmt env;
-        expr_opt env None)
+        expr_opt env tok None)
       else e
   | G.If (tok, cond, st1, opt_st2) ->
       (* if cond then e1 else e2
@@ -1108,8 +1108,8 @@ and stmt_expr env ?e_gen st =
           stmt_expr env st
       | __else__ -> todo ())
   | G.Return (t, eorig, _) ->
-      mk_s (Return (t, expr_opt env eorig)) |> add_stmt env;
-      expr_opt env None
+      mk_s (Return (t, expr_opt env t eorig)) |> add_stmt env;
+      expr_opt env t None
   | G.DefStmt (ent, G.VarDef { G.vinit = Some e; vtype = opt_ty })
     when def_expr_evaluates_to_value env.lang ->
       type_opt env opt_ty;
@@ -1182,9 +1182,9 @@ and arg_with_pre_stmts env arg =
 and args_with_pre_stmts env args =
   with_pre_stmts env (fun env -> arguments env args)
 
-and expr_with_pre_stmts_opt env eopt =
+and expr_with_pre_stmts_opt env tok eopt =
   match eopt with
-  | None -> ([], expr_opt env None)
+  | None -> ([], expr_opt env tok None)
   | Some e -> expr_with_pre_stmts env e
 
 and for_var_or_expr_list env xs =
@@ -1515,7 +1515,7 @@ and stmt_aux env st =
       let lbl = lookup_label env lbl in
       [ mk_s (Goto (tok, lbl)) ]
   | G.Return (tok, eopt, _) ->
-      let ss, e = expr_with_pre_stmts_opt env eopt in
+      let ss, e = expr_with_pre_stmts_opt env tok eopt in
       ss @ [ mk_s (Return (tok, e)) ]
   | G.Assert (tok, args, _) ->
       let ss, args = args_with_pre_stmts env (Tok.unbracket args) in


### PR DESCRIPTION
This helps at-exit sinks (Pro feature) work on `return;` statements.

Helps PA-3337

test plan:
semgrep-core -lang cpp -dump_il
See semgrep/semgrep-proprietary#1244

