### PR TITLE
chore(ci): update permissions for the release workflow

### DIFF
--- a/.github/workflows/libs/gha.libsonnet
+++ b/.github/workflows/libs/gha.libsonnet
@@ -27,7 +27,8 @@
     // More details at
     // https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect
     'id-token': 'write',
-    // needed when the job modifies the repository
+    // Needed when the job modifies the repository such as performing
+    // gh release commands.
     contents: 'write',
   },
 

--- a/.github/workflows/release.jsonnet
+++ b/.github/workflows/release.jsonnet
@@ -390,9 +390,10 @@ local homebrew_core_pr_job =
       ],
     },
   },
-  // These extra permissions are needed by some of the jobs, e.g. build-test-docker.
+  // These extra permissions are needed by some of the jobs, e.g. build-test-docker,
+  // and create_release_job.
   permissions: {
-    contents: 'read',
+    contents: 'write',
     'id-token': 'write',
   },
   jobs: {

--- a/.github/workflows/release.jsonnet
+++ b/.github/workflows/release.jsonnet
@@ -13,6 +13,7 @@
 
 local semgrep = import 'libs/semgrep.libsonnet';
 local actions = import 'libs/actions.libsonnet';
+local gha = import 'libs/gha.libsonnet';
 local release_homebrew = import 'release-homebrew.jsonnet';
 
 // ----------------------------------------------------------------------------
@@ -392,10 +393,7 @@ local homebrew_core_pr_job =
   },
   // These extra permissions are needed by some of the jobs, e.g. build-test-docker,
   // and create_release_job.
-  permissions: {
-    contents: 'write',
-    'id-token': 'write',
-  },
+  permissions: gha.write_permissions,
   jobs: {
     'park-pypi-packages': park_pypi_packages_job,
     'build-test-docker': build_test_docker_job,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -254,5 +254,5 @@ name: release
         required: true
         type: boolean
 permissions:
-  contents: read
+  contents: write
   id-token: write


### PR DESCRIPTION
It seems like the `gh release` command in our release workflow needs `contents: write` permissions.

Our 2 previous releases were stuck because of this. Example: https://github.com/semgrep/semgrep/actions/runs/7906461889/job/21582207159

It only failed during the past 2 releases because our github tier got updated and the default permissions changed then.

This PR updates this permission without depending on default permissions having sufficient privileges.