### PR TITLE
feat(secrets): send historical info to app

### DIFF
--- a/cli/src/semgrep/rule_match.py
+++ b/cli/src/semgrep/rule_match.py
@@ -533,6 +533,7 @@ class RuleMatch:
             # string instead of a ValidationState. Fix the monkey
             # patchable version if you want monkey patching to work.
             validation_state=self.match.extra.validation_state,
+            historical_info=self.match.extra.historical_info,
         )
 
         if self.extra.get("fixed_lines"):

--- a/cli/src/semgrep/rule_match.py
+++ b/cli/src/semgrep/rule_match.py
@@ -530,6 +530,8 @@ class RuleMatch:
             validation_state=self.match.extra.validation_state,
             historical_info=self.match.extra.historical_info,
         )
+        print(f"hist={self.match.extra.historical_info}")
+        print(f"ret={ret}")
 
         if self.extra.get("fixed_lines"):
             ret.fixed_lines = self.extra.get("fixed_lines")

--- a/cli/src/semgrep/rule_match.py
+++ b/cli/src/semgrep/rule_match.py
@@ -530,8 +530,6 @@ class RuleMatch:
             validation_state=self.match.extra.validation_state,
             historical_info=self.match.extra.historical_info,
         )
-        print(f"hist={self.match.extra.historical_info}")
-        print(f"ret={ret}")
 
         if self.extra.get("fixed_lines"):
             ret.fixed_lines = self.extra.get("fixed_lines")

--- a/cli/src/semgrep/rule_match.py
+++ b/cli/src/semgrep/rule_match.py
@@ -528,6 +528,7 @@ class RuleMatch:
             # string instead of a ValidationState. Fix the monkey
             # patchable version if you want monkey patching to work.
             validation_state=self.match.extra.validation_state,
+            historical_info=self.match.extra.historical_info,
         )
 
         if self.extra.get("fixed_lines"):

--- a/cli/src/semgrep/rule_match.py
+++ b/cli/src/semgrep/rule_match.py
@@ -535,6 +535,8 @@ class RuleMatch:
             validation_state=self.match.extra.validation_state,
             historical_info=self.match.extra.historical_info,
         )
+        print(f"hist={self.match.extra.historical_info}")
+        print(f"ret={ret}")
 
         if self.extra.get("fixed_lines"):
             ret.fixed_lines = self.extra.get("fixed_lines")

--- a/cli/src/semgrep/rule_match.py
+++ b/cli/src/semgrep/rule_match.py
@@ -535,8 +535,6 @@ class RuleMatch:
             validation_state=self.match.extra.validation_state,
             historical_info=self.match.extra.historical_info,
         )
-        print(f"hist={self.match.extra.historical_info}")
-        print(f"ret={ret}")
 
         if self.extra.get("fixed_lines"):
             ret.fixed_lines = self.extra.get("fixed_lines")

--- a/cli/tests/default/unit/snapshots/test_rule_match/test_rule_match_to_app_finding_historical_info/results.json
+++ b/cli/tests/default/unit/snapshots/test_rule_match/test_rule_match_to_app_finding_historical_info/results.json
@@ -10,6 +10,11 @@
     "pattern_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
     "start_line_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
   },
+  "historical_info": {
+    "git_blob": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "git_commit": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "git_commit_timestamp": "2020-12-09T16:09:53Z"
+  },
   "index": 0,
   "is_blocking": true,
   "line": 0,

--- a/cli/tests/default/unit/snapshots/test_rule_match/test_rule_match_to_app_finding_historical_info/results.json
+++ b/cli/tests/default/unit/snapshots/test_rule_match/test_rule_match_to_app_finding_historical_info/results.json
@@ -1,0 +1,22 @@
+{
+  "check_id": "rule.id",
+  "column": 0,
+  "commit_date": "1970-01-01T00:00:00",
+  "end_column": 0,
+  "end_line": 0,
+  "hashes": {
+    "code_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "end_line_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "pattern_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "start_line_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  "index": 0,
+  "is_blocking": true,
+  "line": 0,
+  "match_based_id": "ac39ef6548f7e4407744659d806fdcd7ed74bff05adf3663a15a6f58a0207a628bf9bc7dd83c598afda27a848c236df8d179557e064e82d8bd776020635992ad_0",
+  "message": "message",
+  "metadata": {},
+  "path": "foo.py",
+  "severity": 2,
+  "syntactic_id": "0639a4883ba9b83e767a5dc4c09e001a"
+}

--- a/cli/tests/default/unit/test_rule_match.py
+++ b/cli/tests/default/unit/test_rule_match.py
@@ -450,6 +450,38 @@ def test_rule_match_to_app_finding(snapshot, mocker):
     snapshot.assert_match(app_finding_str, "results.json")
 
 
+@pytest.mark.quick
+def test_rule_match_to_app_finding_historical_info(snapshot, mocker):
+    mocker.patch.object(RuleMatch, "get_lines", lambda self: "foo()")
+    match = RuleMatch(
+        message="message",
+        severity=out.MatchSeverity(out.Error()),
+        match=out.CoreMatch(
+            check_id=out.RuleId("rule.id"),
+            path=out.Fpath("foo.py"),
+            start=out.Position(0, 0, 0),
+            end=out.Position(0, 0, 0),
+            extra=out.CoreMatchExtra(
+                metavars=out.Metavars({}),
+                engine_kind=out.EngineKind(out.OSS()),
+                is_ignored=False,
+                historical_info=out.HistoricalInfo(
+                    git_blob=out.Sha1("a" * 40),
+                    git_commit=out.Sha1("b" * 40),
+                    git_commit_timestamp=out.Datetime("2020-12-09T16:09:53Z"),
+                ),
+            ),
+        ),
+        extra={},
+    )
+    app_finding = match.to_app_finding_format("0")
+    app_finding.commit_date = "1970-01-01T00:00:00"
+    app_finding_str = (
+        json.dumps(app_finding.to_json(), indent=2, sort_keys=True) + "\n"
+    )  # Needed because pre-commit always adds a newline, seems weird
+    snapshot.assert_match(app_finding_str, "results.json")
+
+
 def create_sca_rule_match(sca_kind, reachable_in_code, transitivity):
     dependency_match = out.DependencyMatch(
         dependency_pattern=out.DependencyPattern(

--- a/src/osemgrep/cli_ci/Ci_subcommand.ml
+++ b/src/osemgrep/cli_ci/Ci_subcommand.ml
@@ -469,6 +469,7 @@ let finding_of_cli_match _commit_date index (m : OutJ.cli_match) : OutJ.finding
       (* TODO *)
       dataflow_trace = None;
       validation_state = None;
+      historical_info = None;
     }
   in
   r


### PR DESCRIPTION
This updates `RuleMatch.to_app_finding_format` to include the historical
information about a finding. This is relevant for historical findings,
or any other findings which was generated for a git blob target.

Test plan: Additional pytest coverage in e8abd36ff8a1dfa0113bc7fe2baf2da45554ae82