### PR TITLE
Osemgrep sarif nudge

### DIFF
--- a/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -631,7 +631,10 @@ let run_scan_files (_caps : < Cap.stdout >) (conf : Scan_CLI.conf)
     (* step 5: report the matches *)
     (* outputting the result on stdout! in JSON/Text/... depending on conf *)
     let cli_output =
-      Output.output_result { conf.output_conf with output_format } profiler res
+      let is_logged_in = Semgrep_login.is_logged_in () in
+      Output.output_result
+        { conf.output_conf with output_format }
+        profiler ~is_logged_in res
     in
     Profiler.stop_ign profiler ~name:"total_time";
 

--- a/src/osemgrep/configuring/Semgrep_envvars.ml
+++ b/src/osemgrep/configuring/Semgrep_envvars.ml
@@ -87,6 +87,8 @@ type t = {
   (* deprecated *)
   in_agent : bool;
   min_fetch_depth : int;
+  (* TODO(reynir): is this deprecated?! *)
+  mock_using_registry : bool;
 }
 
 (* What about temp? Well we use ocaml stdlib definition of a temp directory.
@@ -149,6 +151,7 @@ let of_current_sys_env () : t =
     in_gh_action = in_env "GITHUB_WORKSPACE";
     in_agent = in_env "SEMGREP_AGENT";
     min_fetch_depth = env_or int_of_string "SEMGREP_GHA_MIN_FETCH_DEPTH" 0;
+    mock_using_registry = in_env "MOCK_USING_REGISTRY";
   }
 
 (* less: make it Lazy? so at least not run in ocaml init time before main() *)

--- a/src/osemgrep/configuring/Semgrep_envvars.mli
+++ b/src/osemgrep/configuring/Semgrep_envvars.mli
@@ -47,6 +47,8 @@ type t = {
   in_agent : bool;
   (* $SEMGREP_xxx *)
   min_fetch_depth : int;
+  (* $MOCK_USING_REGISTRY *)
+  mock_using_registry : bool;
 }
 
 val v : t ref

--- a/src/osemgrep/reporting/Output.ml
+++ b/src/osemgrep/reporting/Output.ml
@@ -58,7 +58,7 @@ let string_of_severity (severity : OutJ.match_severity) : string =
 (*****************************************************************************)
 
 let dispatch_output_format (output_format : Output_format.t) (conf : conf)
-    (cli_output : OutJ.cli_output) (hrules : Rule.hrules) =
+    (cli_output : OutJ.cli_output) is_logged_in (hrules : Rule.hrules) =
   (* TOPORT? Sort keys for predictable output. Helps with snapshot tests *)
   match output_format with
   | Json ->
@@ -135,7 +135,9 @@ let dispatch_output_format (output_format : Output_format.t) (conf : conf)
   (* matches have already been displayed in a file_match_results_hook *)
   | TextIncremental -> ()
   | Sarif ->
-      let sarif_json = Sarif_output.sarif_output hrules cli_output in
+      let sarif_json =
+        Sarif_output.sarif_output is_logged_in hrules cli_output
+      in
       Out.put (Yojson.Basic.to_string sarif_json)
   | Junit_xml ->
       let junit_xml = Junit_xml_output.junit_xml_output cli_output in
@@ -169,7 +171,7 @@ let preprocess_result (conf : conf) (res : Core_runner.result) : OutJ.cli_output
  * output.output() all at once.
  * TODO: take a more precise conf than Scan_CLI.conf at some point
  *)
-let output_result (conf : conf) (profiler : Profiler.t)
+let output_result (conf : conf) (profiler : Profiler.t) ~is_logged_in
     (res : Core_runner.result) : OutJ.cli_output =
   (* In theory, we should build the JSON CLI output only for the
    * Json conf.output_format, but cli_output contains lots of data-structures
@@ -179,6 +181,7 @@ let output_result (conf : conf) (profiler : Profiler.t)
   let cli_output () = preprocess_result conf res in
   (* TOPORT? output.output() *)
   let cli_output = Profiler.record profiler ~name:"ignores_times" cli_output in
-  dispatch_output_format conf.output_format conf cli_output res.hrules;
+  dispatch_output_format conf.output_format conf cli_output is_logged_in
+    res.hrules;
   cli_output
 [@@profiling]

--- a/src/osemgrep/reporting/Output.mli
+++ b/src/osemgrep/reporting/Output.mli
@@ -36,4 +36,9 @@ val preprocess_result : conf -> Core_runner.result -> OutJ.cli_output
  *
  * ugly: this also apply autofixes depending on the configuration.
  *)
-val output_result : conf -> Profiler.t -> Core_runner.result -> OutJ.cli_output
+val output_result :
+  conf ->
+  Profiler.t ->
+  is_logged_in:bool ->
+  Core_runner.result ->
+  OutJ.cli_output

--- a/src/osemgrep/reporting/Sarif_output.ml
+++ b/src/osemgrep/reporting/Sarif_output.ml
@@ -426,21 +426,20 @@ let error_to_sarif_notification (e : OutT.cli_error) =
       ("level", `String level);
     ]
 
-let sarif_output hrules (cli_output : OutT.cli_output) =
+let sarif_output is_logged_in hrules (cli_output : OutT.cli_output) =
   let sarif_schema =
     "https://docs.oasis-open.org/sarif/sarif/v2.1.0/os/schemas/sarif-schema-2.1.0.json"
   in
-  let engine_label =
+  let engine_label, is_pro =
     match cli_output.OutT.engine_requested with
     | Some `OSS
     | None ->
-        "OSS"
-    | Some `PRO -> "PRO"
+        ("OSS", false)
+    | Some `PRO -> ("PRO", true)
   in
   let run =
     let hide_nudge =
-      (* TODO is_logged_in or is_pro or not is_using_registry *)
-      true
+      is_logged_in || is_pro || not Metrics_.g.is_using_registry
     in
     let rules = rules hide_nudge hrules in
     let tool =

--- a/src/osemgrep/reporting/Sarif_output.ml
+++ b/src/osemgrep/reporting/Sarif_output.ml
@@ -439,7 +439,10 @@ let sarif_output is_logged_in hrules (cli_output : OutT.cli_output) =
   in
   let run =
     let hide_nudge =
-      is_logged_in || is_pro || not Metrics_.g.is_using_registry
+      let is_using_registry =
+        Metrics_.g.is_using_registry || !Semgrep_envvars.v.mock_using_registry
+      in
+      is_logged_in || is_pro || not is_using_registry
     in
     let rules = rules hide_nudge hrules in
     let tool =


### PR DESCRIPTION
This implements the nudge in the sarif output. The status of `MOCK_USING_REGISTRY` environment variable is unclear to me (that is, if it is deprecated or not), but it is used in one test which passes when this PR is combined with #9655.