### PR TITLE
Dogfood: add 'val' keyword in AST

### DIFF
--- a/languages/ocaml/generic/ocaml_to_generic.ml
+++ b/languages/ocaml/generic/ocaml_to_generic.ml
@@ -714,11 +714,11 @@ and item { i; iattrs } =
       let ent = G.basic_entity v1 ~attrs in
       let def = G.Exception (v1, v2) in
       [ G.DefStmt (ent, G.TypeDef { G.tbody = def }) |> G.s ]
-  | External (t, v1, v2, v3) ->
-      let v1 = ident v1 and v2 = type_ v2 and _v3 = list (wrap string) v3 in
-      let attrs = [ G.KeywordAttr (G.Extern, t) ] @ attrs in
-      let ent = G.basic_entity v1 ~attrs in
-      let def = G.Signature v2 in
+  | External (texternal, v1, v2, v3) ->
+      let id = ident v1 and ty = type_ v2 and _strs = list (wrap string) v3 in
+      let attrs = [ G.KeywordAttr (G.Extern, texternal) ] @ attrs in
+      let ent = G.basic_entity id ~attrs in
+      let def = G.Signature { sig_tok = texternal; sig_type = ty } in
       [ G.DefStmt (ent, def) |> G.s ]
   | Open (t, v1) ->
       let v1 = module_name v1 in
@@ -726,10 +726,10 @@ and item { i; iattrs } =
         { G.d = G.ImportAll (t, G.DottedName v1, fake "*"); d_attrs = attrs }
       in
       [ G.DirectiveStmt dir |> G.s ]
-  | Val (_t, v1, v2) ->
-      let v1 = ident v1 and v2 = type_ v2 in
-      let ent = G.basic_entity v1 ~attrs in
-      let def = G.Signature v2 in
+  | Val (tval, v1, v2) ->
+      let id = ident v1 and ty = type_ v2 in
+      let ent = G.basic_entity id ~attrs in
+      let def = G.Signature { sig_tok = tval; sig_type = ty } in
       [ G.DefStmt (ent, def) |> G.s ]
   | Let (tlet, v1, v2) ->
       let _v1 = rec_opt v1 and v2 = list let_binding v2 in

--- a/libs/ast_generic/AST_generic.ml
+++ b/libs/ast_generic/AST_generic.ml
@@ -1657,7 +1657,7 @@ and definition_kind =
   | ModuleDef of module_definition
   | MacroDef of macro_definition
   (* in a header file (e.g., .mli in OCaml or 'module sig') *)
-  | Signature of type_
+  | Signature of signature_definition
   (* Only used inside a function.
    * Needed for languages without local VarDef (e.g., Python/PHP)
    * where the first use is also its declaration. In that case when we
@@ -1956,6 +1956,15 @@ and module_definition_kind =
  * an empty list of parameters, but they are not MacroVar
  *)
 and macro_definition = { macroparams : ident list; macrobody : any list }
+
+(* ------------------------------------------------------------------------- *)
+(* Signature definition *)
+(* ------------------------------------------------------------------------- *)
+and signature_definition = {
+  (* ex: 'val' in OCaml *)
+  sig_tok : tok;
+  sig_type : type_;
+}
 
 (*****************************************************************************)
 (* Directives (Module import/export, package) *)

--- a/libs/ast_generic/AST_generic_to_v1.ml
+++ b/libs/ast_generic/AST_generic_to_v1.ml
@@ -1029,8 +1029,8 @@ and map_definition_kind = function
   | MacroDef v1 ->
       let v1 = map_macro_definition v1 in
       `MacroDef v1
-  | Signature v1 ->
-      let v1 = map_type_ v1 in
+  | Signature { sig_tok = _; sig_type } ->
+      let v1 = map_type_ sig_type in
       `Signature v1
   | UseOuterDecl v1 ->
       let v1 = map_tok v1 in

--- a/libs/ast_generic/Meta_AST.ml
+++ b/libs/ast_generic/Meta_AST.ml
@@ -1142,7 +1142,7 @@ and vof_definition_kind = function
       let v1 = vof_macro_definition v1 in
       OCaml.VSum ("MacroDef", [ v1 ])
   | Signature v1 ->
-      let v1 = vof_type_ v1 in
+      let v1 = vof_signature_definition v1 in
       OCaml.VSum ("Signature", [ v1 ])
   | UseOuterDecl v1 ->
       let v1 = vof_tok v1 in
@@ -1179,6 +1179,16 @@ and vof_macro_definition
   let bnds = bnd :: bnds in
   let arg = OCaml.vof_list vof_ident v_macroparams in
   let bnd = ("macroparams", arg) in
+  let bnds = bnd :: bnds in
+  OCaml.VDict bnds
+
+and vof_signature_definition { sig_tok; sig_type } =
+  let bnds = [] in
+  let arg = vof_type_ sig_type in
+  let bnd = ("sig_type", arg) in
+  let bnds = bnd :: bnds in
+  let arg = vof_tok sig_tok in
+  let bnd = ("sig_tok", arg) in
   let bnds = bnd :: bnds in
   OCaml.VDict bnds
 

--- a/src/matching/Generic_vs_generic.ml
+++ b/src/matching/Generic_vs_generic.ml
@@ -2934,7 +2934,7 @@ and m_definition_kind a b =
   | G.TypeDef a1, B.TypeDef b1 -> m_type_definition a1 b1
   | G.ModuleDef a1, B.ModuleDef b1 -> m_module_definition a1 b1
   | G.MacroDef a1, B.MacroDef b1 -> m_macro_definition a1 b1
-  | G.Signature a1, B.Signature b1 -> m_type_ a1 b1
+  | G.Signature a1, B.Signature b1 -> m_signature_definition a1 b1
   | G.UseOuterDecl a1, B.UseOuterDecl b1 -> m_tok a1 b1
   | G.OtherDef (a1, a2), B.OtherDef (b1, b2) ->
       m_todo_kind a1 b1 >>= fun () -> (m_list m_any) a2 b2
@@ -2956,6 +2956,13 @@ and m_enum_entry_definition a b =
   | { G.ee_args = a1; ee_body = a2 }, { B.ee_args = b1; ee_body = b2 } ->
       let* () = m_option m_arguments a1 b1 in
       let* () = m_option (m_bracket m_fields) a2 b2 in
+      return ()
+
+and m_signature_definition a b =
+  match (a, b) with
+  | { G.sig_tok = a1; sig_type = a2 }, { B.sig_tok = b1; sig_type = b2 } ->
+      let* () = m_tok a1 b1 in
+      let* () = m_type_ a2 b2 in
       return ()
 
 and m_type_parameter a b =

--- a/tests/autofix/ocaml/val.fix
+++ b/tests/autofix/ocaml/val.fix
@@ -1,0 +1,1 @@
+val foo : float

--- a/tests/autofix/ocaml/val.fixed
+++ b/tests/autofix/ocaml/val.fixed
@@ -1,0 +1,2 @@
+(* MATCH: *)
+val foo : float

--- a/tests/autofix/ocaml/val.ml
+++ b/tests/autofix/ocaml/val.ml
@@ -1,0 +1,2 @@
+(* MATCH: *)
+val foo: int

--- a/tests/autofix/ocaml/val.sgrep
+++ b/tests/autofix/ocaml/val.sgrep
@@ -1,0 +1,1 @@
+val foo: int


### PR DESCRIPTION
I was doing some OCaml refactoring use semgrep autofix,
but got some bad behavior because 'val' was not in the AST.

test plan:
test file included
make test