### PR TITLE
Fix the warnings generated by the autofix code in 'make check'

### DIFF
--- a/src/fixing/Autofix.ml
+++ b/src/fixing/Autofix.ml
@@ -1,6 +1,6 @@
 (* Nat Mote
  *
- * Copyright (C) 2019-2022 r2c
+ * Copyright (C) 2019-2022 Semgrep Inc.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/src/fixing/Autofix_printer.ml
+++ b/src/fixing/Autofix_printer.ml
@@ -1,6 +1,6 @@
 (* Nat Mote
  *
- * Copyright (C) 2019-2022 r2c
+ * Copyright (C) 2019-2022 Semgrep Inc.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
@@ -68,6 +68,10 @@ module JsTsPrinter = Hybrid_print.Make (struct
   class printer = Ugly_print_AST.jsts_printer
 end)
 
+module OCamlPrinter = Hybrid_print.Make (struct
+  class printer = Ugly_print_AST.ocaml_printer
+end)
+
 let get_printer lang external_printer :
     (Ugly_print_AST.printer_t, string) result =
   match lang with
@@ -78,6 +82,7 @@ let get_printer lang external_printer :
   | Lang.Js
   | Lang.Ts ->
       Ok (new JsTsPrinter.printer external_printer)
+  | Lang.Ocaml -> Ok (new OCamlPrinter.printer external_printer)
   | __else__ -> Error (spf "No printer available for %s" (Lang.to_string lang))
 
 let original_source_of_ast source any =

--- a/src/printing/Ugly_print_AST.ml
+++ b/src/printing/Ugly_print_AST.ml
@@ -1,6 +1,6 @@
 (* Nat Mote
  *
- * Copyright (C) 2019-2022 r2c
+ * Copyright (C) 2019-2022 Semgrep Inc.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
@@ -306,4 +306,9 @@ class jsts_printer : printer_t =
   object (_self)
     inherit base_printer
     inherit! common_printer
+  end
+
+class ocaml_printer : printer_t =
+  object (_self)
+    inherit base_printer
   end

--- a/src/printing/Ugly_print_AST.mli
+++ b/src/printing/Ugly_print_AST.mli
@@ -67,3 +67,4 @@ end
 
 class python_printer : printer_t
 class jsts_printer : printer_t
+class ocaml_printer : printer_t


### PR DESCRIPTION
test plan:
'make check' does not display autofix warning anymore