### PR TITLE
Rename experimental option `taint_match_on` to `taint_focus_on`

### DIFF
--- a/changelog.d/pa-3272.changed
+++ b/changelog.d/pa-3272.changed
@@ -1,0 +1,4 @@
+Deprecated option `taint_match_on` introduced in 1.51.0, it is being renamed
+to `taint_focus_on`. Note that `taint_match_on` was experimental, and
+`taint_focus_on` is experimental too. Option `taint_match_on` will continue
+to work but it will be completely removed at some point after 1.63.0.

--- a/interfaces/Rule_options.atd
+++ b/interfaces/Rule_options.atd
@@ -39,7 +39,9 @@ type t = {
   ~symbolic_propagation <ocaml default="false"> : bool;
 
   (* metavariables common to a source and sink will be unified *)
+  (* taint_match_on is DEPRECATED and to be removed after 1.63.0 *)
   ~taint_match_on <ocaml default="`Sink">: taint_match_on;
+  ~taint_focus_on <ocaml default="`Sink">: taint_match_on;
   ~taint_unify_mvars <ocaml default="false"> : bool;
   ~taint_assume_safe_functions <ocaml default="false"> : bool;
   ~taint_assume_safe_indexes <ocaml default="false"> : bool;

--- a/src/engine/Match_tainting_mode.ml
+++ b/src/engine/Match_tainting_mode.ml
@@ -883,10 +883,19 @@ let check_rule per_file_formula_cache (rule : R.taint_rule) match_hook
   (* TODO: 'debug_taint' should just be part of 'res'
      * (i.e., add a "debugging" field to 'Report.match_result'). *)
   let taint_config, _TODO_debug_taint, expls =
+    let match_on =
+      (* TEMPORARY HACK to support both taint_match_on (DEPRECATED) and
+       * taint_focus_on (preferred name by SR). *)
+      match (xconf.config.taint_focus_on, xconf.config.taint_match_on) with
+      | `Source, _
+      | _, `Source ->
+          `Source
+      | `Sink, `Sink -> `Sink
+    in
     let handle_findings _ findings _env =
       findings
       |> List.iter (fun finding ->
-             pms_of_finding ~match_on:xconf.config.taint_match_on finding
+             pms_of_finding ~match_on finding
              |> List.iter (fun pm -> Stack_.push pm matches))
     in
     taint_config_of_rule ~per_file_formula_cache xconf !!file (ast, []) rule

--- a/tests/rules/taint_match_on_source.yaml
+++ b/tests/rules/taint_match_on_source.yaml
@@ -3,7 +3,7 @@ rules:
     message: Test
     severity: ERROR
     options:
-      taint_match_on: source
+      taint_focus_on: source
     mode: taint
     languages:
       - python


### PR DESCRIPTION
SR preferred `taint_focus_on`.

Follows: 9b77bc90cff ("tainting: Enable matching on the source (#9277)")

Related to PA-3272

test plan:
make test

