### PR TITLE
tech debt: remove skipped_target from Core_profiling.Debug

### DIFF
--- a/src/core/Core_profiling.mli
+++ b/src/core/Core_profiling.mli
@@ -3,10 +3,7 @@
 type debug_mode = MDebug | MTime | MNo_info [@@deriving show]
 
 type 'a debug_info =
-  | Debug of {
-      skipped_targets : Semgrep_output_v1_t.skipped_target list;
-      profiling : 'a;
-    }
+  | Debug of { profiling : 'a }
   | Time of { profiling : 'a }
   | No_info
 [@@deriving show]

--- a/src/core/Core_result.ml
+++ b/src/core/Core_result.ml
@@ -1,6 +1,6 @@
 (* Yoann Padioleau
  *
- * Copyright (C) 2023 Semgrep Inc.
+ * Copyright (C) 2023-2024 Semgrep Inc.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
@@ -21,8 +21,8 @@ module E = Core_error
 (*****************************************************************************)
 (* (Core) Scan result information.
  *
- * In addition to the results (matches + errors), we may also report extra
- * information, such as the skipped targets or the profiling times.
+ * In addition to the results (matches + errors), we report extra
+ * information such as the skipped targets or optional profiling times.
  *
  * Yet another way to store matches/findings.
  * Just like for Core_error.ml, "core" results are translated at some point in
@@ -32,6 +32,7 @@ module E = Core_error
  *
  * From the simplest matches to the most complex we have:
  * Pattern_match.t (and its alias Rule_match.t)
+ * -> processed_match
  * -> Core_result.xxx (this file)
  * -> Semgrep_output_v1.core_output
  *  -> Core_runner.result
@@ -66,8 +67,8 @@ type 'a match_result = {
 type matches_single_file = Core_profiling.partial_profiling match_result
 [@@deriving show]
 
-(* What is postprocessing information?
-   These are just match-specific information that we "after" a core scan has
+(* What is a processsed match?
+   These are just match-specific information that we add "after" a scan has
    occurred. This information is initially set to a nullary value, but will be
    filled in by Pre_post_core_scan.
 
@@ -79,10 +80,10 @@ type matches_single_file = Core_profiling.partial_profiling match_result
    These edits start as all None, but will be filled in by
    `Autofix.produce_autofixes`, and the associated Autofix_processor step.
 
-   alt: we could have added this to `Pattern_match.t`, but that felt a bit early.
-   alt: we could have produced this information when going from Core_result.t to
-   Out.core_output, but this would require us to do autofixing and ignoring at
-   the same time as output, which conflates process of producing output and
+   alt: we could have added this to `Pattern_match.t`, but felt a bit early.
+   alt: we could have produced this information when going from Core_result.t
+   to Out.core_output, but this would require us to do autofixing and ignoring
+   at the same time as output, which conflates process of producing output and
    side-effectively applying autofixes / filtering. In addition, the `Autofix`
    and `Nosemgrep` modules are not available from that directory.
 *)
@@ -94,21 +95,17 @@ type processed_match = {
 [@@deriving show]
 
 type t = {
-  (* old: matches : Pattern_match.t list
-     Why did we add `postprocessing_info` here?
-
-     See the `postprocessing_info` type for more.
-  *)
+  (* old: matches : Pattern_match.t list *)
   processed_matches : processed_match list;
   errors : Core_error.t list;
+  scanned : Fpath.t list;
+  skipped_targets : Semgrep_output_v1_t.skipped_target list;
   skipped_rules : Rule.invalid_rule_error list;
   rules_with_targets : Rule.rule list;
-  (* may contain also skipped_target information *)
   extra : Core_profiling.t Core_profiling.debug_info;
   explanations : Matching_explanation.t list option;
   rules_by_engine : (Rule_ID.t * Engine_kind.t) list;
   interfile_languages_used : Xlang.t list;
-  scanned : Fpath.t list;
 }
 [@@deriving show]
 
@@ -143,19 +140,20 @@ let mk_final_result_with_just_errors (errors : Core_error.t list) : t =
     (* default values *)
     processed_matches = [];
     rules_with_targets = [];
+    skipped_targets = [];
+    scanned = [];
     skipped_rules = [];
     extra = No_info;
     explanations = None;
     rules_by_engine = [];
     interfile_languages_used = [];
-    scanned = [];
   }
 
 (* Create a match result *)
 let make_match_result matches errors profiling =
   let extra =
     match !mode with
-    | MDebug -> Debug { skipped_targets = []; profiling }
+    | MDebug -> Debug { profiling }
     | MTime -> Time { profiling }
     | MNo_info -> No_info
   in
@@ -169,8 +167,7 @@ let modify_match_result_profiling (result : _ match_result) f : _ match_result =
   let extra =
     (* should match mode *)
     match result.extra with
-    | Debug { skipped_targets; profiling } ->
-        Debug { skipped_targets; profiling = f profiling }
+    | Debug { profiling } -> Debug { profiling = f profiling }
     | Time { profiling } -> Time { profiling = f profiling }
     | No_info -> No_info
   in
@@ -195,25 +192,23 @@ let add_rule : Rule.rule -> times match_result -> rule_profiling match_result =
 let collate_results init_extra unzip_extra base_case_extra final_extra results :
     _ match_result =
   let unzip_results l =
-    let rec unzip all_matches all_errors (all_skipped_targets, all_profiling)
-        all_explanations (l : _ match_result list) =
+    let rec unzip all_matches all_errors all_profiling all_explanations
+        (l : _ match_result list) =
       match l with
       | { matches; errors; extra; explanations } :: l ->
           unzip (matches :: all_matches) (errors :: all_errors)
-            (unzip_extra extra all_skipped_targets all_profiling)
+            (unzip_extra extra all_profiling)
             (explanations :: all_explanations)
             l
       | [] ->
           ( List.rev all_matches,
             List.rev all_errors,
-            base_case_extra all_skipped_targets all_profiling,
+            base_case_extra all_profiling,
             List.rev all_explanations )
     in
     unzip [] [] init_extra [] l
   in
-  let matches, errors, (skipped_targets, profiling), explanations =
-    unzip_results results
-  in
+  let matches, errors, profiling, explanations = unzip_results results in
   {
     matches = List.flatten matches;
     (* We deduplicate errors here to avoid repeat PartialParsing errors
@@ -224,14 +219,14 @@ let collate_results init_extra unzip_extra base_case_extra final_extra results :
        See also the note in semgrep_output_v1.atd.
     *)
     errors = List.fold_left E.ErrorSet.union E.ErrorSet.empty errors;
-    extra = final_extra skipped_targets profiling;
+    extra = final_extra profiling;
     explanations = List.flatten explanations;
   }
 
 (* Aggregate a list of pattern results into one result *)
 let collate_pattern_results (results : Core_profiling.times match_result list) :
     Core_profiling.times match_result =
-  let init_extra = ([], { parse_time = 0.0; match_time = 0.0 }) in
+  let init_extra = { parse_time = 0.0; match_time = 0.0 } in
 
   let unzip_profiling (a : Core_profiling.times) (b : Core_profiling.times) =
     let ({ match_time; parse_time } : Core_profiling.times) = a in
@@ -245,62 +240,47 @@ let collate_pattern_results (results : Core_profiling.times match_result list) :
     }
   in
 
-  let unzip_extra extra all_skipped_targets all_profiling =
+  let unzip_extra extra all_profiling =
     (* should match mode *)
     match extra with
-    | Core_profiling.Debug { skipped_targets; profiling } ->
-        ( skipped_targets :: all_skipped_targets,
-          unzip_profiling profiling all_profiling )
+    | Core_profiling.Debug { profiling } ->
+        unzip_profiling profiling all_profiling
     | Core_profiling.Time { profiling } ->
-        (all_skipped_targets, unzip_profiling profiling all_profiling)
-    | Core_profiling.No_info -> (all_skipped_targets, all_profiling)
+        unzip_profiling profiling all_profiling
+    | Core_profiling.No_info -> all_profiling
   in
+  (* TODO: remove this once Core_profiling is fully cleaned up *)
+  let base_case_extra all_profiling = all_profiling in
 
-  let base_case_extra all_skipped_targets all_profiling =
-    (List.rev all_skipped_targets, all_profiling)
-  in
-
-  let final_extra skipped_targets profiling =
+  let final_extra profiling =
     match !mode with
-    | Core_profiling.MDebug ->
-        Core_profiling.Debug
-          { skipped_targets = List.flatten skipped_targets; profiling }
+    | Core_profiling.MDebug -> Core_profiling.Debug { profiling }
     | Core_profiling.MTime -> Core_profiling.Time { profiling }
     | Core_profiling.MNo_info -> Core_profiling.No_info
   in
-
   collate_results init_extra unzip_extra base_case_extra final_extra results
 
 (* Aggregate a list of rule results into one result for the target *)
 let collate_rule_results (file : Fpath.t)
     (results : rule_profiling match_result list) :
     partial_profiling match_result =
-  let init_extra = ([], []) in
+  let init_extra = [] in
 
-  let unzip_extra extra all_skipped_targets all_profiling =
+  let unzip_extra extra all_profiling =
     match extra with
-    | Debug { skipped_targets; profiling } ->
-        (skipped_targets :: all_skipped_targets, profiling :: all_profiling)
-    | Time { profiling } -> (all_skipped_targets, profiling :: all_profiling)
-    | No_info -> (all_skipped_targets, all_profiling)
+    | Debug { profiling } -> profiling :: all_profiling
+    | Time { profiling } -> profiling :: all_profiling
+    | No_info -> all_profiling
   in
 
-  let base_case_extra all_skipped_targets all_profiling =
-    (List.rev all_skipped_targets, List.rev all_profiling)
-  in
+  let base_case_extra all_profiling = List.rev all_profiling in
 
-  let final_extra skipped_targets profiling =
+  let final_extra profiling =
     match !mode with
-    | MDebug ->
-        Debug
-          {
-            skipped_targets = List.flatten skipped_targets;
-            profiling = { file; rule_times = profiling };
-          }
+    | MDebug -> Debug { profiling = { file; rule_times = profiling } }
     | MTime -> Time { profiling = { file; rule_times = profiling } }
     | MNo_info -> No_info
   in
-
   collate_results init_extra unzip_extra base_case_extra final_extra results
 
 (*****************************************************************************)
@@ -312,8 +292,8 @@ let make_final_result
     (results : Core_profiling.file_profiling match_result list)
     (rules_with_engine : (Rule.t * Engine_kind.t) list)
     (skipped_rules : Rule.invalid_rule_error list) (scanned : Fpath.t list)
-    (interfile_languages_used : Xlang.t list) ~rules_parse_time =
-  (* contenating information from the match_result list *)
+    (interfile_languages_used : Xlang.t list) ~rules_parse_time : t =
+  (* concatenating information from the match_result list *)
   let unprocessed_matches =
     results
     |> List.concat_map (fun (x : _ match_result) -> x.matches)
@@ -332,16 +312,9 @@ let make_final_result
   in
 
   (* Create extra *)
-  let get_skipped_targets (result : _ match_result) =
-    (* TODO? shouldn't we always compute the skipped_target? *)
-    match result.extra with
-    | Debug { skipped_targets; profiling = _profiling } -> skipped_targets
-    | Time _profiling -> []
-    | No_info -> []
-  in
   let get_profiling (result : _ match_result) =
     match result.extra with
-    | Debug { skipped_targets = _skipped_targets; profiling } -> profiling
+    | Debug { profiling } -> profiling
     | Time { profiling } -> profiling
     | No_info ->
         Logs.debug (fun m ->
@@ -365,11 +338,7 @@ let make_final_result
       }
     in
     match !mode with
-    | MDebug ->
-        let skipped_targets =
-          results |> List.concat_map (fun x -> get_skipped_targets x)
-        in
-        Debug { skipped_targets; profiling = mk_profiling () }
+    | MDebug -> Debug { profiling = mk_profiling () }
     | MTime -> Time { profiling = mk_profiling () }
     | MNo_info -> No_info
   in
@@ -377,11 +346,12 @@ let make_final_result
     processed_matches = unprocessed_matches;
     errors;
     extra;
+    scanned;
+    skipped_targets = [];
     skipped_rules;
     rules_with_targets = [];
     explanations = (if explanations =*= [] then None else Some explanations);
     rules_by_engine =
       rules_with_engine |> List_.map (fun (r, ek) -> (fst r.Rule.id, ek));
     interfile_languages_used;
-    scanned;
   }

--- a/src/core/Core_result.mli
+++ b/src/core/Core_result.mli
@@ -1,6 +1,6 @@
-(* See the .ml file for why we have this instead of just matches. *)
 type processed_match = {
   pm : Pattern_match.t;
+  (* semgrep-core is now responsible for the nosemgrep and autofix *)
   is_ignored : bool;
   autofix_edit : Textedit.t option;
 }
@@ -10,16 +10,6 @@ type processed_match = {
 type t = {
   processed_matches : processed_match list;
   errors : Core_error.t list;
-  (* extra information useful to also give to the user (in JSON or
-   * in textual reports) or for tools (e.g., the playground).
-   *)
-  skipped_rules : Rule.invalid_rule_error list;
-  rules_with_targets : Rule.rule list;
-  (* may contain skipped_target info *)
-  extra : Core_profiling.t Core_profiling.debug_info;
-  explanations : Matching_explanation.t list option;
-  rules_by_engine : (Rule_ID.t * Engine_kind.t) list;
-  interfile_languages_used : Xlang.t list;
   (* The targets are all the files that were considered valid targets for the
    * semgrep scan. This excludes files that were filtered out on purpose
    * due to being in the wrong language, too big, etc.
@@ -30,6 +20,16 @@ type t = {
    * but I'm not sure we're doing it.
    *)
   scanned : Fpath.t list;
+  (* extra information useful to also give to the user (in JSON or
+   * in textual reports) or for tools (e.g., the playground).
+   *)
+  skipped_targets : Semgrep_output_v1_t.skipped_target list;
+  skipped_rules : Rule.invalid_rule_error list;
+  rules_with_targets : Rule.rule list;
+  extra : Core_profiling.t Core_profiling.debug_info;
+  explanations : Matching_explanation.t list option;
+  rules_by_engine : (Rule_ID.t * Engine_kind.t) list;
+  interfile_languages_used : Xlang.t list;
 }
 [@@deriving show]
 

--- a/src/core_scan/Core_scan.ml
+++ b/src/core_scan/Core_scan.ml
@@ -1079,7 +1079,7 @@ let mk_target_handler (config : Core_scan_config.t) (valid_rules : Rule.t list)
       (matches, was_scanned)
 
 (* This is the main function used by pysemgrep right now.
- * This is also called now from osemgrep.
+ * This is also now called from osemgrep.
  * It takes a set of rules and a set of targets and iteratively process those
  * targets.
  * coupling: If you modify this function, you probably need also to modify
@@ -1182,21 +1182,11 @@ let scan ?match_hook config ((valid_rules, invalid_rules), rules_parse_time) :
   (* concatenate all errors *)
   let errors = rule_errors @ new_errors @ res.errors in
 
-  (* Concatenate all the skipped targets
-   * TODO: maybe we should move skipped_target out of Debug and always
-   * do it?
-   *)
-  let extra =
-    match res.extra with
-    | Core_profiling.Debug { skipped_targets; profiling } ->
-        let skipped_targets = skipped @ new_skipped @ skipped_targets in
-        Logs.info (fun m ->
-            m ~tags "there were %d skipped targets"
-              (List.length skipped_targets));
-        Core_profiling.Debug { skipped_targets; profiling }
-    | (Core_profiling.Time _ | Core_profiling.No_info) as x -> x
-  in
-  { res with processed_matches; errors; extra }
+  (* Concatenate all the skipped targets *)
+  let skipped_targets = skipped @ new_skipped @ res.skipped_targets in
+  Logs.info (fun m ->
+      m ~tags "there were %d skipped targets" (List.length skipped_targets));
+  { res with processed_matches; errors }
 
 (*****************************************************************************)
 (* Entry point *)

--- a/src/core_scan/Core_scan.ml
+++ b/src/core_scan/Core_scan.ml
@@ -1186,7 +1186,11 @@ let scan ?match_hook config ((valid_rules, invalid_rules), rules_parse_time) :
   let skipped_targets = skipped @ new_skipped @ res.skipped_targets in
   Logs.info (fun m ->
       m ~tags "there were %d skipped targets" (List.length skipped_targets));
-  { res with processed_matches; errors }
+  (* TODO: returning, or not skipped_targets does not seem to have any impact
+   * on our testsuite, weird. We need to add more tests. Maybe because
+   * both pysemgrep and osemgrep do their own skip targets management.
+   *)
+  { res with processed_matches; errors; skipped_targets }
 
 (*****************************************************************************)
 (* Entry point *)

--- a/src/engine/Match_extract_mode.ml
+++ b/src/engine/Match_extract_mode.ml
@@ -186,7 +186,7 @@ let map_bindings map_loc bindings =
   let map_binding (mvar, mval) = (mvar, map_tokens map_loc mval) in
   List_.map map_binding bindings
 
-let map_res map_loc (Extracted tmpfile) (Original file) :
+let map_res map_loc (Extracted _tmpfile) (Original file) :
     match_result_location_adjuster =
  fun (mr : Core_result.matches_single_file) : Core_result.matches_single_file ->
   let matches =
@@ -208,15 +208,8 @@ let map_res map_loc (Extracted tmpfile) (Original file) :
   in
   let extra =
     match mr.extra with
-    | Core_profiling.Debug { skipped_targets; profiling } ->
-        let skipped_targets =
-          List_.map
-            (fun (st : Semgrep_output_v1_t.skipped_target) ->
-              { st with path = (if st.path =*= tmpfile then file else st.path) })
-            skipped_targets
-        in
-        Core_profiling.Debug
-          { skipped_targets; profiling = { profiling with file } }
+    | Core_profiling.Debug { profiling } ->
+        Core_profiling.Debug { profiling = { profiling with file } }
     | Core_profiling.Time { profiling } ->
         Core_profiling.Time { profiling = { profiling with file } }
     | Core_profiling.No_info -> Core_profiling.No_info

--- a/src/engine/Match_rules.ml
+++ b/src/engine/Match_rules.ml
@@ -1,6 +1,6 @@
 (* Yoann Padioleau
  *
- * Copyright (C) 2019-2022 r2c
+ * Copyright (C) 2019-2024 Semgrep Inc.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
@@ -16,7 +16,6 @@ open Common
 open Fpath_.Operators
 module R = Rule
 module RP = Core_result
-module Resp = Semgrep_output_v1_t
 module E = Core_error
 module OutJ = Semgrep_output_v1_t
 
@@ -25,8 +24,7 @@ let tags = Logs_.create_tags [ __MODULE__ ]
 (*****************************************************************************)
 (* Prelude *)
 (*****************************************************************************)
-(* Small wrapper around Match_search_mode and Match_tainting_mode
- *)
+(* Small wrapper around Match_search_mode and Match_tainting_mode *)
 
 (*****************************************************************************)
 (* Types *)
@@ -36,6 +34,7 @@ exception File_timeout of Rule_ID.t list
 
 (* TODO make this one of the Semgrep_error_code exceptions *)
 exception Multistep_rules_not_available
+
 (*****************************************************************************)
 (* Helpers *)
 (*****************************************************************************)
@@ -57,25 +56,9 @@ let timeout_function (rule : Rule.t) file timeout f =
             file);
       None
 
-let skipped_target_of_rule (file_and_more : Xtarget.t) (rule : R.rule) :
-    Resp.skipped_target =
-  let rule_id, _ = rule.id in
-  let details =
-    Some
-      (spf
-         "No need to perform deeper matching because target does not contain \
-          some elements necessary for the rule to match '%s'"
-         (Rule_ID.to_string rule_id))
-  in
-  {
-    path = file_and_more.path.internal_path_to_content;
-    reason = Irrelevant_rule;
-    details;
-    rule_id = Some rule_id;
-  }
-
 let is_relevant_rule_for_xtarget r xconf xtarget =
-  let { path = { internal_path_to_content; _ }; lazy_content; _ } : Xtarget.t =
+  let { Xtarget.path = { internal_path_to_content; _ }; lazy_content; _ }
+      (* : Xtarget.t *) =
     xtarget
   in
   let xconf = Match_env.adjust_xconfig_with_rule_options xconf r.R.options in
@@ -127,15 +110,16 @@ let group_rules xconf rules xtarget =
   in
   (relevant_taint_rules_groups, relevant_nontaint_rules, skipped_rules)
 
-(* Given a thunk [f] that computes the results of running the engine on a single
-    rule, this function simply instruments the computation on a single rule with
-    some boilerplate logic, like setting the last matched rule, timing out if
-    it takes too long, and producing a faulty match result in that case.
-
-    In particular, we need this to call [Match_tainting_mode.check_rules], which
-    will iterate over each rule in a different place, and so needs access to this
-    logic.
-*)
+(* Given a thunk [f] that computes the results of running the engine on a
+ * single rule, this function simply instruments the computation on a single
+ * rule with some boilerplate logic, like setting the last matched rule,
+ * timing out if it takes too long, and producing a faulty match result in
+ * that case.
+ *
+ * In particular, we need this to call [Match_tainting_mode.check_rules],
+ * which will iterate over each rule in a different place, and so needs
+ * access to this logic.
+ *)
 let per_rule_boilerplate_fn ~timeout ~timeout_threshold =
   let cnt_timeout = ref 0 in
   let rule_timeouts = ref [] in
@@ -168,14 +152,19 @@ let per_rule_boilerplate_fn ~timeout ~timeout_threshold =
 
 let check ~match_hook ~timeout ~timeout_threshold
     ?(dependency_match_table : Match_dependency.dependency_match_table option)
-    (xconf : Match_env.xconfig) rules xtarget =
+    (xconf : Match_env.xconfig) (rules : Rule.rules) (xtarget : Xtarget.t) :
+    Core_result.matches_single_file =
   let get_dep_matches =
     match dependency_match_table with
     | Some table -> Hashtbl.find_opt table
     | None -> fun _ -> None
   in
-  let { path = { internal_path_to_content; _ }; lazy_ast_and_errors; xlang; _ }
-      : Xtarget.t =
+  let {
+    Xtarget.path = { internal_path_to_content; _ };
+    lazy_ast_and_errors;
+    xlang;
+    _;
+  } (* : Xtarget.t *) =
     xtarget
   in
   Logs.debug (fun m ->
@@ -198,8 +187,10 @@ let check ~match_hook ~timeout ~timeout_threshold
      just one rule at once.
 
      The taint rules are "grouped", see [group_rule] for more.
+
+     TODO: skipped_rules?
   *)
-  let relevant_taint_rules_groups, relevant_nontaint_rules, skipped_rules =
+  let relevant_taint_rules_groups, relevant_nontaint_rules, _skipped_rules =
     group_rules xconf rules xtarget
   in
 
@@ -234,14 +225,35 @@ let check ~match_hook ~timeout ~timeout_threshold
   let res =
     RP.collate_rule_results xtarget.path.internal_path_to_content res_total
   in
+
+  (* TODO: detect if a target was fully skipped because no rule
+   * were irrelevant.
+   * We used to report that for each rule independently via
+   *
+   * let skipped_target_of_rule (file_and_more : Xtarget.t) (rule : R.rule) :
+   *     OutJ.skipped_target =
+   *   let rule_id, _ = rule.id in
+   *   let details =
+   *     Some
+   *       (spf
+   *          "No need to perform matching because target does not contain \
+   *           some elements necessary for the rule to match '%s'"
+   *          (Rule_ID.to_string rule_id))
+   *   in
+   *   {
+   *     path = file_and_more.path.internal_path_to_content;
+   *     reason = Irrelevant_rule;
+   *     details;
+   *     rule_id = Some rule_id;
+   *   }
+   *
+   * when skipped_target was part of profiling info, but now
+   * skipped_target is only in the Core_result.t (and not in the
+   * intermediate match_result).
+   *)
   let extra =
     match res.extra with
-    | Core_profiling.Debug { skipped_targets; profiling } ->
-        let skipped =
-          List_.map (skipped_target_of_rule xtarget) skipped_rules
-        in
-        Core_profiling.Debug
-          { skipped_targets = skipped @ skipped_targets; profiling }
+    | Core_profiling.Debug { profiling } -> Core_profiling.Debug { profiling }
     | Core_profiling.Time profiling -> Core_profiling.Time profiling
     | Core_profiling.No_info -> Core_profiling.No_info
   in

--- a/src/reporting/Core_json_output.ml
+++ b/src/reporting/Core_json_output.ml
@@ -405,22 +405,21 @@ let core_output_of_matches_and_errors (res : Core_result.t) : OutJ.core_output =
   in
   let errs = !E.g_errors @ new_errs @ res.errors in
   E.g_errors := [];
-  let skipped_targets, profiling =
+  let profiling =
     match res.extra with
-    | Core_profiling.Debug { skipped_targets; profiling } ->
-        (Some skipped_targets, Some profiling)
-    | Core_profiling.Time { profiling } -> (None, Some profiling)
-    | Core_profiling.No_info -> (None, None)
+    | Core_profiling.Debug { profiling } -> Some profiling
+    | Core_profiling.Time { profiling } -> Some profiling
+    | Core_profiling.No_info -> None
   in
   {
     results = matches |> OutUtils.sort_core_matches;
     errors = errs |> List_.map error_to_error;
     paths =
       {
-        skipped = skipped_targets;
         (* TODO: those are set later in Cli_json_output.ml,
-         * but should we compute scanned here instead?
+         * but should we compute skipped and scanned here instead?
          *)
+        skipped = None;
         scanned = [];
       };
     skipped_rules =


### PR DESCRIPTION
We should always return skipped_target information, so make no sense
to have it under this complex Core_profiling type.

I'll make a further PR to simplify even more Core_profiling.t

test plan:
make
make test