### PR TITLE
Emit fixed_lines in Cli_json_output at all times when dryrun is true.

### DIFF
--- a/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -104,7 +104,9 @@ let file_match_results_hook (conf : Scan_CLI.conf) (rules : Rule.rules)
     in
     let hrules = Rule.hrules_of_rules rules in
     core_matches
-    |> List_.map (Cli_json_output.cli_match_of_core_match hrules)
+    |> List_.map
+         (Cli_json_output.cli_match_of_core_match
+            ~dryrun:conf.output_conf.dryrun hrules)
     |> Cli_json_output.dedup_and_sort
   in
   let cli_matches =

--- a/src/osemgrep/cli_scan/Validate_subcommand.ml
+++ b/src/osemgrep/cli_scan/Validate_subcommand.ml
@@ -139,7 +139,7 @@ let run_conf (caps : caps) (conf : conf) : Exit_code.t =
         let res = Core_runner.create_core_result metarules result_and_exn in
         (* TODO? sanity check errors below too? *)
         let OutJ.{ results; errors = _; _ } =
-          Cli_json_output.cli_output_of_core_results
+          Cli_json_output.cli_output_of_core_results ~dryrun:true
             ~logging_level:conf.common.logging_level res.core res.hrules
             res.scanned
         in

--- a/src/osemgrep/reporting/Cli_json_output.mli
+++ b/src/osemgrep/reporting/Cli_json_output.mli
@@ -1,5 +1,6 @@
 (* entry point *)
 val cli_output_of_core_results :
+  dryrun:bool ->
   logging_level:Logs.level option ->
   (* essentially Core_runner.result *)
   Semgrep_output_v1_t.core_output ->
@@ -12,7 +13,10 @@ val exit_code_of_error_type : Semgrep_output_v1_t.error_type -> Exit_code.t
 
 (* internals used also for incremental display of matches *)
 val cli_match_of_core_match :
-  Rule.hrules -> Semgrep_output_v1_t.core_match -> Semgrep_output_v1_t.cli_match
+  dryrun:bool ->
+  Rule.hrules ->
+  Semgrep_output_v1_t.core_match ->
+  Semgrep_output_v1_t.cli_match
 
 val index_match_based_ids :
   Semgrep_output_v1_t.cli_match list -> Semgrep_output_v1_t.cli_match list

--- a/src/osemgrep/reporting/Output.ml
+++ b/src/osemgrep/reporting/Output.ml
@@ -156,8 +156,8 @@ let dispatch_output_format (output_format : Output_format.t) (conf : conf)
 let preprocess_result (conf : conf) (res : Core_runner.result) : OutJ.cli_output
     =
   let cli_output : OutJ.cli_output =
-    Cli_json_output.cli_output_of_core_results ~logging_level:conf.logging_level
-      res.core res.hrules res.scanned
+    Cli_json_output.cli_output_of_core_results ~dryrun:conf.dryrun
+      ~logging_level:conf.logging_level res.core res.hrules res.scanned
   in
   cli_output |> fun results ->
   {

--- a/src/osemgrep/reporting/Sarif_output.ml
+++ b/src/osemgrep/reporting/Sarif_output.ml
@@ -174,10 +174,9 @@ let fixed_lines (cli_match : OutT.cli_match) fix =
       []
 
 let sarif_fix (cli_match : OutT.cli_match) =
-  match cli_match.extra.fix with
+  match cli_match.extra.fixed_lines with
   | None -> []
-  | Some fix ->
-      let fixed_lines = fixed_lines cli_match fix in
+  | Some fixed_lines ->
       let description_text =
         spf "%s\n Autofix: Semgrep rule suggested fix" cli_match.extra.message
       in


### PR DESCRIPTION
This change does not directly fix any test cases, but paves the path for (at least one currently failing) test_autofix.py test.

This is how the PySemgrep does it:

        if not dryrun:
            _write_contents(rule_match.path, fixobj.fixed_contents)
            modified_files.add(filepath)
            modified_files_offsets[filepath] = new_file_offset
        else:
            rule_match.extra[
                "fixed_lines"
            ] = fixobj.fixed_lines

