### PR TITLE
feat(osemgrep): files-only output

### DIFF
--- a/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -46,7 +46,6 @@ type conf = {
   output : string option;
   output_conf : Output.conf;
   incremental_output : bool;
-  files_only : bool;
   (* Networking options *)
   metrics : Metrics_.config;
   version_check : bool;
@@ -111,7 +110,6 @@ let default : conf =
     output = None;
     output_conf = Output.default;
     incremental_output = false;
-    files_only = false;
     rewrite_rule_ids = true;
     (* will send metrics only if the user uses the registry or the app *)
     metrics = Metrics_.Auto;
@@ -1217,7 +1215,6 @@ let cmdline_term caps ~allow_empty_config : conf Term.t =
       output;
       output_conf;
       incremental_output;
-      files_only;
       engine_type;
       rewrite_rule_ids;
       common;

--- a/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -472,7 +472,7 @@ let o_incremental_output : bool Term.t =
 
 let o_files_only : bool Term.t =
   let info =
-    Arg.info [ "files_only" ]
+    Arg.info [ "files-only" ]
       ~doc:{|Output only the names of files containing matches|}
   in
   Arg.value (Arg.flag info)

--- a/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -468,9 +468,10 @@ let o_incremental_output : bool Term.t =
   in
   Arg.value (Arg.flag info)
 
-let o_files_only : bool Term.t =
+(* osemgrep-only: *)
+let o_files_with_matches : bool Term.t =
   let info =
-    Arg.info [ "files-only" ]
+    Arg.info [ "files-with-matches" ]
       ~doc:{|Output only the names of files containing matches|}
   in
   Arg.value (Arg.flag info)
@@ -880,7 +881,7 @@ let cmdline_term caps ~allow_empty_config : conf Term.t =
    * of the corresponding '$ o_xx $' further below! *)
   let combine allow_untrusted_validators autofix baseline_commit common config
       dataflow_traces diff_depth dryrun dump_ast dump_command_for_core
-      dump_engine_path emacs error exclude_ exclude_rule_ids files_only
+      dump_engine_path emacs error exclude_ exclude_rule_ids files_with_matches
       force_color gitlab_sast gitlab_secrets include_ incremental_output json
       junit_xml lang ls matching_explanations max_chars_per_line
       max_lines_per_finding max_memory_mb max_target_bytes metrics num_jobs
@@ -945,7 +946,7 @@ let cmdline_term caps ~allow_empty_config : conf Term.t =
           "Mutually exclusive options --json/--emacs/--vim/--sarif/...";
       match () with
       | _ when text -> Output_format.Text
-      | _ when files_only -> Output_format.Files_only
+      | _ when files_with_matches -> Output_format.Files_with_matches
       | _ when json -> Output_format.Json
       | _ when emacs -> Output_format.Emacs
       | _ when vim -> Output_format.Vim
@@ -1234,7 +1235,7 @@ let cmdline_term caps ~allow_empty_config : conf Term.t =
     const combine $ o_allow_untrusted_validators $ o_autofix $ o_baseline_commit
     $ CLI_common.o_common $ o_config $ o_dataflow_traces $ o_diff_depth
     $ o_dryrun $ o_dump_ast $ o_dump_command_for_core $ o_dump_engine_path
-    $ o_emacs $ o_error $ o_exclude $ o_exclude_rule_ids $ o_files_only
+    $ o_emacs $ o_error $ o_exclude $ o_exclude_rule_ids $ o_files_with_matches
     $ o_force_color $ o_gitlab_sast $ o_gitlab_secrets $ o_include
     $ o_incremental_output $ o_json $ o_junit_xml $ o_lang $ o_ls
     $ o_matching_explanations $ o_max_chars_per_line $ o_max_lines_per_finding

--- a/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -46,6 +46,7 @@ type conf = {
   output : string option;
   output_conf : Output.conf;
   incremental_output : bool;
+  files_only : bool;
   (* Networking options *)
   metrics : Metrics_.config;
   version_check : bool;
@@ -110,6 +111,7 @@ let default : conf =
     output = None;
     output_conf = Output.default;
     incremental_output = false;
+    files_only = false;
     rewrite_rule_ids = true;
     (* will send metrics only if the user uses the registry or the app *)
     metrics = Metrics_.Auto;
@@ -465,6 +467,13 @@ let o_json : bool Term.t =
 let o_incremental_output : bool Term.t =
   let info =
     Arg.info [ "incremental-output" ] ~doc:{|Output results incrementally.|}
+  in
+  Arg.value (Arg.flag info)
+
+let o_files_only : bool Term.t =
+  let info =
+    Arg.info [ "files_only" ]
+      ~doc:{|Output only the names of files containing matches|}
   in
   Arg.value (Arg.flag info)
 
@@ -873,16 +882,16 @@ let cmdline_term caps ~allow_empty_config : conf Term.t =
    * of the corresponding '$ o_xx $' further below! *)
   let combine allow_untrusted_validators autofix baseline_commit common config
       dataflow_traces diff_depth dryrun dump_ast dump_command_for_core
-      dump_engine_path emacs error exclude_ exclude_rule_ids force_color
-      gitlab_sast gitlab_secrets include_ incremental_output json junit_xml lang
-      ls matching_explanations max_chars_per_line max_lines_per_finding
-      max_memory_mb max_target_bytes metrics num_jobs no_secrets_validation
-      nosem optimizations oss output pattern pro project_root pro_intrafile
-      pro_lang remote replacement respect_gitignore rewrite_rule_ids sarif
-      scan_unknown_extensions secrets severity show_supported_languages strict
-      target_roots test test_ignore_todo text time_flag timeout
-      _timeout_interfileTODO timeout_threshold trace validate version
-      version_check vim =
+      dump_engine_path emacs error exclude_ exclude_rule_ids files_only
+      force_color gitlab_sast gitlab_secrets include_ incremental_output json
+      junit_xml lang ls matching_explanations max_chars_per_line
+      max_lines_per_finding max_memory_mb max_target_bytes metrics num_jobs
+      no_secrets_validation nosem optimizations oss output pattern pro
+      project_root pro_intrafile pro_lang remote replacement respect_gitignore
+      rewrite_rule_ids sarif scan_unknown_extensions secrets severity
+      show_supported_languages strict target_roots test test_ignore_todo text
+      time_flag timeout _timeout_interfileTODO timeout_threshold trace validate
+      version version_check vim =
     (* ugly: call setup_logging ASAP so the Logs.xxx below are displayed
      * correctly *)
     Std_msg.setup ?highlight_setting:(if force_color then Some On else None) ();
@@ -938,6 +947,7 @@ let cmdline_term caps ~allow_empty_config : conf Term.t =
           "Mutually exclusive options --json/--emacs/--vim/--sarif/...";
       match () with
       | _ when text -> Output_format.Text
+      | _ when files_only -> Output_format.Files_only
       | _ when json -> Output_format.Json
       | _ when emacs -> Output_format.Emacs
       | _ when vim -> Output_format.Vim
@@ -1207,6 +1217,7 @@ let cmdline_term caps ~allow_empty_config : conf Term.t =
       output;
       output_conf;
       incremental_output;
+      files_only;
       engine_type;
       rewrite_rule_ids;
       common;
@@ -1226,15 +1237,15 @@ let cmdline_term caps ~allow_empty_config : conf Term.t =
     const combine $ o_allow_untrusted_validators $ o_autofix $ o_baseline_commit
     $ CLI_common.o_common $ o_config $ o_dataflow_traces $ o_diff_depth
     $ o_dryrun $ o_dump_ast $ o_dump_command_for_core $ o_dump_engine_path
-    $ o_emacs $ o_error $ o_exclude $ o_exclude_rule_ids $ o_force_color
-    $ o_gitlab_sast $ o_gitlab_secrets $ o_include $ o_incremental_output
-    $ o_json $ o_junit_xml $ o_lang $ o_ls $ o_matching_explanations
-    $ o_max_chars_per_line $ o_max_lines_per_finding $ o_max_memory_mb
-    $ o_max_target_bytes $ o_metrics $ o_num_jobs $ o_no_secrets_validation
-    $ o_nosem $ o_optimizations $ o_oss $ o_output $ o_pattern $ o_pro
-    $ o_project_root $ o_pro_intrafile $ o_pro_languages $ o_remote
-    $ o_replacement $ o_respect_gitignore $ o_rewrite_rule_ids $ o_sarif
-    $ o_scan_unknown_extensions $ o_secrets $ o_severity
+    $ o_emacs $ o_error $ o_exclude $ o_exclude_rule_ids $ o_files_only
+    $ o_force_color $ o_gitlab_sast $ o_gitlab_secrets $ o_include
+    $ o_incremental_output $ o_json $ o_junit_xml $ o_lang $ o_ls
+    $ o_matching_explanations $ o_max_chars_per_line $ o_max_lines_per_finding
+    $ o_max_memory_mb $ o_max_target_bytes $ o_metrics $ o_num_jobs
+    $ o_no_secrets_validation $ o_nosem $ o_optimizations $ o_oss $ o_output
+    $ o_pattern $ o_pro $ o_project_root $ o_pro_intrafile $ o_pro_languages
+    $ o_remote $ o_replacement $ o_respect_gitignore $ o_rewrite_rule_ids
+    $ o_sarif $ o_scan_unknown_extensions $ o_secrets $ o_severity
     $ o_show_supported_languages $ o_strict $ o_target_roots $ o_test
     $ Test_CLI.o_test_ignore_todo $ o_text $ o_time $ o_timeout
     $ o_timeout_interfile $ o_timeout_threshold $ o_trace $ o_validate

--- a/src/osemgrep/cli_scan/Scan_CLI.mli
+++ b/src/osemgrep/cli_scan/Scan_CLI.mli
@@ -25,7 +25,6 @@ type conf = {
   output_conf : Output.conf;
   (* osemgrep-only: *)
   incremental_output : bool;
-  files_only : bool;
   (* text output config (TODO: make a separate type gathering all of them)
    * or add them under Output_format.Text
    *)

--- a/src/osemgrep/cli_scan/Scan_CLI.mli
+++ b/src/osemgrep/cli_scan/Scan_CLI.mli
@@ -25,6 +25,7 @@ type conf = {
   output_conf : Output.conf;
   (* osemgrep-only: *)
   incremental_output : bool;
+  files_only : bool;
   (* text output config (TODO: make a separate type gathering all of them)
    * or add them under Output_format.Text
    *)

--- a/src/osemgrep/reporting/Output.ml
+++ b/src/osemgrep/reporting/Output.ml
@@ -150,6 +150,14 @@ let dispatch_output_format (output_format : Output_format.t) (conf : conf)
         Gitlab_output.secrets_output cli_output.results
       in
       Out.put (Yojson.Basic.to_string gitlab_secrets_json)
+  | Files_only ->
+      let files =
+        List.fold_left
+          (fun acc (m : OutJ.cli_match) ->
+            Common2.StringSet.add (Fpath.to_string m.path) acc)
+          Common2.StringSet.empty cli_output.results
+      in
+      Out.put (files |> Common2.StringSet.to_list |> String.concat "\n")
 
 (*****************************************************************************)
 (* Entry points *)

--- a/src/osemgrep/reporting/Output.ml
+++ b/src/osemgrep/reporting/Output.ml
@@ -150,14 +150,11 @@ let dispatch_output_format (output_format : Output_format.t) (conf : conf)
         Gitlab_output.secrets_output cli_output.results
       in
       Out.put (Yojson.Basic.to_string gitlab_secrets_json)
-  | Files_only ->
-      let files =
-        List.fold_left
-          (fun acc (m : OutJ.cli_match) ->
-            Common2.StringSet.add (Fpath.to_string m.path) acc)
-          Common2.StringSet.empty cli_output.results
-      in
-      Out.put (files |> Common2.StringSet.to_list |> String.concat "\n")
+  | Files_with_matches ->
+      cli_output.results
+      |> List_.map (fun (x : OutT.cli_match) -> !!(x.path))
+      |> Set_.of_list |> Set_.elements |> List_.sort |> String.concat "\n"
+      |> Out.put
 
 (*****************************************************************************)
 (* Entry points *)

--- a/src/osemgrep/reporting/Output_format.ml
+++ b/src/osemgrep/reporting/Output_format.ml
@@ -12,6 +12,7 @@ type t =
   | Gitlab_sast
   | Gitlab_secrets
   | Junit_xml
+  | Files_only
   (* used to disable the final display of match results because
    * we displayed them incrementally instead
    *)
@@ -27,5 +28,6 @@ let keep_ignores = function
   | Gitlab_sast
   | Gitlab_secrets
   | Junit_xml
+  | Files_only
   | Incremental ->
       false

--- a/src/osemgrep/reporting/Output_format.ml
+++ b/src/osemgrep/reporting/Output_format.ml
@@ -12,7 +12,7 @@ type t =
   | Gitlab_sast
   | Gitlab_secrets
   | Junit_xml
-  | Files_only
+  | Files_with_matches
   (* used to disable the final display of match results because
    * we displayed them incrementally instead
    *)
@@ -28,6 +28,6 @@ let keep_ignores = function
   | Gitlab_sast
   | Gitlab_secrets
   | Junit_xml
-  | Files_only
+  | Files_with_matches
   | Incremental ->
       false


### PR DESCRIPTION
## What:
This PR adds a `--files_only` flag to `osemgrep`, which will cause Semgrep to only output a newline-separated list of all the unique files which produce matches.

## Why:
When doing the mass autofix migration in `semgrep-app`, I needed to insert an import into each file which also had a match according to some Semgrep rule. There wasn't an easy way for me to do this, though, as I had to obtain the JSON output and then programmatically inspect it with Python to get that working.

Scripting with Semgrep would be easier if you could easily pipe the files matched into some other code, so that's what this does.

## Test plan:
![image](https://github.com/semgrep/semgrep/assets/49291449/9a83cfe1-68a9-4489-9091-d49f48962bae)

You can also do cool things with this flag, like see how many files in `semgrep-rules` which are using rule features that are not present in Simple Mode!
![image](https://github.com/semgrep/semgrep/assets/49291449/c76cbbfe-fa0c-40d9-8f31-81642a0a9012)
