### PR TITLE
chore: update more permissions in workflows

### DIFF
--- a/.github/workflows/libs/gha.libsonnet
+++ b/.github/workflows/libs/gha.libsonnet
@@ -22,7 +22,10 @@
     workflow_call: null,
   },
   write_permissions: {
-    // needed when we want to upload data to s3
+    // Needed when we want to upload data to s3 or more generally
+    // when connecting to cloud services that use Open ID Connect.
+    // More details at
+    // https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect
     'id-token': 'write',
     // needed when the job modifies the repository
     contents: 'write',

--- a/.github/workflows/start-release.jsonnet
+++ b/.github/workflows/start-release.jsonnet
@@ -563,10 +563,7 @@ local notify_failure_job = {
     workflow_dispatch: input,
   },
   // These extra permissions are needed by some of the jobs, e.g. check-semgrep-pro.
-  permissions: {
-    contents: 'read',
-    'id-token': 'write',
-  },
+  permissions: gha.write_permissions,
   jobs: {
     'get-version': get_version_job,
     'check-semgrep-pro': check_semgrep_pro_job,

--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -511,5 +511,5 @@ name: start-release
         required: true
         type: boolean
 permissions:
-  contents: read
+  contents: write
   id-token: write

--- a/.github/workflows/tests.jsonnet
+++ b/.github/workflows/tests.jsonnet
@@ -573,10 +573,7 @@ local ignore_md = {
     } + ignore_md,
   },
   // These extra permissions are needed by some of the jobs, e.g. build-test-javascript.
-  permissions: {
-    contents: 'write',
-    'id-token': 'write',
-  },
+  permissions: gha.write_permissions,
   jobs: {
     'test-semgrep-core': test_semgrep_core_job,
     'test-osemgrep': test_osemgrep_job,


### PR DESCRIPTION
Follow up from https://github.com/semgrep/semgrep/pull/9771

Also needed an extra write permission for start-release that depends on check-semgrep-pro-version (needs write permissions).

Test plan: this update will be used in release v1.61.1.
