### PR TITLE
Propagate tainted fields in base object assign instruction

### DIFF
--- a/src/tainting/Dataflow_tainting.ml
+++ b/src/tainting/Dataflow_tainting.ml
@@ -1788,6 +1788,12 @@ let transfer :
                  * See [Taint_lval_env] for details. *)
                 lval_env' |> Lval_env.add lval taints
               else
+                let lval_env' =
+                  match x.i with
+                  | Assign (lval, e) ->
+                      Lval_env.propagate_field lval e lval_env'
+                  | _ -> lval_env'
+                in
                 (* The RHS returns no taint, but taint could propagate by
                  * side-effect too. So, we check whether the taint assigned
                  * to 'lval' has changed to determine whether we need to

--- a/src/tainting/Taint_lval_env.mli
+++ b/src/tainting/Taint_lval_env.mli
@@ -79,6 +79,7 @@ val clean : env -> IL.lval -> env
     clean the entire array! This seems drastic but it should help reducing FPs.
  *)
 
+val propagate_field : IL.lval -> IL.exp -> env -> env
 val add_control_taints : env -> Taint.taints -> env
 val get_control_taints : env -> Taint.taints
 

--- a/tests/tainting_rules/java/tainted_obj.java
+++ b/tests/tainting_rules/java/tainted_obj.java
@@ -1,0 +1,9 @@
+class Test {
+    void test() {
+        Foo x = new Foo();
+        x.t = taint_source();
+        Foo y = x;
+        //ERROR:
+        sink(y.t, z);
+    }
+}

--- a/tests/tainting_rules/java/tainted_obj.yaml
+++ b/tests/tainting_rules/java/tainted_obj.yaml
@@ -1,0 +1,15 @@
+rules:
+  - id: java-test
+    languages:
+      - java
+    message: test
+    severity: INFO
+    mode: taint
+    pattern-sources:
+      - pattern: taint_source()
+    pattern-sinks:
+      - patterns:
+          - pattern: sink($X, ...)
+          - focus-metavariable:
+              - $X
+


### PR DESCRIPTION
test plan: https://github.com/semgrep/semgrep-proprietary/pull/1292

closes cas-6533