### PR TITLE
feat: Add an origin for git objects

### DIFF
--- a/libs/commons/ATD_string_wrap.ml
+++ b/libs/commons/ATD_string_wrap.ml
@@ -45,22 +45,20 @@ module Sha256 = struct
 end
 
 module Datetime = struct
-  type t = Timedesc.t
+  type t = Timedesc.Timestamp.t
 
-  let unwrap tm : string = Timedesc.to_rfc3339 tm
+  let unwrap tm : string = Timedesc.Timestamp.to_rfc3339 tm
 
   let wrap s =
     (* Note that RFC 3339 is a subset of ISO 8601, so this does align with
      * unwrap. *)
-    match Timedesc.of_iso8601 s with
+    match Timedesc.Timestamp.of_iso8601 s with
     | Ok dt -> dt
     | Error s -> failwith (spf "wrong datetime format: %s" s)
 
   let () =
     Testo.test "Datetime" (fun () ->
-        let now =
-          Timedesc.now ?tz_of_date_time:(Some Timedesc.Time_zone.utc) ()
-        in
+        let now = Timedesc.Timestamp.now () in
         let s : string = unwrap now in
         let now' = wrap s in
         if not (now =*= now') then

--- a/libs/commons2/common2.ml
+++ b/libs/commons2/common2.ml
@@ -1207,10 +1207,6 @@ let int64_of_string_c_octal_opt s =
     int64_of_string_opt ("0o" ^ s)
   else int64_of_string_opt s
 
-let int_of_string_opt s =
-  try Some (int_of_string s) with
-  | Failure _ -> None
-
 let int_of_string_c_octal_opt s =
   let open Common in
   if s =~ "^0\\([0-7]+\\)$" then

--- a/libs/commons2/common2.mli
+++ b/libs/commons2/common2.mli
@@ -422,7 +422,6 @@ val int_of_stringbits : string -> int
 val int_of_octal : string -> int
 val int_of_all : string -> int
 val int64_of_string_opt : string -> int64 option
-val int_of_string_opt : string -> int option
 
 (* like int_of_string_opt, but also converts C octals like 0400 in
  * the right value. *)

--- a/libs/git_wrapper/Git_wrapper.ml
+++ b/libs/git_wrapper/Git_wrapper.ml
@@ -695,14 +695,14 @@ let batch_cat_file_blob ?cwd blob_shas =
                 (* Now use the size from the header line to read the whole
                    contents all at once *)
                 let contents = really_input_string chan size in
-                (* discard trailing newline *)
                 ignore (input_char chan);
+                (* discard trailing newline *)
                 let obj = { kind; sha; extra = { contents } } in
                 Ok obj
             | _ -> Error ("invalid git object: " ^ metadata)),
             chan )
   in
-  let output = UCommon.new_temp_file "git-batch-cat-files" ".log" |> Fpath.v in
+  let output = UTmp.new_temp_file "git-batch-cat-files" ".log" in
   let input = blob_shas |> String.concat "\n" in
   match Bos.OS.Cmd.(run_io cmd (in_string input) |> out_file output) with
   | Ok ((), (_, `Exited 0)) ->

--- a/libs/git_wrapper/Git_wrapper.ml
+++ b/libs/git_wrapper/Git_wrapper.ml
@@ -187,6 +187,14 @@ let temporary_remote_checkout_path url =
   let name = rand_prefix ^ "_" ^ name in
   let tmp_dir = Fpath.v (Filename.get_temp_dir_name ()) in
   Fpath.add_seg tmp_dir name
+
+let obj_type_of_string = function
+  | "commit" -> Some Commit
+  | "blob" -> Some Blob
+  | "tree" -> Some Tree
+  | "tag" -> Some Tag
+  | _ -> None
+
 (*****************************************************************************)
 (* Entry points *)
 (*****************************************************************************)
@@ -625,13 +633,6 @@ let cat_file_blob ?cwd sha =
   | Ok (s, _)
   | Error (`Msg s) ->
       Error s
-
-let obj_type_of_string = function
-  | "commit" -> Some Commit
-  | "blob" -> Some Blob
-  | "tree" -> Some Tree
-  | "tag" -> Some Tag
-  | _ -> None
 
 let batch_cat_file_blob ?cwd blob_shas =
   let cmd =

--- a/libs/git_wrapper/Git_wrapper.ml
+++ b/libs/git_wrapper/Git_wrapper.ml
@@ -648,7 +648,6 @@ let batch_cat_file_blob ?cwd blob_shas =
                   change to read from stdio, we probably should _not_ buffer so
                   we can stream output. *)
                "--buffer";
-               (* Null terminate the header line. Requires git >2.42.0. *)
              ]))
   in
   (* Each object is formatted as

--- a/libs/git_wrapper/Git_wrapper.ml
+++ b/libs/git_wrapper/Git_wrapper.ml
@@ -710,8 +710,8 @@ let batch_cat_file_blob ?cwd blob_shas =
          way to "stream" the output of the command. *)
       let chan = In_channel.open_bin !!output in
       Ok (Seq.unfold get_next_obj chan)
-  | Ok ((), (_, _status)) ->
-      Error "git exited with nonzero code or was terminated due to a signal"
+  | Ok ((), (_, `Exited n)) -> Error (spf "git exited with nonzero code %d" n)
+  | Ok ((), (_, `Signaled s)) -> Error (spf "git terminated due to signal %d" s)
   | Error (`Msg s) -> Error s
 
 let object_size ?cwd sha =

--- a/libs/git_wrapper/Git_wrapper.mli
+++ b/libs/git_wrapper/Git_wrapper.mli
@@ -199,15 +199,24 @@ val batch_cat_file_blob :
 (** [batch_cat_file_blob blobs] will run [git cat-file --batch] for each blob
     object whose sha is listed in [blobs] and return either:
     {ul
-      {- [Ok output], where [output] is the batch output, itself either [Ok info],
-    where [info] is the information returned about that blob; or [Error message]
-    where [message] is a brief message indicating why git could not perform the
-    action in relation to an individual blob, e.g., a sha in [blobs] is not the
-    sha of a blob or does not designate an object.}
+      {- [Ok output], where [output] is a sequence batch output, where the
+      elements are either [Ok info], where [info] is the information returned
+      about that blob; or [Error message] where [message] is a brief message
+      indicating why git could not perform the action in relation to an
+      individual blob, e.g., a sha in [blobs] is not the sha of a blob or does
+      not designate an object.
+
+      Note that the output Seq must be consumed to prevent a resource leak,
+      since this is implemented by saving the results, and then parsing
+      additional blobs on-demand. Ideally we would rely on Eio for this, but
+      that's currently blocked on 5.x.}
       {- [Error message], where [message] is a brief message indicating why git
       could not perform the entire batch operation, e.g., the directory in
       which git was run is not a git repo.}
     }
+
+    Note: we make no ordering guarantee of objects in the output list relative
+    to the order in the input list.
  *)
 
 val object_size : ?cwd:Fpath.t -> sha -> int option

--- a/libs/git_wrapper/Git_wrapper.mli
+++ b/libs/git_wrapper/Git_wrapper.mli
@@ -130,19 +130,29 @@ val is_tracked_by_git : ?cwd:Fpath.t -> Fpath.t -> bool
 
 (* precondition: cwd must be a directory *)
 val dirty_files : ?cwd:Fpath.t -> unit -> Fpath.t list
-(** Returns a list of files that are dirty in a git repo *)
+(** [dirty_files ()] is the list of files which are dirty in a git repo, i.e.,
+    files which differ at all from the current index to the HEAD commit, plus
+    untracked files. Note that this means this list includes files which were
+    deleted. *)
 
 val init : ?cwd:Fpath.t -> ?branch:string -> unit -> unit
-(** Initialize a git repo in the given directory.
+(** [init ()] creates an empty git repository in the current directory. If
+    [cwd] is specified, its value is passed to git's [-C] flag. If
+    [branch] is specified, it is used as the name of the default branch.
+    Otherwise the default branch is named 'main' to avoid warnings that depend
+    on the git version.
+
+    Initialize a git repo in the given directory.
     The branch is set by default to 'main' to avoid warnings that depend
     on the git version.
 *)
 
 val add : ?cwd:Fpath.t -> ?force:bool -> Fpath.t list -> unit
-(** Add the given files to the git repo *)
+(** [add files] adds the [files] to the git index. *)
 
 val commit : ?cwd:Fpath.t -> string -> unit
-(** Commit the given files to the git repo with the given message *)
+(** [commit msg] creates a commit with containing the current contents of the
+    index with [msg] as the commit message. *)
 
 val get_project_url : ?cwd:Fpath.t -> unit -> string option
 (** [get_project_url ()] tries to get the URL of the project from
@@ -152,7 +162,7 @@ val get_project_url : ?cwd:Fpath.t -> unit -> string option
 *)
 
 val get_git_logs : ?cwd:Fpath.t -> ?since:float option -> unit -> string list
-(** [get_git_logs()] will run 'git log' in the current directory
+(** [get_git_logs ()] will run 'git log' in the current directory
     and returns for each log a JSON string that fits the schema
     defined in semgrep_output_v1.atd contribution type.
     It returns an empty list if it found nothing relevant.
@@ -162,39 +172,41 @@ val get_git_logs : ?cwd:Fpath.t -> ?since:float option -> unit -> string list
 
 val cat_file_batch_check_all_objects :
   ?cwd:Fpath.t -> unit -> batch_check_extra obj list option
-(** [cat_file_batch_all_objects ()] will run `git log
- * --batch-all-objects --batch-check` in the current working directory (or such
- * directory provided by `cwd`)
- *
- * A batch format sufficient for obtaining the information in
- * [batch_check_extra] will be used and that information will be attached to each
- * object.
+(** [cat_file_batch_all_objects ()] will run [git log
+   --batch-all-objects --batch-check] in the current working directory (or such
+   directory provided by [cwd])
+
+   A batch format sufficient for obtaining the information in
+   [batch_check_extra] will be used and that information will be attached to each
+   object.
  *)
 
 val cat_file_blob : ?cwd:Fpath.t -> sha -> (string, string) result
-(** [cat_file_blob sha] will run `git cat-file blob sha` and return either
- * - [Ok contents], where [contents] is the contents of the blob; or
- * - [Error message] where [message] is a brief message indicating why git
- *   could not perform the action, e.g., [sha] is not the sha of a blob or
- *   [sha] does not designate an object.
+(** [cat_file_blob sha] will run [git cat-file blob sha] and return either
+    {ul
+      {- [Ok contents], where [contents] is the contents of the blob; or}
+      {- [Error message] where [message] is a brief message indicating why git
+      could not perform the action, e.g., [sha] is not the sha of a blob or
+      [sha] does not designate an object.}
+    }
  *)
 
 val object_size : ?cwd:Fpath.t -> sha -> int option
 (** [object_size sha] evaluates to [Some s] where [s] is the size of the object
-  * designated by [sha] in bytes, or [None] if an error occured (e.g. the
-  * object didn't exist).
+    designated by [sha] in bytes, or [None] if an error occured (e.g. the
+    object didn't exist).
   *)
 
 val commit_timestamp : ?cwd:Fpath.t -> sha -> Timedesc.Timestamp.t option
 (** [commit_datetime sha] evaluates to [Some dt] where [dt] is the date and
- * time of the commit designated by [sha] or [None] if an error occured (e.g.,
- * the sha was for another object type).
+   time of the commit designated by [sha] or [None] if an error occured (e.g.,
+   the sha was for another object type).
  *)
 
 val ls_tree :
   ?cwd:Fpath.t -> ?recurse:bool -> sha -> ls_tree_extra obj list option
 (** [ls_tree ~recurse sha] will run `git ls-tree --full-tree` and report the
- * listed objects and their file paths relative to that tree. If [recurse] is
- * specified to be true (it is false by default) then the `-r` option is passed
- * and git will recurse into subtrees.
+   listed objects and their file paths relative to that tree. If [recurse] is
+   specified to be true (it is false by default) then the `-r` option is passed
+   and git will recurse into subtrees.
  *)

--- a/libs/git_wrapper/Git_wrapper.mli
+++ b/libs/git_wrapper/Git_wrapper.mli
@@ -86,6 +86,7 @@ type 'extra obj = { kind : obj_type; sha : sha; extra : 'extra }
 [@@deriving show]
 
 type batch_check_extra = { size : int } [@@deriving show]
+type batch_extra = { contents : string } [@@deriving show]
 type ls_tree_extra = { path : Fpath.t } [@@deriving show]
 
 (* git status *)
@@ -188,6 +189,24 @@ val cat_file_blob : ?cwd:Fpath.t -> sha -> (string, string) result
       {- [Error message] where [message] is a brief message indicating why git
       could not perform the action, e.g., [sha] is not the sha of a blob or
       [sha] does not designate an object.}
+    }
+ *)
+
+val batch_cat_file_blob :
+  ?cwd:Fpath.t ->
+  sha list ->
+  ((batch_extra obj, string) result Seq.t, string) result
+(** [batch_cat_file_blob blobs] will run [git cat-file --batch] for each blob
+    object whose sha is listed in [blobs] and return either:
+    {ul
+      {- [Ok output], where [output] is the batch output, itself either [Ok info],
+    where [info] is the information returned about that blob; or [Error message]
+    where [message] is a brief message indicating why git could not perform the
+    action in relation to an individual blob, e.g., a sha in [blobs] is not the
+    sha of a blob or does not designate an object.}
+      {- [Error message], where [message] is a brief message indicating why git
+      could not perform the entire batch operation, e.g., the directory in
+      which git was run is not a git repo.}
     }
  *)
 

--- a/libs/lib_parsing/Origin.ml
+++ b/libs/lib_parsing/Origin.ml
@@ -15,11 +15,18 @@
 
 (* See Origin.mli for top-level documentation of this module. *)
 
-type t = File of Fpath.t [@@deriving show, eq, ord]
+type t =
+  | File of Fpath.t
+  | GitBlob of {
+      sha : Git_wrapper.sha;
+      paths : (Git_wrapper.sha * Fpath.t) list;
+    }
+[@@deriving show, eq, ord]
 
 let to_string (s : t) =
   match s with
   | File path -> Fpath.to_string path
+  | GitBlob { sha; _ } -> [%show: Git_wrapper.sha] sha
 
 let to_string_opt ?(unspecified = "unknown") (s : t option) =
   match s with

--- a/libs/lib_parsing/Origin.mli
+++ b/libs/lib_parsing/Origin.mli
@@ -79,7 +79,7 @@ type t =
               given only the blob's sha, and requires additional information
               like what commits we care about, if not all. These are relative
               to the git root.
-        
+
               This is used for e.g., a rule's path-based include & excludes. *)
     }
 [@@deriving show, eq, ord]

--- a/libs/lib_parsing/dune
+++ b/libs/lib_parsing/dune
@@ -6,6 +6,7 @@
    fpath
    sexplib
    paths
+   git_wrapper
 
    commons
    commons2

--- a/src/core/Target.ml
+++ b/src/core/Target.ml
@@ -41,9 +41,7 @@ type t = Regular of regular | Lockfile of lockfile [@@deriving show]
     which contains the contents of the git blob object identified by [sha] *)
 let tempfile_of_git_blob sha =
   let contents = Git_wrapper.cat_file_blob sha |> Result.get_ok in
-  let file =
-    UCommon.new_temp_file "git-blob" ([%show: Git_wrapper.sha] sha) |> Fpath.v
-  in
+  let file = UTmp.new_temp_file "git-blob" ([%show: Git_wrapper.sha] sha) in
   UFile.write_file file contents;
   file
 

--- a/src/core/Target.ml
+++ b/src/core/Target.ml
@@ -37,9 +37,9 @@ type regular = {
 
 type t = Regular of regular | Lockfile of lockfile [@@deriving show]
 
-(** [git_blob_to_tempfile sha] is the path to a newly created temporary file
+(** [tempfile_of_git_blob sha] is the path to a newly created temporary file
     which contains the contents of the git blob object identified by [sha] *)
-let git_blob_to_tempfile sha =
+let tempfile_of_git_blob sha =
   let contents = Git_wrapper.cat_file_blob sha |> Result.get_ok in
   let file =
     UCommon.new_temp_file "git-blob" ([%show: Git_wrapper.sha] sha) |> Fpath.v
@@ -51,7 +51,7 @@ let path_of_origin (origin : Origin.t) : path =
   match origin with
   | File file -> { origin; internal_path_to_content = file }
   | GitBlob { sha; _ } ->
-      { origin; internal_path_to_content = git_blob_to_tempfile sha }
+      { origin; internal_path_to_content = tempfile_of_git_blob sha }
 
 let mk_regular ?lockfile analyzer products (origin : Origin.t) : regular =
   { path = path_of_origin origin; analyzer; products; lockfile }

--- a/src/core/Target.ml
+++ b/src/core/Target.ml
@@ -37,11 +37,21 @@ type regular = {
 
 type t = Regular of regular | Lockfile of lockfile [@@deriving show]
 
+(** [git_blob_to_tempfile sha] is the path to a newly created temporary file
+    which contains the contents of the git blob object identified by [sha] *)
+let git_blob_to_tempfile sha =
+  let contents = Git_wrapper.cat_file_blob sha |> Result.get_ok in
+  let file =
+    UCommon.new_temp_file "git-blob" ([%show: Git_wrapper.sha] sha) |> Fpath.v
+  in
+  UFile.write_file file contents;
+  file
+
 let path_of_origin (origin : Origin.t) : path =
   match origin with
   | File file -> { origin; internal_path_to_content = file }
-(* This may create tempfile in the future if still required by
-   Match_seach_mode et al., e.g., in the case of a GitBlob origin *)
+  | GitBlob { sha; _ } ->
+      { origin; internal_path_to_content = git_blob_to_tempfile sha }
 
 let mk_regular ?lockfile analyzer products (origin : Origin.t) : regular =
   { path = path_of_origin origin; analyzer; products; lockfile }

--- a/src/core/Xtarget.ml
+++ b/src/core/Xtarget.ml
@@ -24,7 +24,8 @@ type t = {
 
 let parse_file parser (analyzer : Xlang.t) path =
   let lang =
-    (* ew. We fail tests if this gets pulled out of the lazy block. *)
+    (* Possibly better to determine this sooner/change how lazy_ast_and_errors
+       works for regex or other non-parsing analyzers *)
     match analyzer with
     | L (lang, []) -> lang
     | L (_lang, _ :: _) ->

--- a/src/core/Xtarget.ml
+++ b/src/core/Xtarget.ml
@@ -23,20 +23,19 @@ type t = {
 }
 
 let parse_file parser (analyzer : Xlang.t) path =
-  lazy
-    (let lang =
-       (* ew. We fail tests if this gets pulled out of the lazy block. *)
-       match analyzer with
-       | L (lang, []) -> lang
-       | L (_lang, _ :: _) ->
-           failwith
-             "xlang from the language field in -target should be unique (this \
-              shouldn't happen FIXME)"
-       | _ ->
-           (* alt: could return an empty program, but better to be defensive *)
-           failwith "requesting generic AST for an unspecified target language"
-     in
-     parser lang path)
+  let lang =
+    (* ew. We fail tests if this gets pulled out of the lazy block. *)
+    match analyzer with
+    | L (lang, []) -> lang
+    | L (_lang, _ :: _) ->
+        failwith
+          "xlang from the language field in -target should be unique (this \
+           shouldn't happen FIXME)"
+    | _ ->
+        (* alt: could return an empty program, but better to be defensive *)
+        failwith "requesting generic AST for an unspecified target language"
+  in
+  parser lang path
 
 let resolve parser (target : Target.regular) : t =
   {
@@ -44,5 +43,6 @@ let resolve parser (target : Target.regular) : t =
     xlang = target.analyzer;
     lazy_content = lazy (UFile.read_file target.path.internal_path_to_content);
     lazy_ast_and_errors =
-      parse_file parser target.analyzer target.path.internal_path_to_content;
+      lazy
+        (parse_file parser target.analyzer target.path.internal_path_to_content);
   }

--- a/src/core_scan/Core_scan.ml
+++ b/src/core_scan/Core_scan.ml
@@ -219,8 +219,7 @@ let filter_existing_targets (targets : Target.t list) :
            | GitBlob { sha; _ } ->
                Right
                  {
-                   Semgrep_output_v1_t.path =
-                     Target.internal_path_to_content target;
+                   Semgrep_output_v1_t.path = Target.internal_path target;
                    reason = Nonexistent_file;
                    details =
                      Some

--- a/src/osemgrep/cli_ci/Git_metadata.ml
+++ b/src/osemgrep/cli_ci/Git_metadata.ml
@@ -128,9 +128,9 @@ class meta caps ~scan_environment ~(baseline_ref : Digestif.SHA1.t option) env =
         Git_wrapper.git_check_output caps#exec [ "show"; "-s"; "--format=%an" ]
       in
       (* Returns strict ISO 8601 time as str of head commit *)
-      let commit_timestamp : Timedesc.t =
+      let commit_timestamp : Timedesc.Timestamp.t =
         Git_wrapper.git_check_output caps#exec [ "show"; "-s"; "--format=%cI" ]
-        |> Timedesc.of_iso8601 |> Result.get_ok
+        |> Timedesc.Timestamp.of_iso8601 |> Result.get_ok
       in
       {
         semgrep_version = Version.version;

--- a/src/osemgrep/core/Metrics_.ml
+++ b/src/osemgrep/core/Metrics_.ml
@@ -125,8 +125,7 @@ type t = {
   mutable payload : Semgrep_metrics_t.payload;
 }
 
-let now () : Timedesc.t =
-  Timedesc.now ?tz_of_date_time:(Some Timedesc.Time_zone.utc) ()
+let now () : Timedesc.Timestamp.t = Timedesc.Timestamp.now ()
 
 let default_payload =
   {

--- a/src/osemgrep/reporting/Gitlab_output.ml
+++ b/src/osemgrep/reporting/Gitlab_output.ml
@@ -160,14 +160,12 @@ let output f matches =
       ]
   in
   let start_time = Metrics_.g.payload.started_at
-  and end_time =
-    Timedesc.now ?tz_of_date_time:(Some Timedesc.Time_zone.utc) ()
-  in
+  and end_time = Timedesc.Timestamp.now () in
   let scan =
     `Assoc
       [
-        ("start_time", `String (Timedesc.to_rfc3339 start_time));
-        ("end_time", `String (Timedesc.to_rfc3339 end_time));
+        ("start_time", `String (Timedesc.Timestamp.to_rfc3339 start_time));
+        ("end_time", `String (Timedesc.Timestamp.to_rfc3339 end_time));
         ("analyzer", tool);
         ("scanner", tool);
         ("version", `String Version.version);

--- a/src/reporting/Core_json_output.ml
+++ b/src/reporting/Core_json_output.ml
@@ -256,14 +256,14 @@ let unsafe_match_to_match
                    git_blob;
                    git_commit_timestamp =
                      (* TODO: CACHE THIS *)
-                     (match Git_wrapper.commit_timestamp commit with
+                     (match Git_wrapper.commit_timestamp commit_sha with
                      | Some x -> x
                      | None ->
                          Logs.warn (fun m ->
                              m
                                "Issue getting timestamp for commit %a. \
                                 Reporting current time."
-                               Git_wrapper.pp_sha sha);
+                               Git_wrapper.pp_sha commit_sha);
                          Timedesc.Timestamp.now ());
                  }
                   : OutJ.historical_info) ))

--- a/src/reporting/Core_json_output.ml
+++ b/src/reporting/Core_json_output.ml
@@ -223,23 +223,50 @@ let unsafe_match_to_match
     Metavar_replacement.interpolate_metavars x.rule_id.message
       (Metavar_replacement.of_bindings x.env)
   in
+  let path, historical_info =
+    match x.path.origin with
+    (* We need to do this, because in Terraform, we may end up with a `file` which
+       does not correspond to the actual location of the tokens. This `file` is
+       erroneous, and should be replaced by the location of the code of the match,
+       if possible. Not if it's fake, though.
+       In other languages, this should hopefully not happen.
+    *)
+    | File path ->
+        if
+          (!!path <> min_loc.pos.file || !!path <> max_loc.pos.file)
+          && min_loc.pos.file <> "FAKE TOKEN LOCATION"
+        then (Fpath.v min_loc.pos.file, None)
+        else (path, None)
+    (* TODO(cooper): if we can have a uri or something more general than a
+     * file path here then we can stop doing this hack. *)
+    | GitBlob { sha; paths } -> (
+        match paths with
+        | [] -> (x.path.internal_path_to_content (* no better path *), None)
+        | (commit, path) :: _ ->
+            let git_commit =
+              Digestif.SHA1.of_hex (Git_wrapper.show_sha commit)
+            in
+            ( path,
+              Some
+                ({
+                   git_commit;
+                   git_commit_timestamp =
+                     (match Git_wrapper.commit_timestamp commit with
+                     | Some x -> x
+                     | None ->
+                         Logs.warn (fun m ->
+                             m
+                               "Issue getting timestamp for commit %a. \
+                                Reporting current time."
+                               Git_wrapper.pp_sha sha);
+                         Timedesc.Timestamp.now ());
+                 }
+                  : OutJ.historical_info) ))
+  in
   {
     check_id = x.rule_id.id;
     (* inherited location *)
-    path =
-      (match x.path.origin with
-      (* We need to do this, because in Terraform, we may end up with a `file` which
-         does not correspond to the actual location of the tokens. This `file` is
-         erroneous, and should be replaced by the location of the code of the match,
-         if possible. Not if it's fake, though.
-         In other languages, this should hopefully not happen.
-      *)
-      | File path ->
-          if
-            (!!path <> min_loc.pos.file || !!path <> max_loc.pos.file)
-            && min_loc.pos.file <> "FAKE TOKEN LOCATION"
-          then Fpath.v min_loc.pos.file
-          else path);
+    path;
     start = startp;
     end_ = endp;
     (* end inherited location *)
@@ -256,7 +283,7 @@ let unsafe_match_to_match
         (* TODO *)
         engine_kind = x.engine_kind;
         validation_state = Some x.validation_state;
-        historical_info = None;
+        historical_info;
         extra_extra = None;
       };
   }

--- a/src/reporting/Core_json_output.ml
+++ b/src/reporting/Core_json_output.ml
@@ -239,18 +239,23 @@ let unsafe_match_to_match
         else (path, None)
     (* TODO(cooper): if we can have a uri or something more general than a
      * file path here then we can stop doing this hack. *)
-    | GitBlob { sha; paths } -> (
+    | GitBlob { sha = blob_sha; paths } -> (
         match paths with
         | [] -> (x.path.internal_path_to_content (* no better path *), None)
-        | (commit, path) :: _ ->
+        | (commit_sha, path) :: _ ->
+            let git_blob =
+              Some (Digestif.SHA1.of_hex (Git_wrapper.show_sha blob_sha))
+            in
             let git_commit =
-              Digestif.SHA1.of_hex (Git_wrapper.show_sha commit)
+              Digestif.SHA1.of_hex (Git_wrapper.show_sha commit_sha)
             in
             ( path,
               Some
                 ({
                    git_commit;
+                   git_blob;
                    git_commit_timestamp =
+                     (* TODO: CACHE THIS *)
                      (match Git_wrapper.commit_timestamp commit with
                      | Some x -> x
                      | None ->


### PR DESCRIPTION
This PR adds an additional variant on `Origin.t` for targets generated from git objects. There are some related updates to Git_wrapper implementing additional functionality needed to effectively use these, as well as a minor type update for some timestamp types.

I am not a huge fan of `Git_wrapper.batch_cat_file_blob`, but I don't see a better way to do it (without Lwt or Eio).

Test plan: existing coverage here; additional functionality using this will be tested in pro.