### PR TITLE
Fix the warnings on "pattern-either" not valid

### DIFF
--- a/.semgrepignore
+++ b/.semgrepignore
@@ -25,11 +25,15 @@
 # To ignore a file with a literal ':' character, escape it with
 # a backslash, e.g. "\:foo".
 
-/tests
 # Test data
+/tests
 /cli/tests/e2e/targets/
 /cli/tests/e2e/snapshots/
 /cli/tests/performance/targets/
+
+# has some constructs that AST_to_IL has trouble translating ('...' in target code)
+/cli/stubs/
+*.pyi
 
 # rules being tested for performance
 /perf/rules/

--- a/src/engine/Test_engine.ml
+++ b/src/engine/Test_engine.ml
@@ -319,7 +319,7 @@ let make_test_rule_file ?(fail_callback = fun _i m -> Alcotest.fail m)
 
 let find_rule_files roots =
   roots |> UFile.files_of_dirs_or_files_no_vcs_nofilter
-  |> List.filter Parse_rule.is_valid_rule_filename
+  |> List.filter Rule_file.is_valid_rule_filename
 
 (*****************************************************************************)
 (* Entry point *)

--- a/src/osemgrep/cli_test/Test_subcommand.ml
+++ b/src/osemgrep/cli_test/Test_subcommand.ml
@@ -197,7 +197,7 @@ let run_conf (caps : caps) (conf : Test_CLI.conf) : Exit_code.t =
         (* coupling: similar to Test_engine.test_rules() *)
         let rule_files =
           [ dir ] |> UFile.files_of_dirs_or_files_no_vcs_nofilter
-          |> List.filter Parse_rule.is_valid_rule_filename
+          |> List.filter Rule_file.is_valid_rule_filename
         in
         rule_files
         |> List_.map (fun rule_file ->

--- a/src/osemgrep/networking/Rule_fetching.ml
+++ b/src/osemgrep/networking/Rule_fetching.ml
@@ -428,7 +428,7 @@ let rules_from_dashdash_config_async ~rewrite_rule_ids ~token_opt
        * was not given, but this feature was removed, so now we can KISS.
        *)
       List_files.list dir
-      |> List.filter Parse_rule.is_valid_rule_filename
+      |> List.filter Rule_file.is_valid_rule_filename
       |> List_.map (fun file ->
              load_rules_from_file ~rewrite_rule_ids ~origin:(Local_file file)
                ~registry_caching caps file)

--- a/src/parsing/Parse_rule.mli
+++ b/src/parsing/Parse_rule.mli
@@ -1,14 +1,9 @@
-(*
-   Rule parsing
-*)
-
 (* Parse a rule file, either in YAML or JSON (or even Jsonnet) format
    depending on the filename extension.
 
    The parser accepts invalid rules, skips them, and returns them in
    the list of errors.
    This will not raise Rule.Err (Rule.InvalidRule ...) exceptions.
-
    However, this function may raise the other (Rule.Err ...) exns
    (e.g., Rule.InvalidYaml).
 
@@ -20,18 +15,6 @@ val parse_and_filter_invalid_rules :
   ?rewrite_rule_ids:(Rule_ID.t -> Rule_ID.t) option ->
   Fpath.t ->
   Rule.rules * Rule.invalid_rule_error list
-
-(* ex: foo.yaml, foo.yml, but not foo.test.yaml.
- *
- * Note that even if parse() above accepts JSON (and Jsonnet) files,
- * foo.json (and foo.jsonnet) are currently not considered
- * valid_rule_filename.
- *
- * This function is currently used for osemgrep, to get all
- * the valid rule files when using --config <DIR>,
- * and also in Test_engine.ml.
- *)
-val is_valid_rule_filename : Fpath.t -> bool
 
 (* This is used for parsing -e/-f extended patterns in Run_semgrep.ml
  * and now also in osemgrep Config_resolver.ml.

--- a/src/parsing/Rule_file.ml
+++ b/src/parsing/Rule_file.ml
@@ -1,0 +1,28 @@
+open Fpath_.Operators
+module FT = File_type
+
+(*****************************************************************************)
+(* Valid rule filename checks *)
+(*****************************************************************************)
+
+(* alt: could define
+ * type yaml_kind = YamlRule | YamlTest | YamlFixed | YamlOther
+ *)
+let is_test_yaml_file (filepath : Fpath.t) : bool =
+  (* .test.yaml files are YAML target files rather than config files! *)
+  let filepath = !!filepath in
+  Filename.check_suffix filepath ".test.yaml"
+  || Filename.check_suffix filepath ".test.yml"
+  || Filename.check_suffix filepath ".test.fixed.yaml"
+  || Filename.check_suffix filepath ".test.fixed.yml"
+
+(* coupling: with Parse_rule.parse_file *)
+let is_valid_rule_filename (filename : Fpath.t) : bool =
+  match File_type.file_type_of_file filename with
+  (* ".yml" or ".yaml" *)
+  | FT.Config FT.Yaml -> not (is_test_yaml_file filename)
+  (* old: we were allowing Jsonnet before, but better to skip
+   * them for now to avoid adding a jsonnet dependency in our docker/CI
+   * FT.Config (FT.Json FT.Jsonnet) when not unit_testing -> true
+   *)
+  | _else_ -> false

--- a/src/parsing/Rule_file.mli
+++ b/src/parsing/Rule_file.mli
@@ -1,0 +1,11 @@
+(* ex: foo.yaml, foo.yml, but not foo.test.yaml.
+ *
+ * Note that even if parse() above accepts JSON (and Jsonnet) files,
+ * foo.json (and foo.jsonnet) are currently not considered
+ * valid_rule_filename.
+ *
+ * This function is currently used for osemgrep, to get all
+ * the valid rule files when using --config <DIR>,
+ * and also in Test_engine.ml.
+ *)
+val is_valid_rule_filename : Fpath.t -> bool


### PR DESCRIPTION
In Parse_rule.ml we report when some fields in the yaml were not
"consumed" that is we skip them. We were reporting some
wrong warnings about "pattern-either" or "pattern-regex" not
recognized. Now they are.

test plan:
make check
does not show those warnings anymore