### PR TITLE
fix: tainting: Precise identification of sources/sanitizers/sinks

### DIFF
--- a/changelog.d/rules-6457.changed
+++ b/changelog.d/rules-6457.changed
@@ -1,0 +1,14 @@
+taint-mode: Improve inference of best matches for exact-sources, exact-sanitizers,
+and sinks. Now we also avoid FPs in cases such as:
+
+    dangerouslySetInnerHTML = {
+      // ok:
+      {__html: props ? DOMPurify.sanitize(props.text) : ''} // no more FPs!
+    }
+
+where `props` is tainted and the sink specification is:
+
+    patterns:
+      - pattern: |
+         <$Y ... dangerouslySetInnerHTML={{__html: $X}} />
+      - focus-metavariable: $X

--- a/changelog.d/rules-6457.changed
+++ b/changelog.d/rules-6457.changed
@@ -10,5 +10,10 @@ where `props` is tainted and the sink specification is:
 
     patterns:
       - pattern: |
-         <$Y ... dangerouslySetInnerHTML={{__html: $X}} />
+         dangerouslySetInnerHTML={{__html: $X}}
       - focus-metavariable: $X
+
+Previously Semgrep wrongly considered the individual subexpressions of the
+conditional as sinks, including the `props` in `props ? ...`, thus producing a
+false positive. Now it will only consider the conditional expression as a whole
+as the sink.

--- a/src/analyzing/AST_to_IL.ml
+++ b/src/analyzing/AST_to_IL.ml
@@ -905,7 +905,7 @@ and call_special _env (x, tok) =
     | G.Instanceof -> Instanceof
     | G.Sizeof -> Sizeof
     | G.ConcatString _kindopt -> Concat
-    | G.Spread -> Spread
+    | G.Spread -> SpreadFn
     | G.Require -> Require
     | G.EncodedString _
     | G.Defined

--- a/src/il/dune
+++ b/src/il/dune
@@ -17,6 +17,7 @@
       ppx_deriving.show
       ppx_deriving.eq
       ppx_hash
+      visitors.ppx
    )
  )
 )

--- a/src/tainting/Dataflow_tainting.ml
+++ b/src/tainting/Dataflow_tainting.ml
@@ -103,7 +103,7 @@ type env = {
   config : config;
   fun_name : var option;
   lval_env : Lval_env.t;
-  top_matches : TM.Top_matches.t;
+  best_matches : TM.Best_matches.t;
   java_props : java_props_cache;
 }
 
@@ -174,7 +174,7 @@ let union_map_taints_and_vars env f xs =
 let any_is_best_sanitizer env any =
   env.config.is_sanitizer any
   |> List.filter (fun (m : R.taint_sanitizer TM.t) ->
-         (not m.spec.sanitizer_exact) || TM.is_best_match env.top_matches m)
+         (not m.spec.sanitizer_exact) || TM.is_best_match env.best_matches m)
 
 (* TODO: We could return source matches already split by `by-side-effect` here ? *)
 let any_is_best_source ?(is_lval = false) env any =
@@ -187,13 +187,13 @@ let any_is_best_source ?(is_lval = false) env any =
           *  backwards compatibility we keep it this way. *)
          | Yes
          | No ->
-             (not m.spec.source_exact) || TM.is_best_match env.top_matches m)
+             (not m.spec.source_exact) || TM.is_best_match env.best_matches m)
 
 let any_is_best_sink env any =
   env.config.is_sink any
   |> List.filter (fun (tm : R.taint_sink TM.t) ->
          (* at-exit sinks are handled in 'check_tainted_at_exit_sinks' *)
-         (not tm.spec.sink_at_exit) && TM.is_best_match env.top_matches tm)
+         (not tm.spec.sink_at_exit) && TM.is_best_match env.best_matches tm)
 
 let orig_is_source config orig = config.is_source (any_of_orig orig)
 
@@ -884,7 +884,7 @@ let rec check_tainted_lval env (lval : IL.lval) : Taints.t * Lval_env.t =
   in
   let sinks =
     lval_is_sink env lval
-    |> List.filter (TM.is_best_match env.top_matches)
+    |> List.filter (TM.is_best_match env.best_matches)
     |> List_.map TM.sink_of_match
   in
   let findings = findings_of_tainted_sinks { env with lval_env } taints sinks in
@@ -1638,7 +1638,7 @@ let check_tainted_instr env instr : Taints.t * Lval_env.t =
 let check_tainted_return env tok e : Taints.t * Lval_env.t =
   let sinks =
     any_is_best_sink env (G.Tk tok) @ orig_is_best_sink env e.eorig
-    |> List.filter (TM.is_best_match env.top_matches)
+    |> List.filter (TM.is_best_match env.best_matches)
     |> List_.map TM.sink_of_match
   in
   let taints, var_env' = check_tainted_expr env e in
@@ -1713,10 +1713,10 @@ let transfer :
     Lval_env.t ->
     string option ->
     flow:F.cfg ->
-    top_matches:TM.Top_matches.t ->
+    best_matches:TM.Best_matches.t ->
     java_props:java_props_cache ->
     Lval_env.t D.transfn =
- fun lang options config enter_env opt_name ~flow ~top_matches ~java_props
+ fun lang options config enter_env opt_name ~flow ~best_matches ~java_props
      (* the transfer function to update the mapping at node index ni *)
        mapping ni ->
   (* DataflowX.display_mapping flow mapping show_tainted; *)
@@ -1729,7 +1729,7 @@ let transfer :
       config;
       fun_name = opt_name;
       lval_env = in';
-      top_matches;
+      best_matches;
       java_props;
     }
   in
@@ -1838,11 +1838,12 @@ let (fixpoint :
     | None -> Lval_env.empty
     | Some in_env -> in_env
   in
-  let top_matches =
-    (* Here we compute the "canonical" or "top" sink matches, for each sink we check
-     * whether there is a "best match" among the top nodes in the CFG.
-     * See NOTE "Top matches" *)
-    TM.top_level_matches_in_nodes
+  let best_matches =
+    (* Here we compute the "canonical" or "best" source/sanitizer/sink matches,
+     * for each source/sanitizer/sink we check whether there is a "best match"
+     * among all the potential matches in the CFG.
+     * See NOTE "Best matches" *)
+    TM.best_matches_in_nodes
       ~matches_of_orig:(fun orig ->
         let sources =
           orig_is_source config orig |> List.to_seq
@@ -1868,7 +1869,7 @@ let (fixpoint :
     DataflowX.fixpoint ~timeout:Limits_semgrep.taint_FIXPOINT_TIMEOUT
       ~eq_env:Lval_env.equal ~init:init_mapping
       ~trans:
-        (transfer lang options config enter_env opt_name ~flow ~top_matches
+        (transfer lang options config enter_env opt_name ~flow ~best_matches
            ~java_props)
         (* tainting is a forward analysis! *)
       ~forward:true ~flow

--- a/src/tainting/Dataflow_tainting.ml
+++ b/src/tainting/Dataflow_tainting.ml
@@ -29,6 +29,9 @@ module TM = Taint_smatch
 
 let logger = Logging.get_logger [ __MODULE__ ]
 
+(* TODO: Rename things to make clear that there are "sub-matches" and there are
+ * "best matches". *)
+
 (*****************************************************************************)
 (* Prelude *)
 (*****************************************************************************)
@@ -1844,7 +1847,7 @@ let (fixpoint :
      * among all the potential matches in the CFG.
      * See NOTE "Best matches" *)
     TM.best_matches_in_nodes
-      ~matches_of_orig:(fun orig ->
+      ~sub_matches_of_orig:(fun orig ->
         let sources =
           orig_is_source config orig |> List.to_seq
           |> Seq.filter (fun (m : R.taint_source TM.t) -> m.spec.source_exact)

--- a/src/tainting/Taint.ml
+++ b/src/tainting/Taint.ml
@@ -472,7 +472,8 @@ module Taint_set = struct
                * Otherwise we end up with taint sets where most of the taints are
                * essentially the same. This is probably due to
                * [see note "Taint-tracking via ranges" in Match_tainting_mode],
-               * and not having "Top_sources" [see note "Top matches" in 'Taint_smatch'].
+               * and not having "Best_sources" [see note "Best matches" in 'Taint_smatch'].
+               * TOOD: Revisit ^^^ now we have `exact: true` sources.
                *)
               let ts1' = of_list ts1 in
               let ts2' = of_list ts2 in

--- a/src/tainting/Taint_smatch.ml
+++ b/src/tainting/Taint_smatch.ml
@@ -36,7 +36,7 @@ type any = Any : 'a t -> any
  * (See note "Taint-tracking via ranges" in 'Match_tainting_mode.ml' for context.)
  *
  * We use sub-range checks to determine whether a piece of code is a source/sink/etc,
- * and this can lead to unintuitive results. For example,
+ * and this can lead to unintuitive results. For example, in the past,
  *
  *     sink(if tainted then ok1 else ok2)
  *
@@ -50,21 +50,25 @@ type any = Any : 'a t -> any
  * expression. But in the IL, `echo` is represented as a `Call` instruction and
  * the ';' is not part of the`iorig`.
  *
- * So, given a source/sink/etc specification, we check whether the spec matches
- * any of the instructions or (sub)expressions in the CFG. Given two matches,
- * if one is contained inside the other, then we consider them the same match and
- * we take the larger one as the canonical. We store the canonical matches in a
- * 'Best_matches' data structure, and we use these "best matches" matches as a
- * practical definition of what an "exact match" is.
+ * So, given a source/sink/etc specification, we look for all the sub-matches of
+ * that spec on every instruction and (sub)expression in the CFG, and we try find
+ * the "best matches".
+ *
+ * The way we determine the best-matches is by taking the sub-matches two by two,
+ * if one sub-match is contained inside the other, then we take the larger one as
+ * the canonical. We repeat this until we find the ones that fit the spec the best.
+ * We store the canonical matches in this 'Best_matches' data structure, and we use
+ * these "best matches" as a practical definition of what an "exact match" is.
  *
  * For example, if the sink specification is `echo ...;`, and the code we have is
- * `echo $_GET['foo'];`, then this method will determine that `echo $_GET['foo']`
- * is the best match we can get, and that becomes the definition of exact. Then,
- * when we check whether an expression or instruction is a sink, if its range is a
- * strict sub-range of one of these best matches, we simply disregard it (because it
- * is not an exact match). In our example above the best sink match will be
- * `sink(if tainted then ok1 else ok2)`, so we will disregard `tainted` as a sink
- * because we know there is a better match.
+ * `echo $_GET['foo'];`, the sub-matches are `$_GET`, `'foo'` and n`$_GET['foo']`.
+ * And this method will determine that `echo $_GET['foo']` is the best match of all,
+ * and that is what we will consider an "exact" match for the `echo ...;` sink.
+ *
+ * In our example above, `tainted`, `ok1` and `ok2` are all potential sub-matches,
+ * but not the "best" ones. The sub match `sink(if tainted then ok1 else ok2)`,
+ * contains them all and it will be considered the "best"/"exact" match for that
+ * sink. Thus, we will not have a FP due to `tainted` being considered a sink.
  *)
 module Best_matches = struct
   (* For m, m' in S.t, not (m.range $<=$ m'.range) && not (m'.range $<=$ m.range) *)
@@ -94,43 +98,44 @@ module Best_matches = struct
            m.spec_id ^ ":" ^ Range.content_at_range !!(m.spec_pm.file) m.range)
     |> String.concat " ; "
 
-  let rec add (Any m' as x') top_matches =
+  let rec add (Any m' as x') best_matches =
     (* We check if we have another match for the *same* source/sink/etc spec
      * (i.e., same 'source_id'/'sink_id'/etc), and if so we must keep the
      * best match and drop the other one. *)
-    match S.find_opt x' top_matches with
-    | None -> S.add x' top_matches
+    match S.find_opt x' best_matches with
+    | None -> S.add x' best_matches
     | Some (Any m as x) ->
         let r = m.range in
         let r' = m'.range in
         (* Note that by `S`s definition, either `r` is contained in `r'` or vice-versa. *)
         if r'.start > r.start || r'.end_ < r.end_ then
           (* The new match is a worse fit so we keep the current one. *)
-          top_matches
+          best_matches
         else
           (* We found a better (larger) match! *)
-          (* There may be several matches in `top_matches` that are subsumed by `m'`.
+          (* There may be several matches in `best_matches` that are subsumed by `m'`.
            * E.g. we could have found sinks at ranges (1,5) and (6,10), and then
            * we find that there is better sink match at range (1,10). This
            * new larger match subsumes both (1,5) and (6, 10) matches.
-           * Thus, before we try adding `m'` to `top_matches`, we need to make sure
+           * Thus, before we try adding `m'` to `best_matches`, we need to make sure
            * that there is no other match `m` that is included in `m'`.
            * Otherwise `m'` would be considered a duplicate and it would not
            * be added (e.g., if we try adding the range (1,10) to a set that
            * still contains the range (6,10), given our `compare` function above
            * the (1,10) range will be considered a duplicate), hence the
            * recursive call to `add` here. *)
-          add x' (S.remove x top_matches)
+          add x' (S.remove x best_matches)
 
-  let is_best_match top_matches m' =
-    match S.find_opt (Any m') top_matches with
+  let is_best_match best_matches m' =
+    match S.find_opt (Any m') best_matches with
     | None -> true
     | Some (Any m) -> m.range =*= m'.range
 end
 
 let is_best_match = Best_matches.is_best_match
 
-let best_matches_in_nodes ~matches_of_orig flow =
+(* See NOTE "Best matches" for more context. *)
+let best_matches_in_nodes ~sub_matches_of_orig flow =
   let find_origs_visitor =
     object (_self : 'self)
       inherit [_] IL.iter as super
@@ -144,9 +149,36 @@ let best_matches_in_nodes ~matches_of_orig flow =
         super#visit_exp acc e
     end
   in
-  (* We traverse the CFG and we check whether the (sub)expressions match
-   * any taint specification. Those that do match a spec are potential
-   * "best-fit matches". *)
+  (* We traverse the CFG and we check for every sub-match for a taint specification.
+   * These are the potential matches that we will pass to the 'Best_matches' data
+   * structure, from which it will select the "best matches".
+   *
+   * For example, this code `sink(if tainted then ok1 else ok2)` is translated
+   * in the following IL:
+   *
+   *     if tainted:
+   *       tmp := ok1
+   *     else:
+   *       tmp := ok2
+   *     sink(!tmp)
+   *
+   * The CFG is essentially:
+   *
+   *     if tainted -> tmp := ok1 | ->  sink([tmp])
+   *               \-> tmp := ok2 |
+   *
+   * We then check `tainted`, `tmp := ok1`, `ok1`, `tmp := ok2`, `ok2`,
+   * `sink(!tmp)`, `sink`,  and`!tmp`, for sub-matches against the spec:
+   *
+   *     - patterns:
+   *       - pattern: sink($X)
+   *       - focus-metavariable: $X
+   *
+   * All of `tainted`, `ok1`, `ok2`, and `!tmp` are potential sub-matches.
+   * Yet `!tmp`, which has `if tainted then ok1 else ok2` as 'eorig', and
+   * thus has a range that contains them all, is the chosen as the "best"
+   * match of the sink spec.
+   * *)
   flow.CFG.reachable |> CFG.NodeiSet.to_seq
   |> Seq.concat_map (fun ni ->
          let node = flow.CFG.graph#nodes#assoc ni in
@@ -155,5 +187,5 @@ let best_matches_in_nodes ~matches_of_orig flow =
            find_origs_visitor#visit_node origs node;
            !origs
          in
-         all_origs |> Seq.concat_map matches_of_orig)
+         all_origs |> Seq.concat_map sub_matches_of_orig)
   |> Seq.fold_left (fun s x -> Best_matches.add x s) Best_matches.empty

--- a/src/tainting/Taint_smatch.mli
+++ b/src/tainting/Taint_smatch.mli
@@ -14,7 +14,8 @@ type 'spec t = {
   spec : 'spec;
       (** The specification on which the match is based, e.g. a taint source.
       * This spec should have a pattern formula. *)
-  spec_id : string;  (** See 'source_id' etc in 'Rule' and 'Parse_rule'. *)
+  spec_id : string;
+      (** See 'source_id' etc in 'Rule' and 'Parse_rule', this is the very same id. *)
   spec_pm : Pattern_match.t;
       (** What the spec's pattern formula actually matches in the target file. *)
   range : Range.t;
@@ -23,7 +24,9 @@ type 'spec t = {
   overlap : overlap;
       (** The overlap of this match ('range') with the spec match ('spec_pm'). *)
 }
-(** A match for a taint spec *)
+(** A sub-match for a taint spec, the 'range' is a subset of the range delimited by
+ * the spec. This is more of a candidate, sometimes we are fine with a submatch, but
+ * sometimes we want the "best match", see NOTE "Best matches". *)
 
 val is_exact : 'spec t -> bool
 (** An exact match, i.e. overlap 0.99. Typically useful for l-values. *)
@@ -51,5 +54,7 @@ val is_best_match : Best_matches.t -> 'spec t -> bool
 (** Similar to 'is_exact' but based on "top matches". *)
 
 val best_matches_in_nodes :
-  matches_of_orig:(IL.orig -> any Seq.t) -> (IL.node, _) CFG.t -> Best_matches.t
+  sub_matches_of_orig:(IL.orig -> any Seq.t) ->
+  (IL.node, _) CFG.t ->
+  Best_matches.t
 (** Collect the top-level matches in a CFG. *)

--- a/src/tainting/Taint_smatch.mli
+++ b/src/tainting/Taint_smatch.mli
@@ -29,6 +29,7 @@ val is_exact : 'spec t -> bool
 (** An exact match, i.e. overlap 0.99. Typically useful for l-values. *)
 
 val sink_of_match : Rule.taint_sink t -> Taint.sink
+val _show : 'spec t -> string
 
 (** Any kind of spec-match (existential type). *)
 type any = Any : 'a t -> any
@@ -40,15 +41,15 @@ type any = Any : 'a t -> any
  * If one match is contained in another one, we only keep the _larges_ match.
  * For example, given `foo(...)` then `foo(x)` will be recorded as a top-level
  * match, whereas `foo` or `x` will not. *)
-module Top_matches : sig
+module Best_matches : sig
   type t
 
   val _debug : t -> string
 end
 
-val is_best_match : Top_matches.t -> 'spec t -> bool
+val is_best_match : Best_matches.t -> 'spec t -> bool
 (** Similar to 'is_exact' but based on "top matches". *)
 
-val top_level_matches_in_nodes :
-  matches_of_orig:(IL.orig -> any Seq.t) -> (IL.node, _) CFG.t -> Top_matches.t
+val best_matches_in_nodes :
+  matches_of_orig:(IL.orig -> any Seq.t) -> (IL.node, _) CFG.t -> Best_matches.t
 (** Collect the top-level matches in a CFG. *)

--- a/tests/rules/taint_best_fit_sink.py
+++ b/tests/rules/taint_best_fit_sink.py
@@ -5,6 +5,9 @@ sink(tainted())
 sink(ok1 if tainted() else ok2)
 
 #ok:test
+sink([ok1 if tainted() else ok2])
+
+#ok:test
 sink(not_a_propagator(tainted()))
 
 #ok:test

--- a/tests/rules/taint_best_fit_sink3.py
+++ b/tests/rules/taint_best_fit_sink3.py
@@ -4,6 +4,9 @@ sink(tainted())
 # ok:test
 sink(ok1 if tainted() else ok2)
 
+# ok:test
+sink([ok1 if tainted() else ok2])
+
 #ok:test
 sink(not_a_propagator(tainted()))
 

--- a/tests/rules/taint_best_fit_sink7.js
+++ b/tests/rules/taint_best_fit_sink7.js
@@ -1,0 +1,10 @@
+import DOMPurify from "dompurify"
+
+function ok(props) {
+  <span
+  dangerouslySetInnerHTML = {
+      // ok: test
+      {__html: props ? DOMPurify.sanitize(props.text) : ''}
+    }
+/>
+}

--- a/tests/rules/taint_best_fit_sink7.yaml
+++ b/tests/rules/taint_best_fit_sink7.yaml
@@ -1,0 +1,19 @@
+rules:
+  - id: test
+    message:  Test
+    languages:
+      - javascript
+    severity: WARNING
+    mode: taint
+    pattern-sources:
+      - patterns:
+          - pattern: |
+              function ...(..., $X, ...) { ... }
+          - focus-metavariable: $X
+    pattern-sanitizers:
+      - pattern: $S.sanitize(...)
+    pattern-sinks:
+      - patterns:
+          - pattern: |
+              <$Y ... dangerouslySetInnerHTML={{__html: $X}} />
+          - focus-metavariable: $X

--- a/tests/rules/taint_best_fit_sink8.py
+++ b/tests/rules/taint_best_fit_sink8.py
@@ -1,0 +1,11 @@
+#ruleid: test
+sink([tainted(), safe()])
+
+#ok: test
+sink([safe(), tainted()])
+
+#ok: test
+sink([safe(), safe()])
+
+#ok: test
+sink([ok1 if tainted() else ok2, safe()])

--- a/tests/rules/taint_best_fit_sink8.yaml
+++ b/tests/rules/taint_best_fit_sink8.yaml
@@ -1,0 +1,14 @@
+rules:
+  - id: test
+    languages:
+      - python
+    message: Match
+    mode: taint
+    pattern-sinks:
+      - patterns:
+        - pattern: sink([$X, ...])
+        - focus-metavariable: $X
+    pattern-sources:
+      - pattern: tainted(...)
+    severity: WARNING
+


### PR DESCRIPTION
When computing the best matches for a sink (or a source or a sanitizer), it is not enough to just look at the top origs of each CFG node (... and we knew it was not enough but it was left as a TODO). For example, this `{__html: props ? DOMPurify.sanitize(props.text) : ''}` will be translated into (roughly) the following IL:

    if props:
      tmp := DOMPurify.sanitize(props.text);
    else:
      tmp := ''
    {__html: !tmp}

The expression whose `eorig` corresponds to the actual sink we want to infer is `!tmp` and it is nested within a record expression. Previously we just looked at the "top" expression of each CFG node, so we looked at `{__html: !tmp}` alone and we missed the nested `!tmp`.

Now we visit all the IL expressions and check every `eorig` so that we don't miss anything.

Follows: dc397cc558d ("tainting: Make identification of sinks (even) more precise (#9342)")

Helps RULES-6457

test plan:
make test # new tests

