### PR TITLE
fix(validate): correctly handle metavariables in conditions

### DIFF
--- a/tests/metachecks/explicit-regex-capture.rule.yaml
+++ b/tests/metachecks/explicit-regex-capture.rule.yaml
@@ -1,0 +1,11 @@
+rules:
+- id: explicit-regex-capture-noop-rule
+  pattern: |
+     non-present-string
+  message: |
+     The point of this test is to verify the hardcoded checks
+     correctly validate this rule that uses a regex metavariable.
+     Due to the way tests are set up, a rule is necessary to 
+     trigger a test. This rule is not expected to match.
+  languages: [yaml]
+  severity: WARNING

--- a/tests/metachecks/explicit-regex-capture.rule.yaml
+++ b/tests/metachecks/explicit-regex-capture.rule.yaml
@@ -3,9 +3,9 @@ rules:
   pattern: |
      non-present-string
   message: |
-     The point of this test is to verify the hardcoded checks
-     correctly validate this rule that uses a regex metavariable.
-     Due to the way tests are set up, a rule is necessary to 
-     trigger a test. This rule is not expected to match.
+     The point of this test is to verify that the hardcoded checks
+     correctly mark the `explicit-regex-capture.yaml` rule as valid.
+     Due to the way tests are set up, a metacheck rule is necessary 
+     to trigger a test. This rule is not expected to match.
   languages: [yaml]
   severity: WARNING

--- a/tests/metachecks/explicit-regex-capture.yaml
+++ b/tests/metachecks/explicit-regex-capture.yaml
@@ -1,0 +1,15 @@
+rules:
+  - id: explicit-regex-capture
+    languages:
+      - python
+    message: |
+       Using a metavariable-regex with a named capture group
+    patterns:
+      - pattern: |
+          $R = $VAL
+      - metavariable-regex:
+          metavariable: $VAL
+          regex: \"?(?<REGEX>\b([0-9a-f]{40})\b)
+      - focus-metavariable: $REGEX
+    severity: ERROR
+

--- a/tests/metachecks/implicit-regex-capture.rule.yaml
+++ b/tests/metachecks/implicit-regex-capture.rule.yaml
@@ -3,9 +3,9 @@ rules:
   pattern: |
      non-present-string
   message: |
-     The point of this test is to verify the hardcoded checks
-     correctly validate this rule that uses a regex metavariable.
-     Due to the way tests are set up, a rule is necessary to 
-     trigger a test. This rule is not expected to match.
+     The point of this test is to verify that the hardcoded checks
+     correctly mark the `implicit-regex-capture.yaml` rule as valid.
+     Due to the way tests are set up, a metacheck rule is necessary 
+     to trigger a test. This rule is not expected to match.
   languages: [yaml]
   severity: WARNING

--- a/tests/metachecks/implicit-regex-capture.rule.yaml
+++ b/tests/metachecks/implicit-regex-capture.rule.yaml
@@ -1,0 +1,11 @@
+rules:
+- id: implicit-regex-capture-noop-rule
+  pattern: |
+     non-present-string
+  message: |
+     The point of this test is to verify the hardcoded checks
+     correctly validate this rule that uses a regex metavariable.
+     Due to the way tests are set up, a rule is necessary to 
+     trigger a test. This rule is not expected to match.
+  languages: [yaml]
+  severity: WARNING

--- a/tests/metachecks/implicit-regex-capture.yaml
+++ b/tests/metachecks/implicit-regex-capture.yaml
@@ -1,0 +1,15 @@
+rules:
+  - id: implicit-regex-capture
+    languages:
+      - python
+    message: |
+       Using a metavariable-regex with a named capture group
+    patterns:
+      - pattern: |
+          $R = $VAL
+      - metavariable-regex:
+          metavariable: $VAL
+          regex: \"?(\b([0-9a-f]{40})\b)
+      - focus-metavariable: $1
+    severity: ERROR
+

--- a/tests/metachecks/metavariable-pattern.rule.yaml
+++ b/tests/metachecks/metavariable-pattern.rule.yaml
@@ -1,0 +1,11 @@
+rules:
+- id: explicit-regex-capture-noop-rule
+  pattern: |
+     non-present-string
+  message: |
+     The point of this test is to verify the hardcoded checks
+     correctly validate this rule that uses a regex metavariable.
+     Due to the way tests are set up, a rule is necessary to 
+     trigger a test. This rule is not expected to match.
+  languages: [yaml]
+  severity: WARNING

--- a/tests/metachecks/metavariable-pattern.rule.yaml
+++ b/tests/metachecks/metavariable-pattern.rule.yaml
@@ -3,9 +3,9 @@ rules:
   pattern: |
      non-present-string
   message: |
-     The point of this test is to verify the hardcoded checks
-     correctly validate this rule that uses a regex metavariable.
-     Due to the way tests are set up, a rule is necessary to 
-     trigger a test. This rule is not expected to match.
+     The point of this test is to verify that the hardcoded checks
+     correctly mark the `metavariable-pattern.yaml` rule as valid.
+     Due to the way tests are set up, a metacheck rule is necessary 
+     to trigger a test. This rule is not expected to match.
   languages: [yaml]
   severity: WARNING

--- a/tests/metachecks/metavariable-pattern.yaml
+++ b/tests/metachecks/metavariable-pattern.yaml
@@ -1,0 +1,16 @@
+rules:
+  - id: explicit-regex-capture
+    languages:
+      - python
+    message: |
+       Using a metavariable-regex with a named capture group
+    patterns:
+      - pattern: |
+          $R = $VAL
+      - metavariable-pattern:
+          metavariable: $VAL
+          pattern: |
+             "$STR"
+      - focus-metavariable: $STR
+    severity: ERROR
+


### PR DESCRIPTION
Since we can focus on a metavariable defined inside a condition created earlier as one of the conjuncts of an `and`, we need to include the metavariables of a condition in the possible metavariables set.

Test plan: automated tests. Also, run the added tests using

`semgrep-core -check_rules explicit-regex-capture.rule.yaml explicit-regex-capture.yaml`

To validate that these are, in fact, valid rules, create a test file regex_test_file.py:
```
x = "529837523aaaa798789789bbb987987897ccc798"
```

Then run

`semgrep-core -rules explicit-regex-capture.yaml regex-test-file.py -l python`

