### PR TITLE
refactor: Create lines_of_range utility

### DIFF
--- a/libs/commons/String_.ml
+++ b/libs/commons/String_.ml
@@ -39,3 +39,46 @@ let show ?(max_len = 200) str =
 let trim_cr s =
   let len = String.length s in
   if len > 0 && s.[len - 1] = '\r' then String.sub s 0 (len - 1) else s
+
+let lines_of_range (start_offset, end_offset) str =
+  let len = String.length str in
+  if
+    start_offset > end_offset || end_offset > len || start_offset < 0 || len = 0
+  then []
+  else
+    (* Search left for a '\n' char so we can determine the start of the first
+     * line in the range. *)
+    let start_offset =
+      (* Consider start_offset here:
+       * "foo\nbar\n"
+       *     ^
+       * We want to include "foo" in the result, so we move the cursor left one
+       * character in this case.
+       *
+       * NB: This can result in a start_offset of -1. That is acceptable to
+       * rindex_from_opt and the unit tests exercise that case.
+       *)
+      if str.[start_offset] = '\n' then start_offset - 1 else start_offset
+    in
+    let start_line_offset =
+      match String.rindex_from_opt str start_offset '\n' with
+      | None -> 0
+      | Some x ->
+          (* We want to start the resulting substring at the beginning of the
+           * line and not include the newline character itself, so add one. Note
+           * that this can set `start_line_offset` to `len`, but that is an
+           * acceptable second argument to `String.sub`. *)
+          x + 1
+    in
+    (* Search right for a '\n' char so we can determine the end of the last line
+     * in the range. *)
+    let end_line_offset =
+      match String.index_from_opt str end_offset '\n' with
+      | None -> len
+      | Some x -> x
+    in
+    let substr =
+      String.sub str start_line_offset (end_line_offset - start_line_offset)
+    in
+    let lines = String.split_on_char '\n' substr in
+    List_.map trim_cr lines

--- a/libs/commons/String_.mli
+++ b/libs/commons/String_.mli
@@ -36,3 +36,8 @@ val show : ?max_len:int -> string -> string
  * reading an input line from an input stream or when splitting a string by the
  * line feed character ('\n'). *)
 val trim_cr : string -> string
+
+(* Returns the entirety of all of the lines in the given string that are
+ * included in the given range. Strips trailing newline characters from each
+ * line. See unit tests for examples. *)
+val lines_of_range : int * int -> string -> string list

--- a/libs/commons/tests/Unit_String_.ml
+++ b/libs/commons/tests/Unit_String_.ml
@@ -50,10 +50,61 @@ let test_trim_cr () =
   check "foo" "foo\r";
   check "" "\r"
 
+let test_lines_of_range () =
+  let check expected input range =
+    Alcotest.(check (list string))
+      __LOC__ expected
+      (String_.lines_of_range range input)
+  in
+  (* - Out of bounds start and end - *)
+  check [] "foo\nbar\n" (-1, 5);
+  check [] "foo\nbar\n" (4, 9);
+  (* - Normal cases - *)
+  check [ "bar" ] "foo\nbar\n" (4, 5);
+  check [ "foo"; "bar" ] "foo\nbar\n" (0, 5);
+  (* - No trailing newline - *)
+  check [ "foo"; "bar" ] "foo\nbar" (0, 5);
+  (* - No newline at all - *)
+  check [ "foo" ] "foo" (1, 2);
+  (* - Edge cases - *)
+  check [ "x" ] "x\n" (0, 1);
+  check [ ""; "x" ] "\nx\n" (0, 2);
+  check [ ""; "x" ] "\n\nx\n" (1, 3);
+  check [ "" ] "\n" (0, 0);
+  check [ ""; "" ] "\n" (0, 1);
+  check [ ""; "" ] "\n\n" (0, 1);
+  check [ ""; ""; "" ] "\n\n\n" (0, 2);
+  (* - Start on or adjacent to a newline character - *)
+  check [ "foo" ] "foo\nbar\n" (3, 3);
+  check [ "foo" ] "foo\nbar\n" (2, 3);
+  check [ "foo"; "bar" ] "foo\nbar\n" (3, 4);
+  check [ "foo"; "bar" ] "foo\nbar\n" (3, 5);
+  check [ "bar" ] "foo\nbar\n" (4, 5);
+  check [ "bar" ] "foo\nbar\n" (7, 7);
+  (* This, like some of the edge cases above, is a bit weird. Position 8 is
+   * after newline character, so we consider it part of a nonexistent third line
+   * and end up including an empty string. I (nmote) am not sure that this is
+   * really desirable, but it's also unlikely to come up often in practice since
+   * typically newline characters are not typically used as the start or end of
+   * a range. *)
+  check [ "bar"; "" ] "foo\nbar\n" (7, 8);
+  (* - End on or adjacent to a newline character - *)
+  check [ "foo" ] "foo\nbar\n" (1, 2);
+  check [ "foo" ] "foo\nbar\n" (1, 3);
+  check [ "foo"; "bar" ] "foo\nbar\n" (1, 4);
+  (* - Carriage return ('\r') - *)
+  check [ "bar" ] "foo\r\nbar\r\n" (5, 6);
+  check [ "foo"; "bar" ] "foo\r\nbar\r\n" (1, 6);
+  (* - Empty string - *)
+  check [] "" (0, 0);
+  (* - Zero length range - *)
+  check [ "bar" ] "foo\nbar\n" (4, 4)
+
 let tests =
   Testo.categorize "String_"
     [
       t "safe_sub" test_safe_sub;
       t ~checked_output:Stdout "show" test_show;
       t "trim_cr" test_trim_cr;
+      t "lines_of_range" test_lines_of_range;
     ]


### PR DESCRIPTION
This is similar to UFile.lines_of_file. It has two important differences:

- It operates on offsets (i.e. byte indices into the file) rather than lines.
- It operates on a string rather than a file path.

Operating on offsets makes this more compatible with utilities that use `Textedit.t`. This is also likely a bit more efficient than the `lines_of_file` utility, since it does not require splitting the full string by line.

I plan to use this to refactor the osemgrep autofix application code, with the following goals:

- Improve readability, testing, and maintainability.
- Allow for the code to be reused for a direct RPC call from Python to OCaml, so that we can remove the remaining autofix application logic in `autofix.py`

Test plan: Unit tests. Also used in my work in progress and this utility correctly creates the `fixed_lines` values for all autofix e2e tests.

