### PR TITLE
Call opam update in install-deps-from-semgrep-core

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -280,10 +280,11 @@ OPTIONAL_DEPS = $(REQUIRED_DEPS) ./dev/optional.opam
 
 # This target is portable; it only assumes you have 'gcc', 'opam' and
 # other build-essential tools and a working OCaml (e.g., ocamlc) switch setup.
-# Note that this target is now called from our Dockerfile, so do not
-# run 'opam update' below to not slow down things.
+# Note that we call opam update below because semgrep.opam may mention
+# new packages that are covered yet by our ocaml-layer docker image.
 .PHONY: install-deps-for-semgrep-core
 install-deps-for-semgrep-core: semgrep.opam
+	opam update -y
 	# Fetch, build and install the tree-sitter runtime library locally.
 	cd libs/ocaml-tree-sitter-core \
 	&& ./configure \
@@ -417,7 +418,6 @@ homebrew-setup:
 .PHONY: setup
 setup: semgrep.opam
 	./scripts/check-bash-version
-	opam update -y
 	$(MAKE) install-deps-for-semgrep-core
 
 # Install optional development dependencies in addition to build dependencies.

--- a/scripts/osx-setup-for-release.sh
+++ b/scripts/osx-setup-for-release.sh
@@ -16,9 +16,6 @@ opam init --no-setup --bare
 #still needed?
 #brew update
 
-# we might need recent packages and the self-hosted runner opam might be behind
-opam update
-
 # Some CI runners have tree-sitter preinstalled which interfere with
 # out static linking plans below so better to remove it.
 # TODO: fix setup-m1-builder.sh instead?


### PR DESCRIPTION
Otherwise we get failures on PRs requiring new packages as in
https://github.com/semgrep/semgrep/actions/runs/7816332885/job/21321615830?pr=9701

test plan:
make install-deps-for-semgrep-core

check CI has green checks