### PR TITLE
refactor: tainting: Replace flat l-values with taint shapes

### DIFF
--- a/src/configuring/Flag_semgrep.ml
+++ b/src/configuring/Flag_semgrep.ml
@@ -24,7 +24,7 @@ let filter_irrelevant_patterns = ref false
 let max_target_bytes = ref 5_000_000
 
 (* Maximum number of tainted lvals to save. *)
-let max_tainted_lvals = ref Limits_semgrep.taint_MAX_TAINTED_LVALS
+let max_tainted_vars = ref Limits_semgrep.taint_MAX_TAINTED_VARS
 
 (* Maximum size of the taints set for each lval *)
 let max_taint_set_size = ref Limits_semgrep.taint_MAX_TAINT_SET_SIZE

--- a/src/configuring/Limits_semgrep.ml
+++ b/src/configuring/Limits_semgrep.ml
@@ -35,8 +35,11 @@ let svalue_prop_MAX_VISIT_SYM_IN_CYCLE_CHECK = 1000
  * Note that 'Time_limit.set_timeout' cannot be nested. *)
 let taint_FIXPOINT_TIMEOUT = 0.1
 
-(** Bounds the number of l-values we can track. *)
-let taint_MAX_TAINTED_LVALS = 100
+(** Bounds the number of variables we can track. *)
+let taint_MAX_TAINTED_VARS = 50
+
+(** Bounds the number of fields we can track per l-value. *)
+let taint_MAX_OBJ_FIELDS = 10
 
 (** Bounds the number of taints we can track per l-value.
  *

--- a/src/configuring/Limits_semgrep.ml
+++ b/src/configuring/Limits_semgrep.ml
@@ -38,7 +38,8 @@ let taint_FIXPOINT_TIMEOUT = 0.1
 (** Bounds the number of variables we can track. *)
 let taint_MAX_TAINTED_VARS = 50
 
-(** Bounds the number of fields we can track per l-value. *)
+(** Bounds the number of fields we can track per l-value, that is, the number of
+ * fields in an 'Obj' shape, see 'Taint_shape.shape'. *)
 let taint_MAX_OBJ_FIELDS = 10
 
 (** Bounds the number of taints we can track per l-value.

--- a/src/core_cli/Core_CLI.ml
+++ b/src/core_cli/Core_CLI.ml
@@ -555,9 +555,9 @@ let options caps actions =
        when running out of memory. This value should be less than the actual \
        memory available because the limit will be exceeded before it gets \
        detected. Try 5% less or 15000 if you have 16 GB." );
-    ( "-max_tainted_lvals",
-      Arg.Set_int Flag_semgrep.max_tainted_lvals,
-      "<int> maximum number of lvals to store. This is mostly for internal use \
+    ( "-max_tainted_vars",
+      Arg.Set_int Flag_semgrep.max_tainted_vars,
+      "<int> maximum number of vars to store. This is mostly for internal use \
        to make performance testing easier" );
     ( "-max_taint_set_size",
       Arg.Set_int Flag_semgrep.max_taint_set_size,

--- a/src/engine/Match_tainting_mode.ml
+++ b/src/engine/Match_tainting_mode.ml
@@ -1,6 +1,6 @@
 (* Iago Abal, Yoann Padioleau
  *
- * Copyright (C) 2019-2022 r2c
+ * Copyright (C) 2019-2024 Semgrep Inc.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/src/engine/Match_tainting_mode.ml
+++ b/src/engine/Match_tainting_mode.ml
@@ -518,7 +518,7 @@ let sources_of_taints ?preferred_label taints =
            | Src src -> Some (src, tokens, sink_trace)
            (* even if there is any taint "variable", it's irrelevant for the
             * finding, since the precondition is satisfied. *)
-           | Arg _
+           | Var _
            | Control ->
                None)
   in
@@ -565,7 +565,7 @@ let trace_of_source source =
 
 let pms_of_finding ~match_on finding =
   match finding with
-  | T.ToArg _
+  | T.ToLval _
   | T.ToReturn _ ->
       []
   | ToSink
@@ -634,7 +634,7 @@ let pms_of_finding ~match_on finding =
 (*****************************************************************************)
 
 let taint_config_of_rule ~per_file_formula_cache xconf file ast_and_errors
-    ({ mode = `Taint spec; _ } as rule : R.taint_rule) handle_findings =
+    ({ mode = `Taint spec; _ } as rule : R.taint_rule) handle_results =
   let file = Fpath.v file in
   let formula_cache = per_file_formula_cache in
   let xconf = Match_env.adjust_xconfig_with_rule_options xconf rule.options in
@@ -743,7 +743,7 @@ let taint_config_of_rule ~per_file_formula_cache xconf file ast_and_errors
         (fun x -> any_is_in_sanitizers_matches rule x sanitizers_ranges);
       is_sink = (fun x -> any_is_in_sinks_matches rule x sinks_ranges);
       unify_mvars = config.taint_unify_mvars;
-      handle_findings;
+      handle_results;
     },
     {
       sources = sources_ranges;
@@ -945,14 +945,14 @@ let check_rule ?dep_matches per_file_formula_cache (rule : R.taint_rule)
           `Source
       | `Sink, `Sink -> `Sink
     in
-    let handle_findings _ findings _env =
-      findings
-      |> List.iter (fun finding ->
-             pms_of_finding ~match_on finding
+    let handle_results _ results _env =
+      results
+      |> List.iter (fun result ->
+             pms_of_finding ~match_on result
              |> List.iter (fun pm -> Stack_.push pm matches))
     in
     taint_config_of_rule ~per_file_formula_cache xconf
-      !!internal_path_to_content (ast, []) rule handle_findings
+      !!internal_path_to_content (ast, []) rule handle_results
   in
 
   (match !hook_setup_hook_function_taint_signature with

--- a/src/engine/Match_tainting_mode.mli
+++ b/src/engine/Match_tainting_mode.mli
@@ -53,7 +53,7 @@ val taint_config_of_rule :
   AST_generic.program * Tok.location list ->
   Rule.taint_rule ->
   (Dataflow_tainting.var option ->
-  Taint.finding list ->
+  Taint.result list ->
   Taint_lval_env.t ->
   unit) ->
   Dataflow_tainting.config * debug_taint * Matching_explanation.t list

--- a/src/engine/Pro_hooks.ml
+++ b/src/engine/Pro_hooks.ml
@@ -52,11 +52,11 @@ let pro_hooks_refs =
     Pro_hook_ref Dataflow_svalue.hook_constness_of_function;
     Pro_hook_ref Dataflow_svalue.hook_transfer_of_assume;
     Pro_hook_ref Match_tainting_mode.hook_setup_hook_function_taint_signature;
+    Pro_hook_ref Taint.hook_arg_offset_of_il_offset;
     Pro_hook_ref Taint_lval_env.hook_propagate_to;
     Pro_hook_ref Taint_lval_env.hook_normalize_rev_offset;
     Pro_hook_ref Dataflow_tainting.hook_function_taint_signature;
     Pro_hook_ref Dataflow_tainting.hook_find_attribute_in_class;
-    Pro_hook_ref Dataflow_tainting.hook_arg_offset_of_il_offset;
     Pro_hook_ref Dataflow_tainting.hook_check_tainted_at_exit_sinks;
   ]
 

--- a/src/engine/Pro_hooks.ml
+++ b/src/engine/Pro_hooks.ml
@@ -52,7 +52,7 @@ let pro_hooks_refs =
     Pro_hook_ref Dataflow_svalue.hook_constness_of_function;
     Pro_hook_ref Dataflow_svalue.hook_transfer_of_assume;
     Pro_hook_ref Match_tainting_mode.hook_setup_hook_function_taint_signature;
-    Pro_hook_ref Taint.hook_arg_offset_of_il_offset;
+    Pro_hook_ref Taint.hook_offset_of_IL;
     Pro_hook_ref Taint_lval_env.hook_propagate_to;
     Pro_hook_ref Taint_lval_env.hook_normalize_rev_offset;
     Pro_hook_ref Dataflow_tainting.hook_function_taint_signature;

--- a/src/engine/Test_dataflow_tainting.ml
+++ b/src/engine/Test_dataflow_tainting.ml
@@ -22,7 +22,7 @@ let pr2_ranges (file : Fpath.t) (rwms : RM.t list) : unit =
          in
          UCommon.pr2 (code_text ^ " @l." ^ line_str))
 
-let test_tainting (lang : Lang.t) (file : Fpath.t) options config def =
+let test_tainting (lang : Lang.t) (_file : Fpath.t) options config def =
   UCommon.pr2 "\nDataflow";
   UCommon.pr2 "--------";
   let flow, mapping =
@@ -31,21 +31,7 @@ let test_tainting (lang : Lang.t) (file : Fpath.t) options config def =
       (Dataflow_tainting.mk_empty_java_props_cache ())
       def
   in
-  let taint_to_str taint =
-    let show_taint t =
-      match t.Taint.orig with
-      | Taint.Src src ->
-          let tok1, tok2 = (fst (Taint.pm_of_trace src.call_trace)).range_loc in
-          let r = Range.range_of_token_locations tok1 tok2 in
-          Range.content_at_range file r
-      | Taint.Arg arg -> Taint._show_arg arg
-      | Taint.Control -> "<control>"
-    in
-    taint |> Taint.Taint_set.elements |> List_.map show_taint
-    |> String.concat ", "
-    |> fun str -> "{ " ^ str ^ " }"
-  in
-  DataflowX.display_mapping flow mapping (Taint_lval_env.to_string taint_to_str)
+  DataflowX.display_mapping flow mapping Taint_lval_env.to_string
 
 let test_dfg_tainting rules_file file =
   let rules_file = Fpath.v rules_file in

--- a/src/il/Display_IL.ml
+++ b/src/il/Display_IL.ml
@@ -16,6 +16,11 @@ let string_of_offset offset =
   | Dot a -> ident_str_of_name a
   | Index _ -> "[...]"
 
+let string_of_offset_list offset =
+  if offset <> [] then
+    "." ^ String.concat "." (List_.map string_of_offset offset)
+  else ""
+
 let string_of_lval { base; rev_offset } =
   string_of_base base
   ^

--- a/src/il/Display_IL.mli
+++ b/src/il/Display_IL.mli
@@ -1,3 +1,4 @@
 val display_cfg : IL.cfg -> unit
 val short_string_of_node_kind : IL.node_kind -> string
+val string_of_offset_list : IL.offset list -> string
 val string_of_lval : IL.lval -> string

--- a/src/il/IL_helpers.ml
+++ b/src/il/IL_helpers.ml
@@ -136,6 +136,30 @@ let rlvals_of_node = function
   | NTodo _ ->
       []
 
+let orig_of_node = function
+  | Enter
+  | Exit ->
+      None
+  | TrueNode e
+  | FalseNode e
+  | NCond (_, e)
+  | NReturn (_, e)
+  | NThrow (_, e) ->
+      Some e.eorig
+  | NInstr i -> Some i.iorig
+  | NGoto _
+  | Join
+  | NLambda _
+  | NOther _
+  | NTodo _ ->
+      None
+
+module NameOrdered = struct
+  type t = name
+
+  let compare = IL.compare_name
+end
+
 module LvalOrdered = struct
   type t = lval
 
@@ -173,21 +197,3 @@ module LvalOrdered = struct
             ro1 ro2
     | _, _ -> Stdlib.compare lval1 lval2
 end
-
-let orig_of_node = function
-  | Enter
-  | Exit ->
-      None
-  | TrueNode e
-  | FalseNode e
-  | NCond (_, e)
-  | NReturn (_, e)
-  | NThrow (_, e) ->
-      Some e.eorig
-  | NInstr i -> Some i.iorig
-  | NGoto _
-  | Join
-  | NLambda _
-  | NOther _
-  | NTodo _ ->
-      None

--- a/src/il/IL_helpers.mli
+++ b/src/il/IL_helpers.mli
@@ -21,11 +21,18 @@ val lvar_of_instr_opt : IL.instr -> IL.name option
 val rlvals_of_node : IL.node_kind -> IL.lval list
 (** The lvalues that occur in the RHS of a node. *)
 
+val orig_of_node : IL.node_kind -> IL.orig option
+
+(** Useful to instantiate data strutures like Map and Set. *)
+module NameOrdered : sig
+  type t = IL.name
+
+  val compare : t -> t -> int
+end
+
 (** Useful to instantiate data strutures like Map and Set. *)
 module LvalOrdered : sig
   type t = IL.lval
 
   val compare : t -> t -> int
 end
-
-val orig_of_node : IL.node_kind -> IL.orig option

--- a/src/tainting/Dataflow_tainting.mli
+++ b/src/tainting/Dataflow_tainting.mli
@@ -91,10 +91,6 @@ val hook_find_attribute_in_class :
   (AST_generic.name -> string -> AST_generic.name option) option ref
 (** Pro inter-file (aka deep) *)
 
-val hook_arg_offset_of_il_offset :
-  (IL.offset -> Taint.arg_offset option) option ref
-(** Pro index sensitivity *)
-
 val hook_check_tainted_at_exit_sinks :
   (config ->
   Taint_lval_env.t ->

--- a/src/tainting/Dataflow_tainting.mli
+++ b/src/tainting/Dataflow_tainting.mli
@@ -52,12 +52,12 @@ type config = {
       (** Test whether 'any' is a sanitizer, this corresponds to
       * 'pattern-sanitizers:' in taint-mode. *)
   unify_mvars : bool;  (** Unify metavariables in sources and sinks? *)
-  handle_findings :
+  handle_results :
     var option (** function name ('None' if anonymous) *) ->
-    Taint.finding list ->
+    Taint.result list ->
     Taint_lval_env.t ->
     unit;
-      (** Callback to report findings. *)
+      (** Callback to report results. *)
 }
 (** Taint rule instantiated for a given file.
   *

--- a/src/tainting/Taint.ml
+++ b/src/tainting/Taint.ml
@@ -1,6 +1,6 @@
 (* Iago Abal
  *
- * Copyright (C) 2022-2024 r2c
+ * Copyright (C) 2022-2024 Semgrep Inc.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/src/tainting/Taint.ml
+++ b/src/tainting/Taint.ml
@@ -121,64 +121,62 @@ let rec pm_of_trace = function
 
 let trace_of_pm (pm, x) = PM (pm, x)
 
-let rec _show_call_trace show_thing = function
+let rec show_call_trace show_thing = function
   | PM (pm, x) ->
       let toks = Lazy.force pm.PM.tokens |> List.filter Tok.is_origintok in
       let s = toks |> List_.map Tok.content_of_tok |> String.concat " " in
       Printf.sprintf "%s [%s]" s (show_thing x)
   | Call (_e, _, trace) ->
-      Printf.sprintf "Call(... %s)" (_show_call_trace show_thing trace)
+      Printf.sprintf "Call(... %s)" (show_call_trace show_thing trace)
 
 (*****************************************************************************)
 (* Taint arguments ("variables", kind of) *)
 (*****************************************************************************)
 
-type arg_pos = { name : string; index : int } [@@deriving show, ord]
+type arg = { name : string; index : int } [@@deriving show, ord]
+type base = BGlob of IL.name | BThis | BArg of arg [@@deriving show, ord]
 
-type arg_base = BGlob of IL.name | BThis | BArg of arg_pos
+type offset = Ofld of IL.name | Oint of int | Ostr of string | Oany
 [@@deriving show, ord]
 
-type arg_offset = Ofld of IL.name | Oint of int | Ostr of string | Oany
-[@@deriving show, ord]
+type lval = { base : base; offset : offset list } [@@deriving show]
 
-type arg = { base : arg_base; offset : arg_offset list } [@@deriving show]
+let hook_offset_of_IL = ref None
 
-let hook_arg_offset_of_il_offset = ref None
-
-let compare_arg { base = base1; offset = offset1 }
+let compare_lval { base = base1; offset = offset1 }
     { base = base2; offset = offset2 } =
-  match compare_arg_base base1 base2 with
-  | 0 -> List.compare compare_arg_offset offset1 offset2
+  match compare_base base1 base2 with
+  | 0 -> List.compare compare_offset offset1 offset2
   | other -> other
 
-let _show_pos { name = s; index = i } = Printf.sprintf "arg(%s@%d)" s i
+let show_pos { name = s; index = i } = Printf.sprintf "arg(%s@%d)" s i
 
-let _show_base base =
+let show_base base =
   match base with
   | BGlob name -> fst name.ident
   | BThis -> "this"
-  | BArg pos -> _show_pos pos
+  | BArg pos -> show_pos pos
 
-let _show_offset offset =
+let show_offset offset =
   match offset with
   | Ofld n -> "." ^ fst n.IL.ident
   | Oint i -> Printf.sprintf "[%d]" i
   | Ostr s -> Printf.sprintf "[%s]" s
   | Oany -> "[*]"
 
-let _show_arg { base; offset = os } =
-  _show_base base
-  ^ if os <> [] then os |> List_.map _show_offset |> String.concat "" else ""
+let show_lval { base; offset = os } =
+  show_base base
+  ^ if os <> [] then os |> List_.map show_offset |> String.concat "" else ""
 
-let offset_of_IL il_offset =
-  match !hook_arg_offset_of_il_offset with
+let offset_of_IL (o : IL.offset) =
+  match !hook_offset_of_IL with
   | None -> (
-      match il_offset.IL.o with
+      match o.o with
       | Dot n -> Ofld n
       | Index _ ->
           (* no index-sensitivity in OSS *)
           Oany)
-  | Some offset_of_IL -> offset_of_IL il_offset
+  | Some offset_of_IL -> offset_of_IL o
 
 (*****************************************************************************)
 (* Taint *)
@@ -197,7 +195,7 @@ type source = {
 }
 [@@deriving show]
 
-and orig = Src of source | Arg of arg | Control [@@deriving show]
+and orig = Src of source | Var of lval | Control [@@deriving show]
 and taint = { orig : orig; tokens : tainted_tokens } [@@deriving show]
 
 let compare_precondition (_ts1, f1) (_ts2, f2) =
@@ -243,35 +241,28 @@ let compare_source
 let compare_orig orig1 orig2 =
   match (orig1, orig2) with
   | Src p, Src q -> compare_source p q
-  | Arg a1, Arg a2 -> compare_arg a1 a2
+  | Var lv1, Var lv2 -> compare_lval lv1 lv2
   | Control, Control -> 0
-  | Src _, (Arg _ | Control) -> -1
-  | Arg _, Control -> -1
-  | Arg _, Src _ -> 1
-  | Control, (Arg _ | Src _) -> 1
+  | Src _, (Var _ | Control) -> -1
+  | Var _, Control -> -1
+  | Var _, Src _ -> 1
+  | Control, (Var _ | Src _) -> 1
 
 let compare_taint taint1 taint2 =
   (* THINK: Right now we disregard the trace because we just want to keep one
    * potential path. *)
   compare_orig taint1.orig taint2.orig
 
-let _show_taint_label taint =
-  match taint.orig with
-  | Src src -> src.label
-  | Arg arg -> _show_arg arg
-  | Control -> "<control>"
-
-let rec _show_precondition = function
+let rec show_precondition = function
   | R.PLabel str -> str
   | R.PBool b -> Bool.to_string b
-  | R.PNot p -> Printf.sprintf "not %s" (_show_precondition p)
+  | R.PNot p -> Printf.sprintf "not %s" (show_precondition p)
   | R.PAnd [ p1; p2 ] ->
-      Printf.sprintf "(%s and %s)" (_show_precondition p1)
-        (_show_precondition p2)
+      Printf.sprintf "(%s and %s)" (show_precondition p1) (show_precondition p2)
   | R.PAnd _ -> "(and ...)"
   | R.POr _ -> "(or ...)"
 
-let rec _show_source { call_trace; label; precondition } =
+let rec show_source { call_trace; label; precondition } =
   (* We want to show the actual label, not the originating label.
      This may change, for instance, if we have ever propagated this taint to
      a different label.
@@ -295,35 +286,35 @@ let rec _show_source { call_trace; label; precondition } =
     else if label = ts.label then Printf.sprintf " :%s" label
     else Printf.sprintf " :%s->%s" ts.label label
   in
-  let precondition_str = _show_taints_with_precondition precondition in
+  let precondition_str = show_taints_with_precondition precondition in
   Printf.sprintf "[%s%s @l.%d%s%s]" num_calls_str matched_str matched_line
     label_str precondition_str
 
-and _show_taints_with_precondition precondition =
+and show_taints_with_precondition precondition =
   match precondition with
   | None -> ""
   | Some (ts, pre) ->
       Common.spf "/PRE|%s|if %s/"
-        (List_.map _show_taint ts |> String.concat " + ")
-        (_show_precondition pre)
+        (List_.map show_taint ts |> String.concat " + ")
+        (show_precondition pre)
 
-and _show_taint taint =
+and show_taint taint =
   match taint.orig with
-  | Src src -> _show_source src
-  | Arg arg -> _show_arg arg
+  | Src src -> show_source src
+  | Var lval -> show_lval lval
   | Control -> "<control>"
 
-let _show_sink { rule_sink; _ } = rule_sink.R.sink_id
+let show_sink { rule_sink; _ } = rule_sink.R.sink_id
 
 type taint_to_sink_item = { taint : taint; sink_trace : unit call_trace }
 [@@deriving show]
 
-let _show_taint_to_sink_item { taint; sink_trace } =
-  Printf.sprintf "%s@{%s}" (_show_taint taint)
-    (_show_call_trace [%show: unit] sink_trace)
+let show_taint_to_sink_item { taint; sink_trace } =
+  Printf.sprintf "%s@{%s}" (show_taint taint)
+    (show_call_trace [%show: unit] sink_trace)
 
-let _show_taints_and_traces taints =
-  Common2.string_of_list _show_taint_to_sink_item taints
+let show_taints_and_traces taints =
+  Common2.string_of_list show_taint_to_sink_item taints
 
 let compare_taint_to_sink_item { taint = taint1; sink_trace = _ }
     { taint = taint2; sink_trace = _ } =
@@ -356,57 +347,56 @@ let compare_taints_to_sink
       | other -> other)
   | other -> other
 
-type finding =
+type result =
   | ToSink of taints_to_sink
   | ToReturn of taint list * G.tok
-  | ToArg of taint list * arg (* TODO: CleanArg ? *)
-[@@deriving show]
+  | ToLval of taint list * lval (* TODO: CleanArg ? *)
 
-let _show_taints_to_sink { taints_with_precondition = taints, _; sink; _ } =
-  Common.spf "%s ~~~> %s" (_show_taints_and_traces taints) (_show_sink sink)
+let show_taints_to_sink { taints_with_precondition = taints, _; sink; _ } =
+  Common.spf "%s ~~~> %s" (show_taints_and_traces taints) (show_sink sink)
 
-let _show_finding = function
-  | ToSink x -> _show_taints_to_sink x
+let show_result = function
+  | ToSink x -> show_taints_to_sink x
   | ToReturn (taints, _) ->
-      Printf.sprintf "return (%s)" (Common2.string_of_list _show_taint taints)
-  | ToArg (taints, a2) ->
+      Printf.sprintf "return (%s)" (Common2.string_of_list show_taint taints)
+  | ToLval (taints, lval) ->
       Printf.sprintf "%s ----> %s"
-        (Common2.string_of_list _show_taint taints)
-        (_show_arg a2)
+        (Common2.string_of_list show_taint taints)
+        (show_lval lval)
 
-let compare_finding fi1 fi2 =
-  match (fi1, fi2) with
+let compare_result r1 r2 =
+  match (r1, r2) with
   | ToSink tts1, ToSink tts2 -> compare_taints_to_sink tts1 tts2
   | ToReturn (ts1, tok1), ToReturn (ts2, tok2) -> (
       match List.compare compare_taint ts1 ts2 with
       | 0 -> Tok.compare tok1 tok2
       | other -> other)
-  | ToArg (ts1, a1), ToArg (ts2, a2) -> (
+  | ToLval (ts1, lv1), ToLval (ts2, lv2) -> (
       match List.compare compare_taint ts1 ts2 with
-      | 0 -> compare_arg a1 a2
+      | 0 -> compare_lval lv1 lv2
       | other -> other)
-  | ToSink _, (ToReturn _ | ToArg _) -> -1
-  | ToReturn _, ToArg _ -> -1
+  | ToSink _, (ToReturn _ | ToLval _) -> -1
+  | ToReturn _, ToLval _ -> -1
   | ToReturn _, ToSink _ -> 1
-  | ToArg _, (ToSink _ | ToReturn _) -> 1
+  | ToLval _, (ToSink _ | ToReturn _) -> 1
 
-module Findings = Set.Make (struct
-  type t = finding
+module Results = Set.Make (struct
+  type t = result
 
-  let compare = compare_finding
+  let compare = compare_result
 end)
 
-module Findings_tbl = Hashtbl.Make (struct
-  type t = finding
+module Results_tbl = Hashtbl.Make (struct
+  type t = result
 
-  let equal fi1 fi2 = compare_finding fi1 fi2 =|= 0
+  let equal r1 r2 = compare_result r1 r2 =|= 0
   let hash = Hashtbl.hash
 end)
 
-type signature = Findings.t
+type signature = Results.t
 
-let _show_signature s =
-  s |> Findings.to_seq |> List.of_seq |> List_.map _show_finding
+let show_signature s =
+  s |> Results.to_seq |> List.of_seq |> List_.map show_result
   |> [%show: string list]
 
 (*****************************************************************************)
@@ -481,7 +471,7 @@ module Taint_set = struct
     (* Here we assume that 'compare taint1 taint2 = 0' so we could keep any
        * of them, but we want "the best" one, e.g. the one with the shortest trace. *)
     match (taint1.orig, taint2.orig) with
-    | Arg _, Arg _
+    | Var _, Var _
     | Control, Control ->
         (* Polymorphic taint should only be intraprocedural so the call-trace is irrelevant. *)
         if List.length taint1.tokens < List.length taint2.tokens then taint1
@@ -533,7 +523,7 @@ module Taint_set = struct
           List.length taint1.tokens < List.length taint2.tokens
         then taint1
         else taint2
-    | (Src _ | Arg _ | Control), (Src _ | Arg _ | Control) ->
+    | (Src _ | Var _ | Control), _ ->
         Logs.debug (fun m ->
             m ~tags:error
               "Taint_set.pick_taint: Ooops, the impossible happened!");
@@ -560,7 +550,7 @@ end
 type taints = Taint_set.t
 
 let show_taints taints =
-  taints |> Taint_set.elements |> List_.map _show_taint |> String.concat ", "
+  taints |> Taint_set.elements |> List_.map show_taint |> String.concat ", "
   |> fun str -> "{ " ^ str ^ " }"
 
 (*****************************************************************************)
@@ -639,7 +629,7 @@ and labels_in_taints taints =
   taints
   |> Taint_set.iter (fun taint ->
          match taint.orig with
-         | Arg _
+         | Var _
          | Control ->
              has_poly_taint := true
          | Src { label; precondition = None; _ } ->
@@ -693,14 +683,14 @@ let filter_relevant_taints requires taints =
   |> Taint_set.filter (fun t ->
          match t.orig with
          | Src src -> LabelSet.mem src.label labels
-         | Arg _
+         | Var _
          | Control ->
              true)
 
 (* Just a straightforward bottom-up map on preconditions. *)
 let rec map_preconditions f taint =
   match taint.orig with
-  | Arg _
+  | Var _
   | Control ->
       Some taint
   | Src { precondition = None; _ } -> Some taint

--- a/src/tainting/Taint.ml
+++ b/src/tainting/Taint.ml
@@ -397,7 +397,7 @@ type signature = Results.t
 
 let show_signature s =
   s |> Results.to_seq |> List.of_seq |> List_.map show_result
-  |> [%show: string list]
+  |> String.concat " + "
 
 (*****************************************************************************)
 (* Taint sets *)

--- a/src/tainting/Taint.mli
+++ b/src/tainting/Taint.mli
@@ -41,12 +41,20 @@ type arg_offset =
   | Ofld of IL.name  (** A field, like `.a` *)
   | Oint of int  (** A constant integer index, like `[42]` *)
   | Ostr of string  (** A constant string index, like `['foo']` *)
+  | Oany
 [@@deriving show]
+
+val compare_arg_offset : arg_offset -> arg_offset -> int
+val _show_offset : arg_offset -> string
+val offset_of_IL : IL.offset -> arg_offset
 
 type arg = { base : arg_base; offset : arg_offset list } [@@deriving show]
 (** An 'arg' taint acts like a taint variable that refers to a specific formal
  * argument of a function/method, or to a specific offset of it. See 'signature'
  * for more details. *)
+
+val hook_arg_offset_of_il_offset : (IL.offset -> arg_offset) option ref
+(** Pro index sensitivity *)
 
 type source = {
   call_trace : Rule.taint_source call_trace;

--- a/src/tainting/Taint.mli
+++ b/src/tainting/Taint.mli
@@ -261,8 +261,8 @@ type signature = Results.t
  *     {ToSink {taints_with_precondition = [(x#0).a]; sink = ... ; ...}}
  *
  * where '(x#0).a' is taint variable that denotes the taint of the offset `.a`
- * of the parameter `x` of the function `foo`. The signature tells us that
- * '(x#0).a' will reaach a sink.
+ * of the parameter `x` (where '#0' means it is the first argument) of `foo`.
+ * The signature tells us that '(x#0).a' will reach a sink.
  *
  * Given a concrete call `foo(obj)`, Semgrep will instantiate this signature with
  * taint assigned to `obj.a` in that calling context. If it is tainted, then

--- a/src/tainting/Taint_lval_env.ml
+++ b/src/tainting/Taint_lval_env.ml
@@ -218,17 +218,11 @@ let add lval new_taints
         | None -> lval_env
         | Some tainted ->
             let new_taints =
-              (* If the lvalue is a simple variable, we record it as part of
-                 the taint trace. *)
-              match lval with
-              | { IL.base = Var var; rev_offset = [] } ->
-                  let var_tok = snd var.ident in
-                  if Tok.is_fake var_tok then new_taints
-                  else
-                    new_taints
-                    |> Taints.map (fun t ->
-                           { t with tokens = var_tok :: t.tokens })
-              | __else__ -> new_taints
+              let var_tok = snd var.ident in
+              if Tok.is_fake var_tok then new_taints
+              else
+                new_taints
+                |> Taints.map (fun t -> { t with tokens = var_tok :: t.tokens })
             in
             {
               tainted =

--- a/src/tainting/Taint_lval_env.mli
+++ b/src/tainting/Taint_lval_env.mli
@@ -60,8 +60,9 @@ val add : add_fn
 
 (* THINK: Perhaps keep propagators outside of this environment? *)
 val propagate_to : Dataflow_var_env.var -> Taint.taints -> env -> env
+val find_var_opt : env -> IL.name -> Taint_shape.ref option
 
-val dumb_find : env -> IL.lval -> [> `Clean | `None | `Tainted of Taint.taints ]
+val dumb_find : env -> IL.lval -> [ `Clean | `None | `Tainted of Taint.taints ]
 (** Look up an l-value on the environemnt and return whether it's tainted, clean,
     or we hold no info about it. It does not check sub-lvalues, e.g. if we record
     that 'x.a' is tainted but had no explicit info about 'x.a.b', checking for
@@ -100,6 +101,5 @@ val equal_by_lval : env -> env -> IL.lval -> bool
 (** Check whether two environments assign the exact same taint to an l-value
  * and each one of its extensions. *)
 
-val to_string : (Taint.taints -> string) -> env -> string
-val seq_of_tainted : env -> (IL.lval * Taint.taints) Seq.t
-val find_tainted_lvals_of_common_base : env -> IL.base -> IL.lval list
+val to_string : env -> string
+val seq_of_tainted : env -> (IL.name * Taint_shape.ref) Seq.t

--- a/src/tainting/Taint_shape.ml
+++ b/src/tainting/Taint_shape.ml
@@ -31,9 +31,9 @@ let error = Logs_.create_tags (base_tag_strings @ [ "error" ])
 (*****************************************************************************)
 
 module Fields = Map.Make (struct
-  type t = T.arg_offset
+  type t = T.offset
 
-  let compare = T.compare_arg_offset
+  let compare = T.compare_offset
 end)
 
 type shape =
@@ -70,7 +70,7 @@ let find_offset_in_obj o obj =
         Logs.debug (fun m ->
             m ~tags:warning
               "Already tracking too many fields, will not track %s"
-              (T._show_offset o));
+              (T.show_offset o));
         (Oany, obj))
 
 (*****************************************************************************)
@@ -110,7 +110,7 @@ and show_shape = function
 and show_obj obj =
   obj |> Fields.to_seq
   |> Seq.map (fun (o, o_ref) ->
-         spf "%s : %s" (T._show_offset o) (show_ref o_ref))
+         spf "%s : %s" (T.show_offset o) (show_ref o_ref))
   |> List.of_seq |> String.concat "; "
 
 (*****************************************************************************)
@@ -278,7 +278,7 @@ and clean_obj offset obj =
 (* Enumerate tainted offsets *)
 (*****************************************************************************)
 
-let rec enum_in_ref ref : (T.arg_offset list * Taints.t) Seq.t =
+let rec enum_in_ref ref : (T.offset list * Taints.t) Seq.t =
   let (Ref (taints, shape)) = ref in
   let x =
     match taints with

--- a/src/tainting/Taint_shape.ml
+++ b/src/tainting/Taint_shape.ml
@@ -1,0 +1,302 @@
+(* Iago Abal
+ *
+ * Copyright (C) 2022-2024 r2c
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * version 2.1 as published by the Free Software Foundation, with the
+ * special exception on linking described in file LICENSE.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
+ * LICENSE for more details.
+ *)
+
+open Common
+module T = Taint
+module Taints = T.Taint_set
+
+(*****************************************************************************)
+(* Prelude *)
+(*****************************************************************************)
+
+let base_tag_strings = [ __MODULE__; "taint" ]
+let _tags = Logs_.create_tags base_tag_strings
+let warning = Logs_.create_tags (base_tag_strings @ [ "warning" ])
+let error = Logs_.create_tags (base_tag_strings @ [ "error" ])
+
+(*****************************************************************************)
+(* Types *)
+(*****************************************************************************)
+
+module Fields = Map.Make (struct
+  type t = T.arg_offset
+
+  let compare = T.compare_arg_offset
+end)
+
+type shape =
+  | Bot  (** don't know or don't care *)
+  | Ptr of ref  (** a pointer *)
+  | Obj of obj  (** a struct-like thing *)
+
+and ref =
+  | Ref of Xtaint.t * shape
+      (** INVARIANT(ref): If 'xtaint' is '`Clean', then every ref in 'shape' is "clean" too.
+   *     (If we add aliasing we may need to revisit this.) *)
+
+(* The "default" taints for non-constant indexes are given by the 'Oany' offset.
+ *
+ * THINK: Instead of 'Oany' maybe have an explicit field ? *)
+and obj = ref Fields.t
+
+(*****************************************************************************)
+(* Helpers *)
+(*****************************************************************************)
+
+let ref_none_bot = Ref (`None, Bot)
+
+let find_offset_in_obj o obj =
+  let o = T.offset_of_IL o in
+  match Fields.find_opt o obj with
+  | Some _ -> (o, obj)
+  | None ->
+      let num_fields = Fields.cardinal obj in
+      if num_fields <= Limits_semgrep.taint_MAX_OBJ_FIELDS then
+        let obj = Fields.add o ref_none_bot obj in
+        (o, obj)
+      else (
+        Logs.debug (fun m ->
+            m ~tags:warning
+              "Already tracking too many fields, will not track %s"
+              (T._show_offset o));
+        (Oany, obj))
+
+(*****************************************************************************)
+(* Equality *)
+(*****************************************************************************)
+
+let rec equal_ref ref1 ref2 =
+  let (Ref (taints1, shape1)) = ref1 in
+  let (Ref (taints2, shape2)) = ref2 in
+  Xtaint.equal taints1 taints2 && equal_shape shape1 shape2
+
+and equal_shape shape1 shape2 =
+  match (shape1, shape2) with
+  | Bot, Bot -> true
+  | Ptr ref1, Ptr ref2 -> equal_ref ref1 ref2
+  | Obj obj1, Obj obj2 -> equal_obj obj1 obj2
+  | Bot, _
+  | Ptr _, _
+  | Obj _, _ ->
+      false
+
+and equal_obj obj1 obj2 = Fields.equal equal_ref obj1 obj2
+
+(*****************************************************************************)
+(* Pretty-printing *)
+(*****************************************************************************)
+
+let rec show_ref ref =
+  let (Ref (xtaint, shape)) = ref in
+  spf "ref<%s>(%s)" (Xtaint.show xtaint) (show_shape shape)
+
+and show_shape = function
+  | Bot -> "_|_"
+  | Ptr ref -> spf "ptr %s" (show_ref ref)
+  | Obj obj -> spf "obj {|%s|}" (show_obj obj)
+
+and show_obj obj =
+  obj |> Fields.to_seq
+  |> Seq.map (fun (o, o_ref) ->
+         spf "%s : %s" (T._show_offset o) (show_ref o_ref))
+  |> List.of_seq |> String.concat "; "
+
+(*****************************************************************************)
+(* Union (merging shapes) *)
+(*****************************************************************************)
+
+let rec union_ref ref1 ref2 =
+  let (Ref (xtaint1, shape1)) = ref1 in
+  let (Ref (xtaint2, shape2)) = ref2 in
+  let xtaint = Xtaint.union xtaint1 xtaint2 in
+  let shape = union_shape shape1 shape2 in
+  Ref (xtaint, shape)
+
+and union_shape shape1 shape2 =
+  match (shape1, shape2) with
+  | Bot, shape
+  | shape, Bot ->
+      shape
+  | Ptr ref1, Ptr ref2 -> Ptr (union_ref ref1 ref2)
+  | Obj obj1, Obj obj2 -> Obj (union_obj obj1 obj2)
+  | Ptr _, (Obj _ as shape_obj)
+  | (Obj _ as shape_obj), Ptr _ ->
+      Logs.debug (fun m ->
+          m ~tags:error "Union of incompatible shapes: %s U %s"
+            (show_shape shape1) (show_shape shape2));
+      (* THINK: Keep the 'Ptr' one ? Do something else ? *)
+      shape_obj
+
+and union_obj obj1 obj2 =
+  Fields.union (fun _ x y -> Some (union_ref x y)) obj1 obj2
+
+(*****************************************************************************)
+(* Collect/union all taints *)
+(*****************************************************************************)
+
+(* THINK: Generalize to "fold" ? *)
+
+let union_taints_in_ref =
+  let rec go_ref acc ref =
+    let (Ref (xtaint, shape)) = ref in
+    match xtaint with
+    | `Clean ->
+        (* Due to INVARIANT(ref) we can just stop here. *)
+        acc
+    | `None -> go_shape acc shape
+    | `Tainted taints -> go_shape (Taints.union taints acc) shape
+  and go_shape acc = function
+    | Bot -> acc
+    | Ptr ref -> go_ref acc ref
+    | Obj obj -> go_obj acc obj
+  and go_obj acc obj =
+    Fields.fold (fun _ o_ref acc -> go_ref acc o_ref) obj acc
+  in
+  go_ref Taints.empty
+
+(*****************************************************************************)
+(* Find xtaint for an offset *)
+(*****************************************************************************)
+
+let rec find_xtaint_ref offset ref =
+  let (Ref (xtaint, shape)) = ref in
+  match offset with
+  | [] -> xtaint
+  | _ :: _ -> find_xtaint_shape offset shape
+
+and find_xtaint_shape offset = function
+  (* offset <> [] *)
+  | Bot -> `None
+  | Ptr ref -> find_xtaint_ref offset ref
+  | Obj obj -> find_xtaint_obj offset obj
+
+and find_xtaint_obj offset obj =
+  (* offset <> [] *)
+  match offset with
+  | [] ->
+      Logs.debug (fun m ->
+          m ~tags:error "fix_xtaint_obj: Impossible happened: empty offset");
+      `None
+  | o :: offset -> (
+      match T.offset_of_IL o with
+      | Oany (* arbitrary index [*] *) ->
+          (* consider all fields/indexes *)
+          Fields.fold
+            (fun _ ref acc -> Xtaint.union acc (find_xtaint_ref offset ref))
+            obj `None
+      | o -> (
+          match Fields.find_opt o obj with
+          | None -> `None
+          | Some o_ref -> find_xtaint_ref offset o_ref))
+
+(*****************************************************************************)
+(* Update the xtaint of an offset *)
+(*****************************************************************************)
+
+let rec update_ref f offset ref =
+  match (ref, offset) with
+  | Ref (xtaint, shape), [] -> Ref (f xtaint, shape)
+  | Ref (xtaint, shape), _ :: _ ->
+      let shape = update_shape f offset shape in
+      Ref (xtaint, shape)
+
+and update_shape f offset = function
+  | Bot ->
+      let shape = Obj Fields.empty in
+      update_shape f offset shape
+  | Ptr ref ->
+      let ref = update_ref f offset ref in
+      Ptr ref
+  | Obj obj ->
+      let obj = update_obj f offset obj in
+      Obj obj
+
+and update_obj f offset obj =
+  match offset with
+  | [] ->
+      Logs.debug (fun m ->
+          m ~tags:error "update_obj: Impossible happened: empty offset");
+      obj
+  | o :: offset -> (
+      let o, obj = find_offset_in_obj o obj in
+      match o with
+      | Oany -> Fields.map (update_ref f offset) obj
+      | o ->
+          Fields.update o (Option.map (fun ref -> update_ref f offset ref)) obj)
+
+(*****************************************************************************)
+(* Clean taint *)
+(*****************************************************************************)
+
+let rec clean_ref offset ref =
+  let (Ref (xtaint, shape)) = ref in
+  match offset with
+  | [] ->
+      (* See INVARIANT(ref)
+       *
+       * THINK: If we had aliasing, we would have to keep the previous shape
+       *  and just clean it all ? And we would also need to remove the 'Clean'
+       *  mark from other refs that may be pointing to this ref in order to
+       *  maintain the invariant ? *)
+      Ref (`Clean, Bot)
+  | _ :: _ ->
+      let shape = clean_shape offset shape in
+      Ref (xtaint, shape)
+
+and clean_shape offset = function
+  | Bot ->
+      let shape = Obj Fields.empty in
+      clean_shape offset shape
+  | Ptr ref -> Ptr (clean_ref offset ref)
+  | Obj obj -> Obj (clean_obj offset obj)
+
+and clean_obj offset obj =
+  match offset with
+  | [] ->
+      Logs.debug (fun m ->
+          m ~tags:error "clean_obj: Impossible happened: empty offset");
+      obj
+  | o :: offset -> (
+      let o, obj = find_offset_in_obj o obj in
+      match o with
+      | Oany -> Fields.map (clean_ref offset) obj
+      | o -> Fields.update o (Option.map (fun ref -> clean_ref offset ref)) obj)
+
+(*****************************************************************************)
+(* Enumerate tainted offsets *)
+(*****************************************************************************)
+
+let rec enum_in_ref ref : (T.arg_offset list * Taints.t) Seq.t =
+  let (Ref (taints, shape)) = ref in
+  let x =
+    match taints with
+    | `Tainted taints -> Seq.cons ([], taints) Seq.empty
+    | `Clean
+    | `None ->
+        Seq.empty
+  in
+  Seq.append x (enum_in_shape shape)
+
+and enum_in_shape = function
+  | Bot -> Seq.empty
+  | Ptr ref -> enum_in_ref ref
+  | Obj obj -> enum_in_obj obj
+
+and enum_in_obj obj =
+  obj |> Fields.to_seq
+  |> Seq.map (fun (o, ref) ->
+         enum_in_ref ref
+         |> Seq.map (fun (offset, taints) -> (o :: offset, taints)))
+  |> Seq.concat

--- a/src/tainting/Taint_shape.mli
+++ b/src/tainting/Taint_shape.mli
@@ -1,0 +1,89 @@
+(** Taint shapes *)
+
+module Fields : Map.S with type key = Taint.offset
+
+(**
+ * For example, a record expression #{ a: "tainted", b: "safe" } would have
+ * the shape `obj {| a: ref<{"tainted"}>(_|_) |}`. Note that `b` is omitted
+ * because it has no taint.
+ *
+ * 'Obj' shapes are open, if a field is not specified then it has the same
+ * taint as its parent 'ref'. *)
+type shape =
+  | Bot  (** _|_, don't know or don't care *)
+  | Obj of obj  (** a struct-like thing *)
+
+and ref =
+  | Ref of Xtaint.t * shape
+      (** A "reference cell", like a `ref` in OCaml, or a variable in C.
+   *
+   * A ref may be explicitly tainted ('`Tainted'), not explicitly tainted
+   * ('`None' / "0"),  or explicitly clean ('`Clean' / "C").
+   *
+   * A ref that is not explicitly tainted inherits any taints from "parent"
+   * refs. A ref that is explicitly clean it is clean regardless.
+   *
+   * For example, given a variable `x` and the following statements:
+   *
+   *     x.a := "tainted";
+   *     x.a.u := "clean";
+   *
+   * We could assign the following shape to `x`:
+   *
+   *     ref<0>( obj {|
+   *             a: ref<"tainted">( obj {|
+   *                     u: ref<C>(_|_)
+   *                     |} )
+   *             |} )
+   *
+   * We have that `x` itself has no taint directly assigned to it, but `x.a` is
+   * tainted (by the string `"tainted"`). Other fields like `x.b` are not tainted.
+   * When it comes to `x.a`, we have that `x.a.u` has been explicitly marked clean,
+   * so `x.a.u` will be considered clean despite `x.a` being tainted. Any other field
+   * of `x.a` such as `x.a.v` will inherit the same taint as `x.a`.
+   *
+   * INVARIANT(ref): To keep shapes minimal:
+   *   1. If the xtaint is '`None', then the shape is not 'Bot' and we can reach
+   *      another 'ref' whose xtaint is either '`Tainted' or '`Clean'.
+   *   2. If the xtaint is '`Clean', then the shape is 'Bot'.
+   *      (If we add aliasing we may need to revisit this, and instead just mark
+   *       every reachable 'ref' as clean too.)
+   *
+   * TODO: We can attach "region ids" to refs and assign taints to regions rather than
+   *   to refs directly, then we can have alias analysis.
+   *)
+
+and obj = ref Fields.t
+(**
+ * The "default" taints for non-constant indexes are given by the 'Oany' offset.
+ *
+ * THINK: Instead of 'Oany' maybe have an explicit field ?
+ *)
+
+val equal_ref : ref -> ref -> bool
+val show_ref : ref -> string
+
+val union_ref : ref -> ref -> ref
+(** Merge refs at JOIN nodes of the CFG. *)
+
+val union_taints_in_ref : ref -> Taint.taints
+(** Collect and union all taints reachable via a ref. *)
+
+val find_xtaint_ref : IL.offset list -> ref -> Xtaint.t
+
+val taint_ref : Taint.taints -> IL.offset list -> ref -> ref
+(** [taint_ref taints offset ref] adds 'taints' to the 'offset' in 'ref'.  *)
+
+val clean_ref : IL.offset list -> ref -> ref
+(** [clean_ref offset ref] marks the 'offset' in 'ref' as clean.  *)
+
+val enum_in_ref : ref -> (Taint.offset list * Taint.taints) Seq.t
+(**
+ * Enumerate all offsets in a ref and their taint.
+ *
+ * For example,
+ *
+ *     enum_in_ref (ref<0>( obj {| a: ref<{"tainted"}>(_|_) |} ))
+ *
+ * would return a sequence with the pair (.a, "tainted").
+ *)

--- a/src/tainting/Taint_shape.mli
+++ b/src/tainting/Taint_shape.mli
@@ -7,7 +7,7 @@ module Fields : Map.S with type key = Taint.offset
  * the shape `obj {| a: ref<{"tainted"}>(_|_) |}`. Note that `b` is omitted
  * because it has no taint.
  *
- * 'Obj' shapes are open, if a field is not specified then it has the same
+ * 'Obj' shapes are extensible, if a field is not specified then it has the same
  * taint as its parent 'ref'. *)
 type shape =
   | Bot  (** _|_, don't know or don't care *)

--- a/src/tainting/Xtaint.ml
+++ b/src/tainting/Xtaint.ml
@@ -1,0 +1,48 @@
+(* Iago Abal
+ *
+ * Copyright (C) 2022-2024 r2c
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * version 2.1 as published by the Free Software Foundation, with the
+ * special exception on linking described in file LICENSE.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
+ * LICENSE for more details.
+ *)
+
+module Taints = Taint.Taint_set
+
+type t = [ `Tainted of Taints.t | `None  (** no info *) | `Clean ]
+
+let equal xt1 xt2 =
+  match (xt1, xt2) with
+  | `Tainted taints1, `Tainted taints2 -> Taints.equal taints1 taints2
+  | `None, `None
+  | `Clean, `Clean ->
+      true
+  | `Tainted _, _
+  | `None, _
+  | `Clean, _ ->
+      false
+
+let show = function
+  | `Tainted taints -> Taint.show_taints taints
+  | `None -> "0"
+  | `Clean -> "C"
+
+let union xt1 xt2 =
+  match (xt1, xt2) with
+  | `Tainted taints1, `Tainted taints2 ->
+      `Tainted (Taints.union taints1 taints2)
+  | `Tainted taints, (`None | `Clean)
+  | (`None | `Clean), `Tainted taints ->
+      `Tainted taints
+  | `None, `None -> `None
+  | `Clean, `Clean -> `Clean
+  | `None, `Clean
+  | `Clean, `None ->
+      (* THINK *)
+      `Clean

--- a/src/tainting/Xtaint.ml
+++ b/src/tainting/Xtaint.ml
@@ -1,6 +1,6 @@
 (* Iago Abal
  *
- * Copyright (C) 2022-2024 r2c
+ * Copyright (C) 2024 Semgrep Inc.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
@@ -15,7 +15,8 @@
 
 module Taints = Taint.Taint_set
 
-type t = [ `Tainted of Taints.t | `None  (** no info *) | `Clean ]
+type t = [ `Tainted of Taints.t | `None | `Clean ]
+type t_or_sanitized = [ t | `Sanitized ]
 
 let equal xt1 xt2 =
   match (xt1, xt2) with
@@ -46,3 +47,10 @@ let union xt1 xt2 =
   | `Clean, `None ->
       (* THINK *)
       `Clean
+
+let to_taints = function
+  | `None
+  | `Clean
+  | `Sanitized ->
+      Taints.empty
+  | `Tainted taints -> taints

--- a/src/tainting/Xtaint.mli
+++ b/src/tainting/Xtaint.mli
@@ -1,0 +1,21 @@
+(** eXtended taint
+ *
+ * Represents the "taint status" of a variable or l-value.
+ *)
+
+type t = [ `Tainted of Taint.taints | `None  (** no info *) | `Clean ]
+(** See 'Taint_shape.ref'. *)
+
+type t_or_sanitized = [ t | `Sanitized ]
+(** When checking the taint of an l-value, we want to distinguish between "clean",
+ * meaning the l-value was cleaned in the past and it's marked as clean in the
+ * environment, and "sanitized", meaning this very occurrence of the l-value is
+ * matching a sanitizer. See NOTE [lval/sanitized] in 'Dataflow_tainting'. *)
+
+val equal : t -> t -> bool
+val show : t -> string
+
+val union : t -> t -> t
+(** Merge xtaints at JOIN nodes of the CFG. *)
+
+val to_taints : t_or_sanitized -> Taint.taints


### PR DESCRIPTION
Instead of tracking individual l-values in a "flat" taint environment, we now track variables and their "taint shapes". This allows for more natural operations over shapes that should make the implementation of field-sensitive related features cleaner.

Also, renamed some taint-related types hopefully making them less confusing. In particular, a taint "finding" is now called a "result" to avoid confusing it with Semgrep findings; and taint "arg"s are now "lval"s, since they are basically a restricted form of l-values.

Note that this PR is mainly a refactoring, for now we are not adding any new feature. (Well, it does improve on the inference if `ToLval` results by #9825, see Pro PR's test case).

By adding a new test following #9825, I ended up finding a bug due to `List.rev` offsets when we should not, and I fixed it.

test plan:
make test
Ran a full comparison wrt latest (see run 6d669), showing no regression at all.
See semgrep/semgrep-proprietary#1347