### PR TITLE
feat: include blob size in ls-tree output

### DIFF
--- a/libs/git_wrapper/Git_wrapper.mli
+++ b/libs/git_wrapper/Git_wrapper.mli
@@ -87,7 +87,7 @@ type 'extra obj = { kind : obj_type; sha : sha; extra : 'extra }
 
 type batch_check_extra = { size : int } [@@deriving show]
 type batch_extra = { contents : string } [@@deriving show]
-type ls_tree_extra = { path : Fpath.t } [@@deriving show]
+type ls_tree_extra = { path : Fpath.t; size : int } [@@deriving show]
 
 (* git status *)
 val status : ?cwd:Fpath.t -> ?commit:string -> unit -> status


### PR DESCRIPTION
This adds the filesize to the `ls-tree` return value, so we don't need to make a separate query for it.