### PR TITLE
osemgrep: implement junit_xml output

### DIFF
--- a/cli/tests/e2e/test_output.py
+++ b/cli/tests/e2e/test_output.py
@@ -288,7 +288,7 @@ def test_junit_xml_output(run_semgrep_in_tmp: RunSemgrep, snapshot):
     filename = snapshot.snapshot_dir / "results.xml"
     expected = _etree_to_dict(cElementTree.XML(filename.read_text()))
 
-    assert expected == result
+    assert result == expected
 
 
 @pytest.mark.kinda_slow

--- a/dune-project
+++ b/dune-project
@@ -444,10 +444,11 @@ For more information see https://semgrep.dev
     (easy_logging ( = 0.8.1 ))
     (easy_logging_yojson ( = 0.8.1 ))
     logs
-    ; JSON/YAML
+    ; JSON/YAML/XML
     atdgen
     (yojson ( >= 2.0.0 ))
     yaml
+    xmlm
     ; CLI
     cmdliner
     ; PPX

--- a/semgrep.opam
+++ b/semgrep.opam
@@ -34,6 +34,7 @@ depends: [
   "atdgen"
   "yojson" {>= "2.0.0"}
   "yaml"
+  "xmlm"
   "cmdliner"
   "ppxlib"
   "ppx_deriving"

--- a/src/osemgrep/reporting/Junit_xml_output.ml
+++ b/src/osemgrep/reporting/Junit_xml_output.ml
@@ -1,0 +1,67 @@
+module OutT = Semgrep_output_v1_t
+
+let string_of_severity = function
+  | `Info -> "INFO"
+  | `Warning -> "WARNING"
+  | `Error -> "ERROR"
+  | `Experiment -> "EXPERIMENT"
+  | `Inventory -> "INVENTORY"
+
+let junit_test_cases out (results : OutT.cli_match list) =
+  results
+  |> List.iter (fun (result : OutT.cli_match) ->
+         let open Xmlm in
+         output out
+           (`El_start
+             ( ("", "testcase"),
+               [
+                 (("", "name"), Rule_ID.to_string result.check_id);
+                 (("", "classname"), Fpath.to_string result.path);
+                 (("", "file"), Fpath.to_string result.path);
+                 (("", "line"), string_of_int result.start.line);
+               ] ));
+         output out
+           (`El_start
+             ( ("", "failure"),
+               [
+                 (("", "type"), string_of_severity result.extra.severity);
+                 (("", "message"), result.extra.message);
+               ] ));
+         output out (`Data result.extra.lines);
+         output out `El_end;
+         output out `El_end)
+
+let junit_xml_output (cli_output : OutT.cli_output) =
+  let b = Buffer.create 1024 in
+  let open Xmlm in
+  let out = Xmlm.make_output (`Buffer b) in
+  let num_results = List.length cli_output.results in
+  output out (`Dtd None);
+  output out
+    (`El_start
+      ( ("", "testsuites"),
+        [
+          (("", "disabled"), "0");
+          (("", "errors"), "0");
+          (("", "failures"), string_of_int num_results);
+          (("", "tests"), string_of_int num_results);
+          (* XXX(reynir): due to python quirk this is a flaot *)
+          (("", "time"), "0.0");
+        ] ));
+  output out
+    (`El_start
+      ( ("", "testsuite"),
+        [
+          (("", "disabled"), "0");
+          (("", "errors"), "0");
+          (("", "failures"), string_of_int num_results);
+          (("", "name"), "semgrep results");
+          (("", "skipped"), "0");
+          (("", "tests"), string_of_int num_results);
+          (* XXX(reynir): due to python quirk this is an integer *)
+          (("", "time"), "0");
+        ] ));
+  junit_test_cases out cli_output.results;
+  output out `El_end;
+  output out `El_end;
+  Buffer.contents b

--- a/src/osemgrep/reporting/Output.ml
+++ b/src/osemgrep/reporting/Output.ml
@@ -137,9 +137,11 @@ let dispatch_output_format (output_format : Output_format.t) (conf : conf)
   | Sarif ->
       let sarif_json = Sarif_output.sarif_output hrules cli_output in
       Out.put (Yojson.Basic.to_string sarif_json)
-  | Gitlab_sast
-  | Gitlab_secrets
   | Junit_xml ->
+      let junit_xml = Junit_xml_output.junit_xml_output cli_output in
+      Out.put junit_xml
+  | Gitlab_sast
+  | Gitlab_secrets ->
       Out.put
         (spf "TODO: output format %s not supported yet"
            (Output_format.show output_format))

--- a/src/osemgrep/reporting/dune
+++ b/src/osemgrep/reporting/dune
@@ -8,6 +8,7 @@
    fmt
    terminal_size
    digestif
+   xmlm
 
   osemgrep_configuring
    osemgrep_core


### PR DESCRIPTION
This implements the junit_xml output for osemgrep. The single junit_xml test does not pass because the order of the test results is different. Otherwise it closely mimics the pysemgrep junit_xml output.

The reason for the difference in order is because the osemgrep code uses the cli_output (json) which is sorted. Maybe the solution is to sort the output in pysemgrep as well? Especially with the following comment in mind:

    # Sort results so as to guarantee the same results across different
    # runs. Results may arrive in a different order due to parallelism
    # (-j option).
