### PR TITLE
cli: Group "missing plugin" errors and report as one warning

### DIFF
--- a/changelog.d/ea-842.changed
+++ b/changelog.d/ea-842.changed
@@ -1,0 +1,2 @@
+"Missing plugin" errors (i.e., rules that cannot be run without `--pro`) will now
+be grouped and reported as a single warning.

--- a/cli/src/semgrep/error.py
+++ b/cli/src/semgrep/error.py
@@ -160,6 +160,12 @@ class SemgrepCoreError(SemgrepError):
         """
         return isinstance(self.core.error_type.value, out.Timeout)
 
+    def is_missing_plugin(self) -> bool:
+        """
+        Return if this error is due to a missing plugin
+        """
+        return isinstance(self.core.error_type.value, out.MissingPlugin)
+
     @property
     def _error_message(self) -> str:
         """


### PR DESCRIPTION
If Semgrep were to find 100 rules that target a Pro language such as Elixir, while being logged in but running OSS, then it will generate 100 messages like:

> [INFO] Missing plugin for rule elixir.lang.security.command-injection.command-injection:
> Missing Semgrep extension needed for parsing Elixir target. Try adding `--pro` to your command.

This is not great UX so, as a very quick-fix for Elixir's launch this week, this PR groups all these errors and reports them as one single warning like:

> Warning: 100 rule(s) were skipped because they require Pro (try `--pro`), for example: elixir.lang.security.command-injection.command-injection

But this PR doesn't change the fact that these are being reported as errors, and it does not provide any way to see the complete list of rules that require Pro.

We need a proper fix to follow this one. I think these should be reported as skipped rules rather than errors, and Semgrep should give you a summary (e.g. "100 rules skipped because you are running OSS"), but still show the complete list of rules being skipped with `--verbose`.

Closes EA-842

test plan:
Run `semgrep -c p/elixir` on an Elixir file while logged in
You will just get one warning like:
> Warning: 14 rule(s) were skipped because they require Pro (try `--pro`), for example: elixir.lang.security.sql-injection.sql-injection

