### PR TITLE
chore(ci): explicitly specify permissions for workflows that need them

### DIFF
--- a/.github/workflows/release.jsonnet
+++ b/.github/workflows/release.jsonnet
@@ -390,6 +390,11 @@ local homebrew_core_pr_job =
       ],
     },
   },
+  // These extra permissions are needed by some of the jobs, e.g. build-test-docker.
+  permissions: {
+    contents: 'read',
+    'id-token': 'write',
+  },
   jobs: {
     'park-pypi-packages': park_pypi_packages_job,
     'build-test-docker': build_test_docker_job,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -253,3 +253,6 @@ name: release
           state (like pushing to PyPI/Docker/Homebrew)
         required: true
         type: boolean
+permissions:
+  contents: read
+  id-token: write

--- a/.github/workflows/start-release.jsonnet
+++ b/.github/workflows/start-release.jsonnet
@@ -562,6 +562,11 @@ local notify_failure_job = {
   on: {
     workflow_dispatch: input,
   },
+  // These extra permissions are needed by some of the jobs, e.g. check-semgrep-pro.
+  permissions: {
+    contents: 'read',
+    'id-token': 'write',
+  },
   jobs: {
     'get-version': get_version_job,
     'check-semgrep-pro': check_semgrep_pro_job,

--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -510,3 +510,6 @@ name: start-release
           (branches, tags, images, or PyPI packages).
         required: true
         type: boolean
+permissions:
+  contents: read
+  id-token: write

--- a/.github/workflows/tests.jsonnet
+++ b/.github/workflows/tests.jsonnet
@@ -573,6 +573,7 @@ local ignore_md = {
     } + ignore_md,
   },
   permissions: {
+    'contents': 'read',
     'id-token': 'write',
   },
   jobs: {

--- a/.github/workflows/tests.jsonnet
+++ b/.github/workflows/tests.jsonnet
@@ -572,8 +572,9 @@ local ignore_md = {
       ],
     } + ignore_md,
   },
+  // These extra permissions are needed by some of the jobs, e.g. build-test-javascript.
   permissions: {
-    'contents': 'read',
+    contents: 'write',
     'id-token': 'write',
   },
   jobs: {

--- a/.github/workflows/tests.jsonnet
+++ b/.github/workflows/tests.jsonnet
@@ -572,6 +572,9 @@ local ignore_md = {
       ],
     } + ignore_md,
   },
+  permissions: {
+    'id-token': 'write',
+  },
   jobs: {
     'test-semgrep-core': test_semgrep_core_job,
     'test-osemgrep': test_osemgrep_job,

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -427,5 +427,5 @@ name: tests
       - '**.md'
   workflow_dispatch: null
 permissions:
-  contents: read
+  contents: write
   id-token: write

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -426,3 +426,5 @@ name: tests
     paths-ignore:
       - '**.md'
   workflow_dispatch: null
+permissions:
+  id-token: write

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -427,4 +427,5 @@ name: tests
       - '**.md'
   workflow_dispatch: null
 permissions:
+  contents: read
   id-token: write


### PR DESCRIPTION
We've recently been upgraded to Github enterprise, but because of that, it seems like the default permissions for all workflows are changed. 

Some of the checks that were previously passing are now failing. Now we need to explicitly specify permissions needed (which I think is a good thing for security).

Looked at all jobs that have the permission field and make all the depending of those jobs have the least permissions that would allow all their sub-jobs to be happy.

Test: While some permissions were misconfigured, some checks weren't running, but now all checks (the # of checks match the checks in previous PRs before the enterprise upgrade) are running.