### PR TITLE
Remove useless pytest markers

### DIFF
--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -8,6 +8,7 @@ testpaths = [
     "tests/e2e-pro",
     "tests/consistency",
 ]
+addopts = "--strict-markers"
 markers = [
     "quick: test takes less than 100 ms",
     "kinda_slow: test takes up to 2s",

--- a/cli/tests/e2e/test_check.py
+++ b/cli/tests/e2e/test_check.py
@@ -695,7 +695,6 @@ def test_metavariable_propagation_comparison(run_semgrep_in_tmp: RunSemgrep, sna
     )
 
 
-@pytest.mark.osempass
 @pytest.mark.kinda_slow
 def test_taint_mode(run_semgrep_in_tmp: RunSemgrep, snapshot):
     snapshot.assert_match(

--- a/cli/tests/e2e/test_extract.py
+++ b/cli/tests/e2e/test_extract.py
@@ -2,7 +2,6 @@ import pytest
 from tests.fixtures import RunSemgrep
 
 
-@pytest.mark.osempass
 @pytest.mark.kinda_slow
 def test_extract(run_semgrep_in_tmp: RunSemgrep, snapshot):
     """
@@ -17,7 +16,6 @@ def test_extract(run_semgrep_in_tmp: RunSemgrep, snapshot):
     )
 
 
-@pytest.mark.osempass
 @pytest.mark.kinda_slow
 def test_extract_exclude(run_semgrep_in_tmp: RunSemgrep, snapshot):
     """
@@ -32,7 +30,6 @@ def test_extract_exclude(run_semgrep_in_tmp: RunSemgrep, snapshot):
     )
 
 
-@pytest.mark.osempass
 @pytest.mark.kinda_slow
 def test_extract_include(run_semgrep_in_tmp: RunSemgrep, snapshot):
     """

--- a/cli/tests/e2e/test_output.py
+++ b/cli/tests/e2e/test_output.py
@@ -44,7 +44,6 @@ def _etree_to_dict(t):
 
 
 @pytest.mark.kinda_slow
-@pytest.mark.osempass
 def test_output_highlighting(run_semgrep_in_tmp: RunSemgrep, snapshot):
     results, _errors = run_semgrep_in_tmp(
         "rules/cli_test/basic/",
@@ -60,7 +59,6 @@ def test_output_highlighting(run_semgrep_in_tmp: RunSemgrep, snapshot):
 
 
 @pytest.mark.kinda_slow
-@pytest.mark.osempass
 def test_output_highlighting__no_color(run_semgrep_in_tmp: RunSemgrep, snapshot):
     results, _errors = run_semgrep_in_tmp(
         "rules/cli_test/basic/",
@@ -76,7 +74,6 @@ def test_output_highlighting__no_color(run_semgrep_in_tmp: RunSemgrep, snapshot)
 
 
 @pytest.mark.kinda_slow
-@pytest.mark.osempass
 def test_output_highlighting__force_color_and_no_color(
     run_semgrep_in_tmp: RunSemgrep, snapshot
 ):
@@ -202,7 +199,6 @@ def test_output_format_osemfail(run_semgrep_in_tmp: RunSemgrep, snapshot, format
 
 
 @pytest.mark.kinda_slow
-@pytest.mark.osempass
 def test_long_rule_id(run_semgrep_in_tmp: RunSemgrep, snapshot):
     stdout, _ = run_semgrep_in_tmp(
         "rules/cli_test/long_rule_id/long_rule_id.yaml",


### PR DESCRIPTION
We no longer use `@pytest.mark.osempass` since success with both pysemgrep and osemgrep is the default expectation. There were warnings printed by pytest. They're now errors.