### PR TITLE
tainting: pro: Capture changes to parameters' fields in taint signatures

### DIFF
--- a/changelog.d/flow-70.fixed
+++ b/changelog.d/flow-70.fixed
@@ -1,0 +1,1 @@
+fix: taint signatures do not capture changes to parameters' fields

--- a/src/il/IL.ml
+++ b/src/il/IL.ml
@@ -465,3 +465,16 @@ type any = L of lval | E of exp | I of instr | S of stmt | Ss of stmt list
 let str_of_name name = Common.spf "%s:%s" (fst name.ident) (G.SId.show name.sid)
 let ident_str_of_name name = fst name.ident
 let str_of_label ((n, _), _) = n
+
+let rec equal_base base1 base2 =
+  match (base1, base2) with
+  | Var name1, Var name2 -> compare_name name1 name2 = 0
+  | VarSpecial (This, _), VarSpecial (This, _) -> true
+  | VarSpecial (Super, _), VarSpecial (Super, _) -> true
+  | VarSpecial (Self, _), VarSpecial (Self, _) -> true
+  | VarSpecial (Parent, _), VarSpecial (Parent, _) -> true
+  | ( Mem { e = Fetch { base = base1; rev_offset = [] }; _ },
+      Mem { e = Fetch { base = base2; rev_offset = [] }; _ } ) ->
+      (* Deref e.g. *base *)
+      equal_base base1 base2
+  | _ -> false

--- a/src/tainting/Dataflow_tainting.ml
+++ b/src/tainting/Dataflow_tainting.ml
@@ -1730,7 +1730,7 @@ let findings_from_arg_updates_at_exit enter_env exit_env : T.finding list =
   enter_env |> Lval_env.seq_of_tainted
   |> Seq.flat_map (fun ({ base; _ }, enter_taints) ->
          (* We need to consider all lvals of the same base component
-            due to index sensitivity. *)
+            due to field and index sensitivity. *)
          Lval_env.find_tainted_lvals_of_common_base exit_env base
          |> List_.map (fun l -> (l, enter_taints))
          |> List.to_seq)

--- a/src/tainting/Dataflow_tainting.ml
+++ b/src/tainting/Dataflow_tainting.ml
@@ -1727,7 +1727,14 @@ let findings_from_arg_updates_at_exit enter_env exit_env : T.finding list =
   (* TOOD: We need to get a map of `lval` to `Taint.arg`, and if an extension
    * of `lval` has new taints, then we can compute its correspoding `Taint.arg`
    * extension and generate an `ArgToArg` finding too. *)
-  enter_env |> Lval_env.seq_of_tainted |> List.of_seq
+  enter_env |> Lval_env.seq_of_tainted
+  |> Seq.flat_map (fun (lval, enter_taints) ->
+         (* We need to consider all lvals of the same base component
+            due to index sensitivity. *)
+         Lval_env.find_tainted_lvals_of_common_base exit_env lval
+         |> List.map (fun l -> (l, enter_taints))
+         |> List.to_seq)
+  |> List.of_seq
   |> List.concat_map (fun (lval, enter_taints) ->
          (* For each lval in the enter_env, we get its `T.arg`, and check
           * if it got new taints at the exit_env. If so, we generate an

--- a/src/tainting/Dataflow_tainting.ml
+++ b/src/tainting/Dataflow_tainting.ml
@@ -1732,7 +1732,7 @@ let findings_from_arg_updates_at_exit enter_env exit_env : T.finding list =
          (* We need to consider all lvals of the same base component
             due to index sensitivity. *)
          Lval_env.find_tainted_lvals_of_common_base exit_env lval
-         |> List.map (fun l -> (l, enter_taints))
+         |> List_.map (fun l -> (l, enter_taints))
          |> List.to_seq)
   |> List.of_seq
   |> List.concat_map (fun (lval, enter_taints) ->

--- a/src/tainting/Dataflow_tainting.ml
+++ b/src/tainting/Dataflow_tainting.ml
@@ -1728,10 +1728,10 @@ let findings_from_arg_updates_at_exit enter_env exit_env : T.finding list =
    * of `lval` has new taints, then we can compute its correspoding `Taint.arg`
    * extension and generate an `ArgToArg` finding too. *)
   enter_env |> Lval_env.seq_of_tainted
-  |> Seq.flat_map (fun (lval, enter_taints) ->
+  |> Seq.flat_map (fun ({ base; _ }, enter_taints) ->
          (* We need to consider all lvals of the same base component
             due to index sensitivity. *)
-         Lval_env.find_tainted_lvals_of_common_base exit_env lval
+         Lval_env.find_tainted_lvals_of_common_base exit_env base
          |> List_.map (fun l -> (l, enter_taints))
          |> List.to_seq)
   |> List.of_seq

--- a/src/tainting/Taint_lval_env.ml
+++ b/src/tainting/Taint_lval_env.ml
@@ -482,19 +482,7 @@ let to_string taint_to_str
 let seq_of_tainted env = LvalMap.to_seq env.tainted
 
 let find_tainted_lvals_of_common_base { tainted; _ } base =
-  let rec eq_base base1 base2 =
-    match (base1, base2) with
-    | IL.Var name1, IL.Var name2 when IL.compare_name name1 name2 = 0 -> true
-    | VarSpecial (This, _), VarSpecial (This, _) -> true
-    | VarSpecial (Super, _), VarSpecial (Super, _) -> true
-    | VarSpecial (Self, _), VarSpecial (Self, _) -> true
-    | VarSpecial (Parent, _), VarSpecial (Parent, _) -> true
-    | ( Mem { e = Fetch { base = base1; rev_offset = [] }; _ },
-        Mem { e = Fetch { base = base2; rev_offset = [] }; _ } ) ->
-        eq_base base1 base2
-    | _ -> false
-  in
   LvalMap.fold
     (fun ({ base = base'; _ } as lval) _ l ->
-      if eq_base base base' then lval :: l else l)
+      if IL.equal_base base base' then lval :: l else l)
     tainted []

--- a/src/tainting/Taint_lval_env.ml
+++ b/src/tainting/Taint_lval_env.ml
@@ -26,6 +26,7 @@ module LvalMap = Map.Make (LV.LvalOrdered)
 module LvalSet = Set.Make (LV.LvalOrdered)
 
 let tags = Logs_.create_tags [ __MODULE__ ]
+let ( =*= ) = Common.( =*= )
 
 type taints_to_propagate = T.taints VarMap.t
 type pending_propagation_dests = IL.lval VarMap.t
@@ -480,3 +481,9 @@ let to_string taint_to_str
       pending_propagation_dests "[PENDING PROPAGATION DESTS]"
 
 let seq_of_tainted env = LvalMap.to_seq env.tainted
+
+let find_tainted_lvals_of_common_base { tainted; _ } { IL.base; _ } =
+  LvalMap.fold
+    (fun ({ base = base'; _ } as lval) _ l ->
+      if base =*= base' then lval :: l else l)
+    tainted []

--- a/src/tainting/Taint_lval_env.mli
+++ b/src/tainting/Taint_lval_env.mli
@@ -102,4 +102,4 @@ val equal_by_lval : env -> env -> IL.lval -> bool
 
 val to_string : (Taint.taints -> string) -> env -> string
 val seq_of_tainted : env -> (IL.lval * Taint.taints) Seq.t
-val find_tainted_lvals_of_common_base : env -> IL.lval -> IL.lval list
+val find_tainted_lvals_of_common_base : env -> IL.base -> IL.lval list

--- a/src/tainting/Taint_lval_env.mli
+++ b/src/tainting/Taint_lval_env.mli
@@ -102,3 +102,4 @@ val equal_by_lval : env -> env -> IL.lval -> bool
 
 val to_string : (Taint.taints -> string) -> env -> string
 val seq_of_tainted : env -> (IL.lval * Taint.taints) Seq.t
+val find_tainted_lvals_of_common_base : env -> IL.lval -> IL.lval list


### PR DESCRIPTION
Taint signatures were not capturing when taint went into specific fields of parameters or of a field of the current class. For example, given `this.x = "tainted"` we correctly tracked `x` as tainted, but given `this.x.y = "tainted"` we did not record `x.y` as tainted. 

Closes FLOW-70

test plan: `make test` in https://github.com/semgrep/semgrep-proprietary/pull/1333