### PR TITLE
feat: Add an option for adding a separate display name for repositories

### DIFF
--- a/changelog.d/gh-8953.added
+++ b/changelog.d/gh-8953.added
@@ -1,0 +1,3 @@
+Created a new environment variable SEMGREP_REPO_DISPLAY_NAME for use in semgrep CI.
+Currently, this does nothing. The goal is to provide a way to override the display
+name of a repo in the Semgrep App.

--- a/cli/src/semgrep/config_resolver.py
+++ b/cli/src/semgrep/config_resolver.py
@@ -262,7 +262,7 @@ class ConfigLoader:
             semgrep_version=out.Version(__VERSION__),
             scan_environment="semgrep-scan",
             repository=repo_name,
-            repository_display=repo_display_name,
+            repo_display_name=repo_display_name,
             repo_url=None,
             branch=None,
             commit=None,

--- a/cli/src/semgrep/config_resolver.py
+++ b/cli/src/semgrep/config_resolver.py
@@ -248,6 +248,7 @@ class ConfigLoader:
         self, require_repo_name: bool
     ) -> out.ProjectMetadata:
         repo_name = os.environ.get("SEMGREP_REPO_NAME")
+        repo_display_name = os.environ.get("SEMGREP_REPO_DISPLAY_NAME", repo_name)
 
         if repo_name is None:
             if require_repo_name:
@@ -261,6 +262,7 @@ class ConfigLoader:
             semgrep_version=out.Version(__VERSION__),
             scan_environment="semgrep-scan",
             repository=repo_name,
+            repository_display=repo_display_name,
             repo_url=None,
             branch=None,
             commit=None,

--- a/cli/src/semgrep/meta.py
+++ b/cli/src/semgrep/meta.py
@@ -114,6 +114,12 @@ class GitMeta:
         return str(os.path.basename(repo_root_str))
 
     @property
+    def repo_display_name(self) -> str:
+        repo_display_name = os.getenv("SEMGREP_REPO_DISPLAY_NAME", self.repo_name)
+        if repo_display_name:
+            return repo_display_name
+
+    @property
     def repo_url(self) -> Optional[str]:
         env = get_state().env
         repo_url = os.getenv("SEMGREP_REPO_URL")
@@ -264,6 +270,12 @@ class GithubMeta(GitMeta):
             return repo_name
         else:
             raise Exception("Could not get repo_name when running in GithubAction")
+
+    @property
+    def repo_display_name(self) -> str:
+        repo_display_name = os.getenv("SEMGREP_REPO_DISPLAY_NAME", self.repo_name)
+        if repo_display_name:
+            return repo_display_name
 
     @property
     def repo_url(self) -> Optional[str]:
@@ -660,6 +672,12 @@ class GitlabMeta(GitMeta):
         return super().repo_name
 
     @property
+    def repo_display_name(self) -> str:
+        repo_display_name = os.getenv("SEMGREP_REPO_DISPLAY_NAME", self.repo_name)
+        if repo_display_name:
+            return repo_display_name
+
+    @property
     def repo_url(self) -> Optional[str]:
         project_url = os.getenv("SEMGREP_REPO_URL", os.getenv("CI_PROJECT_URL"))
 
@@ -763,6 +781,12 @@ class CircleCIMeta(GitMeta):
         return f"{project_name}/{repo_name}"
 
     @property
+    def repo_display_name(self) -> str:
+        repo_display_name = os.getenv("SEMGREP_REPO_DISPLAY_NAME", self.repo_name)
+        if repo_display_name:
+            return repo_display_name
+
+    @property
     def repo_url(self) -> Optional[str]:
         repo_url = os.getenv("SEMGREP_REPO_URL")
         if repo_url:
@@ -825,6 +849,12 @@ class JenkinsMeta(GitMeta):
         return name if name else super().repo_name
 
     @property
+    def repo_display_name(self) -> str:
+        repo_display_name = os.getenv("SEMGREP_REPO_DISPLAY_NAME", self.repo_name)
+        if repo_display_name:
+            return repo_display_name
+
+    @property
     def repo_url(self) -> Optional[str]:
         repo_url = os.getenv("SEMGREP_REPO_URL")
         if repo_url:
@@ -878,6 +908,12 @@ class BitbucketMeta(GitMeta):
             # try pulling from url
             name = get_repo_name_from_repo_url(os.getenv("BITBUCKET_GIT_HTTP_ORIGIN"))
         return name if name else super().repo_name
+
+    @property
+    def repo_display_name(self) -> str:
+        repo_display_name = os.getenv("SEMGREP_REPO_DISPLAY_NAME", self.repo_name)
+        if repo_display_name:
+            return repo_display_name
 
     @property
     def repo_url(self) -> Optional[str]:
@@ -941,6 +977,12 @@ class AzurePipelinesMeta(GitMeta):
 
         name = get_repo_name_from_repo_url(self.repo_url)
         return name if name else super().repo_name
+
+    @property
+    def repo_display_name(self) -> str:
+        repo_display_name = os.getenv("SEMGREP_REPO_DISPLAY_NAME", self.repo_name)
+        if repo_display_name:
+            return repo_display_name
 
     @property
     def repo_url(self) -> Optional[str]:
@@ -1025,6 +1067,12 @@ class BuildkiteMeta(GitMeta):
         return name if name else super().repo_name
 
     @property
+    def repo_display_name(self) -> str:
+        repo_display_name = os.getenv("SEMGREP_REPO_DISPLAY_NAME", self.repo_name)
+        if repo_display_name:
+            return repo_display_name
+
+    @property
     def repo_url(self) -> Optional[str]:
         repo_url = os.getenv("SEMGREP_REPO_URL")
         if repo_url:
@@ -1091,6 +1139,12 @@ class TravisMeta(GitMeta):
 
         repo_name = os.getenv("TRAVIS_REPO_SLUG")
         return repo_name if repo_name else super().repo_name
+
+    @property
+    def repo_display_name(self) -> str:
+        repo_display_name = os.getenv("SEMGREP_REPO_DISPLAY_NAME", self.repo_name)
+        if repo_display_name:
+            return repo_display_name
 
     @property
     def repo_url(self) -> Optional[str]:

--- a/cli/src/semgrep/meta.py
+++ b/cli/src/semgrep/meta.py
@@ -209,6 +209,7 @@ class GitMeta:
             # REQUIRED for semgrep-app backend
             repository=self.repo_name,
             # OPTIONAL for semgrep-app backend
+            repo_display_name=self.repo_display_name,
             repo_url=uri_opt(self.repo_url),
             branch=self.branch,
             ci_job_url=uri_opt(self.ci_job_url),

--- a/cli/src/semgrep/meta.py
+++ b/cli/src/semgrep/meta.py
@@ -116,8 +116,7 @@ class GitMeta:
     @property
     def repo_display_name(self) -> str:
         repo_display_name = os.getenv("SEMGREP_REPO_DISPLAY_NAME", self.repo_name)
-        if repo_display_name:
-            return repo_display_name
+        return repo_display_name or self.repo_name
 
     @property
     def repo_url(self) -> Optional[str]:
@@ -275,8 +274,7 @@ class GithubMeta(GitMeta):
     @property
     def repo_display_name(self) -> str:
         repo_display_name = os.getenv("SEMGREP_REPO_DISPLAY_NAME", self.repo_name)
-        if repo_display_name:
-            return repo_display_name
+        return repo_display_name or self.repo_name
 
     @property
     def repo_url(self) -> Optional[str]:
@@ -675,8 +673,7 @@ class GitlabMeta(GitMeta):
     @property
     def repo_display_name(self) -> str:
         repo_display_name = os.getenv("SEMGREP_REPO_DISPLAY_NAME", self.repo_name)
-        if repo_display_name:
-            return repo_display_name
+        return repo_display_name or self.repo_name
 
     @property
     def repo_url(self) -> Optional[str]:
@@ -784,8 +781,7 @@ class CircleCIMeta(GitMeta):
     @property
     def repo_display_name(self) -> str:
         repo_display_name = os.getenv("SEMGREP_REPO_DISPLAY_NAME", self.repo_name)
-        if repo_display_name:
-            return repo_display_name
+        return repo_display_name or self.repo_name
 
     @property
     def repo_url(self) -> Optional[str]:
@@ -852,8 +848,7 @@ class JenkinsMeta(GitMeta):
     @property
     def repo_display_name(self) -> str:
         repo_display_name = os.getenv("SEMGREP_REPO_DISPLAY_NAME", self.repo_name)
-        if repo_display_name:
-            return repo_display_name
+        return repo_display_name or self.repo_name
 
     @property
     def repo_url(self) -> Optional[str]:
@@ -913,8 +908,7 @@ class BitbucketMeta(GitMeta):
     @property
     def repo_display_name(self) -> str:
         repo_display_name = os.getenv("SEMGREP_REPO_DISPLAY_NAME", self.repo_name)
-        if repo_display_name:
-            return repo_display_name
+        return repo_display_name or self.repo_name
 
     @property
     def repo_url(self) -> Optional[str]:
@@ -982,8 +976,7 @@ class AzurePipelinesMeta(GitMeta):
     @property
     def repo_display_name(self) -> str:
         repo_display_name = os.getenv("SEMGREP_REPO_DISPLAY_NAME", self.repo_name)
-        if repo_display_name:
-            return repo_display_name
+        return repo_display_name or self.repo_name
 
     @property
     def repo_url(self) -> Optional[str]:
@@ -1070,8 +1063,7 @@ class BuildkiteMeta(GitMeta):
     @property
     def repo_display_name(self) -> str:
         repo_display_name = os.getenv("SEMGREP_REPO_DISPLAY_NAME", self.repo_name)
-        if repo_display_name:
-            return repo_display_name
+        return repo_display_name or self.repo_name
 
     @property
     def repo_url(self) -> Optional[str]:
@@ -1144,8 +1136,7 @@ class TravisMeta(GitMeta):
     @property
     def repo_display_name(self) -> str:
         repo_display_name = os.getenv("SEMGREP_REPO_DISPLAY_NAME", self.repo_name)
-        if repo_display_name:
-            return repo_display_name
+        return repo_display_name or self.repo_name
 
     @property
     def repo_url(self) -> Optional[str]:

--- a/cli/src/semgrep/meta.py
+++ b/cli/src/semgrep/meta.py
@@ -207,8 +207,8 @@ class GitMeta:
             semgrep_version=out.Version(__VERSION__),
             # REQUIRED for semgrep-app backend
             repository=self.repo_name,
-            # OPTIONAL for semgrep-app backend
             repo_display_name=self.repo_display_name,
+            # OPTIONAL for semgrep-app backend
             repo_url=uri_opt(self.repo_url),
             branch=self.branch,
             ci_job_url=uri_opt(self.ci_job_url),

--- a/cli/src/semgrep/meta.py
+++ b/cli/src/semgrep/meta.py
@@ -115,8 +115,8 @@ class GitMeta:
 
     @property
     def repo_display_name(self) -> str:
-        repo_display_name = os.getenv("SEMGREP_REPO_DISPLAY_NAME", self.repo_name)
-        return repo_display_name or self.repo_name
+        # Using the 'or' for the typechecker
+        return os.getenv("SEMGREP_REPO_DISPLAY_NAME") or self.repo_name
 
     @property
     def repo_url(self) -> Optional[str]:
@@ -273,8 +273,7 @@ class GithubMeta(GitMeta):
 
     @property
     def repo_display_name(self) -> str:
-        repo_display_name = os.getenv("SEMGREP_REPO_DISPLAY_NAME", self.repo_name)
-        return repo_display_name or self.repo_name
+        return super().repo_display_name
 
     @property
     def repo_url(self) -> Optional[str]:
@@ -672,8 +671,7 @@ class GitlabMeta(GitMeta):
 
     @property
     def repo_display_name(self) -> str:
-        repo_display_name = os.getenv("SEMGREP_REPO_DISPLAY_NAME", self.repo_name)
-        return repo_display_name or self.repo_name
+        return super().repo_display_name
 
     @property
     def repo_url(self) -> Optional[str]:
@@ -780,8 +778,7 @@ class CircleCIMeta(GitMeta):
 
     @property
     def repo_display_name(self) -> str:
-        repo_display_name = os.getenv("SEMGREP_REPO_DISPLAY_NAME", self.repo_name)
-        return repo_display_name or self.repo_name
+        return super().repo_display_name
 
     @property
     def repo_url(self) -> Optional[str]:
@@ -847,8 +844,7 @@ class JenkinsMeta(GitMeta):
 
     @property
     def repo_display_name(self) -> str:
-        repo_display_name = os.getenv("SEMGREP_REPO_DISPLAY_NAME", self.repo_name)
-        return repo_display_name or self.repo_name
+        return super().repo_display_name
 
     @property
     def repo_url(self) -> Optional[str]:
@@ -907,8 +903,7 @@ class BitbucketMeta(GitMeta):
 
     @property
     def repo_display_name(self) -> str:
-        repo_display_name = os.getenv("SEMGREP_REPO_DISPLAY_NAME", self.repo_name)
-        return repo_display_name or self.repo_name
+        return super().repo_display_name
 
     @property
     def repo_url(self) -> Optional[str]:
@@ -975,8 +970,7 @@ class AzurePipelinesMeta(GitMeta):
 
     @property
     def repo_display_name(self) -> str:
-        repo_display_name = os.getenv("SEMGREP_REPO_DISPLAY_NAME", self.repo_name)
-        return repo_display_name or self.repo_name
+        return super().repo_display_name
 
     @property
     def repo_url(self) -> Optional[str]:
@@ -1062,8 +1056,7 @@ class BuildkiteMeta(GitMeta):
 
     @property
     def repo_display_name(self) -> str:
-        repo_display_name = os.getenv("SEMGREP_REPO_DISPLAY_NAME", self.repo_name)
-        return repo_display_name or self.repo_name
+        return super().repo_display_name
 
     @property
     def repo_url(self) -> Optional[str]:
@@ -1135,8 +1128,7 @@ class TravisMeta(GitMeta):
 
     @property
     def repo_display_name(self) -> str:
-        repo_display_name = os.getenv("SEMGREP_REPO_DISPLAY_NAME", self.repo_name)
-        return repo_display_name or self.repo_name
+        return super().repo_display_name
 
     @property
     def repo_url(self) -> Optional[str]:

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-azure-pipelines-overwrite-autodetected-variables/meta.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-azure-pipelines-overwrite-autodetected-variables/meta.json
@@ -18,6 +18,7 @@
     "pull_request_id": "34566",
     "pull_request_title": null,
     "is_full_scan": true,
+    "repo_display_name": "a/repo/name",
     "commit_timestamp": "1970-01-01T00:00:00Z",
     "is_sca_scan": false,
     "is_code_scan": false,

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-azure-pipelines/meta.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-azure-pipelines/meta.json
@@ -18,6 +18,7 @@
     "pull_request_id": "1234",
     "pull_request_title": null,
     "is_full_scan": true,
+    "repo_display_name": "project_name/project_name",
     "commit_timestamp": "1970-01-01T00:00:00Z",
     "is_sca_scan": false,
     "is_code_scan": false,

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-bitbucket-overwrite-autodetected-variables/meta.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-bitbucket-overwrite-autodetected-variables/meta.json
@@ -18,6 +18,7 @@
     "pull_request_id": "99999",
     "pull_request_title": null,
     "is_full_scan": true,
+    "repo_display_name": "a/repo/name",
     "commit_timestamp": "1970-01-01T00:00:00Z",
     "is_sca_scan": false,
     "is_code_scan": false,

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-bitbucket/meta.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-bitbucket/meta.json
@@ -18,6 +18,7 @@
     "pull_request_id": "35",
     "pull_request_title": null,
     "is_full_scan": true,
+    "repo_display_name": "project_name/project_name",
     "commit_timestamp": "1970-01-01T00:00:00Z",
     "is_sca_scan": false,
     "is_code_scan": false,

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-buildkite-overwrite-autodetected-variables/meta.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-buildkite-overwrite-autodetected-variables/meta.json
@@ -18,6 +18,7 @@
     "pull_request_id": "99999",
     "pull_request_title": null,
     "is_full_scan": true,
+    "repo_display_name": "a/repo/name",
     "commit_timestamp": "1970-01-01T00:00:00Z",
     "is_sca_scan": false,
     "is_code_scan": false,

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-buildkite/meta.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-buildkite/meta.json
@@ -18,6 +18,7 @@
     "pull_request_id": "35",
     "pull_request_title": null,
     "is_full_scan": true,
+    "repo_display_name": "project_name/project_name",
     "commit_timestamp": "1970-01-01T00:00:00Z",
     "is_sca_scan": false,
     "is_code_scan": false,

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-circleci-overwrite-autodetected-variables/meta.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-circleci-overwrite-autodetected-variables/meta.json
@@ -18,6 +18,7 @@
     "pull_request_id": "99999",
     "pull_request_title": null,
     "is_full_scan": true,
+    "repo_display_name": "a/repo/name",
     "commit_timestamp": "1970-01-01T00:00:00Z",
     "is_sca_scan": false,
     "is_code_scan": false,

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-circleci/meta.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-circleci/meta.json
@@ -18,6 +18,7 @@
     "pull_request_id": "35",
     "pull_request_title": null,
     "is_full_scan": true,
+    "repo_display_name": "project_name/project_name",
     "commit_timestamp": "1970-01-01T00:00:00Z",
     "is_sca_scan": false,
     "is_code_scan": false,

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-github-enterprise/meta.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-github-enterprise/meta.json
@@ -20,6 +20,7 @@
     "is_full_scan": true,
     "repo_id": "4",
     "org_id": "2",
+    "repo_display_name": "project_name/project_name",
     "commit_timestamp": "1970-01-01T00:00:00Z",
     "is_sca_scan": false,
     "is_code_scan": false,

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-github-pr-semgrepconfig/meta.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-github-pr-semgrepconfig/meta.json
@@ -20,6 +20,7 @@
     "is_full_scan": false,
     "repo_id": "4",
     "org_id": "2",
+    "repo_display_name": "project_name/project_name",
     "commit_timestamp": "1970-01-01T00:00:00Z",
     "is_sca_scan": false,
     "is_code_scan": false,

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-github-pr/meta.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-github-pr/meta.json
@@ -20,6 +20,7 @@
     "is_full_scan": false,
     "repo_id": "4",
     "org_id": "2",
+    "repo_display_name": "project_name/project_name",
     "commit_timestamp": "1970-01-01T00:00:00Z",
     "is_sca_scan": false,
     "is_code_scan": false,

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-github-push-special-env-vars/meta.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-github-push-special-env-vars/meta.json
@@ -20,6 +20,7 @@
     "is_full_scan": true,
     "repo_id": "4",
     "org_id": "2",
+    "repo_display_name": "project_name/project_name",
     "commit_timestamp": "1970-01-01T00:00:00Z",
     "is_sca_scan": false,
     "is_code_scan": false,

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-github-push/meta.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-github-push/meta.json
@@ -20,6 +20,7 @@
     "is_full_scan": true,
     "repo_id": "4",
     "org_id": "2",
+    "repo_display_name": "project_name/project_name",
     "commit_timestamp": "1970-01-01T00:00:00Z",
     "is_sca_scan": false,
     "is_code_scan": false,

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-gitlab-push/meta.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-gitlab-push/meta.json
@@ -18,6 +18,7 @@
     "pull_request_id": null,
     "pull_request_title": null,
     "is_full_scan": true,
+    "repo_display_name": "project_name/project_name",
     "commit_timestamp": "1970-01-01T00:00:00Z",
     "is_sca_scan": false,
     "is_code_scan": false,

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-gitlab-special-env-vars/meta.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-gitlab-special-env-vars/meta.json
@@ -18,6 +18,7 @@
     "pull_request_id": "unused-iid-test-placeholder",
     "pull_request_title": "unused-merge-request-title-test-placeholder",
     "is_full_scan": false,
+    "repo_display_name": "project_name/project_name",
     "commit_timestamp": "1970-01-01T00:00:00Z",
     "base_sha": "sanitized",
     "start_sha": "unused-commit-test-placeholder",

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-gitlab/meta.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-gitlab/meta.json
@@ -18,6 +18,7 @@
     "pull_request_id": "unused-iid-test-placeholder",
     "pull_request_title": "unused-merge-request-title-test-placeholder",
     "is_full_scan": false,
+    "repo_display_name": "project_name/project_name",
     "commit_timestamp": "1970-01-01T00:00:00Z",
     "base_sha": "sanitized",
     "start_sha": "unused-commit-test-placeholder",

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/meta.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/meta.json
@@ -18,6 +18,7 @@
     "pull_request_id": null,
     "pull_request_title": null,
     "is_full_scan": true,
+    "repo_display_name": "a/repo/name",
     "commit_timestamp": "1970-01-01T00:00:00Z",
     "is_sca_scan": false,
     "is_code_scan": false,

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-jenkins-overwrite-autodetected-variables/meta.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-jenkins-overwrite-autodetected-variables/meta.json
@@ -18,6 +18,7 @@
     "pull_request_id": null,
     "pull_request_title": null,
     "is_full_scan": true,
+    "repo_display_name": "a/repo/name",
     "commit_timestamp": "1970-01-01T00:00:00Z",
     "is_sca_scan": false,
     "is_code_scan": false,

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-jenkins/meta.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-jenkins/meta.json
@@ -18,6 +18,7 @@
     "pull_request_id": null,
     "pull_request_title": null,
     "is_full_scan": true,
+    "repo_display_name": "org/repo",
     "commit_timestamp": "1970-01-01T00:00:00Z",
     "is_sca_scan": false,
     "is_code_scan": false,

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-local/meta.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-local/meta.json
@@ -18,6 +18,7 @@
     "pull_request_id": null,
     "pull_request_title": null,
     "is_full_scan": true,
+    "repo_display_name": "checkout_project_name",
     "commit_timestamp": "1970-01-01T00:00:00Z",
     "is_sca_scan": false,
     "is_code_scan": false,

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-self-hosted/meta.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-self-hosted/meta.json
@@ -18,6 +18,7 @@
     "pull_request_id": "35",
     "pull_request_title": null,
     "is_full_scan": true,
+    "repo_display_name": "org_name/project_name/project_name",
     "commit_timestamp": "1970-01-01T00:00:00Z",
     "is_sca_scan": false,
     "is_code_scan": false,

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-travis-overwrite-autodetected-variables/meta.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-travis-overwrite-autodetected-variables/meta.json
@@ -18,6 +18,7 @@
     "pull_request_id": "99999",
     "pull_request_title": null,
     "is_full_scan": true,
+    "repo_display_name": "a/repo/name",
     "commit_timestamp": "1970-01-01T00:00:00Z",
     "is_sca_scan": false,
     "is_code_scan": false,

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-travis/meta.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-travis/meta.json
@@ -18,6 +18,7 @@
     "pull_request_id": "35",
     "pull_request_title": null,
     "is_full_scan": true,
+    "repo_display_name": "project_name/project_name",
     "commit_timestamp": "1970-01-01T00:00:00Z",
     "is_sca_scan": false,
     "is_code_scan": false,

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-unparsable_url/meta.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/autofix-unparsable_url/meta.json
@@ -18,6 +18,7 @@
     "pull_request_id": "35",
     "pull_request_title": null,
     "is_full_scan": true,
+    "repo_display_name": "org_name/project_name/project_name",
     "commit_timestamp": "1970-01-01T00:00:00Z",
     "is_sca_scan": false,
     "is_code_scan": false,

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-azure-pipelines-overwrite-autodetected-variables/meta.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-azure-pipelines-overwrite-autodetected-variables/meta.json
@@ -18,6 +18,7 @@
     "pull_request_id": "34566",
     "pull_request_title": null,
     "is_full_scan": true,
+    "repo_display_name": "a/repo/name",
     "commit_timestamp": "1970-01-01T00:00:00Z",
     "is_sca_scan": false,
     "is_code_scan": false,

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-azure-pipelines/meta.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-azure-pipelines/meta.json
@@ -18,6 +18,7 @@
     "pull_request_id": "1234",
     "pull_request_title": null,
     "is_full_scan": true,
+    "repo_display_name": "project_name/project_name",
     "commit_timestamp": "1970-01-01T00:00:00Z",
     "is_sca_scan": false,
     "is_code_scan": false,

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-bitbucket-overwrite-autodetected-variables/meta.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-bitbucket-overwrite-autodetected-variables/meta.json
@@ -18,6 +18,7 @@
     "pull_request_id": "99999",
     "pull_request_title": null,
     "is_full_scan": true,
+    "repo_display_name": "a/repo/name",
     "commit_timestamp": "1970-01-01T00:00:00Z",
     "is_sca_scan": false,
     "is_code_scan": false,

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-bitbucket/meta.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-bitbucket/meta.json
@@ -18,6 +18,7 @@
     "pull_request_id": "35",
     "pull_request_title": null,
     "is_full_scan": true,
+    "repo_display_name": "project_name/project_name",
     "commit_timestamp": "1970-01-01T00:00:00Z",
     "is_sca_scan": false,
     "is_code_scan": false,

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-buildkite-overwrite-autodetected-variables/meta.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-buildkite-overwrite-autodetected-variables/meta.json
@@ -18,6 +18,7 @@
     "pull_request_id": "99999",
     "pull_request_title": null,
     "is_full_scan": true,
+    "repo_display_name": "a/repo/name",
     "commit_timestamp": "1970-01-01T00:00:00Z",
     "is_sca_scan": false,
     "is_code_scan": false,

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-buildkite/meta.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-buildkite/meta.json
@@ -18,6 +18,7 @@
     "pull_request_id": "35",
     "pull_request_title": null,
     "is_full_scan": true,
+    "repo_display_name": "project_name/project_name",
     "commit_timestamp": "1970-01-01T00:00:00Z",
     "is_sca_scan": false,
     "is_code_scan": false,

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-circleci-overwrite-autodetected-variables/meta.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-circleci-overwrite-autodetected-variables/meta.json
@@ -18,6 +18,7 @@
     "pull_request_id": "99999",
     "pull_request_title": null,
     "is_full_scan": true,
+    "repo_display_name": "a/repo/name",
     "commit_timestamp": "1970-01-01T00:00:00Z",
     "is_sca_scan": false,
     "is_code_scan": false,

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-circleci/meta.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-circleci/meta.json
@@ -18,6 +18,7 @@
     "pull_request_id": "35",
     "pull_request_title": null,
     "is_full_scan": true,
+    "repo_display_name": "project_name/project_name",
     "commit_timestamp": "1970-01-01T00:00:00Z",
     "is_sca_scan": false,
     "is_code_scan": false,

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-github-enterprise/meta.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-github-enterprise/meta.json
@@ -20,6 +20,7 @@
     "is_full_scan": true,
     "repo_id": "4",
     "org_id": "2",
+    "repo_display_name": "project_name/project_name",
     "commit_timestamp": "1970-01-01T00:00:00Z",
     "is_sca_scan": false,
     "is_code_scan": false,

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-github-pr-semgrepconfig/meta.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-github-pr-semgrepconfig/meta.json
@@ -20,6 +20,7 @@
     "is_full_scan": false,
     "repo_id": "4",
     "org_id": "2",
+    "repo_display_name": "project_name/project_name",
     "commit_timestamp": "1970-01-01T00:00:00Z",
     "is_sca_scan": false,
     "is_code_scan": false,

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-github-pr/meta.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-github-pr/meta.json
@@ -20,6 +20,7 @@
     "is_full_scan": false,
     "repo_id": "4",
     "org_id": "2",
+    "repo_display_name": "project_name/project_name",
     "commit_timestamp": "1970-01-01T00:00:00Z",
     "is_sca_scan": false,
     "is_code_scan": false,

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-github-push-special-env-vars/meta.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-github-push-special-env-vars/meta.json
@@ -20,6 +20,7 @@
     "is_full_scan": true,
     "repo_id": "4",
     "org_id": "2",
+    "repo_display_name": "project_name/project_name",
     "commit_timestamp": "1970-01-01T00:00:00Z",
     "is_sca_scan": false,
     "is_code_scan": false,

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-github-push/meta.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-github-push/meta.json
@@ -20,6 +20,7 @@
     "is_full_scan": true,
     "repo_id": "4",
     "org_id": "2",
+    "repo_display_name": "project_name/project_name",
     "commit_timestamp": "1970-01-01T00:00:00Z",
     "is_sca_scan": false,
     "is_code_scan": false,

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-gitlab-push/meta.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-gitlab-push/meta.json
@@ -18,6 +18,7 @@
     "pull_request_id": null,
     "pull_request_title": null,
     "is_full_scan": true,
+    "repo_display_name": "project_name/project_name",
     "commit_timestamp": "1970-01-01T00:00:00Z",
     "is_sca_scan": false,
     "is_code_scan": false,

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-gitlab-special-env-vars/meta.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-gitlab-special-env-vars/meta.json
@@ -18,6 +18,7 @@
     "pull_request_id": "unused-iid-test-placeholder",
     "pull_request_title": "unused-merge-request-title-test-placeholder",
     "is_full_scan": false,
+    "repo_display_name": "project_name/project_name",
     "commit_timestamp": "1970-01-01T00:00:00Z",
     "base_sha": "sanitized",
     "start_sha": "unused-commit-test-placeholder",

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-gitlab/meta.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-gitlab/meta.json
@@ -18,6 +18,7 @@
     "pull_request_id": "unused-iid-test-placeholder",
     "pull_request_title": "unused-merge-request-title-test-placeholder",
     "is_full_scan": false,
+    "repo_display_name": "project_name/project_name",
     "commit_timestamp": "1970-01-01T00:00:00Z",
     "base_sha": "sanitized",
     "start_sha": "unused-commit-test-placeholder",

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/meta.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/meta.json
@@ -18,6 +18,7 @@
     "pull_request_id": null,
     "pull_request_title": null,
     "is_full_scan": true,
+    "repo_display_name": "a/repo/name",
     "commit_timestamp": "1970-01-01T00:00:00Z",
     "is_sca_scan": false,
     "is_code_scan": false,

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-jenkins-overwrite-autodetected-variables/meta.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-jenkins-overwrite-autodetected-variables/meta.json
@@ -18,6 +18,7 @@
     "pull_request_id": null,
     "pull_request_title": null,
     "is_full_scan": true,
+    "repo_display_name": "a/repo/name",
     "commit_timestamp": "1970-01-01T00:00:00Z",
     "is_sca_scan": false,
     "is_code_scan": false,

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-jenkins/meta.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-jenkins/meta.json
@@ -18,6 +18,7 @@
     "pull_request_id": null,
     "pull_request_title": null,
     "is_full_scan": true,
+    "repo_display_name": "org/repo",
     "commit_timestamp": "1970-01-01T00:00:00Z",
     "is_sca_scan": false,
     "is_code_scan": false,

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-local/meta.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-local/meta.json
@@ -18,6 +18,7 @@
     "pull_request_id": null,
     "pull_request_title": null,
     "is_full_scan": true,
+    "repo_display_name": "checkout_project_name",
     "commit_timestamp": "1970-01-01T00:00:00Z",
     "is_sca_scan": false,
     "is_code_scan": false,

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-self-hosted/meta.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-self-hosted/meta.json
@@ -18,6 +18,7 @@
     "pull_request_id": "35",
     "pull_request_title": null,
     "is_full_scan": true,
+    "repo_display_name": "org_name/project_name/project_name",
     "commit_timestamp": "1970-01-01T00:00:00Z",
     "is_sca_scan": false,
     "is_code_scan": false,

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-travis-overwrite-autodetected-variables/meta.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-travis-overwrite-autodetected-variables/meta.json
@@ -18,6 +18,7 @@
     "pull_request_id": "99999",
     "pull_request_title": null,
     "is_full_scan": true,
+    "repo_display_name": "a/repo/name",
     "commit_timestamp": "1970-01-01T00:00:00Z",
     "is_sca_scan": false,
     "is_code_scan": false,

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-travis/meta.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-travis/meta.json
@@ -18,6 +18,7 @@
     "pull_request_id": "35",
     "pull_request_title": null,
     "is_full_scan": true,
+    "repo_display_name": "project_name/project_name",
     "commit_timestamp": "1970-01-01T00:00:00Z",
     "is_sca_scan": false,
     "is_code_scan": false,

--- a/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-unparsable_url/meta.json
+++ b/cli/tests/e2e-pro/snapshots/test_ci/test_full_run/noautofix-unparsable_url/meta.json
@@ -18,6 +18,7 @@
     "pull_request_id": "35",
     "pull_request_title": null,
     "is_full_scan": true,
+    "repo_display_name": "org_name/project_name/project_name",
     "commit_timestamp": "1970-01-01T00:00:00Z",
     "is_sca_scan": false,
     "is_code_scan": false,

--- a/src/osemgrep/cli_ci/Git_metadata.ml
+++ b/src/osemgrep/cli_ci/Git_metadata.ml
@@ -42,10 +42,15 @@ let env : env Term.t =
       value & opt (some string) None & info [ "semgrep-repo-name" ] ~env ~doc)
   in
   let semgrep_repo_display_name =
-    let doc = "The name the repository should be displayed as for this scan. Setting it allows users to scan individual repos in one monorepo separately." in
+    let doc =
+      "The name the repository should be displayed as for this scan. Setting \
+       it allows users to scan individual repos in one monorepo separately."
+    in
     let env = XCmd.Env.info "SEMGREP_REPO_DISPLAY_NAME" in
     Arg.(
-      value & opt (some string) None & info [ " semgrep-repo-display-name" ] ~env ~doc)
+      value
+      & opt (some string) None
+      & info [ " semgrep-repo-display-name" ] ~env ~doc)
   in
   let semgrep_repo_url =
     let doc = "The URL of the Git repository." in
@@ -86,8 +91,9 @@ let env : env Term.t =
     let env = XCmd.Env.info "SEMGREP_BRANCH" in
     Arg.(value & opt (some string) None & info [ "semgrep-branch" ] ~env ~doc)
   in
-  let run _SEMGREP_REPO_NAME _SEMGREP_REPO_DISPLAY_NAME _SEMGREP_REPO_URL _SEMGREP_COMMIT _SEMGREP_JOB_URL
-      _SEMGREP_PR_ID _SEMGREP_PR_TITLE _SEMGREP_BRANCH =
+  let run _SEMGREP_REPO_NAME _SEMGREP_REPO_DISPLAY_NAME _SEMGREP_REPO_URL
+      _SEMGREP_COMMIT _SEMGREP_JOB_URL _SEMGREP_PR_ID _SEMGREP_PR_TITLE
+      _SEMGREP_BRANCH =
     {
       _SEMGREP_REPO_NAME;
       _SEMGREP_REPO_DISPLAY_NAME;
@@ -100,8 +106,9 @@ let env : env Term.t =
     }
   in
   Term.(
-    const run $ semgrep_repo_name $ semgrep_repo_display_name $ semgrep_repo_url $ semgrep_commit
-    $ semgrep_job_url $ semgrep_pr_id $ semgrep_pr_title $ semgrep_branch)
+    const run $ semgrep_repo_name $ semgrep_repo_display_name $ semgrep_repo_url
+    $ semgrep_commit $ semgrep_job_url $ semgrep_pr_id $ semgrep_pr_title
+    $ semgrep_branch)
 
 (*****************************************************************************)
 (* Entry point *)

--- a/src/osemgrep/cli_ci/Git_metadata.ml
+++ b/src/osemgrep/cli_ci/Git_metadata.ml
@@ -18,6 +18,7 @@ module XCmd = Cmdliner.Cmd
 
 type env = {
   _SEMGREP_REPO_NAME : string option;
+  _SEMGREP_REPO_DISPLAY_NAME : string option;
   _SEMGREP_REPO_URL : Uri.t option;
   _SEMGREP_COMMIT : Digestif.SHA1.t option;
   _SEMGREP_JOB_URL : Uri.t option;
@@ -39,6 +40,12 @@ let env : env Term.t =
     let env = XCmd.Env.info "SEMGREP_REPO_NAME" in
     Arg.(
       value & opt (some string) None & info [ "semgrep-repo-name" ] ~env ~doc)
+  in
+  let semgrep_repo_display_name =
+    let doc = "The name the repository should be displayed as for this scan. Setting it allows users to scan individual repos in one monorepo separately." in
+    let env = XCmd.Env.info "SEMGREP_REPO_DISPLAY_NAME" in
+    Arg.(
+      value & opt (some string) None & info [ " semgrep-repo-display-name" ] ~env ~doc)
   in
   let semgrep_repo_url =
     let doc = "The URL of the Git repository." in
@@ -79,10 +86,11 @@ let env : env Term.t =
     let env = XCmd.Env.info "SEMGREP_BRANCH" in
     Arg.(value & opt (some string) None & info [ "semgrep-branch" ] ~env ~doc)
   in
-  let run _SEMGREP_REPO_NAME _SEMGREP_REPO_URL _SEMGREP_COMMIT _SEMGREP_JOB_URL
+  let run _SEMGREP_REPO_NAME _SEMGREP_REPO_DISPLAY_NAME _SEMGREP_REPO_URL _SEMGREP_COMMIT _SEMGREP_JOB_URL
       _SEMGREP_PR_ID _SEMGREP_PR_TITLE _SEMGREP_BRANCH =
     {
       _SEMGREP_REPO_NAME;
+      _SEMGREP_REPO_DISPLAY_NAME;
       _SEMGREP_REPO_URL;
       _SEMGREP_COMMIT;
       _SEMGREP_JOB_URL;
@@ -92,7 +100,7 @@ let env : env Term.t =
     }
   in
   Term.(
-    const run $ semgrep_repo_name $ semgrep_repo_url $ semgrep_commit
+    const run $ semgrep_repo_name $ semgrep_repo_display_name $ semgrep_repo_url $ semgrep_commit
     $ semgrep_job_url $ semgrep_pr_id $ semgrep_pr_title $ semgrep_branch)
 
 (*****************************************************************************)
@@ -123,6 +131,7 @@ class meta caps ~scan_environment ~(baseline_ref : Digestif.SHA1.t option) env =
         repository = self#repo_name;
         (* OPTIONAL for semgrep backed *)
         repo_url = self#repo_url;
+        repo_display_name = Some self#repo_display_name;
         branch = self#branch;
         ci_job_url = self#ci_job_url;
         commit = self#commit_sha;
@@ -161,6 +170,11 @@ class meta caps ~scan_environment ~(baseline_ref : Digestif.SHA1.t option) env =
               [ "rev-parse"; "--show-toplevel" ]
           in
           Fpath.basename (Fpath.v str)
+
+    method repo_display_name =
+      match env._SEMGREP_REPO_DISPLAY_NAME with
+      | Some repo_display_name -> repo_display_name
+      | None -> self#repo_name
 
     method repo_url =
       match env._SEMGREP_REPO_URL with

--- a/src/osemgrep/cli_ci/Git_metadata.mli
+++ b/src/osemgrep/cli_ci/Git_metadata.mli
@@ -4,6 +4,7 @@
 
 type env = {
   _SEMGREP_REPO_NAME : string option;
+  _SEMGREP_REPO_DISPLAY_NAME : string option;
   _SEMGREP_REPO_URL : Uri.t option;
   _SEMGREP_COMMIT : Digestif.SHA1.t option;
   _SEMGREP_JOB_URL : Uri.t option;
@@ -37,6 +38,7 @@ object
   method pr_id : string option
   method pr_title : string option
   method repo_name : string
+  method repo_display_name : string
   method repo_url : Uri.t option
   method merge_base_ref : Digestif.SHA1.t option
 end

--- a/src/osemgrep/cli_ci/Github_metadata.mli
+++ b/src/osemgrep/cli_ci/Github_metadata.mli
@@ -32,6 +32,7 @@ object
   method pr_id : string option
   method pr_title : string option
   method repo_name : string
+  method repo_display_name: string
   method repo_url : Uri.t option
   method merge_base_ref : Digestif.SHA1.t option
 end

--- a/src/osemgrep/cli_ci/Github_metadata.mli
+++ b/src/osemgrep/cli_ci/Github_metadata.mli
@@ -32,7 +32,7 @@ object
   method pr_id : string option
   method pr_title : string option
   method repo_name : string
-  method repo_display_name: string
+  method repo_display_name : string
   method repo_url : Uri.t option
   method merge_base_ref : Digestif.SHA1.t option
 end


### PR DESCRIPTION
Closes #8953 

People running Semgrep on monorepos may want to scan the sub repositories separately. Add a repo display name separate from the actual repo name to allow people to configure this.

Test plan: 

Added a print statement on `ci.py` line 294 to output `project_meta`. Here's the result:
```
➜  engine git:(emma/gh-8953-allow-overriding-display-name) ✗  SEMGREP_REPO_DISPLAY_NAME="EMMA_TESTING_NAME" semgrep ci --dry-run

                  
                  
┌────────────────┐
│ Debugging Info │
└────────────────┘
                  
  SCAN ENVIRONMENT
  versions    - semgrep 1.59.1 on python 3.11.7                        
  environment - running in environment git, triggering event is unknown
            
  CONNECTION
ProjectMetadata(semgrep_version=Version(value='1.59.1'), scan_environment='git', repository='semgrep', repo_url=Uri(value='https://github.com/semgrep/semgrep'), branch='emma/gh-8953-allow-overriding-display-name', commit=Sha1(value='67b81f5f1b42a594d17b87ace32b08b80186256e'), commit_title="Not sure why pre-commit didn't run", commit_author_email='emma@semgrep.com', commit_author_name='Emma Jin', commit_author_username=None, commit_author_image_url=None, ci_job_url=None, on='unknown', pull_request_author_username=None, pull_request_author_image_url=None, pull_request_id=None, pull_request_title=None, is_full_scan=True, repo_id=None, org_id=None, repo_display_name='EMMA_TESTING_NAME', commit_timestamp=Datetime(value='2024-02-12T16:23:40'), base_sha=None, start_sha=None, is_sca_scan=False, is_code_scan=False, is_secrets_scan=False)
  Initializing scan   .    
```

I also ran with just `SEMGREP_REPO_NAME` overridden to check that this also affects the display name.

```
➜  engine git:(emma/gh-8953-allow-overriding-display-name) ✗  SEMGREP_REPO_NAME="EMMA_TESTING_NAME" semgrep ci --dry-run 

                  
                  
┌────────────────┐
│ Debugging Info │
└────────────────┘
                  
  SCAN ENVIRONMENT
  versions    - semgrep 1.59.1 on python 3.11.7                        
  environment - running in environment git, triggering event is unknown
            
  CONNECTION
ProjectMetadata(semgrep_version=Version(value='1.59.1'), scan_environment='git', repository='EMMA_TESTING_NAME', repo_url=Uri(value='https://github.com/semgrep/semgrep'), branch='emma/gh-8953-allow-overriding-display-name', commit=Sha1(value='67b81f5f1b42a594d17b87ace32b08b80186256e'), commit_title="Not sure why pre-commit didn't run", commit_author_email='emma@semgrep.com', commit_author_name='Emma Jin', commit_author_username=None, commit_author_image_url=None, ci_job_url=None, on='unknown', pull_request_author_username=None, pull_request_author_image_url=None, pull_request_id=None, pull_request_title=None, is_full_scan=True, repo_id=None, org_id=None, repo_display_name='EMMA_TESTING_NAME', commit_timestamp=Datetime(value='2024-02-12T16:23:40'), base_sha=None, start_sha=None, is_sca_scan=False, is_code_scan=False, is_secrets_scan=False)
  Initializing scan  ..              
```

