### PR TITLE
capabilities: introduce CLI.caps

### DIFF
--- a/src/main/Main.ml
+++ b/src/main/Main.ml
@@ -57,7 +57,7 @@ let () =
       | "osemgrep.bc"
       | "osemgrep"
       | "osemgrep.exe" ->
-          let exit_code = CLI.main caps argv in
+          let exit_code = CLI.main (caps :> CLI.caps) argv in
           (* remove? or make debug-only? or use Logs.info? *)
           if exit_code <> Exit_code.ok then
             Printf.eprintf "Error: %s\nExiting with error status %i: %s\n%!"

--- a/src/osemgrep/cli/CLI.ml
+++ b/src/osemgrep/cli/CLI.ml
@@ -34,8 +34,10 @@ module Env = Semgrep_envvars
 *)
 
 (*****************************************************************************)
-(* Constants *)
+(* Types and constants *)
 (*****************************************************************************)
+
+type caps = < Cap.stdout ; Cap.network ; Cap.exec ; Cap.random ; Cap.signal >
 
 let default_subcommand = "scan"
 
@@ -120,7 +122,7 @@ let known_subcommands =
     "interactive";
   ]
 
-let dispatch_subcommand (caps : Cap.all_caps) (argv : string array) =
+let dispatch_subcommand (caps : caps) (argv : string array) =
   match Array.to_list argv with
   (* impossible because argv[0] contains the program name *)
   | [] -> assert false
@@ -270,7 +272,7 @@ let before_exit ~profile () : unit =
 (*****************************************************************************)
 
 (* called from ../../main/Main.ml *)
-let main (caps : Cap.all_caps) (argv : string array) : Exit_code.t =
+let main (caps : caps) (argv : string array) : Exit_code.t =
   Printexc.record_backtrace true;
   let debug = Array.mem "--debug" argv in
   let profile = Array.mem "--profile" argv in

--- a/src/osemgrep/cli/CLI.mli
+++ b/src/osemgrep/cli/CLI.mli
@@ -1,3 +1,8 @@
+(* no exit, no argv
+ * TODO: Cap.files_argv, Cap.domain, Cap.thread
+ *)
+type caps = < Cap.stdout ; Cap.network ; Cap.exec ; Cap.random ; Cap.signal >
+
 (*
    Parse the semgrep command line, run the requested subcommand, and return
    an exit status.
@@ -9,7 +14,7 @@
    Exceptions are caught and turned into an appropriate exit code
    (unless you used --debug).
 *)
-val main : Cap.all_caps -> string array -> Exit_code.t
+val main : caps -> string array -> Exit_code.t
 
 (* set in semgrep-pro *)
 val hook_semgrep_interactive : (string array -> Exit_code.t) ref

--- a/src/osemgrep/tests/Osemgrep_tests.ml
+++ b/src/osemgrep/tests/Osemgrep_tests.ml
@@ -2,6 +2,6 @@
    Osemgrep end-to-end tests.
 *)
 
-let tests caps =
+let tests (caps : CLI.caps) =
   Testo.categorize_suites "OSemgrep end-to-end"
     [ Test_osemgrep.tests caps; Test_target_selection.tests caps ]

--- a/src/osemgrep/tests/Osemgrep_tests.mli
+++ b/src/osemgrep/tests/Osemgrep_tests.mli
@@ -2,4 +2,4 @@
    Osemgrep end-to-end tests.
 *)
 
-val tests : Cap.all_caps -> Testo.test list
+val tests : CLI.caps -> Testo.test list

--- a/src/osemgrep/tests/Test_osemgrep.ml
+++ b/src/osemgrep/tests/Test_osemgrep.ml
@@ -33,7 +33,7 @@ module TL = Test_login_subcommand
 (*****************************************************************************)
 
 (* no need for a token to access public rules in the registry *)
-let test_scan_config_registry_no_token (caps : Cap.all_caps) =
+let test_scan_config_registry_no_token (caps : CLI.caps) =
   Testo.create __FUNCTION__ (fun () ->
       Testutil_files.with_tempdir ~chdir:true (fun _tmp_path ->
           TL.with_logs
@@ -101,7 +101,7 @@ let test_scan_config_registry_with_invalid_token caps : Testo.test =
 (* Entry point *)
 (*****************************************************************************)
 
-let tests caps =
+let tests (caps : CLI.caps) =
   Testo.categorize "Osemgrep (e2e)"
     [
       test_scan_config_registry_no_token caps;

--- a/src/osemgrep/tests/Test_osemgrep.mli
+++ b/src/osemgrep/tests/Test_osemgrep.mli
@@ -1,4 +1,2 @@
-(* we need all_caps here because we call directly CLI.main in some
- * tests
- *)
-val tests : Cap.all_caps -> Testo.test list
+(* we need CLI.caps here because we call directly CLI.main in some tests *)
+val tests : CLI.caps -> Testo.test list

--- a/src/osemgrep/tests/Test_target_selection.mli
+++ b/src/osemgrep/tests/Test_target_selection.mli
@@ -2,4 +2,4 @@
    Test Osemgrep's target selection on real git (or other) repos.
 *)
 
-val tests : Cap.all_caps -> Testo.test list
+val tests : CLI.caps -> Testo.test list

--- a/src/tests/Test.ml
+++ b/src/tests/Test.ml
@@ -71,7 +71,7 @@ let tests (caps : Cap.all_caps) =
       Unit_Fetching.tests (caps :> < Cap.network >);
       Test_login_subcommand.tests (caps :> < Cap.stdout ; Cap.network >);
       Test_publish_subcommand.tests (caps :> < Cap.stdout ; Cap.network >);
-      Osemgrep_tests.tests caps;
+      Osemgrep_tests.tests (caps :> CLI.caps);
       (* Networking tests disabled as they will get rate limited sometimes *)
       (* And the SSL issues they've been testing have been stable *)
       (*Unit_Networking.tests;*)


### PR DESCRIPTION
Better than using all_caps there, and give opportunity
to see in one place what actually needs the semgrep engine to run

test plan:
make