### PR TITLE
test: allow for a wider range of paths for `--dump-engine-path` test

### DIFF
--- a/cli/tests/e2e-pysemgrep/test_utility_commands.py
+++ b/cli/tests/e2e-pysemgrep/test_utility_commands.py
@@ -34,4 +34,4 @@ def test_dump_engine():
         encoding="utf-8",
     )
 
-    assert re.match(r"/[\w/]+/semgrep-core", result)
+    assert re.match(r"/[\w/\_\-\.]+/semgrep-core", result)


### PR DESCRIPTION
In nixpkgs semgrep-core is being output to a path such as:
`/nix/store/k8r0326l6ms2v0dhgj706r5g7f4ha_i8y-semgrep-core-1.61.1/bin/semgrep-core`

If that is output by `semgrep` when used with `--dump-engine-path` the test fails.
This change expands the regex to allow for that match too.
