### PR TITLE
fix(dockerfile): remove comment parsing hack

### DIFF
--- a/changelog.d/gh-9628-2.fixed
+++ b/changelog.d/gh-9628-2.fixed
@@ -1,0 +1,1 @@
+Fixed Dockerfile parsing bug where multiline comments were parsed incorrectly.

--- a/languages/dockerfile/tree-sitter/Parse_dockerfile_tree_sitter.ml
+++ b/languages/dockerfile/tree-sitter/Parse_dockerfile_tree_sitter.ml
@@ -650,15 +650,8 @@ let label_pair (env : env) (x : CST.label_pair) : label_pair =
 *)
 let comment_line (env : env)
     (((hash_tok, comment_tok), backslash_tok) : CST.comment_line) : tok =
-  let tok =
-    Tok.combine_toks (token env hash_tok)
-      [ token env comment_tok; token env backslash_tok ]
-  in
-  (* TODO: the token called backslash_tok should be a newline according
-     to the grammar, not a backslash. Looks like a bug in the parser.
-     We have to add the newline here to end the comment and get correct
-     line locations. *)
-  Tok.tok_add_s "\n" tok
+  Tok.combine_toks (token env hash_tok)
+    [ token env comment_tok; token env backslash_tok ]
 
 let shell_command (env : env) (x : CST.shell_command) =
   match x with

--- a/tests/patterns/dockerfile/multiline_comment.dockerfile
+++ b/tests/patterns/dockerfile/multiline_comment.dockerfile
@@ -1,0 +1,9 @@
+FROM alpine:3.19
+
+CMD echo "foo" && \
+   # Bug happens becuase of this comment (remove comment and see no bug) \
+   # MATCH:
+   echo "bar"
+
+# MATCH:
+CMD echo "bar"

--- a/tests/patterns/dockerfile/multiline_comment.sgrep
+++ b/tests/patterns/dockerfile/multiline_comment.sgrep
@@ -1,0 +1,1 @@
+echo "bar"


### PR DESCRIPTION
Closes https://github.com/semgrep/semgrep/issues/9628

We previously added a newline to comments with `\` compensate for the Dockerfile tree sitter parser. This appears to no longer be necessary.

Tests plan: added test

Run the added test without this change and with. Before the change, the wrong line will be reported.

