### PR TITLE
OCaml: parse correctly typed patterns

### DIFF
--- a/dev/optional.opam
+++ b/dev/optional.opam
@@ -16,4 +16,5 @@ depends: [
   "feather" # used by hello_script.ml
   "ocaml-lsp-server" {= "1.15.1-4.14"} # used by the VSCode extension
   "earlybird" {= "1.2.1"} # used by the VSCode extension
+  "py" "qcheck" "qcheck-alcotest" # used by libs/python-str-repr/test
 ]

--- a/languages/ocaml/tree-sitter/Parse_ocaml_tree_sitter.ml
+++ b/languages/ocaml/tree-sitter/Parse_ocaml_tree_sitter.ml
@@ -1120,7 +1120,7 @@ and map_class_field (env : env) (x : CST.class_field) : class_field =
       let m_params = List_.map (map_parameter env) v5 in
       let m_rettype =
         match v6 with
-        | Some x -> Some (map_polymorphic_typed env x)
+        | Some x -> Some (map_polymorphic_typed env x |> snd)
         | None -> None
       in
       let m_body =
@@ -1555,7 +1555,7 @@ and map_external_ (env : env) ((v1, v2, v3, v4, v5, v6, v7) : CST.external_) :
   let v1 = token env v1 (* "external" *) in
   let _v2 = map_attribute_opt env v2 in
   let v3 = map_value_name env v3 in
-  let typ = map_polymorphic_typed env v4 in
+  let typ = map_polymorphic_typed env v4 |> snd in
   let _v5 = token env v5 (* "=" *) in
   let v6 = List_.map (map_string_ env) v6 in
   let v7 = List_.map (map_item_attribute env) v7 in
@@ -1582,7 +1582,7 @@ and map_field_declaration (env : env) ((v1, v2, v3) : CST.field_declaration) =
     | None -> None
   in
   let v2 = str env v2 (* pattern "[a-z_][a-zA-Z0-9_']*" *) in
-  let v3 = map_polymorphic_typed env v3 in
+  let v3 = map_polymorphic_typed env v3 |> snd in
   (v2, v3, v1)
 
 and map_field_expression (env : env) ((v1, v2, v3) : CST.field_expression) =
@@ -1749,36 +1749,41 @@ and map_labeled_argument (env : env) (x : CST.labeled_argument) =
 and map_let_binding (env : env) ((v1, v2, v3) : CST.let_binding) : let_binding =
   let pat = map_binding_pattern_ext env v1 in
   let lattrs = List_.map (map_item_attribute env) v3 in
-  let v2 =
-    match v2 with
-    | Some (v1, v2, v3, v4, v5) -> (
-        let v1 = List_.map (map_parameter env) v1 in
-        let v2 =
-          match v2 with
-          | Some x -> Some (map_polymorphic_typed env x)
-          | None -> None
-        in
-        let _v3 =
-          match v3 with
-          | Some (v1, v2) ->
-              let _v1 = token env v1 (* ":>" *) in
-              let v2 = map_type_ext env v2 in
-              Some v2
-          | None -> None
-        in
-        let v4 = token env v4 (* "=" *) in
-        let v5 = map_sequence_expression_ext env v5 |> seq1 in
-        match (pat, v1, v2) with
-        | PatVar id, _, _ ->
-            LetClassic
-              { lname = id; lparams = v1; lrettype = v2; lbody = v5; lattrs }
-        | pat, [], None -> LetPattern (pat, v5)
-        (* TODO: grammar js is wrong there too, this can not happen *)
-        | _ -> raise (Parsing_error.Other_error ("Invalid let binding", v4)))
-    (* TODO: grammar.js is wrong, this can not happen *)
-    | None -> raise Impossible
-  in
-  v2
+  match v2 with
+  | Some (v1, v2, v3, v4, v5) -> (
+      let lparams = List_.map (map_parameter env) v1 in
+      let tyopt =
+        match v2 with
+        | Some x -> Some (map_polymorphic_typed env x)
+        | None -> None
+      in
+      let _tycastopt =
+        match v3 with
+        | Some (v1, v2) ->
+            let _v1 = token env v1 (* ":>" *) in
+            let v2 = map_type_ext env v2 in
+            Some v2
+        | None -> None
+      in
+      let teq = token env v4 (* "=" *) in
+      let lbody = map_sequence_expression_ext env v5 |> seq1 in
+      match (pat, lparams, tyopt) with
+      | PatVar id, _, _ ->
+          LetClassic
+            {
+              lname = id;
+              lparams;
+              lrettype = tyopt |> Option.map snd;
+              lbody;
+              lattrs;
+            }
+      | pat, [], None -> LetPattern (pat, lbody)
+      | pat, [], Some (tcolon, ty) ->
+          LetPattern (PatTyped (pat, tcolon, ty), lbody)
+      (* TODO: grammar js is wrong there too, this can not happen *)
+      | _ -> raise (Parsing_error.Other_error ("Invalid let binding", teq)))
+  (* TODO: grammar.js is wrong, this can not happen *)
+  | None -> raise Impossible
 
 and map_list_binding_pattern (env : env)
     ((v1, v2, v3) : CST.list_binding_pattern) =
@@ -2273,9 +2278,9 @@ and map_polymorphic_type (env : env) (x : CST.polymorphic_type) : type_ =
   | `Type_ext x -> map_type_ext env x
 
 and map_polymorphic_typed (env : env) ((v1, v2) : CST.polymorphic_typed) =
-  let _v1 = token env v1 (* ":" *) in
-  let v2 = map_polymorphic_type env v2 in
-  v2
+  let tcolon = token env v1 (* ":" *) in
+  let ty = map_polymorphic_type env v2 in
+  (tcolon, ty)
 
 and map_record_binding_pattern (env : env)
     ((v1, v2, v3, v4, v5, v6) : CST.record_binding_pattern) =
@@ -2432,7 +2437,7 @@ and map_signature_item (env : env) (x : CST.signature_item) : item =
       let v1 = token env v1 (* "val" *) in
       let _v2 = map_attribute_opt env v2 in
       let v3 = map_value_name env v3 in
-      let v4 = map_polymorphic_typed env v4 in
+      let v4 = map_polymorphic_typed env v4 |> snd in
       let v5 = List_.map (map_item_attribute env) v5 in
       { i = Val (v1, v3, v4); iattrs = v5 }
   | `Exte x -> map_external_ env x

--- a/src/engine/Match_rules.ml
+++ b/src/engine/Match_rules.ml
@@ -158,12 +158,8 @@ let check ~match_hook ~timeout ~timeout_threshold
     | Some table -> Hashtbl.find_opt table
     | None -> fun _ -> None
   in
-  let {
-    Xtarget.path = { internal_path_to_content; _ };
-    lazy_ast_and_errors;
-    xlang;
-    _;
-  } (* : Xtarget.t *) =
+  let { path = { internal_path_to_content; _ }; lazy_ast_and_errors; xlang; _ }
+      : Xtarget.t =
     xtarget
   in
   Logs.debug (fun m ->

--- a/src/engine/Match_rules.ml
+++ b/src/engine/Match_rules.ml
@@ -57,8 +57,7 @@ let timeout_function (rule : Rule.t) file timeout f =
       None
 
 let is_relevant_rule_for_xtarget r xconf xtarget =
-  let { Xtarget.path = { internal_path_to_content; _ }; lazy_content; _ }
-      (* : Xtarget.t *) =
+  let { path = { internal_path_to_content; _ }; lazy_content; _ } : Xtarget.t =
     xtarget
   in
   let xconf = Match_env.adjust_xconfig_with_rule_options xconf r.R.options in

--- a/src/targeting/Find_targets.ml
+++ b/src/targeting/Find_targets.ml
@@ -118,9 +118,7 @@ type filter_result =
   | Ignore_silently (* ignore and don't report this file *)
 
 let filter_path (ign : Semgrepignore.t) (fppath : Fppath.t) : filter_result =
-  let { Fppath.fpath; ppath } (* TODO(tree-sitter-ocaml fail) : Fppath.t *) =
-    fppath
-  in
+  let { fpath; ppath } : Fppath.t = fppath in
   let status, selection_events = Semgrepignore.select ign ppath in
   match status with
   | Ignored ->

--- a/tests/parsing/ocaml/typed_pattern.ml
+++ b/tests/parsing/ocaml/typed_pattern.ml
@@ -1,0 +1,3 @@
+let foo () =
+  let { xx = a } : Zz.t = foobar in
+  a


### PR DESCRIPTION
test plan:
```
~/yy/bin/semgrep-core -l ocaml -dump_ast typed_pattern.ml
[00.00][INFO](cli, Core_CLI): Executed as: /home/pad/yy/bin/semgrep-core -l ocaml -dump_ast typed_pattern.ml
[00.00][INFO](cli, Core_CLI): Version: semgrep-core version: 1.61.1
Pr(
  [DefStmt(
     ({
       name=EN(
              Id(("foo", ()),
                {id_info_id=4; id_flags=Ref(0); id_resolved=Ref(None);
                 id_type=Ref(None); id_svalue=Ref(None); }));
       attrs=[]; tparams=[]; },
      FuncDef(
        {fkind=(Function, ()); fparams=[ParamPattern(PatLiteral(Unit(())))];
         frettype=None;
         fbody=FBStmt(
                 OtherStmt(OS_ExprStmt2,
                   [E(
                      StmtExpr(
                        Block(
                          [ExprStmt(
                             LetPattern(
                               PatTyped(PatRecord([]),
                                 {t_attrs=[];
                                  t=TyN(
                                      IdQualified(
                                        {name_last=(("t", ()), None);
                                         name_top=None;
                                         name_middle=Some(QDots(
                                                            [(("Zz", ()),
                                                              None)]));
                                         name_info={id_info_id=1;
                                                    id_flags=Ref(0);
                                                    id_resolved=Ref(None);
                                                    id_type=Ref(None);
                                                    id_svalue=Ref(None); };
                                         }));
                                  }),
                               N(
                                 Id(("foobar", ()),
                                   {id_info_id=2; id_flags=Ref(0);
                                    id_resolved=Ref(None); id_type=Ref(
                                    None); id_svalue=Ref(None); }))), ());
                           ExprStmt(
                             N(
                               Id(("a", ()),
                                 {id_info_id=3; id_flags=Ref(0);
                                  id_resolved=Ref(None); id_type=Ref(
                                  None); id_svalue=Ref(None); })), ())])))]));
         })))])
```