### PR TITLE
tainting: pro: Record call trace for ToArg findings

### DIFF
--- a/changelog.d/pa-3373.fixed
+++ b/changelog.d/pa-3373.fixed
@@ -1,0 +1,28 @@
+taint-mode: Pro: Taint traces will now reflect when taint is propagated via
+class fields, such as in this example:
+
+```java
+class Test {
+
+  private String str;
+
+  public setStr() {
+    this.str = "tainted";
+  }
+
+  public useStr() {
+    //ruleid: test
+    sink(this.str);
+  }
+
+  public test() {
+    setStr();
+    useStr();
+  }
+
+}
+```
+
+Previously Semgrep will report that taint originated at `this.str = "tainted"`,
+but it would not tell you how the control flow got there. Now the taint trace
+will indicate that we get there by calling `setStr()` inside `test()`.

--- a/src/tainting/Dataflow_tainting.ml
+++ b/src/tainting/Dataflow_tainting.ml
@@ -1497,7 +1497,16 @@ let check_function_signature env fun_exp args args_taints =
             |> List.concat_map (fun t ->
                    let dst_taints =
                      match t.T.orig with
-                     | Src _ -> (
+                     | Src src -> (
+                         let call_trace =
+                           T.Call (eorig, t.tokens, src.call_trace)
+                         in
+                         let t =
+                           {
+                             Taint.orig = Src { src with call_trace };
+                             tokens = [];
+                           }
+                         in
                          match t |> subst_in_precondition with
                          | None -> Taints.empty
                          | Some t -> Taints.singleton t)


### PR DESCRIPTION
Taint traces will now include the calls involved in getting a class field tainted, instead of simply pointing to the statement that tainted the field.

Closes PA-3373

test plan:
See semgrep/semgrep-proprietary#1264

