### PR TITLE
refactor: Make Path_test_utils.ml

### DIFF
--- a/libs/paths/Path_test_utils.ml
+++ b/libs/paths/Path_test_utils.ml
@@ -1,0 +1,59 @@
+open Printf
+open Fpath_.Operators
+
+type file_tree = Dir of string * file_tree list | File of string * file_kind
+and file_kind = Regular of string | Symlink of string
+
+let write_file path data =
+  let oc = open_out_bin !!path in
+  output_string oc data;
+  close_out oc
+
+let rec create_files parent (x : file_tree) =
+  match x with
+  | Dir (name, files) ->
+      let dir_path = parent / name in
+      Unix.mkdir !!dir_path 0o777;
+      List.iter (create_files dir_path) files
+  | File (name, Regular data) ->
+      let path = parent / name in
+      write_file path data
+  | File (name, Symlink target_path) ->
+      let link_path = parent / name in
+      Unix.symlink target_path !!link_path
+
+let rec delete_files parent (x : file_tree) =
+  match x with
+  | Dir (name, files) ->
+      let dir_path = parent / name in
+      List.iter (delete_files dir_path) files;
+      Sys.rmdir !!dir_path
+  | File (name, _) -> Sys.remove !!(parent / name)
+
+(*
+   Create a temporary file tree as specified. The user-specified function
+   takes the root folder as argument and can assume that all the files
+   were created according to the specification.
+   Files are deleted automatically.
+*)
+let with_file_trees trees func =
+  let workspace =
+    Fpath.v (Filename.get_temp_dir_name ())
+    (* This is meant only to be used in test code. *)
+    (* nosemgrep: forbid-random *)
+    / sprintf "test-list_files-%i" (Random.bits ())
+  in
+  Unix.mkdir !!workspace 0o777;
+  Common.protect
+    ~finally:(fun () ->
+      try Sys.rmdir !!workspace with
+      | _ -> ())
+    (fun () ->
+      List.iter (create_files workspace) trees;
+      Common.protect
+        ~finally:(fun () -> List.iter (delete_files workspace) trees)
+        (fun () -> func workspace))
+
+(* Convenience function for cases where only one file tree is desired in the
+ * root directory. *)
+let with_file_tree tree func = with_file_trees [ tree ] func

--- a/libs/paths/Unit_list_files.ml
+++ b/libs/paths/Unit_list_files.ml
@@ -2,65 +2,10 @@
    Test List_files
 *)
 
-(* warning 37 [unused-constructor]): constructor X is never used to build
-   values. *)
-[@@@warning "-37"]
-
-open Printf
 open Fpath_.Operators
+open Path_test_utils
 
 let t = Testo.create
-
-type file_tree = Dir of string * file_tree list | File of string * file_kind
-and file_kind = Regular of string | Symlink of string
-
-let write_file path data =
-  let oc = open_out_bin !!path in
-  output_string oc data;
-  close_out oc
-
-let rec create_files parent (x : file_tree) =
-  match x with
-  | Dir (name, files) ->
-      let dir_path = parent / name in
-      Unix.mkdir !!dir_path 0o777;
-      List.iter (create_files dir_path) files
-  | File (name, Regular data) ->
-      let path = parent / name in
-      write_file path data
-  | File (name, Symlink target_path) ->
-      let link_path = parent / name in
-      Unix.symlink target_path !!link_path
-
-let rec delete_files parent (x : file_tree) =
-  match x with
-  | Dir (name, files) ->
-      let dir_path = parent / name in
-      List.iter (delete_files dir_path) files;
-      Sys.rmdir !!dir_path
-  | File (name, _) -> Sys.remove !!(parent / name)
-
-(*
-   Create a temporary file tree as specified. The user-specified function
-   takes the root folder as argument and can assume that all the files
-   were created according to the specification.
-   Files are deleted automatically.
-*)
-let with_file_tree tree func =
-  let workspace =
-    Fpath.v (Filename.get_temp_dir_name ())
-    / sprintf "test-list_files-%i" (Random.bits ())
-  in
-  Unix.mkdir !!workspace 0o777;
-  Common.protect
-    ~finally:(fun () ->
-      try Sys.rmdir !!workspace with
-      | _ -> ())
-    (fun () ->
-      create_files workspace tree;
-      Common.protect
-        ~finally:(fun () -> delete_files workspace tree)
-        (fun () -> func workspace))
 
 let test_regular_file_as_root () =
   with_file_tree


### PR DESCRIPTION
I've encountered another case where it is helpful to create a directory with a variety of files in it, in order to set up a test. We could mock, but that's more trouble and this allows for a more authentic integration test anyway.

This also introduces a new variant of `with_file_tree`: `with_file_trees`, which can be used in cases where we want multiple files to exist in the automatically-created workspace directory.

Test plan: Automated tests

