### PR TITLE
feat(naming): create block scopes in if statements

### DIFF
--- a/changelog.d/pa-3185.added
+++ b/changelog.d/pa-3185.added
@@ -1,3 +1,22 @@
-Tainting has better support for if statements. In particular, for
+Naming has better support for if statements. In particular, for
 languages with block scope, shadowed variables inside if-else blocks
 that are tainted won't "leak" outside of those blocks.
+
+This helps with features related to naming, such as tainting.
+
+For example, previously in Go, the x in sink(x) will report
+that x is tainted, even though the x that is tainted is the
+one inside the scope of the if block.
+
+```go
+func f() {
+  x := "safe";
+  if (c) {
+    x := "tainted";
+  }
+  // x should not be tainted
+  sink(x);
+}
+```
+
+This is now fixed.

--- a/changelog.d/pa-3185.added
+++ b/changelog.d/pa-3185.added
@@ -1,0 +1,3 @@
+Tainting has better support for if statements. In particular, for
+languages with block scope, shadowed variables inside if-else blocks
+that are tainted won't "leak" outside of those blocks.

--- a/src/naming/Naming_AST.ml
+++ b/src/naming/Naming_AST.ml
@@ -233,11 +233,13 @@ let lookup_nonlocal_scope id scopes =
 
 let has_block_scope (lang : Lang.t) =
   match lang with
+  (* These languages don't have block scope *)
   | Ruby
   | Python
   | Php ->
       false
   | _js_ when Lang.is_js lang -> false
+  (* The rest do. *)
   | _else_ -> true
 
 (*****************************************************************************)


### PR DESCRIPTION
Helps PA-3185.

Currently if statements don't create block scope. This causes definitions inside if/else blocks to leak outside.

For example, the following will have a false positive.

```go
func f() {
  x := "safe";
  if (c) {
    x := "tainted"; // this is a different x
  }
  sink(x); // false positive
}
```

This PR fixes that for languages that have block scope.

Tested with `make test`. No existing tests are failing.

New tests are added at https://github.com/semgrep/semgrep-proprietary/pull/1245.

