### PR TITLE
fix: type error in release workflow

### DIFF
--- a/.github/workflows/release.jsonnet
+++ b/.github/workflows/release.jsonnet
@@ -130,7 +130,7 @@ local push_docker_job(artifact_name) = {
   with: {
     'artifact-name': artifact_name,
     'repository-name': 'returntocorp/semgrep',
-    'dry-run': "${{ inputs.dry-run == 'true' }}",
+    'dry-run': "${{ inputs.dry-run }}",
   },
 };
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,7 +116,7 @@ jobs:
     with:
       artifact-name: image-release
       repository-name: returntocorp/semgrep
-      dry-run: ${{ inputs.dry-run == 'true' }}
+      dry-run: ${{ inputs.dry-run }}
   push-docker-nonroot:
     needs:
     - wait-for-build-test
@@ -125,7 +125,7 @@ jobs:
     with:
       artifact-name: image-release-nonroot
       repository-name: returntocorp/semgrep
-      dry-run: ${{ inputs.dry-run == 'true' }}
+      dry-run: ${{ inputs.dry-run }}
   upload-wheels:
     name: Upload Wheels to PyPI
     runs-on: ubuntu-latest


### PR DESCRIPTION
The `release` workflow had a type error where it tried to compare a boolean to a string, resulting in all runs of `release`, even with `dry-run: true`, updating the `canary` docker image.