### PR TITLE
Masking another JSON field that changes frequently

### DIFF
--- a/cli/tests/conftest.py
+++ b/cli/tests/conftest.py
@@ -317,6 +317,8 @@ class SemgrepResult:
         stderr = mask_variable_text(
             self.raw_stderr, mask, clean_fingerprint=self.clean_fingerprint
         )
+        # This is a list of pairs (title, data) containing different
+        # kinds of output to put into the snapshot.
         sections = {
             "command": mask_variable_text(
                 self.command, mask, clean_fingerprint=self.clean_fingerprint
@@ -331,6 +333,7 @@ class SemgrepResult:
             sections["stdout - plain"] == sections["stdout - color"]
             and sections["stderr - plain"] == sections["stderr - color"]
         ):
+            # Minimize duplicate output.
             sections["stdout - color"] = "<same as above: stdout - plain>"
             sections["stderr - color"] = "<same as above: stderr - plain>"
         return "\n\n".join(

--- a/cli/tests/e2e/snapshots/test_metrics/test_metrics_payload/pro_flag0/metrics-payload.json
+++ b/cli/tests/e2e/snapshots/test_metrics/test_metrics_payload/pro_flag0/metrics-payload.json
@@ -10,7 +10,7 @@
     "os": "Linux",
     "projectHash": null,
     "rulesHash": "7f693c12172d20798fe56ef8555cf42accb11ae6fc115d0d87405f2a988e9805",
-    "version": "x.x.x"
+    "version": "<MASKED DIGITS>.<MASKED DIGITS>.<MASKED DIGITS>"
   },
   "errors": {
     "errors": [],
@@ -56,7 +56,7 @@
         "size": 300
       }
     ],
-    "maxMemoryBytes": 42336256,
+    "maxMemoryBytes": "<MASKED DIGITS>",
     "numRules": 2,
     "numTargets": 3,
     "profilingTimes": {


### PR DESCRIPTION
This is way of masking fields is too tricky, not to mention all the untyped, undocumented hackery that's going on. Anyway. This hides the field `maxMemoryBytes`.