### PR TITLE
fix: remove --help to get docker description to match expectations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -231,7 +231,7 @@ RUN printf "[safe]\n	directory = /src"  > ~semgrep/.gitconfig && \
 # In case of problems, if you need to debug the docker image, run 'docker build .',
 # identify the SHA of the build image and run 'docker run -it <sha> /bin/bash'
 # to interactively explore the docker image.
-CMD ["semgrep", "--help"]
+CMD ["semgrep"]
 LABEL maintainer="support@semgrep.com"
 
 ###############################################################################


### PR DESCRIPTION
## Description

With the release of our new [`semgrep/semgrep`](https://hub.docker.com/r/semgrep/semgrep) Docker image, I noticed that our provided get started command errors out.

<img width="834" alt="Screenshot 2024-02-09 at 10 36 14 AM" src="https://github.com/semgrep/semgrep/assets/5779832/ca8e9d42-4e8e-410c-9572-945b09ae6c70">

This PR intends to fix the behavior.

### Test Plan
- [x] Building succeeds (`docker build --target semgrep-oss -t zz-semgrep .`)
- [x] Running docker image without arguments shows help (`docker run --rm -v "${PWD}:/src" zz-semgrep`)


🚫  Running docker image with `--help` as instructions show works 😢 