### PR TITLE
feat(ci): use semgrep container from semgrep docker org

### DIFF
--- a/.github/workflows/semgrep.jsonnet
+++ b/.github/workflows/semgrep.jsonnet
@@ -15,7 +15,7 @@ local semgrep_ci_job = {
   'runs-on': 'ubuntu-20.04',
   container: {
     // We're dogfooding the canary here!
-    image: 'returntocorp/semgrep:canary',
+    image: 'semgrep/semgrep:canary',
   },
   env: semgrep.secrets,
   steps: [

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -13,7 +13,7 @@ jobs:
   semgrep-ci:
     runs-on: ubuntu-20.04
     container:
-      image: returntocorp/semgrep:canary
+      image: semgrep/semgrep:canary
     env:
       SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
       E2E_APP_TOKEN: ${{ secrets.SEMGREP_E2E_APP_TOKEN }}


### PR DESCRIPTION
We're now publishing semgrep containers to the semgrep Docker org. Dogfood them!