### PR TITLE
Read log level from environment variables

### DIFF
--- a/libs/commons/Logs_.mli
+++ b/libs/commons/Logs_.mli
@@ -136,3 +136,10 @@ val mask_time : string -> string
    This is crude. Beware false positives.
 *)
 val mask_log_lines : string -> string
+
+(*
+   Formatting utilities for common containers:
+*)
+val list : ('a -> string) -> 'a list -> string
+val option : ('a -> string) -> 'a option -> string
+val array : ('a -> string) -> 'a array -> string


### PR DESCRIPTION
A small step for semgrep but a small step for mankind.

This is a bit rushed but I need it now to debug another branch because pytest doesn't invoke semgrep with in debug mode but there's a bug occurring seemingly only in the test environment.

test plan:
```
PYTEST_LOG_LEVEL=debug pipenv run pytest -k test_regex_rule__child
```
Replace the test name with any failing test you're trying to debug and enjoy more logging.
