### PR TITLE
chore: Only run semgrep-comparison on pull requests

### DIFF
--- a/.github/workflows/tests.jsonnet
+++ b/.github/workflows/tests.jsonnet
@@ -393,6 +393,7 @@ local benchmarks_full_job = {
 };
 
 local trigger_semgrep_comparison_argo = {
+  'if': "github.event_name == 'pull_request'",
   secrets: 'inherit',
   needs: [
     'push-docker-returntocorp',

--- a/.github/workflows/tests.jsonnet
+++ b/.github/workflows/tests.jsonnet
@@ -393,7 +393,7 @@ local benchmarks_full_job = {
 };
 
 local trigger_semgrep_comparison_argo = {
-  'if': "github.event_name == 'pull_request'",
+  'if': "${{ github.event_name == 'pull_request' && !startsWith(github.event.pull_request.base.ref, 'release') && !startsWith(github.head_ref, 'release') }}",
   secrets: 'inherit',
   needs: [
     'push-docker-returntocorp',

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -411,7 +411,7 @@ jobs:
       artifact-name: image-test
       repository-name: returntocorp/semgrep
   trigger-semgrep-comparison-argo:
-    if: github.event_name == 'pull_request'
+    if: ${{ github.event_name == 'pull_request' && !startsWith(github.event.pull_request.base.ref, 'release') && !startsWith(github.head_ref, 'release') }}
     needs:
       - push-docker-returntocorp
     secrets: inherit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -411,6 +411,7 @@ jobs:
       artifact-name: image-test
       repository-name: returntocorp/semgrep
   trigger-semgrep-comparison-argo:
+    if: github.event_name == 'pull_request'
     needs:
       - push-docker-returntocorp
     secrets: inherit


### PR DESCRIPTION
This check triggered by this workflow was [unknowingly running on a mandatory release workflow check](https://github.com/semgrep/semgrep/actions/runs/7996557795/job/21839372553), `start-release`, which is run manually with via `workflow_dispatch`.

This PR adds a condition which only triggers the check on pull requests.

### Tests

Manually tested the `if:` condition on a dummy repo here.
* Merge from a 'release' branch into something else https://github.com/semgrep/WebGoat/actions/runs/8011012017/job/21883300880?pr=35
* Merge into a release branch https://github.com/semgrep/WebGoat/actions/runs/8010860542/job/21882814335?pr=34
* Anything else https://github.com/semgrep/WebGoat/actions/runs/8010992981/job/21883239356?pr=33