### PR TITLE
Fix log timestamps shown before calls to 'setup_logging'

### DIFF
--- a/libs/commons/Logs_.ml
+++ b/libs/commons/Logs_.ml
@@ -30,8 +30,8 @@ open Common
 (* alt: use Mtime_clock.now () *)
 let now () : float = UUnix.gettimeofday ()
 
-(* in seconds; it can be reset later *)
-let time_program_start = ref (now ())
+(* in seconds *)
+let time_program_start = now ()
 
 let default_skip_libs =
   [
@@ -175,7 +175,7 @@ let reporter ~dst ~require_one_of_these_tags
             (* Add a header *)
             Format.kfprintf k dst
               ("@[[%05.2f]%a%a: " ^^ fmt ^^ "@]@.")
-              (current -. !time_program_start)
+              (current -. time_program_start)
               Logs_fmt.pp_header (level, header) pp_tags tags
           in
           match level with
@@ -293,7 +293,6 @@ let setup_logging ?(highlight_setting = Std_msg.get_highlight_setting ())
   in
   Fmt_tty.setup_std_outputs ?style_renderer ();
   Logs.set_level ~all:true level;
-  time_program_start := now ();
   Logs.set_reporter
     (reporter ~dst ~require_one_of_these_tags ~read_tags_from_env_var ());
   Logs.debug (fun m ->

--- a/libs/commons/Logs_.ml
+++ b/libs/commons/Logs_.ml
@@ -27,8 +27,11 @@ open Common
      This variable is set when we configure loggers.
 *)
 
-(* in seconds *)
-let time_program_start = ref 0.
+(* alt: use Mtime_clock.now () *)
+let now () : float = UUnix.gettimeofday ()
+
+(* in seconds; it can be reset later *)
+let time_program_start = ref (now ())
 
 let default_skip_libs =
   [
@@ -121,9 +124,6 @@ let pp_sgr ppf style =
   Format.pp_print_as ppf 0 "\027[";
   Format.pp_print_as ppf 0 style;
   Format.pp_print_as ppf 0 "m"
-
-(* alt: use Mtime_clock.now () *)
-let now () : float = UUnix.gettimeofday ()
 
 (* a complicated way of saying (not (is_empty (inter a b))) *)
 let has_nonempty_intersection tag_str_list tag_set =

--- a/libs/commons/Logs_.ml
+++ b/libs/commons/Logs_.ml
@@ -30,7 +30,7 @@ open Common
 (* alt: use Mtime_clock.now () *)
 let now () : float = UUnix.gettimeofday ()
 
-(* in seconds *)
+(* unix time in seconds *)
 let time_program_start = now ()
 
 let default_skip_libs =


### PR DESCRIPTION
test plan:
Before:
```
$ semgrep show
[1709096337.46][ERROR]: 'semgrep show' expects a subcommand. Try 'semgrep show --help'.
Error: fatal error
Exiting with error status 2: osemgrep show
```
After:
```
$ semgrep show
[00.07][ERROR]: 'semgrep show' expects a subcommand. Try 'semgrep show --help'.
Error: fatal error
Exiting with error status 2: osemgrep show
```

I also removed the line that resets the timeline in `setup_logging` because we don't want logs to appear to travel backwards in time. The origin of times is now set to whenever the `Logs_` module is initialized.
