### PR TITLE
refactor: Move ctype_of_literal to AST_generic_helpers

### DIFF
--- a/libs/ast_generic/AST_generic_helpers.ml
+++ b/libs/ast_generic/AST_generic_helpers.ml
@@ -372,6 +372,12 @@ let parameter_to_catch_exn_opt p =
   | OtherParam _ ->
       None
 
+let ctype_of_literal = function
+  | G.Bool _ -> G.Cbool
+  | G.Int _ -> G.Cint
+  | G.String _ -> G.Cstr
+  | ___else___ -> G.Cany
+
 (*****************************************************************************)
 (* Abstract position and svalue for comparison *)
 (*****************************************************************************)

--- a/libs/ast_generic/AST_generic_helpers.mli
+++ b/libs/ast_generic/AST_generic_helpers.mli
@@ -81,6 +81,7 @@ val name_is_global : AST_generic.resolved_name_kind -> bool
 val parameter_to_catch_exn_opt :
   AST_generic.parameter -> AST_generic.catch_exn option
 
+val ctype_of_literal : AST_generic.literal -> AST_generic.const_type
 val opt_to_label_ident : AST_generic.ident option -> AST_generic.label_ident
 
 val has_keyword_attr :

--- a/src/analyzing/Dataflow_svalue.ml
+++ b/src/analyzing/Dataflow_svalue.ml
@@ -102,12 +102,6 @@ let result_of_function_call_is_constant lang f args =
 let eq_literal l1 l2 = G.equal_literal l1 l2
 let eq_ctype t1 t2 = t1 =*= t2
 
-let ctype_of_literal = function
-  | G.Bool _ -> G.Cbool
-  | G.Int _ -> G.Cint
-  | G.String _ -> G.Cstr
-  | ___else___ -> G.Cany
-
 let eq c1 c2 =
   match (c1, c2) with
   | G.Lit l1, G.Lit l2 -> eq_literal l1 l2
@@ -158,11 +152,11 @@ let union c1 c2 =
   | G.Sym _, _any ->
       G.NotCst
   | G.Lit l1, G.Lit l2 ->
-      let t1 = ctype_of_literal l1 and t2 = ctype_of_literal l2 in
+      let t1 = H.ctype_of_literal l1 and t2 = H.ctype_of_literal l2 in
       G.Cst (union_ctype t1 t2)
   | G.Lit l1, G.Cst t2
   | G.Cst t2, G.Lit l1 ->
-      let t1 = ctype_of_literal l1 in
+      let t1 = H.ctype_of_literal l1 in
       G.Cst (union_ctype t1 t2)
   | G.Cst t1, G.Cst t2 -> G.Cst (union_ctype t1 t2)
 
@@ -337,7 +331,7 @@ and eval_op env wop args =
   | _op, [ G.Cst t1; G.Cst t2 ] -> G.Cst (union_ctype t1 t2)
   | _op, [ G.Lit l1; G.Cst t2 ]
   | _op, [ G.Cst t2; G.Lit l1 ] ->
-      let t1 = ctype_of_literal l1 in
+      let t1 = H.ctype_of_literal l1 in
       G.Cst (union_ctype t1 t2)
   | ___else___ -> G.NotCst
 


### PR DESCRIPTION
This makes it more widely-accessible and I'd like it available for an upcoming change.

Test plan: Automated tests

