### PR TITLE
fix: Handle `ModuleNotFoundErrror`

### DIFF
--- a/cli/bin/semgrep
+++ b/cli/bin/semgrep
@@ -86,7 +86,7 @@ def find_semgrep_core_path(pro=False, extra_message=""):
                 if pro and not is_correct_pro_version(path):
                     raise CoreNotFound(f"The installed version of {core} is out of date.{extra_message}")
                 return str(path)
-    except FileNotFoundError as e:
+    except ModuleNotFoundError as e:
         pass
 
     # Second, try in PATH. In certain context such as Homebrew

--- a/cli/bin/semgrep
+++ b/cli/bin/semgrep
@@ -86,7 +86,7 @@ def find_semgrep_core_path(pro=False, extra_message=""):
                 if pro and not is_correct_pro_version(path):
                     raise CoreNotFound(f"The installed version of {core} is out of date.{extra_message}")
                 return str(path)
-    except ModuleNotFoundError as e:
+    except (FileNotFoundError, ModuleNotFoundError) as e:
         pass
 
     # Second, try in PATH. In certain context such as Homebrew


### PR DESCRIPTION
`importlib.resources.as_file` raises a `ModuleNotFoundError` if `semgrep.bin` is not a valid module. In those cases, `semgrep` should gracefully degrade to checking if the relevant binary is in the `PATH`.