### PR TITLE
Fix mask for dates in our snapshot

### DIFF
--- a/cli/tests/conftest.py
+++ b/cli/tests/conftest.py
@@ -246,7 +246,8 @@ ALWAYS_MASK: Maskers = (
     re.compile(r"python (\d+[.]\d+[.]\d+[ ]+)"),
     re.compile(r'SEMGREP_SETTINGS_FILE="(.+?)"'),
     re.compile(r'SEMGREP_VERSION_CACHE_PATH="(.+?)"'),
-    re.compile(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}"),
+    # Dates
+    re.compile(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+Z)?"),
     # Hide any substring that resembles a temporary file path.
     # This may be a little too broad but it's simpler than inspecting
     # specific JSON fields on case-per-case basis.

--- a/cli/tests/conftest.py
+++ b/cli/tests/conftest.py
@@ -247,7 +247,7 @@ ALWAYS_MASK: Maskers = (
     re.compile(r'SEMGREP_SETTINGS_FILE="(.+?)"'),
     re.compile(r'SEMGREP_VERSION_CACHE_PATH="(.+?)"'),
     # Dates
-    re.compile(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+Z)?"),
+    re.compile(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:(?:\.\d+)?Z)?"),
     # Hide any substring that resembles a temporary file path.
     # This may be a little too broad but it's simpler than inspecting
     # specific JSON fields on case-per-case basis.


### PR DESCRIPTION
The switch to Timedesc.rfc_xxx added some .023434Z
to our time, and the masking regexp was not handling it.

test plan:
make
make copy-core-for-cli
cd cli
make osempass