### PR TITLE
feat: incremental printing of json results

### DIFF
--- a/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -44,6 +44,7 @@ type conf = {
   (* file or URL (None means output to stdout) *)
   output : string option;
   output_conf : Output.conf;
+  incremental_output : bool;
   (* Networking options *)
   metrics : Metrics_.config;
   registry_caching : bool; (* similar to core_runner_conf.ast_caching *)
@@ -129,6 +130,7 @@ let default : conf =
     engine_type = OSS;
     output = None;
     output_conf = Output.default;
+    incremental_output = false;
     rewrite_rule_ids = true;
     (* will send metrics only if the user uses the registry or the app *)
     metrics = Metrics_.Auto;
@@ -476,6 +478,12 @@ let o_text : bool Term.t =
 let o_json : bool Term.t =
   let info =
     Arg.info [ "json" ] ~doc:{|Output results in Semgrep's JSON format.|}
+  in
+  Arg.value (Arg.flag info)
+
+let o_incremental : bool Term.t =
+  let info =
+    Arg.info [ "incremental" ] ~doc:{|Output results incrementally.|}
   in
   Arg.value (Arg.flag info)
 
@@ -850,15 +858,16 @@ let cmdline_term ~allow_empty_config : conf Term.t =
   let combine allow_untrusted_validators ast_caching autofix baseline_commit
       common config dataflow_traces diff_depth dryrun dump_ast
       dump_command_for_core dump_engine_path emacs error exclude_
-      exclude_rule_ids force_color gitlab_sast gitlab_secrets include_ json
-      junit_xml lang ls matching_explanations max_chars_per_line
-      max_lines_per_finding max_memory_mb max_target_bytes metrics num_jobs
-      no_secrets_validation nosem optimizations oss output pattern pro
-      project_root pro_intrafile pro_lang registry_caching remote replacement
-      respect_gitignore rewrite_rule_ids sarif scan_unknown_extensions secrets
-      severity show_supported_languages strict target_roots test
-      test_ignore_todo text time_flag timeout _timeout_interfileTODO
-      timeout_threshold trace validate version version_check vim =
+      exclude_rule_ids force_color gitlab_sast gitlab_secrets include_
+      incremental json junit_xml lang ls matching_explanations
+      max_chars_per_line max_lines_per_finding max_memory_mb max_target_bytes
+      metrics num_jobs no_secrets_validation nosem optimizations oss output
+      pattern pro project_root pro_intrafile pro_lang registry_caching remote
+      replacement respect_gitignore rewrite_rule_ids sarif
+      scan_unknown_extensions secrets severity show_supported_languages strict
+      target_roots test test_ignore_todo text time_flag timeout
+      _timeout_interfileTODO timeout_threshold trace validate version
+      version_check vim =
     (* ugly: call setup_logging ASAP so the Logs.xxx below are displayed
      * correctly *)
     Std_msg.setup ?highlight_setting:(if force_color then Some On else None) ();
@@ -1164,6 +1173,7 @@ let cmdline_term ~allow_empty_config : conf Term.t =
       version_check;
       output;
       output_conf;
+      incremental_output = incremental;
       engine_type;
       rewrite_rule_ids;
       common;
@@ -1184,16 +1194,16 @@ let cmdline_term ~allow_empty_config : conf Term.t =
     $ o_baseline_commit $ CLI_common.o_common $ o_config $ o_dataflow_traces
     $ o_diff_depth $ o_dryrun $ o_dump_ast $ o_dump_command_for_core
     $ o_dump_engine_path $ o_emacs $ o_error $ o_exclude $ o_exclude_rule_ids
-    $ o_force_color $ o_gitlab_sast $ o_gitlab_secrets $ o_include $ o_json
-    $ o_junit_xml $ o_lang $ o_ls $ o_matching_explanations
-    $ o_max_chars_per_line $ o_max_lines_per_finding $ o_max_memory_mb
-    $ o_max_target_bytes $ o_metrics $ o_num_jobs $ o_no_secrets_validation
-    $ o_nosem $ o_optimizations $ o_oss $ o_output $ o_pattern $ o_pro
-    $ o_project_root $ o_pro_intrafile $ o_pro_languages $ o_registry_caching
-    $ o_remote $ o_replacement $ o_respect_gitignore $ o_rewrite_rule_ids
-    $ o_sarif $ o_scan_unknown_extensions $ o_secrets $ o_severity
-    $ o_show_supported_languages $ o_strict $ o_target_roots $ o_test
-    $ Test_CLI.o_test_ignore_todo $ o_text $ o_time $ o_timeout
+    $ o_force_color $ o_gitlab_sast $ o_gitlab_secrets $ o_include
+    $ o_incremental $ o_json $ o_junit_xml $ o_lang $ o_ls
+    $ o_matching_explanations $ o_max_chars_per_line $ o_max_lines_per_finding
+    $ o_max_memory_mb $ o_max_target_bytes $ o_metrics $ o_num_jobs
+    $ o_no_secrets_validation $ o_nosem $ o_optimizations $ o_oss $ o_output
+    $ o_pattern $ o_pro $ o_project_root $ o_pro_intrafile $ o_pro_languages
+    $ o_registry_caching $ o_remote $ o_replacement $ o_respect_gitignore
+    $ o_rewrite_rule_ids $ o_sarif $ o_scan_unknown_extensions $ o_secrets
+    $ o_severity $ o_show_supported_languages $ o_strict $ o_target_roots
+    $ o_test $ Test_CLI.o_test_ignore_todo $ o_text $ o_time $ o_timeout
     $ o_timeout_interfile $ o_timeout_threshold $ o_trace $ o_validate
     $ o_version $ o_version_check $ o_vim)
 

--- a/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -481,9 +481,9 @@ let o_json : bool Term.t =
   in
   Arg.value (Arg.flag info)
 
-let o_incremental : bool Term.t =
+let o_incremental_output : bool Term.t =
   let info =
-    Arg.info [ "incremental" ] ~doc:{|Output results incrementally.|}
+    Arg.info [ "incremental-output" ] ~doc:{|Output results incrementally.|}
   in
   Arg.value (Arg.flag info)
 
@@ -859,7 +859,7 @@ let cmdline_term ~allow_empty_config : conf Term.t =
       common config dataflow_traces diff_depth dryrun dump_ast
       dump_command_for_core dump_engine_path emacs error exclude_
       exclude_rule_ids force_color gitlab_sast gitlab_secrets include_
-      incremental json junit_xml lang ls matching_explanations
+      incremental_output json junit_xml lang ls matching_explanations
       max_chars_per_line max_lines_per_finding max_memory_mb max_target_bytes
       metrics num_jobs no_secrets_validation nosem optimizations oss output
       pattern pro project_root pro_intrafile pro_lang registry_caching remote
@@ -1173,7 +1173,7 @@ let cmdline_term ~allow_empty_config : conf Term.t =
       version_check;
       output;
       output_conf;
-      incremental_output = incremental;
+      incremental_output;
       engine_type;
       rewrite_rule_ids;
       common;
@@ -1195,7 +1195,7 @@ let cmdline_term ~allow_empty_config : conf Term.t =
     $ o_diff_depth $ o_dryrun $ o_dump_ast $ o_dump_command_for_core
     $ o_dump_engine_path $ o_emacs $ o_error $ o_exclude $ o_exclude_rule_ids
     $ o_force_color $ o_gitlab_sast $ o_gitlab_secrets $ o_include
-    $ o_incremental $ o_json $ o_junit_xml $ o_lang $ o_ls
+    $ o_incremental_output $ o_json $ o_junit_xml $ o_lang $ o_ls
     $ o_matching_explanations $ o_max_chars_per_line $ o_max_lines_per_finding
     $ o_max_memory_mb $ o_max_target_bytes $ o_metrics $ o_num_jobs
     $ o_no_secrets_validation $ o_nosem $ o_optimizations $ o_oss $ o_output

--- a/src/osemgrep/cli_scan/Scan_CLI.mli
+++ b/src/osemgrep/cli_scan/Scan_CLI.mli
@@ -23,6 +23,7 @@ type conf = {
   (* file or URL (None means output to stdout) *)
   output : string option;
   output_conf : Output.conf;
+  (* osemgrep-only: *)
   incremental_output : bool;
   (* text output config (TODO: make a separate type gathering all of them)
    * or add them under Output_format.Text

--- a/src/osemgrep/cli_scan/Scan_CLI.mli
+++ b/src/osemgrep/cli_scan/Scan_CLI.mli
@@ -23,6 +23,7 @@ type conf = {
   (* file or URL (None means output to stdout) *)
   output : string option;
   output_conf : Output.conf;
+  incremental_output : bool;
   (* text output config (TODO: make a separate type gathering all of them)
    * or add them under Output_format.Text
    *)

--- a/src/osemgrep/reporting/Output.ml
+++ b/src/osemgrep/reporting/Output.ml
@@ -133,7 +133,7 @@ let dispatch_output_format (output_format : Output_format.t) (conf : conf)
         ~max_lines_per_finding:conf.max_lines_per_finding
         ~color_output:conf.force_color Format.std_formatter cli_output
   (* matches have already been displayed in a file_match_results_hook *)
-  | TextIncremental -> ()
+  | Incremental -> ()
   | Sarif ->
       let sarif_json =
         Sarif_output.sarif_output is_logged_in hrules cli_output

--- a/src/osemgrep/reporting/Output_format.ml
+++ b/src/osemgrep/reporting/Output_format.ml
@@ -15,7 +15,7 @@ type t =
   (* used to disable the final display of match results because
    * we displayed them incrementally instead
    *)
-  | TextIncremental
+  | Incremental
 [@@deriving show]
 
 let keep_ignores = function
@@ -27,5 +27,5 @@ let keep_ignores = function
   | Gitlab_sast
   | Gitlab_secrets
   | Junit_xml
-  | TextIncremental ->
+  | Incremental ->
       false


### PR DESCRIPTION
Currently we print matches incrementally if a develop flag is passed. This adds a flag --incremental that will also enable that, or passed in combination with --json will incrementally print matches in json format separtaed by a newline per match.

Context: for query console we want to be able to stop semgrep after N matches, i.e. check if a repo is vulnerable at all to a rule, and ignore the actual # of occurrences, so we can be a lot faster.

## Test plan

run it manually and see if things print out incrementally
```bash
./bin/osemgrep --experimental --json --incremental --config ~/tmp.yaml
```

