### PR TITLE
feat(metrics): Add findings by product breakdown for SCP users

### DIFF
--- a/cli/src/semgrep/app/scans.py
+++ b/cli/src/semgrep/app/scans.py
@@ -340,14 +340,18 @@ class ScanHandler:
         dependency_counts = {k: len(v) for k, v in lockfile_dependencies.items()}
 
         # NOTE: This mirrors the logic in metrics.py to show the number of
-        #  findings by product for SCP customers. We should consider refactoring
+        #  findings by product for SCP customers. See PA-3312
+        #  We should consider refactoring this logic into a shared function
         #  in a future PR for metric and behavioral consistency.
         #  An open question remains on whether we should be including the number
         #  of ignored findings in this count.
 
         findings_by_product: Dict[str, int] = Counter()
         for r, f in matches_by_rule.items():
-            name = USER_FRIENDLY_PRODUCT_NAMES.get(r.product, r.product)
+            # NOTE: For parity with metrics.py, we are using the human-readable product name,
+            #  (i.e. code) and falling back to the internal json string (i.e. sast) if we
+            #  somehow drift out of sync with the product enum.
+            name = USER_FRIENDLY_PRODUCT_NAMES.get(r.product, r.product.to_json())
             findings_by_product[f"{name}"] += len(f)
 
         complete = out.CiScanComplete(

--- a/cli/src/semgrep/app/scans.py
+++ b/cli/src/semgrep/app/scans.py
@@ -23,6 +23,7 @@ import semgrep.semgrep_interfaces.semgrep_output_v1 as out
 from semdep.parsers.util import DependencyParserError
 from semgrep import __VERSION__
 from semgrep.app.project_config import ProjectConfig
+from semgrep.constants import USER_FRIENDLY_PRODUCT_NAMES
 from semgrep.error import INVALID_API_KEY_EXIT_CODE
 from semgrep.error import SemgrepError
 from semgrep.parsing_data import ParsingData
@@ -338,6 +339,17 @@ class ScanHandler:
 
         dependency_counts = {k: len(v) for k, v in lockfile_dependencies.items()}
 
+        # NOTE: This mirrors the logic in metrics.py to show the number of
+        #  findings by product for SCP customers. We should consider refactoring
+        #  in a future PR for metric and behavioral consistency.
+        #  An open question remains on whether we should be including the number
+        #  of ignored findings in this count.
+
+        findings_by_product: Dict[str, int] = Counter()
+        for r, f in matches_by_rule.items():
+            name = USER_FRIENDLY_PRODUCT_NAMES.get(r.product, r.product)
+            findings_by_product[f"{name}"] += len(f)
+
         complete = out.CiScanComplete(
             exit_code=1
             if any(match.is_blocking and not match.is_ignored for match in all_matches)
@@ -361,6 +373,7 @@ class ScanHandler:
                     for (lang, data) in parse_rate.get_errors_by_lang().items()
                 },
                 engine_requested=engine_requested.name,
+                findings_by_product=findings_by_product,
             ),
         )
 

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_dryrun/None/results.txt
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_dryrun/None/results.txt
@@ -746,7 +746,11 @@ Would have sent complete blob: {
                 "num_bytes": 366
             }
         },
-        "engine_requested": "OSS"
+        "engine_requested": "OSS",
+        "findings_by_product": {
+            "code": 16,
+            "supply-chain": 1
+        }
     },
     "dependency_parser_errors": []
 }

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-azure-pipelines-overwrite-autodetected-variables/complete.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-azure-pipelines-overwrite-autodetected-variables/complete.json
@@ -16,7 +16,11 @@
         "num_bytes": 366
       }
     },
-    "engine_requested": "OSS"
+    "engine_requested": "OSS",
+    "findings_by_product": {
+      "code": 16,
+      "supply-chain": 1
+    }
   },
   "dependency_parser_errors": [],
   "task_id": "00000000-0000-0000-0000-000000000000"

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-azure-pipelines/complete.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-azure-pipelines/complete.json
@@ -16,7 +16,11 @@
         "num_bytes": 366
       }
     },
-    "engine_requested": "OSS"
+    "engine_requested": "OSS",
+    "findings_by_product": {
+      "code": 16,
+      "supply-chain": 1
+    }
   },
   "dependency_parser_errors": [],
   "task_id": "00000000-0000-0000-0000-000000000000"

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-bitbucket-overwrite-autodetected-variables/complete.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-bitbucket-overwrite-autodetected-variables/complete.json
@@ -16,7 +16,11 @@
         "num_bytes": 366
       }
     },
-    "engine_requested": "OSS"
+    "engine_requested": "OSS",
+    "findings_by_product": {
+      "code": 16,
+      "supply-chain": 1
+    }
   },
   "dependency_parser_errors": [],
   "task_id": "00000000-0000-0000-0000-000000000000"

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-bitbucket/complete.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-bitbucket/complete.json
@@ -16,7 +16,11 @@
         "num_bytes": 366
       }
     },
-    "engine_requested": "OSS"
+    "engine_requested": "OSS",
+    "findings_by_product": {
+      "code": 16,
+      "supply-chain": 1
+    }
   },
   "dependency_parser_errors": [],
   "task_id": "00000000-0000-0000-0000-000000000000"

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-buildkite-overwrite-autodetected-variables/complete.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-buildkite-overwrite-autodetected-variables/complete.json
@@ -16,7 +16,11 @@
         "num_bytes": 366
       }
     },
-    "engine_requested": "OSS"
+    "engine_requested": "OSS",
+    "findings_by_product": {
+      "code": 16,
+      "supply-chain": 1
+    }
   },
   "dependency_parser_errors": [],
   "task_id": "00000000-0000-0000-0000-000000000000"

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-buildkite/complete.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-buildkite/complete.json
@@ -16,7 +16,11 @@
         "num_bytes": 366
       }
     },
-    "engine_requested": "OSS"
+    "engine_requested": "OSS",
+    "findings_by_product": {
+      "code": 16,
+      "supply-chain": 1
+    }
   },
   "dependency_parser_errors": [],
   "task_id": "00000000-0000-0000-0000-000000000000"

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-circleci-overwrite-autodetected-variables/complete.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-circleci-overwrite-autodetected-variables/complete.json
@@ -16,7 +16,11 @@
         "num_bytes": 366
       }
     },
-    "engine_requested": "OSS"
+    "engine_requested": "OSS",
+    "findings_by_product": {
+      "code": 16,
+      "supply-chain": 1
+    }
   },
   "dependency_parser_errors": [],
   "task_id": "00000000-0000-0000-0000-000000000000"

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-circleci/complete.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-circleci/complete.json
@@ -16,7 +16,11 @@
         "num_bytes": 366
       }
     },
-    "engine_requested": "OSS"
+    "engine_requested": "OSS",
+    "findings_by_product": {
+      "code": 16,
+      "supply-chain": 1
+    }
   },
   "dependency_parser_errors": [],
   "task_id": "00000000-0000-0000-0000-000000000000"

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-github-enterprise/complete.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-github-enterprise/complete.json
@@ -16,7 +16,11 @@
         "num_bytes": 366
       }
     },
-    "engine_requested": "OSS"
+    "engine_requested": "OSS",
+    "findings_by_product": {
+      "code": 16,
+      "supply-chain": 1
+    }
   },
   "dependency_parser_errors": [],
   "task_id": "00000000-0000-0000-0000-000000000000"

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-github-pr-semgrepconfig/complete.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-github-pr-semgrepconfig/complete.json
@@ -14,7 +14,10 @@
         "num_bytes": 366
       }
     },
-    "engine_requested": "OSS"
+    "engine_requested": "OSS",
+    "findings_by_product": {
+      "code": 16
+    }
   },
   "dependency_parser_errors": [],
   "task_id": "00000000-0000-0000-0000-000000000000"

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-github-pr/complete.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-github-pr/complete.json
@@ -14,7 +14,10 @@
         "num_bytes": 366
       }
     },
-    "engine_requested": "OSS"
+    "engine_requested": "OSS",
+    "findings_by_product": {
+      "code": 16
+    }
   },
   "dependency_parser_errors": [],
   "task_id": "00000000-0000-0000-0000-000000000000"

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-github-push-special-env-vars/complete.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-github-push-special-env-vars/complete.json
@@ -16,7 +16,11 @@
         "num_bytes": 366
       }
     },
-    "engine_requested": "OSS"
+    "engine_requested": "OSS",
+    "findings_by_product": {
+      "code": 16,
+      "supply-chain": 1
+    }
   },
   "dependency_parser_errors": [],
   "task_id": "00000000-0000-0000-0000-000000000000"

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-github-push/complete.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-github-push/complete.json
@@ -16,7 +16,11 @@
         "num_bytes": 366
       }
     },
-    "engine_requested": "OSS"
+    "engine_requested": "OSS",
+    "findings_by_product": {
+      "code": 16,
+      "supply-chain": 1
+    }
   },
   "dependency_parser_errors": [],
   "task_id": "00000000-0000-0000-0000-000000000000"

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-gitlab-push/complete.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-gitlab-push/complete.json
@@ -16,7 +16,11 @@
         "num_bytes": 366
       }
     },
-    "engine_requested": "OSS"
+    "engine_requested": "OSS",
+    "findings_by_product": {
+      "code": 16,
+      "supply-chain": 1
+    }
   },
   "dependency_parser_errors": [],
   "task_id": "00000000-0000-0000-0000-000000000000"

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-gitlab-special-env-vars/complete.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-gitlab-special-env-vars/complete.json
@@ -14,7 +14,10 @@
         "num_bytes": 366
       }
     },
-    "engine_requested": "OSS"
+    "engine_requested": "OSS",
+    "findings_by_product": {
+      "code": 16
+    }
   },
   "dependency_parser_errors": [],
   "task_id": "00000000-0000-0000-0000-000000000000"

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-gitlab/complete.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-gitlab/complete.json
@@ -14,7 +14,10 @@
         "num_bytes": 366
       }
     },
-    "engine_requested": "OSS"
+    "engine_requested": "OSS",
+    "findings_by_product": {
+      "code": 16
+    }
   },
   "dependency_parser_errors": [],
   "task_id": "00000000-0000-0000-0000-000000000000"

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/complete.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/complete.json
@@ -16,7 +16,11 @@
         "num_bytes": 366
       }
     },
-    "engine_requested": "OSS"
+    "engine_requested": "OSS",
+    "findings_by_product": {
+      "code": 16,
+      "supply-chain": 1
+    }
   },
   "dependency_parser_errors": [],
   "task_id": "00000000-0000-0000-0000-000000000000"

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-jenkins-overwrite-autodetected-variables/complete.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-jenkins-overwrite-autodetected-variables/complete.json
@@ -16,7 +16,11 @@
         "num_bytes": 366
       }
     },
-    "engine_requested": "OSS"
+    "engine_requested": "OSS",
+    "findings_by_product": {
+      "code": 16,
+      "supply-chain": 1
+    }
   },
   "dependency_parser_errors": [],
   "task_id": "00000000-0000-0000-0000-000000000000"

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-jenkins/complete.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-jenkins/complete.json
@@ -16,7 +16,11 @@
         "num_bytes": 366
       }
     },
-    "engine_requested": "OSS"
+    "engine_requested": "OSS",
+    "findings_by_product": {
+      "code": 16,
+      "supply-chain": 1
+    }
   },
   "dependency_parser_errors": [],
   "task_id": "00000000-0000-0000-0000-000000000000"

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-local/complete.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-local/complete.json
@@ -16,7 +16,11 @@
         "num_bytes": 366
       }
     },
-    "engine_requested": "OSS"
+    "engine_requested": "OSS",
+    "findings_by_product": {
+      "code": 16,
+      "supply-chain": 1
+    }
   },
   "dependency_parser_errors": [],
   "task_id": "00000000-0000-0000-0000-000000000000"

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-self-hosted/complete.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-self-hosted/complete.json
@@ -16,7 +16,11 @@
         "num_bytes": 366
       }
     },
-    "engine_requested": "OSS"
+    "engine_requested": "OSS",
+    "findings_by_product": {
+      "code": 16,
+      "supply-chain": 1
+    }
   },
   "dependency_parser_errors": [],
   "task_id": "00000000-0000-0000-0000-000000000000"

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-travis-overwrite-autodetected-variables/complete.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-travis-overwrite-autodetected-variables/complete.json
@@ -16,7 +16,11 @@
         "num_bytes": 366
       }
     },
-    "engine_requested": "OSS"
+    "engine_requested": "OSS",
+    "findings_by_product": {
+      "code": 16,
+      "supply-chain": 1
+    }
   },
   "dependency_parser_errors": [],
   "task_id": "00000000-0000-0000-0000-000000000000"

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-travis/complete.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-travis/complete.json
@@ -16,7 +16,11 @@
         "num_bytes": 366
       }
     },
-    "engine_requested": "OSS"
+    "engine_requested": "OSS",
+    "findings_by_product": {
+      "code": 16,
+      "supply-chain": 1
+    }
   },
   "dependency_parser_errors": [],
   "task_id": "00000000-0000-0000-0000-000000000000"

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-unparsable_url/complete.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-unparsable_url/complete.json
@@ -16,7 +16,11 @@
         "num_bytes": 366
       }
     },
-    "engine_requested": "OSS"
+    "engine_requested": "OSS",
+    "findings_by_product": {
+      "code": 16,
+      "supply-chain": 1
+    }
   },
   "dependency_parser_errors": [],
   "task_id": "00000000-0000-0000-0000-000000000000"

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-azure-pipelines-overwrite-autodetected-variables/complete.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-azure-pipelines-overwrite-autodetected-variables/complete.json
@@ -16,7 +16,11 @@
         "num_bytes": 366
       }
     },
-    "engine_requested": "OSS"
+    "engine_requested": "OSS",
+    "findings_by_product": {
+      "code": 16,
+      "supply-chain": 1
+    }
   },
   "dependency_parser_errors": [],
   "task_id": "00000000-0000-0000-0000-000000000000"

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-azure-pipelines/complete.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-azure-pipelines/complete.json
@@ -16,7 +16,11 @@
         "num_bytes": 366
       }
     },
-    "engine_requested": "OSS"
+    "engine_requested": "OSS",
+    "findings_by_product": {
+      "code": 16,
+      "supply-chain": 1
+    }
   },
   "dependency_parser_errors": [],
   "task_id": "00000000-0000-0000-0000-000000000000"

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-bitbucket-overwrite-autodetected-variables/complete.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-bitbucket-overwrite-autodetected-variables/complete.json
@@ -16,7 +16,11 @@
         "num_bytes": 366
       }
     },
-    "engine_requested": "OSS"
+    "engine_requested": "OSS",
+    "findings_by_product": {
+      "code": 16,
+      "supply-chain": 1
+    }
   },
   "dependency_parser_errors": [],
   "task_id": "00000000-0000-0000-0000-000000000000"

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-bitbucket/complete.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-bitbucket/complete.json
@@ -16,7 +16,11 @@
         "num_bytes": 366
       }
     },
-    "engine_requested": "OSS"
+    "engine_requested": "OSS",
+    "findings_by_product": {
+      "code": 16,
+      "supply-chain": 1
+    }
   },
   "dependency_parser_errors": [],
   "task_id": "00000000-0000-0000-0000-000000000000"

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-buildkite-overwrite-autodetected-variables/complete.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-buildkite-overwrite-autodetected-variables/complete.json
@@ -16,7 +16,11 @@
         "num_bytes": 366
       }
     },
-    "engine_requested": "OSS"
+    "engine_requested": "OSS",
+    "findings_by_product": {
+      "code": 16,
+      "supply-chain": 1
+    }
   },
   "dependency_parser_errors": [],
   "task_id": "00000000-0000-0000-0000-000000000000"

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-buildkite/complete.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-buildkite/complete.json
@@ -16,7 +16,11 @@
         "num_bytes": 366
       }
     },
-    "engine_requested": "OSS"
+    "engine_requested": "OSS",
+    "findings_by_product": {
+      "code": 16,
+      "supply-chain": 1
+    }
   },
   "dependency_parser_errors": [],
   "task_id": "00000000-0000-0000-0000-000000000000"

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-circleci-overwrite-autodetected-variables/complete.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-circleci-overwrite-autodetected-variables/complete.json
@@ -16,7 +16,11 @@
         "num_bytes": 366
       }
     },
-    "engine_requested": "OSS"
+    "engine_requested": "OSS",
+    "findings_by_product": {
+      "code": 16,
+      "supply-chain": 1
+    }
   },
   "dependency_parser_errors": [],
   "task_id": "00000000-0000-0000-0000-000000000000"

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-circleci/complete.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-circleci/complete.json
@@ -16,7 +16,11 @@
         "num_bytes": 366
       }
     },
-    "engine_requested": "OSS"
+    "engine_requested": "OSS",
+    "findings_by_product": {
+      "code": 16,
+      "supply-chain": 1
+    }
   },
   "dependency_parser_errors": [],
   "task_id": "00000000-0000-0000-0000-000000000000"

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-github-enterprise/complete.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-github-enterprise/complete.json
@@ -16,7 +16,11 @@
         "num_bytes": 366
       }
     },
-    "engine_requested": "OSS"
+    "engine_requested": "OSS",
+    "findings_by_product": {
+      "code": 16,
+      "supply-chain": 1
+    }
   },
   "dependency_parser_errors": [],
   "task_id": "00000000-0000-0000-0000-000000000000"

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-github-pr-semgrepconfig/complete.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-github-pr-semgrepconfig/complete.json
@@ -14,7 +14,10 @@
         "num_bytes": 366
       }
     },
-    "engine_requested": "OSS"
+    "engine_requested": "OSS",
+    "findings_by_product": {
+      "code": 16
+    }
   },
   "dependency_parser_errors": [],
   "task_id": "00000000-0000-0000-0000-000000000000"

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-github-pr/complete.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-github-pr/complete.json
@@ -14,7 +14,10 @@
         "num_bytes": 366
       }
     },
-    "engine_requested": "OSS"
+    "engine_requested": "OSS",
+    "findings_by_product": {
+      "code": 16
+    }
   },
   "dependency_parser_errors": [],
   "task_id": "00000000-0000-0000-0000-000000000000"

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-github-push-special-env-vars/complete.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-github-push-special-env-vars/complete.json
@@ -16,7 +16,11 @@
         "num_bytes": 366
       }
     },
-    "engine_requested": "OSS"
+    "engine_requested": "OSS",
+    "findings_by_product": {
+      "code": 16,
+      "supply-chain": 1
+    }
   },
   "dependency_parser_errors": [],
   "task_id": "00000000-0000-0000-0000-000000000000"

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-github-push/complete.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-github-push/complete.json
@@ -16,7 +16,11 @@
         "num_bytes": 366
       }
     },
-    "engine_requested": "OSS"
+    "engine_requested": "OSS",
+    "findings_by_product": {
+      "code": 16,
+      "supply-chain": 1
+    }
   },
   "dependency_parser_errors": [],
   "task_id": "00000000-0000-0000-0000-000000000000"

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-gitlab-push/complete.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-gitlab-push/complete.json
@@ -16,7 +16,11 @@
         "num_bytes": 366
       }
     },
-    "engine_requested": "OSS"
+    "engine_requested": "OSS",
+    "findings_by_product": {
+      "code": 16,
+      "supply-chain": 1
+    }
   },
   "dependency_parser_errors": [],
   "task_id": "00000000-0000-0000-0000-000000000000"

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-gitlab-special-env-vars/complete.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-gitlab-special-env-vars/complete.json
@@ -14,7 +14,10 @@
         "num_bytes": 366
       }
     },
-    "engine_requested": "OSS"
+    "engine_requested": "OSS",
+    "findings_by_product": {
+      "code": 16
+    }
   },
   "dependency_parser_errors": [],
   "task_id": "00000000-0000-0000-0000-000000000000"

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-gitlab/complete.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-gitlab/complete.json
@@ -14,7 +14,10 @@
         "num_bytes": 366
       }
     },
-    "engine_requested": "OSS"
+    "engine_requested": "OSS",
+    "findings_by_product": {
+      "code": 16
+    }
   },
   "dependency_parser_errors": [],
   "task_id": "00000000-0000-0000-0000-000000000000"

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/complete.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/complete.json
@@ -16,7 +16,11 @@
         "num_bytes": 366
       }
     },
-    "engine_requested": "OSS"
+    "engine_requested": "OSS",
+    "findings_by_product": {
+      "code": 16,
+      "supply-chain": 1
+    }
   },
   "dependency_parser_errors": [],
   "task_id": "00000000-0000-0000-0000-000000000000"

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-jenkins-overwrite-autodetected-variables/complete.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-jenkins-overwrite-autodetected-variables/complete.json
@@ -16,7 +16,11 @@
         "num_bytes": 366
       }
     },
-    "engine_requested": "OSS"
+    "engine_requested": "OSS",
+    "findings_by_product": {
+      "code": 16,
+      "supply-chain": 1
+    }
   },
   "dependency_parser_errors": [],
   "task_id": "00000000-0000-0000-0000-000000000000"

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-jenkins/complete.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-jenkins/complete.json
@@ -16,7 +16,11 @@
         "num_bytes": 366
       }
     },
-    "engine_requested": "OSS"
+    "engine_requested": "OSS",
+    "findings_by_product": {
+      "code": 16,
+      "supply-chain": 1
+    }
   },
   "dependency_parser_errors": [],
   "task_id": "00000000-0000-0000-0000-000000000000"

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-local/complete.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-local/complete.json
@@ -16,7 +16,11 @@
         "num_bytes": 366
       }
     },
-    "engine_requested": "OSS"
+    "engine_requested": "OSS",
+    "findings_by_product": {
+      "code": 16,
+      "supply-chain": 1
+    }
   },
   "dependency_parser_errors": [],
   "task_id": "00000000-0000-0000-0000-000000000000"

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-self-hosted/complete.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-self-hosted/complete.json
@@ -16,7 +16,11 @@
         "num_bytes": 366
       }
     },
-    "engine_requested": "OSS"
+    "engine_requested": "OSS",
+    "findings_by_product": {
+      "code": 16,
+      "supply-chain": 1
+    }
   },
   "dependency_parser_errors": [],
   "task_id": "00000000-0000-0000-0000-000000000000"

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-travis-overwrite-autodetected-variables/complete.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-travis-overwrite-autodetected-variables/complete.json
@@ -16,7 +16,11 @@
         "num_bytes": 366
       }
     },
-    "engine_requested": "OSS"
+    "engine_requested": "OSS",
+    "findings_by_product": {
+      "code": 16,
+      "supply-chain": 1
+    }
   },
   "dependency_parser_errors": [],
   "task_id": "00000000-0000-0000-0000-000000000000"

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-travis/complete.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-travis/complete.json
@@ -16,7 +16,11 @@
         "num_bytes": 366
       }
     },
-    "engine_requested": "OSS"
+    "engine_requested": "OSS",
+    "findings_by_product": {
+      "code": 16,
+      "supply-chain": 1
+    }
   },
   "dependency_parser_errors": [],
   "task_id": "00000000-0000-0000-0000-000000000000"

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-unparsable_url/complete.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-unparsable_url/complete.json
@@ -16,7 +16,11 @@
         "num_bytes": 366
       }
     },
-    "engine_requested": "OSS"
+    "engine_requested": "OSS",
+    "findings_by_product": {
+      "code": 16,
+      "supply-chain": 1
+    }
   },
   "dependency_parser_errors": [],
   "task_id": "00000000-0000-0000-0000-000000000000"

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_lockfile_parse_failure_reporting/complete.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_lockfile_parse_failure_reporting/complete.json
@@ -16,7 +16,11 @@
         "num_bytes": 366
       }
     },
-    "engine_requested": "OSS"
+    "engine_requested": "OSS",
+    "findings_by_product": {
+      "code": 16,
+      "supply-chain": 1
+    }
   },
   "dependency_parser_errors": [
     {

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_query_dependency/True-config/complete.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_query_dependency/True-config/complete.json
@@ -16,7 +16,11 @@
         "num_bytes": 366
       }
     },
-    "engine_requested": "OSS"
+    "engine_requested": "OSS",
+    "findings_by_product": {
+      "code": 9,
+      "supply-chain": 1
+    }
   },
   "dependency_parser_errors": [],
   "task_id": "00000000-0000-0000-0000-000000000000"

--- a/src/osemgrep/cli_ci/Ci_subcommand.ml
+++ b/src/osemgrep/cli_ci/Ci_subcommand.ml
@@ -567,6 +567,8 @@ let findings_and_complete ~has_blocking_findings ~commit_date ~engine_requested
           parse_rate = [];
           engine_requested =
             Some (Semgrep_output_v1_j.string_of_engine_kind engine_requested);
+          (* TODO: findings_by_product *)
+          findings_by_product = None;
         };
       (* TODO:
            if self._dependency_query:

--- a/src/osemgrep/core/Metrics_.ml
+++ b/src/osemgrep/core/Metrics_.ml
@@ -160,8 +160,11 @@ let default_payload =
     value =
       {
         features = [];
+        (* TODO: proFeatures *)
         proFeatures = None;
+        (* TODO: numFindings *)
         numFindings = None;
+        (* TODO: numFindingsByProduct *)
         numFindingsByProduct = None;
         numIgnored = None;
         ruleHashesWithFindings = None;


### PR DESCRIPTION
## Description
This PR adds the breakdown of findings by product to our CI stats payload for SCP customers. Follow on to #9555

Requires interface change: https://github.com/semgrep/semgrep-interfaces/pull/219

Closes [GROW-104](https://linear.app/r2c/issue/GROW-104).

### Demo
<img width="563" alt="Screenshot 2024-01-29 at 6 01 01 PM" src="https://github.com/semgrep/semgrep/assets/5779832/8a09f816-8408-4828-a3ec-7949055c4164">


## Test Plan
- [x] Validated with `semgrep ci --dry-run`