### PR TITLE
AST_to_IL: Handle nested record patterns

### DIFF
--- a/changelog.d/flow-68.added
+++ b/changelog.d/flow-68.added
@@ -1,0 +1,3 @@
+Dataflow: Added support for nested record patterns such as `{ body: { param } }`
+in the LHS of an assignment. Now given `{ body: { param } } = tainted` Semgrep
+will correctly mark `param` as tainted.

--- a/tests/rules/taint_nested_record_pattern.js
+++ b/tests/rules/taint_nested_record_pattern.js
@@ -1,0 +1,5 @@
+function test() {
+  const { body: { param } } = tainted
+  // ruleid: test
+  sink(param)
+}

--- a/tests/rules/taint_nested_record_pattern.yaml
+++ b/tests/rules/taint_nested_record_pattern.yaml
@@ -1,0 +1,12 @@
+rules:
+  - id: test
+    message: Test
+    mode: taint
+    pattern-sources:
+      - pattern: tainted
+    pattern-sinks:
+      - pattern: sink(...)
+    severity: ERROR
+    languages:
+      - javascript
+      - typescript


### PR DESCRIPTION
To handle assignments like `{ body: { param } } = input`.

Also, took the chance to replace a `fresh_var` with `mk_aux_var` to avoid creating an extra variable when there is no need to. So for the above example we no longer have `_tmp = input` but use `input` directly.

Closes FLOW-68

test plan:
% make test # new test
% semgrep-core -lang js -cfg_il tests/rules/taint_nested_record_pattern.js
    #^ no more extra _tmp variable