### PR TITLE
Show a decent error message on 'semgrep show'

### DIFF
--- a/src/osemgrep/cli_show/Show_CLI.ml
+++ b/src/osemgrep/cli_show/Show_CLI.ml
@@ -97,7 +97,11 @@ let cmdline_term : conf Term.t =
       | [ "supported-languages" ] -> SupportedLanguages
       | [ "identity" ] -> Identity
       | [ "deployment" ] -> Deployment
-      | _ ->
+      | [] ->
+          Error.abort
+            (spf
+               "'semgrep show' expects a subcommand. Try 'semgrep show --help'.")
+      | _ :: _ ->
           Error.abort
             (spf "show command not supported: %s" (String.concat " " args))
     in


### PR DESCRIPTION
test plan:
```
$ semgrep show
[1709096337.46][ERROR]: 'semgrep show' expects a subcommand. Try 'semgrep show --help'.
Error: fatal error
Exiting with error status 2: osemgrep show
```