### PR TITLE
fix: typing issue in rule_match ordering key

### DIFF
--- a/cli/src/semgrep/rule_match.py
+++ b/cli/src/semgrep/rule_match.py
@@ -25,6 +25,7 @@ from semgrep.constants import RuleScanSource
 from semgrep.external.pymmh3 import hash128  # type: ignore[attr-defined]
 from semgrep.rule import Rule
 from semgrep.semgrep_interfaces.semgrep_output_v1 import Direct
+from semgrep.semgrep_interfaces.semgrep_output_v1 import Position
 from semgrep.semgrep_interfaces.semgrep_output_v1 import Sha1
 from semgrep.semgrep_interfaces.semgrep_output_v1 import Transitive
 from semgrep.semgrep_interfaces.semgrep_output_v1 import Transitivity
@@ -93,9 +94,11 @@ class RuleMatch:
     lines: List[str] = field(init=False, repr=False)
     previous_line: str = field(init=False, repr=False)
     syntactic_context: str = field(init=False, repr=False)
-    ci_unique_key: Tuple = field(init=False, repr=False)
-    ordering_key: Tuple = field(init=False, repr=False)
-    match_based_key: Tuple = field(init=False, repr=False)
+    ci_unique_key: Tuple[str, str, str, int] = field(init=False, repr=False)
+    ordering_key: Tuple[str, Position, Position, str, str] = field(
+        init=False, repr=False
+    )
+    match_based_key: Tuple[str, Path, str] = field(init=False, repr=False)
     syntactic_id: str = field(init=False, repr=False)
     match_based_id: str = field(init=False, repr=False)
     code_hash: str = field(init=False, repr=False)
@@ -222,7 +225,7 @@ class RuleMatch:
         return code
 
     @ci_unique_key.default
-    def get_ci_unique_key(self) -> Tuple:
+    def get_ci_unique_key(self) -> Tuple[str, str, str, int]:
         """
         A unique key designed with notification user experience in mind.
 
@@ -247,7 +250,9 @@ class RuleMatch:
             )
         return (self.rule_id, str(path), self.syntactic_context, self.index)
 
-    def get_path_changed_ci_unique_key(self, rename_dict: Dict[str, Path]) -> Tuple:
+    def get_path_changed_ci_unique_key(
+        self, rename_dict: Dict[str, Path]
+    ) -> Tuple[str, str, str, int]:
         """
         A unique key that accounts for filepath renames.
 
@@ -261,7 +266,7 @@ class RuleMatch:
         return (self.rule_id, renamed_path, self.syntactic_context, self.index)
 
     @ordering_key.default
-    def get_ordering_key(self) -> Tuple:
+    def get_ordering_key(self) -> Tuple[str, Position, Position, str, str]:
         """
         Used to sort findings in output.
 
@@ -272,7 +277,7 @@ class RuleMatch:
         when two findings match with different metavariables on the same code.
         """
         return (
-            self.git_blob if self.git_blob else self.path,
+            self.git_blob.value if self.git_blob else str(self.path),
             self.start,
             self.end,
             self.rule_id,
@@ -294,7 +299,7 @@ class RuleMatch:
         return str(binascii.hexlify(hash_bytes), "ascii")
 
     @match_based_key.default
-    def get_match_based_key(self) -> Tuple:
+    def get_match_based_key(self) -> Tuple[str, Path, str]:
         """
         A unique key with match based id's notion of uniqueness in mind.
 

--- a/cli/src/semgrep/util.py
+++ b/cli/src/semgrep/util.py
@@ -234,7 +234,6 @@ def get_lines_from_file(
     return result
 
 
-@functools.lru_cache
 def get_lines_from_git_blob(
     blob_sha: Sha1,
     start_line: int,

--- a/cli/tests/default/unit/test_rule_match.py
+++ b/cli/tests/default/unit/test_rule_match.py
@@ -117,6 +117,56 @@ def test_rule_match_sorting(mocker):
 
 
 @pytest.mark.quick
+def test_rule_match_sorting_with_git_info(mocker):
+    file_content = dedent(
+        """
+        # first line
+        def foo():
+            5 == 5 # nosem
+            6 == 6 # nosem
+        """
+    ).lstrip()
+    mocker.patch.object(Path, "open", mocker.mock_open(read_data=file_content))
+    line3 = RuleMatch(
+        message="message",
+        severity=out.MatchSeverity(out.Error()),
+        match=out.CoreMatch(
+            check_id=out.RuleId("rule_id"),
+            path=out.Fpath("foo.py"),
+            start=out.Position(3, 1, 24),
+            end=out.Position(3, 15, 38),
+            extra=out.CoreMatchExtra(
+                metavars=out.Metavars({}),
+                engine_kind=out.EngineKind(out.OSS()),
+                is_ignored=False,
+            ),
+        ),
+    )
+    line4 = RuleMatch(
+        message="message",
+        severity=out.MatchSeverity(out.Error()),
+        match=out.CoreMatch(
+            check_id=out.RuleId("rule_id"),
+            path=out.Fpath("/tmp/fakepath.py"),
+            start=out.Position(4, 1, 36),
+            end=out.Position(4, 15, 50),
+            extra=out.CoreMatchExtra(
+                metavars=out.Metavars({}),
+                engine_kind=out.EngineKind(out.OSS()),
+                is_ignored=False,
+                historical_info=out.HistoricalInfo(
+                    git_blob=out.Sha1("d7a45f0ee770d69753179824d1c828557ce19054"),
+                    git_commit=out.Sha1("d7a45f0ee770d69753179824d1c828557ce19054"),
+                    git_commit_timestamp=out.Datetime("2024-03-07T20:11:35Z"),
+                ),
+            ),
+        ),
+    )
+    # Should not raise; the values should be comparable without typing issues.
+    [line4, line3].sort()
+
+
+@pytest.mark.quick
 def test_rule_match_hashing(mocker):
     file_content = dedent(
         """


### PR DESCRIPTION
Fixes an issue where different `RuleMatch`es could have different tuple types for their ordering keys, which could cause an issue when sorting them. The specific instance where this could occur (at least one match from a git object and at least one match from a regular file) is not yet able to be triggered by end-users, so this isn't a user-facing change requiring a changelog entry. This also removes caching from one method with a non-hashable parameter; we can add it back if the parameter is made hashable, but that requires an interfaces change.

Adds more explicit types for `RuleMatch`'s tuple fields.

Test plan: existing pytest coverage; additional test for this comparison.