### PR TITLE
chore: no double interpolation of messages

### DIFF
--- a/changelog.d/ea-838.fixed
+++ b/changelog.d/ea-838.fixed
@@ -1,0 +1,3 @@
+Output: Semgrep CLI now no longer sometimes interpolated metavariables twice, if
+the message that was substituted for a metavariable itself contained a valid
+metavariable to be interpolated

--- a/cli/src/semgrep/core_output.py
+++ b/cli/src/semgrep/core_output.py
@@ -15,10 +15,8 @@ from dataclasses import replace
 from typing import Dict
 from typing import List
 from typing import Optional
-from typing import Tuple
 
 import semgrep.semgrep_interfaces.semgrep_output_v1 as out
-import semgrep.util as util
 from semgrep.error import FATAL_EXIT_CODE
 from semgrep.error import OK_EXIT_CODE
 from semgrep.error import SemgrepCoreError
@@ -100,77 +98,10 @@ def core_matches_to_rule_matches(
     """
     rule_table = {rule.id: rule for rule in rules}
 
-    def interpolate(
-        text: str,
-        metavariables: Dict[str, str],
-        propagated_values: Dict[str, str],
-        mask_metavariables: bool,
-    ) -> str:
-        """Interpolates a string with the metavariables contained in it, returning a new string"""
-        if mask_metavariables:
-            for metavariable in metavariables.keys():
-                metavariable_content = metavariables[metavariable]
-                show_until = int(len(metavariable_content) * util.MASK_SHOW_PCT)
-                masked_content = metavariable_content[:show_until] + util.MASK_CHAR * (
-                    len(metavariable_content) - show_until
-                )
-                metavariables[metavariable] = masked_content
-
-                metavariable_value = propagated_values[metavariable]
-                show_until = int(len(metavariable_content) * util.MASK_SHOW_PCT)
-                masked_value = metavariable_value[:show_until] + util.MASK_CHAR * (
-                    len(metavariable_content) - show_until
-                )
-                propagated_values[metavariable] = masked_value
-
-        # Sort by metavariable length to avoid name collisions (eg. $X2 must be handled before $X)
-        for metavariable in sorted(metavariables.keys(), key=len, reverse=True):
-            text = text.replace(
-                "value(" + metavariable + ")", propagated_values[metavariable]
-            )
-            text = text.replace(metavariable, metavariables[metavariable])
-
-        return text
-
-    def read_metavariables(
-        match: out.CoreMatch,
-    ) -> Tuple[Dict[str, str], Dict[str, str]]:
-        matched_values = {}
-        propagated_values = {}
-
-        # open path and ignore non-utf8 bytes. https://stackoverflow.com/a/56441652
-        with open(match.path.value, errors="replace") as fd:
-            for metavariable, metavariable_data in match.extra.metavars.value.items():
-                # Offsets are start inclusive and end exclusive
-                start_offset = metavariable_data.start.offset
-                end_offset = metavariable_data.end.offset
-
-                matched_value = util.read_range(fd, start_offset, end_offset)
-
-                # Use propagated value
-                if metavariable_data.propagated_value:
-                    propagated_value = (
-                        metavariable_data.propagated_value.svalue_abstract_content
-                    )
-                else:
-                    propagated_value = matched_value
-
-                matched_values[metavariable] = matched_value
-                propagated_values[metavariable] = propagated_value
-
-        return matched_values, propagated_values
-
     def convert_to_rule_match(match: out.CoreMatch) -> RuleMatch:
         rule = rule_table[match.check_id.value]
-        matched_values, propagated_values = read_metavariables(match)
 
         message = match.extra.message if match.extra.message else rule.message
-        message = interpolate(
-            message,
-            matched_values,
-            propagated_values,
-            isinstance(rule.product.value, out.Secrets),
-        )
 
         metadata = rule.metadata
         if match.extra.metadata:

--- a/cli/tests/e2e/rules/message_interpolation/interpolated_message.yaml
+++ b/cli/tests/e2e/rules/message_interpolation/interpolated_message.yaml
@@ -1,0 +1,8 @@
+rules:
+  - id: interpolated-message
+    patterns:
+      - pattern: foo($X)
+    languages: [python]
+    severity: ERROR
+    message: |
+      Arg to `foo` is $X

--- a/cli/tests/e2e/snapshots/test_message_interpolation/test_no_double_interpolation/report.json
+++ b/cli/tests/e2e/snapshots/test_message_interpolation/test_no_double_interpolation/report.json
@@ -1,0 +1,52 @@
+{
+  "errors": [],
+  "interfile_languages_used": [],
+  "paths": {
+    "scanned": [
+      "targets/message_interpolation/target_with_metavariable.py"
+    ]
+  },
+  "results": [
+    {
+      "check_id": "rules.message_interpolation.interpolated-message",
+      "end": {
+        "col": 25,
+        "line": 2,
+        "offset": 25
+      },
+      "extra": {
+        "engine_kind": "OSS",
+        "fingerprint": "0x42",
+        "is_ignored": false,
+        "lines": "foo(\"$X is a cool name\")",
+        "message": "Arg to `foo` is \"$X is a cool name\"\n",
+        "metadata": {},
+        "metavars": {
+          "$X": {
+            "abstract_content": "\"$X is a cool name\"",
+            "end": {
+              "col": 24,
+              "line": 2,
+              "offset": 24
+            },
+            "start": {
+              "col": 5,
+              "line": 2,
+              "offset": 5
+            }
+          }
+        },
+        "severity": "ERROR",
+        "validation_state": "NO_VALIDATOR"
+      },
+      "path": "targets/message_interpolation/target_with_metavariable.py",
+      "start": {
+        "col": 1,
+        "line": 2,
+        "offset": 1
+      }
+    }
+  ],
+  "skipped_rules": [],
+  "version": "0.42"
+}

--- a/cli/tests/e2e/targets/message_interpolation/target_with_metavariable.py
+++ b/cli/tests/e2e/targets/message_interpolation/target_with_metavariable.py
@@ -1,0 +1,2 @@
+
+foo("$X is a cool name")

--- a/cli/tests/e2e/test_message_interpolation.py
+++ b/cli/tests/e2e/test_message_interpolation.py
@@ -1,6 +1,8 @@
 import pytest
 from tests.fixtures import RunSemgrep
 
+from semgrep.constants import OutputFormat
+
 
 @pytest.mark.kinda_slow
 @pytest.mark.parametrize(
@@ -46,3 +48,13 @@ def test_message_interpolation(run_semgrep_in_tmp: RunSemgrep, snapshot, rule, t
     snapshot.assert_match(
         run_semgrep_in_tmp(rule, target_name=target).stdout, "results.json"
     )
+
+
+@pytest.mark.quick
+def test_no_double_interpolation(run_semgrep_in_tmp: RunSemgrep, snapshot):
+    stdout, _ = run_semgrep_in_tmp(
+        "rules/message_interpolation/interpolated_message.yaml",
+        target_name="message_interpolation/target_with_metavariable.py",
+        output_format=OutputFormat.JSON,  # Not the real output format; just disables JSON parsing
+    )
+    snapshot.assert_match(stdout, "report.json")


### PR DESCRIPTION
## What:
This PR removes the message interpolation logic from `pysemgrep`, since it is now done in `semgrep-core`.

## Why:
[Message interpolation in core](https://github.com/semgrep/semgrep/blob/267617a761271579492cfff1bb4e71cc555cbbeb/src/reporting/Core_json_output.ml#L222-L224) was added in a [previous PR](https://github.com/semgrep/semgrep/commit/fc13203403195915a981e00b3dc73c65814b57d5), but the corresponding logic was not removed in `pysemgrep`.

This means that it was possible for `semgrep-core` to interpolate a metavariable, and then for `pysemgrep` to do it again. Now, this doesn't usually present an issue, except in cases where the result of interpolation still includes a metavariable to be interpolated.

## How:
Removed the logic from `pysemgrep`, and added a test which demonstrates that `osemgrep` and `pysemgrep` now display the same output behavior.

## Test plan:
Automated test, and tested manually.

Before:
![image](https://github.com/semgrep/semgrep/assets/49291449/a2cbce92-fc39-4536-8068-4978a9bd2f48)

After:
![image](https://github.com/semgrep/semgrep/assets/49291449/e81cfe04-7a14-4fcb-a42f-332e09699473)

Notice how the interpolated message no longer repeats itself.

Closes EA-838