### PR TITLE
chore(semgrep.js): let emcc have more memory

### DIFF
--- a/js/language_server/Makefile
+++ b/js/language_server/Makefile
@@ -43,7 +43,7 @@ dist/language-server-wasm.js: ../libyaml/dist/libyaml.o ../libpcre/dist/libpcre.
 		-O3 \
 		$^ \
 		$(EMCC_DEFAULTS) \
-		-s INITIAL_MEMORY=31457280 \
+		-s INITIAL_MEMORY=64MB \
 		-s SINGLE_FILE=1 \
 		$(EMCC_DEFAULTS) \
 		-sEXPORTED_FUNCTIONS=_malloc,_free,$(YAML_EXPORTED_FUNCTIONS),$(PCRE_EXPORTED_FUNCTIONS),$(TREESITTER_EXPORTED_FUNCTIONS),$(PARSER_EXPORTED_FUNCTIONS) \


### PR DESCRIPTION
This PR just bumps the amount of memory `emcc` has, because https://github.com/semgrep/semgrep/actions/runs/7761891797/job/21172455655?pr=9688 is failing without it.