### PR TITLE
Osemgrep fingerprint: omit pattern-propagators

### DIFF
--- a/cli/tests/e2e/test_output_sarif.py
+++ b/cli/tests/e2e/test_output_sarif.py
@@ -34,7 +34,6 @@ def test_sarif_output_rule_board(run_semgrep_in_tmp: RunSemgrep, snapshot):
 
 
 @pytest.mark.kinda_slow
-@pytest.mark.osemfail
 def test_sarif_output_with_source(run_semgrep_in_tmp: RunSemgrep, snapshot):
     stdout = run_semgrep_in_tmp(
         "rules/eqeq-source.yml",

--- a/src/osemgrep/reporting/Cli_json_output.ml
+++ b/src/osemgrep/reporting/Cli_json_output.ml
@@ -267,9 +267,9 @@ let cli_error_of_core_error (x : OutJ.core_error) : OutJ.cli_error =
  *)
 let match_based_id_partial (rule : Rule.t) (rule_id : Rule_ID.t) metavars path :
     string =
-  (* the python implementation does not include sanitizers; so as to not
-   * break fingerprints we ignore sanitizers, too. see above assumptions
-   * on why.
+  (* the python implementation does not include sanitizers and propagators; so
+   * as to not break fingerprints we ignore sanitizers, too. see above
+   * assumptions on why.
    *)
   let mode =
     match rule.mode with

--- a/src/osemgrep/reporting/Cli_json_output.ml
+++ b/src/osemgrep/reporting/Cli_json_output.ml
@@ -273,8 +273,8 @@ let match_based_id_partial (rule : Rule.t) (rule_id : Rule_ID.t) metavars path :
    *)
   let mode =
     match rule.mode with
-    | `Taint { Rule.sources; sanitizers = _; sinks; propagators } ->
-        `Taint { Rule.sources; sanitizers = None; sinks; propagators }
+    | `Taint { Rule.sources; sanitizers = _; sinks; propagators = _ } ->
+        `Taint { Rule.sources; sanitizers = None; sinks; propagators = [] }
     | (`Search _ | `Extract _ | `Steps _) as mode -> mode
   in
   let formulae = Rule.formula_of_mode mode in


### PR DESCRIPTION
Like in https://github.com/semgrep/semgrep/pull/9655 I noticed `"pattern-propagators"` is missing in `RuleValidation.PATTERN_KEYS` in pysemgrep and so it occurs to me we should omit all `propagators` formulae as well when computing the matchBasedId. Maybe @ajbt200128 can confirm and has an explanation for this? There is no test case covering this so there is no change in number of tests passing due to this change.

This PR also marks a test osempass due to both #9655 and #9656 being merged.