### PR TITLE
tainting: Faster checks for propagator matches

### DIFF
--- a/src/core/Range.ml
+++ b/src/core/Range.ml
@@ -43,6 +43,22 @@ type t = { start : charpos; end_ : charpos } [@@deriving show]
 exception NotValidRange of string
 
 (*****************************************************************************)
+(* Comparisons *)
+(*****************************************************************************)
+
+let equal r1 r2 =
+  let { start = a1; end_ = b1 } = r1 in
+  let { start = a2; end_ = b2 } = r2 in
+  Int.equal a1 a2 && Int.equal b1 b2
+
+let compare r1 r2 =
+  let { start = a1; end_ = b1 } = r1 in
+  let { start = a2; end_ = b2 } = r2 in
+  match Int.compare a1 a2 with
+  | 0 -> Int.compare b1 b2
+  | cmp -> cmp
+
+(*****************************************************************************)
 (* Set operations *)
 (*****************************************************************************)
 (* is r1 included or equal to r2 *)

--- a/src/core/Range.mli
+++ b/src/core/Range.mli
@@ -13,6 +13,9 @@ val pp : Format.formatter -> t -> unit
 
 exception NotValidRange of string
 
+val equal : t -> t -> bool
+val compare : t -> t -> int
+
 (* included or equal *)
 val ( $<=$ ) : t -> t -> bool
 

--- a/src/engine/Match_tainting_mode.ml
+++ b/src/engine/Match_tainting_mode.ml
@@ -355,16 +355,6 @@ let overlap_with ~match_range r =
   float_of_int (r.Range.end_ - r.Range.start + 1)
   /. float_of_int (r1.Range.end_ - r1.Range.start + 1)
 
-let is_exact_match ~match_range r =
-  let r1 = match_range in
-  let overlap =
-    (* We want to know how well the AST node `any' is matching
-       * the taint-annotated code range, this is a ratio in [0.0, 1.0]. *)
-    float_of_int (r.Range.end_ - r.Range.start + 1)
-    /. float_of_int (r1.Range.end_ - r1.Range.start + 1)
-  in
-  Range.( $<=$ ) r r1 && overlap > 0.99
-
 let any_is_in_sources_matches rule any matches =
   let ( let* ) = option_bind_list in
   let* r = range_of_any any in
@@ -383,33 +373,46 @@ let any_is_in_sources_matches rule any matches =
               })
          else None)
 
+(* Builds a table to quickly look up for propagator matches, taking advantage of
+ * the requirement that propagators must be exact matches.
+ *
+ * OBS: Previously we allowed these matches if they had an overlap of >0.99, but
+ *   to be honest that was arbitrary and fragile (the overlap largely depends on
+ *   the amount of text being matched). Typically propagators from/to match
+ *   l-values and those typically we can count as being 100% perfect matches.
+ *   If this causes problems we can always roll back, but all tests still work.
+ *)
+let propagators_table_of_matches rule matches =
+  let mk_match prop var kind r =
+    let spec_pm = RM.range_to_pattern_match_adjusted rule prop.rwm in
+    let spec : D.a_propagator = { kind; prop = prop.spec; var } in
+    {
+      Taint_smatch.spec;
+      spec_id = prop.spec.propagator_id;
+      spec_pm;
+      range = r;
+      overlap = 1.0;
+    }
+  in
+  let tbl = Hashtbl.create 100 in
+  matches
+  |> List.iter (fun prop ->
+         let var = prop.id in
+         Hashtbl_.push tbl prop.to_ (mk_match prop var `To prop.to_);
+         Hashtbl_.push tbl prop.from (mk_match prop var `From prop.from));
+  tbl
+
 (* Check whether `any` matches either the `from` or the `to` of any of the
- * `pattern-propagators`. Matches must be exact (overlap > 0.99) to make
- * taint propagation more precise and predictable. *)
-let any_is_in_propagators_matches rule any matches :
-    D.a_propagator Taint_smatch.t list =
+ * `pattern-propagators`. Matches must be exact to make taint propagation
+ * more precise and predictable.
+ *
+ * THINK: Now that we have "Best_matches" we could perhaps use that for
+ *   propagators too?
+ *)
+let any_is_in_propagators_matches any tbl : D.a_propagator Taint_smatch.t list =
   match range_of_any any with
   | None -> []
-  | Some r ->
-      matches
-      |> List.concat_map (fun prop ->
-             let var = prop.id in
-             let spec_pm = RM.range_to_pattern_match_adjusted rule prop.rwm in
-             let is_from = is_exact_match ~match_range:prop.from r in
-             let is_to = is_exact_match ~match_range:prop.to_ r in
-             let mk_match kind =
-               let spec : D.a_propagator = { kind; prop = prop.spec; var } in
-               {
-                 Taint_smatch.spec;
-                 spec_id = prop.spec.propagator_id;
-                 spec_pm;
-                 range = r;
-                 overlap = 1.0;
-               }
-             in
-             (if is_from then [ mk_match `From ] else [])
-             @ (if is_to then [ mk_match `To ] else [])
-             @ [])
+  | Some r -> Hashtbl_.get_stack tbl r
 
 let any_is_in_sanitizers_matches rule any matches =
   let ( let* ) = option_bind_list in
@@ -679,6 +682,7 @@ let taint_config_of_rule ~per_file_formula_cache xconf file ast_and_errors
           ]
     else []
   in
+  let propagators_tbl = propagators_table_of_matches rule propagators_ranges in
   let config = xconf.config in
   ( {
       Dataflow_tainting.filepath = !!file;
@@ -687,8 +691,7 @@ let taint_config_of_rule ~per_file_formula_cache xconf file ast_and_errors
         spec.sources |> snd
         |> List.exists (fun (src : R.taint_source) -> src.source_control);
       is_source = (fun x -> any_is_in_sources_matches rule x sources_ranges);
-      is_propagator =
-        (fun x -> any_is_in_propagators_matches rule x propagators_ranges);
+      is_propagator = (fun x -> any_is_in_propagators_matches x propagators_tbl);
       is_sanitizer =
         (fun x -> any_is_in_sanitizers_matches rule x sanitizers_ranges);
       is_sink = (fun x -> any_is_in_sinks_matches rule x sinks_ranges);


### PR DESCRIPTION
Since propagators from/to matches need to be exact, we can just use a hash table to store them. Inter-file rules use a lot of propagators so this actually makes a difference.

test plan:
Check semgrep-compare Argo workflow
See semgrep/semgrep-proprietary#1288
