### PR TITLE
OCaml: handle 'x <- y' obj field assignment

### DIFF
--- a/tests/parsing/ocaml/objfield_assign.ml
+++ b/tests/parsing/ocaml/objfield_assign.ml
@@ -1,0 +1,6 @@
+class foo =
+ object (self)
+  val mutable data = 1
+  method bar () =
+    data <- 2
+ end


### PR DESCRIPTION
This used to trigger an ERROR in 'make check'

test plan:
test file included
'make check' does not show a parse error in libs/commons2/common2.ml