### PR TITLE
fix(validate): propagate down parent metavariables

### DIFF
--- a/src/metachecking/Check_rule.ml
+++ b/src/metachecking/Check_rule.ml
@@ -107,7 +107,7 @@ let check_mvars_of_focus env bound_mvs (t, mv_list) =
          if not (mvar_is_ok mv bound_mvs) then mv_error env mv t)
 
 let unknown_metavar_in_comparison env f =
-  let rec collect_metavars f : MV.mvar Set.t =
+  let rec collect_metavars parent_mvs f : MV.mvar Set.t =
     match f with
     | P { pat; pstr = pstr, _; pid = _pid } ->
         (* TODO currently this guesses that the metavariables are the strings
@@ -134,10 +134,10 @@ let unknown_metavar_in_comparison env f =
         |> List.fold_left Set.union Set.empty
     | Inside (_, f)
     | Anywhere (_, f) ->
-        collect_metavars f
+        collect_metavars parent_mvs f
     | Not (_, _) -> Set.empty
     | Or (_, xs) ->
-        let mv_sets = List_.map collect_metavars xs in
+        let mv_sets = List_.map (collect_metavars parent_mvs) xs in
         List.fold_left
           (* TODO originally we took the intersection, since strictly
            * speaking a metavariable needs to be in all cases of a pattern-either
@@ -150,14 +150,16 @@ let unknown_metavar_in_comparison env f =
             (fun acc mv_set -> Set.union acc mv_set)
           Set.empty mv_sets
     | And (_, { conjuncts; conditions; focus }) ->
-        let mv_sets = List_.map collect_metavars conjuncts in
+        let mv_sets = List_.map (collect_metavars parent_mvs) conjuncts in
         let mvs =
           List.fold_left
             (fun acc mv_set -> Set.union acc mv_set)
             Set.empty mv_sets
         in
-        (* Check that all metavariables in this And-clause's metavariable-comparison clauses appear somewhere else *)
-        conditions |> List.iter (check_mvars_of_condition env mvs);
+        let mvs_to_check = Set.union mvs parent_mvs in
+        (* Check that all metavariables in this And-clause's metavariable-comparison
+           clauses appear somewhere else *)
+        conditions |> List.iter (check_mvars_of_condition env mvs_to_check);
         (* Now collect the metavariables in the conditions, which could be used
            in the focus-metavariable clauses *)
         let cond_mvs =
@@ -170,16 +172,21 @@ let unknown_metavar_in_comparison env f =
                      Set.empty
                  | CondRegexp (_, regex, _) ->
                      Metavariable.mvars_of_regexp_string regex |> Set_.of_list
-                 | CondNestedFormula (_, _, formula) -> collect_metavars formula)
+                 | CondNestedFormula (_, _, formula) ->
+                     collect_metavars mvs formula)
           |> List.fold_left Set.union Set.empty
         in
+        (* Doing the same union twice feels wasteful, but we need to check
+           the parent metavariables in both the conditions and the focus,
+           while we only return the metavariables produced by the node *)
+        let mvs = Set.union cond_mvs mvs_to_check in
+        let mvs_to_check = Set.union cond_mvs mvs_to_check in
         (* Check the focus-metavariable clauses last since they can use metavariables
            in any clause within the And *)
-        let mvs = Set.union cond_mvs mvs in
-        focus |> List.iter (check_mvars_of_focus env mvs);
+        focus |> List.iter (check_mvars_of_focus env mvs_to_check);
         mvs
   in
-  let _ = collect_metavars f in
+  let _ = collect_metavars Set.empty f in
   ()
 
 (* call Check_pattern subchecker *)

--- a/src/metachecking/Check_rule.ml
+++ b/src/metachecking/Check_rule.ml
@@ -179,7 +179,7 @@ let unknown_metavar_in_comparison env f =
         (* Doing the same union twice feels wasteful, but we need to check
            the parent metavariables in both the conditions and the focus,
            while we only return the metavariables produced by the node *)
-        let mvs = Set.union cond_mvs mvs_to_check in
+        let mvs = Set.union cond_mvs mvs in
         let mvs_to_check = Set.union cond_mvs mvs_to_check in
         (* Check the focus-metavariable clauses last since they can use metavariables
            in any clause within the And *)

--- a/src/metachecking/Check_rule.ml
+++ b/src/metachecking/Check_rule.ml
@@ -157,8 +157,8 @@ let unknown_metavar_in_comparison env f =
             Set.empty mv_sets
         in
         let mvs_to_check = Set.union mvs parent_mvs in
-        (* Check that all metavariables in this And-clause's metavariable-comparison
-           clauses appear somewhere else *)
+        (* Check that all metavariables in this And-clause's condition
+           clauses were already bound *)
         conditions |> List.iter (check_mvars_of_condition env mvs_to_check);
         (* Now collect the metavariables in the conditions, which could be used
            in the focus-metavariable clauses *)
@@ -173,7 +173,7 @@ let unknown_metavar_in_comparison env f =
                  | CondRegexp (_, regex, _) ->
                      Metavariable.mvars_of_regexp_string regex |> Set_.of_list
                  | CondNestedFormula (_, _, formula) ->
-                     collect_metavars mvs formula)
+                     collect_metavars mvs_to_check formula)
           |> List.fold_left Set.union Set.empty
         in
         (* Doing the same union twice feels wasteful, but we need to check

--- a/tests/metachecks/nested-focus-metavariable.rule.yaml
+++ b/tests/metachecks/nested-focus-metavariable.rule.yaml
@@ -1,0 +1,11 @@
+rules:
+- id: nested-focus-metavariable-noop-rule
+  pattern: |
+     non-present-string
+  message: |
+     The point of this test is to verify that the hardcoded checks
+     correctly mark the `nested-focus-metavariable.yaml` rule as valid.
+     Due to the way tests are set up, a metacheck rule is necessary 
+     to trigger a test. This rule is not expected to match.
+  languages: [yaml]
+  severity: WARNING

--- a/tests/metachecks/nested-focus-metavariable.yaml
+++ b/tests/metachecks/nested-focus-metavariable.yaml
@@ -1,0 +1,22 @@
+rules:
+  - id: nested-focus-metavariable
+    languages:
+      - cpp
+      - c
+    message: Using a nested-focus-metavariable
+    patterns:
+      - pattern: |
+            $ACTION == $SRC;
+      - metavariable-pattern:
+          metavariable: $ACTION
+          patterns:
+            - pattern-either:
+                - pattern: fopen + $SRC
+                - pattern: |
+                    fopen
+                - patterns:
+                    - pattern: |
+                        $Y.open
+                    - focus-metavariable: $SRC
+      - focus-metavariable: $ACTION
+    severity: WARNING


### PR DESCRIPTION
Before my fix https://github.com/semgrep/semgrep/pull/9851, we weren't checking or collecting from the nested formulas in metavariable-pattern. Now that we are, when we validate those formulas, we need to pass down the metavariables collected in the parent.

Test plan: added tests

