### PR TITLE
fix(release): properly escape single line commands in jsonnet

### DIFF
--- a/.github/workflows/release.jsonnet
+++ b/.github/workflows/release.jsonnet
@@ -25,7 +25,10 @@ local version = "${{ steps.get-version.outputs.VERSION }}";
 local get_version_step = {
   name: 'Get the version',
   id: 'get-version',
-  run: 'echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT',
+  // Note the double escape on this single-line command. If this got updated
+  // to a multi-line command, i.e., with |||, then we would only need
+  // a single backslash to escape.
+  run: 'echo "VERSION=${GITHUB_REF/refs\\/tags\\//}" >> $GITHUB_OUTPUT',
 };
 
 // ----------------------------------------------------------------------------

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
     steps:
       - id: get-version
         name: Get the version
-        run: echo "VERSION=${GITHUB_REF/refs/tags//}" >> $GITHUB_OUTPUT
+        run: echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
       - env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         id: wait-draft-release
@@ -99,7 +99,7 @@ jobs:
           echo "token=$TOKEN" >> $GITHUB_OUTPUT
       - id: get-version
         name: Get the version
-        run: echo "VERSION=${GITHUB_REF/refs/tags//}" >> $GITHUB_OUTPUT
+        run: echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
       - uses: actions/checkout@v3
         with:
           submodules: true


### PR DESCRIPTION
Recently we switched to using yq for converting jsonnet to yml.

It seems like we need to escape properly for single-line commands.

Release v1.61.0 ran into issues because of this. We were trying to extract the version number from `refs/tags/v1.61.0`, but because we didn't escape properly, we ended up getting `tags///tags/v1.61.0` instead of `v1.61.0`.

Searched for all occurrences of backslashes in jsonnet files and release.yaml was the only file with problematic occurrences, if I'm not missing anything.

Test plan: actually release 1.61.1 with this change. This change can't be run in dry run mode unfortunately.