### PR TITLE
fix: Add `--` to git diff command

### DIFF
--- a/cli/src/semgrep/git.py
+++ b/cli/src/semgrep/git.py
@@ -178,7 +178,7 @@ class BaselineHandler:
                 cmd = status_cmd
             else:
                 cmd = [*status_cmd, "--merge-base"]
-            cmd += ["--"]  # -- is a sentinel to avoid ambiguity with file names
+            cmd += ["--"]  # -- is a sentinel to avoid ambiguity between branch and file names
             # nosemgrep: python.lang.security.audit.dangerous-subprocess-use.dangerous-subprocess-use
             raw_output = subprocess.run(
                 cmd,
@@ -193,7 +193,7 @@ class BaselineHandler:
                 logger.warn(
                     "git could not find a single branch-off point, so we will compare the baseline commit directly"
                 )
-                status_cmd += ["--"]  # -- is a sentinel to avoid ambiguity with file names
+                status_cmd += ["--"]  # -- is a sentinel to avoid ambiguity between branch and file names
                 # nosemgrep: python.lang.security.audit.dangerous-subprocess-use.dangerous-subprocess-use
                 raw_output = subprocess.run(
                     status_cmd,

--- a/cli/src/semgrep/git.py
+++ b/cli/src/semgrep/git.py
@@ -172,6 +172,7 @@ class BaselineHandler:
             "--ignore-submodules",
             "--relative",
             self._base_commit,
+            "--",  # end of options, start of file paths
         ]
         try:
             if self._is_mergebase:

--- a/cli/src/semgrep/git.py
+++ b/cli/src/semgrep/git.py
@@ -178,9 +178,10 @@ class BaselineHandler:
                 cmd = status_cmd
             else:
                 cmd = [*status_cmd, "--merge-base"]
+            cmd += ["--"]  # -- is a sentinel to avoid ambiguity with file names
             # nosemgrep: python.lang.security.audit.dangerous-subprocess-use.dangerous-subprocess-use
             raw_output = subprocess.run(
-                cmd + ["--"],  # -- is a sentinel to avoid ambiguity with file names
+                cmd,
                 timeout=env.git_command_timeout,
                 capture_output=True,
                 encoding="utf-8",
@@ -192,9 +193,10 @@ class BaselineHandler:
                 logger.warn(
                     "git could not find a single branch-off point, so we will compare the baseline commit directly"
                 )
+                status_cmd += ["--"]  # -- is a sentinel to avoid ambiguity with file names
                 # nosemgrep: python.lang.security.audit.dangerous-subprocess-use.dangerous-subprocess-use
                 raw_output = subprocess.run(
-                    status_cmd + ["--"],  # -- is a sentinel to avoid ambiguity with file names
+                    status_cmd,
                     timeout=env.git_command_timeout,
                     capture_output=True,
                     encoding="utf-8",

--- a/cli/src/semgrep/git.py
+++ b/cli/src/semgrep/git.py
@@ -172,7 +172,6 @@ class BaselineHandler:
             "--ignore-submodules",
             "--relative",
             self._base_commit,
-            "--",  # end of options, start of file paths
         ]
         try:
             if self._is_mergebase:
@@ -181,7 +180,7 @@ class BaselineHandler:
                 cmd = [*status_cmd, "--merge-base"]
             # nosemgrep: python.lang.security.audit.dangerous-subprocess-use.dangerous-subprocess-use
             raw_output = subprocess.run(
-                cmd,
+                cmd + ["--"],  # -- is a sentinel to avoid ambiguity with file names
                 timeout=env.git_command_timeout,
                 capture_output=True,
                 encoding="utf-8",
@@ -195,7 +194,7 @@ class BaselineHandler:
                 )
                 # nosemgrep: python.lang.security.audit.dangerous-subprocess-use.dangerous-subprocess-use
                 raw_output = subprocess.run(
-                    status_cmd,
+                    status_cmd + ["--"],  # -- is a sentinel to avoid ambiguity with file names
                     timeout=env.git_command_timeout,
                     capture_output=True,
                     encoding="utf-8",

--- a/cli/src/semgrep/git.py
+++ b/cli/src/semgrep/git.py
@@ -178,7 +178,8 @@ class BaselineHandler:
                 cmd = status_cmd
             else:
                 cmd = [*status_cmd, "--merge-base"]
-            cmd += ["--"]  # -- is a sentinel to avoid ambiguity between branch and file names
+            # -- is a sentinel to avoid ambiguity between branch and file names
+            cmd += ["--"]
             # nosemgrep: python.lang.security.audit.dangerous-subprocess-use.dangerous-subprocess-use
             raw_output = subprocess.run(
                 cmd,
@@ -193,7 +194,8 @@ class BaselineHandler:
                 logger.warn(
                     "git could not find a single branch-off point, so we will compare the baseline commit directly"
                 )
-                status_cmd += ["--"]  # -- is a sentinel to avoid ambiguity between branch and file names
+                # -- is a sentinel to avoid ambiguity between branch and file names
+                status_cmd += ["--"]
                 # nosemgrep: python.lang.security.audit.dangerous-subprocess-use.dangerous-subprocess-use
                 raw_output = subprocess.run(
                     status_cmd,

--- a/cli/tests/e2e/test_baseline.py
+++ b/cli/tests/e2e/test_baseline.py
@@ -799,8 +799,8 @@ def test_crisscrossing_merges(complex_merge_repo, current, baseline, snapshot):
 
 def test_conflicting_file_and_main_branch_names(git_tmp_path, snapshot):
     # Test when a file in the root dir has the same name as the main branch
-    foo = git_tmp_path / "main"
-    foo.write_text("foo/n")
+    main_file = git_tmp_path / "main"
+    main_file.write_text("this is a file named 'main'\n")
     subprocess.run(["git", "add", "."], check=True, capture_output=True)
     _git_commit(1)
 

--- a/cli/tests/e2e/test_baseline.py
+++ b/cli/tests/e2e/test_baseline.py
@@ -795,3 +795,14 @@ def test_crisscrossing_merges(complex_merge_repo, current, baseline, snapshot):
     output = run_sentinel_scan(base_commit=baseline)
     assert_out_match(snapshot, output, f"stdout.txt")
     assert_err_match(snapshot, output, f"stderr.txt")
+
+
+def test_conflicting_file_and_main_branch_names(git_tmp_path, snapshot):
+    # Test when a file in the root dir has the same name as the main branch
+    foo = git_tmp_path / "main"
+    foo.write_text("foo/n")
+    subprocess.run(["git", "add", "."], check=True, capture_output=True)
+    _git_commit(1)
+
+    # Ambiguity between the main branch and the file should not cause an error
+    run_sentinel_scan(base_commit="main")


### PR DESCRIPTION
## Problem

Some repositories contain a file in the root dir with the same name as that of the main branch. When this is the case, running a git diff against the main branch results in an error.

```
❯ ls
main
[...]

❯ git symbolic-ref HEAD --short
main

❯ git diff main
fatal: ambiguous argument 'main': both revision and filename
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
```

## Solution

Append a `--` to the command as recommended by git. This clarifies we're providing the name of a _branch_ to diff, not the name of a file.

```
❯ git diff main --
```

Adding this parameter has no effect for repositories without a root file with the same name as the main branch, so we can safely add it to our command across the board.