### PR TITLE
Only iterate through all rules if verbose logging is enabled

### DIFF
--- a/changelog.d/gh-9661.changed
+++ b/changelog.d/gh-9661.changed
@@ -1,0 +1,1 @@
+Prevent unnecessary computation when running scans without verbose logging enabled

--- a/cli/src/semgrep/run_scan.py
+++ b/cli/src/semgrep/run_scan.py
@@ -554,14 +554,15 @@ def run_scan(
         filtered_rules, lambda rule: (isinstance(rule.severity.value, out.Experiment))
     )
 
-    logger.verbose("Rules:")
-    for ruleid in sorted(rule.id for rule in unexperimental_rules):
-        logger.verbose(f"- {ruleid}")
-
-    if len(experimental_rules) > 0:
-        logger.verbose("Experimental Rules:")
-        for ruleid in sorted(rule.id for rule in experimental_rules):
+    if logger.isEnabledFor(logger.VERBOSE_LOG_LEVEL):
+        logger.verbose("Rules:")
+        for ruleid in sorted(rule.id for rule in unexperimental_rules):
             logger.verbose(f"- {ruleid}")
+
+        if len(experimental_rules) > 0:
+            logger.verbose("Experimental Rules:")
+            for ruleid in sorted(rule.id for rule in experimental_rules):
+                logger.verbose(f"- {ruleid}")
 
     (
         rule_matches_by_rule,


### PR DESCRIPTION
We currently iterate through all rules, which can be >10,000, even if verbose logging is disabled. This skips over the entire block if we aren't going to log anything 