### PR TITLE
Use capabilities for tmp access

### DIFF
--- a/TCB/forbid_tmp.jsonnet
+++ b/TCB/forbid_tmp.jsonnet
@@ -16,7 +16,8 @@ local funcs = [
         any:
           [('Filename.' + p) for p in funcs] +
           [('UFilename.' + p) for p in funcs] +
-          ["UTmp.with_tmp_file"], # TODO: UTmp.$F at some point
+          # TODO: UTmp.$F at some point, especially new_temp_file()
+          ["UTmp.with_tmp_file"],
       },
       languages: ['ocaml'],
       paths: {

--- a/TCB/forbid_tmp.jsonnet
+++ b/TCB/forbid_tmp.jsonnet
@@ -22,17 +22,15 @@ local funcs = [
       languages: ['ocaml'],
       paths: {
         exclude: [
-           "UTmp.ml", // TODO: remove at some point
-	   "CapTmp.ml",
+           "UTmp.ml", "CapTmp.ml",
            'TCB/*',
            'tools/*', 'scripts/*', 'stats/*',
            'Test*.ml',  'Unit_*.ml',
         ],
       },
       severity: 'ERROR',
-      //TODO: tell to use CapTmp.ml
       message: |||
-        Do not use directly Filename. Use UTmp.ml instead.
+        Do not use directly Filename or UTmp. Try to use CapTmp instead.
       |||,
     },
   ],

--- a/TCB/forbid_tmp.jsonnet
+++ b/TCB/forbid_tmp.jsonnet
@@ -16,13 +16,13 @@ local funcs = [
         any:
           [('Filename.' + p) for p in funcs] +
           [('UFilename.' + p) for p in funcs] +
-          // TODO: UTmp
-          [],
+          ["UTmp.with_tmp_file"], # TODO: UTmp.$F at some point
       },
       languages: ['ocaml'],
       paths: {
         exclude: [
-	   "UTmp.ml", // TODO: remove at some point
+           "UTmp.ml", // TODO: remove at some point
+	   "CapTmp.ml",
            'TCB/*',
            'tools/*', 'scripts/*', 'stats/*',
            'Test*.ml',  'Unit_*.ml',

--- a/js/language_server/Main.ml
+++ b/js/language_server/Main.ml
@@ -72,7 +72,8 @@ let _ =
 
       let server =
         ref
-          (LS.LanguageServer.create (all_caps :> < Cap.random ; Cap.network >))
+          (LS.LanguageServer.create
+             (all_caps :> < Cap.random ; Cap.network ; Cap.tmp >))
       in
       Js.export_all
         (object%js

--- a/js/tests/Test_jsoo.ml
+++ b/js/tests/Test_jsoo.ml
@@ -93,14 +93,15 @@ let () =
                  Unit_parsing.tests ();
                  Unit_engine.tests ();
                  Unit_entropy.tests;
-                 Unit_LS.tests (all_caps :> < Cap.random ; Cap.network >);
+                 Unit_LS.tests
+                   (all_caps :> < Cap.random ; Cap.network ; Cap.tmp >);
                ]
                |> List.flatten
              in
              let lwt_tests =
                [
                  Test_LS_e2e.lwt_tests
-                   (all_caps :> < Cap.random ; Cap.network >);
+                   (all_caps :> < Cap.random ; Cap.network ; Cap.tmp >);
                ]
                |> List.flatten
              in

--- a/languages/go/menhir/parse_go.ml
+++ b/languages/go/menhir/parse_go.ml
@@ -96,8 +96,8 @@ let parse_program file =
 (* Sub parsers *)
 (*****************************************************************************)
 
-let (program_of_string : string -> Ast_go.program) =
- fun s -> UTmp.with_tmp_file ~str:s ~ext:"go" parse_program
+let program_of_string (caps : < Cap.tmp >) (s : string) : Ast_go.program =
+  CapTmp.with_tmp_file caps#tmp ~str:s ~ext:"go" parse_program
 
 (* for sgrep/spatch *)
 let any_of_string s =

--- a/languages/go/menhir/parse_go.mli
+++ b/languages/go/menhir/parse_go.mli
@@ -1,4 +1,4 @@
 val parse : Fpath.t -> (Ast_go.program, Parser_go.token) Parsing_result.t
 val parse_program : Fpath.t -> Ast_go.program
-val program_of_string : string -> Ast_go.program
 val any_of_string : string -> Ast_go.any
+val program_of_string : < Cap.tmp > -> string -> Ast_go.program

--- a/languages/java/menhir/parse_java.ml
+++ b/languages/java/menhir/parse_java.ml
@@ -100,7 +100,9 @@ let parse_program file =
   let res = parse file in
   res.Parsing_result.ast
 
-let parse_string (w : string) = UTmp.with_tmp_file ~str:w ~ext:"java" parse
+let parse_string (caps : < Cap.tmp >) (w : string) :
+    (Ast_java.program, Parser_java.token) Parsing_result.t =
+  CapTmp.with_tmp_file caps#tmp ~str:w ~ext:"java" parse
 
 (*****************************************************************************)
 (* Sub parsers *)

--- a/languages/java/menhir/parse_java.mli
+++ b/languages/java/menhir/parse_java.mli
@@ -5,7 +5,9 @@ val parse : Fpath.t -> (Ast_java.program, Parser_java.token) Parsing_result.t
 val parse_program : Fpath.t -> Ast_java.program
 
 val parse_string :
-  string -> (Ast_java.program, Parser_java.token) Parsing_result.t
+  < Cap.tmp > ->
+  string ->
+  (Ast_java.program, Parser_java.token) Parsing_result.t
 
 (* for sgrep *)
 val any_of_string : string -> Ast_java.any

--- a/languages/javascript/menhir/parse_js.ml
+++ b/languages/javascript/menhir/parse_js.ml
@@ -307,15 +307,12 @@ let parse_program file =
   let res = parse file in
   res.Parsing_result.ast
 
-let parse_string (w : string) : Ast.a_program =
-  UTmp.with_tmp_file ~str:w ~ext:"js" parse_program
+let program_of_string (caps : < Cap.tmp >) (w : string) : Ast.a_program =
+  CapTmp.with_tmp_file caps#tmp ~str:w ~ext:"js" parse_program
 
 (*****************************************************************************)
 (* Sub parsers *)
 (*****************************************************************************)
-
-let (program_of_string : string -> Ast_js.a_program) =
- fun s -> UTmp.with_tmp_file ~str:s ~ext:"js" (fun file -> parse_program file)
 
 let type_of_string s =
   let lexbuf = Lexing.from_string s in

--- a/languages/javascript/menhir/parse_js.mli
+++ b/languages/javascript/menhir/parse_js.mli
@@ -8,7 +8,6 @@ val parse :
   (Ast_js.a_program, Parser_js.token) Parsing_result.t
 
 val parse_program : Fpath.t -> Ast_js.a_program
-val parse_string : string -> Ast_js.a_program
 
 (* other parsers *)
 
@@ -19,7 +18,7 @@ val any_of_string : string -> Ast_js.any
 val type_of_string : string -> Ast_js.type_
 
 (* to help write test code *)
-val program_of_string : string -> Ast_js.a_program
+val program_of_string : < Cap.tmp > -> string -> Ast_js.a_program
 
 (* internal *)
 val tokens : Parsing_helpers.input_source -> Parser_js.token list

--- a/languages/javascript/menhir/unit_parsing_js.ml
+++ b/languages/javascript/menhir/unit_parsing_js.ml
@@ -9,7 +9,7 @@ let t = Testo.create
 (* ran from the root of the semgrep repository *)
 let tests_path = "tests"
 
-let tests =
+let tests caps =
   Testo.categorize "parsing_js"
     [
       t "regression files" (fun () ->
@@ -48,7 +48,7 @@ let tests =
           try
             Common.save_excursion Flag_parsing.show_parsing_error false
               (fun () ->
-                let _ = Parse_js.program_of_string "echo 1+" in
+                let _ = Parse_js.program_of_string caps "echo 1+" in
                 Alcotest.fail "it should have thrown a Parse_error exception")
           with
           | Parsing_error.Syntax_error _ -> ())

--- a/languages/javascript/menhir/unit_parsing_js.mli
+++ b/languages/javascript/menhir/unit_parsing_js.mli
@@ -1,2 +1,2 @@
 (* Test suite for this folder. *)
-val tests : Testo.test list
+val tests : < Cap.tmp > -> Testo.test list

--- a/languages/ocaml/menhir/unit_parsing_ml.ml
+++ b/languages/ocaml/menhir/unit_parsing_ml.ml
@@ -9,7 +9,7 @@ let t = Testo.create
 (* ran from the root of the semgrep repository *)
 let tests_path = "tests"
 
-let tests =
+let tests (caps : < Cap.tmp >) =
   Testo.categorize "parsing_ml"
     [
       t "regression files" (fun () ->
@@ -28,8 +28,8 @@ let tests =
        * sub-sub expressions inside parenthesis).
        *)
       t "visitor" (fun () ->
-          UTmp.with_tmp_file ~ext:".ml" ~str:"open Foo1\nmodule A = Foo2\n"
-            (fun file ->
+          CapTmp.with_tmp_file caps#tmp ~ext:".ml"
+            ~str:"open Foo1\nmodule A = Foo2\n" (fun file ->
               let _ast = Parse_ml.parse_program file in
               let _cnt = ref 0 in
               (* TODO use Visitor_AST of ml_to_generic

--- a/languages/ocaml/menhir/unit_parsing_ml.mli
+++ b/languages/ocaml/menhir/unit_parsing_ml.mli
@@ -1,2 +1,2 @@
 (* Test suite for this folder. *)
-val tests : Testo.test list
+val tests : < Cap.tmp > -> Testo.test list

--- a/languages/python/menhir/Parse_python.ml
+++ b/languages/python/menhir/Parse_python.ml
@@ -169,8 +169,8 @@ let parse_program ?parsing_mode file =
 (* Sub parsers *)
 (*****************************************************************************)
 
-let (program_of_string : string -> AST_python.program) =
- fun s -> UTmp.with_tmp_file ~str:s ~ext:"py" parse_program
+let program_of_string (caps : < Cap.tmp >) (s : string) : AST_python.program =
+  CapTmp.with_tmp_file caps#tmp ~str:s ~ext:"py" parse_program
 
 let type_of_string ?(parsing_mode = Python) s =
   let lexbuf = Lexing.from_string s in

--- a/languages/python/menhir/Parse_python.mli
+++ b/languages/python/menhir/Parse_python.mli
@@ -31,7 +31,7 @@ val parse_fuzzy:
 *)
 
 (* to help write test code *)
-val program_of_string : string -> AST_python.program
+val program_of_string : < Cap.tmp > -> string -> AST_python.program
 
 (* internal *)
 val tokens :

--- a/languages/tree-sitter-to-generic/Parse_vue_tree_sitter.ml
+++ b/languages/tree-sitter-to-generic/Parse_vue_tree_sitter.ml
@@ -390,8 +390,9 @@ let map_component (env : env) (xs : CST.component) : stmt list =
 (* Entry point *)
 (*****************************************************************************)
 
-(* TODO: move in Parse_tree_sitter_helpers.ml *)
+(* TODO: move in Parse_tree_sitter_helpers.ml and avoid using tmp file *)
 let parse_string_and_adjust_wrt_base content tbase fparse =
+  (* nosemgrep: forbid-tmp *)
   UTmp.with_tmp_file ~str:content ~ext:"js" (fun file ->
       let x = fparse file in
 

--- a/libs/commons/CapTmp.ml
+++ b/libs/commons/CapTmp.ml
@@ -1,0 +1,1 @@
+let with_tmp_file _caps = UTmp.with_tmp_file

--- a/libs/commons/CapTmp.mli
+++ b/libs/commons/CapTmp.mli
@@ -1,0 +1,4 @@
+(* Capability aware wrappers to UTmp.ml *)
+
+val with_tmp_file :
+  Cap.FS.tmp -> str:string -> ext:string -> (Fpath.t -> 'a) -> 'a

--- a/libs/commons2/common2.ml
+++ b/libs/commons2/common2.ml
@@ -4930,8 +4930,8 @@ module Infix = struct
   let ( ==~ ) = ( ==~ )
 end
 
-let with_pr2_to_string f =
-  UTmp.with_tmp_file ~str:"" ~ext:"out" (fun path ->
+let with_pr2_to_string caps f =
+  CapTmp.with_tmp_file caps ~str:"" ~ext:"out" (fun path ->
       let file = Fpath.to_string path in
       redirect_stdout_stderr file f;
       cat file)

--- a/libs/commons2/common2.mli
+++ b/libs/commons2/common2.mli
@@ -109,7 +109,7 @@ val redirect_stdout_opt : filename option -> (unit -> 'a) -> 'a
 val redirect_stdout_stderr : filename -> (unit -> unit) -> unit
 val redirect_stdin : filename -> (unit -> unit) -> unit
 val redirect_stdin_opt : filename option -> (unit -> unit) -> unit
-val with_pr2_to_string : (unit -> unit) -> string list
+val with_pr2_to_string : Cap.FS.tmp -> (unit -> unit) -> string list
 
 (* default = stderr *)
 val _chan : out_channel ref

--- a/libs/ojsonnet/Eval_jsonnet_subst.ml
+++ b/libs/ojsonnet/Eval_jsonnet_subst.ml
@@ -36,9 +36,9 @@ module H = Eval_jsonnet_common
 (* Standard library *)
 (*****************************************************************************)
 
-(*Creates std so that we can add it to the environment when we switch back to
-  * environment model for handling standard library functions
-*)
+(* Creates std so that we can add it to the environment when we switch back to
+ * environment model for handling standard library functions
+ *)
 let pre_std = lazy (Std_jsonnet.get_std_jsonnet ())
 
 (* This is an arbitrary path, used as a placeholder, since we aren't

--- a/libs/ojsonnet/Std_jsonnet.ml
+++ b/libs/ojsonnet/Std_jsonnet.ml
@@ -1680,6 +1680,9 @@ limitations under the License.
 
 (* entry point *)
 let get_std_jsonnet () =
-  (* TODO? Could add a Parse_jsonnet_tree_sitter.parse_string at some point *)
+  (* TODO? Could add a Parse_jsonnet_tree_sitter.parse_string at some point so
+   * no need to use tmp file
+   *)
+  (* nosemgrep: forbid-tmp *)
   UTmp.with_tmp_file ~str:std ~ext:"jsonnet" (fun file ->
       Parse_jsonnet.parse_program file)

--- a/src/engine/Metavariable_pattern.ml
+++ b/src/engine/Metavariable_pattern.ml
@@ -202,6 +202,8 @@ let get_nested_metavar_pattern_bindings get_nested_formula_matches env r mvar
                   let content =
                     Range.content_at_range (Fpath.v mval_file) mval_range
                   in
+                  (* TODO: find a way to not use tmp files! parse strings *)
+                  (* nosemgrep: forbid-tmp *)
                   UTmp.with_tmp_file ~str:content ~ext:"mvar-pattern"
                     (fun (file : Fpath.t) ->
                       let mast' =
@@ -271,6 +273,8 @@ let get_nested_metavar_pattern_bindings get_nested_formula_matches env r mvar
                       m ~tags "nested analysis of |||%s||| with lang '%s'"
                         content (Xlang.to_string xlang));
                   (* We re-parse the matched text as `xlang`. *)
+                  (* TODO: find a way to not use tmp files! parse strings *)
+                  (* nosemgrep: forbid-tmp *)
                   UTmp.with_tmp_file ~str:content ~ext:"mvar-pattern"
                     (fun file ->
                       let ast_and_errors_res =

--- a/src/fixing/Autofix.ml
+++ b/src/fixing/Autofix.ml
@@ -93,8 +93,12 @@ let parse_pattern lang pattern =
       let e = Exception.catch e in
       Error e
 
+(* TODO: should not rely on tmp file, have Parse_target accept a
+ * more flexible origin/source
+ *)
 let parse_target lang text =
   (* ext shouldn't matter, but could use Lang.ext_of_lang if needed *)
+  (* nosemgrep: forbid-tmp *)
   UTmp.with_tmp_file ~str:text ~ext:"check" (fun file ->
       try Ok (Parse_target.just_parse_with_lang lang file) with
       | Time_limit.Timeout _ as e -> Exception.catch_and_reraise e

--- a/src/osemgrep/cli/CLI.ml
+++ b/src/osemgrep/cli/CLI.ml
@@ -37,7 +37,8 @@ module Env = Semgrep_envvars
 (* Types and constants *)
 (*****************************************************************************)
 
-type caps = < Cap.stdout ; Cap.network ; Cap.exec ; Cap.random ; Cap.signal >
+type caps =
+  < Cap.stdout ; Cap.network ; Cap.exec ; Cap.random ; Cap.signal ; Cap.tmp >
 
 let default_subcommand = "scan"
 
@@ -191,7 +192,7 @@ let dispatch_subcommand (caps : caps) (argv : string array) =
             Logout_subcommand.main (caps :> < Cap.stdout >) subcmd_argv
         | "lsp" ->
             Lsp_subcommand.main
-              (caps :> < Cap.random ; Cap.network >)
+              (caps :> < Cap.random ; Cap.network ; Cap.tmp >)
               subcmd_argv
         (* partial support, still use Pysemgrep.Fallback in it *)
         | "scan" ->
@@ -200,7 +201,7 @@ let dispatch_subcommand (caps : caps) (argv : string array) =
               subcmd_argv
         | "ci" ->
             Ci_subcommand.main
-              (caps :> < Cap.stdout ; Cap.network ; Cap.exec >)
+              (caps :> < Cap.stdout ; Cap.network ; Cap.exec ; Cap.tmp >)
               subcmd_argv
         (* osemgrep-only: and by default! no need experimental! *)
         | "install-ci" ->

--- a/src/osemgrep/cli/CLI.ml
+++ b/src/osemgrep/cli/CLI.ml
@@ -182,7 +182,7 @@ let dispatch_subcommand (caps : caps) (argv : string array) =
               subcmd_argv
         | "publish" when experimental ->
             Publish_subcommand.main
-              (caps :> < Cap.stdout ; Cap.network >)
+              (caps :> < Cap.stdout ; Cap.network ; Cap.tmp >)
               subcmd_argv
         | "login" when experimental ->
             Login_subcommand.main
@@ -197,7 +197,7 @@ let dispatch_subcommand (caps : caps) (argv : string array) =
         (* partial support, still use Pysemgrep.Fallback in it *)
         | "scan" ->
             Scan_subcommand.main
-              (caps :> < Cap.stdout ; Cap.network >)
+              (caps :> < Cap.stdout ; Cap.network ; Cap.tmp >)
               subcmd_argv
         | "ci" ->
             Ci_subcommand.main
@@ -209,11 +209,11 @@ let dispatch_subcommand (caps : caps) (argv : string array) =
         | "interactive" -> !hook_semgrep_interactive subcmd_argv
         | "show" ->
             Show_subcommand.main
-              (caps :> < Cap.stdout ; Cap.network >)
+              (caps :> < Cap.stdout ; Cap.network ; Cap.tmp >)
               subcmd_argv
         | "test" ->
             Test_subcommand.main
-              (caps :> < Cap.stdout ; Cap.network >)
+              (caps :> < Cap.stdout ; Cap.network ; Cap.tmp >)
               subcmd_argv
         | _else_ ->
             if experimental then

--- a/src/osemgrep/cli/CLI.mli
+++ b/src/osemgrep/cli/CLI.mli
@@ -1,7 +1,8 @@
 (* no exit, no argv
  * TODO: Cap.files_argv, Cap.domain, Cap.thread
  *)
-type caps = < Cap.stdout ; Cap.network ; Cap.exec ; Cap.random ; Cap.signal >
+type caps =
+  < Cap.stdout ; Cap.network ; Cap.exec ; Cap.random ; Cap.signal ; Cap.tmp >
 
 (*
    Parse the semgrep command line, run the requested subcommand, and return

--- a/src/osemgrep/cli_ci/Ci_subcommand.ml
+++ b/src/osemgrep/cli_ci/Ci_subcommand.ml
@@ -743,7 +743,7 @@ let run_conf (caps : caps) (ci_conf : Ci_CLI.conf) : Exit_code.t =
           Rule_fetching.rules_from_rules_source ~token_opt:settings.api_token
             ~rewrite_rule_ids:conf.rewrite_rule_ids
             ~strict:conf.core_runner_conf.strict
-            (caps :> < Cap.network >)
+            (caps :> < Cap.network ; Cap.tmp >)
             conf.rules_source
         in
         (None, rules_and_origins)

--- a/src/osemgrep/cli_ci/Ci_subcommand.mli
+++ b/src/osemgrep/cli_ci/Ci_subcommand.mli
@@ -8,11 +8,15 @@ module OutJ = Semgrep_output_v1_j
    This function returns an exit code to be passed to the 'exit' function.
 *)
 val main :
-  < Cap.network ; Cap.stdout ; Cap.exec > -> string array -> Exit_code.t
+  < Cap.network ; Cap.stdout ; Cap.exec ; Cap.tmp > ->
+  string array ->
+  Exit_code.t
 
 (* internal *)
 val run_conf :
-  < Cap.network ; Cap.stdout ; Cap.exec > -> Ci_CLI.conf -> Exit_code.t
+  < Cap.network ; Cap.stdout ; Cap.exec ; Cap.tmp > ->
+  Ci_CLI.conf ->
+  Exit_code.t
 
 val rule_is_blocking : JSON.t -> bool
 val finding_is_blocking : OutJ.cli_match -> bool

--- a/src/osemgrep/cli_lsp/Lsp_subcommand.ml
+++ b/src/osemgrep/cli_lsp/Lsp_subcommand.ml
@@ -9,7 +9,7 @@
 (*****************************************************************************)
 (* Types *)
 (*****************************************************************************)
-type caps = < Cap.random ; Cap.network >
+type caps = < Cap.random ; Cap.network ; Cap.tmp >
 
 module Io = RPC_server.MakeLSIO (struct
   type input = Lwt_io.input_channel

--- a/src/osemgrep/cli_lsp/Lsp_subcommand.mli
+++ b/src/osemgrep/cli_lsp/Lsp_subcommand.mli
@@ -5,7 +5,8 @@
 
    This function returns an exit code to be passed to the 'exit' function.
 *)
-val main : < Cap.random ; Cap.network > -> string array -> Exit_code.t
+val main : < Cap.random ; Cap.network ; Cap.tmp > -> string array -> Exit_code.t
 
 (* internal *)
-val run_conf : < Cap.random ; Cap.network > -> Lsp_CLI.conf -> Exit_code.t
+val run_conf :
+  < Cap.random ; Cap.network ; Cap.tmp > -> Lsp_CLI.conf -> Exit_code.t

--- a/src/osemgrep/cli_publish/Publish_subcommand.ml
+++ b/src/osemgrep/cli_publish/Publish_subcommand.ml
@@ -17,7 +17,7 @@ module Http_helpers = Http_helpers.Make (Lwt_platform)
 (*****************************************************************************)
 (* Types *)
 (*****************************************************************************)
-type caps = < Cap.stdout ; Cap.network >
+type caps = < Cap.stdout ; Cap.network ; Cap.tmp >
 
 (*****************************************************************************)
 (* Helpers *)
@@ -42,7 +42,7 @@ let upload_rule caps rule_file (conf : Publish_CLI.conf) test_code_file =
     let rules_and_origins, errors =
       Rule_fetching.rules_from_dashdash_config ~token_opt:(Some caps#token)
         ~rewrite_rule_ids:true
-        (caps :> < Cap.network >)
+        (caps :> < Cap.network ; Cap.tmp >)
         (Rules_config.File (Fpath.v rule_file))
     in
     let rules, invalid_rule_errors =
@@ -209,7 +209,7 @@ let run_conf (caps : caps) (conf : Publish_CLI.conf) : Exit_code.t =
                   | [] -> None
                   | first :: _ -> Some first
                 in
-                let caps = Auth.cap_token_and_network token caps in
+                let caps = Auth.cap_token_and_network_and_tmp token caps in
                 if not (upload_rule caps config_filename conf first_test_case)
                 then fail_count + 1
                 else fail_count)

--- a/src/osemgrep/cli_publish/Publish_subcommand.mli
+++ b/src/osemgrep/cli_publish/Publish_subcommand.mli
@@ -6,4 +6,4 @@
    This function returns an exit code to be passed to the 'exit' function.
 *)
 
-val main : < Cap.stdout ; Cap.network > -> string array -> Exit_code.t
+val main : < Cap.stdout ; Cap.network ; Cap.tmp > -> string array -> Exit_code.t

--- a/src/osemgrep/cli_publish/Test_publish_subcommand.ml
+++ b/src/osemgrep/cli_publish/Test_publish_subcommand.ml
@@ -88,7 +88,7 @@ let with_mocks f =
 (* Tests *)
 (*****************************************************************************)
 
-let test_publish (caps : < Cap.network ; Cap.stdout >) () =
+let test_publish (caps : < Cap.network ; Cap.stdout ; Cap.tmp >) () =
   let tests_path = tests_path () in
   with_test_env (fun () ->
       with_mocks (fun () ->
@@ -120,7 +120,9 @@ let test_publish (caps : < Cap.network ; Cap.stdout >) () =
           (* log back in *)
           Semgrep_envvars.with_envvar "SEMGREP_APP_TOKEN" fake_token (fun () ->
               let exit_code =
-                Login_subcommand.main caps [| "semgrep-login" |]
+                Login_subcommand.main
+                  (caps :> < Cap.network ; Cap.stdout >)
+                  [| "semgrep-login" |]
               in
               assert (exit_code =*= Exit_code.ok));
 
@@ -191,7 +193,7 @@ let test_publish (caps : < Cap.network ; Cap.stdout >) () =
 (* Entry point *)
 (*****************************************************************************)
 
-let tests (caps : < Cap.network ; Cap.stdout >) =
+let tests (caps : < Cap.network ; Cap.stdout ; Cap.tmp >) =
   Testo.categorize "Osemgrep Publish (e2e)"
     [
       t

--- a/src/osemgrep/cli_publish/Test_publish_subcommand.mli
+++ b/src/osemgrep/cli_publish/Test_publish_subcommand.mli
@@ -1,1 +1,1 @@
-val tests : < Cap.network ; Cap.stdout > -> Testo.test list
+val tests : < Cap.network ; Cap.stdout ; Cap.tmp > -> Testo.test list

--- a/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -35,7 +35,7 @@ let tags = Logs_.create_tags [ __MODULE__ ]
 (* Types *)
 (*****************************************************************************)
 (* TODO: probably far more needed at some point *)
-type caps = < Cap.stdout ; Cap.network >
+type caps = < Cap.stdout ; Cap.network ; Cap.tmp >
 
 (*****************************************************************************)
 (* Logging/Profiling/Debugging *)
@@ -317,7 +317,7 @@ let rules_from_rules_source ~token_opt ~rewrite_rule_ids ~strict caps
   let rules_and_origins =
     Rule_fetching.rules_from_rules_source_async ~token_opt ~rewrite_rule_ids
       ~strict
-      (caps :> < Cap.network >)
+      (caps :> < Cap.network ; Cap.tmp >)
       rules_source
   in
   Lwt_platform.run (Lwt.pick (rules_and_origins :: spinner_ls))
@@ -821,7 +821,7 @@ let run_scan_conf (caps : caps) (conf : Scan_CLI.conf) : Exit_code.t =
     rules_from_rules_source ~token_opt:settings.api_token
       ~rewrite_rule_ids:conf.rewrite_rule_ids
       ~strict:conf.core_runner_conf.strict
-      (caps :> < Cap.network >)
+      (caps :> < Cap.network ; Cap.tmp >)
       conf.rules_source
   in
   (* step2: getting the targets *)
@@ -907,15 +907,15 @@ let run_conf (caps : caps) (conf : Scan_CLI.conf) : Exit_code.t =
       Exit_code.ok
   | _ when conf.test <> None ->
       Test_subcommand.run_conf
-        (caps :> < Cap.stdout ; Cap.network >)
+        (caps :> < Cap.stdout ; Cap.network ; Cap.tmp >)
         (Common2.some conf.test)
   | _ when conf.validate <> None ->
       Validate_subcommand.run_conf
-        (caps :> < Cap.stdout ; Cap.network >)
+        (caps :> < Cap.stdout ; Cap.network ; Cap.tmp >)
         (Common2.some conf.validate)
   | _ when conf.show <> None ->
       Show_subcommand.run_conf
-        (caps :> < Cap.stdout ; Cap.network >)
+        (caps :> < Cap.stdout ; Cap.network ; Cap.tmp >)
         (Common2.some conf.show)
   | _ when conf.ls ->
       Ls_subcommand.run ~target_roots:conf.target_roots

--- a/src/osemgrep/cli_scan/Scan_subcommand.mli
+++ b/src/osemgrep/cli_scan/Scan_subcommand.mli
@@ -5,11 +5,14 @@
 
    This function returns an exit code to be passed to the 'exit' function.
 *)
-val main : < Cap.stdout ; Cap.network > -> string array -> Exit_code.t
+val main : < Cap.stdout ; Cap.network ; Cap.tmp > -> string array -> Exit_code.t
 
 (* internal *)
-val run_conf : < Cap.stdout ; Cap.network > -> Scan_CLI.conf -> Exit_code.t
-val run_scan_conf : < Cap.stdout ; Cap.network > -> Scan_CLI.conf -> Exit_code.t
+val run_conf :
+  < Cap.stdout ; Cap.network ; Cap.tmp > -> Scan_CLI.conf -> Exit_code.t
+
+val run_scan_conf :
+  < Cap.stdout ; Cap.network ; Cap.tmp > -> Scan_CLI.conf -> Exit_code.t
 
 (* internal: scan all the files - also used in CI *)
 val run_scan_files :

--- a/src/osemgrep/cli_scan/Validate_subcommand.ml
+++ b/src/osemgrep/cli_scan/Validate_subcommand.ml
@@ -39,7 +39,7 @@ module OutJ = Semgrep_output_v1_t
 (*****************************************************************************)
 
 (* TODO: should use stdout, right now we abuse Logs.app *)
-type caps = < Cap.stdout ; Cap.network >
+type caps = < Cap.stdout ; Cap.network ; Cap.tmp >
 
 (* a slice of Scan_CLI.conf *)
 type conf = {
@@ -77,7 +77,7 @@ let run_conf (caps : caps) (conf : conf) : Exit_code.t =
   let rules_and_origin =
     Rule_fetching.rules_from_rules_source ~token_opt ~rewrite_rule_ids:true
       ~strict:conf.core_runner_conf.strict
-      (caps :> < Cap.network >)
+      (caps :> < Cap.network ; Cap.tmp >)
       conf.rules_source
   in
   let rules, errors =
@@ -121,7 +121,7 @@ let run_conf (caps : caps) (conf : conf) : Exit_code.t =
         let metarules_and_origin, _errors =
           Rule_fetching.rules_from_dashdash_config ~token_opt
             ~rewrite_rule_ids:true (* default *)
-            (caps :> < Cap.network >)
+            (caps :> < Cap.network ; Cap.tmp >)
             config
         in
         let metarules, metaerrors =

--- a/src/osemgrep/cli_scan/Validate_subcommand.mli
+++ b/src/osemgrep/cli_scan/Validate_subcommand.mli
@@ -10,4 +10,4 @@ type conf = {
 }
 [@@deriving show]
 
-val run_conf : < Cap.stdout ; Cap.network > -> conf -> Exit_code.t
+val run_conf : < Cap.stdout ; Cap.network ; Cap.tmp > -> conf -> Exit_code.t

--- a/src/osemgrep/cli_show/Show_subcommand.ml
+++ b/src/osemgrep/cli_show/Show_subcommand.ml
@@ -20,7 +20,7 @@ module J = JSON
 (* Types *)
 (*****************************************************************************)
 (* we need the network for the 'semgrep show identity/deployment' *)
-type caps = < Cap.stdout ; Cap.network >
+type caps = < Cap.stdout ; Cap.network ; Cap.tmp >
 
 (*****************************************************************************)
 (* Helpers *)
@@ -104,7 +104,7 @@ let run_conf (caps : caps) (conf : Show_CLI.conf) : Exit_code.t =
         Rule_fetching.rules_from_dashdash_config
           ~rewrite_rule_ids:true (* command-line default *)
           ~token_opt
-          (caps :> < Cap.network >)
+          (caps :> < Cap.network ; Cap.tmp >)
           config
       in
 

--- a/src/osemgrep/cli_show/Show_subcommand.mli
+++ b/src/osemgrep/cli_show/Show_subcommand.mli
@@ -6,9 +6,10 @@
    This function returns an exit code to be passed to the 'exit' function.
    we need the network for the 'semgrep show identity/deployment'
 *)
-val main : < Cap.stdout ; Cap.network > -> string array -> Exit_code.t
+val main : < Cap.stdout ; Cap.network ; Cap.tmp > -> string array -> Exit_code.t
 
 (* called from main() but also from Scan_subcommand.ml to manage the legacy
  * way to show things (e.g., 'semgrep scan --show-supported-languages')
  *)
-val run_conf : < Cap.stdout ; Cap.network > -> Show_CLI.conf -> Exit_code.t
+val run_conf :
+  < Cap.stdout ; Cap.network ; Cap.tmp > -> Show_CLI.conf -> Exit_code.t

--- a/src/osemgrep/cli_test/Test_subcommand.ml
+++ b/src/osemgrep/cli_test/Test_subcommand.ml
@@ -17,7 +17,7 @@ module OutJ = Semgrep_output_v1_j
 (*****************************************************************************)
 (* Types and constants *)
 (*****************************************************************************)
-type caps = < Cap.stdout ; Cap.network >
+type caps = < Cap.stdout ; Cap.network ; Cap.tmp >
 
 (*****************************************************************************)
 (* Helpers *)
@@ -222,7 +222,9 @@ let run_conf (caps : caps) (conf : Test_CLI.conf) : Exit_code.t =
     | Test_CLI.File (path, config_str)
     | Test_CLI.Dir (path, Some config_str) ->
         let rule_files_and_rules =
-          rule_files_and_rules_of_config_string (caps :> Cap.network) config_str
+          rule_files_and_rules_of_config_string
+            (caps :> < Cap.network ; Cap.tmp >)
+            config_str
         in
         (* alt: use Find_targets.get_target_fpaths but then it requires
          * a Find_targets.conf, and this will respect the .semgrepignore

--- a/src/osemgrep/cli_test/Test_subcommand.mli
+++ b/src/osemgrep/cli_test/Test_subcommand.mli
@@ -5,9 +5,10 @@
 
    This function returns an exit code to be passed to the 'exit' function.
 *)
-val main : < Cap.stdout ; Cap.network > -> string array -> Exit_code.t
+val main : < Cap.stdout ; Cap.network ; Cap.tmp > -> string array -> Exit_code.t
 
 (* called from main() but also from Scan_subcommand.ml to manage the legacy
  * way to show things (e.g., 'semgrep scan --tests <dir>')
  *)
-val run_conf : < Cap.stdout ; Cap.network > -> Test_CLI.conf -> Exit_code.t
+val run_conf :
+  < Cap.stdout ; Cap.network ; Cap.tmp > -> Test_CLI.conf -> Exit_code.t

--- a/src/osemgrep/core/Auth.ml
+++ b/src/osemgrep/core/Auth.ml
@@ -13,8 +13,16 @@ let auth_header_of_token (Token str) = ("Authorization", "Bearer " ^ str)
 
 type cap_token = < token : token >
 
+(* ugly: can't factorize *)
 let cap_token_and_network token caps =
   object
     method network = caps#network
     method token = token
+  end
+
+let cap_token_and_network_and_tmp token caps =
+  object
+    method network = caps#network
+    method token = token
+    method tmp = caps#tmp
   end

--- a/src/osemgrep/core/Auth.mli
+++ b/src/osemgrep/core/Auth.mli
@@ -18,3 +18,8 @@ type cap_token = < token : token >
 
 val cap_token_and_network :
   token -> < Cap.network ; .. > -> < cap_token ; Cap.network >
+
+val cap_token_and_network_and_tmp :
+  token ->
+  < Cap.network ; Cap.tmp ; .. > ->
+  < cap_token ; Cap.network ; Cap.tmp >

--- a/src/osemgrep/language_server/LS.mli
+++ b/src/osemgrep/language_server/LS.mli
@@ -1,4 +1,4 @@
-val start : < Cap.random ; Cap.network > -> unit Lwt.t
+val start : < Cap.random ; Cap.network ; Cap.tmp > -> unit Lwt.t
 (** Entry point of the language server. This will start the server, and communicate over stdin/out using the Language Server Protocol *)
 
 (* exposed for testing purposes *)
@@ -10,5 +10,5 @@ module LanguageServer : sig
     RPC_server.t ->
     (RPC_server.t * Jsonrpc.Packet.t option) Lwt.t
 
-  val create : < Cap.random ; Cap.network > -> RPC_server.t
+  val create : < Cap.random ; Cap.network ; Cap.tmp > -> RPC_server.t
 end

--- a/src/osemgrep/language_server/Test_LS_e2e.mli
+++ b/src/osemgrep/language_server/Test_LS_e2e.mli
@@ -1,2 +1,2 @@
-val tests : < Cap.random ; Cap.network > -> Testo.test list
-val lwt_tests : < Cap.random ; Cap.network > -> Testo_lwt.test list
+val tests : < Cap.random ; Cap.network ; Cap.tmp > -> Testo.test list
+val lwt_tests : < Cap.random ; Cap.network ; Cap.tmp > -> Testo_lwt.test list

--- a/src/osemgrep/language_server/Unit_LS.mli
+++ b/src/osemgrep/language_server/Unit_LS.mli
@@ -1,1 +1,1 @@
-val tests : < Cap.random ; Cap.network > -> Testo.test list
+val tests : < Cap.random ; Cap.network ; Cap.tmp > -> Testo.test list

--- a/src/osemgrep/language_server/server/RPC_server.mli
+++ b/src/osemgrep/language_server/server/RPC_server.mli
@@ -79,5 +79,5 @@ end) : sig
   val handle_client_message :
     Jsonrpc.Packet.t -> t -> (t * Jsonrpc.Packet.t option) Lwt.t
 
-  val create : < Cap.random ; Cap.network > -> t
+  val create : < Cap.random ; Cap.network ; Cap.tmp > -> t
 end

--- a/src/osemgrep/language_server/server/Session.ml
+++ b/src/osemgrep/language_server/server/Session.ml
@@ -37,7 +37,7 @@ type t = {
   user_settings : User_settings.t;
   metrics : LS_metrics.t;
   is_intellij : bool;
-  caps : < Cap.random ; Cap.network >; [@opaque]
+  caps : < Cap.random ; Cap.network ; Cap.tmp >; [@opaque]
 }
 [@@deriving show]
 
@@ -76,7 +76,7 @@ let dirty_files_of_folder folder =
 
 (* TODO: registry caching is not anymore in semgrep-OSS! *)
 let decode_rules caps data =
-  UTmp.with_tmp_file ~str:data ~ext:"json" (fun file ->
+  CapTmp.with_tmp_file caps#tmp ~str:data ~ext:"json" (fun file ->
       match
         Rule_fetching.load_rules_from_file ~rewrite_rule_ids:false ~origin:App
           caps file

--- a/src/osemgrep/language_server/server/Session.mli
+++ b/src/osemgrep/language_server/server/Session.mli
@@ -29,13 +29,13 @@ type t = {
   user_settings : User_settings.t;
   metrics : LS_metrics.t;
   is_intellij : bool;
-  caps : < Cap.random ; Cap.network >; [@opaque]
+  caps : < Cap.random ; Cap.network ; Cap.tmp >; [@opaque]
 }
 
 val show : t -> string
 (** [show t] returns a string representation of the session *)
 
-val create : < Cap.random ; Cap.network > -> ServerCapabilities.t -> t
+val create : < Cap.random ; Cap.network ; Cap.tmp > -> ServerCapabilities.t -> t
 (** [create caps capabilities] creates a [Session.t] given server capabilities *)
 
 val send_metrics : t -> unit

--- a/src/osemgrep/networking/Rule_fetching.mli
+++ b/src/osemgrep/networking/Rule_fetching.mli
@@ -55,7 +55,7 @@ val rules_from_rules_source :
   token_opt:Auth.token option ->
   rewrite_rule_ids:bool ->
   strict:bool ->
-  < Cap.network > ->
+  < Cap.network ; Cap.tmp > ->
   Rules_source.t ->
   rules_and_origin list
 
@@ -64,7 +64,7 @@ val rules_from_rules_source_async :
   token_opt:Auth.token option ->
   rewrite_rule_ids:bool ->
   strict:bool ->
-  < Cap.network > ->
+  < Cap.network ; Cap.tmp > ->
   Rules_source.t ->
   rules_and_origin list Lwt.t
 
@@ -73,7 +73,7 @@ val rules_from_rules_source_async :
 val rules_from_dashdash_config_async :
   rewrite_rule_ids:bool ->
   token_opt:Auth.token option ->
-  < Cap.network ; .. > ->
+  < Cap.network ; Cap.tmp ; .. > ->
   Rules_config.t ->
   (rules_and_origin list * Rule.error list) Lwt.t
 
@@ -84,7 +84,7 @@ val rules_from_dashdash_config_async :
 val rules_from_dashdash_config :
   rewrite_rule_ids:bool ->
   token_opt:Auth.token option ->
-  < Cap.network ; .. > ->
+  < Cap.network ; Cap.tmp ; .. > ->
   Rules_config.t ->
   rules_and_origin list * Rule.error list
 
@@ -92,7 +92,7 @@ val rules_from_dashdash_config :
 val load_rules_from_file :
   rewrite_rule_ids:bool ->
   origin:origin ->
-  < Cap.network ; .. > ->
+  < Cap.network ; Cap.tmp ; .. > ->
   Fpath.t ->
   (rules_and_origin, Rule.error) Result.t
 
@@ -100,6 +100,6 @@ val load_rules_from_url :
   origin:origin ->
   ?token_opt:Auth.token option ->
   ?ext:string ->
-  < Cap.network ; .. > ->
+  < Cap.network ; Cap.tmp ; .. > ->
   Uri.t ->
   (rules_and_origin, Rule.error) Result.t

--- a/src/osemgrep/networking/Unit_Fetching.mli
+++ b/src/osemgrep/networking/Unit_Fetching.mli
@@ -1,1 +1,1 @@
-val tests : < Cap.network > -> Testo.test list
+val tests : < Cap.network ; Cap.tmp > -> Testo.test list

--- a/src/osemgrep/tests/Test_osemgrep.ml
+++ b/src/osemgrep/tests/Test_osemgrep.ml
@@ -107,5 +107,5 @@ let tests (caps : CLI.caps) =
     [
       test_scan_config_registry_no_token caps;
       test_scan_config_registry_with_invalid_token
-        (caps :> < Cap.stdout ; Cap.network >);
+        (caps :> < Cap.stdout ; Cap.network ; Cap.tmp >);
     ]

--- a/src/tests/Test.ml
+++ b/src/tests/Test.ml
@@ -68,10 +68,11 @@ let tests (caps : Cap.all_caps) =
       (* OSemgrep tests *)
       Unit_LS.tests (caps :> < Cap.random ; Cap.network ; Cap.tmp >);
       Unit_Login.tests caps;
-      Unit_Fetching.tests (caps :> < Cap.network >);
+      Unit_Fetching.tests (caps :> < Cap.network ; Cap.tmp >);
       Test_is_blocking_helpers.tests;
       Test_login_subcommand.tests (caps :> < Cap.stdout ; Cap.network >);
-      Test_publish_subcommand.tests (caps :> < Cap.stdout ; Cap.network >);
+      Test_publish_subcommand.tests
+        (caps :> < Cap.stdout ; Cap.network ; Cap.tmp >);
       Osemgrep_tests.tests (caps :> CLI.caps);
       (* Networking tests disabled as they will get rate limited sometimes *)
       (* And the SSL issues they've been testing have been stable *)

--- a/src/tests/Test.ml
+++ b/src/tests/Test.ml
@@ -66,7 +66,7 @@ let tests (caps : Cap.all_caps) =
       Unit_jsonnet.tests ();
       Unit_metachecking.tests ();
       (* OSemgrep tests *)
-      Unit_LS.tests (caps :> < Cap.random ; Cap.network >);
+      Unit_LS.tests (caps :> < Cap.random ; Cap.network ; Cap.tmp >);
       Unit_Login.tests caps;
       Unit_Fetching.tests (caps :> < Cap.network >);
       Test_is_blocking_helpers.tests;
@@ -76,7 +76,7 @@ let tests (caps : Cap.all_caps) =
       (* Networking tests disabled as they will get rate limited sometimes *)
       (* And the SSL issues they've been testing have been stable *)
       (*Unit_Networking.tests;*)
-      Test_LS_e2e.tests (caps :> < Cap.random ; Cap.network >);
+      Test_LS_e2e.tests (caps :> < Cap.random ; Cap.network ; Cap.tmp >);
       (* End OSemgrep tests *)
       Spacegrep_tests.Test.tests ();
       Aliengrep.Unit_tests.tests;


### PR DESCRIPTION
This makes the code more readable to know where we require
tmp. It also provides also good incentive to clean such code
and remove the need for /tmp, which often can speedup things.
Emma did that a long time ago for the parse_pattern many
functions.

test plan:
make check