### PR TITLE
chore: ast_generic: add more elaborate method definition kind

### DIFF
--- a/languages/csharp/generic/Parse_csharp_tree_sitter.ml
+++ b/languages/csharp/generic/Parse_csharp_tree_sitter.ml
@@ -1907,7 +1907,8 @@ and statement (env : env) (x : CST.statement) =
       let def =
         G.FuncDef
           {
-            fkind = (G.Method, tok);
+            (* TODO determine if this is a static function *)
+            fkind = (G.Method None, tok);
             fparams = v6;
             frettype = Some v3;
             fbody = v8;
@@ -3019,7 +3020,7 @@ and declaration (env : env) (x : CST.declaration) : stmt =
       in
       let def =
         G.FuncDef
-          { fkind = (G.Method, tok); fparams = v4; frettype = None; fbody }
+          { fkind = (G.Method None, tok); fparams = v4; frettype = None; fbody }
       in
       let ctor = KeywordAttr (Ctor, tok) in
       let attrs = (ctor :: v1) @ v2 in
@@ -3056,7 +3057,7 @@ and declaration (env : env) (x : CST.declaration) : stmt =
       let def =
         G.FuncDef
           {
-            fkind = (G.Method, v5);
+            fkind = (G.Method None, v5);
             fparams = v8;
             frettype = Some v7;
             fbody = v9;
@@ -3077,7 +3078,12 @@ and declaration (env : env) (x : CST.declaration) : stmt =
       let name = ("Finalize", v3) in
       let def =
         G.FuncDef
-          { fkind = (G.Method, v3); fparams = v5; frettype = None; fbody = v6 }
+          {
+            fkind = (G.Method None, v3);
+            fparams = v5;
+            frettype = None;
+            fbody = v6;
+          }
       in
       let dtor = KeywordAttr (Dtor, v3) in
       let ent = basic_entity name ~attrs:((dtor :: v1) @ v2) in
@@ -3114,7 +3120,7 @@ and declaration (env : env) (x : CST.declaration) : stmt =
                      let funcdef =
                        FuncDef
                          {
-                           fkind = (Method, itok);
+                           fkind = (Method None, itok);
                            fparams = fb [ valparam ];
                            frettype = None;
                            fbody;
@@ -3167,7 +3173,7 @@ and declaration (env : env) (x : CST.declaration) : stmt =
                        let funcdef =
                          FuncDef
                            {
-                             fkind = (Method, itok);
+                             fkind = (Method None, itok);
                              fparams = (lbra, params, rbra);
                              frettype = Some v3;
                              fbody;
@@ -3189,7 +3195,7 @@ and declaration (env : env) (x : CST.declaration) : stmt =
                        let funcdef =
                          FuncDef
                            {
-                             fkind = (Method, itok);
+                             fkind = (Method None, itok);
                              fparams = (lbra, params @ [ valparam ], rbra);
                              frettype = None;
                              fbody;
@@ -3239,7 +3245,7 @@ and declaration (env : env) (x : CST.declaration) : stmt =
       let def =
         G.FuncDef
           {
-            fkind = (G.Method, tok);
+            fkind = (G.Method None, tok);
             fparams = v7;
             frettype = Some v3;
             fbody = v9;
@@ -3273,7 +3279,7 @@ and declaration (env : env) (x : CST.declaration) : stmt =
       let def =
         G.FuncDef
           {
-            fkind = (G.Method, v5);
+            fkind = (G.Method None, v5);
             fparams = v8;
             frettype = Some v3;
             fbody = v9;
@@ -3315,7 +3321,7 @@ and declaration (env : env) (x : CST.declaration) : stmt =
                   let funcdef =
                     FuncDef
                       {
-                        fkind = (Method, itok);
+                        fkind = (Method None, itok);
                         fparams =
                           fb
                             (if has_params then

--- a/languages/dart/generic/Parse_dart_tree_sitter.ml
+++ b/languages/dart/generic/Parse_dart_tree_sitter.ml
@@ -3024,8 +3024,12 @@ let map_method_signature (env : env) (x : CST.method_signature) (attrs, body) =
       DefStmt
         ( ent,
           FuncDef
-            { fkind = (Method, fake "Method"); fparams; frettype = None; fbody }
-        )
+            {
+              fkind = (Method None, fake "Method");
+              fparams;
+              frettype = None;
+              fbody;
+            } )
       |> G.s
   | `Fact_cons_sign x ->
       let attr, dotted, fparams = map_factory_constructor_signature env x in
@@ -3040,7 +3044,7 @@ let map_method_signature (env : env) (x : CST.method_signature) (attrs, body) =
         ( ent,
           FuncDef
             {
-              fkind = (Method, fake "Method");
+              fkind = (Method None, fake "Method");
               fparams;
               frettype = None;
               fbody = body;
@@ -3285,7 +3289,7 @@ let map_declaration_ ?(attrs = []) (env : env) (x : CST.declaration_) :
           ( { name = EN (H2.name_of_ids dotted); attrs; tparams = [] },
             FuncDef
               {
-                fkind = (Method, fake "method");
+                fkind = (Method None, fake "method");
                 fparams;
                 frettype = None;
                 fbody =
@@ -3355,14 +3359,15 @@ let map_declaration_ ?(attrs = []) (env : env) (x : CST.declaration_) :
         | None -> attrs
       in
       let v2 =
-        map_function_signature ~attrs env v2 ((Method, fake "method"), FBNothing)
+        map_function_signature ~attrs env v2
+          ((Method None, fake "method"), FBNothing)
       in
       [ v2 ]
   | `Static_func_sign (v1, v2) ->
       let v1 = KeywordAttr (Static, (* "static" *) token env v1) in
       let v2 =
         map_function_signature ~attrs:([ v1 ] @ attrs) env v2
-          ((Method, fake "method"), FBNothing)
+          ((Method None, fake "method"), FBNothing)
       in
       [ v2 ]
   | `Static_choice_final_or_const_opt_type_static_final_decl_list (v1, v2) ->

--- a/languages/go/generic/go_to_generic.ml
+++ b/languages/go/generic/go_to_generic.ml
@@ -207,8 +207,10 @@ let top_func () =
         let v1 = ident v1 in
         let ftok, params, ret = func_type v2 in
         let ent = G.basic_entity v1 in
+        (* TODO Go actually has explicit recievers. *)
         let fdef =
-          G.FuncDef (mk_func_def (G.Method, ftok) params ret (G.FBDecl G.sc))
+          G.FuncDef
+            (mk_func_def (G.Method None, ftok) params ret (G.FBDecl G.sc))
         in
         G.fld (ent, fdef)
     | EmbeddedInterface v1 ->
@@ -648,7 +650,8 @@ let top_func () =
         and ftok, params, ret = func_type v3
         and v4 = stmt v4 in
         let ent = G.basic_entity v1 in
-        let def = mk_func_def (G.Method, ftok) params ret (G.FBStmt v4) in
+        (* TODO Go has explicit recievers *)
+        let def = mk_func_def (G.Method None, ftok) params ret (G.FBStmt v4) in
         let receiver =
           match v2 with
           | G.Param x -> G.ParamReceiver x

--- a/languages/java/generic/java_to_generic.ml
+++ b/languages/java/generic/java_to_generic.ml
@@ -613,12 +613,22 @@ and method_decl ?(cl_kind = None) { m_var; m_formals; m_throws; m_body } =
     | Some (Interface, _), { s = G.Block (_, [], _); _ } -> G.FBNothing
     | _ -> FBStmt v4
   in
+  let method_kind =
+    {
+      G.has_reciever_parameter = false;
+      G.method_is_static =
+        ent.attrs
+        |> List.exists (function
+             | G.KeywordAttr (G.Static, _) -> true
+             | _ -> false);
+    }
+  in
   ( { ent with G.attrs = ent.G.attrs @ throws },
     {
       G.fparams = fb fparams;
       frettype = rett;
       fbody;
-      fkind = (G.Method, G.fake "");
+      fkind = (G.Method (Some method_kind), G.fake "");
     } )
 
 and field v = var_with_init v

--- a/languages/javascript/generic/js_to_generic.ml
+++ b/languages/javascript/generic/js_to_generic.ml
@@ -674,7 +674,7 @@ and field_classic
       let fkind, tok = def.G.fkind in
       let fkind =
         match fkind with
-        | G.Function -> G.Method
+        | G.Function -> G.Method None
         | x -> x
       in
       ( { ent with G.attrs = ent.G.attrs @ more_attrs },

--- a/languages/javascript/menhir/parser_js.mly
+++ b/languages/javascript/menhir/parser_js.mly
@@ -432,7 +432,7 @@ sgrep_spatch_pattern:
       *)
      Partial (PartialDef (mk_def (Some $4,
       FuncDef
-       { f_kind = (Method, $5)
+       { f_kind = (Method None, $5)
        ; f_params = $5, $6, $7
        ; f_body = Block (fb $5 [])
        ; f_rettype = $8
@@ -457,7 +457,7 @@ sgrep_spatch_pattern:
      let sig_ = (None, ($5, $6, $7), $8) in
      let static = attr_opt Static $2 in
      let async = attr_opt Async $3 in
-     let fun_ = mk_Fun ~attrs:($1 @ static @ async) (Method, $5) sig_ ($9, $10, $11) in
+     let fun_ = mk_Fun ~attrs:($1 @ static @ async) (Method None, $5) sig_ ($9, $10, $11) in
      Property (mk_Field (PN $4) (Some fun_))
    }
 
@@ -470,7 +470,7 @@ sgrep_spatch_pattern:
     "{" function_body "}" EOF
    {
      let sig_ = (None, ($2, $3, $4), $5) in
-     let fun_ = mk_Fun (Method, $2) sig_ ($6, $7, $8) in
+     let fun_ = mk_Fun (Method None, $2) sig_ ($6, $7, $8) in
      Property (mk_Field (PN $1) (Some fun_));
    }
 
@@ -872,7 +872,7 @@ method_definition:
         (match $2 with None -> [] | Some t -> [KeywordAttr (Async, t)]) @
         (match $3 with None -> [] | Some x -> [KeywordAttr x])
       in
-      mk_Field $4 (Some (mk_Fun ~attrs (Method, $6) $5 ($6, $7, $8))) }
+      mk_Field $4 (Some (mk_Fun ~attrs (Method None, $6) $5 ($6, $7, $8))) }
 
 (* we used to enforce that T_GET had a call_signature with 0 param and
  * T_SET with 1 param, but not worth it (tree-sitter-js does not enforce it)

--- a/languages/kotlin/generic/Parse_kotlin_tree_sitter.ml
+++ b/languages/kotlin/generic/Parse_kotlin_tree_sitter.ml
@@ -779,9 +779,10 @@ and class_member_declaration (env : env) (x : CST.class_member_declaration) :
             | None -> G.FBDecl G.sc
           in
           let ent = G.basic_entity v2 ~attrs:v1 in
-          let def =
-            { fkind = (Method, snd v2); fparams; frettype = None; fbody }
+          let fkind =
+            (G.Method (Some G.default_instance_method_kind), snd v2)
           in
+          let def = { fkind; fparams; frettype = None; fbody } in
           (ent, FuncDef def) |> G.fld)
   | `Ellips x ->
       let x = token env x in

--- a/languages/ocaml/generic/ocaml_to_generic.ml
+++ b/languages/ocaml/generic/ocaml_to_generic.ml
@@ -560,7 +560,7 @@ and class_field (fld : class_field) : G.field =
             let e = expr e in
             G.FBExpr e
       in
-      let fdef = G.{ fkind = (Method, m_tok); fparams; frettype; fbody } in
+      let fdef = G.{ fkind = (Method None, m_tok); fparams; frettype; fbody } in
       G.fld (ent, G.FuncDef fdef)
   | InstanceVar { inst_tok = _; inst_name; inst_type; inst_expr } ->
       let id = ident inst_name in

--- a/languages/php/generic/php_to_generic.ml
+++ b/languages/php/generic/php_to_generic.ml
@@ -558,7 +558,7 @@ and function_kind (kind, t) =
     | Function -> G.Function
     | AnonLambda -> G.LambdaKind
     | ShortLambda -> G.Arrow
-    | Method -> G.Method),
+    | Method -> G.Method None),
     t )
 
 and parameters x : G.parameter list = list parameter x

--- a/languages/ruby/generic/ruby_to_generic.ml
+++ b/languages/ruby/generic/ruby_to_generic.ml
@@ -770,7 +770,7 @@ and definition def =
           G.fparams = fb params;
           frettype = None;
           fbody = G.FBStmt body;
-          fkind = (G.Method, t);
+          fkind = (G.Method None, t);
         }
       in
       match kind with

--- a/languages/scala/generic/scala_to_generic.ml
+++ b/languages/scala/generic/scala_to_generic.ml
@@ -1073,7 +1073,7 @@ and v_function_definition
 
 and v_function_kind = function
   | LambdaArrow -> G.Arrow
-  | Def -> G.Method
+  | Def -> G.Method None
 
 and v_fbody body : G.function_body =
   match body with

--- a/languages/solidity/generic/Parse_solidity_tree_sitter.ml
+++ b/languages/solidity/generic/Parse_solidity_tree_sitter.ml
@@ -2211,7 +2211,7 @@ let map_constructor_definition (env : env)
   let attrs = ctor_attr :: attrs in
   let ent = G.basic_entity ("constructor", tctor) ~attrs in
   let def =
-    { fkind = (Method, tctor); fparams = params; frettype = None; fbody }
+    { fkind = (Method None, tctor); fparams = params; frettype = None; fbody }
   in
   (ent, FuncDef def)
 

--- a/languages/swift/generic/Parse_swift_tree_sitter.ml
+++ b/languages/swift/generic/Parse_swift_tree_sitter.ml
@@ -819,7 +819,7 @@ and map_computed_getter (env : env) ((v1, v2, v3) : CST.computed_getter) =
     ( { G.name = G.OtherEntity (v2, []); attrs = []; tparams = [] },
       G.FuncDef
         {
-          G.fkind = (G.Method, v2 |> snd);
+          G.fkind = (G.Method None, v2 |> snd);
           G.fparams = fb [];
           G.frettype = None;
           G.fbody = v3;
@@ -841,7 +841,7 @@ and map_computed_modify (env : env) ((v1, v2, v3) : CST.computed_modify) =
     ( { G.name = G.OtherEntity (v2, []); attrs; tparams = [] },
       G.FuncDef
         {
-          G.fkind = (G.Method, v2 |> snd);
+          G.fkind = (G.Method None, v2 |> snd);
           G.fparams = fb [];
           G.frettype = None;
           G.fbody;
@@ -899,7 +899,7 @@ and map_computed_setter (env : env) ((v1, v2, v3, v4) : CST.computed_setter) =
     ( { G.name = G.OtherEntity (v2, []); attrs; tparams = [] },
       G.FuncDef
         {
-          G.fkind = (G.Method, v2 |> snd);
+          G.fkind = (G.Method None, v2 |> snd);
           G.fparams;
           G.frettype = None;
           G.fbody;
@@ -1288,7 +1288,7 @@ and map_deinit_declaration (env : env) ((v1, v2, v3) : CST.deinit_declaration) =
   let definition_kind =
     G.FuncDef
       {
-        fkind = (G.Method, snd v2);
+        fkind = (G.Method None, snd v2);
         fparams = fb [];
         frettype = None;
         fbody = G.FBStmt v3;
@@ -2134,7 +2134,7 @@ and map_modifierless_function_declaration_no_body (env : env) ~in_class
 
   let attrs = attrs in
   let entity = G.basic_entity ~tparams:v2 ~attrs v1 in
-  let kind = if in_class then G.Method else G.Function in
+  let kind = if in_class then G.Method None else G.Function in
   let definition_kind =
     G.FuncDef
       { fkind = (kind, snd v1); fparams = fb fparams; frettype; fbody = body }
@@ -2720,7 +2720,7 @@ and map_subscript_declaration (env : env)
     ( ent,
       G.FuncDef
         {
-          fkind = (G.Method, v2);
+          fkind = (G.Method None, v2);
           fparams = fb fparams;
           frettype;
           fbody = G.FBStmt v7;

--- a/languages/typescript/tree-sitter/Parse_typescript_tree_sitter.ml
+++ b/languages/typescript/tree-sitter/Parse_typescript_tree_sitter.ml
@@ -2258,7 +2258,7 @@ and method_definition (env : env)
   let _tparams, (v8, tret) = call_signature env v8 in
   let v9 = statement_block env v9 in
   let attrs = v1 @ v2 @ v2bis @ v3 @ v4 @ v5 @ v7 |> List_.map attr in
-  let f_kind = (G.Method, fake) in
+  let f_kind = (G.Method None, fake) in
   let f =
     { f_attrs = []; f_params = v8; f_body = v9; f_rettype = tret; f_kind }
   in

--- a/libs/ast_generic/AST_generic.ml
+++ b/libs/ast_generic/AST_generic.ml
@@ -1728,13 +1728,15 @@ and function_definition = {
 and function_kind =
   | Function
   (* This is a bit redundant with having the func in a field *)
-  | Method
+  | Method of method_kind option
   (* Also redundant; can just check if the fdef is in a Lambda *)
   | LambdaKind
   (* a.k.a short lambdas *)
   | Arrow
   (* for Scala *)
   | BlockCases
+
+and method_kind = { has_reciever_parameter : bool; method_is_static : bool }
 
 (* The brackets are usually '()', but it can be || in Rust (like in Smalltalk)
  * or even sometimes [xxx] in C#.
@@ -2353,6 +2355,16 @@ let attr kwd tok = KeywordAttr (kwd, tok)
 let unhandled_keywordattr (s, t) =
   (* TODO? or use OtherAttribue? *)
   NamedAttr (t, Id ((s, t), empty_id_info ()), Tok.unsafe_fake_bracket [])
+
+(* ------------------------------------------------------------------------- *)
+(* Method kind *)
+(* ------------------------------------------------------------------------- *)
+
+let default_instance_method_kind =
+  { has_reciever_parameter = false; method_is_static = false }
+
+let default_static_method_kind =
+  { has_reciever_parameter = false; method_is_static = false }
 
 (* ------------------------------------------------------------------------- *)
 (* Patterns *)

--- a/libs/ast_generic/AST_generic_to_v1.ml
+++ b/libs/ast_generic/AST_generic_to_v1.ml
@@ -1090,7 +1090,7 @@ and map_variance = function
 
 and map_function_kind = function
   | Function -> `Function
-  | Method -> `Method
+  | Method _ -> `Method
   | LambdaKind -> `LambdaKind
   | Arrow -> `Arrow
   | BlockCases -> `BlockCases

--- a/libs/ast_generic/Meta_AST.ml
+++ b/libs/ast_generic/Meta_AST.ml
@@ -1225,7 +1225,8 @@ and vof_variance = function
 and vof_function_kind = function
   | Function -> OCaml.VSum ("Function", [])
   | LambdaKind -> OCaml.VSum ("LambdaKind", [])
-  | Method -> OCaml.VSum ("Method", [])
+  (* TODO: If this is needed somewhere fill it out. *)
+  | Method _ -> OCaml.VSum ("Method", [])
   | Arrow -> OCaml.VSum ("Arrow", [])
   | BlockCases -> OCaml.VSum ("BlockCases", [])
 


### PR DESCRIPTION
This PR adds two fields to method kinds which allows the parser to encode information about which method definition have an explicit receiver. It is currently option because I suspect that there will be some conversation about this and I didn't want to do the entire port without getting approval. Happy to remove the option and fill these in for the rest of the languages.

A [corresponding PR in pro](https://github.com/semgrep/semgrep-proprietary/pull/1260) uses this information to determine which signatures should drop there receiver parameter.

## Test plan

Pro-Tests use this to remove receiver parameters in signatures which should continue to pass CI.





