### PR TITLE
feat: more Git_wrapper functionality

### DIFF
--- a/cli/tests/e2e/snapshots/test_metrics/test_metrics_payload/pro_flag0/metrics-payload.json
+++ b/cli/tests/e2e/snapshots/test_metrics/test_metrics_payload/pro_flag0/metrics-payload.json
@@ -56,7 +56,7 @@
         "size": 300
       }
     ],
-    "maxMemoryBytes": 42336256,
+    "maxMemoryBytes": 48693248,
     "numRules": 2,
     "numTargets": 3,
     "profilingTimes": {

--- a/dune-project
+++ b/dune-project
@@ -129,7 +129,7 @@ a few other projects developed at r2c.
   (synopsis "Wrappers for the git CLI")
   (description "Utility functions for interacting with git on the command-line.")
   (depends
-    (timedesc (>= "2.0.0"))
+    (timedesc (>= "2.0.0")))
 )
 (package (name glob)
   (synopsis "XXX")

--- a/dune-project
+++ b/dune-project
@@ -126,8 +126,10 @@ a few other projects developed at r2c.
   (description "XXX")
 )
 (package (name git_wrapper)
-  (synopsis "XXX")
-  (description "XXX")
+  (synopsis "Wrappers for the git CLI")
+  (description "Utility functions for interacting with git on the command-line.")
+  (depends
+    (timedesc (>= "2.0.0"))
 )
 (package (name glob)
   (synopsis "XXX")

--- a/dune-project
+++ b/dune-project
@@ -128,8 +128,6 @@ a few other projects developed at r2c.
 (package (name git_wrapper)
   (synopsis "Wrappers for the git CLI")
   (description "Utility functions for interacting with git on the command-line.")
-  (depends
-    (timedesc (>= "2.0.0")))
 )
 (package (name glob)
   (synopsis "XXX")
@@ -472,6 +470,7 @@ For more information see https://semgrep.dev
     uuidm
     trace
     trace-tef ; will probably switch this out for a different backend
+    (timedesc (>= 2.0.0)) ; used via git-wrapper
     (lsp (= 1.15.1-5.0))
     ; web stuff
     uri

--- a/libs/git_wrapper/Git_wrapper.ml
+++ b/libs/git_wrapper/Git_wrapper.ml
@@ -60,7 +60,9 @@ type status = {
 let git : Cmd.name = Cmd.Name "git"
 
 type obj_type = Tag | Commit | Tree | Blob [@@deriving show]
-type sha = string [@@deriving show, eq, ord, sexp]
+
+type sha = (string[@printer fun fmt -> fprintf fmt "%s"])
+[@@deriving show, eq, ord, sexp]
 
 (* See <https://git-scm.com/book/en/v2/Git-Internals-Git-Objects> *)
 type 'extra obj = { kind : obj_type; sha : sha; extra : 'extra }

--- a/libs/git_wrapper/Git_wrapper.ml
+++ b/libs/git_wrapper/Git_wrapper.ml
@@ -624,6 +624,12 @@ let cat_file_blob ?cwd sha =
   | Error (`Msg s) ->
       Error s
 
+let object_size ?cwd sha =
+  let cmd = (git, cd cwd @ [ "cat-file"; "-s"; sha ]) in
+  match UCmd.string_of_run ~trim:false cmd with
+  | Ok (s, (_, `Exited 0)) -> int_of_string_opt s
+  | _ -> None
+
 let ls_tree ?cwd ?(recurse = false) sha : ls_tree_extra obj list option =
   let cmd =
     ( git,

--- a/libs/git_wrapper/Git_wrapper.ml
+++ b/libs/git_wrapper/Git_wrapper.ml
@@ -631,6 +631,14 @@ let object_size ?cwd sha =
   | Ok (s, (_, `Exited 0)) -> int_of_string_opt s
   | _ -> None
 
+let commit_timestamp ?cwd sha =
+  (* %cI - print datetime in strict ISO 8601 format *)
+  let cmd = (git, cd cwd @ [ "show"; "--no-patch"; "--format=%cI"; sha ]) in
+  match UCmd.string_of_run ~trim:false cmd with
+  | Ok (s, (_, `Exited 0)) ->
+      Timedesc.Timestamp.of_iso8601 s |> Result.to_option
+  | _ -> None
+
 let ls_tree ?cwd ?(recurse = false) sha : ls_tree_extra obj list option =
   let cmd =
     ( git,

--- a/libs/git_wrapper/Git_wrapper.ml
+++ b/libs/git_wrapper/Git_wrapper.ml
@@ -13,6 +13,7 @@
  * LICENSE for more details.
  *)
 open Common
+open Sexplib.Std
 open Fpath_.Operators
 
 let logger = Logging.get_logger [ __MODULE__ ]
@@ -59,7 +60,7 @@ type status = {
 let git : Cmd.name = Cmd.Name "git"
 
 type obj_type = Tag | Commit | Tree | Blob [@@deriving show]
-type sha = string [@@deriving show]
+type sha = string [@@deriving show, eq, ord, sexp]
 
 (* See <https://git-scm.com/book/en/v2/Git-Internals-Git-Objects> *)
 type 'extra obj = { kind : obj_type; sha : sha; extra : 'extra }

--- a/libs/git_wrapper/Git_wrapper.mli
+++ b/libs/git_wrapper/Git_wrapper.mli
@@ -179,6 +179,12 @@ val cat_file_blob : ?cwd:Fpath.t -> sha -> (string, string) result
  *   [sha] does not designate an object.
  *)
 
+val object_size : ?cwd:Fpath.t -> sha -> int option
+(** [object_size sha] evaluates to [Some s] where [s] is the size of the object
+  * designated by [sha] in bytes, or [None] if an error occured (e.g. the
+  * object didn't exist).
+  *)
+
 val ls_tree :
   ?cwd:Fpath.t -> ?recurse:bool -> sha -> ls_tree_extra obj list option
 (** [ls_tree ~recurse sha] will run `git ls-tree --full-tree` and report the

--- a/libs/git_wrapper/Git_wrapper.mli
+++ b/libs/git_wrapper/Git_wrapper.mli
@@ -78,7 +78,7 @@ type status = {
 }
 [@@deriving show]
 
-type sha [@@deriving show]
+type sha [@@deriving show, eq, ord, sexp]
 type obj_type = Tag | Commit | Tree | Blob [@@deriving show]
 
 (* See <https://git-scm.com/book/en/v2/Git-Internals-Git-Objects> *)

--- a/libs/git_wrapper/Git_wrapper.mli
+++ b/libs/git_wrapper/Git_wrapper.mli
@@ -185,6 +185,12 @@ val object_size : ?cwd:Fpath.t -> sha -> int option
   * object didn't exist).
   *)
 
+val commit_timestamp : ?cwd:Fpath.t -> sha -> Timedesc.Timestamp.t option
+(** [commit_datetime sha] evaluates to [Some dt] where [dt] is the date and
+ * time of the commit designated by [sha] or [None] if an error occured (e.g.,
+ * the sha was for another object type).
+ *)
+
 val ls_tree :
   ?cwd:Fpath.t -> ?recurse:bool -> sha -> ls_tree_extra obj list option
 (** [ls_tree ~recurse sha] will run `git ls-tree --full-tree` and report the

--- a/libs/git_wrapper/dune
+++ b/libs/git_wrapper/dune
@@ -9,6 +9,7 @@
      fpath
      bos
      uuidm
+     timedesc
 
      commons
   )

--- a/libs/git_wrapper/dune
+++ b/libs/git_wrapper/dune
@@ -14,5 +14,8 @@
   )
   (preprocess (pps
      ppx_deriving.show
+     ppx_deriving.eq
+     ppx_deriving.ord
+     ppx_sexp_conv
 ))
 )

--- a/semgrep.opam
+++ b/semgrep.opam
@@ -52,6 +52,7 @@ depends: [
   "uuidm"
   "trace"
   "trace-tef"
+  "timedesc" {>= "2.0.0"}
   "lsp" {= "1.15.1-5.0"}
   "uri"
   "cohttp-lwt-unix"


### PR DESCRIPTION
Adds
- the ability to get the size of a git object
- the ability to get the timestamp of a git commit (uses [`Timedesc`](https://opam.ocaml.org/packages/timedesc/), since we use it in pro already)
- more derives for `Git_wrapper.sha`
  * eq and ord
  * sexp - needed since we use sexps to serialise some information about targets, so if we want to support git objects in these cases we need to be able to convert their shas to sexps.

This is relied on for historical secrets scanning.