### PR TITLE
osemgrep fingerprints: escape single quotes

### DIFF
--- a/cli/tests/e2e/test_output_sarif.py
+++ b/cli/tests/e2e/test_output_sarif.py
@@ -9,7 +9,6 @@ from semgrep.constants import OutputFormat
 # If there are nosemgrep comments to ignore findings, SARIF output should include them
 # labeled as suppressed.
 @pytest.mark.kinda_slow
-@pytest.mark.osemfail
 def test_sarif_output_include_nosemgrep(run_semgrep_in_tmp: RunSemgrep, snapshot):
     snapshot.assert_match(
         run_semgrep_in_tmp(

--- a/src/osemgrep/reporting/Cli_json_output.ml
+++ b/src/osemgrep/reporting/Cli_json_output.ml
@@ -276,7 +276,10 @@ let match_based_id_partial (rule : Rule.t) (rule_id : Rule_ID.t) metavars path :
   in
   (* Python doesn't escape the double quote character, but ocaml does :/ so we need this monstrosity *)
   let py_esc_reg = Str.regexp "\\\\\\\"" in
+  (* On the other hand Python escapes single quote character, but OCaml does not *)
+  let py_esc_reg' = Str.regexp "'" in
   let xpat_str_interp = Str.global_replace py_esc_reg "\"" xpat_str_interp in
+  let xpat_str_interp = Str.global_replace py_esc_reg' "\\'" xpat_str_interp in
   (* We have been hashing w/ this PosixPath thing in python so we must recreate it here  *)
   (* We also have been hashing a tuple formatted as below *)
   let string =


### PR DESCRIPTION
Python escapes single quotes so we need to escape them as well when computing the fingerprint. This fixes the osemgrep fingerprints for rules with patterns that use single quotes, and made another sarif test pass (not yet marked as such).

There are still issues with how fingerprints are computed. I ran both pysemgrep and osemgrep patched so they print the fingerprint before hashing and found the above error. There are still discrepancies when there are multiple patterns. It seems the order is not always the same, and in some cases pysemgrep seems to omit patterns(?!).