### PR TITLE
bump semgrep-vscode semgrep version

### DIFF
--- a/.github/workflows/start-release.jsonnet
+++ b/.github/workflows/start-release.jsonnet
@@ -508,6 +508,7 @@ local notify_success_job = {
     'bump-semgrep-action',
     'bump-semgrep-rpc',
     'bump-semgrep-app',
+    'bump-semgrep-vscode',
   ],
   'runs-on': 'ubuntu-20.04',
   steps: [
@@ -541,6 +542,7 @@ local notify_failure_job = {
     'bump-semgrep-action',
     'bump-semgrep-rpc',
     'bump-semgrep-app',
+    'bump-semgrep-vscode',
   ],
   'runs-on': 'ubuntu-20.04',
   steps: [
@@ -571,6 +573,7 @@ local notify_failure_job = {
     'bump-semgrep-app': bump_job('semgrep/semgrep-app'),
     'bump-semgrep-action': bump_job('semgrep/semgrep-action'),
     'bump-semgrep-rpc': bump_job('semgrep/semgrep-rpc'),
+    'bump-semgrep-vscode': bump_job('semgrep/semgrep-vscode'),
     'notify-success': notify_success_job,
     'notify-failure': notify_failure_job,
   },

--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -393,6 +393,33 @@ jobs:
       run: gh workflow run bump_version.yml --repo "semgrep/semgrep-rpc" --raw-field
         version="${{ needs.get-version.outputs.version }}"
     if: ${{ ! inputs.dry-run }}
+  bump-semgrep-vscode:
+    runs-on: ubuntu-22.04
+    needs:
+    - get-version
+    - validate-release-trigger
+    - release-setup
+    steps:
+    - name: Get JWT for semgrep-ci GitHub App
+      id: jwt
+      uses: docker://public.ecr.aws/y9k7q4m1/devops/cicd:latest
+      env:
+        EXPIRATION: 600
+        ISSUER: ${{ secrets.SEMGREP_CI_APP_ID }}
+        PRIVATE_KEY: ${{ secrets.SEMGREP_CI_APP_KEY }}
+    - name: Get token for semgrep-ci GitHub App
+      id: token
+      run: "\n      TOKEN=\"$(curl -X POST \\\n      -H \"Authorization: Bearer ${{
+        steps.jwt.outputs.jwt }}\" \\\n      -H \"Accept: application/vnd.github.v3+json\"
+        \\\n      \"https://api.github.com/app/installations/${{ secrets.SEMGREP_CI_APP_INSTALLATION_ID
+        }}/access_tokens\" | \\\n      jq -r .token)\"\n      echo \"::add-mask::$TOKEN\"\n
+        \     echo \"token=$TOKEN\" >> $GITHUB_OUTPUT\n    "
+    - name: Bump semgrep version in semgrep/semgrep-vscode
+      env:
+        GITHUB_TOKEN: ${{ steps.token.outputs.token }}
+      run: gh workflow run bump_version.yml --repo "semgrep/semgrep-vscode" --raw-field
+        version="${{ needs.get-version.outputs.version }}"
+    if: ${{ ! inputs.dry-run }}
   notify-success:
     if: ${{ success() && ! inputs.dry-run }}
     needs:
@@ -402,6 +429,7 @@ jobs:
     - bump-semgrep-action
     - bump-semgrep-rpc
     - bump-semgrep-app
+    - bump-semgrep-vscode
     runs-on: ubuntu-20.04
     steps:
     - run: echo "${{ needs.get-version.outputs.version }}"
@@ -425,6 +453,7 @@ jobs:
     - bump-semgrep-action
     - bump-semgrep-rpc
     - bump-semgrep-app
+    - bump-semgrep-vscode
     runs-on: ubuntu-20.04
     steps:
     - name: Notify Failure


### PR DESCRIPTION
Updates `start-release` to bump the semgrep version of the VSCode plugin.

Depends on https://github.com/semgrep/semgrep-vscode/pull/90