### PR TITLE
Add Elixir to Pro languages

### DIFF
--- a/changelog.d/gh-9609.changed
+++ b/changelog.d/gh-9609.changed
@@ -1,0 +1,1 @@
+Add Elixir to Pro languages list in help information.

--- a/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -553,7 +553,7 @@ let blurb =
 let o_pro_languages : bool Term.t =
   let info =
     Arg.info [ "pro-languages" ]
-      ~doc:("Enable Pro languages (currently just Apex). " ^ blurb)
+      ~doc:("Enable Pro languages (currently Apex and Elixir). " ^ blurb)
   in
   Arg.value (Arg.flag info)
 
@@ -570,7 +570,8 @@ let o_pro : bool Term.t =
   let info =
     Arg.info [ "pro" ]
       ~doc:
-        ("Inter-file analysis and Pro languages (currently just Apex). " ^ blurb)
+        ("Inter-file analysis and Pro languages (currently Apex and Elixir). "
+       ^ blurb)
   in
   Arg.value (Arg.flag info)
 


### PR DESCRIPTION
Elixir was moved to become a Pro language in v1.51.0. This change updates the relevant help information to include it in that list along with Apex.

Test plan:

`pipenv run semgrep scan --help` (or run `semgrep scan --help` from the pipenv shell)