### PR TITLE
Switch semgrep-core to Info log level

### DIFF
--- a/src/core_cli/Core_CLI.ml
+++ b/src/core_cli/Core_CLI.ml
@@ -684,9 +684,8 @@ let main_no_exn_handler (caps : Cap.all_caps) (sys_argv : string array) : unit =
   Logs_.setup_logging ?log_to_file:config.log_to_file
     ?require_one_of_these_tags:None
     ~level:
-      (if config.debug then Some Debug
-         (* else if config.verbose then Some App *)
-       else None)
+      (* TODO: command-line option or env variable to choose the log level *)
+      (if config.debug then Some Debug else Some Info)
     ();
   Logs.info (fun m -> m ~tags "Executed as: %s" (argv |> String.concat " "));
   Logs.info (fun m -> m ~tags "Version: %s" version);


### PR DESCRIPTION
This makes semgrep-core default to the Info log level instead of logging nothing. It used to be the case before #9703 and I turned it off out of a fear of the new log messages that started showing up. See the comments at https://github.com/semgrep/semgrep/pull/9703/files#r1485613988

I'm pleasantly surprised (and slightly worried) that no pytest snapshots need to be updated after this change.

Here's a sample semgrep-core run:
```
~/semgrep $ semgrep-core -l py -e x cli/tests/ 
[00.00][INFO](cli, Core_CLI): Executed as: semgrep-core -l py -e x cli/tests/
[00.00][INFO](cli, Core_CLI): Version: semgrep-core version: 1.60.1
[00.05][WARNING](Core_command): -fast does not work with -f/-e, or you need also -json
cli/tests/e2e-pro/targets/autofix/autofix.py:5
   inputs[x] = 1
cli/tests/e2e-pro/targets/autofix/autofix.py:6
   if inputs[x + 1] == True:
cli/tests/e2e-pro/targets/autofix/python-assert-statement.py:7
 x = "abc"
cli/tests/e2e-pro/targets/autofix/python-ranges.py:8
 foo(x[1])
cli/tests/e2e-pro/targets/autofix/python-ranges.py:9
 foo(x[1, 2])
[00.10][ERROR](Pfff_or_tree_sitter): exn (Parsing_error.Syntax_error (cli/tests/e2e-pro/targets/bad/invalid_python.py:1:10 "\n    ")) with Pfff parser
[00.10][ERROR](Parse_tree_sitter_helpers): Partial errors returned by Tree-sitter parser
node type: ERROR
children: [
  "def"
  identifier
  parameters
  identifier
  "="
  identifier
  "."
  identifier
  "("
  string
  ")"
]
Unrecognized construct
[00.10][ERROR](Pfff_or_tree_sitter): partial errors (1) with TreeSitter parser
WARNING: fail to fully parse cli/tests/e2e-pro/targets/bad/invalid_python.py
cli/tests/e2e-pro/targets/basic/stupid.py:8
     x == x
cli/tests/e2e-pro/targets/basic/stupid.py:8
     x == x
cli/tests/e2e-pro/targets/basic/stupid.py:12
 assertTrue(x == x)
cli/tests/e2e-pro/targets/basic/stupid.py:12
 assertTrue(x == x)
cli/tests/e2e-pro/targets/ci/foo.py:9
     x == x  # nosemgrep
cli/tests/e2e-pro/targets/ci/foo.py:9
     x == x  # nosemgrep
cli/tests/e2e-pro/targets/ci/foo.py:15
     x == 5
cli/tests/e2e-pro/targets/match_based_id/before/join.py:2
 x = z+z
cli/tests/e2e-pro/targets/match_based_id/before/join.py:3
 if z == x:
cli/tests/e2e-pro/targets/message_interpolation/pattern_either_basic.py:2
     print(x)
cli/tests/e2e-pro/targets/message_interpolation/propagated_constant.py:3
        x = 0
cli/tests/e2e-pro/targets/message_interpolation/propagated_constant.py:4
        return x == 0
cli/tests/e2e-pro/targets/multiline/stupid.py:11
 x = """
cli/tests/e2e-pro/targets/taint/taint.py:2
     x = 'test string format {}'.format('foo')
cli/tests/e2e-pro/targets/version-constraints/x.py:1
 x = "hello"
cli/tests/e2e-pro/test_api.py:48
     x = subprocess.run(
cli/tests/e2e-pro/test_api.py:58
     assert x.stdout == ""
cli/tests/e2e-pro/test_api.py:59
     assert x.stderr == ""
cli/tests/e2e/targets/autofix/autofix.py:5
   inputs[x] = 1
cli/tests/e2e/targets/autofix/autofix.py:6
   if inputs[x + 1] == True:
cli/tests/e2e/targets/autofix/python-assert-statement.py:7
 x = "abc"
cli/tests/e2e/targets/autofix/python-ranges.py:8
 foo(x[1])
cli/tests/e2e/targets/autofix/python-ranges.py:9
 foo(x[1, 2])
[00.21][ERROR](Pfff_or_tree_sitter): exn (Parsing_error.Syntax_error (cli/tests/e2e/targets/bad/invalid_python.py:1:10 "\n    ")) with Pfff parser
[00.21][ERROR](Parse_tree_sitter_helpers): Partial errors returned by Tree-sitter parser
node type: ERROR
children: [
  "def"
  identifier
  parameters
  identifier
  "="
  identifier
  "."
  identifier
  "("
  string
  ")"
]
Unrecognized construct
[00.21][ERROR](Pfff_or_tree_sitter): partial errors (1) with TreeSitter parser
WARNING: fail to fully parse cli/tests/e2e/targets/bad/invalid_python.py
cli/tests/e2e/targets/basic/stupid.py:8
     x == x
cli/tests/e2e/targets/basic/stupid.py:8
     x == x
cli/tests/e2e/targets/basic/stupid.py:12
 assertTrue(x == x)
cli/tests/e2e/targets/basic/stupid.py:12
 assertTrue(x == x)
cli/tests/e2e/targets/ci/foo.py:9
     x == x  # nosemgrep
cli/tests/e2e/targets/ci/foo.py:9
     x == x  # nosemgrep
cli/tests/e2e/targets/ci/foo.py:15
     x == 5
cli/tests/e2e/targets/match_based_id/before/join.py:2
 x = z+z
cli/tests/e2e/targets/match_based_id/before/join.py:3
 if z == x:
cli/tests/e2e/targets/message_interpolation/pattern_either_basic.py:2
     print(x)
cli/tests/e2e/targets/message_interpolation/propagated_constant.py:3
        x = 0
cli/tests/e2e/targets/message_interpolation/propagated_constant.py:4
        return x == 0
cli/tests/e2e/targets/multiline/stupid.py:11
 x = """
cli/tests/e2e/targets/taint/taint.py:2
     x = 'test string format {}'.format('foo')
cli/tests/e2e/targets/version-constraints/x.py:1
 x = "hello"
[00.32][ERROR](AST_to_IL): cli/tests/fixtures.py:35:8: Cannot translate Semgrep construct(s) into IL
```