### PR TITLE
Scan unedited lockfiles in diff-aware scans

### DIFF
--- a/changelog.d/gh-9899.added
+++ b/changelog.d/gh-9899.added
@@ -1,0 +1,1 @@
+Scan un-changed lockfiles in diff-aware scans

--- a/cli/src/semgrep/dependency_aware_rule.py
+++ b/cli/src/semgrep/dependency_aware_rule.py
@@ -163,7 +163,7 @@ def generate_reachable_sca_findings(
         for match in matches:
             try:
                 lockfile_path = target_manager.find_single_lockfile(
-                    match.path, ecosystem
+                    match.path, ecosystem, ignore_baseline_handler=True
                 )
                 if lockfile_path is None:
                     continue

--- a/cli/src/semgrep/run_scan.py
+++ b/cli/src/semgrep/run_scan.py
@@ -289,7 +289,9 @@ def run_rules(
 
         # Generate stats per lockfile:
         for ecosystem in ECOSYSTEM_TO_LOCKFILES.keys():
-            for lockfile in target_manager.get_lockfiles(ecosystem):
+            for lockfile in target_manager.get_lockfiles(
+                ecosystem, ignore_baseline_handler=True
+            ):
                 # Add lockfiles as a target that was scanned
                 output_extra.all_targets.add(lockfile)
                 # Warning temporal assumption: this is the only place we process

--- a/cli/src/semgrep/target_manager.py
+++ b/cli/src/semgrep/target_manager.py
@@ -496,7 +496,7 @@ class Target:
         )
 
     @lru_cache(maxsize=None)
-    def files(self) -> FrozenSet[Path]:
+    def files(self, ignore_baseline_handler: bool = False) -> FrozenSet[Path]:
         """
         Recursively go through a directory and return list of all files with
         default file extension of language
@@ -505,6 +505,10 @@ class Target:
             return frozenset([self.path])
 
         if self.baseline_handler is not None:
+            # Adding this conditional to scan all lockfiles for their dependencies, even in diff-aware scans
+            if ignore_baseline_handler:
+                return self.files_from_filesystem()
+
             try:
                 return self.files_from_git_diff()
             except (subprocess.CalledProcessError, FileNotFoundError):
@@ -718,12 +722,17 @@ class TargetManager:
         return FilteredFiles(frozenset(kept), frozenset(removed))
 
     @lru_cache(maxsize=None)
-    def get_all_files(self) -> FrozenSet[Path]:
-        return frozenset(f for target in self.targets for f in target.files())
+    def get_all_files(self, ignore_baseline_handler: bool = False) -> FrozenSet[Path]:
+        return frozenset(
+            f for target in self.targets for f in target.files(ignore_baseline_handler)
+        )
 
     @lru_cache(maxsize=None)
     def get_files_for_language(
-        self, lang: Union[None, Language, Ecosystem], product: out.Product
+        self,
+        lang: Union[None, Language, Ecosystem],
+        product: out.Product,
+        ignore_baseline_handler: bool = False,
     ) -> FilteredFiles:
         """
         Return all files that are decendants of any directory in TARGET that have
@@ -734,7 +743,7 @@ class TargetManager:
 
         Note also filters out any directory and descendants of `.git`
         """
-        all_files = self.get_all_files()
+        all_files = self.get_all_files(ignore_baseline_handler)
 
         if lang:
             files = self.filter_by_language(lang, candidates=all_files)
@@ -833,16 +842,23 @@ class TargetManager:
 
     @lru_cache(maxsize=None)
     def get_lockfiles(
-        self, ecosystem: Ecosystem, product: out.Product = SCA_PRODUCT
+        self,
+        ecosystem: Ecosystem,
+        product: out.Product = SCA_PRODUCT,
+        ignore_baseline_handler: bool = False,
     ) -> FrozenSet[Path]:
         """
         Return set of paths to lockfiles for a given ecosystem
 
         Respects semgrepignore/exclude flag
         """
-        return self.get_files_for_language(ecosystem, product).kept
+        return self.get_files_for_language(
+            ecosystem, product, ignore_baseline_handler
+        ).kept
 
-    def find_single_lockfile(self, p: Path, ecosystem: Ecosystem) -> Optional[Path]:
+    def find_single_lockfile(
+        self, p: Path, ecosystem: Ecosystem, ignore_baseline_handler: bool = False
+    ) -> Optional[Path]:
         """
         Find the nearest lockfile in a given ecosystem to P
         Searches only up the directory tree
@@ -850,7 +866,9 @@ class TargetManager:
         If lockfile not in self.get_lockfiles(ecosystem) then return None
         this would happen if the lockfile is ignored by a .semgrepignore or --exclude
         """
-        candidates = self.get_lockfiles(ecosystem)
+        candidates = self.get_lockfiles(
+            ecosystem, ignore_baseline_handler=ignore_baseline_handler
+        )
 
         for path in p.parents:
             for lockfile_pattern in ECOSYSTEM_TO_LOCKFILES[ecosystem]:

--- a/cli/src/semgrep/target_manager.py
+++ b/cli/src/semgrep/target_manager.py
@@ -500,6 +500,8 @@ class Target:
         """
         Recursively go through a directory and return list of all files with
         default file extension of language
+
+        ignore_baseline_handler: if True, will ignore the baseline handler and scan all files. Used in the context of scanning unchanged lockfiles for their dependencies and doing reachability analysis.
         """
         if not self.path.is_dir() and self.path.is_file():
             return frozenset([self.path])
@@ -742,6 +744,8 @@ class TargetManager:
         it is also filtered out
 
         Note also filters out any directory and descendants of `.git`
+
+        ignore_baseline_handler: if True, will ignore the baseline handler and scan all files. Used in the context of scanning unchanged lockfiles for their dependencies and doing reachability analysis.
         """
         all_files = self.get_all_files(ignore_baseline_handler)
 
@@ -851,6 +855,8 @@ class TargetManager:
         Return set of paths to lockfiles for a given ecosystem
 
         Respects semgrepignore/exclude flag
+
+        ignore_baseline_handler: if True, will ignore the baseline handler and scan all files. Used in the context of scanning unchanged lockfiles for their dependencies and doing reachability analysis.
         """
         return self.get_files_for_language(
             ecosystem, product, ignore_baseline_handler
@@ -865,6 +871,8 @@ class TargetManager:
 
         If lockfile not in self.get_lockfiles(ecosystem) then return None
         this would happen if the lockfile is ignored by a .semgrepignore or --exclude
+
+        ignore_baseline_handler: if True, will pass the value downstream and scan all files. Used in the context of scanning unchanged lockfiles for their dependencies and doing reachability analysis.
         """
         candidates = self.get_lockfiles(
             ecosystem, ignore_baseline_handler=ignore_baseline_handler

--- a/cli/tests/default/e2e-pro/snapshots/test_ci/test_full_run/autofix-github-pr-semgrepconfig/findings_and_ignores.json
+++ b/cli/tests/default/e2e-pro/snapshots/test_ci/test_full_run/autofix-github-pr-semgrepconfig/findings_and_ignores.json
@@ -547,7 +547,9 @@
   ],
   "token": null,
   "searched_paths": [
-    "foo.py"
+    "foo.py",
+    "poetry.lock",
+    "yarn.lock"
   ],
   "renamed_paths": [],
   "rule_ids": [

--- a/cli/tests/default/e2e-pro/snapshots/test_ci/test_full_run/autofix-github-pr/findings_and_ignores.json
+++ b/cli/tests/default/e2e-pro/snapshots/test_ci/test_full_run/autofix-github-pr/findings_and_ignores.json
@@ -547,7 +547,9 @@
   ],
   "token": null,
   "searched_paths": [
-    "foo.py"
+    "foo.py",
+    "poetry.lock",
+    "yarn.lock"
   ],
   "renamed_paths": [],
   "rule_ids": [

--- a/cli/tests/default/e2e-pro/snapshots/test_ci/test_full_run/autofix-gitlab-special-env-vars/findings_and_ignores.json
+++ b/cli/tests/default/e2e-pro/snapshots/test_ci/test_full_run/autofix-gitlab-special-env-vars/findings_and_ignores.json
@@ -547,7 +547,9 @@
   ],
   "token": null,
   "searched_paths": [
-    "foo.py"
+    "foo.py",
+    "poetry.lock",
+    "yarn.lock"
   ],
   "renamed_paths": [],
   "rule_ids": [

--- a/cli/tests/default/e2e-pro/snapshots/test_ci/test_full_run/autofix-gitlab/findings_and_ignores.json
+++ b/cli/tests/default/e2e-pro/snapshots/test_ci/test_full_run/autofix-gitlab/findings_and_ignores.json
@@ -547,7 +547,9 @@
   ],
   "token": null,
   "searched_paths": [
-    "foo.py"
+    "foo.py",
+    "poetry.lock",
+    "yarn.lock"
   ],
   "renamed_paths": [],
   "rule_ids": [

--- a/cli/tests/default/e2e-pro/snapshots/test_ci/test_full_run/noautofix-github-pr-semgrepconfig/findings_and_ignores.json
+++ b/cli/tests/default/e2e-pro/snapshots/test_ci/test_full_run/noautofix-github-pr-semgrepconfig/findings_and_ignores.json
@@ -541,7 +541,9 @@
   ],
   "token": null,
   "searched_paths": [
-    "foo.py"
+    "foo.py",
+    "poetry.lock",
+    "yarn.lock"
   ],
   "renamed_paths": [],
   "rule_ids": [

--- a/cli/tests/default/e2e-pro/snapshots/test_ci/test_full_run/noautofix-github-pr/findings_and_ignores.json
+++ b/cli/tests/default/e2e-pro/snapshots/test_ci/test_full_run/noautofix-github-pr/findings_and_ignores.json
@@ -541,7 +541,9 @@
   ],
   "token": null,
   "searched_paths": [
-    "foo.py"
+    "foo.py",
+    "poetry.lock",
+    "yarn.lock"
   ],
   "renamed_paths": [],
   "rule_ids": [

--- a/cli/tests/default/e2e-pro/snapshots/test_ci/test_full_run/noautofix-gitlab-special-env-vars/findings_and_ignores.json
+++ b/cli/tests/default/e2e-pro/snapshots/test_ci/test_full_run/noautofix-gitlab-special-env-vars/findings_and_ignores.json
@@ -541,7 +541,9 @@
   ],
   "token": null,
   "searched_paths": [
-    "foo.py"
+    "foo.py",
+    "poetry.lock",
+    "yarn.lock"
   ],
   "renamed_paths": [],
   "rule_ids": [

--- a/cli/tests/default/e2e-pro/snapshots/test_ci/test_full_run/noautofix-gitlab/findings_and_ignores.json
+++ b/cli/tests/default/e2e-pro/snapshots/test_ci/test_full_run/noautofix-gitlab/findings_and_ignores.json
@@ -541,7 +541,9 @@
   ],
   "token": null,
   "searched_paths": [
-    "foo.py"
+    "foo.py",
+    "poetry.lock",
+    "yarn.lock"
   ],
   "renamed_paths": [],
   "rule_ids": [

--- a/cli/tests/default/e2e-pro/snapshots/test_ci/test_reachable_and_unreachable_diff_scan_findings/config/base_output.txt
+++ b/cli/tests/default/e2e-pro/snapshots/test_ci/test_reachable_and_unreachable_diff_scan_findings/config/base_output.txt
@@ -53,6 +53,11 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
   Initializing scan (deployment=org_name, scan_id=12345)
   Enabled products: Code, Supply Chain
 
+  ENGINE
+  Using Semgrep Pro Version: <MASKED>
+  Installed at <MASKED>
+
+
 ┌─────────────┐
 │ Scan Status │
 └─────────────┘

--- a/cli/tests/default/e2e-pro/snapshots/test_ci/test_reachable_and_unreachable_diff_scan_findings/config/base_output.txt
+++ b/cli/tests/default/e2e-pro/snapshots/test_ci/test_reachable_and_unreachable_diff_scan_findings/config/base_output.txt
@@ -46,7 +46,7 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
 └────────────────┘
 
   SCAN ENVIRONMENT
-  versions    - semgrep <MASKED> on python 3.11.8
+  versions    - semgrep <MASKED> on python <MASKED>
   environment - running in environment git, triggering event is unknown
 
   CONNECTION
@@ -64,12 +64,12 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
 
   SUPPLY CHAIN RULES
 
-  Ecosystem   Rules   Files   Lockfiles   
+  Ecosystem   Rules   Files   Lockfiles
  ─────────────────────────────────────────
   Pypi            3       1   poetry.lock
 
 
-  Analysis   Rules 
+  Analysis   Rules
  ──────────────────
   Basic          2
   Unknown        1
@@ -94,88 +94,9 @@ CI scan completed successfully.
 === end of stderr - plain
 
 === stdout - color
-
-
-┌───────────────────────────────────┐
-│ 2 Reachable Supply Chain Findings │
-└───────────────────────────────────┘
-
-    poetry.lock
-   ❯❯❱ [1msupply-chain-parity-2[0m
-          found another dependency without a pattern
-
-           10┆ name = "mypy"
-
-   ❯❯❱ [1msupply-chain-parity-1[0m
-          found a dependency
-
-           18┆ name = "python-dateutil"
-
-
-┌────────────────────────────────────┐
-│ 1 Unreachable Supply Chain Finding │
-└────────────────────────────────────┘
-
-    poetry.lock
-   ❯❯❱ [1msupply-chain-reachable-1[0m
-          found a reachable vulnerability from a dependency
-
-           10┆ name = "mypy"
-
-
+<same as above: stdout - plain>
 === end of stdout - color
 
 === stderr - color
-
-
-┌────────────────┐
-│ Debugging Info │
-└────────────────┘
-
-  [4mSCAN ENVIRONMENT[0m
-  versions    - semgrep [1m<MASKED>[0m on python [1m3.11.8[0m
-  environment - running in environment [1mgit[0m, triggering event is [1munknown[0m
-
-  [4mCONNECTION[0m
-  Initializing scan (deployment=org_name, scan_id=12345)
-  Enabled products: [1mCode, Supply Chain[0m
-
-┌─────────────┐
-│ Scan Status │
-└─────────────┘
-  Scanning 4 files tracked by git with 0 Code rules, 3 Supply Chain rules:
-
-
-  [4mCODE RULES[0m
-  Nothing to scan.
-
-  [4mSUPPLY CHAIN RULES[0m
-
- [1m [0m[1mEcosystem[0m[1m [0m [1m [0m[1mRules[0m[1m [0m [1m [0m[1mFiles[0m[1m [0m [1m [0m[1mLockfiles  [0m[1m [0m
- ─────────────────────────────────────────
-  Pypi            3       1   poetry.lock
-
-
- [1m [0m[1mAnalysis[0m[1m [0m [1m [0m[1mRules[0m[1m [0m
- ──────────────────
-  Basic          2
-  Unknown        1
-
-
-
-┌──────────────┐
-│ Scan Summary │
-└──────────────┘
-Some files were skipped or only partially analyzed.
-  Scan was limited to files tracked by git.
-
-CI scan completed successfully.
-  Found 3 findings (2 blocking) from 3 rules.
-  Uploading scan results
-  Finalizing scan           View results in Semgrep Cloud Platform:
-    https://semgrep.dev/orgs/org_name/findings?repo=local_scan/checkout_project_name&ref=some/branch-name
-    https://semgrep.dev/orgs/org_name/supply-chain
-  Has findings for blocking rules so exiting with code 1
-  semgrep.dev is suggesting a non-zero exit code (Test Reason)
-
+<same as above: stderr - plain>
 === end of stderr - color

--- a/cli/tests/default/e2e-pro/snapshots/test_ci/test_reachable_and_unreachable_diff_scan_findings/config/base_output.txt
+++ b/cli/tests/default/e2e-pro/snapshots/test_ci/test_reachable_and_unreachable_diff_scan_findings/config/base_output.txt
@@ -1,0 +1,181 @@
+=== command
+SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERSION_CACHE_PATH="<MASKED>" SEMGREP_ENABLE_VERSION_CHECK="0" SEMGREP_SEND_METRICS="off" semgrep ci --no-suppress-errors
+=== end of command
+
+=== exit code
+1
+=== end of exit code
+
+=== stdout - plain
+
+
+┌───────────────────────────────────┐
+│ 2 Reachable Supply Chain Findings │
+└───────────────────────────────────┘
+
+    poetry.lock
+   ❯❯❱ supply-chain-parity-2
+          found another dependency without a pattern
+
+           10┆ name = "mypy"
+
+   ❯❯❱ supply-chain-parity-1
+          found a dependency
+
+           18┆ name = "python-dateutil"
+
+
+┌────────────────────────────────────┐
+│ 1 Unreachable Supply Chain Finding │
+└────────────────────────────────────┘
+
+    poetry.lock
+   ❯❯❱ supply-chain-reachable-1
+          found a reachable vulnerability from a dependency
+
+           10┆ name = "mypy"
+
+
+=== end of stdout - plain
+
+=== stderr - plain
+
+
+┌────────────────┐
+│ Debugging Info │
+└────────────────┘
+
+  SCAN ENVIRONMENT
+  versions    - semgrep <MASKED> on python 3.11.8
+  environment - running in environment git, triggering event is unknown
+
+  CONNECTION
+  Initializing scan (deployment=org_name, scan_id=12345)
+  Enabled products: Code, Supply Chain
+
+┌─────────────┐
+│ Scan Status │
+└─────────────┘
+  Scanning 4 files tracked by git with 0 Code rules, 3 Supply Chain rules:
+
+
+  CODE RULES
+  Nothing to scan.
+
+  SUPPLY CHAIN RULES
+
+  Ecosystem   Rules   Files   Lockfiles   
+ ─────────────────────────────────────────
+  Pypi            3       1   poetry.lock
+
+
+  Analysis   Rules 
+ ──────────────────
+  Basic          2
+  Unknown        1
+
+
+
+┌──────────────┐
+│ Scan Summary │
+└──────────────┘
+Some files were skipped or only partially analyzed.
+  Scan was limited to files tracked by git.
+
+CI scan completed successfully.
+  Found 3 findings (2 blocking) from 3 rules.
+  Uploading scan results
+  Finalizing scan           View results in Semgrep Cloud Platform:
+    https://semgrep.dev/orgs/org_name/findings?repo=local_scan/checkout_project_name&ref=some/branch-name
+    https://semgrep.dev/orgs/org_name/supply-chain
+  Has findings for blocking rules so exiting with code 1
+  semgrep.dev is suggesting a non-zero exit code (Test Reason)
+
+=== end of stderr - plain
+
+=== stdout - color
+
+
+┌───────────────────────────────────┐
+│ 2 Reachable Supply Chain Findings │
+└───────────────────────────────────┘
+
+    poetry.lock
+   ❯❯❱ [1msupply-chain-parity-2[0m
+          found another dependency without a pattern
+
+           10┆ name = "mypy"
+
+   ❯❯❱ [1msupply-chain-parity-1[0m
+          found a dependency
+
+           18┆ name = "python-dateutil"
+
+
+┌────────────────────────────────────┐
+│ 1 Unreachable Supply Chain Finding │
+└────────────────────────────────────┘
+
+    poetry.lock
+   ❯❯❱ [1msupply-chain-reachable-1[0m
+          found a reachable vulnerability from a dependency
+
+           10┆ name = "mypy"
+
+
+=== end of stdout - color
+
+=== stderr - color
+
+
+┌────────────────┐
+│ Debugging Info │
+└────────────────┘
+
+  [4mSCAN ENVIRONMENT[0m
+  versions    - semgrep [1m<MASKED>[0m on python [1m3.11.8[0m
+  environment - running in environment [1mgit[0m, triggering event is [1munknown[0m
+
+  [4mCONNECTION[0m
+  Initializing scan (deployment=org_name, scan_id=12345)
+  Enabled products: [1mCode, Supply Chain[0m
+
+┌─────────────┐
+│ Scan Status │
+└─────────────┘
+  Scanning 4 files tracked by git with 0 Code rules, 3 Supply Chain rules:
+
+
+  [4mCODE RULES[0m
+  Nothing to scan.
+
+  [4mSUPPLY CHAIN RULES[0m
+
+ [1m [0m[1mEcosystem[0m[1m [0m [1m [0m[1mRules[0m[1m [0m [1m [0m[1mFiles[0m[1m [0m [1m [0m[1mLockfiles  [0m[1m [0m
+ ─────────────────────────────────────────
+  Pypi            3       1   poetry.lock
+
+
+ [1m [0m[1mAnalysis[0m[1m [0m [1m [0m[1mRules[0m[1m [0m
+ ──────────────────
+  Basic          2
+  Unknown        1
+
+
+
+┌──────────────┐
+│ Scan Summary │
+└──────────────┘
+Some files were skipped or only partially analyzed.
+  Scan was limited to files tracked by git.
+
+CI scan completed successfully.
+  Found 3 findings (2 blocking) from 3 rules.
+  Uploading scan results
+  Finalizing scan           View results in Semgrep Cloud Platform:
+    https://semgrep.dev/orgs/org_name/findings?repo=local_scan/checkout_project_name&ref=some/branch-name
+    https://semgrep.dev/orgs/org_name/supply-chain
+  Has findings for blocking rules so exiting with code 1
+  semgrep.dev is suggesting a non-zero exit code (Test Reason)
+
+=== end of stderr - color

--- a/cli/tests/default/e2e-pro/snapshots/test_ci/test_reachable_and_unreachable_diff_scan_findings/config/new_output.txt
+++ b/cli/tests/default/e2e-pro/snapshots/test_ci/test_reachable_and_unreachable_diff_scan_findings/config/new_output.txt
@@ -1,0 +1,143 @@
+=== command
+SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERSION_CACHE_PATH="<MASKED>" SEMGREP_ENABLE_VERSION_CHECK="0" SEMGREP_SEND_METRICS="off" semgrep ci --no-suppress-errors --baseline-commit <MASKED>
+=== end of command
+
+=== exit code
+1
+=== end of exit code
+
+=== stdout - plain
+
+
+┌──────────────────────────────────┐
+│ 1 Reachable Supply Chain Finding │
+└──────────────────────────────────┘
+
+    foo.py with lockfile poetry.lock
+   ❯❯❱ supply-chain-reachable-1
+          found a reachable vulnerability from a dependency
+
+            1┆ x = 2
+
+
+=== end of stdout - plain
+
+=== stderr - plain
+
+
+┌────────────────┐
+│ Debugging Info │
+└────────────────┘
+
+  SCAN ENVIRONMENT
+  versions    - semgrep <MASKED> on python 3.11.8
+  environment - running in environment git, triggering event is unknown
+
+  CONNECTION
+  Initializing scan (deployment=org_name, scan_id=12345)
+  Enabled products: Code, Supply Chain
+
+┌─────────────┐
+│ Scan Status │
+└─────────────┘
+  Scanning 1 file tracked by git with 0 Code rules:
+  Nothing to scan.
+  Current version has 1 finding.
+
+Creating git worktree from '<MASKED>' to scan baseline.
+  Will report findings introduced by these commits (may be incomplete for shallow checkouts):
+    * <MASKED> add lockfile
+
+
+
+┌─────────────┐
+│ Scan Status │
+└─────────────┘
+  Scanning 1 file tracked by git with 0 Code rules:
+  Nothing to scan.
+
+
+┌──────────────┐
+│ Scan Summary │
+└──────────────┘
+Some files were skipped or only partially analyzed.
+  Scan was limited to files changed since baseline commit.
+
+CI scan completed successfully.
+  Found 1 finding (1 blocking) from 3 rules.
+  Uploading scan results
+  Finalizing scan           View results in Semgrep Cloud Platform:
+    https://semgrep.dev/orgs/org_name/findings?repo=local_scan/checkout_project_name&ref=some/branch-name
+    https://semgrep.dev/orgs/org_name/supply-chain
+  Has findings for blocking rules so exiting with code 1
+  semgrep.dev is suggesting a non-zero exit code (Test Reason)
+
+=== end of stderr - plain
+
+=== stdout - color
+
+
+┌──────────────────────────────────┐
+│ 1 Reachable Supply Chain Finding │
+└──────────────────────────────────┘
+
+    foo.py with lockfile poetry.lock
+   ❯❯❱ [1msupply-chain-reachable-1[0m
+          found a reachable vulnerability from a dependency
+
+            1┆ x = 2
+
+
+=== end of stdout - color
+
+=== stderr - color
+
+
+┌────────────────┐
+│ Debugging Info │
+└────────────────┘
+
+  [4mSCAN ENVIRONMENT[0m
+  versions    - semgrep [1m<MASKED>[0m on python [1m3.11.8[0m
+  environment - running in environment [1mgit[0m, triggering event is [1munknown[0m
+
+  [4mCONNECTION[0m
+  Initializing scan (deployment=org_name, scan_id=12345)
+  Enabled products: [1mCode, Supply Chain[0m
+
+┌─────────────┐
+│ Scan Status │
+└─────────────┘
+  Scanning 1 file tracked by git with 0 Code rules:
+  Nothing to scan.
+  Current version has 1 finding.
+
+Creating git worktree from '<MASKED>' to scan baseline.
+  Will report findings introduced by these commits (may be incomplete for shallow checkouts):
+    * <MASKED> add lockfile
+
+
+
+┌─────────────┐
+│ Scan Status │
+└─────────────┘
+  Scanning 1 file tracked by git with 0 Code rules:
+  Nothing to scan.
+
+
+┌──────────────┐
+│ Scan Summary │
+└──────────────┘
+Some files were skipped or only partially analyzed.
+  Scan was limited to files changed since baseline commit.
+
+CI scan completed successfully.
+  Found 1 finding (1 blocking) from 3 rules.
+  Uploading scan results
+  Finalizing scan           View results in Semgrep Cloud Platform:
+    https://semgrep.dev/orgs/org_name/findings?repo=local_scan/checkout_project_name&ref=some/branch-name
+    https://semgrep.dev/orgs/org_name/supply-chain
+  Has findings for blocking rules so exiting with code 1
+  semgrep.dev is suggesting a non-zero exit code (Test Reason)
+
+=== end of stderr - color

--- a/cli/tests/default/e2e-pro/snapshots/test_ci/test_reachable_and_unreachable_diff_scan_findings/config/new_output.txt
+++ b/cli/tests/default/e2e-pro/snapshots/test_ci/test_reachable_and_unreachable_diff_scan_findings/config/new_output.txt
@@ -37,6 +37,11 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
   Initializing scan (deployment=org_name, scan_id=12345)
   Enabled products: Code, Supply Chain
 
+  ENGINE
+  Using Semgrep Pro Version: <MASKED>
+  Installed at <MASKED>
+
+
 ┌─────────────┐
 │ Scan Status │
 └─────────────┘

--- a/cli/tests/default/e2e-pro/snapshots/test_ci/test_reachable_and_unreachable_diff_scan_findings/config/new_output.txt
+++ b/cli/tests/default/e2e-pro/snapshots/test_ci/test_reachable_and_unreachable_diff_scan_findings/config/new_output.txt
@@ -30,7 +30,7 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
 └────────────────┘
 
   SCAN ENVIRONMENT
-  versions    - semgrep <MASKED> on python 3.11.8
+  versions    - semgrep <MASKED> on python <MASKED>
   environment - running in environment git, triggering event is unknown
 
   CONNECTION
@@ -75,69 +75,9 @@ CI scan completed successfully.
 === end of stderr - plain
 
 === stdout - color
-
-
-┌──────────────────────────────────┐
-│ 1 Reachable Supply Chain Finding │
-└──────────────────────────────────┘
-
-    foo.py with lockfile poetry.lock
-   ❯❯❱ [1msupply-chain-reachable-1[0m
-          found a reachable vulnerability from a dependency
-
-            1┆ x = 2
-
-
+<same as above: stdout - plain>
 === end of stdout - color
 
 === stderr - color
-
-
-┌────────────────┐
-│ Debugging Info │
-└────────────────┘
-
-  [4mSCAN ENVIRONMENT[0m
-  versions    - semgrep [1m<MASKED>[0m on python [1m3.11.8[0m
-  environment - running in environment [1mgit[0m, triggering event is [1munknown[0m
-
-  [4mCONNECTION[0m
-  Initializing scan (deployment=org_name, scan_id=12345)
-  Enabled products: [1mCode, Supply Chain[0m
-
-┌─────────────┐
-│ Scan Status │
-└─────────────┘
-  Scanning 1 file tracked by git with 0 Code rules:
-  Nothing to scan.
-  Current version has 1 finding.
-
-Creating git worktree from '<MASKED>' to scan baseline.
-  Will report findings introduced by these commits (may be incomplete for shallow checkouts):
-    * <MASKED> add lockfile
-
-
-
-┌─────────────┐
-│ Scan Status │
-└─────────────┘
-  Scanning 1 file tracked by git with 0 Code rules:
-  Nothing to scan.
-
-
-┌──────────────┐
-│ Scan Summary │
-└──────────────┘
-Some files were skipped or only partially analyzed.
-  Scan was limited to files changed since baseline commit.
-
-CI scan completed successfully.
-  Found 1 finding (1 blocking) from 3 rules.
-  Uploading scan results
-  Finalizing scan           View results in Semgrep Cloud Platform:
-    https://semgrep.dev/orgs/org_name/findings?repo=local_scan/checkout_project_name&ref=some/branch-name
-    https://semgrep.dev/orgs/org_name/supply-chain
-  Has findings for blocking rules so exiting with code 1
-  semgrep.dev is suggesting a non-zero exit code (Test Reason)
-
+<same as above: stderr - plain>
 === end of stderr - color


### PR DESCRIPTION
Scanning un-edited lockfiles to capture reachable findings when there are code changes but no lockfile changes. Also, capturing all dependencies on a ref to send to the app for new feature work.