### PR TITLE
feat(matching): allow interpolated vars to work with metavariable regex

### DIFF
--- a/changelog.d/saf-865.added
+++ b/changelog.d/saf-865.added
@@ -1,0 +1,2 @@
+Matching: `metavariable-regex` can now match on metavariables of interpolated
+strings which use variables that have known values.

--- a/src/engine/Eval_generic.ml
+++ b/src/engine/Eval_generic.ml
@@ -539,9 +539,6 @@ let bindings_to_env (config : Rule_options.t) ~file bindings =
                   * string representation, we add it to the environment here. *)
                  string_of_binding mvar mval
            in
-           UCommon.(
-             pr2
-               (spf "mvar %s mval %s" mvar ([%show: Metavariable.mvalue] mval)));
            match mval with
            (* this way we can leverage the constant propagation analysis
               * in metavariable-comparison: too! This simplifies some rules.

--- a/src/engine/Eval_generic.ml
+++ b/src/engine/Eval_generic.ml
@@ -267,6 +267,8 @@ let rec eval env code =
         FN (Id (_, { id_svalue = { contents = Some (Lit lit); _ }; _ })) )
     when env.constant_propagation ->
       value_of_lit ~code lit
+  | G.Call ({ e = IdSpecial (ConcatString op, _); _ }, (_, args, _)) ->
+      String (eval_concat_string_op env code op args)
   | G.N (G.Id ((s, _t), _idinfo))
     when MV.is_metavar_name s || MV.is_metavar_ellipsis s -> (
       try Hashtbl.find env.mvars s with
@@ -297,7 +299,7 @@ let rec eval env code =
   (* Emulate Python str just enough *)
   | G.Call ({ e = G.N (G.Id (("str", _), _)); _ }, (_, [ G.Arg e ], _)) ->
       let v = eval env e in
-      eval_str env ~code v
+      String (eval_str env ~code v)
   (* Convert string to date *)
   | G.Call ({ e = G.N (G.Id (("strptime", _), _)); _ }, (_, [ Arg e ], _)) -> (
       let v = eval env e in
@@ -337,6 +339,34 @@ let rec eval env code =
               m ~tags "regexp %s on %s return %s" re str (show_value v));
           v
       | _ -> raise (NotHandled e))
+  | _ -> raise (NotHandled code)
+
+and eval_concat_string_op env code _op args =
+  (* The op appears to not be important. We can just concatenate all the
+     arguments.
+  *)
+  args |> List_.map (eval_concat_string_element env code) |> String.concat ""
+
+and eval_concat_string_element env code arg =
+  match arg with
+  | G.Arg { e = L (G.String (_, (s, _), _)); _ } -> s
+  | G.Arg
+      {
+        e = G.Call ({ e = IdSpecial (ConcatString op, _); _ }, (_, args, _));
+        _;
+      } ->
+      eval_concat_string_op env code op args
+  | G.Arg
+      {
+        e =
+          Call
+            ( { e = IdSpecial (InterpolatedElement, _); _ },
+              (_, [ G.Arg elem ], _) );
+        _;
+      }
+  | G.Arg elem ->
+      let v = eval env elem in
+      eval_str env ~code v
   | _ -> raise (NotHandled code)
 
 and eval_op op values code =
@@ -433,7 +463,7 @@ and eval_str _env ~code v =
     | AST s -> s
     | List _ -> raise (NotHandled code)
   in
-  String str
+  str
 
 (*****************************************************************************)
 (* Env builders *)
@@ -509,6 +539,9 @@ let bindings_to_env (config : Rule_options.t) ~file bindings =
                   * string representation, we add it to the environment here. *)
                  string_of_binding mvar mval
            in
+           UCommon.(
+             pr2
+               (spf "mvar %s mval %s" mvar ([%show: Metavariable.mvalue] mval)));
            match mval with
            (* this way we can leverage the constant propagation analysis
               * in metavariable-comparison: too! This simplifies some rules.

--- a/tests/rules/mvar_regex_interpolated_var.py
+++ b/tests/rules/mvar_regex_interpolated_var.py
@@ -1,0 +1,11 @@
+
+# ruleid: mvar-regex-interpolated-var
+x = "150"
+
+y = 150
+z = "150"
+
+# ruleid: mvar-regex-interpolated-var
+x = f"{y}"
+# ruleid: mvar-regex-interpolated-var
+x = f"{z}"

--- a/tests/rules/mvar_regex_interpolated_var.yaml
+++ b/tests/rules/mvar_regex_interpolated_var.yaml
@@ -1,0 +1,12 @@
+rules:
+- id: mvar-regex-interpolated-var
+  patterns:
+  - pattern: |
+      x = $Z
+  - metavariable-regex:
+      metavariable: $Z
+      constant-propagation: true
+      regex: "150"
+  message: Working!
+  severity: WARNING
+  languages: [python]

--- a/tests/rules/terraform_mvar_regex_interpolated_var.tf
+++ b/tests/rules/terraform_mvar_regex_interpolated_var.tf
@@ -1,0 +1,28 @@
+variable "v" {
+  type    = string
+  default = "150"
+}
+
+# ruleid: terraform-mvar-regex-interpolated-var
+resource "foo" "bar" {
+    field = "${var.v}"
+}
+
+# ruleid: terraform-mvar-regex-interpolated-var
+resource "foo" "bar" {
+    field = "150"
+}
+
+resource "foo" "bar" {
+    field = "random"
+}
+
+variable "v2" {
+  type    = number
+  default = 150
+}
+
+# ruleid: terraform-mvar-regex-interpolated-var
+resource "foo" "bar" {
+    field = "${var.v2}"
+}

--- a/tests/rules/terraform_mvar_regex_interpolated_var.yaml
+++ b/tests/rules/terraform_mvar_regex_interpolated_var.yaml
@@ -1,0 +1,14 @@
+rules:
+- id: terraform-mvar-regex-interpolated-var
+  patterns:
+  - pattern: |
+      resource $X $Y {
+        field = $Z
+      }
+  - metavariable-regex:
+      metavariable: $Z
+      constant-propagation: true
+      regex: "150"
+  message: Working!
+  severity: WARNING
+  languages: [hcl]


### PR DESCRIPTION
## What:
This PR makes it so `metavariable-regex` on an interpolated string can actually match based off of the variables being interpolated.

## Why:
We want to be able to, in particular, match patterns like `"${var.varname}"` in Terraform, via binding a metavariable to it and checking the contents with `metavariable-regex`.

## How:
We can't do this naively, because `var.varname` is not an `N` metavariable. This means the propagated value is contained inside of it, but `Eval_generic` doesn't know how to access it.

To make `Eval_generic` aware of it, we added logic to simulate the interpolation of the string. This change is not Terraform-specific.

## Test plan:
Automated tests.

Closes SAF-865