### PR TITLE
chore: python: Use the static keyword for static methods in python

### DIFF
--- a/languages/python/generic/Python_to_generic.ml
+++ b/languages/python/generic/Python_to_generic.ml
@@ -903,14 +903,19 @@ and decorator env (t, v1) =
   in
   match dotted_name with
   | Some d_name ->
-      G.NamedAttr
-        ( t,
-          H.name_of_ids d_name,
-          Option.value ~default:(Tok.unsafe_fake_bracket []) args )
+    (match H.name_of_ids d_name, args with
+     (* Use standard static keyword for staticmethod attribute. This
+        is used by other parts of the pro-engine to check if a method
+        is static. *)
+     | (G.Id (("staticmethod", tok), _), (None | Some (_, [], _))) -> G.attr G.Static tok
+     | (name, args) ->
+       G.NamedAttr
+         ( t, name,
+           Option.value ~default:(Tok.unsafe_fake_bracket []) args ))
   | None ->
-      let v1 = expr env v1 in
-      G.OtherAttribute (("pip0614: expr attr", t), [ G.E v1 ])
-
+    let v1 = expr env v1 in
+    G.OtherAttribute (("pip0614: expr attr", t), [ G.E v1 ])
+      
 and alias env (v1, v2) =
   let v1 = name env v1 and v2 = option (ident_and_id_info env) v2 in
   let imported_ident =

--- a/languages/python/generic/Python_to_generic.ml
+++ b/languages/python/generic/Python_to_generic.ml
@@ -902,20 +902,20 @@ and decorator env (t, v1) =
     | _ -> (get_dotted_name v1 [], None)
   in
   match dotted_name with
-  | Some d_name ->
-    (match H.name_of_ids d_name, args with
-     (* Use standard static keyword for staticmethod attribute. This
-        is used by other parts of the pro-engine to check if a method
-        is static. *)
-     | (G.Id (("staticmethod", tok), _), (None | Some (_, [], _))) -> G.attr G.Static tok
-     | (name, args) ->
-       G.NamedAttr
-         ( t, name,
-           Option.value ~default:(Tok.unsafe_fake_bracket []) args ))
+  | Some d_name -> (
+      match (H.name_of_ids d_name, args) with
+      (* Use standard static keyword for staticmethod attribute. This
+         is used by other parts of the pro-engine to check if a method
+         is static. *)
+      | G.Id (("staticmethod", tok), _), (None | Some (_, [], _)) ->
+          G.attr G.Static tok
+      | name, args ->
+          G.NamedAttr
+            (t, name, Option.value ~default:(Tok.unsafe_fake_bracket []) args))
   | None ->
-    let v1 = expr env v1 in
-    G.OtherAttribute (("pip0614: expr attr", t), [ G.E v1 ])
-      
+      let v1 = expr env v1 in
+      G.OtherAttribute (("pip0614: expr attr", t), [ G.E v1 ])
+
 and alias env (v1, v2) =
   let v1 = name env v1 and v2 = option (ident_and_id_info env) v2 in
   let imported_ident =

--- a/tests/patterns/python/static_method.py
+++ b/tests/patterns/python/static_method.py
@@ -1,0 +1,15 @@
+class A:
+    #MATCH:
+    @staticmethod
+    def f():
+        pass
+
+    #MATCH:
+    @staticmethod()
+    def f():
+        pass
+
+    #OK:
+    @staticmethod("A ERROR")
+    def f():
+        pass

--- a/tests/patterns/python/static_method.py
+++ b/tests/patterns/python/static_method.py
@@ -1,15 +1,21 @@
 class A:
     #MATCH:
     @staticmethod
-    def f():
+    def f0():
         pass
+
+    # Not dynamically correct python, but just showing how it behaves
+    # for pattern matching.
 
     #MATCH:
     @staticmethod()
-    def f():
+    def f1():
         pass
 
-    #OK:
+    # Not dynamically correct python, but just showing how it behaves
+    #for pattern matching.
+
+    # OK:
     @staticmethod("A ERROR")
-    def f():
+    def f2():
         pass

--- a/tests/patterns/python/static_method.sgrep
+++ b/tests/patterns/python/static_method.sgrep
@@ -1,0 +1,3 @@
+@staticmethod
+def $FUNC(...):
+    ...


### PR DESCRIPTION
Simple change to the python parser to lower `@staticmethod` and `@staticmethod()` to the static keyword. This is used to eliminate some python specific details in this [semgrep-pro pr](https://github.com/semgrep/semgrep-proprietary/pull/1298).

# Test Plan
Adds a test to check the behavior of matching. CI should continue to work with the exception of semgrep pro, which is changed to work in the PR above.
