### PR TITLE
Fix error that occurs when matching top-level identifiers with meta-var qualified patterns in C++

### DIFF
--- a/changelog.d/pa-3375.fixed
+++ b/changelog.d/pa-3375.fixed
@@ -1,0 +1,3 @@
+Addressed an issue related to matching top-level identifiers with meta-variable
+qualified patterns in C++, such as matching ::foo with ::$A::$B.  This problem
+was specific to Pro Engine-enabled scans.

--- a/src/matching/Generic_vs_generic.ml
+++ b/src/matching/Generic_vs_generic.ml
@@ -471,11 +471,16 @@ let rec m_name_inner a b =
           | [] -> raise Impossible
           | _x :: xs -> List.rev xs |> List_.map (fun id -> (id, None))
         in
+        let new_middle =
+          match new_qualifier with
+          | [] -> None
+          | xs -> Some (B.QDots xs)
+        in
         m_name a
           (B.IdQualified
              {
                nameinfo with
-               name_middle = Some (B.QDots new_qualifier);
+               name_middle = new_middle;
                name_info = B.empty_id_info ();
              }))
   (* semantic! try to handle open in OCaml by querying LSP! The


### PR DESCRIPTION
This PR fixes `Common.Impossible` exception when matching `::foo` with `::$A::$B` in Pro engine enabled scans.

test plan: a test should be included in a pro engine PR.

