### PR TITLE
feat: report findings that can only come from pro

### DIFF
--- a/cli/src/semgrep/dependency_aware_rule.py
+++ b/cli/src/semgrep/dependency_aware_rule.py
@@ -109,7 +109,7 @@ def generate_unreachable_sca_findings(
                         # Output_from_core.atd so we can reuse out.MatchExtra
                         extra=out.CoreMatchExtra(
                             metavars=out.Metavars({}),
-                            engine_kind=out.EngineKind(out.OSS()),
+                            engine_kind=out.EngineOfFinding(out.OSS()),
                             is_ignored=False,
                         ),
                     ),

--- a/cli/src/semgrep/engine.py
+++ b/cli/src/semgrep/engine.py
@@ -161,6 +161,6 @@ class EngineType(Enum):
 
     def to_engine_kind(self) -> out.EngineKind:
         if self.value == EngineType.OSS.value:
-            return out.EngineKind(out.OSS())
+            return out.EngineKind(out.OSS_())
         else:
-            return out.EngineKind(out.PRO())
+            return out.EngineKind(out.PRO_())

--- a/cli/src/semgrep/formatter/sarif.py
+++ b/cli/src/semgrep/formatter/sarif.py
@@ -428,7 +428,7 @@ class SarifFormatter(BaseFormatter):
         """
         is_pro = (
             cli_output_extra.engine_requested
-            and cli_output_extra.engine_requested == out.EngineKind(out.PRO())
+            and cli_output_extra.engine_requested == out.EngineKind(out.PRO_())
         )
         is_using_registry = extra.get("is_using_registry", False)
         is_logged_in = extra.get("is_logged_in", False)

--- a/cli/src/semgrep/join_rule.py
+++ b/cli/src/semgrep/join_rule.py
@@ -374,7 +374,7 @@ def json_to_rule_match(join_rule: Dict[str, Any], match: Dict[str, Any]) -> Rule
         dataflow_trace=cli_match_extra.dataflow_trace,
         engine_kind=cli_match_extra.engine_kind
         if cli_match_extra.engine_kind
-        else out.EngineKind(out.OSS()),
+        else out.EngineOfFinding(out.OSS()),
         is_ignored=False,
     )
     return RuleMatch(

--- a/src/core/Engine_kind.ml
+++ b/src/core/Engine_kind.ml
@@ -1,1 +1,2 @@
 type t = Semgrep_output_v1_t.engine_kind [@@deriving show]
+type flavor = Semgrep_output_v1_t.engine_flavor [@@deriving show]

--- a/src/core/Engine_kind.ml
+++ b/src/core/Engine_kind.ml
@@ -1,2 +1,3 @@
 type t = Semgrep_output_v1_t.engine_kind [@@deriving show]
-type flavor = Semgrep_output_v1_t.engine_flavor [@@deriving show]
+type pro_feature = Semgrep_output_v1_t.pro_feature [@@deriving show]
+type engine_of_finding = Semgrep_output_v1_t.engine_of_finding [@@deriving show]

--- a/src/core/Pattern_match.ml
+++ b/src/core/Pattern_match.ml
@@ -87,7 +87,7 @@ type t = {
    * TODO? do we want to consider the same match but with different engine
    * as separate matches? or better make them equal for dedup purpose?
    *)
-  engine_kind : Engine_kind.t; [@equal fun _a _b -> true]
+  engine_kind : Engine_kind.flavor; [@equal fun _a _b -> true]
   (* location info *)
   path : Target.path;
   (* less: redundant with location? *)

--- a/src/core/Pattern_match.ml
+++ b/src/core/Pattern_match.ml
@@ -87,7 +87,7 @@ type t = {
    * TODO? do we want to consider the same match but with different engine
    * as separate matches? or better make them equal for dedup purpose?
    *)
-  engine_kind : Engine_kind.flavor; [@equal fun _a _b -> true]
+  engine_of_match : Engine_kind.engine_of_finding; [@equal fun _a _b -> true]
   (* location info *)
   path : Target.path;
   (* less: redundant with location? *)
@@ -223,7 +223,7 @@ let no_submatches pms =
   tbl |> Hashtbl.to_seq_values |> Seq.flat_map List.to_seq |> List.of_seq
 [@@profiling]
 
-let to_proprietary pm = { pm with engine_kind = `PRO }
+let to_proprietary pm = { pm with engine_of_match = `PRO }
 
 (* DEAD ?
 

--- a/src/core/Pattern_match.mli
+++ b/src/core/Pattern_match.mli
@@ -2,7 +2,7 @@
 type t = {
   (* rule (or mini rule) responsible for the pattern match found *)
   rule_id : rule_id;
-  engine_kind : Engine_kind.t;
+  engine_kind : Engine_kind.flavor;
   (* location info *)
   path : Target.path;
   range_loc : Tok.location * Tok.location;

--- a/src/core/Pattern_match.mli
+++ b/src/core/Pattern_match.mli
@@ -2,7 +2,7 @@
 type t = {
   (* rule (or mini rule) responsible for the pattern match found *)
   rule_id : rule_id;
-  engine_kind : Engine_kind.flavor;
+  engine_of_match : Engine_kind.engine_of_finding;
   (* location info *)
   path : Target.path;
   range_loc : Tok.location * Tok.location;

--- a/src/core_scan/Core_scan.ml
+++ b/src/core_scan/Core_scan.ml
@@ -242,11 +242,7 @@ let set_matches_to_proprietary_origin_if_needed (xtarget : Xtarget.t)
     Option.is_some !Match_tainting_mode.hook_setup_hook_function_taint_signature
     || Option.is_some !Dataflow_tainting.hook_function_taint_signature
     || Xlang.is_proprietary xtarget.xlang
-  then
-    {
-      matches with
-      Core_result.matches = List_.map PM.to_proprietary matches.matches;
-    }
+  then Report_pro_findings.annotate_pro_findings xtarget matches
   else matches
 
 (*****************************************************************************)

--- a/src/core_scan/Report_pro_findings.ml
+++ b/src/core_scan/Report_pro_findings.ml
@@ -1,0 +1,87 @@
+(*****************************************************************************)
+(* Purpose *)
+(*****************************************************************************)
+(** Support the reporting of pro findings
+
+  * Users want to know when a finding could only be found by the pro engine
+  * so that they can understand the value Semgrep provides. Additionally,
+  * we want to surface our "coolest" findings early to make sure users see
+  * them.
+
+  * To support this, we have a different type for the engine kind for matches,
+  * which includes a `PRO_SPECIFIC` option that reports when a finding could
+  * only be found using the pro engine. This option also allows us to highlight
+  * findings we think users should prioritize.
+  *)
+
+(*****************************************************************************)
+(* Helpers *)
+(*****************************************************************************)
+
+(* Check if the taint trace of the pattern crosses functions or files *)
+
+let filename_of_token (tok : Tok.t) =
+  match tok with
+  | OriginTok loc -> Some loc.pos.file
+  | FakeTok _ -> None
+  | ExpandedTok (loc, _) -> Some loc.pos.file
+  | Ab -> None
+
+let tokens_of_trace_item (trace_item : Pattern_match.taint_trace_item) =
+  let rec tokens_of_call_trace (call_trace : Pattern_match.taint_call_trace) =
+    match call_trace with
+    | Toks ts -> ts
+    | Call { call_toks; intermediate_vars; call_trace } ->
+        call_toks @ intermediate_vars @ tokens_of_call_trace call_trace
+  in
+  tokens_of_call_trace trace_item.source_trace
+  @ tokens_of_call_trace trace_item.sink_trace
+  @ trace_item.tokens
+
+let is_interfile_trace (trace : Pattern_match.taint_trace) =
+  let trace_tokens = trace |> List.concat_map tokens_of_trace_item in
+  let token_filenames = trace_tokens |> List_.map_filter filename_of_token in
+  (* iff two tokens have different filenames, the trace crosses files *)
+  match token_filenames with
+  | []
+  | [ _ ] ->
+      false
+  | f :: fs -> not (List.for_all (fun x -> x = f) fs)
+
+let is_interprocedural_trace (trace : Pattern_match.taint_trace) =
+  trace
+  |> List.exists (fun (trace_item : Pattern_match.taint_trace_item) ->
+         match (trace_item.source_trace, trace_item.sink_trace) with
+         | Call _, _ -> true
+         | _, Call _ -> true
+         | Toks _, Toks _ -> false)
+
+(*****************************************************************************)
+(* Entrypoint *)
+(*****************************************************************************)
+
+let annotate_pro_findings (xtarget : Xtarget.t)
+    (res : Core_profiling.partial_profiling Core_result.match_result) =
+  {
+    res with
+    matches =
+      res.matches
+      |> List_.map (fun (x : Pattern_match.t) ->
+             let proprietary_language = Xlang.is_proprietary xtarget.xlang in
+             let interproc_taint, interfile_taint =
+               match x.taint_trace with
+               | None -> (false, false)
+               | Some trace ->
+                   let trace = Lazy.force trace in
+                   (is_interprocedural_trace trace, is_interfile_trace trace)
+             in
+             let engine_of_match : Engine_kind.engine_of_finding =
+               if
+                 not (proprietary_language || interproc_taint || interfile_taint)
+               then `PRO
+               else
+                 `PRO_REQUIRED
+                   { proprietary_language; interproc_taint; interfile_taint }
+             in
+             { x with engine_of_match });
+  }

--- a/src/core_scan/Report_pro_findings.ml
+++ b/src/core_scan/Report_pro_findings.ml
@@ -20,13 +20,6 @@
 
 (* Check if the taint trace of the pattern crosses functions or files *)
 
-let filename_of_token (tok : Tok.t) =
-  match tok with
-  | OriginTok loc -> Some loc.pos.file
-  | FakeTok _ -> None
-  | ExpandedTok (loc, _) -> Some loc.pos.file
-  | Ab -> None
-
 let tokens_of_trace_item (trace_item : Pattern_match.taint_trace_item) =
   let rec tokens_of_call_trace (call_trace : Pattern_match.taint_call_trace) =
     match call_trace with
@@ -40,13 +33,19 @@ let tokens_of_trace_item (trace_item : Pattern_match.taint_trace_item) =
 
 let is_interfile_trace (trace : Pattern_match.taint_trace) =
   let trace_tokens = trace |> List.concat_map tokens_of_trace_item in
-  let token_filenames = trace_tokens |> List_.map_filter filename_of_token in
+  let token_filenames =
+    trace_tokens
+    |> List_.map_filter (fun t ->
+           match Tok.loc_of_tok t with
+           | Ok { pos; _ } -> Some pos.file
+           | Error _ -> None)
+  in
   (* iff two tokens have different filenames, the trace crosses files *)
   match token_filenames with
   | []
   | [ _ ] ->
       false
-  | f :: fs -> not (List.for_all (fun x -> x = f) fs)
+  | f :: fs -> List.exists (fun x -> x <> f) fs
 
 let is_interprocedural_trace (trace : Pattern_match.taint_trace) =
   trace

--- a/src/core_scan/Report_pro_findings.ml
+++ b/src/core_scan/Report_pro_findings.ml
@@ -90,8 +90,8 @@ let annotate_pro_findings (xtarget : Xtarget.t)
                | Some trace ->
                    let trace = Lazy.force trace in
                    let interfile_trace = is_interfile_trace trace in
-                   (* All interfile findings are necessarily interprocedural, but
-                      the taint trace might not contain a Call node *)
+                   (* All interfile taint findings are necessarily also interprocedural
+                      taint findings, but the taint trace might not contain a Call node *)
                    ( is_interprocedural_trace trace || interfile_trace,
                      interfile_trace )
              in

--- a/src/core_scan/Report_pro_findings.ml
+++ b/src/core_scan/Report_pro_findings.ml
@@ -92,7 +92,7 @@ let annotate_pro_findings (xtarget : Xtarget.t)
                    let interfile_trace = is_interfile_trace trace in
                    (* All interfile taint findings are necessarily also interprocedural
                       taint findings, but the taint trace might not contain a Call node *)
-                   ( is_interprocedural_trace trace || interfile_trace,
+                   ( interfile_trace || is_interprocedural_trace trace,
                      interfile_trace )
              in
              let engine_of_match : Engine_kind.engine_of_finding =

--- a/src/core_scan/Report_pro_findings.ml
+++ b/src/core_scan/Report_pro_findings.ml
@@ -49,8 +49,8 @@ let files_of_trace_item (trace_item : Pattern_match.taint_trace_item) =
     | Toks ts -> files_of_toks ts
     | Call { call_toks; intermediate_vars; call_trace } ->
         let _ =
-          intermediate_vars
           (* intermediate variables will never be in a different file from the other tokens *)
+          intermediate_vars
         in
         FileSet.union (files_of_toks call_toks) (files_of_call_trace call_trace)
   in

--- a/src/core_scan/Report_pro_findings.ml
+++ b/src/core_scan/Report_pro_findings.ml
@@ -73,7 +73,11 @@ let annotate_pro_findings (xtarget : Xtarget.t)
                | None -> (false, false)
                | Some trace ->
                    let trace = Lazy.force trace in
-                   (is_interprocedural_trace trace, is_interfile_trace trace)
+                   let interfile_trace = is_interfile_trace trace in
+                   (* All interfile findings are necessarily interprocedural, but
+                      the taint trace might not contain a Call node *)
+                   ( is_interprocedural_trace trace || interfile_trace,
+                     interfile_trace )
              in
              let engine_of_match : Engine_kind.engine_of_finding =
                if

--- a/src/core_scan/Report_pro_findings.mli
+++ b/src/core_scan/Report_pro_findings.mli
@@ -1,0 +1,4 @@
+val annotate_pro_findings :
+  Xtarget.t ->
+  Core_profiling.partial_profiling Core_result.match_result ->
+  Core_profiling.partial_profiling Core_result.match_result

--- a/src/engine/Match_dependency.ml
+++ b/src/engine/Match_dependency.ml
@@ -87,8 +87,8 @@ let check_rule rule (xtarget : Lockfile_xtarget.t) dependency_formula =
                    pattern_string = "";
                  };
                path = xtarget.target.path;
-               (* TODO: should be pro? Where is this supposed to be set? *)
-               engine_kind = `OSS;
+               (* TODO: should be pro if the pro engine is used in the match *)
+               engine_of_match = `OSS;
                range_loc = dep.Dependency.loc;
                tokens = lazy dep.Dependency.toks;
                env = [];

--- a/src/engine/Match_search_mode.ml
+++ b/src/engine/Match_search_mode.ml
@@ -393,7 +393,7 @@ let apply_focus_on_ranges env (focus_mvars_list : R.focus_mv_list list)
                tokens = lazy (MV.ii_of_mval mval);
                env = range.mvars;
                taint_trace = None;
-               engine_kind = `OSS;
+               engine_of_match = `OSS;
                validation_state = `No_validator;
                severity_override = None;
                metadata_override = None;

--- a/src/engine/Xpattern_matcher.ml
+++ b/src/engine/Xpattern_matcher.ml
@@ -93,7 +93,7 @@ let (matches_of_matcher :
                               env;
                               taint_trace = None;
                               tokens = lazy [ info_of_token_location loc1 ];
-                              engine_kind = `OSS;
+                              engine_of_match = `OSS;
                               validation_state = `No_validator;
                               severity_override = None;
                               metadata_override = None;

--- a/src/matching/Match_patterns.ml
+++ b/src/matching/Match_patterns.ml
@@ -172,7 +172,7 @@ let match_rules_and_recurse m_env path hook matches rules matcher k any x =
                           (* This will be overrided later on by the Pro engine, if this is
                              from a Pro run.
                           *)
-                          engine_kind = `OSS;
+                          engine_of_match = `OSS;
                           validation_state = `No_validator;
                           severity_override = None;
                           metadata_override = None;
@@ -343,7 +343,7 @@ let check ~hook ?(mvar_context = None) ?(range_filter = fun _ -> true)
                                   range_loc;
                                   tokens;
                                   taint_trace = None;
-                                  engine_kind = `OSS;
+                                  engine_of_match = `OSS;
                                   validation_state = `No_validator;
                                   severity_override = None;
                                   metadata_override = None;
@@ -408,7 +408,7 @@ let check ~hook ?(mvar_context = None) ?(range_filter = fun _ -> true)
                                     range_loc;
                                     tokens;
                                     taint_trace = None;
-                                    engine_kind = `OSS;
+                                    engine_of_match = `OSS;
                                     validation_state = `No_validator;
                                     severity_override = None;
                                     metadata_override = None;
@@ -458,7 +458,7 @@ let check ~hook ?(mvar_context = None) ?(range_filter = fun _ -> true)
                                       range_loc;
                                       tokens;
                                       taint_trace = None;
-                                      engine_kind = `OSS;
+                                      engine_of_match = `OSS;
                                       validation_state = `No_validator;
                                       severity_override = None;
                                       metadata_override = None;
@@ -554,7 +554,7 @@ let check ~hook ?(mvar_context = None) ?(range_filter = fun _ -> true)
                                       range_loc;
                                       tokens;
                                       taint_trace = None;
-                                      engine_kind = `OSS;
+                                      engine_of_match = `OSS;
                                       validation_state = `No_validator;
                                       severity_override = None;
                                       metadata_override = None;

--- a/src/reporting/Core_json_output.ml
+++ b/src/reporting/Core_json_output.ml
@@ -254,7 +254,7 @@ let unsafe_match_to_match
           Option.map (fun edit -> edit.Textedit.replacement_text) autofix_edit;
         is_ignored;
         (* TODO *)
-        engine_kind = x.engine_kind;
+        engine_kind = x.engine_of_match;
         validation_state = Some x.validation_state;
         historical_info = None;
         extra_extra = None;


### PR DESCRIPTION
See corresponding semgrep-proprietary PR https://github.com/semgrep/semgrep-proprietary/pull/1334

Test plan:
```
➜  apex git:(emma/saf-846-findings-due-to-language-are-marked-as-pro-lite) ✗ pwd
/Users/emma/workspace/semgrep-proprietary/tests/rules/apex
➜  apex git:(emma/saf-846-findings-due-to-language-are-marked-as-pro-lite) ✗ ds -rules cp_class_attribute.yaml . -l apex -json

!!!This is a proprietary extension of semgrep.!!!
!!!You should not call directly this program.!!!
.
{"version":"1.62.0","results":[{"check_id":"test","path":"./cp_class_attribute.cls","start":{"line":13,"col":3,"offset":441},"end":{"line":13,"col":59,"offset":497},"extra":{"message":"Semgrep found a match","metavars":{},"engine_kind":["PRO_REQUIRED",{"interproc_taint":false,"interfile_taint":false,"proprietary_language":true}],"is_ignored":false,"validation_state":"NO_VALIDATOR"}}],"errors":[],"paths":{"scanned":[]},"rules_by_engine":[["test","OSS"]],"engine_requested":"OSS","interfile_languages_used":[],"skipped_rules":[]}
```
