### PR TITLE
Update product flag help to provide more details and guidance

### DIFF
--- a/changelog.d/pa-3383.changed
+++ b/changelog.d/pa-3383.changed
@@ -1,0 +1,1 @@
+Added information on product-related flags to help output, especially for Semgrep Secrets.

--- a/src/osemgrep/cli_ci/Ci_CLI.ml
+++ b/src/osemgrep/cli_ci/Ci_CLI.ml
@@ -77,7 +77,10 @@ let o_code : bool Term.t =
   Arg.value (Arg.flag info)
 
 let o_beta_testing_secrets : bool Term.t =
-  let info = Arg.info [ "beta-testing-secrets" ] in
+  let info =
+    Arg.info [ "beta-testing-secrets" ]
+      ~doc:{|Please use --secrets instead of --beta-testing-secrets.|}
+  in
   Arg.value (Arg.flag info)
 
 let o_secrets : bool Term.t =

--- a/src/osemgrep/cli_ci/Ci_CLI.ml
+++ b/src/osemgrep/cli_ci/Ci_CLI.ml
@@ -67,11 +67,13 @@ let o_internal_ci_scan_results : bool Term.t =
   Arg.value (Arg.flag info)
 
 let o_supply_chain : bool Term.t =
-  let info = Arg.info [ "supply-chain" ] in
+  let info =
+    Arg.info [ "supply-chain" ] ~doc:{|Run Semgrep Supply Chain product.|}
+  in
   Arg.value (Arg.flag info)
 
 let o_code : bool Term.t =
-  let info = Arg.info [ "code" ] in
+  let info = Arg.info [ "code" ] ~doc:{|Run Semgrep Code (SAST) product.|} in
   Arg.value (Arg.flag info)
 
 let o_beta_testing_secrets : bool Term.t =
@@ -82,8 +84,9 @@ let o_secrets : bool Term.t =
   let info =
     Arg.info [ "secrets" ]
       ~doc:
-        {|Support for secret validation. Requires Semgrep Secrets,
-contact support@semgrep.com for more information on this.|}
+        {|Run Semgrep Secrets product, including support for secret validation.
+          Requires access to Secrets, contact support@semgrep.com for more
+          information.|}
   in
   Arg.value (Arg.flag info)
 

--- a/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -515,14 +515,15 @@ let o_secrets : bool Term.t =
     Arg.info
       [ "beta-testing-secrets-enabled" ]
       ~doc:
-        {|Enable support for secret validation. Requires Semgrep Secrets,
-contact support@semgrep.com for more information on this.|}
+        {|Please use --secrets instead of --beta-testing-secrets.
+          Requires Semgrep Secrets, contact support@semgrep.com for more
+          information on this.|}
   in
   Arg.value (Arg.flag info)
 
 let o_no_secrets_validation : bool Term.t =
   let info =
-    Arg.info [ "no-secrets-validation" ] ~doc:{|Disables secrets validation|}
+    Arg.info [ "no-secrets-validation" ] ~doc:{|Disables secret validation.|}
   in
   Arg.value (Arg.flag info)
 


### PR DESCRIPTION
* Provides additional detail on product-related CLI flags. 
* Adds redirect for secrets beta testing flags that are no longer recommended.

To test:
`pipenv run semgrep ci --help`