### PR TITLE
fix: report token errors properly

### DIFF
--- a/changelog.d/gh-9628.fixed
+++ b/changelog.d/gh-9628.fixed
@@ -1,3 +1,9 @@
-When Semgrep fails to produce a bytepos from a line/col position (an internal
-error that should be impossible), we previously silently moved on. This causes
-problems with Autofix, however, so it's better to give a clear error message.
+Previously, some people got the error:
+
+```
+Encountered error when running rules: Other syntax error at line NO FILE INFO YET:-1:
+Invalid_argument: String.sub / Bytes.sub
+```
+
+Semgrep should now report this error properly with a file name and line number and
+handle it gracefully.

--- a/changelog.d/gh-9628.fixed
+++ b/changelog.d/gh-9628.fixed
@@ -1,0 +1,3 @@
+When Semgrep fails to produce a bytepos from a line/col position (an internal
+error that should be impossible), we previously silently moved on. This causes
+problems with Autofix, however, so it's better to give a clear error message.

--- a/languages/bash/tree-sitter/Parse_bash_tree_sitter.ml
+++ b/languages/bash/tree-sitter/Parse_bash_tree_sitter.ml
@@ -1484,7 +1484,7 @@ let parse_pattern str =
     (fun cst ->
       let file = "<pattern>" in
       let env =
-        { H.file; conv = (fun _ -> raise Not_found); extra = AST_bash.Pattern }
+        { H.file; conv = H.line_col_to_pos_str str; extra = AST_bash.Pattern }
       in
       let tok = Tok.first_tok_of_file file in
       program env ~tok cst)

--- a/languages/bash/tree-sitter/Parse_bash_tree_sitter.ml
+++ b/languages/bash/tree-sitter/Parse_bash_tree_sitter.ml
@@ -1484,7 +1484,11 @@ let parse_pattern str =
     (fun cst ->
       let file = "<pattern>" in
       let env =
-        { H.file; conv = H.line_col_to_pos_str str; extra = AST_bash.Pattern }
+        {
+          H.file;
+          conv = H.line_col_to_pos_pattern str;
+          extra = AST_bash.Pattern;
+        }
       in
       let tok = Tok.first_tok_of_file file in
       program env ~tok cst)

--- a/languages/cairo/generic/Parse_cairo_tree_sitter.ml
+++ b/languages/cairo/generic/Parse_cairo_tree_sitter.ml
@@ -995,5 +995,7 @@ let parse_pattern str =
     (fun () -> parse_expression_or_source_file str)
     (fun cst ->
       let file = "<pattern>" in
-      let env = { H.file; conv = H.line_col_to_pos_str str; extra = Pattern } in
+      let env =
+        { H.file; conv = H.line_col_to_pos_pattern str; extra = Pattern }
+      in
       map_source_file env cst)

--- a/languages/cairo/generic/Parse_cairo_tree_sitter.ml
+++ b/languages/cairo/generic/Parse_cairo_tree_sitter.ml
@@ -995,7 +995,5 @@ let parse_pattern str =
     (fun () -> parse_expression_or_source_file str)
     (fun cst ->
       let file = "<pattern>" in
-      let env =
-        { H.file; conv = (fun _ -> raise Not_found); extra = Pattern }
-      in
+      let env = { H.file; conv = H.line_col_to_pos_str str; extra = Pattern } in
       map_source_file env cst)

--- a/languages/cpp/tree-sitter/Parse_cpp_tree_sitter.ml
+++ b/languages/cpp/tree-sitter/Parse_cpp_tree_sitter.ml
@@ -4934,7 +4934,7 @@ let parse_pattern str =
     (fun () -> parse_expression_or_source_file str)
     (fun cst ->
       let file = "<pattern>" in
-      let env = { H.file; conv = H.line_col_to_pos_str str; extra = () } in
+      let env = { H.file; conv = H.line_col_to_pos_pattern str; extra = () } in
       let x = map_program_or_expr env cst in
       match x with
       | Left [ s ] -> Toplevel s

--- a/languages/cpp/tree-sitter/Parse_cpp_tree_sitter.ml
+++ b/languages/cpp/tree-sitter/Parse_cpp_tree_sitter.ml
@@ -4934,7 +4934,7 @@ let parse_pattern str =
     (fun () -> parse_expression_or_source_file str)
     (fun cst ->
       let file = "<pattern>" in
-      let env = { H.file; conv = (fun _ -> raise Not_found); extra = () } in
+      let env = { H.file; conv = H.line_col_to_pos_str str; extra = () } in
       let x = map_program_or_expr env cst in
       match x with
       | Left [ s ] -> Toplevel s

--- a/languages/csharp/generic/Parse_csharp_tree_sitter.ml
+++ b/languages/csharp/generic/Parse_csharp_tree_sitter.ml
@@ -3396,5 +3396,5 @@ let parse_pattern str =
     (fun () -> parse_pattern_aux str)
     (fun cst ->
       let file = "<pattern>" in
-      let env = { H.file; conv = H.line_col_to_pos_str str; extra = () } in
+      let env = { H.file; conv = H.line_col_to_pos_pattern str; extra = () } in
       compilation_unit env cst)

--- a/languages/csharp/generic/Parse_csharp_tree_sitter.ml
+++ b/languages/csharp/generic/Parse_csharp_tree_sitter.ml
@@ -3396,5 +3396,5 @@ let parse_pattern str =
     (fun () -> parse_pattern_aux str)
     (fun cst ->
       let file = "<pattern>" in
-      let env = { H.file; conv = (fun _ -> raise Not_found); extra = () } in
+      let env = { H.file; conv = H.line_col_to_pos_str str; extra = () } in
       compilation_unit env cst)

--- a/languages/dart/generic/Parse_dart_tree_sitter.ml
+++ b/languages/dart/generic/Parse_dart_tree_sitter.ml
@@ -3866,9 +3866,7 @@ let parse_pattern str =
     (fun () -> parse_expression_or_source_file str)
     (fun cst ->
       let file = "<pattern>" in
-      let env =
-        { H.file; conv = (fun _ -> raise Not_found); extra = Pattern }
-      in
+      let env = { H.file; conv = H.line_col_to_pos_str str; extra = Pattern } in
       let any = map_program env cst in
       (* this will be simplified i:f needed in Parse_pattern.normalize_any *)
       any)

--- a/languages/dart/generic/Parse_dart_tree_sitter.ml
+++ b/languages/dart/generic/Parse_dart_tree_sitter.ml
@@ -3866,7 +3866,9 @@ let parse_pattern str =
     (fun () -> parse_expression_or_source_file str)
     (fun cst ->
       let file = "<pattern>" in
-      let env = { H.file; conv = H.line_col_to_pos_str str; extra = Pattern } in
+      let env =
+        { H.file; conv = H.line_col_to_pos_pattern str; extra = Pattern }
+      in
       let any = map_program env cst in
       (* this will be simplified i:f needed in Parse_pattern.normalize_any *)
       any)

--- a/languages/dockerfile/tree-sitter/Parse_dockerfile_tree_sitter.ml
+++ b/languages/dockerfile/tree-sitter/Parse_dockerfile_tree_sitter.ml
@@ -1070,7 +1070,11 @@ let parse_pattern str =
     (fun cst ->
       let file = "<pattern>" in
       let env =
-        { H.file; conv = H.line_col_to_pos_str str; extra = (input_kind, Sh) }
+        {
+          H.file;
+          conv = H.line_col_to_pos_pattern str;
+          extra = (input_kind, Sh);
+        }
       in
       source_file env cst)
 

--- a/languages/dockerfile/tree-sitter/Parse_dockerfile_tree_sitter.ml
+++ b/languages/dockerfile/tree-sitter/Parse_dockerfile_tree_sitter.ml
@@ -1070,7 +1070,7 @@ let parse_pattern str =
     (fun cst ->
       let file = "<pattern>" in
       let env =
-        { H.file; conv = (fun _ -> raise Not_found); extra = (input_kind, Sh) }
+        { H.file; conv = H.line_col_to_pos_str str; extra = (input_kind, Sh) }
       in
       source_file env cst)
 

--- a/languages/html/generic/Parse_html_tree_sitter.ml
+++ b/languages/html/generic/Parse_html_tree_sitter.ml
@@ -277,7 +277,7 @@ let parse_pattern str =
     (fun () -> Tree_sitter_html.Parse.string str)
     (fun cst ->
       let file = "<pattern>" in
-      let env = { H.file; conv = (fun _ -> raise Not_found); extra = () } in
+      let env = { H.file; conv = H.line_col_to_pos_str str; extra = () } in
 
       match map_fragment env cst with
       | Left xs -> (

--- a/languages/html/generic/Parse_html_tree_sitter.ml
+++ b/languages/html/generic/Parse_html_tree_sitter.ml
@@ -277,7 +277,7 @@ let parse_pattern str =
     (fun () -> Tree_sitter_html.Parse.string str)
     (fun cst ->
       let file = "<pattern>" in
-      let env = { H.file; conv = H.line_col_to_pos_str str; extra = () } in
+      let env = { H.file; conv = H.line_col_to_pos_pattern str; extra = () } in
 
       match map_fragment env cst with
       | Left xs -> (

--- a/languages/java/tree-sitter/Parse_java_tree_sitter.ml
+++ b/languages/java/tree-sitter/Parse_java_tree_sitter.ml
@@ -1949,5 +1949,5 @@ let parse_pattern str =
     (fun () -> Tree_sitter_java.Parse.string str)
     (fun cst ->
       let file = "<pattern>" in
-      let env = { H.file; conv = H.line_col_to_pos_str str; extra = () } in
+      let env = { H.file; conv = H.line_col_to_pos_pattern str; extra = () } in
       program env file cst)

--- a/languages/java/tree-sitter/Parse_java_tree_sitter.ml
+++ b/languages/java/tree-sitter/Parse_java_tree_sitter.ml
@@ -1949,5 +1949,5 @@ let parse_pattern str =
     (fun () -> Tree_sitter_java.Parse.string str)
     (fun cst ->
       let file = "<pattern>" in
-      let env = { H.file; conv = (fun _ -> raise Not_found); extra = () } in
+      let env = { H.file; conv = H.line_col_to_pos_str str; extra = () } in
       program env file cst)

--- a/languages/jsonnet/tree-sitter/Parse_jsonnet_tree_sitter.ml
+++ b/languages/jsonnet/tree-sitter/Parse_jsonnet_tree_sitter.ml
@@ -703,6 +703,6 @@ let parse_pattern str =
     (fun () -> Tree_sitter_jsonnet.Parse.string str)
     (fun cst ->
       let file = "<pattern>" in
-      let env = { H.file; conv = (fun _ -> raise Not_found); extra = () } in
+      let env = { H.file; conv = H.line_col_to_pos_str str; extra = () } in
       let e = map_document env cst in
       E e)

--- a/languages/jsonnet/tree-sitter/Parse_jsonnet_tree_sitter.ml
+++ b/languages/jsonnet/tree-sitter/Parse_jsonnet_tree_sitter.ml
@@ -703,6 +703,6 @@ let parse_pattern str =
     (fun () -> Tree_sitter_jsonnet.Parse.string str)
     (fun cst ->
       let file = "<pattern>" in
-      let env = { H.file; conv = H.line_col_to_pos_str str; extra = () } in
+      let env = { H.file; conv = H.line_col_to_pos_pattern str; extra = () } in
       let e = map_document env cst in
       E e)

--- a/languages/julia/generic/Parse_julia_tree_sitter.ml
+++ b/languages/julia/generic/Parse_julia_tree_sitter.ml
@@ -2448,9 +2448,7 @@ let parse_pattern str =
     (fun () -> Tree_sitter_julia.Parse.string str)
     (fun cst ->
       let file = "<pattern>" in
-      let env =
-        { H.file; conv = (fun _ -> raise Not_found); extra = Pattern }
-      in
+      let env = { H.file; conv = H.line_col_to_pos_str str; extra = Pattern } in
       match map_source_file env cst with
       | [ s ] -> (
           match s.G.s with

--- a/languages/julia/generic/Parse_julia_tree_sitter.ml
+++ b/languages/julia/generic/Parse_julia_tree_sitter.ml
@@ -2448,7 +2448,9 @@ let parse_pattern str =
     (fun () -> Tree_sitter_julia.Parse.string str)
     (fun cst ->
       let file = "<pattern>" in
-      let env = { H.file; conv = H.line_col_to_pos_str str; extra = Pattern } in
+      let env =
+        { H.file; conv = H.line_col_to_pos_pattern str; extra = Pattern }
+      in
       match map_source_file env cst with
       | [ s ] -> (
           match s.G.s with

--- a/languages/kotlin/generic/Parse_kotlin_tree_sitter.ml
+++ b/languages/kotlin/generic/Parse_kotlin_tree_sitter.ml
@@ -2333,7 +2333,5 @@ let parse_pattern str =
     (fun () -> parse_expression_or_source_file str)
     (fun cst ->
       let file = "<pattern>" in
-      let env =
-        { H.file; conv = (fun _ -> raise Not_found); extra = Pattern }
-      in
+      let env = { H.file; conv = H.line_col_to_pos_str str; extra = Pattern } in
       source_file env cst)

--- a/languages/kotlin/generic/Parse_kotlin_tree_sitter.ml
+++ b/languages/kotlin/generic/Parse_kotlin_tree_sitter.ml
@@ -2333,5 +2333,7 @@ let parse_pattern str =
     (fun () -> parse_expression_or_source_file str)
     (fun cst ->
       let file = "<pattern>" in
-      let env = { H.file; conv = H.line_col_to_pos_str str; extra = Pattern } in
+      let env =
+        { H.file; conv = H.line_col_to_pos_pattern str; extra = Pattern }
+      in
       source_file env cst)

--- a/languages/lisp/tree-sitter/Parse_clojure_tree_sitter.ml
+++ b/languages/lisp/tree-sitter/Parse_clojure_tree_sitter.ml
@@ -325,7 +325,7 @@ let parse_pattern str =
     (fun () -> Tree_sitter_clojure.Parse.string str)
     (fun cst ->
       let file = "<pattern>" in
-      let env = { H.file; conv = H.line_col_to_pos_str str; extra = () } in
+      let env = { H.file; conv = H.line_col_to_pos_pattern str; extra = () } in
       let e = map_source env cst in
       (* this will be simplified if needed in Parse_pattern.normalize_any *)
       Raw e)

--- a/languages/lisp/tree-sitter/Parse_clojure_tree_sitter.ml
+++ b/languages/lisp/tree-sitter/Parse_clojure_tree_sitter.ml
@@ -325,7 +325,7 @@ let parse_pattern str =
     (fun () -> Tree_sitter_clojure.Parse.string str)
     (fun cst ->
       let file = "<pattern>" in
-      let env = { H.file; conv = (fun _ -> raise Not_found); extra = () } in
+      let env = { H.file; conv = H.line_col_to_pos_str str; extra = () } in
       let e = map_source env cst in
       (* this will be simplified if needed in Parse_pattern.normalize_any *)
       Raw e)

--- a/languages/lua/generic/Parse_lua_tree_sitter.ml
+++ b/languages/lua/generic/Parse_lua_tree_sitter.ml
@@ -805,6 +805,6 @@ let parse_pattern str =
     (fun () -> Tree_sitter_lua.Parse.string str)
     (fun cst ->
       let file = "<pattern>" in
-      let env = { H.file; conv = H.line_col_to_pos_str str; extra = () } in
+      let env = { H.file; conv = H.line_col_to_pos_pattern str; extra = () } in
       let xs = map_program env cst in
       G.Ss xs)

--- a/languages/lua/generic/Parse_lua_tree_sitter.ml
+++ b/languages/lua/generic/Parse_lua_tree_sitter.ml
@@ -805,6 +805,6 @@ let parse_pattern str =
     (fun () -> Tree_sitter_lua.Parse.string str)
     (fun cst ->
       let file = "<pattern>" in
-      let env = { H.file; conv = (fun _ -> raise Not_found); extra = () } in
+      let env = { H.file; conv = H.line_col_to_pos_str str; extra = () } in
       let xs = map_program env cst in
       G.Ss xs)

--- a/languages/promql/generic/Parse_promql_tree_sitter.ml
+++ b/languages/promql/generic/Parse_promql_tree_sitter.ml
@@ -406,6 +406,6 @@ let parse_pattern str =
     (fun () -> Tree_sitter_promql.Parse.string str)
     (fun cst ->
       let file = "<pattern>" in
-      let env = { H.file; conv = H.line_col_to_pos_str str; extra = () } in
+      let env = { H.file; conv = H.line_col_to_pos_pattern str; extra = () } in
       let e = map_query env cst in
       G.E e)

--- a/languages/promql/generic/Parse_promql_tree_sitter.ml
+++ b/languages/promql/generic/Parse_promql_tree_sitter.ml
@@ -406,6 +406,6 @@ let parse_pattern str =
     (fun () -> Tree_sitter_promql.Parse.string str)
     (fun cst ->
       let file = "<pattern>" in
-      let env = { H.file; conv = (fun _ -> raise Not_found); extra = () } in
+      let env = { H.file; conv = H.line_col_to_pos_str str; extra = () } in
       let e = map_query env cst in
       G.E e)

--- a/languages/protobuf/generic/Parse_protobuf_tree_sitter.ml
+++ b/languages/protobuf/generic/Parse_protobuf_tree_sitter.ml
@@ -696,6 +696,6 @@ let parse_pattern str =
     (fun () -> Tree_sitter_proto.Parse.string str)
     (fun cst ->
       let file = "<pattern>" in
-      let env = { H.file; conv = H.line_col_to_pos_str str; extra = () } in
+      let env = { H.file; conv = H.line_col_to_pos_pattern str; extra = () } in
       let xs = map_source_file env cst in
       G.Raw xs)

--- a/languages/protobuf/generic/Parse_protobuf_tree_sitter.ml
+++ b/languages/protobuf/generic/Parse_protobuf_tree_sitter.ml
@@ -696,6 +696,6 @@ let parse_pattern str =
     (fun () -> Tree_sitter_proto.Parse.string str)
     (fun cst ->
       let file = "<pattern>" in
-      let env = { H.file; conv = (fun _ -> raise Not_found); extra = () } in
+      let env = { H.file; conv = H.line_col_to_pos_str str; extra = () } in
       let xs = map_source_file env cst in
       G.Raw xs)

--- a/languages/python/tree-sitter/Parse_python_tree_sitter.ml
+++ b/languages/python/tree-sitter/Parse_python_tree_sitter.ml
@@ -1679,5 +1679,5 @@ let parse_pattern str =
     (fun () -> Tree_sitter_python.Parse.string str)
     (fun cst ->
       let file = "<pattern>" in
-      let env = { H.file; conv = H.line_col_to_pos_str str; extra = () } in
+      let env = { H.file; conv = H.line_col_to_pos_pattern str; extra = () } in
       Program (map_module_ env cst))

--- a/languages/python/tree-sitter/Parse_python_tree_sitter.ml
+++ b/languages/python/tree-sitter/Parse_python_tree_sitter.ml
@@ -1679,5 +1679,5 @@ let parse_pattern str =
     (fun () -> Tree_sitter_python.Parse.string str)
     (fun cst ->
       let file = "<pattern>" in
-      let env = { H.file; conv = (fun _ -> raise Not_found); extra = () } in
+      let env = { H.file; conv = H.line_col_to_pos_str str; extra = () } in
       Program (map_module_ env cst))

--- a/languages/r/generic/Parse_r_tree_sitter.ml
+++ b/languages/r/generic/Parse_r_tree_sitter.ml
@@ -601,5 +601,5 @@ let parse_pattern str =
     (fun () -> Tree_sitter_r.Parse.string str)
     (fun cst ->
       let file = "<pattern>" in
-      let env = { H.file; conv = H.line_col_to_pos_str str; extra = () } in
+      let env = { H.file; conv = H.line_col_to_pos_pattern str; extra = () } in
       G.Ss (map_program env cst))

--- a/languages/r/generic/Parse_r_tree_sitter.ml
+++ b/languages/r/generic/Parse_r_tree_sitter.ml
@@ -601,5 +601,5 @@ let parse_pattern str =
     (fun () -> Tree_sitter_r.Parse.string str)
     (fun cst ->
       let file = "<pattern>" in
-      let env = { H.file; conv = (fun _ -> raise Not_found); extra = () } in
+      let env = { H.file; conv = H.line_col_to_pos_str str; extra = () } in
       G.Ss (map_program env cst))

--- a/languages/ruby/tree-sitter/Parse_ruby_tree_sitter.ml
+++ b/languages/ruby/tree-sitter/Parse_ruby_tree_sitter.ml
@@ -2440,7 +2440,7 @@ let parse_pattern string =
     (fun cst ->
       let file = "<file>" in
       let env =
-        { H.file; conv = (fun _ -> raise Not_found); extra = Pattern }
+        { H.file; conv = H.line_col_to_pos_str string; extra = Pattern }
       in
       if debug then Boilerplate.dump_tree cst;
       Ss (program env cst))

--- a/languages/ruby/tree-sitter/Parse_ruby_tree_sitter.ml
+++ b/languages/ruby/tree-sitter/Parse_ruby_tree_sitter.ml
@@ -2440,7 +2440,7 @@ let parse_pattern string =
     (fun cst ->
       let file = "<file>" in
       let env =
-        { H.file; conv = H.line_col_to_pos_str string; extra = Pattern }
+        { H.file; conv = H.line_col_to_pos_pattern string; extra = Pattern }
       in
       if debug then Boilerplate.dump_tree cst;
       Ss (program env cst))

--- a/languages/rust/generic/Parse_rust_tree_sitter.ml
+++ b/languages/rust/generic/Parse_rust_tree_sitter.ml
@@ -3692,5 +3692,7 @@ let parse_pattern str =
     (fun () -> parse_expression_or_source_file str)
     (fun cst ->
       let file = "<pattern>" in
-      let env = { H.file; conv = H.line_col_to_pos_str str; extra = Pattern } in
+      let env =
+        { H.file; conv = H.line_col_to_pos_pattern str; extra = Pattern }
+      in
       map_source_file env cst)

--- a/languages/rust/generic/Parse_rust_tree_sitter.ml
+++ b/languages/rust/generic/Parse_rust_tree_sitter.ml
@@ -3692,7 +3692,5 @@ let parse_pattern str =
     (fun () -> parse_expression_or_source_file str)
     (fun cst ->
       let file = "<pattern>" in
-      let env =
-        { H.file; conv = (fun _ -> raise Not_found); extra = Pattern }
-      in
+      let env = { H.file; conv = H.line_col_to_pos_str str; extra = Pattern } in
       map_source_file env cst)

--- a/languages/solidity/generic/Parse_solidity_tree_sitter.ml
+++ b/languages/solidity/generic/Parse_solidity_tree_sitter.ml
@@ -2509,5 +2509,5 @@ let parse_pattern str =
     (fun () -> Tree_sitter_solidity.Parse.string str)
     (fun cst ->
       let file = "<pattern>" in
-      let env = { H.file; conv = H.line_col_to_pos_str str; extra = () } in
+      let env = { H.file; conv = H.line_col_to_pos_pattern str; extra = () } in
       map_source_file env cst)

--- a/languages/solidity/generic/Parse_solidity_tree_sitter.ml
+++ b/languages/solidity/generic/Parse_solidity_tree_sitter.ml
@@ -2509,5 +2509,5 @@ let parse_pattern str =
     (fun () -> Tree_sitter_solidity.Parse.string str)
     (fun cst ->
       let file = "<pattern>" in
-      let env = { H.file; conv = (fun _ -> raise Not_found); extra = () } in
+      let env = { H.file; conv = H.line_col_to_pos_str str; extra = () } in
       map_source_file env cst)

--- a/languages/swift/generic/Parse_swift_tree_sitter.ml
+++ b/languages/swift/generic/Parse_swift_tree_sitter.ml
@@ -3301,5 +3301,7 @@ let parse_pattern str =
     (fun () -> Tree_sitter_swift.Parse.string str)
     (fun cst ->
       let file = "<pattern>" in
-      let env = { H.file; conv = H.line_col_to_pos_str str; extra = Pattern } in
+      let env =
+        { H.file; conv = H.line_col_to_pos_pattern str; extra = Pattern }
+      in
       map_source_file env cst)

--- a/languages/swift/generic/Parse_swift_tree_sitter.ml
+++ b/languages/swift/generic/Parse_swift_tree_sitter.ml
@@ -3301,7 +3301,5 @@ let parse_pattern str =
     (fun () -> Tree_sitter_swift.Parse.string str)
     (fun cst ->
       let file = "<pattern>" in
-      let env =
-        { H.file; conv = (fun _ -> raise Not_found); extra = Pattern }
-      in
+      let env = { H.file; conv = H.line_col_to_pos_str str; extra = Pattern } in
       map_source_file env cst)

--- a/languages/terraform/tree-sitter/Parse_terraform_tree_sitter.ml
+++ b/languages/terraform/tree-sitter/Parse_terraform_tree_sitter.ml
@@ -651,5 +651,5 @@ let parse_pattern str =
     (fun () -> parse_expression_or_source_file str)
     (fun cst ->
       let file = "<pattern>" in
-      let env = { H.file; conv = H.line_col_to_pos_str str; extra = () } in
+      let env = { H.file; conv = H.line_col_to_pos_pattern str; extra = () } in
       map_config_file env cst)

--- a/languages/terraform/tree-sitter/Parse_terraform_tree_sitter.ml
+++ b/languages/terraform/tree-sitter/Parse_terraform_tree_sitter.ml
@@ -651,5 +651,5 @@ let parse_pattern str =
     (fun () -> parse_expression_or_source_file str)
     (fun cst ->
       let file = "<pattern>" in
-      let env = { H.file; conv = (fun _ -> raise Not_found); extra = () } in
+      let env = { H.file; conv = H.line_col_to_pos_str str; extra = () } in
       map_config_file env cst)

--- a/languages/tree-sitter-to-generic/Parse_hack_tree_sitter.ml
+++ b/languages/tree-sitter-to-generic/Parse_hack_tree_sitter.ml
@@ -2981,7 +2981,7 @@ let parse_pattern str =
        * Imitate what we do in php_to_generic.ml?
        *)
       let extra = Pattern in
-      let env = { H.file; conv = (fun _ -> raise Not_found); extra } in
+      let env = { H.file; conv = H.line_col_to_pos_str str; extra } in
       (* TODO: G.Ss (script env cst) but regressions *)
       match script env cst with
       | [ { G.s = G.ExprStmt (e, _); _ } ] -> G.E e

--- a/languages/tree-sitter-to-generic/Parse_hack_tree_sitter.ml
+++ b/languages/tree-sitter-to-generic/Parse_hack_tree_sitter.ml
@@ -2981,7 +2981,7 @@ let parse_pattern str =
        * Imitate what we do in php_to_generic.ml?
        *)
       let extra = Pattern in
-      let env = { H.file; conv = H.line_col_to_pos_str str; extra } in
+      let env = { H.file; conv = H.line_col_to_pos_pattern str; extra } in
       (* TODO: G.Ss (script env cst) but regressions *)
       match script env cst with
       | [ { G.s = G.ExprStmt (e, _); _ } ] -> G.E e

--- a/languages/typescript/tree-sitter/Parse_typescript_tree_sitter.ml
+++ b/languages/typescript/tree-sitter/Parse_typescript_tree_sitter.ml
@@ -3229,7 +3229,7 @@ let parse_pattern str =
       (fun () -> (Tree_sitter_typescript.Parse.string str :> cst_result))
     (fun cst ->
       let file = "<pattern>" in
-      let env = { H.file; conv = (fun _ -> raise Not_found); extra = () } in
+      let env = { H.file; conv = H.line_col_to_pos_str str; extra = () } in
       match program env cst with
       | Program ss -> Stmts ss
       | other -> other)

--- a/languages/typescript/tree-sitter/Parse_typescript_tree_sitter.ml
+++ b/languages/typescript/tree-sitter/Parse_typescript_tree_sitter.ml
@@ -3229,7 +3229,7 @@ let parse_pattern str =
       (fun () -> (Tree_sitter_typescript.Parse.string str :> cst_result))
     (fun cst ->
       let file = "<pattern>" in
-      let env = { H.file; conv = H.line_col_to_pos_str str; extra = () } in
+      let env = { H.file; conv = H.line_col_to_pos_pattern str; extra = () } in
       match program env cst with
       | Program ss -> Stmts ss
       | other -> other)

--- a/libs/lib_parsing_tree_sitter/Parse_tree_sitter_helpers.ml
+++ b/libs/lib_parsing_tree_sitter/Parse_tree_sitter_helpers.ml
@@ -75,12 +75,16 @@ let token env (tok : Tree_sitter_run.Token.t) =
   (* Parse_info is 1-line based and 0-column based, like Emacs *)
   let line = start.Tree_sitter_run.Loc.row + 1 in
   let column = start.Tree_sitter_run.Loc.column in
+  let file = env.file in
   let bytepos =
     try h (line, column) with
-    | Not_found -> -1
-    (* TODO? more strict? raise exn? *)
+    | Not_found ->
+        raise
+          (Tok.NoTokenLocation
+             (Printf.sprintf
+                "Could not convert from location %d:%d in %s to a position" line
+                column file))
   in
-  let file = env.file in
   let pos = Pos.make ~line ~column ~file bytepos in
   let tok_loc = { Tok.str; pos } in
   Tok.tok_of_loc tok_loc

--- a/libs/lib_parsing_tree_sitter/Parse_tree_sitter_helpers.ml
+++ b/libs/lib_parsing_tree_sitter/Parse_tree_sitter_helpers.ml
@@ -68,33 +68,8 @@ let line_col_to_pos file =
       full_charpos_to_pos_aux ());
   Hashtbl.find h
 
-(* mostly a copy-paste of Pos.full_convertors_str *)
-let line_col_to_pos_str str =
-  let size = String.length str + 2 in
-  let h = Hashtbl.create size in
-  let charpos = ref 0 in
-  let line = ref 0 in
-  let str_lines = String.split_on_char '\n' str in
-  let full_charpos_to_pos_aux () =
-    List.iter
-      (fun s ->
-        incr line;
-        let len = String.length s + 1 in
-
-        (* '... +1 do'  cos input_line dont return the trailing \n *)
-        for i = 0 to len - 1 do
-          Hashtbl.add h (!line, i) (!charpos + i)
-        done;
-        charpos := !charpos + len)
-      str_lines
-  in
-  full_charpos_to_pos_aux ();
-  (* This is equivalent to returning `Hashtbl.find h` but Semgrep complains
-     and honestly Semgrep is valid *)
-  fun key ->
-    match Hashtbl.find_opt h key with
-    | None -> raise Not_found
-    | Some x -> x
+(* Patterns are given as a one line string with `\n` characters *)
+let line_col_to_pos_pattern _str (_line, col) = col
 
 let token env (tok : Tree_sitter_run.Token.t) =
   let loc, str = tok in

--- a/libs/lib_parsing_tree_sitter/Parse_tree_sitter_helpers.ml
+++ b/libs/lib_parsing_tree_sitter/Parse_tree_sitter_helpers.ml
@@ -107,13 +107,11 @@ let token env (tok : Tree_sitter_run.Token.t) =
   let bytepos =
     try h (line, column) with
     | Not_found ->
-        if (line = 1 && column = 0) || file = "<pattern>" then 0
-        else
-          raise
-            (Tok.NoTokenLocation
-               (Printf.sprintf
-                  "Could not convert from location %d:%d in %s to a position"
-                  line column file))
+        raise
+          (Tok.NoTokenLocation
+             (Printf.sprintf
+                "Could not convert from location %d:%d in %s to a position" line
+                column file))
   in
   let pos = Pos.make ~line ~column ~file bytepos in
   let tok_loc = { Tok.str; pos } in

--- a/libs/lib_parsing_tree_sitter/Parse_tree_sitter_helpers.ml
+++ b/libs/lib_parsing_tree_sitter/Parse_tree_sitter_helpers.ml
@@ -59,11 +59,9 @@ let line_col_to_pos file =
           done
         with
         | End_of_file ->
-            (* bugfix: this is wrong:  Hashtbl.add h (!line, 0) !charpos;
-             * because an ident on the last line would get
-             * the last charpos.
-             *)
-            ()
+            (* We need to add this in case there is a trailing \n in the
+               end of the file *)
+            Hashtbl.add h (!line + 1, 0) !charpos
       in
       full_charpos_to_pos_aux ());
   Hashtbl.find h

--- a/libs/lib_parsing_tree_sitter/Parse_tree_sitter_helpers.mli
+++ b/libs/lib_parsing_tree_sitter/Parse_tree_sitter_helpers.mli
@@ -8,6 +8,9 @@ type 'a env = {
 (* to fill in conv *)
 val line_col_to_pos : string (* filename *) -> int * int -> int
 
+(* to fill in conv for pattern parsing *)
+val line_col_to_pos_str : string (* contents *) -> int * int -> int
+
 (* Tree_sitter_run tokens to Tok.t converters *)
 val token : 'a env -> Tree_sitter_run.Token.t -> Tok.t
 val str : 'a env -> Tree_sitter_run.Token.t -> string * Tok.t

--- a/libs/lib_parsing_tree_sitter/Parse_tree_sitter_helpers.mli
+++ b/libs/lib_parsing_tree_sitter/Parse_tree_sitter_helpers.mli
@@ -9,7 +9,7 @@ type 'a env = {
 val line_col_to_pos : string (* filename *) -> int * int -> int
 
 (* to fill in conv for pattern parsing *)
-val line_col_to_pos_str : string (* contents *) -> int * int -> int
+val line_col_to_pos_pattern : string (* contents *) -> int * int -> int
 
 (* Tree_sitter_run tokens to Tok.t converters *)
 val token : 'a env -> Tree_sitter_run.Token.t -> Tok.t


### PR DESCRIPTION
Fixes the error handling for https://github.com/semgrep/semgrep/issues/9628

When we can't figure out how to convert a row/column to a bytepos, we just put in -1 and move on. In the linked Github issue, this causes an opaque exception when we try to use the bytepos in autofix. Better to raise an exception.

Fixing this gives us a clearer error message for the above Dockerfile that we fail to parse and causes us to gracefully skip the file instead of aborting. In a follow up PR, I will fix the error.

Fixing this also reveals some problems with pattern and target parsing. I have fixed those so that tests pass on this PR.

Test plan: automated tests

To see the new error, run `p/default` against the Dockerfile in the issue. I wasn't sure how to add an automated test for the error message showing up because it's hard to induce it.

