### PR TITLE
Osemgrep: gitlab_sast and gitlab_secrets output

### DIFF
--- a/src/osemgrep/reporting/Gitlab_output.ml
+++ b/src/osemgrep/reporting/Gitlab_output.ml
@@ -68,19 +68,6 @@ let format_cli_match (cli_match : OutT.cli_match) =
              )
     *)
   in
-
-  (* TODO (time)
-         metrics = get_state().metrics
-          start_time = datetime.fromisoformat(metrics.payload.started_at.value)
-          start_time = start_time.replace(tzinfo=None)
-          output_dict = {
-              "scan": {
-                  "start_time": start_time.isoformat(
-                      timespec="seconds",
-                  ),
-                  "end_time": datetime.now().isoformat(timespec="seconds"),
-              },
-  *)
   let r =
     [
       ("id", `String "TODO");
@@ -168,11 +155,18 @@ let output f matches =
         ("vendor", `Assoc [ ("name", `String "Semgrep") ]);
       ]
   in
+  let start_time = Metrics_.g.payload.started_at
+  and end_time = Unix.(gmtime (time ())) in
+  let tm_to_string { Unix.tm_sec; tm_min; tm_hour; tm_mday; tm_mon; tm_year; _ }
+      =
+    spf "%04d-%02d-%02dT%02d:%02d:%02d" (1900 + tm_year) (1 + tm_mon) tm_mday
+      tm_hour tm_min tm_sec
+  in
   let scan =
     `Assoc
       [
-        ("start_time", `String "TODO");
-        ("end_time", `String "TODO");
+        ("start_time", `String (tm_to_string start_time));
+        ("end_time", `String (tm_to_string end_time));
         ("analyzer", tool);
         ("scanner", tool);
         ("version", `String Version.version);

--- a/src/osemgrep/reporting/Gitlab_output.ml
+++ b/src/osemgrep/reporting/Gitlab_output.ml
@@ -1,0 +1,198 @@
+open Common
+module OutT = Semgrep_output_v1_t
+
+(* from formatter/gitlab_sast.py *)
+(* TODO: Semgrep states currently don't map super well to Gitlab schema.*)
+let to_gitlab_severity = function
+  | `Info -> "Info"
+  | `Warning -> "Medium"
+  | `Error -> "High"
+  | `Experiment
+  | `Inventory ->
+      raise Todo
+
+let format_cli_match (cli_match : OutT.cli_match) =
+  let metadata = JSON.from_yojson cli_match.extra.metadata in
+  let source =
+    match JSON.member "source" metadata with
+    | Some (JSON.String s) -> s
+    | Some _
+    | None ->
+        "not available"
+  in
+  let confidence_details, confidence_flags =
+    match JSON.member "confidence" metadata with
+    | Some (JSON.String c) ->
+        ( [
+            ( "confidence",
+              `Assoc
+                [
+                  ("type", `String "text");
+                  ("name", `String "confidence");
+                  ("value", `String c);
+                ] );
+          ],
+          if String.equal c "LOW" then
+            [
+              `Assoc
+                [
+                  ("type", `String "flagged-as-likely-false-positive");
+                  ("origin", `String "Semgrep");
+                  ( "description",
+                    `String "This finding is from a low confidence rule." );
+                ];
+            ]
+          else [] )
+    | Some _
+    | None ->
+        ([], [])
+  and exposure_details, exposure_flags =
+    ([], [])
+    (* TODO
+       if rule_match.exposure_type:
+         result["details"]["exposure"] = {
+             "type": "text",
+             "name": "exposure",
+             "value": rule_match.exposure_type,
+         }
+         if rule_match.exposure_type == "unreachable":
+             result["flags"].append(
+                 {
+                     "type": "flagged-as-likely-false-positive",
+                     "origin": "Semgrep Supply Chain",
+                     "description": (
+                         "Semgrep found no way to reach this vulnerability "
+                         "while scanning your code."
+                     ),
+                 }
+             )
+    *)
+  in
+
+  (* TODO (time)
+         metrics = get_state().metrics
+          start_time = datetime.fromisoformat(metrics.payload.started_at.value)
+          start_time = start_time.replace(tzinfo=None)
+          output_dict = {
+              "scan": {
+                  "start_time": start_time.isoformat(
+                      timespec="seconds",
+                  ),
+                  "end_time": datetime.now().isoformat(timespec="seconds"),
+              },
+  *)
+  let r =
+    `Assoc
+      [
+        ("id", `String "TODO");
+        (*str(rule_match.uuid),  # create UUID from sha256 hash *)
+        ("category", `String "sast");
+        (* CVE is a required field from Gitlab schema.
+           It also is part of the determination for uniqueness
+           of a detected secret
+           /regardless/ of differentiated ID. See issue 262648.
+           https://gitlab.com/gitlab-org/gitlab/-/issues/262648
+           Gitlab themselves mock a CVE for findings that lack a CVE
+           Format: path:hash-of-file-path:check_id *)
+        ( "cve",
+          `String
+            (spf "%s:%s:%s"
+               (Fpath.to_string cli_match.path)
+               Digestif.SHA256.(
+                 to_hex (digest_string (Fpath.to_string cli_match.path)))
+               (Rule_ID.to_string cli_match.check_id)) );
+        ("message", `String cli_match.extra.message);
+        (* added to the GitLab SAST schema in 16.x, c.f.
+           https://gitlab.com/gitlab-org/gitlab/-/issues/339812
+           The above "message" field should be unused in 16.x and later! *)
+        ("description", `String cli_match.extra.message);
+        ("severity", `String (to_gitlab_severity cli_match.extra.severity));
+        ( "scanner",
+          `Assoc
+            [
+              ("id", `String "semgrep");
+              ("name", `String "Semgrep");
+              ("vendor", `Assoc [ ("name", `String "Semgrep") ]);
+            ] );
+        ( "location",
+          `Assoc
+            [
+              ("file", `String (Fpath.to_string cli_match.path));
+              (* Gitlab only uses line identifiers *)
+              ("start_line", `Int cli_match.start.line);
+              ("end_line", `Int cli_match.end_.line);
+            ] );
+        ( "identifiers",
+          `List
+            [
+              `Assoc
+                [
+                  ("type", `String "semgrep_type");
+                  ( "name",
+                    `String ("Semgrep - " ^ Rule_ID.to_string cli_match.check_id)
+                  );
+                  ("value", `String (Rule_ID.to_string cli_match.check_id));
+                  ("url", `String source);
+                ];
+            ] );
+        ("flags", `List (confidence_flags @ exposure_flags));
+        ("details", `Assoc (confidence_details @ exposure_details));
+      ]
+  in
+  r
+
+(* Format matches in GitLab SAST report compliant JSON.
+   - Written based on:
+     https://github.com/returntocorp/semgrep-action/blob/678eff1a4269ed04b76631771688c8be860ec4e9/src/semgrep_agent/findings.py#L137-L165
+   - Docs:
+     https://docs.gitlab.com/ee/user/application_security/sast/#reports-json-format
+   - Schema:
+     https://gitlab.com/gitlab-org/security-products/security-report-schemas/-/blob/master/dist/sast-report-format.json
+*)
+let sast_output matches =
+  let header =
+    [
+      ( "$schema",
+        `String
+          "https://gitlab.com/gitlab-org/security-products/security-report-schemas/-/blob/master/dist/sast-report-format.json"
+      );
+      ("version", `String "15.0.4");
+    ]
+  in
+  let tool =
+    `Assoc
+      [
+        ("id", `String "semgrep");
+        ("name", `String "Semgrep");
+        ("url", `String "https://semgrep.dev");
+        ("version", `String Version.version);
+        ("vendor", `Assoc [ ("name", `String "Semgrep") ]);
+      ]
+  in
+  let scan =
+    `Assoc
+      [
+        ("start_time", `String "TODO");
+        ("end_time", `String "TODO");
+        ("analyzer", tool);
+        ("scanner", tool);
+        ("version", `String Version.version);
+        ("status", `String "success");
+        ("type", `String "sast");
+      ]
+  in
+  let vulnerabilities =
+    List_.map_filter
+      (fun (cli_match : OutT.cli_match) ->
+        match cli_match.extra.severity with
+        | `Experiment
+        | `Inventory ->
+            None
+        | `Info
+        | `Warning
+        | `Error ->
+            Some (format_cli_match cli_match))
+      matches
+  in
+  `Assoc
+    (header @ [ ("scan", scan); ("vulnerabilities", `List vulnerabilities) ])

--- a/src/osemgrep/reporting/Gitlab_output.ml
+++ b/src/osemgrep/reporting/Gitlab_output.ml
@@ -197,7 +197,8 @@ let secrets_format_cli_match (cli_match : OutT.cli_match) =
   let more =
     [
       ("category", `String "secret_detection");
-      ("raw_source_code_extract", `String cli_match.extra.lines);
+      ( "raw_source_code_extract",
+        `List [ `String (cli_match.extra.lines ^ "\n") ] );
       ( "commit",
         `Assoc
           [

--- a/src/osemgrep/reporting/Output.ml
+++ b/src/osemgrep/reporting/Output.ml
@@ -146,9 +146,10 @@ let dispatch_output_format (output_format : Output_format.t) (conf : conf)
       let gitlab_sast_json = Gitlab_output.sast_output cli_output.results in
       Out.put (Yojson.Basic.to_string gitlab_sast_json)
   | Gitlab_secrets ->
-      Out.put
-        (spf "TODO: output format %s not supported yet"
-           (Output_format.show output_format))
+      let gitlab_secrets_json =
+        Gitlab_output.secrets_output cli_output.results
+      in
+      Out.put (Yojson.Basic.to_string gitlab_secrets_json)
 
 (*****************************************************************************)
 (* Entry points *)

--- a/src/osemgrep/reporting/Output.ml
+++ b/src/osemgrep/reporting/Output.ml
@@ -142,7 +142,9 @@ let dispatch_output_format (output_format : Output_format.t) (conf : conf)
   | Junit_xml ->
       let junit_xml = Junit_xml_output.junit_xml_output cli_output in
       Out.put junit_xml
-  | Gitlab_sast
+  | Gitlab_sast ->
+      let gitlab_sast_json = Gitlab_output.sast_output cli_output.results in
+      Out.put (Yojson.Basic.to_string gitlab_sast_json)
   | Gitlab_secrets ->
       Out.put
         (spf "TODO: output format %s not supported yet"


### PR DESCRIPTION
~~missing bits are start_time and end_time (will continue to work on this)~~

the question is about `id` -- here murmur3 hash (python hashlib mmh3, hash128) is used over rule_match.cli_unique_key. In OCaml, we don't have murmur3 yet -- is it worth to implement, or can we use e.g. fingerprint or match_based_id instead?

The exposure_type is not there, since I'm not sure where rule_match.exposure_type originates from -- is there by chance a test case that I can develop against? (NB: the sarif osemgrep output also doesn't handle the exposure_type - in python there is:
```python
        if rule_match.exposure_type:
            rule_match_sarif["properties"]["exposure"] = rule_match.exposure_type
```
).