### PR TITLE
Sarif keep ignored

### DIFF
--- a/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -573,9 +573,22 @@ let run_scan_files (_caps : < Cap.stdout >) (conf : Scan_CLI.conf)
       let res = Core_runner.create_core_result filtered_rules exn_and_matches in
       (* step 3'': filter via nosemgrep *)
       let keep_ignored =
-        (not conf.core_runner_conf.nosem) (* --disable-nosem *) || false
-        (* TODO(dinosaure): [false] depends on the output formatter. Currently,
-           we just have the JSON output. *)
+        (not conf.core_runner_conf.nosem)
+        (* --disable-nosem *)
+        ||
+        match output_format with
+        | Sarif -> true
+        | Text
+        | Json
+        | Emacs
+        | Vim
+        | Gitlab_sast
+        | Gitlab_secrets
+        | Junit_xml
+        | TextIncremental ->
+            false
+        (* TODO(reynir): sarif wants to keep ignored results. we should
+           probably not hide this knowledge deep in here *)
       in
       let filtered_matches =
         Nosemgrep.filter_ignored ~keep_ignored res.core.results

--- a/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -575,20 +575,7 @@ let run_scan_files (_caps : < Cap.stdout >) (conf : Scan_CLI.conf)
       let keep_ignored =
         (not conf.core_runner_conf.nosem)
         (* --disable-nosem *)
-        ||
-        match output_format with
-        | Sarif -> true
-        | Text
-        | Json
-        | Emacs
-        | Vim
-        | Gitlab_sast
-        | Gitlab_secrets
-        | Junit_xml
-        | TextIncremental ->
-            false
-        (* TODO(reynir): sarif wants to keep ignored results. we should
-           probably not hide this knowledge deep in here *)
+        || Output_format.keep_ignores output_format
       in
       let filtered_matches =
         Nosemgrep.filter_ignored ~keep_ignored res.core.results

--- a/src/osemgrep/reporting/Output_format.ml
+++ b/src/osemgrep/reporting/Output_format.ml
@@ -17,3 +17,15 @@ type t =
    *)
   | TextIncremental
 [@@deriving show]
+
+let keep_ignores = function
+  | Sarif -> true
+  | Text
+  | Json
+  | Emacs
+  | Vim
+  | Gitlab_sast
+  | Gitlab_secrets
+  | Junit_xml
+  | TextIncremental ->
+      false


### PR DESCRIPTION
This is a continuation of #9608. When the output format is sarif we should keep ignored rules for the output. The logic was stubbed out, and gets us closer to more sarif tests passing (although no new tests passes with this change).