### PR TITLE
fix: Undo lazy pattern parsing

### DIFF
--- a/changelog.d/pattern-parse.fixed
+++ b/changelog.d/pattern-parse.fixed
@@ -1,0 +1,1 @@
+Improved error handling for rules with invalid patterns. Now, scans will still complete and findings from other rules will be reported.

--- a/cli/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badpattern/error-in-color.txt
+++ b/cli/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badpattern/error-in-color.txt
@@ -5,10 +5,23 @@
 └─────────────┘
   Scanning 23 files tracked by git with 1 Code rule:
   Scanning 11 files.
-[31m[41m[22m[24m[[0m[38;5;231m[41m[1m[24mERROR[0m[31m[41m[22m[24m][0m Pattern parse error in rule rules.syntax.eqeq-is-bad:
- Invalid pattern for Python:
---- pattern ---
+[31m[41m[22m[24m[[0m[38;5;231m[41m[1m[24mERROR[0m[31m[41m[22m[24m][0m Rule parse error in rule rules.syntax.eqeq-is-bad:
+ Invalid pattern for Python: invalid rule rules.syntax.eqeq-is-bad, <MASKED>:11:21: Invalid pattern for Python: Stdlib.Parsing.Parse_error
+----- pattern -----
 $X == $X 3
---- end pattern ---
-Pattern error: Stdlib.Parsing.Parse_error
+----- end pattern -----
 
+----- pattern -----
+$X == $X 3
+----- end pattern -----
+
+
+
+┌──────────────┐
+│ Scan Summary │
+└──────────────┘
+Some files were skipped or only partially analyzed.
+  Scan was limited to files tracked by git.
+  Partially scanned: 1 files only partially analyzed due to parsing or internal Semgrep errors
+
+Ran 1 rule on 11 files: 0 findings.

--- a/cli/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badpattern/error.json
+++ b/cli/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badpattern/error.json
@@ -3,54 +3,26 @@
     {
       "code": 2,
       "level": "error",
-      "message": "Pattern parse error in rule rules.syntax.eqeq-is-bad:\n Invalid pattern for Python:\n--- pattern ---\n$X == $X 3\n--- end pattern ---\nPattern error: Stdlib.Parsing.Parse_error\n",
+      "message": "Rule parse error in rule rules.syntax.eqeq-is-bad:\n Invalid pattern for Python: invalid rule rules.syntax.eqeq-is-bad, <MASKED>:11:21: Invalid pattern for Python: Stdlib.Parsing.Parse_error\n----- pattern -----\n$X == $X 3\n----- end pattern -----\n\n----- pattern -----\n$X == $X 3\n----- end pattern -----\n",
       "rule_id": "rules.syntax.eqeq-is-bad",
-      "spans": [
-        {
-          "config_end": {
-            "col": 13,
-            "line": 0,
-            "offset": -1
-          },
-          "config_path": [
-            "rules",
-            "0",
-            "patterns",
-            "0",
-            "pattern"
-          ],
-          "config_start": {
-            "col": 1,
-            "line": 0,
-            "offset": -1
-          },
-          "end": {
-            "col": 34,
-            "line": 11,
-            "offset": 222
-          },
-          "file": "<MASKED>",
-          "start": {
-            "col": 22,
-            "line": 11,
-            "offset": 210
-          }
-        }
-      ],
-      "type": [
-        "PatternParseError",
-        [
-          "pattern",
-          "0",
-          "patterns",
-          "0",
-          "rules"
-        ]
-      ]
+      "type": "Rule parse error"
     }
   ],
+  "interfile_languages_used": [],
   "paths": {
-    "scanned": []
+    "scanned": [
+      "targets/basic/inside.py",
+      "targets/basic/metavariable-comparison-bad-content.py",
+      "targets/basic/metavariable-comparison-base.py",
+      "targets/basic/metavariable-comparison-strip.py",
+      "targets/basic/metavariable-comparison.py",
+      "targets/basic/metavariable-regex-multi-regex.py",
+      "targets/basic/metavariable-regex-multi-rule.py",
+      "targets/basic/metavariable-regex.py",
+      "targets/basic/nosem.py",
+      "targets/basic/regex.py",
+      "targets/basic/stupid.py"
+    ]
   },
   "results": [],
   "skipped_rules": [],

--- a/cli/tests/e2e/snapshots/test_rule_parser/test_rule_parser_cli_pattern/error.json
+++ b/cli/tests/e2e/snapshots/test_rule_parser/test_rule_parser_cli_pattern/error.json
@@ -3,50 +3,16 @@
     {
       "code": 2,
       "level": "error",
-      "message": "Pattern parse error in rule -:\n Invalid pattern for C:\n--- pattern ---\n#include<asdf><<>>><$X>\n--- end pattern ---\nPattern error: Stdlib.Parsing.Parse_error\n",
+      "message": "Rule parse error in rule -:\n Invalid pattern for C: invalid rule -, <MASKED>:9:17: Invalid pattern for C: Stdlib.Parsing.Parse_error\n----- pattern -----\n#include<asdf><<>>><$X>\n----- end pattern -----\n\n----- pattern -----\n#include<asdf><<>>><$X>\n----- end pattern -----\n",
       "rule_id": "-",
-      "spans": [
-        {
-          "config_end": {
-            "col": 26,
-            "line": 0,
-            "offset": -1
-          },
-          "config_path": [
-            "rules",
-            "0",
-            "pattern"
-          ],
-          "config_start": {
-            "col": 1,
-            "line": 0,
-            "offset": -1
-          },
-          "end": {
-            "col": 43,
-            "line": 9,
-            "offset": 166
-          },
-          "file": "<MASKED>",
-          "start": {
-            "col": 18,
-            "line": 9,
-            "offset": 141
-          }
-        }
-      ],
-      "type": [
-        "PatternParseError",
-        [
-          "pattern",
-          "0",
-          "rules"
-        ]
-      ]
+      "type": "Rule parse error"
     }
   ],
+  "interfile_languages_used": [],
   "paths": {
-    "scanned": []
+    "scanned": [
+      "targets/basic/nosem.c"
+    ]
   },
   "results": [],
   "skipped_rules": [],

--- a/cli/tests/e2e/snapshots/test_rule_parser/test_rule_parser_cli_pattern/error.txt
+++ b/cli/tests/e2e/snapshots/test_rule_parser/test_rule_parser_cli_pattern/error.txt
@@ -5,10 +5,23 @@
 └─────────────┘
   Scanning 23 files tracked by git with 1 Code rule:
   Scanning 1 file.
-[31m[41m[22m[24m[[0m[38;5;231m[41m[1m[24mERROR[0m[31m[41m[22m[24m][0m Pattern parse error in rule -:
- Invalid pattern for C:
---- pattern ---
+[31m[41m[22m[24m[[0m[38;5;231m[41m[1m[24mERROR[0m[31m[41m[22m[24m][0m Rule parse error in rule -:
+ Invalid pattern for C: invalid rule -, <MASKED>:9:17: Invalid pattern for C: Stdlib.Parsing.Parse_error
+----- pattern -----
 #include<asdf><<>>><$X>
---- end pattern ---
-Pattern error: Stdlib.Parsing.Parse_error
+----- end pattern -----
 
+----- pattern -----
+#include<asdf><<>>><$X>
+----- end pattern -----
+
+
+
+┌──────────────┐
+│ Scan Summary │
+└──────────────┘
+Some files were skipped or only partially analyzed.
+  Scan was limited to files tracked by git.
+  Partially scanned: 1 files only partially analyzed due to parsing or internal Semgrep errors
+
+Ran 1 rule on 1 file: 0 findings.

--- a/cli/tests/e2e/snapshots/test_rule_validation/test_validation_of_invalid_rules/rulesinvalid-rulesinvalid-pattern.yaml/results.txt
+++ b/cli/tests/e2e/snapshots/test_rule_validation/test_validation_of_invalid_rules/rulesinvalid-rulesinvalid-pattern.yaml/results.txt
@@ -4,5 +4,9 @@ Configuration is invalid - found 1 configuration error(s), and 2 rule(s).
 --- pattern ---
 print..);
 --- end pattern ---
-Pattern error: Stdlib.Parsing.Parse_error
+Pattern error: invalid rule print, rules/invalid-rules/invalid-pattern.yaml:8:11: Invalid pattern for Python: Stdlib.Parsing.Parse_error
+----- pattern -----
+print..);
+----- end pattern -----
+
 

--- a/cli/tests/e2e/snapshots/test_semgrep_core_parse_error/test_rule_parser__failure__error_messages/settings0/error.txt
+++ b/cli/tests/e2e/snapshots/test_semgrep_core_parse_error/test_rule_parser__failure__error_messages/settings0/error.txt
@@ -9,4 +9,49 @@ Rules:
 └─────────────┘
   Scanning 1 file tracked by git with 1 Code rule:
   Scanning 1 file.
+
+========================================
+Files skipped:
+========================================
+
+  [1m[24mAlways skipped by Semgrep:[0m
+
+   • <none>
+
+  [1m[24mSkipped by .gitignore:[0m
+  [1m[24m(Disable by passing --no-git-ignore)[0m
+
+   • <all files not listed by `git ls-files` were skipped>
+
+  [1m[24mSkipped by .semgrepignore:[0m
+  [1m[24m- https://semgrep.dev/docs/ignoring-files-folders-code/#understanding-semgrep-defaults[0m
+
+   • <none>
+
+  [1m[24mSkipped by --include patterns:[0m
+
+   • <none>
+
+  [1m[24mSkipped by --exclude patterns:[0m
+
+   • <none>
+
+  [1m[24mSkipped by limiting to files smaller than 1000000 bytes:[0m
+  [1m[24m(Adjust with the --max-target-bytes flag)[0m
+
+   • <none>
+
+  [1m[24mPartially analyzed due to parsing or internal Semgrep errors[0m
+
+   • [36m[22m[24m<MASKED> with rule rules.broken-rule[0m
+
+
+
+┌──────────────┐
+│ Scan Summary │
+└──────────────┘
+Some files were skipped or only partially analyzed.
+  Partially scanned: 1 files only partially analyzed due to parsing or internal Semgrep errors
+
+Ran 1 rule on 1 file: 0 findings.
 Not sending pseudonymous metrics since metrics are configured to OFF and registry usage is False

--- a/cli/tests/e2e/snapshots/test_semgrep_core_parse_error/test_rule_parser__failure__error_messages/settings0/out.json
+++ b/cli/tests/e2e/snapshots/test_semgrep_core_parse_error/test_rule_parser__failure__error_messages/settings0/out.json
@@ -3,54 +3,16 @@
     {
       "code": 2,
       "level": "error",
-      "message": "Pattern parse error in rule rules.broken-rule:\n Invalid pattern for Java:\n--- pattern ---\n@$HTTP_METHOD\npublic $RET $FUNC(..., @Auth $REQ, ...) { ... }\n\n--- end pattern ---\nPattern error: Stdlib.Parsing.Parse_error\n",
+      "message": "Rule parse error in rule rules.broken-rule:\n Invalid pattern for Java: Stdlib.Parsing.Parse_error\n----- pattern -----\n@$HTTP_METHOD\npublic $RET $FUNC(..., @Auth $REQ, ...) { ... }\n\n----- end pattern -----\n",
       "rule_id": "rules.broken-rule",
-      "spans": [
-        {
-          "config_end": {
-            "col": 67,
-            "line": 0,
-            "offset": -1
-          },
-          "config_path": [
-            "rules",
-            "0",
-            "patterns",
-            "1",
-            "pattern-not"
-          ],
-          "config_start": {
-            "col": 1,
-            "line": 0,
-            "offset": -1
-          },
-          "end": {
-            "col": 92,
-            "line": 14,
-            "offset": 292
-          },
-          "file": "<MASKED>",
-          "start": {
-            "col": 26,
-            "line": 14,
-            "offset": 226
-          }
-        }
-      ],
-      "type": [
-        "PatternParseError",
-        [
-          "pattern-not",
-          "1",
-          "patterns",
-          "0",
-          "rules"
-        ]
-      ]
+      "type": "Rule parse error"
     }
   ],
+  "interfile_languages_used": [],
   "paths": {
-    "scanned": [],
+    "scanned": [
+      "targets/bad/basic_java.java"
+    ],
     "skipped": [
       {
         "path": "<MASKED>",

--- a/js/languages/shared/Makefile.include
+++ b/js/languages/shared/Makefile.include
@@ -53,27 +53,12 @@ VERSION ?= 0.0.1
 .PHONY: default
 default: build
 
-# We should get rid of this when https://github.com/llvm/llvm-project/pull/67715 is released (or if you've built clang yourself)
-ifdef TEST_EXPECTS_FAST_CLANG # Skip testing these targets when testing with EMCC_TEST_OPTIMIZATION
-
-.PHONY: test
-test:
-	echo "Skipping tests"
-
-.PHONY: build
-build:
-	echo "Skipping build"
-else
-
 .PHONY: test
 test: build
 	npm test
 
 .PHONY: build
 build: dist/index.cjs dist/index.mjs dist/index.d.ts
-
-
-endif
 
 .PHONY: package
 package: build

--- a/js/tests/index.test.js
+++ b/js/tests/index.test.js
@@ -22,6 +22,7 @@ const languages = [
   "promql",
   "python",
   "r",
+  "ruby",
   "rust",
   "scala",
   "solidity",

--- a/src/core/Rule.ml
+++ b/src/core/Rule.ml
@@ -338,7 +338,7 @@ let is_sink_func_with_focus sink_formula =
         false
   in
   let rec is_call_pattern = function
-    | P { pat = Sem ((lazy (E { e = Call _; _ })), _); _ } -> true
+    | P { pat = Sem (E { e = Call _; _ }, _); _ } -> true
     | Or (_tok, formulas) ->
         (* Each case in an 'Or' is independent, all must be call patterns. *)
         List.for_all is_call_pattern formulas

--- a/src/core/Xpattern.ml
+++ b/src/core/Xpattern.ml
@@ -34,12 +34,9 @@ type regexp_string = string [@@deriving show, eq, hash]
 type pattern_id = int [@@deriving show, eq]
 
 type xpattern_kind =
-  (* opti: parsing Semgrep patterns lazily improves speed significantly.
-   * Parsing 'p/default', which contains more than 1000 rules, including
-   * lots of Ruby rules (Dyp, used to parse Ruby, has a slow startup time),
-   * goes from 13s to just 0.2s!
-   *)
-  | Sem of Pattern.t Lazy.t * Lang.t (* language used for parsing the pattern *)
+  (* bugfix: We previously made pattern parsing lazy which helps performance but
+   * it breaks error handling, since pattern parsing can raise an exception. *)
+  | Sem of Pattern.t * Lang.t (* language used for parsing the pattern *)
   | Spacegrep of Spacegrep.Pattern_AST.t
   | Aliengrep of Aliengrep.Pat_compile.t
   | Regexp of regexp_string

--- a/src/core_cli/Core_CLI.ml
+++ b/src/core_cli/Core_CLI.ml
@@ -194,8 +194,7 @@ let dump_patterns_of_rule (file : Fpath.t) =
   List.iter
     (fun { Xpattern.pat; _ } ->
       match pat with
-      | Sem (lazypat, _) ->
-          let any = Lazy.force lazypat in
+      | Sem (any, _) ->
           let v = Meta_AST.vof_any any in
           let s = dump_v_to_format v in
           UCommon.pr s

--- a/src/core_cli/Core_command.ml
+++ b/src/core_cli/Core_command.ml
@@ -169,7 +169,7 @@ let semgrep_core_with_one_pattern (config : Core_scan_config.t) : unit =
             let xlang = Xlang.L (lang, []) in
             let xpat =
               Xpattern.mk_xpat
-                (Xpattern.Sem (lazy pattern, lang))
+                (Xpattern.Sem (pattern, lang))
                 (pattern_string, fk)
             in
             Rule.rule_of_xpattern xlang xpat)

--- a/src/metachecking/Check_rule.ml
+++ b/src/metachecking/Check_rule.ml
@@ -171,7 +171,7 @@ let check_pattern (lang : Xlang.t) f =
   visit_new_formula
     (fun { pat; pstr = _pat_str; pid = _ } ~inside:_ ->
       match (pat, lang) with
-      | Sem ((lazy semgrep_pat), _lang), L (lang, _rest) ->
+      | Sem (semgrep_pat, _lang), L (lang, _rest) ->
           Check_pattern.check lang semgrep_pat
       | Spacegrep _spacegrep_pat, LSpacegrep -> ()
       | Aliengrep _aliengrep_pat, LAliengrep -> ()

--- a/src/optimizing/Analyze_rule.ml
+++ b/src/optimizing/Analyze_rule.ml
@@ -270,7 +270,7 @@ let id_mvars_of_formula f =
   f
   |> R.visit_new_formula (fun xp ~inside:_ ->
          match xp with
-         | { pat = XP.Sem ((lazy pat), lang); _ } ->
+         | { pat = XP.Sem (pat, lang); _ } ->
              id_mvars :=
                Analyze_pattern.extract_mvars_in_id_position ~lang pat
                |> MvarSet.union !id_mvars
@@ -328,7 +328,7 @@ and leaf_step1 ~is_id_mvar f =
 
 and xpat_step1 pat =
   match pat.XP.pat with
-  | XP.Sem ((lazy pat), lang) ->
+  | XP.Sem (pat, lang) ->
       let ids, mvars = Analyze_pattern.extract_strings_and_mvars ~lang pat in
       Some (StringsAndMvars (ids, mvars))
   (* less: could also extract ids and mvars, but maybe no need to

--- a/src/osemgrep/language_server/Unit_LS.ml
+++ b/src/osemgrep/language_server/Unit_LS.ml
@@ -45,7 +45,7 @@ let mock_run_results (files : string list) : Core_runner.result =
   let fk = Tok.unsafe_fake_tok "" in
   let xlang = Xlang.L (lang, []) in
   let pattern = Parse_pattern.parse_pattern lang pattern_string in
-  let xpat = Xpattern.mk_xpat (Xpattern.Sem (lazy pattern, lang)) in
+  let xpat = Xpattern.mk_xpat (Xpattern.Sem (pattern, lang)) in
   let xpat = xpat (pattern_string, fk) in
   let rule = Rule.rule_of_xpattern xlang xpat in
   let rule = { rule with id = (Rule_ID.of_string "print", fk) } in

--- a/src/osemgrep/networking/Rule_fetching.ml
+++ b/src/osemgrep/networking/Rule_fetching.ml
@@ -495,13 +495,6 @@ let rules_from_pattern pattern : rules_and_origin list =
   let fk = Tok.unsafe_fake_tok "" in
   let rules_and_origin_for_xlang xlang =
     let xpat = Parse_rule.parse_xpattern xlang (pat, fk) in
-    (* force the parsing of the pattern to get the parse error if any *)
-    (match xpat.XP.pat with
-    | XP.Sem (lpat, _) -> Lazy.force lpat |> ignore
-    | XP.Spacegrep _
-    | XP.Aliengrep _
-    | XP.Regexp _ ->
-        ());
     let rule = Rule.rule_of_xpattern xlang xpat in
     let rule = { rule with id = (Constants.rule_id_for_dash_e, fk); fix } in
     { rules = [ rule ]; errors = []; origin = CLI_argument }

--- a/src/parsing/Parse_rule_formula.ml
+++ b/src/parsing/Parse_rule_formula.ml
@@ -148,14 +148,13 @@ let parse_rule_xpattern env (str, tok) =
        * good error management and error recovery so the error should
        * find its way to the JSON error field anyway.
        *)
-      let lpat =
-        lazy
-          ((* we need to raise the right error *)
-           try_and_raise_invalid_pattern_if_error env (str, tok) (fun () ->
-               Parse_pattern.parse_pattern lang ~print_errors:false
-                 ~rule_options:env.options str))
+      let pat =
+        (* we need to raise the right error *)
+        try_and_raise_invalid_pattern_if_error env (str, tok) (fun () ->
+            Parse_pattern.parse_pattern lang ~print_errors:false
+              ~rule_options:env.options str)
       in
-      XP.mk_xpat (XP.Sem (lpat, lang)) (str, tok)
+      XP.mk_xpat (XP.Sem (pat, lang)) (str, tok)
   | Xlang.LRegex ->
       XP.mk_xpat (XP.Regexp (parse_regexp env (str, tok))) (str, tok)
   | Xlang.LSpacegrep -> (


### PR DESCRIPTION
We have a bunch of error handling at rule creation time which nicely handles pattern parse errors. An optimization made pattern parsing lazy, so any exceptions related to pattern parsing are no longer raised at rule creation time. Instead, they are raised whenever the patterns are accessed downstream, in code that was not designed to handle errors with patterns. Unfortunately, this means that a pattern parse error will mean that any target to which that rule is applied will end up with no scan results. This means, for example, that running a Python rule with an invalid pattern will mean that semgrep-core reports no results at all for Python files.

Now that we've addressed the performance issues with the Ruby parser, parsing rule patterns up front is no longer unacceptably slow. It would be nice to do them lazily, but without some investment in error handling, it's too dangerous.

Partially addresses PA-3325.

Test plan:

Created a directory with just a single Java file. Ran `semgrep scan --config p/default -d` to get the underlying `semgrep-core` command. Ran that `semgrep-core` command 10 times before this change and 10 times after.

The mean before was 1.233 s, the mean after was 1.891 s, with fairly low standard deviations for both. This is an increase of about 650 ms. This seems to be an acceptable performance hit.

Also, see the snapshot updates. The message changed slightly to indicate that the error was handled during rule parsing. You can also see that the scans completed, and that the list of scanned files is now nonempty.

Also, create a Semgrep org with only two rules in the policy: One python rule with a syntax error in the pattern, and one that just looks for `print("hi")`. Run `semgrep ci --oss-only`. Before, only the pattern parse error is reported. After, both the pattern parse error and the finding are reported. However, it still does not upload the findings to the app.

Run the same test with `semgrep ci --pro`. Before, it errored out and did not produce results. Now, it completes successfully, uploads results to the app, and does not report the problem with the rule.

Future work should make both OSS and Pro report the error on the CLI but also upload findings to the app.

