### PR TITLE
feat!: Remove old postprocessor syntax

### DIFF
--- a/changelog.d/scrt-320.changed
+++ b/changelog.d/scrt-320.changed
@@ -1,0 +1,1 @@
+Removed an internal legacy syntax for secrets rules (`mode: semgrep_internal_postprocessor`).

--- a/src/core/Extract.ml
+++ b/src/core/Extract.ml
@@ -75,7 +75,6 @@ type adjusters = {
 let is_extract_rule (r : Rule.t) : bool =
   match r.mode with
   | `Extract _ -> true
-  | `Secrets _
   | `Search _
   | `Taint _
   | `Steps _ ->
@@ -98,8 +97,7 @@ let filter_extract_rules (rules : Rule.t list) : Rule.extract_rule list =
          | `Extract _ as e -> Some ({ r with mode = e } : Rule.extract_rule)
          | `Search _
          | `Taint _
-         | `Steps _
-         | `Secrets _ ->
+         | `Steps _ ->
              None)
 
 let adjusters_of_extracted_targets

--- a/src/core/Rule.ml
+++ b/src/core/Rule.ml
@@ -470,17 +470,6 @@ type response = {
 }
 [@@deriving show]
 
-type secrets = {
-  (* postprocessor-patterns:
-   * Each pattern in this list represents a piece of a "secret"; with any
-   * bindings made available in the request post matching.
-   *)
-  secrets : formula list;
-  request : request;
-  response : response;
-}
-[@@deriving show]
-
 type http_match_clause = {
   status_code : Parsed_int.t option;
   (* Optional. Empty list if not set *)
@@ -554,7 +543,6 @@ type fix_regexp = {
 type search_mode = [ `Search of formula ] [@@deriving show]
 type taint_mode = [ `Taint of taint_spec ] [@@deriving show]
 type extract_mode = [ `Extract of extract ] [@@deriving show]
-type secrets_mode = [ `Secrets of secrets ] [@@deriving show]
 
 (* Steps mode includes rules that use search_mode and taint_mode.
  * Later, if we keep it, we might want to make all rules have steps,
@@ -679,8 +667,7 @@ type 'mode rule_info = {
 (* Later, if we keep it, we might want to make all rules have steps,
    but for the experiment this is easier to remove *)
 
-type mode =
-  [ search_mode | taint_mode | extract_mode | secrets_mode | steps_mode ]
+type mode = [ search_mode | taint_mode | extract_mode | steps_mode ]
 [@@deriving show]
 
 (* the general type *)
@@ -697,7 +684,6 @@ type hrules = (Rule_ID.t, t) Hashtbl.t
 type search_rule = search_mode rule_info [@@deriving show]
 type taint_rule = taint_mode rule_info [@@deriving show]
 type extract_rule = extract_mode rule_info [@@deriving show]
-type secrets_rule = secrets_mode rule_info [@@deriving show]
 type steps_rule = steps_mode rule_info [@@deriving show]
 
 (*****************************************************************************)
@@ -710,42 +696,21 @@ let hrules_of_rules (rules : 'mode rule_info list) :
   rules |> List_.map (fun r -> (fst r.id, r)) |> Hashtbl_.hash_of_list
 
 let partition_rules (rules : rules) :
-    search_rule list
-    * taint_rule list
-    * extract_rule list
-    * secrets_rule list
-    * steps_rule list =
-  let rec part_rules search taint extract secrets step = function
-    | [] ->
-        ( List.rev search,
-          List.rev taint,
-          List.rev extract,
-          List.rev secrets,
-          List.rev step )
+    search_rule list * taint_rule list * extract_rule list * steps_rule list =
+  let rec part_rules search taint extract step = function
+    | [] -> (List.rev search, List.rev taint, List.rev extract, List.rev step)
     | r :: l -> (
         match r.mode with
         | `Search _ as s ->
-            part_rules
-              ({ r with mode = s } :: search)
-              taint extract secrets step l
+            part_rules ({ r with mode = s } :: search) taint extract step l
         | `Taint _ as t ->
-            part_rules search
-              ({ r with mode = t } :: taint)
-              extract secrets step l
+            part_rules search ({ r with mode = t } :: taint) extract step l
         | `Extract _ as e ->
-            part_rules search taint
-              ({ r with mode = e } :: extract)
-              secrets step l
-        | `Secrets _ as s ->
-            part_rules search taint extract
-              ({ r with mode = s } :: secrets)
-              step l
+            part_rules search taint ({ r with mode = e } :: extract) step l
         | `Steps _ as j ->
-            part_rules search taint extract secrets
-              ({ r with mode = j } :: step)
-              l)
+            part_rules search taint extract ({ r with mode = j } :: step) l)
   in
-  part_rules [] [] [] [] [] rules
+  part_rules [] [] [] [] rules
 
 (* for informational messages *)
 let show_id rule = rule.id |> fst |> Rule_ID.to_string
@@ -956,7 +921,6 @@ let rec formula_of_mode (mode : mode) =
       @ List_.map (fun sink -> sink.sink_formula) sinks
       @ List_.map (fun prop -> prop.propagator_formula) propagators
   | `Extract { formula; extract = _; _ } -> [ formula ]
-  | `Secrets { secrets; _ } -> secrets
   | `Steps steps ->
       List.concat_map
         (fun step -> formula_of_mode (step.step_mode :> mode))

--- a/src/engine/Match_rules.ml
+++ b/src/engine/Match_rules.ml
@@ -106,20 +106,6 @@ let group_rules xconf rules xtarget =
            | _ when not relevant_rule -> Right3 r
            | `Taint _ as mode -> Left3 { r with mode }
            | (`Extract _ | `Search _) as mode -> Middle3 { r with mode }
-           (* We are planning on removing `Secret mode and adding generic
-              post processors to rules which only get run when run with secrets
-              validation enabled. Until such time, run secrets rules that haven't
-              been turned to search rule by the pro-engine as search rules, and
-              just discard the validators. *)
-           | `Secrets { secrets = [ formula ]; _ } ->
-               logger#info
-                 "Running secret rule as search rule without validation.";
-               Middle3 { r with mode = `Search formula }
-           (* Silently skip malformed secrets rules for now. *)
-           | `Secrets _ as mode ->
-               logger#error
-                 "Skipping malformed secrets rule without validation.";
-               Right3 { r with mode }
            | `Steps _ ->
                UCommon.pr2 (Rule.show_rule r);
                raise Multistep_rules_not_available)

--- a/src/engine/Test_dataflow_tainting.ml
+++ b/src/engine/Test_dataflow_tainting.ml
@@ -71,7 +71,7 @@ let test_dfg_tainting rules_file file =
            | Xlang.L (x, xs) -> List.mem lang (x :: xs)
            | _ -> false)
   in
-  let _search_rules, taint_rules, _extract_rules, _secrets_rules, _join_rules =
+  let _search_rules, taint_rules, _extract_rules, _join_rules =
     Rule.partition_rules rules
   in
   let rule = List_.hd_exn "unexpected empty list" taint_rules in

--- a/src/engine/Unit_engine.ml
+++ b/src/engine/Unit_engine.ml
@@ -643,7 +643,7 @@ let filter_irrelevant_rules_tests () =
 (*****************************************************************************)
 
 let get_extract_source_lang file rules =
-  let _, _, erules, _, _ = R.partition_rules rules in
+  let _, _, erules, _ = R.partition_rules rules in
   let erule_langs =
     erules |> List_.map (fun r -> r.R.target_analyzer) |> List.sort_uniq compare
   in
@@ -688,12 +688,11 @@ let tainting_test lang rules_file file =
            | Xlang.L (x, xs) -> List.mem lang (x :: xs)
            | _ -> false)
   in
-  let search_rules, taint_rules, extract_rules, secrets_rules, join_rules =
+  let search_rules, taint_rules, extract_rules, join_rules =
     Rule.partition_rules rules
   in
   assert (search_rules =*= []);
   assert (extract_rules =*= []);
-  assert (secrets_rules =*= []);
   assert (join_rules =*= []);
   let xconf = Match_env.default_xconfig in
 

--- a/src/metachecking/Check_rule.ml
+++ b/src/metachecking/Check_rule.ml
@@ -198,7 +198,6 @@ let check r =
   | `Search f
   | `Extract { formula = f; _ } ->
       check_formula { r; errors = ref [] } r.target_analyzer f
-  | `Secrets _ -> (* TODO *) []
   | `Taint _ -> (* TODO *) []
   | `Steps _ -> (* TODO *) []
 

--- a/src/metachecking/Translate_rule.ml
+++ b/src/metachecking/Translate_rule.ml
@@ -318,9 +318,7 @@ let translate_files fparser xs =
                         ]
                     | `Taint spec ->
                         [ ("taint", (translate_taint_spec spec :> Yaml.value)) ]
-                    | `Steps _ -> failwith "step rules not currently handled"
-                    | `Secrets _ ->
-                        failwith "secrets rules not currently handled")
+                    | `Steps _ -> failwith "step rules not currently handled")
            in
            (file, formulas))
   in

--- a/src/optimizing/Analyze_rule.ml
+++ b/src/optimizing/Analyze_rule.ml
@@ -652,9 +652,7 @@ let regexp_prefilter_of_rule ~cache (r : R.rule) =
           regexp_prefilter_of_formula ~xlang:r.target_analyzer f
       | `Taint spec ->
           regexp_prefilter_of_taint_rule ~xlang:r.target_analyzer r.R.id spec
-      | `Secrets _ (* TODO *)
-      | `Steps _ ->
-          (* TODO *) None
+      | `Steps _ -> (* TODO *) None
     with
     (* TODO: see tests/rules/tainted-filename.yaml,
                  tests/rules/kotlin_slow_import.yaml *)


### PR DESCRIPTION
This was phased out several releases ago (see also https://github.com/semgrep/semgrep/pull/8846), and we should now be able to remove it and simplify the code. This syntax is undocumented and unused internally; externally it was never part of a documented public API.

Test plan: existing tests
BREAKING CHANGE: Rules using the legacy postprocessor syntax will no longer parse.