### PR TITLE
test: Fix broken pattern used in test

### DIFF
--- a/tests/ls/ci/rule_conf_resp.json
+++ b/tests/ls/ci/rule_conf_resp.json
@@ -2,6 +2,6 @@
   "deployment_id": 1,
   "deployment_name": "test",
   "policy_names": [],
-  "rule_config": "{\n  \"rules\": [ {\n    \"id\": \"test\",\n    \"languages\": [\n      \"go\"\n    ],\n    \"message\": \"test\",\n    \"pattern\": \"fmt.Printf(\\'$X\\')\",\n    \"severity\": \"ERROR\"\n  } ]\n}",
+  "rule_config": "{\n  \"rules\": [ {\n    \"id\": \"test\",\n    \"languages\": [\n      \"go\"\n    ],\n    \"message\": \"test\",\n    \"pattern\": \"fmt.Printf(\\\"$X\\\")\",\n    \"severity\": \"ERROR\"\n  } ]\n}",
   "triage_ignored_match_based_ids":["e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"]
 }


### PR DESCRIPTION
In #9611, I am undoing a change that introduced lazy pattern parsing. This restores correct error handling when invalid patterns are encountered. This pattern is incorrect: It uses single quotes for a string literal in Go. Go uses double quotes. Additionally, the single quotes were escaped unnecessarily, which may have also caused issues.

Combined with my changes in #9611, this leads to a test failure. I guess invalid rules aren't included in the list of rules stored for an LS session, and there is an assertion in the `ci_tests` function in `Unit_LS.ml` that checks the length of the list of rules. Without my changes in #9611, this rule is incorrectly considered valid because the pattern parse error does not appear at rule parsing time.

Test plan: Rebase #9611 on top of this and verify that `make core-test` passes.

