### PR TITLE
libs/python-str-repr: Require just Dune 3.7 as everywhere else

### DIFF
--- a/libs/python-str-repr/dune-project
+++ b/libs/python-str-repr/dune-project
@@ -1,4 +1,4 @@
-(lang dune 3.11)
+(lang dune 3.7)
 
 (name python-str-repr)
 


### PR DESCRIPTION
test plan:
make # still works

