### PR TITLE
Implement ci actions in osemgrep

### DIFF
--- a/src/osemgrep/cli_ci/Ci_subcommand.ml
+++ b/src/osemgrep/cli_ci/Ci_subcommand.ml
@@ -729,9 +729,7 @@ let run_conf (caps : caps) (ci_conf : Ci_CLI.conf) : Exit_code.t =
   let scan_id, scan_config, rules_and_origin =
     scan_config_and_rules_from_deployment ~dry_run prj_meta caps' depl
   in
-  (* TODO: we should use those fields! the pattern match is useless but it's
-   * just to get compilation error when we add new fields in scan_config
-   *)
+  (* TODO: we should use those fields! *)
   let {
     (* this is used in scan_config_and_rules_from_deployment *)
     OutJ.rule_config = _;
@@ -740,6 +738,8 @@ let run_conf (caps : caps) (ci_conf : Ci_CLI.conf) : Exit_code.t =
      *)
     deployment_id = _;
     deployment_name = _;
+    (* since 1.64.0 *)
+    actions;
     (* TODO: seems unused *)
     policy_names = _;
     (* TODO: lots of info in there to customize, should
@@ -758,6 +758,7 @@ let run_conf (caps : caps) (ci_conf : Ci_CLI.conf) : Exit_code.t =
   } =
     scan_config
   in
+  actions |> List.iter Eval_ci_action.eval;
 
   (* TODO:
      if dataflow_traces is None:

--- a/src/osemgrep/cli_ci/Eval_ci_action.ml
+++ b/src/osemgrep/cli_ci/Eval_ci_action.ml
@@ -1,0 +1,23 @@
+module OutJ = Semgrep_output_v1_j
+
+(*****************************************************************************)
+(* Prelude *)
+(*****************************************************************************)
+(* Actions are sent by the backend to the CLI to customize dynamically its
+ * behavior.
+ *
+ * This can be used for example to force people to update Semgrep.
+ *)
+
+(*****************************************************************************)
+(* Entry point *)
+(*****************************************************************************)
+
+let eval (action : OutJ.action) : unit =
+  match action with
+  | `Delay f -> Unix.sleepf f
+  | `Message str -> Logs.app (fun m -> m "%s" str)
+  | `Exit code ->
+      Error.exit_code_exn
+        (Exit_code.of_int ~__LOC__ ~code
+           ~description:"exit action from semgrep.dev")

--- a/src/osemgrep/cli_ci/Eval_ci_action.mli
+++ b/src/osemgrep/cli_ci/Eval_ci_action.mli
@@ -1,0 +1,2 @@
+(* this may raise exn like Error.Exit_code *)
+val eval : Semgrep_output_v1_t.action -> unit


### PR DESCRIPTION
test plan:
not really, as they can't be generated easily from the backend yet,
but we need this ASAP so that we can customize at least
semgrep CLI starting at 1.64.0