### PR TITLE
Draft to add pro indicators to CLI output

### DIFF
--- a/cli/src/semgrep/rule_match.py
+++ b/cli/src/semgrep/rule_match.py
@@ -25,6 +25,7 @@ from semgrep.constants import RuleScanSource
 from semgrep.external.pymmh3 import hash128  # type: ignore[attr-defined]
 from semgrep.rule import Rule
 from semgrep.semgrep_interfaces.semgrep_output_v1 import Direct
+from semgrep.semgrep_interfaces.semgrep_output_v1 import PROREQUIRED
 from semgrep.semgrep_interfaces.semgrep_output_v1 import Transitive
 from semgrep.semgrep_interfaces.semgrep_output_v1 import Transitivity
 from semgrep.util import get_lines
@@ -481,6 +482,18 @@ class RuleMatch:
             )
             == "block"
         )
+
+    @property
+    def is_interfile_taint_finding(self) -> bool:
+        if isinstance(self.match.extra.engine_kind.value, PROREQUIRED):
+            return self.match.extra.engine_kind.value.value.interfile_taint
+        return False
+
+    @property
+    def is_interproc_taint_finding(self) -> bool:
+        if isinstance(self.match.extra.engine_kind.value, PROREQUIRED):
+            return self.match.extra.engine_kind.value.value.interproc_taint
+        return False
 
     @property
     def is_blocking(self) -> bool:


### PR DESCRIPTION
I don't stand by these choices, just wanted to explore what text output could look like.

Test plan:
```
➜  WebGoat git:(1a7e4d61) pwd
/Users/emma/workspace/examples-annotations/repos/java/SQLi/vuln-repos/WebGoat
➜  WebGoat git:(1a7e4d61) semgrep --config ../../../../../rules/deepsemgrep-sqli-rules.yaml . --pro
```

Should have three sections, for interfile, interproc, and other

