### PR TITLE
tainting: Add `exact: false` sinks

### DIFF
--- a/changelog.d/flow-1.changed
+++ b/changelog.d/flow-1.changed
@@ -1,0 +1,10 @@
+taint-mode: Added `exact: false` sinks so that one can specify that _anything_
+inside a code region is a sink, e.g. `if (...) { ... }`. This used to be the
+semantics of sink specifications until Semgrep 1.1.0, when we made sink matching
+more precise by default. Now we allow reverting to the old semantics.
+
+In addition, when `exact: true` (the default), we simplified the heuristic used
+to support traditional `sink(...)`-like specs together with the option
+`taint_assume_safe_functions: true`, now we will consider that if the spec
+formula is not a `patterns` with a `focus-metavarible`, then we must look for
+taint in the arguments of a function call.

--- a/src/core/Rule.ml
+++ b/src/core/Rule.ml
@@ -179,6 +179,10 @@ and taint_source = {
   source_id : string;  (** See 'Parse_rule.parse_taint_source'. *)
   source_formula : formula;
   source_exact : bool;
+      (** If 'false' (the default), if the formula were e.g. `source(...)`, then the
+      * `ok` inside `source(sink(ok))` is considered tainted, and `sink(ok)` is
+      * reported. If 'true', only the entire `source(sink(ok))` expression will be
+      * considered tainted, and `sink(ok)` is fine. *)
   source_by_side_effect : by_side_effect;
   source_control : bool;
   label : string;
@@ -210,6 +214,11 @@ and taint_sanitizer = {
   sanitizer_id : string;
   sanitizer_formula : formula;
   sanitizer_exact : bool;
+      (** If 'false' (the default), if the formula were e.g. `sanitize(...)`, then
+      * the `tainted` inside `sanitize(sink(tainted))` is considered sanitized,
+      * and `sink(tainted)` is fine. If 'true', only the entire expression
+      * `sanitize(sink(tainted))` will be considered sanitized, and `sink(tainted)`
+      * will be reported. *)
   sanitizer_by_side_effect : bool;
   not_conflicting : bool;
       (* If [not_conflicting] is enabled, the sanitizer cannot conflict with
@@ -230,6 +239,12 @@ and taint_sanitizer = {
 and taint_sink = {
   sink_id : string;  (** See 'Parse_rule.parse_taint_sink'. *)
   sink_formula : formula;
+  sink_exact : bool;
+      (** If 'true' (the default), if the formula were e.g. `sink(...)`, then the
+      * `tainted` inside `sink(if tainted then ok1 else ok2)` is not considered a
+      * sink, and nothing is reported. If 'false', then every subexpression in
+      * `sink(if tainted then ok1 else ok2)` is considered a sink, and we report
+      * a finding due to `tainted`. *)
   sink_requires : precondition_with_range option;
       (* A Boolean expression over taint labels. See also 'taint_source'.
        * The sink will only trigger a finding if the data that reaches it
@@ -237,39 +252,13 @@ and taint_sink = {
        *)
   sink_at_exit : bool;
       (* Whether this sink only applies to instructions at exit positions. *)
-  sink_is_func_with_focus : bool;
-      (* True if the 'sink_formula' has the following shape:
+  sink_has_focus : bool;
+      (* True if the 'sink_formula' has "focus", so it matches something and then
+       * focuses on a specific part of the match.
        *
-       *     patterns:
-       *     - pattern: <func>(<args>)
-       *     - focus-metavariable: $MVAR
-       *
-       * or, more generally, a shape like:
-       *
-       *     patterns:
-       *     - pattern-either:
-       *       - patterns:
-       *         - pattern-inside: |
-       *             <P>
-       *         - pattern: <func>(<args>)
-       *       - ...
-       *     - focus-metavariable: $MVAR
-       *
-       * that is, it matches a function call, and focuses on a specific part of
-       * the match.
-       *
-       * Then we infer that there is a preference for a "more precise" match of
-       * the sink, in constrast with other sink patterns such as `sink(...)`. We
-       * infer that the function call itself is not the sink, but more likely it
-       * is either the <func> or one (or more) of the <args>.
-       *
-       * WHY BOTHER WITH ALL THIS? Well, because for a long time most sink specs
-       * were of the form `sink(...)` and we want to maintain backwards
-       * compatibility for all those rules out there.
+       * See NOTE(sink_has_focus) in module 'Dataflow_tainting' and
+       * `Rule.is_formula_with_focus`.
        *)
-      (* TODO: Add `exact: true` option to sinks so one can skip this heuristic, and
-       * it could be a good default for "syntax 2.0". The current behavior could be
-       * `exact: compat`, and the old behavior could be `exact: false`. *)
 }
 
 (* e.g. if we want to specify that adding tainted data to a `HashMap` makes
@@ -322,50 +311,12 @@ let get_sink_requires { sink_requires; _ } =
   | None -> PLabel default_source_label
   | Some { precondition; _ } -> precondition
 
-(* Check if a formula is matching a function call and focusing on one of
- * its subexpressions.
+(* Check if a formula has "focus" (i.e., `focus-metavariable` in syntax 1.0)
  *
- * See 'taint_sink', field 'sink_is_func_with_focus'. *)
-let is_sink_func_with_focus sink_formula =
-  let rec is_inside_or_not = function
-    | Inside _
-    | Not _ ->
-        true
-    | Or (_, formulas) -> List.for_all is_inside_or_not formulas
-    | P _
-    | And _
-    | Anywhere _ ->
-        false
-  in
-  let rec is_call_pattern = function
-    | P { pat = Sem ((lazy (E { e = Call _; _ })), _); _ } -> true
-    | Or (_tok, formulas) ->
-        (* Each case in an 'Or' is independent, all must be call patterns. *)
-        List.for_all is_call_pattern formulas
-    | And (_, { conjuncts; focus = []; _ }) ->
-        (* NOTE: No `focus-metavariable:` here to make sure this is matching a call. *)
-        is_call_pattern_conjuncts conjuncts
-    | P _
-    | Inside _
-    | Not _
-    | And _
-    | Anywhere _ ->
-        false
-  and is_call_pattern_conjuncts conjuncts =
-    (* The conjuncts that are 'inside' or 'not' (or an OR of those) can be
-     * disregarded, they just provide context. But the remaining conjuncts
-     * must all correspond to a func-call pattern. *)
-    let remaining_conjuncts =
-      List.filter (fun f -> not (is_inside_or_not f)) conjuncts
-    in
-    remaining_conjuncts <> []
-    && List.for_all is_call_pattern remaining_conjuncts
-  in
-  match sink_formula with
-  (* THINK: Should we just assume that if there is 'focus' then the match should
-   * be exact regardless of whether the 'conjuncts' are matching a function call? *)
-  | And (_, { conjuncts; focus = [ _focus ]; _ }) ->
-      is_call_pattern_conjuncts conjuncts
+ * See 'taint_sink', field 'sink_has_focus'. *)
+let is_formula_with_focus formula =
+  match formula with
+  | And (_, { conjuncts = _; conditions = _; focus = _ :: _ }) -> true
   | __else__ -> false
 
 (*****************************************************************************)

--- a/src/metachecking/Translate_rule.ml
+++ b/src/metachecking/Translate_rule.ml
@@ -125,18 +125,20 @@ and translate_taint_sink
     {
       sink_id = _;
       sink_formula;
+      sink_exact;
       sink_requires;
       sink_at_exit;
-      sink_is_func_with_focus = _;
+      sink_has_focus = _;
     } : [> `O of (string * Yaml.value) list ] =
   let (`O sink_f) = translate_formula sink_formula in
+  let exact_obj = if sink_exact then [] else [ ("exact", `Bool false) ] in
   let at_exit_obj = if sink_at_exit then [ ("at-exit", `Bool true) ] else [] in
   let requires_obj =
     match sink_requires with
     | None -> []
     | Some { range; _ } -> [ ("requires", `String (range_to_string range)) ]
   in
-  `O (List.concat [ sink_f; requires_obj; at_exit_obj ])
+  `O (List.concat [ sink_f; exact_obj; requires_obj; at_exit_obj ])
 
 and translate_taint_sanitizer
     {

--- a/src/parsing/Parse_rule.ml
+++ b/src/parsing/Parse_rule.ml
@@ -395,14 +395,18 @@ let parse_taint_sink ~(is_old : bool) env (key : key) (value : G.expr) :
     let sink_at_exit =
       take_opt dict env parse_bool "at-exit" |> Option.value ~default:false
     in
+    let sink_exact =
+      take_opt dict env parse_bool "exact" |> Option.value ~default:true
+    in
     let sink_formula = f env dict in
-    let sink_is_func_with_focus = Rule.is_sink_func_with_focus sink_formula in
+    let sink_has_focus = Rule.is_formula_with_focus sink_formula in
     {
       R.sink_id;
       sink_formula;
+      sink_exact;
       sink_requires;
       sink_at_exit;
-      sink_is_func_with_focus;
+      sink_has_focus;
     }
   in
   if is_old then
@@ -414,15 +418,14 @@ let parse_taint_sink ~(is_old : bool) env (key : key) (value : G.expr) :
         let sink_formula =
           R.P (Parse_rule_formula.parse_rule_xpattern env value)
         in
-        let sink_is_func_with_focus =
-          Rule.is_sink_func_with_focus sink_formula
-        in
+        let sink_has_focus = Rule.is_formula_with_focus sink_formula in
         {
           sink_id;
           sink_formula;
+          sink_exact = true;
           sink_requires = None;
           sink_at_exit = false;
-          sink_is_func_with_focus;
+          sink_has_focus;
         }
     | Right dict ->
         parse_from_dict dict Parse_rule_formula.parse_formula_from_dict

--- a/src/tainting/Dataflow_tainting.ml
+++ b/src/tainting/Dataflow_tainting.ml
@@ -1568,13 +1568,17 @@ let check_tainted_instr env instr : Taints.t * Lval_env.t =
         let e_taints, lval_env =
           check_function_call_callee { env with lval_env } e
         in
-        (* After we introduced Top_sinks, we need to explicitly support sinks like
-         * `sink(...)` by considering that all of the parameters are sinks. To make
-         * sure that we are backwards compatible, we do this for any sink that does
-         * not match the `Rule.is_func_sink_with_focus` form.
+        (* NOTE(sink_has_focus):
+         * After we made sink specs "exact" by default, we need this trick to
+         * be backwards compatible wrt to specifications like `sink(...)`. Even
+         * if the sink is "exact", if it has NO focus, then we consider that all
+         * of the parameters of the function are sinks. So, even if
+         * `taint_assume_safe_functions: true`, if the spec is `sink(...)`, we
+         * still report `sink(tainted)`.
          *)
         check_orig_if_sink { env with lval_env } instr.iorig all_args_taints
-          ~filter_sinks:(fun m -> not m.spec.sink_is_func_with_focus);
+          ~filter_sinks:(fun m ->
+            not (m.spec.sink_exact && m.spec.sink_has_focus));
         let call_taints, lval_env =
           match
             check_function_signature { env with lval_env } e args args_taints
@@ -1887,7 +1891,9 @@ let (fixpoint :
           |> Seq.map (fun m -> TM.Any m)
         in
         let sinks =
-          orig_is_sink config orig |> List.to_seq |> Seq.map (fun m -> TM.Any m)
+          orig_is_sink config orig |> List.to_seq
+          |> Seq.filter (fun (m : R.taint_sink TM.t) -> m.spec.sink_exact)
+          |> Seq.map (fun m -> TM.Any m)
         in
         sources |> Seq.append sanitizers |> Seq.append sinks)
       flow

--- a/tests/rules/taint_non_exact_sink.py
+++ b/tests/rules/taint_non_exact_sink.py
@@ -1,0 +1,14 @@
+#ruleid: test
+sink(tainted())
+
+#ruleid: test
+sink(ok1 if tainted() else ok2)
+
+#ruleid: test
+sink([ok1 if tainted() else ok2])
+
+#ruleid: test
+sink(not_a_propagator(tainted()))
+
+#ruleid: test
+sink(some_array[tainted()])

--- a/tests/rules/taint_non_exact_sink.yaml
+++ b/tests/rules/taint_non_exact_sink.yaml
@@ -1,0 +1,13 @@
+rules:
+  - id: test
+    languages:
+      - python
+    message: Match
+    mode: taint
+    pattern-sources:
+      - pattern: tainted(...)
+    pattern-sinks:
+      - exact: false
+        pattern: sink(...)
+    severity: WARNING
+


### PR DESCRIPTION
Simplify heuristic to make `exact: true` sinks (the current default) be backwards compatible with `sink(...)` specs, now we simply require that the spec formula is an 'And' with `focus`, so it's trivial to know when the heuristic will trigger.

And add `exact: false` sinks because there are rules that do rely on those old semantics of sink specs.

Closes FLOW-1

test plan:
make test # one new test

