### PR TITLE
Revert "refactor(rules): decouple conditions from `And`s"

### DIFF
--- a/js/engine/tests/__snapshots__/index.test.js.snap
+++ b/js/engine/tests/__snapshots__/index.test.js.snap
@@ -181,6 +181,76 @@ exports[`misc js representation handles large ints 1`] = `
               "children": [],
               "loc": {
                 "end": {
+                  "col": 73,
+                  "line": 9,
+                  "offset": 190,
+                },
+                "path": "test-representation.json",
+                "start": {
+                  "col": 24,
+                  "line": 9,
+                  "offset": 141,
+                },
+              },
+              "matches": [
+                {
+                  "check_id": "test",
+                  "end": {
+                    "col": 30,
+                    "line": 1,
+                    "offset": 29,
+                  },
+                  "extra": {
+                    "engine_kind": "OSS",
+                    "is_ignored": false,
+                    "message": "test",
+                    "metavars": {
+                      "$ABOVE_SIGNED_INT32": {
+                        "abstract_content": "3000000000",
+                        "end": {
+                          "col": 29,
+                          "line": 1,
+                          "offset": 28,
+                        },
+                        "start": {
+                          "col": 19,
+                          "line": 1,
+                          "offset": 18,
+                        },
+                      },
+                      "$BELOW_SIGNED_INT32": {
+                        "abstract_content": "2000000000",
+                        "end": {
+                          "col": 17,
+                          "line": 1,
+                          "offset": 16,
+                        },
+                        "start": {
+                          "col": 7,
+                          "line": 1,
+                          "offset": 6,
+                        },
+                      },
+                    },
+                    "validation_state": "NO_VALIDATOR",
+                  },
+                  "path": "test-representation.py",
+                  "start": {
+                    "col": 1,
+                    "line": 1,
+                    "offset": 0,
+                  },
+                },
+              ],
+              "op": [
+                "XPat",
+                "print($BELOW_SIGNED_INT32, $ABOVE_SIGNED_INT32)",
+              ],
+            },
+            {
+              "children": [],
+              "loc": {
+                "end": {
                   "col": 112,
                   "line": 12,
                   "offset": 342,
@@ -250,15 +320,15 @@ exports[`misc js representation handles large ints 1`] = `
           ],
           "loc": {
             "end": {
-              "col": 73,
-              "line": 9,
-              "offset": 190,
+              "col": 20,
+              "line": 10,
+              "offset": 211,
             },
             "path": "test-representation.json",
             "start": {
-              "col": 24,
-              "line": 9,
-              "offset": 141,
+              "col": 13,
+              "line": 10,
+              "offset": 204,
             },
           },
           "matches": [
@@ -311,10 +381,7 @@ exports[`misc js representation handles large ints 1`] = `
               },
             },
           ],
-          "op": [
-            "XPat",
-            "print($BELOW_SIGNED_INT32, $ABOVE_SIGNED_INT32)",
-          ],
+          "op": "And",
         },
       ],
       "loc": {

--- a/src/core/Rule.ml
+++ b/src/core/Rule.ml
@@ -63,27 +63,9 @@ type 'a loc = {
  * We use 'deriving hash' for formula because of the
  * Match_tainting_mode.Formula_tbl formula cache.
  *)
-type formula = {
-  f : formula_kind;
-  (* metavariable-xyz:'s *)
-  conditions : (tok * metavar_cond) list;
-  (* focus-metavariable:'s *)
-  focus : focus_mv_list list;
-}
-
-and formula_kind =
+type formula =
   | P of Xpattern.t (* a leaf pattern *)
-  (* The conjunction must contain at least
-     * one positive "term" (unless it's inside a CondNestedFormula, in which
-     * case there is not such a restriction).
-     * See also split_and().
-     * CAVEAT: This is not required in the metavariable-pattern case, such as
-       metavariable-pattern:
-         metavariable: $MVAR
-         patterns:
-         - pattern-not: "foo"
-  *)
-  | And of tok * formula list
+  | And of tok * conjunction
   | Or of tok * formula list
   (* There are currently restrictions on where a Not can appear in a formula.
    * It must be inside an And to be intersected with "positive" formula.
@@ -108,6 +90,20 @@ and formula_kind =
   *)
   | Anywhere of tok * formula
 
+(* The conjunction must contain at least
+ * one positive "term" (unless it's inside a CondNestedFormula, in which
+ * case there is not such a restriction).
+ * See also split_and().
+ *)
+and conjunction = {
+  (* pattern-inside:'s and pattern:'s *)
+  conjuncts : formula list;
+  (* metavariable-xyz:'s *)
+  conditions : (tok * metavar_cond) list;
+  (* focus-metavariable:'s *)
+  focus : focus_mv_list list;
+}
+
 and metavar_cond =
   | CondEval of AST_generic.expr (* see Eval_generic.ml *)
   (* todo: at some point we should remove CondRegexp and have just
@@ -123,8 +119,7 @@ and metavar_cond =
       MV.mvar * Xpattern.regexp_string * bool (* constant-propagation *)
   | CondType of
       MV.mvar
-      * Xlang.t option
-      (* when the type expression is in different lang *)
+      * Xlang.t option (* when the type expression is in different lang *)
       * string list (* raw input string saved for regenerating rule yaml *)
       * AST_generic.type_ list
     (* LATER: could parse lazily, like the patterns *)
@@ -319,9 +314,9 @@ let get_sink_requires { sink_requires; _ } =
 (* Check if a formula has "focus" (i.e., `focus-metavariable` in syntax 1.0)
  *
  * See 'taint_sink', field 'sink_has_focus'. *)
-let is_formula_with_focus (formula : formula) =
+let is_formula_with_focus formula =
   match formula with
-  | { focus = _ :: _; _ } -> true
+  | And (_, { conjuncts = _; conditions = _; focus = _ :: _ }) -> true
   | __else__ -> false
 
 (*****************************************************************************)
@@ -859,21 +854,20 @@ let () = Printexc.register_printer opt_string_of_exn
    That way, pattern leaves underneath an Inside/Anywhere will properly be
    paired with a true boolean.
 *)
-let visit_new_formula func formula =
+let visit_new_formula f formula =
   let bref = ref false in
-  let rec visit_new_formula func formula =
-    match formula.f with
-    | P p -> func p ~inside:!bref
+  let rec visit_new_formula f formula =
+    match formula with
+    | P p -> f p ~inside:!bref
     | Anywhere (_, formula)
     | Inside (_, formula) ->
-        Common.save_excursion bref true (fun () ->
-            visit_new_formula func formula)
-    | Not (_, x) -> visit_new_formula func x
+        Common.save_excursion bref true (fun () -> visit_new_formula f formula)
+    | Not (_, x) -> visit_new_formula f x
     | Or (_, xs)
-    | And (_, xs) ->
-        xs |> List.iter (visit_new_formula func)
+    | And (_, { conjuncts = xs; _ }) ->
+        xs |> List.iter (visit_new_formula f)
   in
-  visit_new_formula func formula
+  visit_new_formula f formula
 
 (* used by the metachecker for precise error location *)
 let tok_of_formula = function
@@ -919,11 +913,6 @@ let xpatterns_of_rule rule =
   List.iter (visit_new_formula visit) formulae;
   !xpat_store
 
-let mk_formula ?(focus = []) ?(conditions = []) kind =
-  { f = kind; focus; conditions }
-
-let f kind = mk_formula kind
-
 (*****************************************************************************)
 (* Converters *)
 (*****************************************************************************)
@@ -941,7 +930,7 @@ let selector_and_analyzer_of_xlang (xlang : Xlang.t) :
 let split_and (xs : formula list) : formula list * (tok * formula) list =
   xs
   |> Either_.partition_either (fun e ->
-         match e.f with
+         match e with
          (* positives *)
          | P _
          | And _
@@ -960,7 +949,7 @@ let rule_of_xpattern (xlang : Xlang.t) (xpat : Xpattern.t) : rule =
   let target_selector, target_analyzer = selector_and_analyzer_of_xlang xlang in
   {
     id = (Rule_ID.of_string "-e", fk);
-    mode = `Search (f (P xpat));
+    mode = `Search (P xpat);
     min_version = None;
     max_version = None;
     (* alt: could put xpat.pstr for the message *)

--- a/src/engine/Match_search_mode.ml
+++ b/src/engine/Match_search_mode.ml
@@ -275,7 +275,7 @@ let matches_of_patterns ?mvar_context ?range_filter rule (xconf : xconfig)
 *)
 let selector_equal s1 s2 = s1.mvar = s2.mvar
 
-let selector_from_formula ({ f; _ } : Rule.formula) =
+let selector_from_formula f =
   match f with
   | R.P { Xpattern.pat = Sem ((lazy pattern), _); pid; pstr } -> (
       match pattern with
@@ -306,7 +306,7 @@ let rec remove_selectors (selector, acc) formulas =
       in
       remove_selectors (selector, acc) xs
 
-let specialize_and (conjuncts : Rule.formula list) =
+let specialize_and ({ conjuncts; _ } : Rule.conjunction) =
   let pos, neg = Rule.split_and conjuncts in
   let selector_opt, pos =
     (* We only want a selector if there is something to select from. *)
@@ -724,86 +724,9 @@ and get_nested_formula_matches env formula range =
 (* Formula evaluation *)
 (*****************************************************************************)
 
-and evaluate_formula env opt_context ({ f; focus; conditions } : Rule.formula) =
-  let ranges, expls = evaluate_formula_kind env opt_context f in
-  (* let's apply additional filters.
-      * TODO: Note that some metavariable-regexp may be part of an
-      * AND where not all patterns define the metavar, e.g.,
-        *   pattern-inside: def $FUNC() ...
-      *   pattern: return $X
-      *   metavariable-regexp: $FUNC regex: (foo|bar)
-      * in which case the order in which we do the operation matters
-      * (at this point intersect_range will have filtered the
-      *  range of the pattern_inside).
-      * alternative solutions?
-      *  - bind closer metavariable-regexp with the relevant pattern
-      *  - propagate metavariables when intersecting ranges
-      *  - distribute filter_range in intersect_range?
-      * See https://github.com/returntocorp/semgrep/issues/2664
-  *)
-  let ranges, filter_expls =
-    conditions
-    |> List.fold_left
-         (fun (ranges_with_bindings, acc_expls) (tok, cond) ->
-           let ranges_with_bindings =
-             filter_ranges env ranges_with_bindings cond
-           in
-           let expl =
-             if_explanations env
-               (List_.map fst ranges_with_bindings)
-               []
-               (OutJ.Filter (Tok.content_of_tok tok), tok)
-           in
-           (ranges_with_bindings, expl :: acc_expls))
-         (List_.map (fun x -> (x, [])) ranges, [])
-  in
-
-  (* Here, we unpack all the persistent bindings for each instance of the inner
-      `metavariable-pattern`s that succeeded.
-
-      We just take those persistent bindings and add them to the original range,
-      now that we're done with the filtering step.
-  *)
-  let ranges_with_persistent_bindings =
-    ranges
-    |> List.concat_map (fun (r, new_bindings_list) ->
-           (* At a prior step, we ensured that all these new bindings were nonempty.
-               We should keep around a copy of the original range, because otherwise
-               if we have no new bindings to add, we'll kill the range.
-           *)
-           r
-           :: (new_bindings_list
-              |> List_.map (fun new_bindings ->
-                     { r with RM.mvars = new_bindings @ r.RM.mvars })))
-  in
-
-  let ranges =
-    apply_focus_on_ranges env focus ranges_with_persistent_bindings
-  in
-  let focus_expls =
-    match focus with
-    | [] -> []
-    (* less: what if have multiple focus-metavariable? *)
-    | (tok, _mvar) :: _rest ->
-        [
-          if_explanations env ranges [] (OutJ.Filter "metavariable-focus", tok);
-        ]
-  in
-
-  let new_expls =
-    match expls with
-    | None -> None
-    | Some ({ ME.children; _ } as me) ->
-        let children =
-          List_.map (fun x -> Some x) children @ focus_expls @ filter_expls
-          |> List_.map_filter Fun.id
-        in
-        Some { me with ME.children }
-  in
-  (ranges, new_expls)
-
-and evaluate_formula_kind env opt_context (kind : Rule.formula_kind) =
-  match kind with
+and evaluate_formula (env : env) (opt_context : RM.t option) (e : R.formula) :
+    RM.ranges * Matching_explanation.t option =
+  match e with
   | R.P ({ XP.pid = id; pstr = pstr, tok; _ } as xpat) ->
       let match_results = Hashtbl_.get_stack env.pattern_matches id in
       let kind = if Xpattern.is_regexp xpat then RM.Regexp else RM.Plain in
@@ -835,7 +758,7 @@ and evaluate_formula_kind env opt_context (kind : Rule.formula_kind) =
       let ranges = List.flatten ranges in
       let expl = if_explanations env ranges expls (OutJ.Or, tok) in
       (ranges, expl)
-  | R.And (t, conj) -> (
+  | R.And (t, ({ conditions = conds; focus; _ } as conj)) -> (
       (* we now treat pattern: and pattern-inside: differently. We first
           * process the pattern: and then the pattern-inside.
           * This fixed only one mismatch in semgrep-rules.
@@ -858,12 +781,12 @@ and evaluate_formula_kind env opt_context (kind : Rule.formula_kind) =
         List_.map (evaluate_formula env opt_context) pos |> Common2.unzip
       in
       (* subtle: we need to process and intersect the pattern-inside after
-          * (see tests/rules/inside.yaml).
-          * TODO: this is ugly; AND should be commutative, so we should just
-          * merge ranges, not just filter one or the other.
-          * update: however we have some tests that rely on pattern-inside:
-          * being special, see tests/rules/and_inside.yaml.
-      *)
+       * (see tests/rules/inside.yaml).
+       * TODO: this is ugly; AND should be commutative, so we should just
+       * merge ranges, not just filter one or the other.
+       * update: however we have some tests that rely on pattern-inside:
+       * being special, see tests/rules/and_inside.yaml.
+       *)
       let posrs, posrs_inside =
         posrs
         |> Either_.partition_either (fun xs ->
@@ -910,9 +833,74 @@ and evaluate_formula_kind env opt_context (kind : Rule.formula_kind) =
                    (ranges, expl :: acc_expls))
                  (ranges, [])
           in
+          (* let's apply additional filters.
+           * TODO: Note that some metavariable-regexp may be part of an
+           * AND where not all patterns define the metavar, e.g.,
+            *   pattern-inside: def $FUNC() ...
+           *   pattern: return $X
+           *   metavariable-regexp: $FUNC regex: (foo|bar)
+           * in which case the order in which we do the operation matters
+           * (at this point intersect_range will have filtered the
+           *  range of the pattern_inside).
+           * alternative solutions?
+           *  - bind closer metavariable-regexp with the relevant pattern
+           *  - propagate metavariables when intersecting ranges
+           *  - distribute filter_range in intersect_range?
+           * See https://github.com/returntocorp/semgrep/issues/2664
+           *)
+          let ranges, filter_expls =
+            conds
+            |> List.fold_left
+                 (fun (ranges_with_bindings, acc_expls) (tok, cond) ->
+                   let ranges_with_bindings =
+                     filter_ranges env ranges_with_bindings cond
+                   in
+                   let expl =
+                     if_explanations env
+                       (List_.map fst ranges_with_bindings)
+                       []
+                       (OutJ.Filter (Tok.content_of_tok tok), tok)
+                   in
+                   (ranges_with_bindings, expl :: acc_expls))
+                 (List_.map (fun x -> (x, [])) ranges, [])
+          in
 
+          (* Here, we unpack all the persistent bindings for each instance of the inner
+             `metavariable-pattern`s that succeeded.
+
+             We just take those persistent bindings and add them to the original range,
+             now that we're done with the filtering step.
+          *)
+          let ranges_with_persistent_bindings =
+            ranges
+            |> List.concat_map (fun (r, new_bindings_list) ->
+                   (* At a prior step, we ensured that all these new bindings were nonempty.
+                      We should keep around a copy of the original range, because otherwise
+                      if we have no new bindings to add, we'll kill the range.
+                   *)
+                   r
+                   :: (new_bindings_list
+                      |> List_.map (fun new_bindings ->
+                             { r with RM.mvars = new_bindings @ r.RM.mvars })))
+          in
+
+          let ranges =
+            apply_focus_on_ranges env focus ranges_with_persistent_bindings
+          in
+          let focus_expls =
+            match focus with
+            | [] -> []
+            (* less: what if have multiple focus-metavariable? *)
+            | (tok, _mvar) :: _rest ->
+                [
+                  if_explanations env ranges []
+                    (OutJ.Filter "metavariable-focus", tok);
+                ]
+          in
           let expl =
-            if_explanations env ranges (posrs_expls @ negs_expls) (OutJ.And, t)
+            if_explanations env ranges
+              (posrs_expls @ negs_expls @ filter_expls @ focus_expls)
+              (OutJ.And, t)
           in
           (ranges, expl))
   | R.Not _ -> failwith "Invalid Not; you can only negate inside an And"

--- a/src/metachecking/Check_rule.ml
+++ b/src/metachecking/Check_rule.ml
@@ -84,38 +84,8 @@ let unknown_metavar_in_comparison env f =
     (* TODO: remove when we kill numeric capture groups *)
     Metavariable.is_metavar_for_capture_group mv || Set.mem mv mvs
   in
-  let rec collect_metavars { f; conditions; focus } : MV.mvar Set.t =
-    let mvs = collect_metavars' f in
-    (* Check that all metavariables in this and-clause's metavariable-comparison clauses appear somewhere else *)
-    let mv_error mv t =
-      (* TODO make this message more helpful by detecting specific
-          variants of this *)
-      error env t
-        (mv
-       ^ " is used in a 'metavariable-*' conditional or 'focus-metavariable' \
-          operator but is never bound by a positive pattern (or is only bound \
-          by negative patterns like 'pattern-not')")
-    in
-    conditions
-    |> List.iter (fun (t, metavar_cond) ->
-           match metavar_cond with
-           | CondEval _ -> ()
-           | CondRegexp (mv, _, _) ->
-               if not (mvar_is_ok mv mvs) then mv_error mv t
-           | CondType (mv, _, _, _) ->
-               if not (mvar_is_ok mv mvs) then mv_error mv t
-           | CondNestedFormula (mv, _, _) ->
-               if not (mvar_is_ok mv mvs) then mv_error mv t
-           | CondAnalysis (mv, _) ->
-               if not (mvar_is_ok mv mvs) then mv_error mv t);
-    focus
-    |> List.iter (fun (t, mv_list) ->
-           mv_list
-           |> List.iter (fun mv ->
-                  if not (mvar_is_ok mv mvs) then mv_error mv t));
-    mvs
-  and collect_metavars' kind : MV.mvar Set.t =
-    match kind with
+  let rec collect_metavars f : MV.mvar Set.t =
+    match f with
     | P { pat; pstr = pstr, _; pid = _pid } ->
         (* TODO currently this guesses that the metavariables are the strings
            that have a valid metavariable name. We should ideally have each
@@ -143,7 +113,6 @@ let unknown_metavar_in_comparison env f =
     | Anywhere (_, f) ->
         collect_metavars f
     | Not (_, _) -> Set.empty
-    | And (_, xs)
     | Or (_, xs) ->
         let mv_sets = List_.map collect_metavars xs in
         List.fold_left
@@ -157,6 +126,42 @@ let unknown_metavar_in_comparison env f =
            *)
             (fun acc mv_set -> Set.union acc mv_set)
           Set.empty mv_sets
+    | And (_, { conjuncts; conditions; focus }) ->
+        let mv_sets = List_.map collect_metavars conjuncts in
+        let mvs =
+          List.fold_left
+            (fun acc mv_set -> Set.union acc mv_set)
+            Set.empty mv_sets
+        in
+        (* Check that all metavariables in this and-clause's metavariable-comparison clauses appear somewhere else *)
+        let mv_error mv t =
+          (* TODO make this message more helpful by detecting specific
+             variants of this *)
+          error env t
+            (mv
+           ^ " is used in a 'metavariable-*' conditional or \
+              'focus-metavariable' operator but is never bound by a positive \
+              pattern (or is only bound by negative patterns like \
+              'pattern-not')")
+        in
+        conditions
+        |> List.iter (fun (t, metavar_cond) ->
+               match metavar_cond with
+               | CondEval _ -> ()
+               | CondRegexp (mv, _, _) ->
+                   if not (mvar_is_ok mv mvs) then mv_error mv t
+               | CondType (mv, _, _, _) ->
+                   if not (mvar_is_ok mv mvs) then mv_error mv t
+               | CondNestedFormula (mv, _, _) ->
+                   if not (mvar_is_ok mv mvs) then mv_error mv t
+               | CondAnalysis (mv, _) ->
+                   if not (mvar_is_ok mv mvs) then mv_error mv t);
+        focus
+        |> List.iter (fun (t, mv_list) ->
+               mv_list
+               |> List.iter (fun mv ->
+                      if not (mvar_is_ok mv mvs) then mv_error mv t));
+        mvs
   in
   let _ = collect_metavars f in
   ()

--- a/src/metachecking/Translate_rule.ml
+++ b/src/metachecking/Translate_rule.ml
@@ -228,47 +228,41 @@ and translate_taint_spec
        ])
 
 and translate_formula f : [> `O of (string * Yaml.value) list ] =
-  let rec aux { f; focus; conditions } =
-    let mk_focus_obj (_, mv_list) =
-      match mv_list with
-      | [] ->
-          (* probably shouldn't happen... *)
-          []
-      | [ mv ] -> [ `O [ ("focus", `String mv) ] ]
-      | mvs -> [ `O [ ("focus", `A (List_.map (fun x -> `String x) mvs)) ] ]
-    in
-    let where_obj =
-      match (focus, conditions) with
-      | [], [] -> []
-      | _ ->
-          [
-            ( "where",
-              `A
-                (List_.map
-                   (fun (_, cond) -> translate_metavar_cond cond)
-                   conditions
-                @ List.concat_map mk_focus_obj focus) );
-          ]
-    in
-    let (`O objs) = aux' f in
-    `O (objs @ where_obj)
-  and aux' kind =
-    match kind with
-    | P { pat; pstr; _ } -> (
-        match pat with
-        | Sem (_, _)
-        | Spacegrep _
-        | Aliengrep _ ->
-            `O [ ("pattern", `String (fst pstr)) ]
-        | Regexp _ -> `O [ ("regex", `String (fst pstr)) ])
-    | Inside (_, f) -> `O [ ("inside", (aux f :> Yaml.value)) ]
-    | Anywhere (_, f) -> `O [ ("anywhere", (aux f :> Yaml.value)) ]
-    | Not (_, f) -> `O [ ("not", (aux f :> Yaml.value)) ]
-    | And (_, conjuncts) ->
-        `O [ ("all", `A (List_.map aux conjuncts :> Yaml.value list)) ]
-    | Or (_, fs) -> `O [ ("any", `A (List_.map aux fs :> Yaml.value list)) ]
-  in
-  aux f
+  match f with
+  | P { pat; pstr; _ } -> (
+      match pat with
+      | Sem (_, _)
+      | Spacegrep _
+      | Aliengrep _ ->
+          `O [ ("pattern", `String (fst pstr)) ]
+      | Regexp _ -> `O [ ("regex", `String (fst pstr)) ])
+  | Anywhere (_, f) -> `O [ ("anywhere", (translate_formula f :> Yaml.value)) ]
+  | Inside (_, f) -> `O [ ("inside", (translate_formula f :> Yaml.value)) ]
+  | And (_, { conjuncts; focus; conditions; _ }) ->
+      let mk_focus_obj (_, mv_list) =
+        match mv_list with
+        | [] ->
+            (* probably shouldn't happen... *)
+            []
+        | [ mv ] -> [ `O [ ("focus", `String mv) ] ]
+        | mvs -> [ `O [ ("focus", `A (List_.map (fun x -> `String x) mvs)) ] ]
+      in
+      `O
+        (("all", `A (List_.map translate_formula conjuncts :> Yaml.value list))
+        ::
+        (if focus =*= [] && conditions =*= [] then []
+         else
+           [
+             ( "where",
+               `A
+                 (List_.map
+                    (fun (_, cond) -> translate_metavar_cond cond)
+                    conditions
+                 @ List.concat_map mk_focus_obj focus) );
+           ]))
+  | Or (_, fs) ->
+      `O [ ("any", `A (List_.map translate_formula fs :> Yaml.value list)) ]
+  | Not (_, f) -> `O [ ("not", (translate_formula f :> Yaml.value)) ]
 
 let rec json_to_yaml json : Yaml.value =
   match json with

--- a/src/optimizing/Analyze_rule.ml
+++ b/src/optimizing/Analyze_rule.ml
@@ -128,24 +128,23 @@ let option_map f xs =
 
 (* less: move the Not to leaves, applying DeMorgan, and then filter them? *)
 let rec (remove_not : Rule.formula -> Rule.formula option) =
- fun ({ f; conditions; focus } as formula) ->
-  let reconstruct f = R.mk_formula ~conditions ~focus f in
+ fun f ->
   match f with
-  | R.And (t, xs) ->
+  | R.And (t, { conjuncts = xs; conditions = conds; focus }) ->
       let ys = List_.map_filter remove_not xs in
       if List_.null ys then (
         Logs.debug (fun m -> m ~tags "null And after remove_not");
         None)
-      else Some (R.And (t, ys) |> reconstruct)
+      else Some (R.And (t, { conjuncts = ys; conditions = conds; focus }))
   | R.Or (t, xs) ->
       (* See NOTE "AND vs OR and map_filter". *)
       let* ys = option_map remove_not xs in
       if List_.null ys then (
         Logs.debug (fun m -> m ~tags "null Or after remove_not");
         None)
-      else Some (R.Or (t, ys) |> reconstruct)
-  | R.Not (_, formula) -> (
-      match formula.f with
+      else Some (R.Or (t, ys))
+  | R.Not (_, f) -> (
+      match f with
       | R.P _ -> None
       (* double negation *)
       | R.Not (_, f) -> remove_not f
@@ -166,9 +165,13 @@ let rec (remove_not : Rule.formula -> Rule.formula option) =
       | R.Anywhere _ ->
           Logs.debug (fun m -> m ~tags "Not Anywhere");
           None)
-  | R.Inside _ -> Some formula
-  | R.Anywhere _ -> Some formula
-  | R.P _ -> Some formula
+  | R.Inside (t, formula) ->
+      let* formula = remove_not formula in
+      Some (R.Inside (t, formula))
+  | R.Anywhere (t, formula) ->
+      let* formula = remove_not formula in
+      Some (R.Anywhere (t, formula))
+  | R.P pat -> Some (P pat)
 
 let remove_not_final f =
   let final_opt = remove_not f in
@@ -187,77 +190,63 @@ type cnf_step0 = step0 cnf [@@deriving show]
  * by List_.map, but we still get some Stack_overflow because of the many
  * calls to @.
  *)
-let (cnf : Rule.formula -> cnf_step0) =
- fun formula ->
-  let rec aux { Rule.f; conditions; _ } =
-    let augment_with_conditions (And x) =
-      let conditions =
-        List_.map (fun (_t, cond) -> Or [ LCond cond ]) conditions
+let rec (cnf : Rule.formula -> cnf_step0) =
+ fun f ->
+  match f with
+  | R.P pat -> And [ Or [ LPat pat ] ]
+  | R.Not (_, _f) ->
+      (* should be filtered by remove_not *)
+      failwith "call remove_not before cnf"
+  (* old:
+   * (match f with
+   * | R.Leaf x -> And [Or [Not x]]
+   * (* double negation *)
+   * | R.Not f -> cnf f
+   * (* de Morgan's laws *)
+   * | R.Or _xs -> failwith "Not Or"
+   * | R.And _xs -> failwith "Not And"
+   * )
+   *)
+  | R.Inside (_, formula)
+  | R.Anywhere (_, formula) ->
+      cnf formula
+  | R.And (_, { conjuncts = xs; conditions = conds; _ }) ->
+      let ys = List_.map cnf xs in
+      let zs = List_.map (fun (_t, cond) -> And [ Or [ LCond cond ] ]) conds in
+      And (ys @ zs |> List.concat_map (function And ors -> ors))
+  | R.Or (_, xs) ->
+      let is_dangerously_large p q =
+        List.compare_length_with p 10_000 > 0
+        || List.compare_length_with q 10_000 > 0
+        ||
+        let p_len = List.length p in
+        let q_len = List.length q in
+        (* Divide rather than multiply to avoid integer overflow *)
+        p_len > Int.div 50_000 q_len
       in
-      And (x @ conditions)
-    in
-    aux' f |> augment_with_conditions
-  and aux' kind =
-    match kind with
-    | R.P pat -> And [ Or [ LPat pat ] ]
-    | R.Not (_, _f) ->
-        (* should be filtered by remove_not *)
-        failwith "call remove_not before cnf"
-    (* old:
-       * (match f with
-       * | R.Leaf x -> And [Or [Not x]]
-       * (* double negation *)
-       * | R.Not f -> cnf f
-       * (* de Morgan's laws *)
-       * | R.Or _xs -> failwith "Not Or"
-       * | R.And _xs -> failwith "Not And"
-       * )
-    *)
-    | R.Inside (_, formula)
-    | R.Anywhere (_, formula) ->
-        aux formula
-    | R.And (_, xs) ->
-        let ys = List_.map aux xs in
-        And
-          (List.concat_map
-             (function
-               | And x -> x)
-             ys)
-    | R.Or (_, xs) ->
-        let is_dangerously_large p q =
-          List.compare_length_with p 10_000 > 0
-          || List.compare_length_with q 10_000 > 0
-          ||
-          let p_len = List.length p in
-          let q_len = List.length q in
-          (* Divide rather than multiply to avoid integer overflow *)
-          p_len > Int.div 50_000 q_len
-        in
-        let ys = List_.map aux xs in
-        List.fold_left
-          (fun (And ps) (And qs) ->
-            (* Abort before this starts consuming insane amounts of memory. *)
-            if is_dangerously_large ps qs then raise CNF_exploded;
-            (* Distributive law *)
-            And
-              (ps
-              |> List.concat_map (fun pi ->
-                     let ands =
-                       qs
-                       |> List_.map (fun qi ->
-                              let (Or pi_ors) = pi in
-                              let (Or qi_ors) = qi in
-                              (* `ps` is the accumulator so we expect it to be larger *)
-                              let ors = List.rev_append qi_ors pi_ors in
-                              Or ors)
-                     in
-                     ands)))
-          (* If `ys = []`, we have `Or []` which is the same as `false`. Note that
-             * the CNF is then `And [Or []]` rather than `And []` (the latter being
-             * the same `true`). *)
-          (And [ Or [] ]) ys
-  in
-  aux formula
+      let ys = List_.map cnf xs in
+      List.fold_left
+        (fun (And ps) (And qs) ->
+          (* Abort before this starts consuming insane amounts of memory. *)
+          if is_dangerously_large ps qs then raise CNF_exploded;
+          (* Distributive law *)
+          And
+            (ps
+            |> List.concat_map (fun pi ->
+                   let ands =
+                     qs
+                     |> List_.map (fun qi ->
+                            let (Or pi_ors) = pi in
+                            let (Or qi_ors) = qi in
+                            (* `ps` is the accumulator so we expect it to be larger *)
+                            let ors = List.rev_append qi_ors pi_ors in
+                            Or ors)
+                   in
+                   ands)))
+        (* If `ys = []`, we have `Or []` which is the same as `false`. Note that
+         * the CNF is then `And [Or []]` rather than `And []` (the latter being
+         * the same `true`). *)
+        (And [ Or [] ]) ys
 
 (*****************************************************************************)
 (* Step1: just collect strings, mvars, regexps *)
@@ -641,8 +630,11 @@ let regexp_prefilter_of_taint_rule ~xlang (_rule_id, rule_tok) taint_spec =
      * analysis! *)
     R.And
       ( rule_tok,
-        [ R.f (R.Or (rule_tok, sources)); R.f (R.Or (rule_tok, sinks)) ] )
-    |> R.f
+        {
+          conjuncts = [ R.Or (rule_tok, sources); R.Or (rule_tok, sinks) ];
+          conditions = [];
+          focus = [];
+        } )
   in
   regexp_prefilter_of_formula ~xlang f
 

--- a/src/osemgrep/reporting/Semgrep_hashing_functions.ml
+++ b/src/osemgrep/reporting/Semgrep_hashing_functions.ml
@@ -193,15 +193,14 @@ let match_based_id_partial (rule : Rule.t) (rule_id : Rule_ID.t) metavars path :
   let formulae = Rule.formula_of_mode mode in
   (* We need to do this as flattening and sorting does not always produce the
    * same result: [[a c] b] become "a c b" while [a c b] becomes "a b c". *)
-  let rec go formula =
-    match formula.Rule.f with
+  let rec go = function
     | Rule.P p -> fst p.pstr
     | Rule.Anywhere (_, formula)
     | Rule.Inside (_, formula)
     | Rule.Not (_, formula) ->
         go formula
     | Rule.Or (_, formulae)
-    | Rule.And (_, formulae) ->
+    | Rule.And (_, { Rule.conjuncts = formulae; _ }) ->
         let xs = List_.map go formulae in
         String.concat " " (List.sort String.compare xs)
   in

--- a/src/parsing/Parse_rule.ml
+++ b/src/parsing/Parse_rule.ml
@@ -291,7 +291,7 @@ let parse_taint_source ~(is_old : bool) env (key : key) (value : G.expr) :
     match parse_str_or_dict env value with
     | Left value ->
         let source_formula =
-          R.f (R.P (Parse_rule_formula.parse_rule_xpattern env value))
+          R.P (Parse_rule_formula.parse_rule_xpattern env value)
         in
         {
           source_id;
@@ -375,7 +375,7 @@ let parse_taint_sanitizer ~(is_old : bool) env (key : key) (value : G.expr) =
     match parse_str_or_dict env value with
     | Left value ->
         let sanitizer_formula =
-          R.P (Parse_rule_formula.parse_rule_xpattern env value) |> R.f
+          R.P (Parse_rule_formula.parse_rule_xpattern env value)
         in
         {
           sanitizer_id;
@@ -416,7 +416,7 @@ let parse_taint_sink ~(is_old : bool) env (key : key) (value : G.expr) :
     match parse_str_or_dict env value with
     | Left value ->
         let sink_formula =
-          R.P (Parse_rule_formula.parse_rule_xpattern env value) |> R.f
+          R.P (Parse_rule_formula.parse_rule_xpattern env value)
         in
         let sink_has_focus = Rule.is_formula_with_focus sink_formula in
         {

--- a/src/parsing/Parse_rule_formula.ml
+++ b/src/parsing/Parse_rule_formula.ml
@@ -306,7 +306,7 @@ and parse_pair_old env ((key, value) : key * G.expr) : R.formula =
   let get_formula ?(allow_string = false) env x =
     match (parse_str_or_dict env x, x.G.e) with
     | Left (value, t), _ when allow_string ->
-        R.P (parse_rule_xpattern env (value, t)) |> R.f
+        R.P (parse_rule_xpattern env (value, t))
     | Left (s, _), _ ->
         error_at_expr env.id x
           (Common.spf
@@ -333,21 +333,17 @@ and parse_pair_old env ((key, value) : key * G.expr) : R.formula =
   in
   let s, t = key in
   match s with
-  | "pattern" -> R.P (get_pattern value) |> R.f
-  | "pattern-not" -> R.Not (t, get_formula ~allow_string:true env value) |> R.f
-  | "pattern-inside" ->
-      R.Inside (t, get_formula ~allow_string:true env value) |> R.f
+  | "pattern" -> R.P (get_pattern value)
+  | "pattern-not" -> R.Not (t, get_formula ~allow_string:true env value)
+  | "pattern-inside" -> R.Inside (t, get_formula ~allow_string:true env value)
   | "pattern-not-inside" ->
-      R.Not (t, R.Inside (t, get_formula ~allow_string:true env value) |> R.f)
-      |> R.f
-  | "semgrep-internal-pattern-anywhere" ->
-      (match parse_str_or_dict env value with
-      | Left _ -> R.Anywhere (t, R.P (get_pattern value) |> R.f)
+      R.Not (t, R.Inside (t, get_formula ~allow_string:true env value))
+  | "semgrep-internal-pattern-anywhere" -> (
+      match parse_str_or_dict env value with
+      | Left _ -> R.Anywhere (t, R.P (get_pattern value))
       | Right dict -> R.Anywhere (t, parse_formula_old_from_dict env dict))
-      |> R.f
   | "pattern-either" ->
       R.Or (t, parse_listi env key (get_nested_formula_in_list env) value)
-      |> R.f
   | "patterns" ->
       let parse_pattern i expr =
         match parse_str_or_dict env expr with
@@ -408,15 +404,15 @@ and parse_pair_old env ((key, value) : key * G.expr) : R.formula =
       if pos =*= [] && not env.in_metavariable_pattern then
         Rule.raise_error (Some env.id)
           (InvalidRule (MissingPositiveTermInAnd, env.id, t));
-      { f = R.And (t, conjuncts); focus; conditions }
+      R.And (t, { conjuncts; focus; conditions })
   | "pattern-regex" ->
       let x = parse_string_wrap env key value in
       let xpat = XP.mk_xpat (Regexp (parse_regexp env x)) x in
-      R.P xpat |> R.f
+      R.P xpat
   | "pattern-not-regex" ->
       let x = parse_string_wrap env key value in
       let xpat = XP.mk_xpat (Regexp (parse_regexp env x)) x in
-      R.Not (t, R.P xpat |> R.f) |> R.f
+      R.Not (t, R.P xpat)
   | "focus-metavariable"
   | "metavariable-analysis"
   | "metavariable-regex"
@@ -616,7 +612,6 @@ and parse_formula env (value : G.expr) : R.formula =
                      (s, env.target_analyzer, Common.exn_to_s exn, env.path),
                    env.id,
                    t )))
-      |> R.f
   (* If that doesn't work, it should be a key-value pairing.
    *)
   | Right dict -> (
@@ -711,11 +706,7 @@ and produce_constraint env dict tok indicator =
             let env' = { env' with in_metavariable_pattern = true } in
             let formula = parse_pair env' ps in
             match formula with
-            | {
-             f = R.P { pat = Xpattern.Regexp regexp; _ };
-             focus = [];
-             conditions = [];
-            } ->
+            | R.P { pat = Xpattern.Regexp regexp; _ } ->
                 (* TODO: always on by default *)
                 [ Left (t, R.CondRegexp (metavar, regexp, true)) ]
             | _ -> [ Left (t, CondNestedFormula (metavar, opt_xlang, formula)) ]
@@ -746,8 +737,8 @@ and produce_constraint env dict tok indicator =
       in
       List.flatten [ pat; typ ]
 
-and constrain_where env (_t1, _t2) where_key (value : G.expr) formula :
-    R.formula =
+and constrain_where env (t1, _t2) where_key (value : G.expr) formula : R.formula
+    =
   let env = { env with path = "where" :: env.path } in
   (* TODO: first token, or principal token? *)
   let parse_where_pair env (where_value : G.expr) =
@@ -762,31 +753,38 @@ and constrain_where env (_t1, _t2) where_key (value : G.expr) formula :
     |> List.flatten
     |> Either_.partition_either (fun x -> x)
   in
-  {
-    formula with
-    conditions = formula.conditions @ conditions;
-    focus = formula.focus @ focus;
-  }
+  let tok, conditions, focus, conjuncts =
+    (* If the modified pattern is also an `And`, collect the conditions and focus
+        and fold them together.
+    *)
+    match formula with
+    | And (tok, { conjuncts; conditions = conditions2; focus = focus2 }) ->
+        (tok, conditions @ conditions2, focus @ focus2, conjuncts)
+    (* Otherwise, we consider the modified pattern a degenerate singleton `And`.
+    *)
+    | _ -> (t1, conditions, focus, [ formula ])
+  in
+  R.And (tok, { conjuncts; conditions; focus })
 
 and parse_pair env ((key, value) : key * G.expr) : R.formula =
   let env = { env with path = fst key :: env.path } in
   let get_string_pattern str_e = parse_xpattern_expr env str_e in
   let s, t = key in
   match s with
-  | "pattern" -> R.P (get_string_pattern value) |> R.f
-  | "not" -> R.Not (t, parse_formula env value) |> R.f
-  | "inside" -> R.Inside (t, parse_formula env value) |> R.f
-  | "anywhere" -> R.Anywhere (t, parse_formula env value) |> R.f
+  | "pattern" -> R.P (get_string_pattern value)
+  | "not" -> R.Not (t, parse_formula env value)
+  | "inside" -> R.Inside (t, parse_formula env value)
+  | "anywhere" -> R.Anywhere (t, parse_formula env value)
   | "all" ->
       let conjuncts = parse_listi env key parse_formula value in
       let pos, _ = R.split_and conjuncts in
       if pos =*= [] && not env.in_metavariable_pattern then
         Rule.raise_error (Some env.id)
           (InvalidRule (MissingPositiveTermInAnd, env.id, t));
-      R.And (t, conjuncts) |> R.f
-  | "any" -> R.Or (t, parse_listi env key parse_formula value) |> R.f
+      R.And (t, { conjuncts; focus = []; conditions = [] })
+  | "any" -> R.Or (t, parse_listi env key parse_formula value)
   | "regex" ->
       let x = parse_string_wrap env key value in
       let xpat = XP.mk_xpat (Regexp (parse_regexp env x)) x in
-      R.P xpat |> R.f
+      R.P xpat
   | _ -> error_at_key env.id key (spf "unexpected key %s" (fst key))


### PR DESCRIPTION
Reverts semgrep/semgrep#9696 per [this discussion](https://semgrepinc.slack.com/archives/C048LGPK46L/p1708529678009499).

In summary it causes some rules to fail due to [this assertion](https://github.com/semgrep/semgrep/blob/develop/src/optimizing/Analyze_rule.ml?plain=1#L205). 