### PR TITLE
Add ttok in AST_generic.type_definition

### DIFF
--- a/languages/c/generic/c_to_generic.ml
+++ b/languages/c/generic/c_to_generic.ml
@@ -546,7 +546,12 @@ and struct_def { s_name; s_kind; s_flds } =
                   [ G.basic_field n None (Some t) ])))
           s_flds
       in
-      (entity, G.TypeDef { G.tbody = G.AndType (l, List.flatten fields, r) })
+      ( entity,
+        G.TypeDef
+          {
+            G.ttok = unsafe_fake "type";
+            G.tbody = G.AndType (l, List.flatten fields, r);
+          } )
   | Union ->
       let _l, fields, _r =
         bracket
@@ -556,7 +561,12 @@ and struct_def { s_name; s_kind; s_flds } =
                   G.OrConstructor (n, [ t ]))))
           s_flds
       in
-      (entity, G.TypeDef { G.tbody = G.OrType (List.flatten fields) })
+      ( entity,
+        G.TypeDef
+          {
+            G.ttok = unsafe_fake "type";
+            G.tbody = G.OrType (List.flatten fields);
+          } )
 
 and field_def { fld_name; fld_type } =
   let v1 = option name fld_name in
@@ -573,12 +583,14 @@ and enum_def { e_name = v1; e_type = _v2_TODO; e_consts = v3 } =
       v3
   in
   let entity = G.basic_entity v1 in
-  (entity, G.TypeDef { G.tbody = G.OrType (List.flatten v3) })
+  ( entity,
+    G.TypeDef
+      { G.ttok = unsafe_fake "type"; G.tbody = G.OrType (List.flatten v3) } )
 
 and type_def { t_name = v1; t_type = v2 } =
   let v1 = name v1 and v2 = type_ v2 in
   let entity = G.basic_entity v1 in
-  (entity, G.TypeDef { G.tbody = G.AliasType v2 })
+  (entity, G.TypeDef { G.ttok = unsafe_fake "type"; G.tbody = G.AliasType v2 })
 
 and define_body = function
   | None -> []

--- a/languages/cairo/generic/Parse_cairo_tree_sitter.ml
+++ b/languages/cairo/generic/Parse_cairo_tree_sitter.ml
@@ -712,7 +712,8 @@ and map_const_declaration (env : env) (x : CST.const_declaration) : G.definition
 
 and map_typealias_declaration (env : env) (x : CST.typealias_declaration) :
     G.definition =
-  let _, name, type_parameters, _, ttype, _ = x in
+  let ttype, name, type_parameters, _teq, ty, _tsc = x in
+  let ttype = token env ttype in
 
   let name : G.entity =
     {
@@ -725,9 +726,9 @@ and map_typealias_declaration (env : env) (x : CST.typealias_declaration) :
     }
   in
 
-  let ttype = map_type env ttype in
+  let ty = map_type env ty in
 
-  (name, G.TypeDef { tbody = G.AliasType ttype })
+  (name, G.TypeDef { G.ttok = ttype; tbody = G.AliasType ty })
 
 and map_trait_declaration (env : env) (x : CST.trait_declaration) : G.definition
     =

--- a/languages/csharp/generic/Parse_csharp_tree_sitter.ml
+++ b/languages/csharp/generic/Parse_csharp_tree_sitter.ml
@@ -2950,7 +2950,7 @@ and struct_declaration (env : env)
 and enum_declaration env (v1, v2, v3, v4, v5, v6, v7) =
   let v1 = List.concat_map (attribute_list env) v1 in
   let v2 = List_.map (modifier env) v2 in
-  let _v3TODO = token env v3 (* "enum" *) in
+  let tenum = token env v3 (* "enum" *) in
   let v4 = identifier env v4 (* identifier *) in
   let _v5TODO =
     match v5 with
@@ -2961,12 +2961,12 @@ and enum_declaration env (v1, v2, v3, v4, v5, v6, v7) =
   let _v7 = opt_semi env v7 (* ";" *) in
   let idinfo = empty_id_info () in
   let ent = { name = EN (Id (v4, idinfo)); attrs = v1 @ v2; tparams = [] } in
-  G.DefStmt (ent, G.TypeDef { tbody = OrType v6 }) |> G.s
+  G.DefStmt (ent, G.TypeDef { ttok = tenum; tbody = OrType v6 }) |> G.s
 
 and delegate_declaration env (v1, v2, v3, v4, v5, v6, v7, v8, v9) =
   let v1 = List.concat_map (attribute_list env) v1 in
   let v2 = List_.map (modifier env) v2 in
-  let _v3 = token env v3 (* "delegate" *) in
+  let tdelegate = token env v3 (* "delegate" *) in
   let v4 = type_pattern env v4 in
   let v5 = identifier env v5 (* identifier *) in
   let v6 =
@@ -2981,7 +2981,7 @@ and delegate_declaration env (v1, v2, v3, v4, v5, v6, v7, v8, v9) =
   let func = TyFun (params, v4) |> G.t in
   let idinfo = empty_id_info () in
   let ent = { name = EN (Id (v5, idinfo)); attrs = v1 @ v2; tparams } in
-  DefStmt (ent, TypeDef { tbody = NewType func }) |> G.s
+  DefStmt (ent, TypeDef { ttok = tdelegate; tbody = NewType func }) |> G.s
 
 and record_declaration env (_, _, v3, _, _, _, _, _, _, _, _) =
   let v3 = token env v3 (* "record" *) in

--- a/languages/dart/generic/Parse_dart_tree_sitter.ml
+++ b/languages/dart/generic/Parse_dart_tree_sitter.ml
@@ -2668,7 +2668,7 @@ let map_type_alias ~attrs (env : env) (x : CST.type_alias) : stmt =
   match x with
   | `Type_type_name_opt_type_params_EQ_func_type_SEMI (v1, v2, v3, v4, v5, v6)
     ->
-      let _v1 = (* "typedef" *) token env v1 in
+      let ttypedef = (* "typedef" *) token env v1 in
       let v2 = map_type_name_name env v2 in
       let tparams =
         match v3 with
@@ -2679,7 +2679,8 @@ let map_type_alias ~attrs (env : env) (x : CST.type_alias) : stmt =
       let v5 = map_function_type env v5 in
       let _v6 = (* ";" *) token env v6 in
       DefStmt
-        ({ name = EN v2; attrs; tparams }, TypeDef { tbody = AliasType v5 })
+        ( { name = EN v2; attrs; tparams },
+          TypeDef { ttok = ttypedef; tbody = AliasType v5 } )
       |> G.s
   | `Type_opt_type_type_name_formal_param_part_SEMI (v1, v2, v3, v4, v5) ->
       (* This seems to be the "original" use for typedefs in Dart, which
@@ -2688,7 +2689,7 @@ let map_type_alias ~attrs (env : env) (x : CST.type_alias) : stmt =
          type of the function is specified.
          https://stackoverflow.com/questions/12545762/what-are-function-typedefs-function-type-aliases-in-dart
       *)
-      let _v1 = (* "typedef" *) token env v1 in
+      let tkwd = (* "typedef" *) token env v1 in
       let ret_ty =
         match v2 with
         | Some x -> map_type_ env x
@@ -2700,7 +2701,8 @@ let map_type_alias ~attrs (env : env) (x : CST.type_alias) : stmt =
       let _v5 = (* ";" *) token env v5 in
       let ty = TyFun (params, ret_ty) |> G.t in
       DefStmt
-        ({ name = EN v3; attrs; tparams }, TypeDef { tbody = AliasType ty })
+        ( { name = EN v3; attrs; tparams },
+          TypeDef { ttok = tkwd; tbody = AliasType ty } )
       |> G.s
 
 (* THINK: Seems to be like a Java package...

--- a/languages/go/generic/go_to_generic.ml
+++ b/languages/go/generic/go_to_generic.ml
@@ -617,13 +617,22 @@ let top_func () =
     | DTypeAlias (v1, v2, v3) ->
         let v1 = ident v1 and _v2 = tok v2 and v3 = type_ v3 in
         let ent = G.basic_entity v1 in
-        G.DefStmt (ent, G.TypeDef { G.tbody = G.AliasType v3 }) |> G.s
+        G.DefStmt
+          ( ent,
+            G.TypeDef
+              { G.ttok = fake (snd v1) "typealias"; G.tbody = G.AliasType v3 }
+          )
+        |> G.s
     | DTypeDef (v1, v2, v3) ->
         let id = ident v1 in
         let tparams = option type_parameters v2 |> List_.optlist_to_list in
         let ty = type_ v3 in
         let ent = G.basic_entity id ~tparams in
-        G.DefStmt (ent, G.TypeDef { G.tbody = G.NewType ty }) |> G.s
+        G.DefStmt
+          ( ent,
+            G.TypeDef { G.ttok = fake (snd v1) "type"; G.tbody = G.NewType ty }
+          )
+        |> G.s
   and type_parameters v : G.type_parameters =
     let _, xs, _ = bracket (list type_parameter) v in
     xs

--- a/languages/julia/generic/Parse_julia_tree_sitter.ml
+++ b/languages/julia/generic/Parse_julia_tree_sitter.ml
@@ -1137,8 +1137,9 @@ and map_definition (env : env) (x : CST.definition) : stmt =
       let attrs = map_type_clause_opt env v4 in
       let ent = map_anon_choice_id_00cc266_ent ~attrs ~tparams env v2 in
       let _v5 = (* "end" *) token env v5 in
-      DefStmt (ent, TypeDef { tbody = AbstractType v1 }) |> G.s
+      DefStmt (ent, TypeDef { ttok = v1; tbody = AbstractType v1 }) |> G.s
   | `Prim_defi (v1, v2, v3, v4, v5, v6) ->
+      let v1 = str env v1 in
       (* primitive type *)
       let tparams =
         match v3 with
@@ -1149,7 +1150,8 @@ and map_definition (env : env) (x : CST.definition) : stmt =
       let ent = map_anon_choice_id_00cc266_ent ~attrs ~tparams env v2 in
       let i = map_integer_literal env v5 in
       let _v6 = (* "end" *) token env v6 in
-      DefStmt (ent, TypeDef { tbody = OtherTypeKind (str env v1, [ G.E i ]) })
+      DefStmt
+        (ent, TypeDef { ttok = snd v1; tbody = OtherTypeKind (v1, [ G.E i ]) })
       |> G.s
   | `Struct_defi (v1, v2, v3, v4, v5, v6, v7, v8) ->
       let v1 =
@@ -1157,7 +1159,7 @@ and map_definition (env : env) (x : CST.definition) : stmt =
         | Some tok -> (* "mutable" *) [ KeywordAttr (Mutable, token env tok) ]
         | None -> []
       in
-      let v2 = (* "struct" *) token env v2 in
+      let tstruct = (* "struct" *) token env v2 in
       let tparams =
         match v4 with
         | None -> []
@@ -1166,10 +1168,15 @@ and map_definition (env : env) (x : CST.definition) : stmt =
       let attrs = v1 @ map_type_clause_opt env v5 in
       let _v6 = map_terminator_opt env v6 in
       let v7 = map_source_file env v7 in
-      let v8 = (* "end" *) token env v8 in
+      let tend = (* "end" *) token env v8 in
       let ent = map_anon_choice_id_00cc266_ent ~attrs ~tparams env v3 in
       DefStmt
-        (ent, TypeDef { tbody = AndType (v2, List_.map (fun x -> F x) v7, v8) })
+        ( ent,
+          TypeDef
+            {
+              ttok = tstruct;
+              tbody = AndType (tstruct, List_.map (fun x -> F x) v7, tend);
+            } )
       |> G.s
   | `Func_defi x -> map_function_definition env x
   | `Macro_defi (v1, v2, v3, v4, v5, v6, v7) -> (

--- a/languages/kotlin/generic/Parse_kotlin_tree_sitter.ml
+++ b/languages/kotlin/generic/Parse_kotlin_tree_sitter.ml
@@ -1047,17 +1047,17 @@ and declaration (env : env) (x : CST.declaration) : definition =
       (ent, VarDef vdef)
   | `Type_alias (v0, v1, v2, v3, v4, v5) ->
       let attrs = modifiers_opt env v0 in
-      let _kwd = token env v1 (* "typealias" *) in
+      let tkwd = token env v1 (* "typealias" *) in
       let id = simple_identifier env v2 in
       let tparams =
         match v3 with
         | None -> []
         | Some v3 -> type_parameters env v3
       in
-      let _eq = token env v4 (* "=" *) in
+      let _teq = token env v4 (* "=" *) in
       let t = type_ env v5 in
       let ent = basic_entity ~attrs ~tparams id in
-      let tdef = { tbody = AliasType t } in
+      let tdef = { ttok = tkwd; tbody = AliasType t } in
       (ent, TypeDef tdef)
 
 and delegation_specifier (env : env) (x : CST.delegation_specifier) :

--- a/languages/ocaml/ast/AST_ocaml.ml
+++ b/languages/ocaml/ast/AST_ocaml.ml
@@ -256,7 +256,9 @@ and pattern =
 (* Let binding (global/local/function definition) *)
 (* ------------------------------------------------------------------------- *)
 
-(* Similar to the Fun vs Function dichotomy *)
+(* Similar to the Fun vs Function dichotomy.
+ * TODO: add Tok.t also here, for 'let' 'and' like in type_declaration
+ *)
 and let_binding = LetClassic of let_def | LetPattern of pattern * expr
 
 (* was called fun_binding in the grammar *)
@@ -288,7 +290,13 @@ and parameter =
  *)
 
 (* TODO: keyword attribute: private, constraints *)
-and type_declaration =
+and type_declaration = {
+  (* 'type' or 'and' *)
+  ttok : Tok.t;
+  tkind : type_declaration_kind;
+}
+
+and type_declaration_kind =
   | TyDecl of type_declaration_classic
   (* TODO: Extension (+=) decl, .. *)
   | TyDeclTodo of todo_category
@@ -396,7 +404,7 @@ and item = { i : item_kind; iattrs : attributes }
  * valid in both contexts.
  *)
 and item_kind =
-  | Type of Tok.t * type_declaration list (* mutually recursive *)
+  | Type of type_declaration list (* mutually recursive *)
   | Exception of Tok.t * ident * type_ list
   | External of Tok.t * ident * type_ * string wrap list (* primitive decls *)
   (* TODO: '!' option *)

--- a/languages/ocaml/generic/ocaml_to_generic.ml
+++ b/languages/ocaml/generic/ocaml_to_generic.ml
@@ -576,14 +576,14 @@ and class_field (fld : class_field) : G.field =
       let st = G.OtherStmt (G.OS_Todo, [ G.TodoK todok ]) |> G.s in
       G.F st
 
-and type_declaration x =
-  match x with
+and type_declaration { ttok; tkind } =
+  match tkind with
   | TyDecl { tname; tparams; tbody } ->
       let v1 = ident tname in
       let v2 = list type_parameter tparams in
       let v3 = type_def_kind tbody in
       let entity = { (G.basic_entity v1) with G.tparams = v2 } in
-      let def = { G.tbody = v3 } in
+      let def = { G.ttok; G.tbody = v3 } in
       Either.Left (entity, def)
   | TyDeclTodo categ -> Either.Right categ
 
@@ -699,7 +699,7 @@ and item { i; iattrs } =
   | TopExpr e ->
       let e = expr e in
       [ G.exprstmt e ]
-  | Type (_t, v1) ->
+  | Type v1 ->
       let xs = list type_declaration v1 in
       xs
       |> List_.map (function
@@ -709,11 +709,11 @@ and item { i; iattrs } =
                G.DefStmt (ent, G.TypeDef def) |> G.s
            | Either.Right categ ->
                G.OtherStmt (G.OS_Todo, [ G.TodoK categ ]) |> G.s)
-  | Exception (_t, v1, v2) ->
+  | Exception (texn, v1, v2) ->
       let v1 = ident v1 and v2 = list type_ v2 in
       let ent = G.basic_entity v1 ~attrs in
       let def = G.Exception (v1, v2) in
-      [ G.DefStmt (ent, G.TypeDef { G.tbody = def }) |> G.s ]
+      [ G.DefStmt (ent, G.TypeDef { G.ttok = texn; G.tbody = def }) |> G.s ]
   | External (texternal, v1, v2, v3) ->
       let id = ident v1 and ty = type_ v2 and _strs = list (wrap string) v3 in
       let attrs = [ G.KeywordAttr (G.Extern, texternal) ] @ attrs in

--- a/languages/ocaml/menhir/parser_ml.mly
+++ b/languages/ocaml/menhir/parser_ml.mly
@@ -297,7 +297,7 @@ type_for_lsp: core_type_no_attr EOF { $1 }
 
 signature_or_structure_common:
  | Ttype list_and(type_declaration)
-     { Type ($1, $2) }
+     { Type ($2) }
  | Texternal val_ident ":" core_type_no_attr "=" primitive_declaration
      { External ($1, $2, $4, $6) }
  | Texception TUpperIdent generalized_constructor_arguments
@@ -856,11 +856,16 @@ type_constraint:
 
 type_declaration: type_parameters TLowerIdent type_kind (*TODOAST constraints*)
    { let tparams = $1 |> List.map (fun id -> TyParam id) in
-     match $3 with
-     | None ->
-         TyDecl { tname = $2; tparams; tbody = AbstractType }
-     | Some (_tok_eq, type_kind) ->
-         TyDecl { tname = $2; tparams; tbody = type_kind }
+     (* TODO: get tok from caller *)
+     let ttok = Tok.unsafe_fake_tok "" in
+     let tkind =
+       match $3 with
+       | None ->
+           TyDecl { tname = $2; tparams; tbody = AbstractType }
+       | Some (_tok_eq, type_kind) ->
+           TyDecl { tname = $2; tparams; tbody = type_kind }
+     in
+     { ttok; tkind }
    }
 
 

--- a/languages/ocaml/tree-sitter/Parse_ocaml_tree_sitter.ml
+++ b/languages/ocaml/tree-sitter/Parse_ocaml_tree_sitter.ml
@@ -3078,14 +3078,14 @@ and private_opt env v =
   | None -> None
   | Some tok -> Some (token env tok)
 
-and map_type_binding (env : env) ((v1, v2, v3) : CST.type_binding) :
+and map_type_binding (env : env) ttok ((v1, v2, v3) : CST.type_binding) :
     type_declaration =
   let tparams =
     match v1 with
     | Some x -> map_type_params env x
     | None -> []
   in
-  let v2 =
+  let tkind =
     match v2 with
     | `Id_opt_type_equa_opt_EQ_opt_priv_choice_vari_decl_rep_type_cons
         (v1, v2, v3, v4) ->
@@ -3136,7 +3136,7 @@ and map_type_binding (env : env) ((v1, v2, v3) : CST.type_binding) :
         TyDeclTodo ("ExtensionType", v2)
   in
   let _v3 = List_.map (map_item_attribute env) v3 in
-  v2
+  { ttok; tkind }
 
 and map_type_constraint (env : env) ((v1, v2, v3, v4) : CST.type_constraint) =
   let _v1 = token env v1 (* "constraint" *) in
@@ -3147,23 +3147,23 @@ and map_type_constraint (env : env) ((v1, v2, v3, v4) : CST.type_constraint) =
 
 and map_type_definition (env : env) ((v1, v2, v3, v4, v5) : CST.type_definition)
     =
-  let v1 = token env v1 (* "type" *) in
+  let ttype = token env v1 (* "type" *) in
   let _v2 = map_attribute_opt env v2 in
   let _v3 =
     match v3 with
     | Some tok -> Some (token env tok) (* "nonrec" *)
     | None -> None
   in
-  let v4 = map_type_binding env v4 in
+  let v4 = map_type_binding env ttype v4 in
   let v5 =
     List_.map
       (fun (v1, v2) ->
-        let _v1 = token env v1 (* "and" *) in
-        let v2 = map_type_binding env v2 in
+        let tand = token env v1 (* "and" *) in
+        let v2 = map_type_binding env tand v2 in
         v2)
       v5
   in
-  Type (v1, v4 :: v5) |> mki
+  Type (v4 :: v5) |> mki
 
 and map_type_equation (env : env) ((v1, v2, v3) : CST.type_equation) =
   let teq = map_anon_choice_EQ_4ccabd6 env v1 in

--- a/languages/php/generic/php_to_generic.ml
+++ b/languages/php/generic/php_to_generic.ml
@@ -707,7 +707,7 @@ and type_def { t_name; t_kind } =
   let id = ident t_name in
   let kind = type_def_kind (snd t_name) t_kind in
   let ent = G.basic_entity ~case_insensitive:true id in
-  (ent, { G.tbody = kind })
+  (ent, { G.tbody = kind; ttok = fake "type" })
 
 and type_def_kind _tok = function
   | Alias v1 ->

--- a/languages/rust/generic/Parse_rust_tree_sitter.ml
+++ b/languages/rust/generic/Parse_rust_tree_sitter.ml
@@ -984,7 +984,7 @@ and map_arguments (env : env) ((v1, v2, _v3TODO, v4) : CST.arguments) :
 (* was restricted to appear only in trait_impl_block by ruin *)
 and map_associated_type (env : env) ((v1, v2, v3, v4, v5) : CST.associated_type)
     : G.stmt =
-  let _type_TODO = token env v1 (* "type" *) in
+  let ttype = token env v1 (* "type" *) in
   let ident = ident env v2 in
   (* pattern (r#)?[a-zA-Zα-ωΑ-Ωµ_][a-zA-Zα-ωΑ-Ωµ\d_]* *)
   let type_params =
@@ -1016,7 +1016,7 @@ and map_associated_type (env : env) ((v1, v2, v3, v4, v5) : CST.associated_type)
        | None -> G.AbstractType semicolon
     *)
   in
-  let type_def = { G.tbody = type_def_kind } in
+  let type_def = { G.ttok = ttype; G.tbody = type_def_kind } in
   let ent =
     {
       G.name = G.EN (G.Id (ident, G.empty_id_info ()));
@@ -3359,7 +3359,7 @@ and map_declaration_statement_bis (env : env) outer_attrs (*_visibility*) x :
       in
       [ G.DefStmt (ent, G.ClassDef class_def) |> G.s ]
   | `Union_item (_v0TODO, v1, v2, v3, v4, v5) ->
-      let _unionTODO = token env v1 (* "union" *) in
+      let tunion = token env v1 (* "union" *) in
       let ident = ident env v2 in
       (* pattern (r#)?[a-zA-Zα-ωΑ-Ωµ_][a-zA-Zα-ωΑ-Ωµ\d_]* *)
       let type_params =
@@ -3373,7 +3373,7 @@ and map_declaration_statement_bis (env : env) outer_attrs (*_visibility*) x :
         | None -> []
       in
       let variants = map_field_declaration_list_union env v5 in
-      let type_def = { G.tbody = G.OrType variants } in
+      let type_def = { G.ttok = tunion; G.tbody = G.OrType variants } in
       let ent =
         {
           G.name = G.EN (G.Id (ident, G.empty_id_info ()));
@@ -3383,7 +3383,7 @@ and map_declaration_statement_bis (env : env) outer_attrs (*_visibility*) x :
       in
       [ G.DefStmt (ent, G.TypeDef type_def) |> G.s ]
   | `Enum_item (_v0TODO, v1, v2, v3, v4, v5) ->
-      let _enumTODO = token env v1 (* "enum" *) in
+      let tenum = token env v1 (* "enum" *) in
       let ident = ident env v2 in
       (* pattern (r#)?[a-zA-Zα-ωΑ-Ωµ_][a-zA-Zα-ωΑ-Ωµ\d_]* *)
       let type_params =
@@ -3393,7 +3393,7 @@ and map_declaration_statement_bis (env : env) outer_attrs (*_visibility*) x :
       in
       let _where_clause = Option.map (fun x -> map_where_clause env x) v4 in
       let body = map_enum_variant_list env v5 in
-      let type_def = { G.tbody = body } in
+      let type_def = { G.ttok = tenum; G.tbody = body } in
       let ent =
         {
           G.name = G.EN (G.Id (ident, G.empty_id_info ()));
@@ -3403,7 +3403,7 @@ and map_declaration_statement_bis (env : env) outer_attrs (*_visibility*) x :
       in
       [ G.DefStmt (ent, G.TypeDef type_def) |> G.s ]
   | `Type_item (_v0TODO, v1, v2, v3, v4, v5, v6, v7) ->
-      let _type_TODO = token env v1 (* "type" *) in
+      let ttype = token env v1 (* "type" *) in
       let ident = ident env v2 in
       (* pattern (r#)?[a-zA-Zα-ωΑ-Ωµ_][a-zA-Zα-ωΑ-Ωµ\d_]* *)
       let type_params =
@@ -3416,7 +3416,10 @@ and map_declaration_statement_bis (env : env) outer_attrs (*_visibility*) x :
       let _where_clauseTODO = Option.map (fun x -> map_where_clause env x) v6 in
       let _semicolon = token env v7 (* ";" *) in
       let type_def =
-        { G.tbody = G.NewType (G.TyN (H2.name_of_id ident) |> G.t) }
+        {
+          G.ttok = ttype;
+          G.tbody = G.NewType (G.TyN (H2.name_of_id ident) |> G.t);
+        }
       in
       let ent =
         {

--- a/languages/scala/generic/scala_to_generic.ml
+++ b/languages/scala/generic/scala_to_generic.ml
@@ -1194,9 +1194,9 @@ and v_template_kind = function
   | Singleton -> G.Object
 
 and v_type_definition { ttok = v_ttok; tbody = v_tbody } =
-  let _tok = v_tok v_ttok in
+  let ttok = v_tok v_ttok in
   let arg = v_type_definition_kind v_tbody in
-  { tbody = arg }
+  { ttok; tbody = arg }
 
 and v_type_definition_kind = function
   | TDef (v1, v2) ->

--- a/languages/solidity/generic/Parse_solidity_tree_sitter.ml
+++ b/languages/solidity/generic/Parse_solidity_tree_sitter.ml
@@ -517,13 +517,13 @@ let map_primitive_type (env : env) (x : CST.primitive_type) : type_ =
 
 let map_user_defined_type_definition (env : env)
     ((v1, v2, v3, v4, v5) : CST.user_defined_type_definition) : definition =
-  let _ttype = (* "type" *) token env v1 in
+  let ttype = (* "type" *) token env v1 in
   let id = (* pattern [a-zA-Z$_][a-zA-Z0-9$_]* *) str env v2 in
   let _tis = (* "is" *) token env v3 in
   let ty = map_primitive_type env v4 in
   let _sc = (* ";" *) token env v5 in
   let ent = G.basic_entity id in
-  let def = { tbody = AliasType (* or NewType? *) ty } in
+  let def = { ttok = ttype; tbody = AliasType (* or NewType? *) ty } in
   (ent, TypeDef def)
 
 let map_enum_member (env : env) (x : CST.enum_member) : or_type_element =
@@ -537,7 +537,7 @@ let map_enum_member (env : env) (x : CST.enum_member) : or_type_element =
 
 let map_enum_declaration (env : env)
     ((v1, v2, v3, v4, v5) : CST.enum_declaration) : definition =
-  let _enumkwd = (* "enum" *) token env v1 in
+  let tenum = (* "enum" *) token env v1 in
   let id = (* pattern [a-zA-Z$_][a-zA-Z0-9$_]* *) str env v2 in
   let _lb = (* "{" *) token env v3 in
   let or_elems =
@@ -556,7 +556,7 @@ let map_enum_declaration (env : env)
   in
   let _rb = (* "}" *) token env v5 in
   let ent = G.basic_entity id in
-  let def = { tbody = OrType or_elems } in
+  let def = { ttok = tenum; tbody = OrType or_elems } in
   (ent, TypeDef def)
 
 let map_override_specifier (env : env) ((v1, v2) : CST.override_specifier) =
@@ -2325,7 +2325,7 @@ let map_error_parameter (env : env) ((v1, v2) : CST.error_parameter) : type_ =
 
 let map_error_declaration (env : env)
     ((v1, v2, v3, v4, v5, v6) : CST.error_declaration) : definition =
-  let _terror = (* "error" *) token env v1 in
+  let terror = (* "error" *) token env v1 in
   let id = (* pattern [a-zA-Z$_][a-zA-Z0-9$_]* *) str env v2 in
   let _lp = (* "(" *) token env v3 in
   let params =
@@ -2347,7 +2347,7 @@ let map_error_declaration (env : env)
   let _rp = (* ")" *) token env v5 in
   let _sc = (* ";" *) token env v6 in
   let ent = G.basic_entity id in
-  let def = { tbody = Exception (id, params) } in
+  let def = { ttok = terror; tbody = Exception (id, params) } in
   (ent, TypeDef def)
 
 let map_contract_member (env : env) (x : CST.contract_member) =

--- a/languages/swift/generic/Parse_swift_tree_sitter.ml
+++ b/languages/swift/generic/Parse_swift_tree_sitter.ml
@@ -918,7 +918,7 @@ and map_modifiers_opt env v : G.attribute list =
 
 and map_associatedtype_declaration (env : env)
     ((v1, v2, v3, v4, v5, v6) : CST.associatedtype_declaration) =
-  let v2 = (* "associatedtype" *) token env v2 in
+  let tassoctype = (* "associatedtype" *) token env v2 in
   (* a default value for the associated type is a modifier on the actual
      definition
   *)
@@ -928,7 +928,7 @@ and map_associatedtype_declaration (env : env)
       | Some (v1, ty) ->
           let _v1 = (* eq_custom *) token env v1 in
           let ty = map_type_ env ty in
-          [ G.OtherAttribute (("DefaultType", v2), [ G.T ty ]) ]
+          [ G.OtherAttribute (("DefaultType", tassoctype), [ G.T ty ]) ]
       | None -> []
     in
     map_modifiers_opt env v1 @ default
@@ -948,7 +948,11 @@ and map_associatedtype_declaration (env : env)
   in
   G.DefStmt
     ( G.basic_entity ~attrs:modifiers id,
-      G.TypeDef { tbody = G.OtherTypeKind (("Protocol", v2), protocol) } )
+      G.TypeDef
+        {
+          ttok = tassoctype;
+          tbody = G.OtherTypeKind (("Protocol", tassoctype), protocol);
+        } )
   |> G.s
 
 and map_attribute_argument (env : env) (x : CST.attribute_argument) =
@@ -2187,14 +2191,14 @@ and map_modifierless_property_declaration (env : env) (attrs : G.attribute list)
 and map_modifierless_typealias_declaration (env : env)
     (attrs : G.attribute list)
     ((v1, v2, v3, v4, v5) : CST.modifierless_typealias_declaration) =
-  let _ttypealias = (* "typealias" *) token env v1 in
+  let ttypealias = (* "typealias" *) token env v1 in
   let v2 = map_simple_identifier env v2 in
   let v3 = Option.map (map_type_parameters env) v3 |> List_.optlist_to_list in
   let _v4TODO = (* eq_custom *) token env v4 in
   let v5 = map_type_ env v5 in
   G.DefStmt
     ( G.basic_entity ~tparams:v3 ~attrs v2,
-      G.TypeDef { G.tbody = G.AliasType v5 } )
+      G.TypeDef { G.ttok = ttypealias; G.tbody = G.AliasType v5 } )
   |> G.s
 
 and map_modifiers (env : env) (xs : CST.modifiers) =

--- a/libs/ast_generic/AST_generic.ml
+++ b/libs/ast_generic/AST_generic.ml
@@ -174,7 +174,7 @@
  * convenient to correspond mostly to Semgrep versions. So version below
  * can jump from "1.12.1" to "1.20.0" and that's fine.
  *)
-let version = "1.35.0"
+let version = "1.62.0"
 
 (*****************************************************************************)
 (* Some notes on deriving *)

--- a/libs/ast_generic/AST_generic.ml
+++ b/libs/ast_generic/AST_generic.ml
@@ -1820,7 +1820,16 @@ and variable_definition = {
 (* ------------------------------------------------------------------------- *)
 (* Type definition *)
 (* ------------------------------------------------------------------------- *)
-and type_definition = { tbody : type_definition_kind }
+and type_definition = {
+  (* ex: 'type' in OCaml/Rust/Scala/Solidity/Hack, 'typedef' in C++/Dart,
+   * 'typealias' in Kotlin/Swift, 'newtype' in Hack
+   * 'enum'/'union' in C#/Hack/Solidity/Rust, 'struct' in Julia,
+   * 'exception' and 'and' in OCaml, 'error' in Solidity,
+   * 'associatedtype' in Swift, 'using' in C++, 'delegate' in C#
+   *)
+  ttok : tok;
+  tbody : type_definition_kind;
+}
 
 and type_definition_kind =
   (* Algrebraic data types (ADTs), and basic enums.

--- a/libs/ast_generic/AST_generic_to_v1.ml
+++ b/libs/ast_generic/AST_generic_to_v1.ml
@@ -1173,7 +1173,7 @@ and map_field = function
       let v1 = map_stmt v1 in
       `F v1
 
-and map_type_definition { G.tbody = v_tbody } =
+and map_type_definition { G.tbody = v_tbody; ttok = _ } =
   let v_tbody = map_type_definition_kind v_tbody in
   { B.tbody = v_tbody }
 

--- a/libs/ast_generic/Meta_AST.ml
+++ b/libs/ast_generic/Meta_AST.ml
@@ -1337,10 +1337,13 @@ and vof_field = function
       let v1 = vof_stmt v1 in
       OCaml.VSum ("F", [ v1 ])
 
-and vof_type_definition { tbody = v_tbody } =
+and vof_type_definition { tbody = v_tbody; ttok } =
   let bnds = [] in
   let arg = vof_type_definition_kind v_tbody in
   let bnd = ("tbody", arg) in
+  let bnds = bnd :: bnds in
+  let arg = vof_tok ttok in
+  let bnd = ("ttok", arg) in
   let bnds = bnd :: bnds in
   OCaml.VDict bnds
 

--- a/src/matching/Generic_vs_generic.ml
+++ b/src/matching/Generic_vs_generic.ml
@@ -3262,7 +3262,9 @@ and m_field a b =
 (* ------------------------------------------------------------------------- *)
 and m_type_definition a b =
   match (a, b) with
-  | { G.tbody = a1 }, { B.tbody = b1 } -> m_type_definition_kind a1 b1
+  | { G.ttok = a0; G.tbody = a1 }, { B.ttok = b0; B.tbody = b1 } ->
+      let* () = m_tok a0 b0 in
+      m_type_definition_kind a1 b1
 
 and m_type_definition_kind a b =
   match (a, b) with

--- a/tests/autofix/ocaml/type.fix
+++ b/tests/autofix/ocaml/type.fix
@@ -1,0 +1,1 @@
+type foo = float

--- a/tests/autofix/ocaml/type.fixed
+++ b/tests/autofix/ocaml/type.fixed
@@ -1,0 +1,1 @@
+type foo = float

--- a/tests/autofix/ocaml/type.ml
+++ b/tests/autofix/ocaml/type.ml
@@ -1,0 +1,1 @@
+type foo = int

--- a/tests/autofix/ocaml/type.sgrep
+++ b/tests/autofix/ocaml/type.sgrep
@@ -1,0 +1,1 @@
+type foo = int

--- a/tools/otarzan/lib/Parse.ml
+++ b/tools/otarzan/lib/Parse.ml
@@ -36,7 +36,7 @@ let extract_toplevel_typedefs program : AST_ocaml.type_declaration list list =
         * to type decls with certain attributes (e.g., [@@otarzan]) like
         * for deriving
         *)
-       | { AST_ocaml.i = Type (_t, decls); iattrs = _ } -> Some decls
+       | { AST_ocaml.i = Type decls; iattrs = _ } -> Some decls
        | _else_ -> None)
 
 let extract_typedefs_from_ml_file file =

--- a/tools/otarzan/lib/Print.ml
+++ b/tools/otarzan/lib/Print.ml
@@ -146,7 +146,8 @@ let rec func_for_type (conf : Conf.t) (typ : type_) : out list * string =
      and map_bar env x =
        ...
 *)
-and gen_typedef (conf : Conf.t) is_first typedef : out list =
+and gen_typedef (conf : Conf.t) is_first (typedef : type_declaration_kind) :
+    out list =
   match typedef with
   | TyDecl { tname; tparams = _TODO; tbody } ->
       let name = str_of_ident tname in
@@ -287,7 +288,7 @@ and gen_tuple conf types =
                ])
   | Compare -> [ Line "TODO" ]
 
-let gen_typedef_group conf typedefs =
+let gen_typedef_group conf (typedefs : type_declaration_kind list) =
   let is_first =
     let is_first = ref true in
     fun () ->
@@ -306,8 +307,9 @@ let gen_typedef_group conf typedefs =
 let generate_boilerplate conf typedef_groups =
   let body =
     typedef_groups
-    |> List_.map (fun x ->
-           Inline (gen_typedef_group conf x |> insert_blank_lines))
+    |> List_.map (fun xs ->
+           let xs = xs |> List_.map (fun x -> x.tkind) in
+           Inline (gen_typedef_group conf xs |> insert_blank_lines))
     |> insert_blank_lines
   in
   let prelude = [ Line "let todo _env _v = failwith \"TODO\""; Line "" ] in


### PR DESCRIPTION
This is useful for autofix, otherwise the range is wrong.
Most languages have a keyword like 'type' to introduce
a type definition.

test plan:
test file included
make
make test