### PR TITLE
osemgrep sarif output, part 1

### DIFF
--- a/cli/tests/e2e/test_output_sarif.py
+++ b/cli/tests/e2e/test_output_sarif.py
@@ -90,7 +90,6 @@ def test_sarif_output_with_nosemgrep_and_error(
 
 
 @pytest.mark.kinda_slow
-@pytest.mark.osemfail
 def test_sarif_output_with_autofix(run_semgrep_in_tmp: RunSemgrep, snapshot):
     snapshot.assert_match(
         run_semgrep_in_tmp(

--- a/cli/tests/e2e/test_output_sarif.py
+++ b/cli/tests/e2e/test_output_sarif.py
@@ -23,7 +23,6 @@ def test_sarif_output_include_nosemgrep(run_semgrep_in_tmp: RunSemgrep, snapshot
 
 # Test that rule board information makes its way into SARIF output
 @pytest.mark.kinda_slow
-@pytest.mark.osemfail
 def test_sarif_output_rule_board(run_semgrep_in_tmp: RunSemgrep, snapshot):
     snapshot.assert_match(
         run_semgrep_in_tmp(

--- a/src/osemgrep/reporting/Cli_json_output.ml
+++ b/src/osemgrep/reporting/Cli_json_output.ml
@@ -339,24 +339,8 @@ let cli_match_of_core_match (hrules : Rule.hrules) (m : OutJ.core_match) :
        * we concatenate the lines after? *)
       let lines =
         Semgrep_output_utils.lines_of_file_at_range (start, end_) path
+        |> String.concat "\n"
       in
-      let fixed_lines =
-        Option.map
-          (fun fix ->
-            match (lines, List.rev lines) with
-            | line :: _, last_line :: _ ->
-                let first_line_part = Str.first_chars line (start.col - 1)
-                and last_line_part =
-                  Str.string_after last_line (end_.col - 1)
-                in
-                String.split_on_char '\n'
-                  (first_line_part ^ fix ^ last_line_part)
-            | [], _
-            | _, [] ->
-                assert false)
-          fix
-      in
-      let lines = String.concat "\n" lines in
       {
         check_id;
         path;
@@ -375,7 +359,7 @@ let cli_match_of_core_match (hrules : Rule.hrules) (m : OutJ.core_match) :
             (* TODO: extra fields *)
             fingerprint = match_based_id_partial rule rule_id metavars !!path;
             sca_info = None;
-            fixed_lines;
+            fixed_lines = None;
             dataflow_trace;
             (* It's optional in the CLI output, but not in the core match results!
              *)

--- a/src/osemgrep/reporting/Cli_json_output.ml
+++ b/src/osemgrep/reporting/Cli_json_output.ml
@@ -405,7 +405,9 @@ let index_match_based_ids (matches : OutJ.cli_match list) : OutJ.cli_match list
   (* preserve order *)
   |> List_.mapi (fun i x -> (i, x))
   (* Group by rule and path *)
-  |> Assoc.group_by (fun (_, (x : OutJ.cli_match)) -> (x.path, x.check_id))
+  (* XXX: can we do with grouping by fingerprint only? *)
+  |> Assoc.group_by (fun (_, (x : OutJ.cli_match)) ->
+         (x.path, x.check_id, x.extra.fingerprint))
   (* Sort by start line *)
   |> List_.map (fun (path_and_rule_id, matches) ->
          ( path_and_rule_id,

--- a/src/osemgrep/reporting/Cli_json_output.ml
+++ b/src/osemgrep/reporting/Cli_json_output.ml
@@ -339,8 +339,24 @@ let cli_match_of_core_match (hrules : Rule.hrules) (m : OutJ.core_match) :
        * we concatenate the lines after? *)
       let lines =
         Semgrep_output_utils.lines_of_file_at_range (start, end_) path
-        |> String.concat "\n"
       in
+      let fixed_lines =
+        Option.map
+          (fun fix ->
+            match (lines, List.rev lines) with
+            | line :: _, last_line :: _ ->
+                let first_line_part = Str.first_chars line (start.col - 1)
+                and last_line_part =
+                  Str.string_after last_line (end_.col - 1)
+                in
+                String.split_on_char '\n'
+                  (first_line_part ^ fix ^ last_line_part)
+            | [], _
+            | _, [] ->
+                assert false)
+          fix
+      in
+      let lines = String.concat "\n" lines in
       {
         check_id;
         path;
@@ -359,7 +375,7 @@ let cli_match_of_core_match (hrules : Rule.hrules) (m : OutJ.core_match) :
             (* TODO: extra fields *)
             fingerprint = match_based_id_partial rule rule_id metavars !!path;
             sca_info = None;
-            fixed_lines = None;
+            fixed_lines;
             dataflow_trace;
             (* It's optional in the CLI output, but not in the core match results!
              *)

--- a/src/osemgrep/reporting/Output.ml
+++ b/src/osemgrep/reporting/Output.ml
@@ -135,43 +135,7 @@ let dispatch_output_format (output_format : Output_format.t) (conf : conf)
   (* matches have already been displayed in a file_match_results_hook *)
   | TextIncremental -> ()
   | Sarif ->
-      let sarif_schema =
-        "https://docs.oasis-open.org/sarif/sarif/v2.1.0/os/schemas/sarif-schema-2.1.0.json"
-      in
-      let engine_label =
-        match cli_output.engine_requested with
-        | Some `OSS
-        | None ->
-            "OSS"
-        | Some `PRO -> "PRO"
-      in
-      let run =
-        let rules = Sarif_output.rules hrules in
-        let tool =
-          `Assoc
-            [
-              ( "driver",
-                `Assoc
-                  [
-                    ("name", `String (spf "Semgrep %s" engine_label));
-                    ("semanticVersion", `String (*"%%VERSION%%"*) "1.56.0");
-                    ("rules", `List rules);
-                  ] );
-            ]
-        in
-        let results = `Null (* FIXME *) in
-        let invocations = `Null (* FIXME *) in
-        `Assoc
-          [ ("tool", tool); ("results", results); ("invocations", invocations) ]
-      in
-      let sarif_json =
-        `Assoc
-          [
-            ("version", `String "2.1.0");
-            ("$schema", `String sarif_schema);
-            ("runs", `List [ run ]);
-          ]
-      in
+      let sarif_json = Sarif_output.sarif_output hrules cli_output in
       Out.put (Yojson.Basic.to_string sarif_json)
   | Gitlab_sast
   | Gitlab_secrets

--- a/src/osemgrep/reporting/Sarif_output.ml
+++ b/src/osemgrep/reporting/Sarif_output.ml
@@ -160,10 +160,24 @@ let rules hide_nudge (hrules : Rule.hrules) =
   in
   List.of_seq rules
 
+let fixed_lines (cli_match : OutT.cli_match) fix =
+  let lines = String.split_on_char '\n' cli_match.extra.lines in
+  match (lines, List.rev lines) with
+  | line :: _, last_line :: _ ->
+      let first_line_part = Str.first_chars line (cli_match.start.col - 1)
+      and last_line_part =
+        Str.string_after last_line (cli_match.end_.col - 1)
+      in
+      String.split_on_char '\n' (first_line_part ^ fix ^ last_line_part)
+  | [], _
+  | _, [] ->
+      assert false
+
 let sarif_fix (cli_match : OutT.cli_match) =
-  match cli_match.extra.fixed_lines with
+  match cli_match.extra.fix with
   | None -> []
-  | Some fixed_lines ->
+  | Some fix ->
+      let fixed_lines = fixed_lines cli_match fix in
       let description_text =
         spf "%s\n Autofix: Semgrep rule suggested fix" cli_match.extra.message
       in

--- a/src/osemgrep/reporting/Sarif_output.ml
+++ b/src/osemgrep/reporting/Sarif_output.ml
@@ -1,0 +1,66 @@
+module OutT = Semgrep_output_v1_t
+
+let sarif_severity_of_severity = function
+  | `Info -> "note"
+  | `Warning -> "warning"
+  | `Error -> "error"
+  | `Experiment
+  | `Inventory ->
+      raise Common.Todo
+
+(* We want to produce a json object? with the following shape:
+   { id; name;
+     shortDescription; fullDescription;
+     helpUri; help;
+     defaultConfiguration = { level };
+     properties }
+*)
+let rules (hrules : Rule.hrules) =
+  let rules = Hashtbl.to_seq hrules in
+  let rules =
+    Seq.map
+      (fun (rule_id, rule) ->
+        let metadata = Option.value ~default:JSON.Null rule.Rule.metadata in
+        let short_description =
+          match JSON.member "shortDescription" metadata with
+          | Some (JSON.String shortDescription) -> shortDescription
+          | Some _ -> raise Common.Impossible
+          | None -> Common.spf "Semgrep Finding: %s" (Rule_ID.to_string rule_id)
+        and rule_url =
+          match JSON.member "source" metadata with
+          | Some (JSON.String source) -> [ ("helpUri", `String source) ]
+          | Some _
+          | None ->
+              []
+        and rule_help_text =
+          match JSON.member "help" metadata with
+          | Some (JSON.String txt) -> txt
+          | Some _
+          | None ->
+              rule.message
+        in
+        `Assoc
+          ([
+             ("id", `String (Rule_ID.to_string rule_id));
+             ("name", `String (Rule_ID.to_string rule_id));
+             ("shortDescription", `Assoc [ ("text", `String short_description) ]);
+             ("fullDescription", `Assoc [ ("text", `String rule.message) ]);
+             ( "defaultConfiguration",
+               `Assoc
+                 [
+                   ("level", `String (sarif_severity_of_severity rule.severity));
+                 ] );
+             ( "help",
+               `Assoc
+                 [
+                   ("text", `String rule_help_text);
+                   (* missing text_suffix *)
+                   ("markdown", `String rule_help_text);
+                   (* missing: markdown_interstitial references_markdown *)
+                 ] );
+             (* TODO properties *)
+           ]
+          @ rule_url))
+      rules
+  in
+  List.of_seq rules

--- a/src/osemgrep/reporting/Sarif_output.ml
+++ b/src/osemgrep/reporting/Sarif_output.ml
@@ -1,3 +1,4 @@
+open Common
 module OutT = Semgrep_output_v1_t
 
 let sarif_severity_of_severity = function
@@ -6,7 +7,50 @@ let sarif_severity_of_severity = function
   | `Error -> "error"
   | `Experiment
   | `Inventory ->
-      raise Common.Todo
+      raise Todo
+
+let tags_of_metadata metadata =
+  (* XXX: Tags likely have to be strings, but what do we do with non-string json?! *)
+  let best_effort_string = function
+    | JSON.String s -> s
+    | non_string -> JSON.string_of_json non_string
+  in
+  let cwe =
+    match JSON.member "cwe" metadata with
+    | Some (JSON.Array cwe) -> List_.map best_effort_string cwe
+    | Some single_cwe -> [ best_effort_string single_cwe ]
+    | None -> []
+  in
+  let owasp =
+    match JSON.member "owasp" metadata with
+    | Some (JSON.Array owasp) ->
+        List_.map (fun o -> "OWASP-" ^ best_effort_string o) owasp
+    | Some o -> [ "OWASP-" ^ best_effort_string o ]
+    | None -> []
+  in
+  let confidence =
+    match JSON.member "confidence" metadata with
+    | Some c -> [ best_effort_string c ^ " CONFIDENCE" ]
+    | None -> []
+  in
+  let semgrep_policy_slug =
+    match JSON.member "semgrep.policy" metadata with
+    | Some (JSON.Object _ as sp) -> (
+        match JSON.member "slug" sp with
+        | Some slug -> [ best_effort_string slug ]
+        | None -> [])
+    | Some _
+    | None ->
+        []
+  in
+  let tags =
+    match JSON.member "tags" metadata with
+    | Some (JSON.Array tags) -> List_.map best_effort_string tags
+    | Some _
+    | None ->
+        []
+  in
+  cwe @ owasp @ confidence @ semgrep_policy_slug @ tags
 
 (* We want to produce a json object? with the following shape:
    { id; name;
@@ -24,8 +68,8 @@ let rules (hrules : Rule.hrules) =
         let short_description =
           match JSON.member "shortDescription" metadata with
           | Some (JSON.String shortDescription) -> shortDescription
-          | Some _ -> raise Common.Impossible
-          | None -> Common.spf "Semgrep Finding: %s" (Rule_ID.to_string rule_id)
+          | Some _ -> raise Impossible
+          | None -> spf "Semgrep Finding: %s" (Rule_ID.to_string rule_id)
         and rule_url =
           match JSON.member "source" metadata with
           | Some (JSON.String source) -> [ ("helpUri", `String source) ]
@@ -38,6 +82,20 @@ let rules (hrules : Rule.hrules) =
           | Some _
           | None ->
               rule.message
+        in
+        let security_severity =
+          (* TODO: no test case for this *)
+          match JSON.member "security-severity" metadata with
+          | Some json -> [ ("security-severity", JSON.to_yojson json) ]
+          | None -> []
+        in
+        let properties =
+          let tags = tags_of_metadata metadata in
+          [
+            ("precision", `String "very-high");
+            ("tags", `List (List_.map (fun s -> `String s) tags));
+          ]
+          @ security_severity
         in
         `Assoc
           ([
@@ -58,9 +116,117 @@ let rules (hrules : Rule.hrules) =
                    ("markdown", `String rule_help_text);
                    (* missing: markdown_interstitial references_markdown *)
                  ] );
-             (* TODO properties *)
+             ("properties", `Assoc properties);
            ]
           @ rule_url))
       rules
   in
   List.of_seq rules
+
+let results (cli_output : OutT.cli_output) =
+  let result (cli_match : OutT.cli_match) =
+    let location =
+      `Assoc
+        [
+          ( "physicalLocation",
+            `Assoc
+              [
+                ( "artifactLocation",
+                  `Assoc
+                    [
+                      ("uri", `String (Fpath.to_string cli_match.path));
+                      ("uriBaseId", `String "%SRCROOT%");
+                    ] );
+                ( "region",
+                  `Assoc
+                    [
+                      ( "snippet",
+                        `Assoc [ ("text", `String cli_match.extra.lines) ] );
+                      ("startLine", `Int cli_match.start.line);
+                      ("startColumn", `Int cli_match.start.col);
+                      ("endLine", `Int cli_match.end_.line);
+                      ("endColumn", `Int cli_match.end_.col);
+                    ] );
+              ] );
+        ]
+    in
+    `Assoc
+      [
+        ("ruleId", `String (Rule_ID.to_string cli_match.check_id));
+        ("message", `Assoc [ ("text", `String cli_match.extra.message) ]);
+        ("locations", `List [ location ]);
+        ( "fingerprints",
+          `Assoc [ ("matchBasedId/v1", `String cli_match.extra.fingerprint) ] );
+        ("properties", `Assoc []);
+      ]
+  in
+  List_.map result cli_output.results
+
+let error_to_sarif_notification (e : OutT.cli_error) =
+  let level = sarif_severity_of_severity e.level in
+  let message =
+    Option.value
+      ~default:
+        (Option.value
+           ~default:(Option.value ~default:"" e.short_msg)
+           e.long_msg)
+      e.message
+  in
+  let descriptor = Error.string_of_error_type e.type_ in
+  `Assoc
+    [
+      ("descriptor", `Assoc [ ("id", `String descriptor) ]);
+      ("message", `Assoc [ ("text", `String message) ]);
+      ("level", `String level);
+    ]
+
+let sarif_output hrules (cli_output : OutT.cli_output) =
+  let sarif_schema =
+    "https://docs.oasis-open.org/sarif/sarif/v2.1.0/os/schemas/sarif-schema-2.1.0.json"
+  in
+  let engine_label =
+    match cli_output.OutT.engine_requested with
+    | Some `OSS
+    | None ->
+        "OSS"
+    | Some `PRO -> "PRO"
+  in
+  let run =
+    let rules = rules hrules in
+    let tool =
+      `Assoc
+        [
+          ( "driver",
+            `Assoc
+              [
+                ("name", `String (spf "Semgrep %s" engine_label));
+                ("semanticVersion", `String (*"%%VERSION%%"*) "1.56.0");
+                ("rules", `List rules);
+              ] );
+        ]
+    in
+    let results = results cli_output in
+    let invocation =
+      (* TODO no test case(s) for executionNotifications being non-empty *)
+      let exec_notifs =
+        List_.map error_to_sarif_notification cli_output.errors
+      in
+      `Assoc
+        [
+          ("executionSuccessful", `Bool true);
+          ("toolExecutionNotifications", `List exec_notifs);
+        ]
+    in
+    `Assoc
+      [
+        ("tool", tool);
+        ("results", `List results);
+        ("invocations", `List [ invocation ]);
+      ]
+  in
+  `Assoc
+    [
+      ("version", `String "2.1.0");
+      ("$schema", `String sarif_schema);
+      ("runs", `List [ run ]);
+    ]

--- a/src/osemgrep/reporting/Sarif_output.ml
+++ b/src/osemgrep/reporting/Sarif_output.ml
@@ -171,7 +171,7 @@ let fixed_lines (cli_match : OutT.cli_match) fix =
       String.split_on_char '\n' (first_line_part ^ fix ^ last_line_part)
   | [], _
   | _, [] ->
-      assert false
+      []
 
 let sarif_fix (cli_match : OutT.cli_match) =
   match cli_match.extra.fix with
@@ -325,7 +325,7 @@ let sarif_output hrules (cli_output : OutT.cli_output) =
             `Assoc
               [
                 ("name", `String (spf "Semgrep %s" engine_label));
-                ("semanticVersion", `String (*"%%VERSION%%"*) "1.56.0");
+                ("semanticVersion", `String Version.version);
                 ("rules", `List rules);
               ] );
         ]


### PR DESCRIPTION
This passes already two test cases :)

There are some issues, though:
- we are not using the opam package sarif yet (was easier to get started this way)
- we couldn't find test cases for "security-severity" being present
- neither for "executionNotifications" being non-empty

The version in this PR is hardcoded to 1.56. We set the "hide_nudge" to true in all cases.

When testing, we observed that osemgrep always applies autofixes (i.e. the dryrun is set to false in src/fixing/Autofix.ml).

The failure behaviour if the json metadata is expected to be a string, but some other json type is found, is unclear to us. We implemented a "best_effort_string" which calls JSON.json_to_string in the latter case (should we raise an exception instead?).

Other sarif test cases have mismatches on the fingerprints - not sure whether the matchBasedId is expected to be identical between python and OCaml.

And finally, we put the `fixed_lines` in Sarif_output.ml (instead of putting it into the extra field of the cli_match in Cli_json_output), since otherwise some (autofix) test cases failed (since they expect `fixed_lines` to be not present). Any idea in which cases the fixed_lines should be Some?