### PR TITLE
fix: Apply autofixes in reverse to avoid error-prone bookkeeping

### DIFF
--- a/changelog.d/saf-863.fixed
+++ b/changelog.d/saf-863.fixed
@@ -1,0 +1,1 @@
+Fixed an issue that led to incorrect autofix application in certain cases where multiple fixes were applied to the same line.


### PR DESCRIPTION
SAF-863 has an example of an autofix that has several deletions on the same line. The bookeeping that we do which is supposed to lead to correct behavior in cases like that is evidently failing. I think it used to work but maybe some recent change broke it or maybe there is something special about this case that confounds the bookkeeping.

I can't be bothered to figure it out. There's a much simpler way to do this: just apply all the fixes in reverse. I used the same trick in the equivalent OCaml code in #6391.

Fixes SAF-863

Test plan:

Existing automated tests

Manual test with the case in SAF-863

