### PR TITLE
tainting: Add heuristic to choose label to report trace

### DIFF
--- a/changelog.d/flow-65.fixed
+++ b/changelog.d/flow-65.fixed
@@ -1,0 +1,5 @@
+taint-mode: experimental: For now Semgrep CLI taint traces are not adapted to
+support multiple labels, so Semgrep picks one arbitrary label to report, which
+sometimes it's not the desired one. As a temporary workaround, Semgrep will
+look at the `requires` of the sink, and if it has the shape `A and ...`, then
+it will pick `A` as the preferred label and report its trace.


### PR DESCRIPTION
When using taint labels, not all labels are equally relevant for the finding, but Semgrep can only report one label at present (until we generalize taint traces). Instead of picking always an arbitrary label, we now look into the 'requires' of the sink, and if it has the shape `A and ...` then we pick 'A' as our preferred label to report the trace.

Closes FLOW-65

test plan:
Run Semgrep with `--dataflow-traces` on https://semgrep.dev/playground/s/AbDeL
  #^ Now you get a taint trace for the label 'USER_INPUT'.

