### PR TITLE
fix: handle multiple trailing newline parsing in pyproject.toml and poetry.lock files

### DIFF
--- a/changelog.d/gh-9777.fixed
+++ b/changelog.d/gh-9777.fixed
@@ -1,0 +1,1 @@
+Fixed trailing newline parsing in pyproject.toml and poetry.lock files.

--- a/cli/src/semdep/parsers/poetry.py
+++ b/cli/src/semdep/parsers/poetry.py
@@ -147,7 +147,7 @@ poetry = (
     >> (poetry_dep | poetry_dep_extra | (string("package = []").result(None)))
     .sep_by(new_lines.optional())
     .map(lambda xs: [x for x in xs if x])
-    << string("\n").optional()
+    << new_lines.optional()
 )
 
 
@@ -174,7 +174,7 @@ manifest = (
     >> (manifest_deps | manifest_sections_extra | poetry_source_extra)
     .sep_by(new_lines.optional())
     .map(lambda xs: {y for x in xs if x for y in x})
-    << string("\n").optional()
+    << new_lines.optional()
 )
 
 

--- a/cli/tests/e2e-pro/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awarepython-poetry-sca.yaml-dependency_awaremanifest_parse_error/results.txt
+++ b/cli/tests/e2e-pro/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awarepython-poetry-sca.yaml-dependency_awaremanifest_parse_error/results.txt
@@ -82,7 +82,7 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
   SUPPLY CHAIN RULES
   Nothing to scan.
   Failed to parse [bold]targets/dependency_aware/manifest_parse_error/pyproject.toml[/bold] at [bold]3:1[/bold] -
-  expected one of ['\n', '\n+', '("[^"]*"|[^\\s=]+)\\s*=\\s*', 'EOF', '[', '[[', '[tool.poetry.dependencies]\n']
+  expected one of ['\n+', '("[^"]*"|[^\\s=]+)\\s*=\\s*', 'EOF', '[', '[[', '[tool.poetry.dependencies]\n']
   3 | name ~ "test"
       ^
 

--- a/cli/tests/e2e-pro/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awarepython-poetry-sca.yaml-dependency_awarepoetry_trailing_newlines/results.txt
+++ b/cli/tests/e2e-pro/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awarepython-poetry-sca.yaml-dependency_awarepoetry_trailing_newlines/results.txt
@@ -1,0 +1,54 @@
+=== command
+SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERSION_CACHE_PATH="<MASKED>" SEMGREP_ENABLE_VERSION_CHECK="0" SEMGREP_SEND_METRICS="off" semgrep --strict --config rules/dependency_aware/python-poetry-sca.yaml --json targets/dependency_aware/poetry_trailing_newlines
+=== end of command
+
+=== exit code
+0
+=== end of exit code
+
+=== stdout - plain
+{
+  "errors": [],
+  "interfile_languages_used": [],
+  "paths": {
+    "scanned": [
+      "targets/dependency_aware/poetry_trailing_newlines/poetry.lock"
+    ]
+  },
+  "results": [],
+  "skipped_rules": [],
+  "version": "0.42"
+}
+=== end of stdout - plain
+
+=== stderr - plain
+
+
+┌─────────────┐
+│ Scan Status │
+└─────────────┘
+  Scanning 2 files tracked by git with 0 Code rules, 1 Supply Chain rule:
+
+
+  CODE RULES
+  Nothing to scan.
+
+  SUPPLY CHAIN RULES
+  Nothing to scan.
+
+
+┌──────────────┐
+│ Scan Summary │
+└──────────────┘
+
+Ran 1 rule on 1 file: 0 findings.
+
+=== end of stderr - plain
+
+=== stdout - color
+<same as above: stdout - plain>
+=== end of stdout - color
+
+=== stderr - color
+<same as above: stderr - plain>
+=== end of stderr - color

--- a/cli/tests/e2e-pro/test_dependency_aware_rules.py
+++ b/cli/tests/e2e-pro/test_dependency_aware_rules.py
@@ -188,6 +188,10 @@ pytestmark = pytest.mark.kinda_slow
             "rules/dependency_aware/python-poetry-sca.yaml",
             "dependency_aware/poetry_empty_table",
         ),
+        (
+            "rules/dependency_aware/python-poetry-sca.yaml",
+            "dependency_aware/poetry_trailing_newlines",
+        ),
         # This test should produce a parse error in the manifest file, but it should *still* produce findings, because the lockfile can be parsed
         (
             "rules/dependency_aware/python-poetry-sca.yaml",

--- a/cli/tests/e2e/targets/dependency_aware/poetry_trailing_newlines/poetry.lock
+++ b/cli/tests/e2e/targets/dependency_aware/poetry_trailing_newlines/poetry.lock
@@ -1,6 +1,6 @@
 [[package]]
 category = "main"
-description = "Low-level AMQP client for Python (fork of amqplib)."
+description = "Low-level AMQP client for Python."
 name = "amqp"
 optional = false
 python-versions = ">=3.6"
@@ -10,9 +10,9 @@ version = "5.1.1"
 vine = ">=5.0.0"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -23,9 +23,9 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 version = "0.6.0"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -41,9 +41,9 @@ python = "<3.11"
 version = ">=4"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -55,9 +55,9 @@ python-versions = ">=3.7"
 version = "23.1.0"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -68,9 +68,9 @@ python-versions = "*"
 version = "3.6.4.0"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -86,9 +86,9 @@ jmespath = ">=0.7.1,<1.0.0"
 s3transfer = ">=0.3.0,<0.4.0"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -104,9 +104,9 @@ python-dateutil = ">=2.1,<3.0.0"
 urllib3 = ">=1.25.4,<1.27"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -123,9 +123,9 @@ python = "<3.10"
 version = "*"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -148,9 +148,9 @@ python = "<3.11"
 version = ">=4.1.0"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -171,9 +171,9 @@ pytz = ">0.0-dev"
 vine = ">=5.0.0,<6.0"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -184,9 +184,9 @@ python-versions = ">=3.6"
 version = "2023.7.22"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -201,9 +201,9 @@ version = "1.16.0"
 pycparser = "*"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -214,9 +214,9 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 version = "4.0.0"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -227,9 +227,9 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 version = "7.1.2"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -243,9 +243,9 @@ version = "0.3.0"
 click = ">=7"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -259,9 +259,9 @@ version = "1.1.1"
 click = ">=4.0"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -276,9 +276,9 @@ click = ">=7.0"
 prompt-toolkit = ">=3.0.36"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -289,9 +289,9 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
 version = "5.4"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -305,9 +305,9 @@ version = "0.47.0"
 requests = ">=2.6.0"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -325,9 +325,9 @@ python = ">=3.7"
 version = ">=3.0.0"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -365,9 +365,9 @@ python = ">=3.7"
 version = ">=3"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -378,9 +378,9 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 version = "0.7.1"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -395,9 +395,9 @@ version = "1.2.14"
 wrapt = ">=1.10,<2"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -408,9 +408,9 @@ python-versions = "*"
 version = "0.5.0"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -426,9 +426,9 @@ pytz = "*"
 sqlparse = ">=0.2.2"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -439,9 +439,9 @@ python-versions = "*"
 version = "2.7.1"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -456,9 +456,9 @@ Django = ">=1.6"
 django-fsm = ">=2.1.0"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -475,9 +475,9 @@ future = ">=0.16.0"
 pytz = ">=2016.10"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -491,9 +491,9 @@ version = "3.12.2"
 django = ">=2.2"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -507,9 +507,9 @@ version = "2.0.0"
 defusedxml = ">=0.6.0"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -520,9 +520,9 @@ python-versions = ">=2.7"
 version = "0.4.0"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -534,9 +534,9 @@ python-versions = ">=3.7"
 version = "1.1.3"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -547,9 +547,9 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 version = "0.18.3"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -569,9 +569,9 @@ python = "<3.11"
 version = ">=2.0.0"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -582,9 +582,9 @@ python-versions = ">=3.7"
 version = "3.0.0"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -598,9 +598,9 @@ version = "20.0.4"
 setuptools = ">=3.0"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -623,9 +623,9 @@ singledispatch = "3.4.0.3"
 six = ">=1.11.0"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -636,9 +636,9 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "2.10"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -653,9 +653,9 @@ version = "6.8.0"
 zipp = ">=0.5"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -669,9 +669,9 @@ version = "0.0.1"
 jinja2 = ">=2.7.2"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -685,9 +685,9 @@ version = "2.10.1"
 MarkupSafe = ">=0.23"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -698,9 +698,9 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 version = "0.10.0"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -719,9 +719,9 @@ python = "<3.10"
 version = "*"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -732,9 +732,9 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, != 3.4.*"
 version = "4.9.3"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -745,9 +745,9 @@ python-versions = ">=3.6"
 version = "2.0.1"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -758,9 +758,9 @@ python-versions = ">=3.6"
 version = "4.0.3"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -776,9 +776,9 @@ deprecated = ">=1.2.6"
 importlib-metadata = ">=6.0,<7.0"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -789,9 +789,9 @@ python-versions = "*"
 version = "1.1.0"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -802,9 +802,9 @@ python-versions = "*"
 version = "0.9"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -815,9 +815,9 @@ python-versions = ">=3.6"
 version = "0.17.1"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -831,9 +831,9 @@ version = "3.0.39"
 wcwidth = "*"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -845,9 +845,9 @@ python-versions = ">=3.7"
 version = "4.24.3"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -858,9 +858,9 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "5.8.0"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -871,9 +871,9 @@ python-versions = ">=3.6"
 version = "2.9.8"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -885,9 +885,9 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "2.21"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -901,9 +901,9 @@ version = "2.7.0"
 six = ">=1.5"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -917,9 +917,9 @@ version = "0.7.1"
 click = ">=5.0"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -930,9 +930,9 @@ python-versions = "*"
 version = "2021.1"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -943,9 +943,9 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 version = "3.5.3"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -962,9 +962,9 @@ idna = ">=2.5,<3"
 urllib3 = ">=1.21.1,<1.27"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -978,9 +978,9 @@ version = "0.3.7"
 botocore = ">=1.12.36,<2.0a.0"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "dev"
@@ -991,9 +991,9 @@ python-versions = "*"
 version = "2.53.6"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -1007,9 +1007,9 @@ version = "3.4.0.3"
 six = "*"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -1020,9 +1020,9 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 version = "1.16.0"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -1033,9 +1033,9 @@ python-versions = ">=3.5"
 version = "0.4.4"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -1046,9 +1046,9 @@ python-versions = ">=3.6"
 version = "20.2.0"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -1059,9 +1059,9 @@ python-versions = "*"
 version = "1.4.5.0"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -1072,9 +1072,9 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 version = "1.7.0"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -1085,9 +1085,9 @@ python-versions = ">=3.8"
 version = "4.8.0"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -1098,9 +1098,9 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 version = "1.26.17"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -1111,9 +1111,9 @@ python-versions = ">=3.6"
 version = "5.0.0"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -1124,9 +1124,9 @@ python-versions = "*"
 version = "0.2.8"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -1138,9 +1138,9 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 version = "1.15.0"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -1151,9 +1151,9 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "0.12.0"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -1165,9 +1165,9 @@ python-versions = ">=3.8"
 version = "3.17.0"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -1181,9 +1181,9 @@ version = "5.0"
 setuptools = "*"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [[package]]
 category = "main"
@@ -1197,9 +1197,9 @@ version = "6.0"
 setuptools = "*"
 
 [package.source]
-reference = 'jumo-libs'
+reference = 'libs-libs'
 type = "legacy"
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+url = "https://example.com"
 
 [metadata]
 content-hash = "ef01297f024628704c1559952c6cf60f082af89edd8eeeca52dfc45dca66a884"

--- a/cli/tests/e2e/targets/dependency_aware/poetry_trailing_newlines/poetry.lock
+++ b/cli/tests/e2e/targets/dependency_aware/poetry_trailing_newlines/poetry.lock
@@ -1,0 +1,1286 @@
+[[package]]
+category = "main"
+description = "Low-level AMQP client for Python (fork of amqplib)."
+name = "amqp"
+optional = false
+python-versions = ">=3.6"
+version = "5.1.1"
+
+[package.dependencies]
+vine = ">=5.0.0"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = "A set of tools which enhances ORMs written in Python with more features"
+name = "architect"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "0.6.0"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = "ASGI specs, helper code, and adapters"
+name = "asgiref"
+optional = false
+python-versions = ">=3.7"
+version = "3.7.2"
+
+[package.dependencies]
+[package.dependencies.typing-extensions]
+python = "<3.11"
+version = ">=4"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = "Classes Without Boilerplate"
+marker = "python_version > \"2.7\""
+name = "attrs"
+optional = false
+python-versions = ">=3.7"
+version = "23.1.0"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = "Python multiprocessing fork with improvements and bugfixes"
+name = "billiard"
+optional = false
+python-versions = "*"
+version = "3.6.4.0"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = "The AWS SDK for Python"
+name = "boto3"
+optional = false
+python-versions = ">= 2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
+version = "1.17.8"
+
+[package.dependencies]
+botocore = ">=1.20.8,<1.21.0"
+jmespath = ">=0.7.1,<1.0.0"
+s3transfer = ">=0.3.0,<0.4.0"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = "Low-level, data-driven core of boto 3."
+name = "botocore"
+optional = false
+python-versions = ">= 2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
+version = "1.20.112"
+
+[package.dependencies]
+jmespath = ">=0.7.1,<1.0.0"
+python-dateutil = ">=2.1,<3.0.0"
+urllib3 = ">=1.25.4,<1.27"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = "Python module to generate and modify bytecode"
+marker = "python_version >= \"3.8\""
+name = "bytecode"
+optional = false
+python-versions = ">=3.8"
+version = "0.15.0"
+
+[package.dependencies]
+[package.dependencies.typing-extensions]
+python = "<3.10"
+version = "*"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = "Composable complex class support for attrs and dataclasses."
+marker = "python_version >= \"3.7\""
+name = "cattrs"
+optional = false
+python-versions = ">=3.7"
+version = "23.1.2"
+
+[package.dependencies]
+attrs = ">=20"
+
+[package.dependencies.exceptiongroup]
+python = "<3.11"
+version = "*"
+
+[package.dependencies.typing_extensions]
+python = "<3.11"
+version = ">=4.1.0"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = "Distributed Task Queue."
+name = "celery"
+optional = false
+python-versions = ">=3.6,"
+version = "5.0.5"
+
+[package.dependencies]
+billiard = ">=3.6.3.0,<4.0"
+click = ">=7.0,<8.0"
+click-didyoumean = ">=0.0.3"
+click-plugins = ">=1.1.1"
+click-repl = ">=0.1.6"
+kombu = ">=5.0.0,<6.0"
+pytz = ">0.0-dev"
+vine = ">=5.0.0,<6.0"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = "Python package for providing Mozilla's CA Bundle."
+name = "certifi"
+optional = false
+python-versions = ">=3.6"
+version = "2023.7.22"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = "Foreign Function Interface for Python calling C code."
+marker = "platform_python_implementation == \"CPython\" and sys_platform == \"win32\""
+name = "cffi"
+optional = false
+python-versions = ">=3.8"
+version = "1.16.0"
+
+[package.dependencies]
+pycparser = "*"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = "Universal encoding detector for Python 2 and 3"
+name = "chardet"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "4.0.0"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = "Composable command line interface toolkit"
+name = "click"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "7.1.2"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = "Enables git-like *did-you-mean* feature in click"
+name = "click-didyoumean"
+optional = false
+python-versions = ">=3.6.2,<4.0.0"
+version = "0.3.0"
+
+[package.dependencies]
+click = ">=7"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = "An extension module for click to enable registering CLI commands via setuptools entry-points."
+name = "click-plugins"
+optional = false
+python-versions = "*"
+version = "1.1.1"
+
+[package.dependencies]
+click = ">=4.0"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = "REPL plugin for Click"
+name = "click-repl"
+optional = false
+python-versions = ">=3.6"
+version = "0.3.0"
+
+[package.dependencies]
+click = ">=7.0"
+prompt-toolkit = ">=3.0.36"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = "Code coverage measurement for Python"
+name = "coverage"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
+version = "5.4"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = "The Datadog Python library"
+name = "datadog"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
+version = "0.47.0"
+
+[package.dependencies]
+requests = ">=2.6.0"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = "Distributed quantile sketches"
+name = "ddsketch"
+optional = false
+python-versions = ">=2.7"
+version = "2.0.4"
+
+[package.dependencies]
+six = "*"
+
+[package.dependencies.protobuf]
+python = ">=3.7"
+version = ">=3.0.0"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = "Datadog APM client library"
+name = "ddtrace"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "1.20.9"
+
+[package.dependencies]
+ddsketch = ">=2.0.1"
+envier = "*"
+six = ">=1.12.0"
+typing_extensions = "*"
+xmltodict = ">=0.12"
+
+[package.dependencies.attrs]
+python = ">=2.8"
+version = ">=20"
+
+[package.dependencies.bytecode]
+python = ">=3.8"
+version = "*"
+
+[package.dependencies.cattrs]
+python = ">=3.7"
+version = "*"
+
+[package.dependencies.opentelemetry-api]
+python = ">=3.7"
+version = ">=1"
+
+[package.dependencies.protobuf]
+python = ">=3.7"
+version = ">=3"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = "XML bomb protection for Python stdlib modules"
+name = "defusedxml"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "0.7.1"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = "Python @deprecated decorator to deprecate old python classes, functions or methods."
+marker = "python_version >= \"3.7\""
+name = "deprecated"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "1.2.14"
+
+[package.dependencies]
+wrapt = ">=1.10,<2"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = "Use Database URLs in your Django Application."
+name = "dj-database-url"
+optional = false
+python-versions = "*"
+version = "0.5.0"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = "A high-level Python Web framework that encourages rapid development and clean, pragmatic design."
+name = "django"
+optional = false
+python-versions = ">=3.6"
+version = "3.1.6"
+
+[package.dependencies]
+asgiref = ">=3.2.10,<4"
+pytz = "*"
+sqlparse = ">=0.2.2"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = "Django friendly finite state machine support."
+name = "django-fsm"
+optional = false
+python-versions = "*"
+version = "2.7.1"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = "Integrate django-fsm state transitions into the django admin"
+name = "django-fsm-admin"
+optional = false
+python-versions = "*"
+version = "1.2.4"
+
+[package.dependencies]
+Django = ">=1.6"
+django-fsm = ">=2.1.0"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = "A Django email backend for Amazon's Simple Email Service"
+name = "django-ses"
+optional = false
+python-versions = ">=2.7"
+version = "1.0.3"
+
+[package.dependencies]
+boto3 = ">=1.0.0"
+django = ">1.10"
+future = ">=0.16.0"
+pytz = ">=2016.10"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = "Web APIs for Django, made easy."
+name = "djangorestframework"
+optional = false
+python-versions = ">=3.5"
+version = "3.12.2"
+
+[package.dependencies]
+django = ">=2.2"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = "XML support for Django REST Framework"
+name = "djangorestframework-xml"
+optional = false
+python-versions = ">=3.5"
+version = "2.0.0"
+
+[package.dependencies]
+defusedxml = ">=0.6.0"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = "Python application configuration via the environment"
+name = "envier"
+optional = false
+python-versions = ">=2.7"
+version = "0.4.0"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = "Backport of PEP 654 (exception groups)"
+marker = "python_version >= \"3.7\" and python_version < \"3.11\""
+name = "exceptiongroup"
+optional = false
+python-versions = ">=3.7"
+version = "1.1.3"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = "Clean single-source support for Python 3 and 2"
+name = "future"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+version = "0.18.3"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = "Coroutine-based network library"
+name = "gevent"
+optional = false
+python-versions = ">=3.8"
+version = "23.9.1"
+
+[package.dependencies]
+cffi = ">=1.12.2"
+"zope.event" = "*"
+"zope.interface" = "*"
+
+[package.dependencies.greenlet]
+python = "<3.11"
+version = ">=2.0.0"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = "Lightweight in-process concurrent programming"
+name = "greenlet"
+optional = false
+python-versions = ">=3.7"
+version = "3.0.0"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = "WSGI HTTP Server for UNIX"
+name = "gunicorn"
+optional = false
+python-versions = ">=3.4"
+version = "20.0.4"
+
+[package.dependencies]
+setuptools = ">=3.0"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = "Utils used across hermes projects"
+name = "hermes-utils"
+optional = false
+python-versions = "*"
+version = "2.8.13"
+
+[package.dependencies]
+Jinja2 = "2.10.1"
+datadog = ">=0.29.2"
+django = ">=1.11.10"
+pint = "0.9"
+prometheus_client = ">=0.7.0"
+python-dateutil = "2.7.0"
+python-dotenv = "0.7.1"
+requests = ">=2.18.4"
+singledispatch = "3.4.0.3"
+six = ">=1.11.0"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = "Internationalized Domain Names in Applications (IDNA)"
+name = "idna"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "2.10"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = "Read metadata from Python packages"
+marker = "python_version >= \"3.7\""
+name = "importlib-metadata"
+optional = false
+python-versions = ">=3.8"
+version = "6.8.0"
+
+[package.dependencies]
+zipp = ">=0.5"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = "Command-line interface to Jinja2 for templating in shell scripts."
+name = "j2cli-3"
+optional = false
+python-versions = "*"
+version = "0.0.1"
+
+[package.dependencies]
+jinja2 = ">=2.7.2"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = "A small but fast and easy to use stand-alone template engine written in pure python."
+name = "jinja2"
+optional = false
+python-versions = "*"
+version = "2.10.1"
+
+[package.dependencies]
+MarkupSafe = ">=0.23"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = "JSON Matching Expressions"
+name = "jmespath"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+version = "0.10.0"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = "Messaging library for Python."
+name = "kombu"
+optional = false
+python-versions = ">=3.8"
+version = "5.3.2"
+
+[package.dependencies]
+amqp = ">=5.1.1,<6.0.0"
+vine = "*"
+
+[package.dependencies.typing-extensions]
+python = "<3.10"
+version = "*"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = "Powerful and Pythonic XML processing library combining libxml2/libxslt with the ElementTree API."
+name = "lxml"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, != 3.4.*"
+version = "4.9.3"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = "Safely add untrusted strings to HTML/XML markup."
+name = "markupsafe"
+optional = false
+python-versions = ">=3.6"
+version = "2.0.1"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = "Rolling backport of unittest.mock for all Pythons"
+name = "mock"
+optional = false
+python-versions = ">=3.6"
+version = "4.0.3"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = "OpenTelemetry Python API"
+marker = "python_version >= \"3.7\""
+name = "opentelemetry-api"
+optional = false
+python-versions = ">=3.7"
+version = "1.20.0"
+
+[package.dependencies]
+deprecated = ">=1.2.6"
+importlib-metadata = ">=6.0,<7.0"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = "Pika Python AMQP Client Library"
+name = "pika"
+optional = false
+python-versions = "*"
+version = "1.1.0"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = "Physical quantities module"
+name = "pint"
+optional = false
+python-versions = "*"
+version = "0.9"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = "Python client for the Prometheus monitoring system."
+name = "prometheus-client"
+optional = false
+python-versions = ">=3.6"
+version = "0.17.1"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = "Library for building powerful interactive command lines in Python"
+name = "prompt-toolkit"
+optional = false
+python-versions = ">=3.7.0"
+version = "3.0.39"
+
+[package.dependencies]
+wcwidth = "*"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = ""
+marker = "python_version >= \"3.7\""
+name = "protobuf"
+optional = false
+python-versions = ">=3.7"
+version = "4.24.3"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = "Cross-platform lib for process and system monitoring in Python."
+name = "psutil"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "5.8.0"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = "psycopg2 - Python-PostgreSQL Database Adapter"
+name = "psycopg2-binary"
+optional = false
+python-versions = ">=3.6"
+version = "2.9.8"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = "C parser in Python"
+marker = "platform_python_implementation == \"CPython\" and sys_platform == \"win32\""
+name = "pycparser"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "2.21"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = "Extensions to the standard Python datetime module"
+name = "python-dateutil"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+version = "2.7.0"
+
+[package.dependencies]
+six = ">=1.5"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = "Add .env support to your django/flask apps in development and deployments"
+name = "python-dotenv"
+optional = false
+python-versions = "*"
+version = "0.7.1"
+
+[package.dependencies]
+click = ">=5.0"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = "World timezone definitions, modern and historical"
+name = "pytz"
+optional = false
+python-versions = "*"
+version = "2021.1"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = "Python client for Redis key-value store"
+name = "redis"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "3.5.3"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = "Python HTTP for Humans."
+name = "requests"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "2.25.1"
+
+[package.dependencies]
+certifi = ">=2017.4.17"
+chardet = ">=3.0.2,<5"
+idna = ">=2.5,<3"
+urllib3 = ">=1.21.1,<1.27"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = "An Amazon S3 Transfer Manager"
+name = "s3transfer"
+optional = false
+python-versions = "*"
+version = "0.3.7"
+
+[package.dependencies]
+botocore = ">=1.12.36,<2.0a.0"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "dev"
+description = "Python bindings for Selenium"
+name = "selenium"
+optional = false
+python-versions = "*"
+version = "2.53.6"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = "This library brings functools.singledispatch from Python 3.4 to Python 2.6-3.3."
+name = "singledispatch"
+optional = false
+python-versions = "*"
+version = "3.4.0.3"
+
+[package.dependencies]
+six = "*"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = "Python 2 and 3 compatibility utilities"
+name = "six"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+version = "1.16.0"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = "A non-validating SQL parser."
+name = "sqlparse"
+optional = false
+python-versions = ">=3.5"
+version = "0.4.4"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = "Structured Logging for Python"
+name = "structlog"
+optional = false
+python-versions = ">=3.6"
+version = "20.2.0"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = "Lightweight SOAP client"
+name = "suds-py3"
+optional = false
+python-versions = "*"
+version = "1.4.5.0"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = "Traceback serialization library."
+name = "tblib"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "1.7.0"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = "Backported and Experimental Type Hints for Python 3.8+"
+name = "typing-extensions"
+optional = false
+python-versions = ">=3.8"
+version = "4.8.0"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = "HTTP library with thread-safe connection pooling, file post, and more."
+name = "urllib3"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
+version = "1.26.17"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = "Promises, promises, promises."
+name = "vine"
+optional = false
+python-versions = ">=3.6"
+version = "5.0.0"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = "Measures the displayed width of unicode strings in a terminal"
+name = "wcwidth"
+optional = false
+python-versions = "*"
+version = "0.2.8"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = "Module for decorators, wrappers and monkey patching."
+marker = "python_version >= \"3.7\""
+name = "wrapt"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+version = "1.15.0"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = "Makes working with XML feel like you are working with JSON"
+name = "xmltodict"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "0.12.0"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = "Backport of pathlib-compatible object wrapper for zip files"
+marker = "python_version >= \"3.7\""
+name = "zipp"
+optional = false
+python-versions = ">=3.8"
+version = "3.17.0"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = "Very basic event publishing system"
+name = "zope.event"
+optional = false
+python-versions = ">=3.7"
+version = "5.0"
+
+[package.dependencies]
+setuptools = "*"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[[package]]
+category = "main"
+description = "Interfaces for Python"
+name = "zope.interface"
+optional = false
+python-versions = ">=3.7"
+version = "6.0"
+
+[package.dependencies]
+setuptools = "*"
+
+[package.source]
+reference = 'jumo-libs'
+type = "legacy"
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+[metadata]
+content-hash = "ef01297f024628704c1559952c6cf60f082af89edd8eeeca52dfc45dca66a884"
+python-versions = "3.9.16"
+
+[metadata.hashes]
+amqp = ["2c1b13fecc0893e946c65cbd5f36427861cffa4ea2201d8f6fca22e2a373b5e2", "6f0956d2c23d8fa6e7691934d8c3930eadb44972cbbd1a7ae3a520f735d43359"]
+architect = ["6f8445b80fa5053daa09e781637da5e859a263927e5e75fc6b43eb2ee73cd852", "a1bc1b25fd549ef27b6f920ec5085bec4751947beb2918d3cbaf9036b4911bb4"]
+asgiref = ["89b2ef2247e3b562a16eef663bc0e2e703ec6468e2fa8a5cd61cd449786d4f6e", "9e0ce3aa93a819ba5b45120216b23878cf6e8525eb3848653452b4192b92afed"]
+attrs = ["1f28b4522cdc2fb4256ac1a020c78acf9cba2c6b461ccd2c126f3aa8e8335d04", "6279836d581513a26f1bf235f9acd333bc9115683f14f7e8fae46c98fc50e015"]
+billiard = ["299de5a8da28a783d51b197d496bef4f1595dd023a93a4f59dde1886ae905547", "87103ea78fa6ab4d5c751c4909bcff74617d985de7fa8b672cf8618afd5a875b"]
+boto3 = ["819890e92268d730bdef1d8bac08fb069b148bec21f2172a1a99380798224e1b", "c294eb103db0ab6c55a53f68cc87761ff7e564733e7b23e51dac475a18c0a12b"]
+botocore = ["6d51de0981a3ef19da9e6a3c73b5ab427e3c0c8b92200ebd38d087299683dd2b", "d0b9b70b6eb5b65bb7162da2aaf04b6b086b15cc7ea322ddc3ef2f5e07944dcf"]
+bytecode = ["0908a8348cabf366b5c1865daabcdc0d650cb0cbdeb1750cc90564852f81945c", "a66718dc1d246b4fec52b5850c15592344a56c8bdb28fd243c895ccf00f8371f"]
+cattrs = ["b2bb14311ac17bed0d58785e5a60f022e5431aca3932e3fc5cc8ed8639de50a4", "db1c821b8c537382b2c7c66678c3790091ca0275ac486c76f3c8f3920e83c657"]
+celery = ["5e8d364e058554e83bbb116e8377d90c79be254785f357cb2cec026e79febe13", "f4efebe6f8629b0da2b8e529424de376494f5b7a743c321c8a2ddc2b1414921c"]
+certifi = ["539cc1d13202e33ca466e88b2807e29f4c13049d6d87031a3c110744495cb082", "92d6037539857d8206b8f6ae472e8b77db8058fec5937a1ef3f54304089edbb9"]
+cffi = ["0c9ef6ff37e974b73c25eecc13952c55bceed9112be2d9d938ded8e856138bcc", "131fd094d1065b19540c3d72594260f118b231090295d8c34e19a7bbcf2e860a", "1b8ebc27c014c59692bb2664c7d13ce7a6e9a629be20e54e7271fa696ff2b417", "2c56b361916f390cd758a57f2e16233eb4f64bcbeee88a4881ea90fca14dc6ab", "2d92b25dbf6cae33f65005baf472d2c245c050b1ce709cc4588cdcdd5495b520", "31d13b0f99e0836b7ff893d37af07366ebc90b678b6664c955b54561fc36ef36", "32c68ef735dbe5857c810328cb2481e24722a59a2003018885514d4c09af9743", "3686dffb02459559c74dd3d81748269ffb0eb027c39a6fc99502de37d501faa8", "582215a0e9adbe0e379761260553ba11c58943e4bbe9c36430c4ca6ac74b15ed", "5b50bf3f55561dac5438f8e70bfcdfd74543fd60df5fa5f62d94e5867deca684", "5bf44d66cdf9e893637896c7faa22298baebcd18d1ddb6d2626a6e39793a1d56", "6602bc8dc6f3a9e02b6c22c4fc1e47aa50f8f8e6d3f78a5e16ac33ef5fefa324", "673739cb539f8cdaa07d92d02efa93c9ccf87e345b9a0b556e3ecc666718468d", "68678abf380b42ce21a5f2abde8efee05c114c2fdb2e9eef2efdb0257fba1235", "68e7c44931cc171c54ccb702482e9fc723192e88d25a0e133edd7aff8fcd1f6e", "6b3d6606d369fc1da4fd8c357d026317fbb9c9b75d36dc16e90e84c26854b088", "748dcd1e3d3d7cd5443ef03ce8685043294ad6bd7c02a38d1bd367cfd968e000", "7651c50c8c5ef7bdb41108b7b8c5a83013bfaa8a935590c5d74627c047a583c7", "7b78010e7b97fef4bee1e896df8a4bbb6712b7f05b7ef630f9d1da00f6444d2e", "7e61e3e4fa664a8588aa25c883eab612a188c725755afff6289454d6362b9673", "80876338e19c951fdfed6198e70bc88f1c9758b94578d5a7c4c91a87af3cf31c", "8895613bcc094d4a1b2dbe179d88d7fb4a15cee43c052e8885783fac397d91fe", "88e2b3c14bdb32e440be531ade29d3c50a1a59cd4e51b1dd8b0865c54ea5d2e2", "8f8e709127c6c77446a8c0a8c8bf3c8ee706a06cd44b1e827c3e6a2ee6b8c098", "9cb4a35b3642fc5c005a6755a5d17c6c8b6bcb6981baf81cea8bfbc8903e8ba8", "9f90389693731ff1f659e55c7d1640e2ec43ff725cc61b04b2f9c6d8d017df6a", "a09582f178759ee8128d9270cd1344154fd473bb77d94ce0aeb2a93ebf0feaf0", "a6a14b17d7e17fa0d207ac08642c8820f84f25ce17a442fd15e27ea18d67c59b", "a72e8961a86d19bdb45851d8f1f08b041ea37d2bd8d4fd19903bc3083d80c896", "abd808f9c129ba2beda4cfc53bde801e5bcf9d6e0f22f095e45327c038bfe68e", "ac0f5edd2360eea2f1daa9e26a41db02dd4b0451b48f7c318e217ee092a213e9", "b29ebffcf550f9da55bec9e02ad430c992a87e5f512cd63388abb76f1036d8d2", "b2ca4e77f9f47c55c194982e10f058db063937845bb2b7a86c84a6cfe0aefa8b", "b7be2d771cdba2942e13215c4e340bfd76398e9227ad10402a8767ab1865d2e6", "b84834d0cf97e7d27dd5b7f3aca7b6e9263c56308ab9dc8aae9784abb774d404", "b86851a328eedc692acf81fb05444bdf1891747c25af7529e39ddafaf68a4f3f", "bcb3ef43e58665bbda2fb198698fcae6776483e0c4a631aa5647806c25e02cc0", "c0f31130ebc2d37cdd8e44605fb5fa7ad59049298b3f745c74fa74c62fbfcfc4", "c6a164aa47843fb1b01e941d385aab7215563bb8816d80ff3a363a9f8448a8dc", "d8a9d3ebe49f084ad71f9269834ceccbf398253c9fac910c4fd7053ff1386936", "db8e577c19c0fda0beb7e0d4e09e0ba74b1e4c092e0e40bfa12fe05b6f6d75ba", "dc9b18bf40cc75f66f40a7379f6a9513244fe33c0e8aa72e2d56b0196a7ef872", "e09f3ff613345df5e8c3667da1d918f9149bd623cd9070c983c013792a9a62eb", "e4108df7fe9b707191e55f33efbcb2d81928e10cea45527879a4749cbe472614", "e6024675e67af929088fda399b2094574609396b1decb609c55fa58b028a32a1", "e70f54f1796669ef691ca07d046cd81a29cb4deb1e5f942003f401c0c4a2695d", "e715596e683d2ce000574bae5d07bd522c781a822866c20495e52520564f0969", "e760191dd42581e023a68b758769e2da259b5d52e3103c6060ddc02c9edb8d7b", "ed86a35631f7bfbb28e108dd96773b9d5a6ce4811cf6ea468bb6a359b256b1e4", "ee07e47c12890ef248766a6e55bd38ebfb2bb8edd4142d56db91b21ea68b7627", "fa3a0128b152627161ce47201262d3140edb5a5c3da88d73a1b790a959126956", "fcc8eb6d5902bb1cf6dc4f187ee3ea80a1eba0a89aba40a5cb20a5087d961357"]
+chardet = ["0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa", "f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5"]
+click = ["d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a", "dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc"]
+click-didyoumean = ["a0713dc7a1de3f06bc0df5a9567ad19ead2d3d5689b434768a6145bff77c0667", "f184f0d851d96b6d29297354ed981b7dd71df7ff500d82fa6d11f0856bee8035"]
+click-plugins = ["46ab999744a9d831159c3411bb0c79346d94a444df9a3a3742e9ed63645f264b", "5d262006d3222f5057fd81e1623d4443e41dcda5dc815c06b442aa3c02889fc8"]
+click-repl = ["17849c23dba3d667247dc4defe1757fff98694e90fe37474f3feebb69ced26a9", "fb7e06deb8da8de86180a33a9da97ac316751c094c6899382da7feeeeb51b812"]
+coverage = ["03ed2a641e412e42cc35c244508cf186015c217f0e4d496bf6d7078ebe837ae7", "04b14e45d6a8e159c9767ae57ecb34563ad93440fc1b26516a89ceb5b33c1ad5", "0cdde51bfcf6b6bd862ee9be324521ec619b20590787d1655d005c3fb175005f", "0f48fc7dc82ee14aeaedb986e175a429d24129b7eada1b7e94a864e4f0644dde", "107d327071061fd4f4a2587d14c389a27e4e5c93c7cba5f1f59987181903902f", "1375bb8b88cb050a2d4e0da901001347a44302aeadb8ceb4b6e5aa373b8ea68f", "14a9f1887591684fb59fdba8feef7123a0da2424b0652e1b58dd5b9a7bb1188c", "16baa799ec09cc0dcb43a10680573269d407c159325972dd7114ee7649e56c66", "1b811662ecf72eb2d08872731636aee6559cae21862c36f74703be727b45df90", "1ccae21a076d3d5f471700f6d30eb486da1626c380b23c70ae32ab823e453337", "2f2cf7a42d4b7654c9a67b9d091ec24374f7c58794858bff632a2039cb15984d", "322549b880b2d746a7672bf6ff9ed3f895e9c9f108b714e7360292aa5c5d7cf4", "32ab83016c24c5cf3db2943286b85b0a172dae08c58d0f53875235219b676409", "3fe50f1cac369b02d34ad904dfe0771acc483f82a1b54c5e93632916ba847b37", "4a780807e80479f281d47ee4af2eb2df3e4ccf4723484f77da0bb49d027e40a1", "4a8eb7785bd23565b542b01fb39115a975fefb4a82f23d407503eee2c0106247", "5bee3970617b3d74759b2d2df2f6a327d372f9732f9ccbf03fa591b5f7581e39", "60a3307a84ec60578accd35d7f0c71a3a971430ed7eca6567399d2b50ef37b8c", "6625e52b6f346a283c3d563d1fd8bae8956daafc64bb5bbd2b8f8a07608e3994", "66a5aae8233d766a877c5ef293ec5ab9520929c2578fd2069308a98b7374ea8c", "68fb816a5dd901c6aff352ce49e2a0ffadacdf9b6fae282a69e7a16a02dad5fb", "6b588b5cf51dc0fd1c9e19f622457cc74b7d26fe295432e434525f1c0fae02bc", "6c4d7165a4e8f41eca6b990c12ee7f44fef3932fac48ca32cecb3a1b2223c21f", "6d2e262e5e8da6fa56e774fb8e2643417351427604c2b177f8e8c5f75fc928ca", "6d9c88b787638a451f41f97446a1c9fd416e669b4d9717ae4615bd29de1ac135", "755c56beeacac6a24c8e1074f89f34f4373abce8b662470d3aa719ae304931f3", "7e40d3f8eb472c1509b12ac2a7e24158ec352fc8567b77ab02c0db053927e339", "812eaf4939ef2284d29653bcfee9665f11f013724f07258928f849a2306ea9f9", "84df004223fd0550d0ea7a37882e5c889f3c6d45535c639ce9802293b39cd5c9", "859f0add98707b182b4867359e12bde806b82483fb12a9ae868a77880fc3b7af", "87c4b38288f71acd2106f5d94f575bc2136ea2887fdb5dfe18003c881fa6b370", "89fc12c6371bf963809abc46cced4a01ca4f99cba17be5e7d416ed7ef1245d19", "9564ac7eb1652c3701ac691ca72934dd3009997c81266807aef924012df2f4b3", "9754a5c265f991317de2bac0c70a746efc2b695cf4d49f5d2cddeac36544fb44", "a565f48c4aae72d1d3d3f8e8fb7218f5609c964e9c6f68604608e5958b9c60c3", "a636160680c6e526b84f85d304e2f0bb4e94f8284dd765a1911de9a40450b10a", "a839e25f07e428a87d17d857d9935dd743130e77ff46524abb992b962eb2076c", "b62046592b44263fa7570f1117d372ae3f310222af1fc1407416f037fb3af21b", "b7f7421841f8db443855d2854e25914a79a1ff48ae92f70d0a5c2f8907ab98c9", "ba7ca81b6d60a9f7a0b4b4e175dcc38e8fef4992673d9d6e6879fd6de00dd9b8", "bb32ca14b4d04e172c541c69eec5f385f9a075b38fb22d765d8b0ce3af3a0c22", "c0ff1c1b4d13e2240821ef23c1efb1f009207cb3f56e16986f713c2b0e7cd37f", "c669b440ce46ae3abe9b2d44a913b5fd86bb19eb14a8701e88e3918902ecd345", "c67734cff78383a1f23ceba3b3239c7deefc62ac2b05fa6a47bcd565771e5880", "c6809ebcbf6c1049002b9ac09c127ae43929042ec1f1dbd8bb1615f7cd9f70a0", "cd601187476c6bed26a0398353212684c427e10a903aeafa6da40c63309d438b", "ebfa374067af240d079ef97b8064478f3bf71038b78b017eb6ec93ede1b6bcec", "fbb17c0d0822684b7d6c09915677a32319f16ff1115df5ec05bdcaaee40b35f3", "fff1f3a586246110f34dc762098b5afd2de88de507559e63553d7da643053786"]
+datadog = ["47be3b2c3d709a7f5b709eb126ed4fe6cc7977d618fe5c158dd89c2a9f7d9916", "a45ec997ab554208837e8c44d81d0e1456539dc14da5743687250e028bc809b7"]
+ddsketch = ["3227a270fd686a29d3a7128f9352ccf852314410380fc11384356f1ae2a75938", "32f7314077fec8747d4faebaec2c854b5ffc399c5f552f73fa94024f48d74d64"]
+ddtrace = ["0c9cb9a0a488c5e38e892c032c8ab015b45230491b2cb1d67cde1abaf27a5ce8", "0ccf947181a582c467e28e86c43199353985a809ae3a696d883cd34262aa9c52", "0e1fdfba3f6db7d1586db9258e180fef3787857cf215f4593f4be15361c4bfcc", "13bb5448a91024a24d416b3a2d4f0fc98df29891b4a656e430d40ea99d54b4f8", "14790a7285cb34bd5789cb56734051f55cb9f972bf89a16a60269d978eb1ae4c", "166fd59d0dc1beb69ef9e3e41312a2cf8dc14c74f212b52d0278ad9827c45646", "1a203d4cba28c8212f1ba01a8ab4b37576657b9a9f2b6e630df1b5680ff605d8", "1c3b0124e44220fb6ca17576531977e5ee3ab29027bef862b347da78553e5710", "1d5dfda6994ecf7862b8f1c764ff0ed44ed42f7a854bc84d9a187fceb062e035", "1f2515085ddf4c21d6d1d1dbdfe3a2d7190cf17b760bd51a65d72475ea8963d2", "2ea20fdeb2ea9b5e1775e27a45fb4242de0ffc5c3b4d75eafb15152ede21028c", "33a775528229e9f727b3a097cada3f4ef7bea0b2f20cea28a0a55254fb6ea2cf", "355a3e96cf2c3ee82bb23e6d83323360162091648d3643c35d1b6edb71c5e27a", "37772c1e5cec0cd73d83208eb375121a04994716f1d6f67c119d5ea1b0885868", "39402a2eed47a309b16fb21c0a33ee2f29bf7b958058d8f0062010e81c38a1be", "3a9eae4acd338a22e0fe817180f8cbcfc9c57ceb06f7dbdb54c8a8fe5d38b6fb", "44dfdeae86816e8224da3b00adb0f644756c2d9b8009d5a28297d6e63592daf6", "4585f2d425e76277806757b49618dffb218d594028e2c3232b9a28255bc53586", "462b2b4684ea6b41eeda1fb9ebb120db6fb6ad01f48b16b6abfefcec4a13a47a", "474048f00fbdd2cf1c620c5e0691361cd3eae5925c5fe3a29e89ffead67c3595", "493f1b3bd3dde2cd5bd14d41823c1fa0066dbfe3bfb4078679d833ad8522bf0e", "49e54c2fc683f6f004ee1b99851d82223fae5b4062a6d68aa1942e4a815097ed", "4bf15bd8ffe042e5c2266505fa21d616e42ce869a0fc54e6f1165b21c021f459", "502c0cf5ca6eab766f0813c967d1b37a49324d5cbae18974a10c55bf9e2dcbc9", "57885bca8f121e516fa3c2e447c07a1ff43a0e559469146f3f5a90a12b96208a", "59d8e19ce88c75703924ac9ecce87f153b927cb0ffd647e995de3aac6286542e", "5e8275dc5d219a5890d27b8c4b5d512308b93059203d70f866c62305b10c8762", "5f098746dd735f0a588140b484353a70097cda7865bc796a8ae2624ed7ce93ed", "68ff2713bd7a6c9cca6f3a628b3877f193657f7a63b5ba478d8d857b0f2b687d", "69989b8cdf4411b53c9d52bec5bc049c66bca7d0154f4a1d3c67dcfbdb76c0e7", "69f069eca6153fff11a619097322a986f8eaf5ec1b6ae4a478ac9ded41e5c266", "6dd7afb678cc597a4ad89c04acb67305c83791df105d1d93119e7ebe7eb2eca4", "6e20e18a561c67f89507849f45b09f2d5f772de42795c55cfb81bbdd34be952f", "7227cbc0fcb2fb442275762a4dc40500bdc32791ec6346f4e896452a8436718c", "72a91f0e40bd505c278f6d8db332988554e0a504d12b26634efa46b573efec7d", "739912f7e487e955990b2f8f89221542d44a6f156cc3e3be7e9636b21b19c9b7", "769d135da209f74aa826351d11378e36ce141d88c8d983fa1d05c78beea4a4bc", "779d651b56d4d8fad1bd75247806fcbdf257298e991cbf166c736a2dfbf04995", "7800e9e9cf294eac0fc71faf650296d00bd7cad76d87afa43affbc8847e089f2", "8657fd2596d27ecb1054fb5edd95da90ec075148575be2ae0bb69069fcab23ed", "8e5e8cbe0e232b30b3db419132378f85fc5cb74c165191b54cb94bd8115266b0", "93ac90699ee4db7cb4a6e911b9a14f8a4bfe7c2ab1a8228614da32a8b445671c", "98a8a617b27b07fac5111a9ebe1bcf49f1522e09b64756174c4edfacecead45c", "9b8d10661c1de13d4e0df01264d15771579d081975f568dff0134a2a1849c305", "9c0c710187d38659b57713e1a6fc6c543596ca8c7bc1b8897b3e9da8df1f3568", "a4a252841fc6610594c455a0bc42fa6c3736a2fbe3caf90d8fa104381178e9a2", "a6a51b5e7cae8579aa7fd09d52a6384afcab646a6731976e62e225490ed7ddd8", "ad954febc65054b488d2512c5067c29d2d5ba5e1a091affee82882a19240555d", "bdb887b32b43cd91fd756e805aef6b64dc01b8b67b8f7d1cf4223ce79c8661f8", "be04399e50670125dd21888ecde9ff75b4f9ee1fc341430f68222c037d82d984", "c25a0e8d3e4b4e535daddf6f1c33258c979d6cfab30a54d42d8b32987debfa85", "c31a3c25a6f52dc1134c9d62464b56801476ad2017c6608af97faf75d92e6f49", "c4be379a9cefe21a78b32c6091dc333ec09c4f504f750e1c194bd4a996173b77", "c66d51eab6dcf6adb72059648502ca7ecc6b51735657eeae29b77054e1843d8e", "c88357d2d405d3003c81cdeb18172698ed263a27f85579696b3e94ed94c60695", "cd2ca709923953a946bfef7d57a518863ea2ebd0e8d207479c74f73d5e9969a4", "d78c84dcf40a8bba8b11232a43c8c521935aecffdd2d60b36efa0cfcec8d4b21", "d88ab57be4194532fa28a7b3d6a1f74793fe244f0dfb117a8d46e297e63127c8", "db8d82a2f4066b1d714432835ab96d8881e98d780c4096524d90b8e9e3096c24", "dbbc0e8e7967c75c00a8cc254dc1123b84af44ded424c73c864e1c6018e22561", "dbbce93ce7bd24e6b2718a064244fcf438852d73747e87ce192a9c427c2907da", "de091d97294b206774b3344663d4c31e60f0c875d2fd1aeba8127f9e34cc60a0", "dfc56d1092598bd43b028d12bba4b78e67b4d8443bbf75a66a12bdcd2a760ecb", "e05cd8bc036c9792e0da30fa324e1a57303618288b4dd06d20e656f8c762e878", "e20cadf49d97f233eb77a83c13c300995c6f7729a9d90f18422e4064a56358bd", "e4e6e9a1087d5d8fecf8e27a90696d9b75b991337c6e392b019c9c0bdb169c49", "e6680dce6f5fcacdd84a0123303b4ff1034b147f5f4afb7f75b023d29695b6cb", "f6ff4cdfa09dcdb9ea87d51a1f5eba618e2e04f795f6b5fc04877547a207cf5f", "f71b234343f8a538a077469010db1b583d3307dc075f760bad34e59bc6b77315"]
+defusedxml = ["1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", "a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61"]
+deprecated = ["6fac8b097794a90302bdbb17b9b815e732d3c4720583ff1b198499d78470466c", "e5323eb936458dccc2582dc6f9c322c852a775a27065ff2b0c4970b9d53d01b3"]
+dj-database-url = ["4aeaeb1f573c74835b0686a2b46b85990571159ffc21aa57ecd4d1e1cb334163", "851785365761ebe4994a921b433062309eb882fedd318e1b0fcecc607ed02da9"]
+django = ["169e2e7b4839a7910b393eec127fd7cbae62e80fa55f89c6510426abf673fe5f", "c6c0462b8b361f8691171af1fb87eceb4442da28477e12200c40420176206ba7"]
+django-fsm = ["219b204777a932720d8583cb1f34713bd08b4713e1beb39ab2e674810e21d5e9", "c96a844853de0f5dc67791b64beb367b5d56f992dff7c00f9b88c483e09f15ec"]
+django-fsm-admin = ["b10a75688bbd3714aef97db03121218b9a5963436c7805e1524bbd48a0e6c0a4"]
+django-ses = ["45f041acb9f2f8df85f3fddd63b04f1d381982bdc7730a3dc1f88e5795758bdd", "9c0a3e59e1e2424093820fa7cd519aa35f9ba978c26917a97a30c682449f0df6"]
+djangorestframework = ["0209bafcb7b5010fdfec784034f059d512256424de2a0f084cb82b096d6dd6a7", "0898182b4737a7b584a2c73735d89816343369f259fea932d90dc78e35d8ac33"]
+djangorestframework-xml = ["35f6c811d0ab8c8466b26db234e16a2ed32d76381715257aebf4c7be2c202ca1", "975955fbb0d49ac44a90bdeb33b7923d95b79884d283f983e116c80a936ef4d0"]
+envier = ["7b91af0f16ea3e56d91ec082f038987e81b441fc19c657a8b8afe0909740a706", "e68dcd1ed67d8b6313883e27dff3e701b7fba944d2ed4b7f53d0cc2e12364a82"]
+exceptiongroup = ["097acd85d473d75af5bb98e41b61ff7fe35efe6675e4f9370ec6ec5126d160e9", "343280667a4585d195ca1cf9cef84a4e178c4b6cf2274caef9859782b567d5e3"]
+future = ["34a17436ed1e96697a86f9de3d15a3b0be01d8bc8de9c1dffd59fb8234ed5307"]
+gevent = ["272cffdf535978d59c38ed837916dfd2b5d193be1e9e5dcc60a5f4d5025dd98a", "2c7b5c9912378e5f5ccf180d1fdb1e83f42b71823483066eddbe10ef1a2fcaa2", "36a549d632c14684bcbbd3014a6ce2666c5f2a500f34d58d32df6c9ea38b6535", "4368f341a5f51611411ec3fc62426f52ac3d6d42eaee9ed0f9eebe715c80184e", "43daf68496c03a35287b8b617f9f91e0e7c0d042aebcc060cadc3f049aadd653", "455e5ee8103f722b503fa45dedb04f3ffdec978c1524647f8ba72b4f08490af1", "45792c45d60f6ce3d19651d7fde0bc13e01b56bb4db60d3f32ab7d9ec467374c", "4e24c2af9638d6c989caffc691a039d7c7022a31c0363da367c0d32ceb4a0648", "52b4abf28e837f1865a9bdeef58ff6afd07d1d888b70b6804557e7908032e599", "52e9f12cd1cda96603ce6b113d934f1aafb873e2c13182cf8e86d2c5c41982ea", "5f3c781c84794926d853d6fb58554dc0dcc800ba25c41d42f6959c344b4db5a6", "62d121344f7465e3739989ad6b91f53a6ca9110518231553fe5846dbe1b4518f", "65883ac026731ac112184680d1f0f1e39fa6f4389fd1fc0bf46cc1388e2599f9", "707904027d7130ff3e59ea387dddceedb133cc742b00b3ffe696d567147a9c9e", "72c002235390d46f94938a96920d8856d4ffd9ddf62a303a0d7c118894097e34", "7532c17bc6c1cbac265e751b95000961715adef35a25d2b0b1813aa7263fb397", "78eebaf5e73ff91d34df48f4e35581ab4c84e22dd5338ef32714264063c57507", "7c1abc6f25f475adc33e5fc2dbcc26a732608ac5375d0d306228738a9ae14d3b", "7c28e38dcde327c217fdafb9d5d17d3e772f636f35df15ffae2d933a5587addd", "7ccf0fd378257cb77d91c116e15c99e533374a8153632c48a3ecae7f7f4f09fe", "921dda1c0b84e3d3b1778efa362d61ed29e2b215b90f81d498eb4d8eafcd0b7a", "a2898b7048771917d85a1d548fd378e8a7b2ca963db8e17c6d90c76b495e0e2b", "a3c5e9b1f766a7a64833334a18539a362fb563f6c4682f9634dea72cbe24f771", "ada07076b380918829250201df1d016bdafb3acf352f35e5693b59dceee8dd2e", "b101086f109168b23fa3586fccd1133494bdb97f86920a24dc0b23984dc30b69", "bf456bd6b992eb0e1e869e2fd0caf817f0253e55ca7977fd0e72d0336a8c1c6a", "bf7af500da05363e66f122896012acb6e101a552682f2352b618e541c941a011", "c3e5d2fa532e4d3450595244de8ccf51f5721a05088813c1abd93ad274fe15e7", "c84d34256c243b0a53d4335ef0bc76c735873986d478c53073861a92566a8d71", "d163d59f1be5a4c4efcdd13c2177baaf24aadf721fdf2e1af9ee54a998d160f5", "d57737860bfc332b9b5aa438963986afe90f49645f6e053140cfa0fa1bdae1ae", "dbb22a9bbd6a13e925815ce70b940d1578dbe5d4013f20d23e8a11eddf8d14a7", "dcb8612787a7f4626aa881ff15ff25439561a429f5b303048f0fca8a1c781c39", "dd6c32ab977ecf7c7b8c2611ed95fa4aaebd69b74bf08f4b4960ad516861517d", "de350fde10efa87ea60d742901e1053eb2127ebd8b59a7d3b90597eb4e586599", "e1ead6863e596a8cc2a03e26a7a0981f84b6b3e956101135ff6d02df4d9a6b07", "ed7a048d3e526a5c1d55c44cb3bc06cfdc1947d06d45006cc4cf60dedc628904", "f632487c87866094546a74eefbca2c74c1d03638b715b6feb12e80120960185a", "fae8d5b5b8fa2a8f63b39f5447168b02db10c888a3e387ed7af2bd1b8612e543", "fde6402c5432b835fbb7698f1c7f2809c8d6b2bd9d047ac1f5a7c1d5aa569303"]
+greenlet = ["02a807b2a58d5cdebb07050efe3d7deaf915468d112dfcf5e426d0564aa3aa4a", "0b72b802496cccbd9b31acea72b6f87e7771ccfd7f7927437d592e5c92ed703c", "0d3f83ffb18dc57243e0151331e3c383b05e5b6c5029ac29f754745c800f8ed9", "10b5582744abd9858947d163843d323d0b67be9432db50f8bf83031032bc218d", "123910c58234a8d40eaab595bc56a5ae49bdd90122dde5bdc012c20595a94c14", "19834e3f91f485442adc1ee440171ec5d9a4840a1f7bd5ed97833544719ce10b", "1d363666acc21d2c204dd8705c0e0457d7b2ee7a76cb16ffc099d6799744ac99", "211ef8d174601b80e01436f4e6905aca341b15a566f35a10dd8d1e93f5dbb3b7", "269d06fa0f9624455ce08ae0179430eea61085e3cf6457f05982b37fd2cefe17", "2e7dcdfad252f2ca83c685b0fa9fba00e4d8f243b73839229d56ee3d9d219314", "334ef6ed8337bd0b58bb0ae4f7f2dcc84c9f116e474bb4ec250a8bb9bd797a66", "343675e0da2f3c69d3fb1e894ba0a1acf58f481f3b9372ce1eb465ef93cf6fed", "37f60b3a42d8b5499be910d1267b24355c495064f271cfe74bf28b17b099133c", "38ad562a104cd41e9d4644f46ea37167b93190c6d5e4048fcc4b80d34ecb278f", "3c0d36f5adc6e6100aedbc976d7428a9f7194ea79911aa4bf471f44ee13a9464", "3fd2b18432e7298fcbec3d39e1a0aa91ae9ea1c93356ec089421fabc3651572b", "4a1a6244ff96343e9994e37e5b4839f09a0207d35ef6134dce5c20d260d0302c", "4cd83fb8d8e17633ad534d9ac93719ef8937568d730ef07ac3a98cb520fd93e4", "527cd90ba3d8d7ae7dceb06fda619895768a46a1b4e423bdb24c1969823b8362", "553d6fb2324e7f4f0899e5ad2c427a4579ed4873f42124beba763f16032959af", "56867a3b3cf26dc8a0beecdb4459c59f4c47cdd5424618c08515f682e1d46692", "621fcb346141ae08cb95424ebfc5b014361621b8132c48e538e34c3c93ac7365", "63acdc34c9cde42a6534518e32ce55c30f932b473c62c235a466469a710bfbf9", "6512592cc49b2c6d9b19fbaa0312124cd4c4c8a90d28473f86f92685cc5fef8e", "6672fdde0fd1a60b44fb1751a7779c6db487e42b0cc65e7caa6aa686874e79fb", "6a5b2d4cdaf1c71057ff823a19d850ed5c6c2d3686cb71f73ae4d6382aaa7a06", "6a68d670c8f89ff65c82b936275369e532772eebc027c3be68c6b87ad05ca695", "6bb36985f606a7c49916eff74ab99399cdfd09241c375d5a820bb855dfb4af9f", "73b2f1922a39d5d59cc0e597987300df3396b148a9bd10b76a058a2f2772fc04", "7709fd7bb02b31908dc8fd35bfd0a29fc24681d5cc9ac1d64ad07f8d2b7db62f", "8060b32d8586e912a7b7dac2d15b28dbbd63a174ab32f5bc6d107a1c4143f40b", "80dcd3c938cbcac986c5c92779db8e8ce51a89a849c135172c88ecbdc8c056b7", "813720bd57e193391dfe26f4871186cf460848b83df7e23e6bef698a7624b4c9", "831d6f35037cf18ca5e80a737a27d822d87cd922521d18ed3dbc8a6967be50ce", "871b0a8835f9e9d461b7fdaa1b57e3492dd45398e87324c047469ce2fc9f516c", "952256c2bc5b4ee8df8dfc54fc4de330970bf5d79253c863fb5e6761f00dda35", "96d9ea57292f636ec851a9bb961a5cc0f9976900e16e5d5647f19aa36ba6366b", "9a812224a5fb17a538207e8cf8e86f517df2080c8ee0f8c1ed2bdaccd18f38f4", "9adbd8ecf097e34ada8efde9b6fec4dd2a903b1e98037adf72d12993a1c80b51", "9de687479faec7db5b198cc365bc34addd256b0028956501f4d4d5e9ca2e240a", "a048293392d4e058298710a54dfaefcefdf49d287cd33fb1f7d63d55426e4355", "aa15a2ec737cb609ed48902b45c5e4ff6044feb5dcdfcf6fa8482379190330d7", "abe1ef3d780de56defd0c77c5ba95e152f4e4c4e12d7e11dd8447d338b85a625", "ad6fb737e46b8bd63156b8f59ba6cdef46fe2b7db0c5804388a2d0519b8ddb99", "b1660a15a446206c8545edc292ab5c48b91ff732f91b3d3b30d9a915d5ec4779", "b505fcfc26f4148551826a96f7317e02c400665fa0883fe505d4fcaab1dabfdd", "b822fab253ac0f330ee807e7485769e3ac85d5eef827ca224feaaefa462dc0d0", "bdd696947cd695924aecb3870660b7545a19851f93b9d327ef8236bfc49be705", "bdfaeecf8cc705d35d8e6de324bf58427d7eafb55f67050d8f28053a3d57118c", "be557119bf467d37a8099d91fbf11b2de5eb1fd5fc5b91598407574848dc910f", "c3692ecf3fe754c8c0f2c95ff19626584459eab110eaab66413b1e7425cd84e9", "c6b5ce7f40f0e2f8b88c28e6691ca6806814157ff05e794cdd161be928550f4c", "c94e4e924d09b5a3e37b853fe5924a95eac058cb6f6fb437ebb588b7eda79870", "cc3e2679ea13b4de79bdc44b25a0c4fcd5e94e21b8f290791744ac42d34a0353", "d1e22c22f7826096ad503e9bb681b05b8c1f5a8138469b255eb91f26a76634f2", "d5539f6da3418c3dc002739cb2bb8d169056aa66e0c83f6bacae0cd3ac26b423", "d55db1db455c59b46f794346efce896e754b8942817f46a1bada2d29446e305a", "e09dea87cc91aea5500262993cbd484b41edf8af74f976719dd83fe724644cd6", "e52a712c38e5fb4fd68e00dc3caf00b60cb65634d50e32281a9d6431b33b4af1", "e693e759e172fa1c2c90d35dea4acbdd1d609b6936115d3739148d5e4cd11947", "ecf94aa539e97a8411b5ea52fc6ccd8371be9550c4041011a091eb8b3ca1d810", "f351479a6914fd81a55c8e68963609f792d9b067fb8a60a042c585a621e0de4f", "f47932c434a3c8d3c86d865443fadc1fbf574e9b11d6650b656e602b1797908a"]
+gunicorn = ["1904bb2b8a43658807108d59c3f3d56c2b6121a701161de0ddf9ad140073c626", "cd4a810dd51bf497552cf3f863b575dabd73d6ad6a91075b65936b151cbf4f9c"]
+hermes-utils = ["2776a18fbf8e1d85182776bcddd09795c2423598d4214334d317c79b138bb7f5"]
+idna = ["b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6", "b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"]
+importlib-metadata = ["3ebb78df84a805d7698245025b975d9d67053cd94c79245ba4b3eb694abe68bb", "dbace7892d8c0c4ac1ad096662232f831d4e64f4c4545bd53016a3e9d4654743"]
+j2cli-3 = ["2d369a5503bdc7f0f8bd3a9cf35d9016ddb6b7d6804907dee1f33d456f91b611"]
+jinja2 = ["065c4f02ebe7f7cf559e49ee5a95fb800a9e4528727aec6f24402a5374c65013", "14dd6caf1527abb21f08f86c784eac40853ba93edb79552aa1e4b8aef1b61c7b"]
+jmespath = ["b85d0567b8666149a93172712e68920734333c0ce7e89b78b3e987f71e5ed4f9", "cdf6525904cc597730141d61b36f2e4b8ecc257c420fa2f4549bac2c2d0cb72f"]
+kombu = ["0ba213f630a2cb2772728aef56ac6883dc3a2f13435e10048f6e97d48506dbbd", "b753c9cfc9b1e976e637a7cbc1a65d446a22e45546cd996ea28f932082b7dc9e"]
+lxml = ["05186a0f1346ae12553d66df1cfce6f251589fea3ad3da4f3ef4e34b2d58c6a3", "075b731ddd9e7f68ad24c635374211376aa05a281673ede86cbe1d1b3455279d", "081d32421db5df44c41b7f08a334a090a545c54ba977e47fd7cc2deece78809a", "0a3d3487f07c1d7f150894c238299934a2a074ef590b583103a45002035be120", "0bfd0767c5c1de2551a120673b72e5d4b628737cb05414f03c3277bf9bed3305", "0c0850c8b02c298d3c7006b23e98249515ac57430e16a166873fc47a5d549287", "0e2cb47860da1f7e9a5256254b74ae331687b9672dfa780eed355c4c9c3dbd23", "120fa9349a24c7043854c53cae8cec227e1f79195a7493e09e0c12e29f918e52", "1247694b26342a7bf47c02e513d32225ededd18045264d40758abeb3c838a51f", "141f1d1a9b663c679dc524af3ea1773e618907e96075262726c7612c02b149a4", "14e019fd83b831b2e61baed40cab76222139926b1fb5ed0e79225bc0cae14584", "1509dd12b773c02acd154582088820893109f6ca27ef7291b003d0e81666109f", "17a753023436a18e27dd7769e798ce302963c236bc4114ceee5b25c18c52c693", "1e224d5755dba2f4a9498e150c43792392ac9b5380aa1b845f98a1618c94eeef", "1f447ea5429b54f9582d4b955f5f1985f278ce5cf169f72eea8afd9502973dd5", "23eed6d7b1a3336ad92d8e39d4bfe09073c31bfe502f20ca5116b2a334f8ec02", "25f32acefac14ef7bd53e4218fe93b804ef6f6b92ffdb4322bb6d49d94cad2bc", "2c74524e179f2ad6d2a4f7caf70e2d96639c0954c943ad601a9e146c76408ed7", "303bf1edce6ced16bf67a18a1cf8339d0db79577eec5d9a6d4a80f0fb10aa2da", "3331bece23c9ee066e0fb3f96c61322b9e0f54d775fccefff4c38ca488de283a", "3e9bdd30efde2b9ccfa9cb5768ba04fe71b018a25ea093379c857c9dad262c40", "411007c0d88188d9f621b11d252cce90c4a2d1a49db6c068e3c16422f306eab8", "42871176e7896d5d45138f6d28751053c711ed4d48d8e30b498da155af39aebd", "46f409a2d60f634fe550f7133ed30ad5321ae2e6630f13657fb9479506b00601", "48628bd53a426c9eb9bc066a923acaa0878d1e86129fd5359aee99285f4eed9c", "48d6ed886b343d11493129e019da91d4039826794a3e3027321c56d9e71505be", "4930be26af26ac545c3dffb662521d4e6268352866956672231887d18f0eaab2", "4aec80cde9197340bc353d2768e2a75f5f60bacda2bab72ab1dc499589b3878c", "4c28a9144688aef80d6ea666c809b4b0e50010a2aca784c97f5e6bf143d9f129", "4d2d1edbca80b510443f51afd8496be95529db04a509bc8faee49c7b0fb6d2cc", "4dd9a263e845a72eacb60d12401e37c616438ea2e5442885f65082c276dfb2b2", "4f1026bc732b6a7f96369f7bfe1a4f2290fb34dce00d8644bc3036fb351a4ca1", "4fb960a632a49f2f089d522f70496640fdf1218f1243889da3822e0a9f5f3ba7", "50670615eaf97227d5dc60de2dc99fb134a7130d310d783314e7724bf163f75d", "50baa9c1c47efcaef189f31e3d00d697c6d4afda5c3cde0302d063492ff9b477", "53ace1c1fd5a74ef662f844a0413446c0629d151055340e9893da958a374f70d", "5515edd2a6d1a5a70bfcdee23b42ec33425e405c5b351478ab7dc9347228f96e", "56dc1f1ebccc656d1b3ed288f11e27172a01503fc016bcabdcbc0978b19352b7", "578695735c5a3f51569810dfebd05dd6f888147a34f0f98d4bb27e92b76e05c2", "57aba1bbdf450b726d58b2aea5fe47c7875f5afb2c4a23784ed78f19a0462574", "57d6ba0ca2b0c462f339640d22882acc711de224d769edf29962b09f77129cbf", "5c245b783db29c4e4fbbbfc9c5a78be496c9fea25517f90606aa1f6b2b3d5f7b", "5c31c7462abdf8f2ac0577d9f05279727e698f97ecbb02f17939ea99ae8daa98", "64f479d719dc9f4c813ad9bb6b28f8390360660b73b2e4beb4cb0ae7104f1c12", "65299ea57d82fb91c7f019300d24050c4ddeb7c5a190e076b5f48a2b43d19c42", "6689a3d7fd13dc687e9102a27e98ef33730ac4fe37795d5036d18b4d527abd35", "690dafd0b187ed38583a648076865d8c229661ed20e48f2335d68e2cf7dc829d", "6fc3c450eaa0b56f815c7b62f2b7fba7266c4779adcf1cece9e6deb1de7305ce", "704f61ba8c1283c71b16135caf697557f5ecf3e74d9e453233e4771d68a1f42d", "71c52db65e4b56b8ddc5bb89fb2e66c558ed9d1a74a45ceb7dcb20c191c3df2f", "71d66ee82e7417828af6ecd7db817913cb0cf9d4e61aa0ac1fde0583d84358db", "7d298a1bd60c067ea75d9f684f5f3992c9d6766fadbc0bcedd39750bf344c2f4", "8b77946fd508cbf0fccd8e400a7f71d4ac0e1595812e66025bac475a8e811694", "8d7e43bd40f65f7d97ad8ef5c9b1778943d02f04febef12def25f7583d19baac", "8df133a2ea5e74eef5e8fc6f19b9e085f758768a16e9877a60aec455ed2609b2", "8ed74706b26ad100433da4b9d807eae371efaa266ffc3e9191ea436087a9d6a7", "92af161ecbdb2883c4593d5ed4815ea71b31fafd7fd05789b23100d081ecac96", "97047f0d25cd4bcae81f9ec9dc290ca3e15927c192df17331b53bebe0e3ff96d", "9719fe17307a9e814580af1f5c6e05ca593b12fb7e44fe62450a5384dbf61b4b", "9767e79108424fb6c3edf8f81e6730666a50feb01a328f4a016464a5893f835a", "9a92d3faef50658dd2c5470af249985782bf754c4e18e15afb67d3ab06233f13", "9bb6ad405121241e99a86efff22d3ef469024ce22875a7ae045896ad23ba2340", "9e28c51fa0ce5674be9f560c6761c1b441631901993f76700b1b30ca6c8378d6", "aca086dc5f9ef98c512bac8efea4483eb84abbf926eaeedf7b91479feb092458", "ae8b9c6deb1e634ba4f1930eb67ef6e6bf6a44b6eb5ad605642b2d6d5ed9ce3c", "b0a545b46b526d418eb91754565ba5b63b1c0b12f9bd2f808c852d9b4b2f9b5c", "b4e4bc18382088514ebde9328da057775055940a1f2e18f6ad2d78aa0f3ec5b9", "b6420a005548ad52154c8ceab4a1290ff78d757f9e5cbc68f8c77089acd3c432", "b86164d2cff4d3aaa1f04a14685cbc072efd0b4f99ca5708b2ad1b9b5988a991", "bb3bb49c7a6ad9d981d734ef7c7193bc349ac338776a0360cc671eaee89bcf69", "bef4e656f7d98aaa3486d2627e7d2df1157d7e88e7efd43a65aa5dd4714916cf", "c0781a98ff5e6586926293e59480b64ddd46282953203c76ae15dbbbf302e8bb", "c2006f5c8d28dee289f7020f721354362fa304acbaaf9745751ac4006650254b", "c41bfca0bd3532d53d16fd34d20806d5c2b1ace22a2f2e4c0008570bf2c58833", "cd47b4a0d41d2afa3e58e5bf1f62069255aa2fd6ff5ee41604418ca925911d76", "cdb650fc86227eba20de1a29d4b2c1bfe139dc75a0669270033cb2ea3d391b85", "cef2502e7e8a96fe5ad686d60b49e1ab03e438bd9123987994528febd569868e", "d27be7405547d1f958b60837dc4c1007da90b8b23f54ba1f8b728c78fdb19d50", "d37017287a7adb6ab77e1c5bee9bcf9660f90ff445042b790402a654d2ad81d8", "d3ff32724f98fbbbfa9f49d82852b159e9784d6094983d9a8b7f2ddaebb063d4", "d73d8ecf8ecf10a3bd007f2192725a34bd62898e8da27eb9d32a58084f93962b", "dd708cf4ee4408cf46a48b108fb9427bfa00b9b85812a9262b5c668af2533ea5", "e3cd95e10c2610c360154afdc2f1480aea394f4a4f1ea0a5eacce49640c9b190", "e4da8ca0c0c0aea88fd46be8e44bd49716772358d648cce45fe387f7b92374a7", "eadfbbbfb41b44034a4c757fd5d70baccd43296fb894dba0295606a7cf3124aa", "ed667f49b11360951e201453fc3967344d0d0263aa415e1619e85ae7fd17b4e0", "f3df3db1d336b9356dd3112eae5f5c2b8b377f3bc826848567f10bfddfee77e9", "f6bdac493b949141b733c5345b6ba8f87a226029cbabc7e9e121a413e49441e0", "fbf521479bcac1e25a663df882c46a641a9bff6b56dc8b0fafaebd2f66fb231b", "fc9b106a1bf918db68619fdcd6d5ad4f972fdd19c01d19bdb6bf63f3589a9ec5", "fcdd00edfd0a3001e0181eab3e63bd5c74ad3e67152c84f93f13769a40e073a7", "fe4bda6bd4340caa6e5cf95e73f8fea5c4bfc55763dd42f1b50a94c1b4a2fbd4"]
+markupsafe = ["01a9b8ea66f1658938f65b93a85ebe8bc016e6769611be228d797c9d998dd298", "023cb26ec21ece8dc3907c0e8320058b2e0cb3c55cf9564da612bc325bed5e64", "0446679737af14f45767963a1a9ef7620189912317d095f2d9ffa183a4d25d2b", "04635854b943835a6ea959e948d19dcd311762c5c0c6e1f0e16ee57022669194", "0717a7390a68be14b8c793ba258e075c6f4ca819f15edfc2a3a027c823718567", "0955295dd5eec6cb6cc2fe1698f4c6d84af2e92de33fbcac4111913cd100a6ff", "0d4b31cc67ab36e3392bbf3862cfbadac3db12bdd8b02a2731f509ed5b829724", "10f82115e21dc0dfec9ab5c0223652f7197feb168c940f3ef61563fc2d6beb74", "168cd0a3642de83558a5153c8bd34f175a9a6e7f6dc6384b9655d2697312a646", "1d609f577dc6e1aa17d746f8bd3c31aa4d258f4070d61b2aa5c4166c1539de35", "1f2ade76b9903f39aa442b4aadd2177decb66525062db244b35d71d0ee8599b6", "20dca64a3ef2d6e4d5d615a3fd418ad3bde77a47ec8a23d984a12b5b4c74491a", "2a7d351cbd8cfeb19ca00de495e224dea7e7d919659c2841bbb7f420ad03e2d6", "2d7d807855b419fc2ed3e631034685db6079889a1f01d5d9dac950f764da3dad", "2ef54abee730b502252bcdf31b10dacb0a416229b72c18b19e24a4509f273d26", "36bc903cbb393720fad60fc28c10de6acf10dc6cc883f3e24ee4012371399a38", "37205cac2a79194e3750b0af2a5720d95f786a55ce7df90c3af697bfa100eaac", "3c112550557578c26af18a1ccc9e090bfe03832ae994343cfdacd287db6a6ae7", "3dd007d54ee88b46be476e293f48c85048603f5f516008bee124ddd891398ed6", "4296f2b1ce8c86a6aea78613c34bb1a672ea0e3de9c6ba08a960efe0b0a09047", "47ab1e7b91c098ab893b828deafa1203de86d0bc6ab587b160f78fe6c4011f75", "49e3ceeabbfb9d66c3aef5af3a60cc43b85c33df25ce03d0031a608b0a8b2e3f", "4dc8f9fb58f7364b63fd9f85013b780ef83c11857ae79f2feda41e270468dd9b", "4efca8f86c54b22348a5467704e3fec767b2db12fc39c6d963168ab1d3fc9135", "53edb4da6925ad13c07b6d26c2a852bd81e364f95301c66e930ab2aef5b5ddd8", "5855f8438a7d1d458206a2466bf82b0f104a3724bf96a1c781ab731e4201731a", "594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a", "5b6d930f030f8ed98e3e6c98ffa0652bdb82601e7a016ec2ab5d7ff23baa78d1", "5bb28c636d87e840583ee3adeb78172efc47c8b26127267f54a9c0ec251d41a9", "60bf42e36abfaf9aff1f50f52644b336d4f0a3fd6d8a60ca0d054ac9f713a864", "611d1ad9a4288cf3e3c16014564df047fe08410e628f89805e475368bd304914", "6300b8454aa6930a24b9618fbb54b5a68135092bc666f7b06901f897fa5c2fee", "63f3268ba69ace99cab4e3e3b5840b03340efed0948ab8f78d2fd87ee5442a4f", "6557b31b5e2c9ddf0de32a691f2312a32f77cd7681d8af66c2692efdbef84c18", "693ce3f9e70a6cf7d2fb9e6c9d8b204b6b39897a2c4a1aa65728d5ac97dcc1d8", "6a7fae0dd14cf60ad5ff42baa2e95727c3d81ded453457771d02b7d2b3f9c0c2", "6c4ca60fa24e85fe25b912b01e62cb969d69a23a5d5867682dd3e80b5b02581d", "6fcf051089389abe060c9cd7caa212c707e58153afa2c649f00346ce6d260f1b", "7d91275b0245b1da4d4cfa07e0faedd5b0812efc15b702576d103293e252af1b", "89c687013cb1cd489a0f0ac24febe8c7a666e6e221b783e53ac50ebf68e45d86", "8d206346619592c6200148b01a2142798c989edcb9c896f9ac9722a99d4e77e6", "905fec760bd2fa1388bb5b489ee8ee5f7291d692638ea5f67982d968366bef9f", "97383d78eb34da7e1fa37dd273c20ad4320929af65d156e35a5e2d89566d9dfb", "984d76483eb32f1bcb536dc27e4ad56bba4baa70be32fa87152832cdd9db0833", "99df47edb6bda1249d3e80fdabb1dab8c08ef3975f69aed437cb69d0a5de1e28", "9f02365d4e99430a12647f09b6cc8bab61a6564363f313126f775eb4f6ef798e", "a30e67a65b53ea0a5e62fe23682cfe22712e01f453b95233b25502f7c61cb415", "ab3ef638ace319fa26553db0624c4699e31a28bb2a835c5faca8f8acf6a5a902", "aca6377c0cb8a8253e493c6b451565ac77e98c2951c45f913e0b52facdcff83f", "add36cb2dbb8b736611303cd3bfcee00afd96471b09cda130da3581cbdc56a6d", "b2f4bf27480f5e5e8ce285a8c8fd176c0b03e93dcc6646477d4630e83440c6a9", "b7f2d075102dc8c794cbde1947378051c4e5180d52d276987b8d28a3bd58c17d", "baa1a4e8f868845af802979fcdbf0bb11f94f1cb7ced4c4b8a351bb60d108145", "be98f628055368795d818ebf93da628541e10b75b41c559fdf36d104c5787066", "bf5d821ffabf0ef3533c39c518f3357b171a1651c1ff6827325e4489b0e46c3c", "c47adbc92fc1bb2b3274c4b3a43ae0e4573d9fbff4f54cd484555edbf030baf1", "cdfba22ea2f0029c9261a4bd07e830a8da012291fbe44dc794e488b6c9bb353a", "d6c7ebd4e944c85e2c3421e612a7057a2f48d478d79e61800d81468a8d842207", "d7f9850398e85aba693bb640262d3611788b1f29a79f0c93c565694658f4071f", "d8446c54dc28c01e5a2dbac5a25f071f6653e6e40f3a8818e8b45d790fe6ef53", "deb993cacb280823246a026e3b2d81c493c53de6acfd5e6bfe31ab3402bb37dd", "e0f138900af21926a02425cf736db95be9f4af72ba1bb21453432a07f6082134", "e9936f0b261d4df76ad22f8fee3ae83b60d7c3e871292cd42f40b81b70afae85", "f0567c4dc99f264f49fe27da5f735f414c4e7e7dd850cfd8e69f0862d7c74ea9", "f5653a225f31e113b152e56f154ccbe59eeb1c7487b39b9d9f9cdb58e6c79dc5", "f826e31d18b516f653fe296d967d700fddad5901ae07c622bb3705955e1faa94", "f8ba0e8349a38d3001fae7eadded3f6606f0da5d748ee53cc1dab1d6527b9509", "f9081981fe268bd86831e5c75f7de206ef275defcb82bc70740ae6dc507aee51", "fa130dd50c57d53368c9d59395cb5526eda596d3ffe36666cd81a44d56e48872"]
+mock = ["122fcb64ee37cfad5b3f48d7a7d51875d7031aaf3d8be7c42e2bee25044eee62", "7d3fbbde18228f4ff2f1f119a45cdffa458b4c0dee32eb4d2bb2f82554bac7bc"]
+opentelemetry-api = ["06abe351db7572f8afdd0fb889ce53f3c992dbf6f6262507b385cc1963e06983", "982b76036fec0fdaf490ae3dfd9f28c81442a33414f737abc687a32758cdcba5"]
+pika = ["4e1a1a6585a41b2341992ec32aadb7a919d649eb82904fd8e4a4e0871c8cf3af", "9fa76ba4b65034b878b2b8de90ff8660a59d925b087c5bb88f8fdbb4b64a1dbf"]
+pint = ["32d8a9a9d63f4f81194c0014b3b742679dce81a26d45127d9810a68a561fe4e2", "7ece3f639ad58073ce49982b022d464014e6d91d0b3eaa89c8e8ea9c38e32659"]
+prometheus-client = ["21e674f39831ae3f8acde238afd9a27a37d0d2fb5a28ea094f0ce25d2cbf2091", "e537f37160f6807b8202a6fc4764cdd19bac5480ddd3e0d463c3002b34462101"]
+prompt-toolkit = ["04505ade687dc26dc4284b1ad19a83be2f2afe83e7a828ace0c72f3a1df72aac", "9dffbe1d8acf91e3de75f3b544e4842382fc06c6babe903ac9acb74dc6e08d88"]
+protobuf = ["067f750169bc644da2e1ef18c785e85071b7c296f14ac53e0900e605da588719", "12e9ad2ec079b833176d2921be2cb24281fa591f0b119b208b788adc48c2561d", "1b182c7181a2891e8f7f3a1b5242e4ec54d1f42582485a896e4de81aa17540c2", "20651f11b6adc70c0f29efbe8f4a94a74caf61b6200472a9aea6e19898f9fcf4", "2da777d34b4f4f7613cdf85c70eb9a90b1fbef9d36ae4a0ccfe014b0b07906f1", "3d42e9e4796a811478c783ef63dc85b5a104b44aaaca85d4864d5b886e4b05e3", "6e514e8af0045be2b56e56ae1bb14f43ce7ffa0f68b1c793670ccbe2c4fc7d2b", "b0271a701e6782880d65a308ba42bc43874dabd1a0a0f41f72d2dac3b57f8e76", "ba53c2f04798a326774f0e53b9c759eaef4f6a568ea7072ec6629851c8435959", "e29d79c913f17a60cf17c626f1041e5288e9885c8579832580209de8b75f2a52", "f631bb982c5478e0c1c70eab383af74a84be66945ebf5dd6b06fc90079668d0b", "f6ccbcf027761a2978c1406070c3788f6de4a4b2cc20800cc03d52df716ad675", "f6f8dc65625dadaad0c8545319c2e2f0424fede988368893ca3844261342c11a"]
+psutil = ["0066a82f7b1b37d334e68697faba68e5ad5e858279fd6351c8ca6024e8d6ba64", "02b8292609b1f7fcb34173b25e48d0da8667bc85f81d7476584d889c6e0f2131", "0ae6f386d8d297177fd288be6e8d1afc05966878704dad9847719650e44fc49c", "0c9ccb99ab76025f2f0bbecf341d4656e9c1351db8cc8a03ccd62e318ab4b5c6", "0dd4465a039d343925cdc29023bb6960ccf4e74a65ad53e768403746a9207023", "12d844996d6c2b1d3881cfa6fa201fd635971869a9da945cf6756105af73d2df", "1bff0d07e76114ec24ee32e7f7f8d0c4b0514b3fae93e3d2aaafd65d22502394", "245b5509968ac0bd179287d91210cd3f37add77dad385ef238b275bad35fa1c4", "28ff7c95293ae74bf1ca1a79e8805fcde005c18a122ca983abf676ea3466362b", "36b3b6c9e2a34b7d7fbae330a85bf72c30b1c827a4366a07443fc4b6270449e2", "52de075468cd394ac98c66f9ca33b2f54ae1d9bff1ef6b67a212ee8f639ec06d", "5da29e394bdedd9144c7331192e20c1f79283fb03b06e6abd3a8ae45ffecee65", "61f05864b42fedc0771d6d8e49c35f07efd209ade09a5afe6a5059e7bb7bf83d", "6223d07a1ae93f86451d0198a0c361032c4c93ebd4bf6d25e2fb3edfad9571ef", "6323d5d845c2785efb20aded4726636546b26d3b577aded22492908f7c1bdda7", "6ffe81843131ee0ffa02c317186ed1e759a145267d54fdef1bc4ea5f5931ab60", "74f2d0be88db96ada78756cb3a3e1b107ce8ab79f65aa885f76d7664e56928f6", "74fb2557d1430fff18ff0d72613c5ca30c45cdbfcddd6a5773e9fc1fe9364be8", "90d4091c2d30ddd0a03e0b97e6a33a48628469b99585e2ad6bf21f17423b112b", "90f31c34d25b1b3ed6c40cdd34ff122b1887a825297c017e4cbd6796dd8b672d", "99de3e8739258b3c3e8669cb9757c9a861b2a25ad0955f8e53ac662d66de61ac", "c6a5fd10ce6b6344e616cf01cc5b849fa8103fbb5ba507b6b2dee4c11e84c935", "ce8b867423291cb65cfc6d9c4955ee9bfc1e21fe03bb50e177f2b957f1c2469d", "d225cd8319aa1d3c85bf195c4e07d17d3cd68636b8fc97e6cf198f782f99af28", "ea313bb02e5e25224e518e4352af4bf5e062755160f77e4b1767dd5ccb65f876", "ea372bcc129394485824ae3e3ddabe67dc0b118d262c568b4d2602a7070afdb0", "f4634b033faf0d968bb9220dd1c793b897ab7f1189956e1aa9eae752527127d3", "fcc01e900c1d7bee2a37e5d6e4f9194760a93597c97fee89c4ae51701de03563"]
+psycopg2-binary = ["01f9731761f711e42459f87bd2ad5d744b9773b5dd05446f3b579a0f077e78e3", "0e3071c947bda6afc6fe2e7b64ebd64fb2cad1bc0e705a3594cb499291f2dfec", "14f85ff2d5d826a7ce9e6c31e803281ed5a096789f47f52cb728c88f488de01b", "15458c81b0d199ab55825007115f697722831656e6477a427783fe75c201c82b", "19d40993701e39c49b50e75cd690a6af796d7e7210941ee0fe49cf12b25840e5", "1d669887df169a9b0c09e0f5b46891511850a9ddfcde3593408af9d9774c5c3a", "1dbad789ebd1e61201256a19dc2e90fed4706bc966ccad4f374648e5336b1ab4", "1f279ba74f0d6b374526e5976c626d2ac3b8333b6a7b08755c513f4d380d3add", "205cecdd81ff4f1ddd687ce7d06879b9b80cccc428d8d6ebf36fcba08bb6d361", "278ebd63ced5a5f3af5394cb75a9a067243eee21f42f0126c6f1cf85eaeb90f9", "3723c3f009e2b2771f2491b330edb7091846f1aad0c08fbbd9a1383d6a0c0841", "395c217156723fe21809dfe8f7a433c5bf8e9bce229944668e4ec709c37c5442", "3ae22a0fa5c516b84ddb189157fabfa3f12eded5d630e1ce260a18e1771f8707", "3b6928a502af71ca2ac9aad535e78c8309892ed3bfa7933182d4c760580c8af4", "3b6c607ecb6a9c245ebe162d63ccd9222d38efa3c858bbe38d32810b08b8f87e", "3fd44b52bc9c74c1512662e8da113a1c55127adeeacebaf460babe766517b049", "4336afc0e81726350bd5863e3c3116d8c12aa7f457d3d0b3b3dc36137fec6feb", "4879ee1d07a6b2c232ae6a74570f4788cd7a29b3cd38bc39bf60225b1d075c78", "4960c881471ca710b81a67ef148c33ee121c1f8e47a639cf7e06537fe9fee337", "4b8b2cdf3bce4dd91dc035fbff4eb812f5607dda91364dc216b0920b97b521c7", "4bfabbd7e70785af726cc0209e8e64b926abf91741eca80678b221aad9e72135", "4d6b592ecc8667e608b9e7344259fbfb428cc053df0062ec3ac75d8270cd5a9f", "5262713988d97a9d4cd54b682dec4a413b87b76790e5b16f480450550d11a8f7", "54bf5c27bd5867a5fa5341fad29f0d5838e2fed617ef5346884baf8b8b16dd82", "565edaf9f691b17a7fdbabd368b5b3e67d0fdc8f7f6b52177c1d3289f4e763fd", "59421806c1a0803ea7de9ed061d656c041a84db0da7e73266b98db4c7ba263da", "59f45cca0765aabb52a5822c72d5ff2ec46a28b1c1702de90dc0d306ec5c2001", "5a0a6e4004697ec98035ff3b8dfc4dba8daa477b23ee891d831cd3cd65ace6be", "5aa0c99c12075c593dcdccbb8a7aaa714b716560cc99ef9206f9e75b77520801", "5aef3296d44d05805e634dbbd2972aa8eb7497926dd86047f5e39a79c3ecc086", "5cbe1e19f59950afd66764e3c905ecee9f2aee9f8df2ef35af6f7948ad93f620", "5debcb23a052f3fb4c165789ea513b562b2fac0f0f4f53eaf3cf4dc648907ff8", "5f955fe6301b84b6fd13970a05f3640fbb62ca3a0d19342356585006c830e038", "6369f4bd4d27944498094dccced1ae7ca43376a59dbfe4c8b6a16e9e3dc3ccce", "63ce1dccfd08d9c5341ac82d62aa04345bc4bf41b5e5b7b2c6c172a28e0eda27", "65403113ac3a4813a1409fb6a1e43c658b459cc8ed8afcc5f4baf02ec8be4334", "673eafbdaa4ed9f5164c90e191c3895cc5f866b9b379fdb59f3a2294e914d9bd", "693a4e7641556f0b421a7d6c6a74058aead407d860ac1cb9d0bf25be0ca73de8", "6e1bb4eb0d9925d65dabaaabcbb279fab444ba66d73f86d4c07dfd11f0139c06", "6f5e70e40dae47a4dc7f8eb390753bb599b0f4ede314580e6faa3b7383695d19", "80451e6b6b7c486828d5c7ed50769532bbb04ec3a411f1e833539d5c10eb691c", "8c84ff9682bc4520504c474e189b3de7c4a4029e529c8b775e39c95c33073767", "91719f53ed2a95ebecefac48d855d811cba9d9fe300acc162993bdfde9bc1c3b", "9a971086db0069aef2fd22ccffb670baac427f4ee2174c4f5c7206254f1e6794", "aeb09db95f38e75ae04e947d283e07be34d03c4c2ace4f0b73dbb9143d506e67", "c68a2e1afb4f2a5bb4b7bb8f90298d21196ac1c66418523e549430b8c4b7cb1e", "c7ff2b6a79a92b1b169b03bb91b41806843f0cdf6055256554495bffed1d496d", "ccaa2ae03990cedde1f618ff11ec89fefa84622da73091a67b44553ca8be6711", "cf60c599c40c266a01c458e9c71db7132b11760f98f08233f19b3e0a2153cbf1", "d29efab3c5d6d978115855a0f2643e0ee8c6450dc536d5b4afec6f52ab99e99e", "d4a19a3332f2ac6d093e60a6f1c589f97eb9f9de7e27ea80d67f188384e31572", "dc145a241e1f6381efb924bcf3e3462d6020b8a147363f9111eb0a9c89331ad7", "de85105c568dc5f0f0efe793209ba83e4675d53d00faffc7a7c7a8bea9e0e19a", "e11373d8e4f1f46cf3065bf613f0df9854803dc95aa4a35354ffac19f8c52127", "e271ad6692d50d70ca75db3bd461bfc26316de78de8fe1f504ef16dcea8f2312", "e3142c7e51b92855cff300580de949e36a94ab3bfa8f353b27fe26535e9b3542", "e46b0f4683539965ce849f2c13fc53e323bb08d84d4ba2e4b3d976f364c84210", "e6ef615d48fa60361e57f998327046bd89679c25d06eee9e78156be5a7a76e03", "e7bdc94217ae20ad03b375a991e107a31814053bee900ad8c967bf82ef3ff02e", "fc37de7e3a87f5966965fc874d33c9b68d638e6c3718fdf32a5083de563428b0"]
+pycparser = ["8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9", "e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206"]
+python-dateutil = ["07009062406cffd554a9b4135cd2ff167c9bf6b7aac61fe946c93e69fad1bbd8", "8f95bb7e6edbb2456a51a1fb58c8dca942024b4f5844cae62c90aa88afe6e300"]
+python-dotenv = ["45e927c34204c90f5faa35ea8709b894f6b1a7712d77eb50940601068040993b", "dc7940052cfe170e881aea40feb4ea7776e6a97170ed038fd2ee7e26e47585f2"]
+pytz = ["83a4a90894bf38e243cf052c8b58f381bfe9a7a483f6a9cab140bc7f702ac4da", "eb10ce3e7736052ed3623d49975ce333bcd712c7bb19a58b9e2089d4057d0798"]
+redis = ["0e7e0cfca8660dea8b7d5cd8c4f6c5e29e11f31158c0b0ae91a397f00e5a05a2", "432b788c4530cfe16d8d943a09d40ca6c16149727e4afe8c2c9d5580c59d9f24"]
+requests = ["27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804", "c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e"]
+s3transfer = ["35627b86af8ff97e7ac27975fe0a98a312814b46c6333d8a6b889627bcd80994", "efa5bd92a897b6a8d5c1383828dca3d52d0790e0756d49740563a3fb6ed03246"]
+selenium = ["5071f43daa2e698d60d5633ab0a6630cc68a852b360be99144f1c4c1ace2746c", "f507181f13768d73b98dd9647a466ea5758ef5c7f07b62a285d2bd8de9b27016"]
+singledispatch = ["5b06af87df13818d14f08a028e42f566640aef80805c3b50c5056b086e3c2b9c", "833b46966687b3de7f438c761ac475213e53b306740f1abfaa86e1d1aae56aa8"]
+six = ["1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926", "8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"]
+sqlparse = ["5430a4fe2ac7d0f93e66f1efc6e1338a41884b7ddf2a350cedd20ccc4d9d28f3", "d446183e84b8349fa3061f0fe7f06ca94ba65b426946ffebe6e3e8295332420c"]
+structlog = ["33dd6bd5f49355e52c1c61bb6a4f20d0b48ce0328cc4a45fe872d38b97a05ccd", "af79dfa547d104af8d60f86eac12fb54825f54a46bc998e4504ef66177103174"]
+suds-py3 = ["0915a7f825c80fa2f0593e040e046bcbc156dd24ba988bb9da6c6604d70155b9", "2b0d433e569c0190ff5e7ed2dfb3287b51bbfb3e51e82361c8bd652c78807167"]
+tblib = ["059bd77306ea7b419d4f76016aef6d7027cc8a0785579b5aad198803435f882c", "289fa7359e580950e7d9743eab36b0691f0310fce64dee7d9c31065b8f723e23"]
+typing-extensions = ["8f92fc8806f9a6b641eaa5318da32b44d401efaac0f6678c9bc448ba3605faa0", "df8e4339e9cb77357558cbdbceca33c303714cf861d1eef15e1070055ae8b7ef"]
+urllib3 = ["24d6a242c28d29af46c3fae832c36db3bbebcc533dd1bb549172cd739c82df21", "94a757d178c9be92ef5539b8840d48dc9cf1b2709c9d6b588232a055c524458b"]
+vine = ["4c9dceab6f76ed92105027c49c823800dd33cacce13bdedc5b914e3514b7fb30", "7d3b1624a953da82ef63462013bbd271d3eb75751489f9807598e8f340bd637e"]
+wcwidth = ["77f719e01648ed600dfa5402c347481c0992263b81a027344f3e1ba25493a704", "8705c569999ffbb4f6a87c6d1b80f324bd6db952f5eb0b95bc07517f4c1813d4"]
+wrapt = ["02fce1852f755f44f95af51f69d22e45080102e9d00258053b79367d07af39c0", "077ff0d1f9d9e4ce6476c1a924a3332452c1406e59d90a2cf24aeb29eeac9420", "078e2a1a86544e644a68422f881c48b84fef6d18f8c7a957ffd3f2e0a74a0d4a", "0970ddb69bba00670e58955f8019bec4a42d1785db3faa043c33d81de2bf843c", "1286eb30261894e4c70d124d44b7fd07825340869945c79d05bda53a40caa079", "21f6d9a0d5b3a207cdf7acf8e58d7d13d463e639f0c7e01d82cdb671e6cb7923", "230ae493696a371f1dbffaad3dafbb742a4d27a0afd2b1aecebe52b740167e7f", "26458da5653aa5b3d8dc8b24192f574a58984c749401f98fff994d41d3f08da1", "2cf56d0e237280baed46f0b5316661da892565ff58309d4d2ed7dba763d984b8", "2e51de54d4fb8fb50d6ee8327f9828306a959ae394d3e01a1ba8b2f937747d86", "2fbfbca668dd15b744418265a9607baa970c347eefd0db6a518aaf0cfbd153c0", "38adf7198f8f154502883242f9fe7333ab05a5b02de7d83aa2d88ea621f13364", "3a8564f283394634a7a7054b7983e47dbf39c07712d7b177b37e03f2467a024e", "3abbe948c3cbde2689370a262a8d04e32ec2dd4f27103669a45c6929bcdbfe7c", "3bbe623731d03b186b3d6b0d6f51865bf598587c38d6f7b0be2e27414f7f214e", "40737a081d7497efea35ab9304b829b857f21558acfc7b3272f908d33b0d9d4c", "41d07d029dd4157ae27beab04d22b8e261eddfc6ecd64ff7000b10dc8b3a5727", "46ed616d5fb42f98630ed70c3529541408166c22cdfd4540b88d5f21006b0eff", "493d389a2b63c88ad56cdc35d0fa5752daac56ca755805b1b0c530f785767d5e", "4ff0d20f2e670800d3ed2b220d40984162089a6e2c9646fdb09b85e6f9a8fc29", "54accd4b8bc202966bafafd16e69da9d5640ff92389d33d28555c5fd4f25ccb7", "56374914b132c702aa9aa9959c550004b8847148f95e1b824772d453ac204a72", "578383d740457fa790fdf85e6d346fda1416a40549fe8db08e5e9bd281c6a475", "58d7a75d731e8c63614222bcb21dd992b4ab01a399f1f09dd82af17bbfc2368a", "5c5aa28df055697d7c37d2099a7bc09f559d5053c3349b1ad0c39000e611d317", "5fc8e02f5984a55d2c653f5fea93531e9836abbd84342c1d1e17abc4a15084c2", "63424c681923b9f3bfbc5e3205aafe790904053d42ddcc08542181a30a7a51bd", "64b1df0f83706b4ef4cfb4fb0e4c2669100fd7ecacfb59e091fad300d4e04640", "74934ebd71950e3db69960a7da29204f89624dde411afbfb3b4858c1409b1e98", "75669d77bb2c071333417617a235324a1618dba66f82a750362eccbe5b61d248", "75760a47c06b5974aa5e01949bf7e66d2af4d08cb8c1d6516af5e39595397f5e", "76407ab327158c510f44ded207e2f76b657303e17cb7a572ffe2f5a8a48aa04d", "76e9c727a874b4856d11a32fb0b389afc61ce8aaf281ada613713ddeadd1cfec", "77d4c1b881076c3ba173484dfa53d3582c1c8ff1f914c6461ab70c8428b796c1", "780c82a41dc493b62fc5884fb1d3a3b81106642c5c5c78d6a0d4cbe96d62ba7e", "7dc0713bf81287a00516ef43137273b23ee414fe41a3c14be10dd95ed98a2df9", "7eebcdbe3677e58dd4c0e03b4f2cfa346ed4049687d839adad68cc38bb559c92", "896689fddba4f23ef7c718279e42f8834041a21342d95e56922e1c10c0cc7afb", "96177eb5645b1c6985f5c11d03fc2dbda9ad24ec0f3a46dcce91445747e15094", "96e25c8603a155559231c19c0349245eeb4ac0096fe3c1d0be5c47e075bd4f46", "9d37ac69edc5614b90516807de32d08cb8e7b12260a285ee330955604ed9dd29", "9ed6aa0726b9b60911f4aed8ec5b8dd7bf3491476015819f56473ffaef8959bd", "a487f72a25904e2b4bbc0817ce7a8de94363bd7e79890510174da9d901c38705", "a4cbb9ff5795cd66f0066bdf5947f170f5d63a9274f99bdbca02fd973adcf2a8", "a74d56552ddbde46c246b5b89199cb3fd182f9c346c784e1a93e4dc3f5ec9975", "a89ce3fd220ff144bd9d54da333ec0de0399b52c9ac3d2ce34b569cf1a5748fb", "abd52a09d03adf9c763d706df707c343293d5d106aea53483e0ec8d9e310ad5e", "abd8f36c99512755b8456047b7be10372fca271bf1467a1caa88db991e7c421b", "af5bd9ccb188f6a5fdda9f1f09d9f4c86cc8a539bd48a0bfdc97723970348418", "b02f21c1e2074943312d03d243ac4388319f2456576b2c6023041c4d57cd7019", "b06fa97478a5f478fb05e1980980a7cdf2712015493b44d0c87606c1513ed5b1", "b0724f05c396b0a4c36a3226c31648385deb6a65d8992644c12a4963c70326ba", "b130fe77361d6771ecf5a219d8e0817d61b236b7d8b37cc045172e574ed219e6", "b56d5519e470d3f2fe4aa7585f0632b060d532d0696c5bdfb5e8319e1d0f69a2", "b67b819628e3b748fd3c2192c15fb951f549d0f47c0449af0764d7647302fda3", "ba1711cda2d30634a7e452fc79eabcadaffedf241ff206db2ee93dd2c89a60e7", "bbeccb1aa40ab88cd29e6c7d8585582c99548f55f9b2581dfc5ba68c59a85752", "bd84395aab8e4d36263cd1b9308cd504f6cf713b7d6d3ce25ea55670baec5416", "c99f4309f5145b93eca6e35ac1a988f0dc0a7ccf9ccdcd78d3c0adf57224e62f", "ca1cccf838cd28d5a0883b342474c630ac48cac5df0ee6eacc9c7290f76b11c1", "cd525e0e52a5ff16653a3fc9e3dd827981917d34996600bbc34c05d048ca35cc", "cdb4f085756c96a3af04e6eca7f08b1345e94b53af8921b25c72f096e704e145", "ce42618f67741d4697684e501ef02f29e758a123aa2d669e2d964ff734ee00ee", "d06730c6aed78cee4126234cf2d071e01b44b915e725a6cb439a879ec9754a3a", "d5fe3e099cf07d0fb5a1e23d399e5d4d1ca3e6dfcbe5c8570ccff3e9208274f7", "d6bcbfc99f55655c3d93feb7ef3800bd5bbe963a755687cbf1f490a71fb7794b", "d787272ed958a05b2c86311d3a4135d3c2aeea4fc655705f074130aa57d71653", "e169e957c33576f47e21864cf3fc9ff47c223a4ebca8960079b8bd36cb014fd0", "e20076a211cd6f9b44a6be58f7eeafa7ab5720eb796975d0c03f05b47d89eb90", "e826aadda3cae59295b95343db8f3d965fb31059da7de01ee8d1c40a60398b29", "eef4d64c650f33347c1f9266fa5ae001440b232ad9b98f1f43dfe7a79435c0a6", "f2e69b3ed24544b0d3dbe2c5c0ba5153ce50dcebb576fdc4696d52aa22db6034", "f87ec75864c37c4c6cb908d282e1969e79763e0d9becdfe9fe5473b7bb1e5f09", "fbec11614dba0424ca72f4e8ba3c420dba07b4a7c206c8c8e4e73f2e98f4c559", "fd69666217b62fa5d7c6aa88e507493a34dec4fa20c5bd925e4bc12fce586639"]
+xmltodict = ["50d8c638ed7ecb88d90561beedbf720c9b4e851a9fa6c47ebd64e99d166d8a21", "8bbcb45cc982f48b2ca8fe7e7827c5d792f217ecf1792626f808bf41c3b86051"]
+zipp = ["0e923e726174922dce09c53c59ad483ff7bbb8e572e00c7f7c46b88556409f31", "84e64a1c28cf7e91ed2078bb8cc8c259cb19b76942096c8d7b84947690cabaf0"]
+"zope.event" = ["2832e95014f4db26c47a13fdaef84cef2f4df37e66b59d8f1f4a8f319a632c26", "bac440d8d9891b4068e2b5a2c5e2c9765a9df762944bda6955f96bb9b91e67cd"]
+"zope.interface" = ["042f2381118b093714081fd82c98e3b189b68db38ee7d35b63c327c470ef8373", "0ec9653825f837fbddc4e4b603d90269b501486c11800d7c761eee7ce46d1bbb", "12175ca6b4db7621aedd7c30aa7cfa0a2d65ea3a0105393e05482d7a2d367446", "1592f68ae11e557b9ff2bc96ac8fc30b187e77c45a3c9cd876e3368c53dc5ba8", "23ac41d52fd15dd8be77e3257bc51bbb82469cf7f5e9a30b75e903e21439d16c", "424d23b97fa1542d7be882eae0c0fc3d6827784105264a8169a26ce16db260d8", "4407b1435572e3e1610797c9203ad2753666c62883b921318c5403fb7139dec2", "48f4d38cf4b462e75fac78b6f11ad47b06b1c568eb59896db5b6ec1094eb467f", "4c3d7dfd897a588ec27e391edbe3dd320a03684457470415870254e714126b1f", "5171eb073474a5038321409a630904fd61f12dd1856dd7e9d19cd6fe092cbbc5", "5a158846d0fca0a908c1afb281ddba88744d403f2550dc34405c3691769cdd85", "6ee934f023f875ec2cfd2b05a937bd817efcc6c4c3f55c5778cbf78e58362ddc", "790c1d9d8f9c92819c31ea660cd43c3d5451df1df61e2e814a6f99cebb292788", "809fe3bf1a91393abc7e92d607976bbb8586512913a79f2bf7d7ec15bd8ea518", "87b690bbee9876163210fd3f500ee59f5803e4a6607d1b1238833b8885ebd410", "89086c9d3490a0f265a3c4b794037a84541ff5ffa28bb9c24cc9f66566968464", "99856d6c98a326abbcc2363827e16bd6044f70f2ef42f453c0bd5440c4ce24e5", "aab584725afd10c710b8f1e6e208dbee2d0ad009f57d674cb9d1b3964037275d", "af169ba897692e9cd984a81cb0f02e46dacdc07d6cf9fd5c91e81f8efaf93d52", "b39b8711578dcfd45fc0140993403b8a81e879ec25d53189f3faa1f006087dca", "b3f543ae9d3408549a9900720f18c0194ac0fe810cecda2a584fd4dca2eb3bb8", "d0583b75f2e70ec93f100931660328965bb9ff65ae54695fb3fa0a1255daa6f2", "dfbbbf0809a3606046a41f8561c3eada9db811be94138f42d9135a5c47e75f6f", "e538f2d4a6ffb6edfb303ce70ae7e88629ac6e5581870e66c306d9ad7b564a58", "eba51599370c87088d8882ab74f637de0c4f04a6d08a312dce49368ba9ed5c2a", "ee4b43f35f5dc15e1fec55ccb53c130adb1d11e8ad8263d68b1284b66a04190d", "f2363e5fd81afb650085c6686f2ee3706975c54f331b426800b53531191fdf28", "f299c020c6679cb389814a3b81200fe55d428012c5e76da7e722491f5d205990", "f72f23bab1848edb7472309e9898603141644faec9fd57a823ea6b4d1c4c8995", "fa90bac61c9dc3e1a563e5babb3fd2c0c1c80567e815442ddbe561eadc803b30"]
+

--- a/cli/tests/e2e/targets/dependency_aware/poetry_trailing_newlines/pyproject.toml
+++ b/cli/tests/e2e/targets/dependency_aware/poetry_trailing_newlines/pyproject.toml
@@ -1,0 +1,55 @@
+[tool.poetry]
+name = "poetry_py3"
+version = "0.1.0"
+description = "Python 3 environment for Hermes SMS"
+authors = ["ninjas"]
+
+
+[[tool.poetry.source]]
+name = 'jumo-libs'
+url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+
+
+[tool.poetry.dependencies]
+python = "3.9.16"
+coverage = "5.4"
+mock = "4.0.3"
+pika = "1.1.0"
+requests = "2.25.1"
+boto3 = "1.17.8"
+redis = "3.5.3"
+psutil= "5.8.0"
+hermes-utils = "=2.8.13"
+j2cli-3 = "0.0.1"
+celery = "=5.0.5"
+dj-database-url = "0.5.0"
+django-fsm-admin = "1.2.4"
+django-fsm = "2.7.1"
+Django = "3.1.6"
+djangorestframework-xml = "2.0.0"
+djangorestframework = "3.12.2"
+gunicorn = "20.0.4"
+structlog = "20.2.0"
+xmltodict = "0.12.0"
+singledispatch = "3.4.0.3"
+tblib = "1.7.0"
+pytz = "=2021.1"
+django-ses = "=1.0.3"
+architect = "=0.6.0"
+gevent = "^23.9"
+greenlet = "^3.0"
+ddtrace = "1.20.9"
+lxml = "^4.9"
+psycopg2-binary = "2.9.8"
+markupsafe = "<2.1"
+suds-py3 = "^1.4"
+
+
+
+[tool.poetry.dev-dependencies]
+selenium = "2.53.6"
+
+[build-system]
+requires = ["poetry == 0.12.17"]
+build-backend = "poetry.masonry.api"
+

--- a/cli/tests/e2e/targets/dependency_aware/poetry_trailing_newlines/pyproject.toml
+++ b/cli/tests/e2e/targets/dependency_aware/poetry_trailing_newlines/pyproject.toml
@@ -6,8 +6,8 @@ authors = ["ninjas"]
 
 
 [[tool.poetry.source]]
-name = 'jumo-libs'
-url = "https://nexus.jumo.world/repository/jumo-pypi/simple"
+name = 'libs1-libs'
+url = "https://example.com"
 
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
This commit addresses an issue where the parser would fail or incorrectly handle files ending with multiple newlines. The fix ensures the parser is tolerant to multiple trailing newlines instead of single. This change is applied to both pyproject.toml and poetry.lock file parsers, ensuring consistent behavior across these file types.
