### PR TITLE
pysemgrep: sort rule matches in junit_xml output

### DIFF
--- a/cli/src/semgrep/formatter/junit_xml.py
+++ b/cli/src/semgrep/formatter/junit_xml.py
@@ -39,8 +39,10 @@ class JunitXmlFormatter(BaseFormatter):
         extra: Mapping[str, Any],
         is_ci_invocation: bool,
     ) -> str:
+        # Sort according to RuleMatch.get_ordering_key
+        sorted_findings = sorted(rule_matches)
         test_cases = [
-            self._rule_match_to_test_case(rule_match) for rule_match in rule_matches
+            self._rule_match_to_test_case(rule_match) for rule_match in sorted_findings
         ]
         ts = TestSuite("semgrep results", test_cases)
         return cast(str, to_xml_report_string([ts]))

--- a/cli/tests/e2e/snapshots/test_output/test_junit_xml_output/results.xml
+++ b/cli/tests/e2e/snapshots/test_output/test_junit_xml_output/results.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" ?>
 <testsuites disabled="0" errors="0" failures="2" tests="2" time="0.0">
 	<testsuite disabled="0" errors="0" failures="2" name="semgrep results" skipped="0" tests="2" time="0">
-		<testcase name="rules.eqeq-is-bad" classname="targets/basic/stupid.py" file="targets/basic/stupid.py" line="3">
-			<failure type="ERROR" message="useless comparison operation `a + b == a + b` or `a + b != a + b`">    return a + b == a + b
-</failure>
-		</testcase>
 		<testcase name="rules.javascript-basic-eqeq-bad" classname="targets/basic/stupid.js" file="targets/basic/stupid.js" line="3">
 			<failure type="ERROR" message="useless comparison">console.log(x == x)
+</failure>
+		</testcase>
+		<testcase name="rules.eqeq-is-bad" classname="targets/basic/stupid.py" file="targets/basic/stupid.py" line="3">
+			<failure type="ERROR" message="useless comparison operation `a + b == a + b` or `a + b != a + b`">    return a + b == a + b
 </failure>
 		</testcase>
 	</testsuite>

--- a/cli/tests/e2e/test_output.py
+++ b/cli/tests/e2e/test_output.py
@@ -278,7 +278,6 @@ def test_debug_experimental_rule(run_semgrep_in_tmp: RunSemgrep, snapshot):
 
 
 @pytest.mark.kinda_slow
-@pytest.mark.osemfail
 def test_junit_xml_output(run_semgrep_in_tmp: RunSemgrep, snapshot):
     output, _ = run_semgrep_in_tmp(
         "rules/eqeq.yaml", output_format=OutputFormat.JUNIT_XML


### PR DESCRIPTION
The motivation is because the output is sorted in e.g. the json output for reproducibility in the presence of parallelism. Another motivation is because osemgrep sorts the output and this change will align pysemgrep with osemgrep and make the junit_xml test pass for osemgrep too.

Previous discussion in https://github.com/semgrep/semgrep/pull/9626.