### PR TITLE
OCaml: add parenthesis in AST_ocaml.ml for type parameters

### DIFF
--- a/languages/ocaml/ast/AST_ocaml.ml
+++ b/languages/ocaml/ast/AST_ocaml.ml
@@ -295,7 +295,7 @@ and type_declaration =
 
 and type_declaration_classic = {
   tname : ident;
-  tparams : type_parameter list;
+  tparams : type_parameters option;
   tbody : type_def_kind;
 }
 
@@ -303,6 +303,17 @@ and type_declaration_classic = {
 and type_parameter =
   | TyParam of ident (* a TyVar, e.g., 'a *)
   | TyParamTodo of todo_category
+
+(* alt: we could be more precise with
+ * and type_parameters =
+ * | NoTyParam
+ * | OneTyParam of type_parameter
+ * | TyParams of type_parameter list bracket
+ * but anyway in the generic AST they are represented like below.
+ *
+ * The bracket can be '('')' for type defs, and '[', ']' for class defs.
+ *)
+and type_parameters = type_parameter list bracket
 
 and type_def_kind =
   | AbstractType
@@ -335,7 +346,7 @@ and mutable_opt = Tok.t option (* mutable *)
 and class_binding = {
   (* c_attrs: 'virtual' *)
   c_name : ident;
-  c_tparams : type_parameter list;
+  c_tparams : type_parameters option;
   c_params : parameter list;
   (* TODO: c_rettype *)
   c_body : class_expr option; (* TODO: attributes *)

--- a/languages/ocaml/generic/ocaml_to_generic.ml
+++ b/languages/ocaml/generic/ocaml_to_generic.ml
@@ -580,7 +580,11 @@ and type_declaration x =
   match x with
   | TyDecl { tname; tparams; tbody } ->
       let v1 = ident tname in
-      let v2 = list type_parameter tparams in
+      let v2 =
+        match tparams with
+        | None -> []
+        | Some (_, xs, _) -> list type_parameter xs
+      in
       let v3 = type_def_kind tbody in
       let entity = { (G.basic_entity v1) with G.tparams = v2 } in
       let def = { G.tbody = v3 } in
@@ -660,7 +664,11 @@ and attribute x =
 and class_binding (c_tok : Tok.t) (binding : class_binding) : G.definition =
   let { c_name; c_tparams; c_params; c_body } = binding in
   let id = ident c_name in
-  let tparams = list type_parameter c_tparams in
+  let tparams =
+    match c_tparams with
+    | None -> []
+    | Some (_, xs, _) -> list type_parameter xs
+  in
   let ent = G.basic_entity ~tparams id in
   let cparams = fb (list parameter c_params) in
   let cbody =

--- a/languages/ocaml/menhir/parser_ml.mly
+++ b/languages/ocaml/menhir/parser_ml.mly
@@ -855,12 +855,11 @@ type_constraint:
 (*----------------------------*)
 
 type_declaration: type_parameters TLowerIdent type_kind (*TODOAST constraints*)
-   { let tparams = $1 |> List.map (fun id -> TyParam id) in
-     match $3 with
+   { match $3 with
      | None ->
-         TyDecl { tname = $2; tparams; tbody = AbstractType }
+         TyDecl { tname = $2; tparams = $1; tbody = AbstractType }
      | Some (_tok_eq, type_kind) ->
-         TyDecl { tname = $2; tparams; tbody = type_kind }
+         TyDecl { tname = $2; tparams = $1; tbody = type_kind }
    }
 
 
@@ -887,11 +886,11 @@ constructor_arguments:
  | "{" label_declarations "}" { [ TyTodo(("InlineRecord", $1), []) ] }
 
 type_parameters:
- |  (*empty*)                          { []  }
- | type_parameter                      { [$1] }
- | "(" list_sep(type_parameter, ",") ")" { $2 }
+ |  (*empty*)                          { None  }
+ | type_parameter                      { Some (Tok.unsafe_fake_bracket [$1]) }
+ | "(" list_sep(type_parameter, ",") ")" { Some ($1, $2, $3) }
 
-type_parameter: ioption(type_variance) "'" ident   { $3 }
+type_parameter: ioption(type_variance) "'" ident   { TyParam $3 }
 
 (* old: list_sep_term(label_declaration, ";") but accept attr after ; *)
 label_declarations:

--- a/languages/ocaml/tree-sitter/Parse_ocaml_tree_sitter.ml
+++ b/languages/ocaml/tree-sitter/Parse_ocaml_tree_sitter.ml
@@ -598,11 +598,11 @@ let map_value_path (env : env) (x : CST.value_path) : name =
       let v3 = map_value_name env v3 in
       (v1, v3)
 
-let map_type_params (env : env) (x : CST.type_params) : type_parameter list =
+let map_type_params (env : env) (x : CST.type_params) : type_parameters =
   match x with
-  | `Type_param x -> [ map_type_param env x ]
+  | `Type_param x -> Tok.unsafe_fake_bracket [ map_type_param env x ]
   | `LPAR_type_param_rep_COMMA_type_param_RPAR (v1, v2, v3, v4) ->
-      let _v1 = token env v1 (* "(" *) in
+      let lp = token env v1 (* "(" *) in
       let v2 = map_type_param env v2 in
       let v3 =
         List_.map
@@ -612,14 +612,14 @@ let map_type_params (env : env) (x : CST.type_params) : type_parameter list =
             v2)
           v3
       in
-      let _v4 = token env v4 (* ")" *) in
-      v2 :: v3
+      let rp = token env v4 (* ")" *) in
+      (lp, v2 :: v3, rp)
 
 let map_anon_LBRACK_type_param_rep_COMMA_type_param_RBRACK_cea5434 (env : env)
     ((v1, v2, v3, v4) :
       CST.anon_LBRACK_type_param_rep_COMMA_type_param_RBRACK_cea5434) :
-    type_parameter list =
-  let _v1 = token env v1 (* "[" *) in
+    type_parameters =
+  let lb = token env v1 (* "[" *) in
   let v2 = map_type_param env v2 in
   let v3 =
     List_.map
@@ -629,8 +629,8 @@ let map_anon_LBRACK_type_param_rep_COMMA_type_param_RBRACK_cea5434 (env : env)
         v2)
       v3
   in
-  let _v4 = token env v4 (* "]" *) in
-  v2 :: v3
+  let rb = token env v4 (* "]" *) in
+  (lb, v2 :: v3, rb)
 
 let map_range_pattern (env : env) ((v1, v2, v3) : CST.range_pattern) =
   let v1 = map_signed_constant env v1 in
@@ -685,8 +685,8 @@ and map_anon_choice_cons_type_771aabb (env : env)
       let _v1 = token env v1 (* "type" *) in
       let _v2 =
         match v2 with
-        | Some x -> map_type_params env x
-        | None -> []
+        | Some x -> Some (map_type_params env x)
+        | None -> None
       in
       let _v3 = map_type_constructor_path env v3 in
       let _v4 = map_type_equation env v4 in
@@ -992,8 +992,9 @@ and map_class_binding (env : env)
   let c_tparams =
     match v2 with
     | Some x ->
-        map_anon_LBRACK_type_param_rep_COMMA_type_param_RBRACK_cea5434 env x
-    | None -> []
+        Some
+          (map_anon_LBRACK_type_param_rep_COMMA_type_param_RBRACK_cea5434 env x)
+    | None -> None
   in
   let c_name = str env v3 (* pattern "[a-z_][a-zA-Z0-9_']*" *) in
   let c_params = List_.map (map_parameter env) v4 in
@@ -1218,8 +1219,9 @@ and map_class_type_binding (env : env)
   let _v2 =
     match v2 with
     | Some x ->
-        map_anon_LBRACK_type_param_rep_COMMA_type_param_RBRACK_cea5434 env x
-    | None -> []
+        Some
+          (map_anon_LBRACK_type_param_rep_COMMA_type_param_RBRACK_cea5434 env x)
+    | None -> None
   in
   let _v3 = token env v3 (* pattern "[a-z_][a-zA-Z0-9_']*" *) in
   let _v4 = token env v4 (* "=" *) in
@@ -3082,8 +3084,8 @@ and map_type_binding (env : env) ((v1, v2, v3) : CST.type_binding) :
     type_declaration =
   let tparams =
     match v1 with
-    | Some x -> map_type_params env x
-    | None -> []
+    | Some x -> Some (map_type_params env x)
+    | None -> None
   in
   let v2 =
     match v2 with

--- a/tools/otarzan/lib/Print.ml
+++ b/tools/otarzan/lib/Print.ml
@@ -126,7 +126,7 @@ let rec func_for_type (conf : Conf.t) (typ : type_) : out list * string =
           (TyDecl
              {
                tname = (local_name, Tok.unsafe_sc);
-               tparams = [];
+               tparams = None;
                tbody = CoreType typ;
              })
       in


### PR DESCRIPTION
This will help autofix code using such types as in
'type foo = (int, float) Hashtbl.t

I'll make a separate PR with the autofix example, which requires
to also change AST_generic.ml

test plan:
make
make test