### PR TITLE
feat(tracing): add data to the top level spans of semgrep otel runs

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -479,7 +479,7 @@ For more information see https://semgrep.dev
     ; tracing
     trace
     ppx_trace
-    (opentelemetry (>= 0.6))
+    (opentelemetry (>= 0.8))
     opentelemetry-client-ocurl
     ambient-context-lwt
     (conf-libcurl (= 1)) ; force older version of conf-libcurl to make windows work

--- a/libs/tracing/Tracing.mli
+++ b/libs/tracing/Tracing.mli
@@ -12,6 +12,16 @@ type top_level_data = { version : string }
 (* Functions to instrument the code *)
 (*****************************************************************************)
 
+val enter_span :
+  ?__FUNCTION__:string ->
+  __FILE__:string ->
+  __LINE__:int ->
+  ?data:(unit -> (string * Trace_core.user_data) list) ->
+  string ->
+  int64
+
+val exit_span : int64 -> unit
+
 val with_span :
   ?__FUNCTION__:string ->
   __FILE__:string ->

--- a/libs/tracing/Tracing.mli
+++ b/libs/tracing/Tracing.mli
@@ -3,6 +3,12 @@
  *)
 
 (*****************************************************************************)
+(* Types *)
+(*****************************************************************************)
+
+type top_level_data = { version : string }
+
+(*****************************************************************************)
 (* Functions to instrument the code *)
 (*****************************************************************************)
 
@@ -20,6 +26,11 @@ val with_span :
 val add_data_to_span : int64 -> (string * Trace_core.user_data) list -> unit
 (** Expose the Trace function to add data to a span *)
 
+val add_data_to_opt_span :
+  int64 option -> (string * Trace_core.user_data) list -> unit
+(** Add data to an optional span. This makes it easier to add data to the
+    top level span that we pass down when present *)
+
 (*****************************************************************************)
 (* Entry points for setting up tracing *)
 (*****************************************************************************)
@@ -27,6 +38,6 @@ val add_data_to_span : int64 -> (string * Trace_core.user_data) list -> unit
 val configure_tracing : string -> unit
 (** Before instrumenting anything, configure some settings. *)
 
-val with_setup : (unit -> 'a) -> 'a
+val with_setup : top_level_data -> (int64 -> 'a) -> 'a
 (** Setup instrumentation and run the passed function.
    Stops instrumenting once that function is finished. *)

--- a/libs/tracing/Tracing.mli
+++ b/libs/tracing/Tracing.mli
@@ -19,7 +19,7 @@
 (* Types *)
 (*****************************************************************************)
 
-type span = Int64.t [@@deriving show]
+type span = Trace_core.span [@@deriving show]
 type user_data = Trace_core.user_data
 
 (*****************************************************************************)

--- a/libs/tracing/Tracing.mli
+++ b/libs/tracing/Tracing.mli
@@ -6,7 +6,22 @@
 (* Types *)
 (*****************************************************************************)
 
-type top_level_data = { version : string }
+type analysis_flags = {
+  secrets_validators : bool;
+  historical_scan : bool;
+  allow_all_origins : bool;
+  deep_intra_file : bool;
+  deep_inter_file : bool;
+}
+
+type top_level_data = { version : string; analysis_flags : analysis_flags }
+
+(*****************************************************************************)
+(* Helpers *)
+(*****************************************************************************)
+
+val oss_analysis : unit -> analysis_flags
+(** For analysis run with the oss engine, we know all the flags will be false *)
 
 (*****************************************************************************)
 (* Functions to instrument the code *)

--- a/libs/tracing/Tracing.mli
+++ b/libs/tracing/Tracing.mli
@@ -4,6 +4,15 @@
  * for Semgrep code using Opentelemetry traces. By default, they send to
  * our Datadog endpoint, but the collector can be customized using the
  * SEMGREP_OTEL_ENDPOINT environment variable.
+ *
+ * To trace a program, start by calling `configure_tracing`. Then, wrap
+ * the entry point of the program (e.g. `Core_command.semgrep_core_dispatch`)
+ * with `with_tracing`. Traces will now be sent for the duration of that
+ * function.
+ *
+ * Running `with_tracing` always sends a trace for the wrapped function.
+ * To trace other functions called within it, run those using `with_span`.
+ * You can attach data to the traces by running `add_data_to_span`.
  *)
 
 (*****************************************************************************)
@@ -11,46 +20,11 @@
 (*****************************************************************************)
 
 type span = Int64.t [@@deriving show]
-
-type analysis_flags = {
-  secrets_validators : bool;
-  (* True when secrets validators are enabled *)
-  allow_all_origins : bool;
-  (* True when secrets validators from any origin may be used.
-     This value is discarded if secrets_validators is false *)
-  historical_scan : bool;
-  (* True when historical scans are enabled *)
-  deep_intra_file : bool;
-  (* True when deep intrafile scans (aka interproc taint) is enabled *)
-  deep_inter_file : bool;
-      (* True when interfile scans are enabled. Only one of `deep_inter_file`
-         and `deep_intrafile` should be true. *)
-}
-[@@deriving show]
-
-type top_level_data = { version : string; analysis_flags : analysis_flags }
-[@@deriving show]
-
-(*****************************************************************************)
-(* Helpers *)
-(*****************************************************************************)
-
-val no_analysis_features : unit -> analysis_flags
-(** For analysis run with the oss engine, we know all the flags will be false *)
+type user_data = Trace_core.user_data
 
 (*****************************************************************************)
 (* Functions to instrument the code *)
 (*****************************************************************************)
-
-val enter_span :
-  ?__FUNCTION__:string ->
-  __FILE__:string ->
-  __LINE__:int ->
-  ?data:(unit -> (string * Trace_core.user_data) list) ->
-  string ->
-  span
-
-val exit_span : span -> unit
 
 val with_span :
   ?__FUNCTION__:string ->
@@ -61,23 +35,25 @@ val with_span :
   (span -> 'a) ->
   'a
 (** Expose the function to instrument code to send traces.
-    In general, we prefer using the ppx *)
+    TODO: after we have a ppx, prefer using the ppx *)
 
 val add_data_to_span : span -> (string * Trace_core.user_data) list -> unit
 (** Expose the Trace function to add data to a span *)
 
 val add_data_to_opt_span :
   span option -> (string * Trace_core.user_data) list -> unit
-(** Add data to an optional span. This makes it easier to add data to the
-    top level span that we pass down when present *)
+(** Convenience version of add_data_to_span for Semgrep *)
 
 (*****************************************************************************)
 (* Entry points for setting up tracing *)
 (*****************************************************************************)
 
 val configure_tracing : string -> unit
-(** Before instrumenting anything, configure some settings. *)
+(** Before instrumenting anything, configure some settings.
+    This should only be run once in a program, because it creates a
+    backend with threads, HTTP connections, etc. when called *)
 
-val with_setup : string -> top_level_data -> (span -> 'a) -> 'a
+val with_tracing :
+  string -> (string * Trace_core.user_data) list -> (span -> 'a) -> 'a
 (** Setup instrumentation and run the passed function.
    Stops instrumenting once that function is finished. *)

--- a/libs/tracing/Tracing.mli
+++ b/libs/tracing/Tracing.mli
@@ -1,26 +1,41 @@
-(** Tracing library for Semgrep using several libraries.
-   See header of Tracing.ml for details
+(** Tracing library for Semgrep
+ *
+ * Provide a simple interface to send contextualized performance metrics
+ * for Semgrep code using Opentelemetry traces. By default, they send to
+ * our Datadog endpoint, but the collector can be customized using the
+ * SEMGREP_OTEL_ENDPOINT environment variable.
  *)
 
 (*****************************************************************************)
 (* Types *)
 (*****************************************************************************)
 
+type span = Int64.t [@@deriving show]
+
 type analysis_flags = {
   secrets_validators : bool;
-  historical_scan : bool;
+  (* True when secrets validators are enabled *)
   allow_all_origins : bool;
+  (* True when secrets validators from any origin may be used.
+     This value is discarded if secrets_validators is false *)
+  historical_scan : bool;
+  (* True when historical scans are enabled *)
   deep_intra_file : bool;
+  (* True when deep intrafile scans (aka interproc taint) is enabled *)
   deep_inter_file : bool;
+      (* True when interfile scans are enabled. Only one of `deep_inter_file`
+         and `deep_intrafile` should be true. *)
 }
+[@@deriving show]
 
 type top_level_data = { version : string; analysis_flags : analysis_flags }
+[@@deriving show]
 
 (*****************************************************************************)
 (* Helpers *)
 (*****************************************************************************)
 
-val oss_analysis : unit -> analysis_flags
+val no_analysis_features : unit -> analysis_flags
 (** For analysis run with the oss engine, we know all the flags will be false *)
 
 (*****************************************************************************)
@@ -33,9 +48,9 @@ val enter_span :
   __LINE__:int ->
   ?data:(unit -> (string * Trace_core.user_data) list) ->
   string ->
-  int64
+  span
 
-val exit_span : int64 -> unit
+val exit_span : span -> unit
 
 val with_span :
   ?__FUNCTION__:string ->
@@ -43,16 +58,16 @@ val with_span :
   __LINE__:int ->
   ?data:(unit -> (string * Trace_core.user_data) list) ->
   string ->
-  (Trace_core.span -> 'a) ->
+  (span -> 'a) ->
   'a
 (** Expose the function to instrument code to send traces.
     In general, we prefer using the ppx *)
 
-val add_data_to_span : int64 -> (string * Trace_core.user_data) list -> unit
+val add_data_to_span : span -> (string * Trace_core.user_data) list -> unit
 (** Expose the Trace function to add data to a span *)
 
 val add_data_to_opt_span :
-  int64 option -> (string * Trace_core.user_data) list -> unit
+  span option -> (string * Trace_core.user_data) list -> unit
 (** Add data to an optional span. This makes it easier to add data to the
     top level span that we pass down when present *)
 
@@ -63,6 +78,6 @@ val add_data_to_opt_span :
 val configure_tracing : string -> unit
 (** Before instrumenting anything, configure some settings. *)
 
-val with_setup : top_level_data -> (int64 -> 'a) -> 'a
+val with_setup : string -> top_level_data -> (span -> 'a) -> 'a
 (** Setup instrumentation and run the passed function.
    Stops instrumenting once that function is finished. *)

--- a/libs/tracing/dune
+++ b/libs/tracing/dune
@@ -7,4 +7,7 @@
   )
  (virtual_modules tracing)
  (default_implementation tracing.unix)
+  (preprocess (pps
+      ppx_deriving.show
+   ))
 )

--- a/libs/tracing/js/Tracing.ml
+++ b/libs/tracing/js/Tracing.ml
@@ -45,4 +45,7 @@ let add_data_to_opt_span (_i : span option)
 (*****************************************************************************)
 
 let configure_tracing (_service_name : string) = ()
-let with_tracing f = f 0L
+
+let with_tracing (_fname : string)
+    (_data : (string * Trace_core.user_data) list) f =
+  f 0L

--- a/libs/tracing/js/Tracing.ml
+++ b/libs/tracing/js/Tracing.ml
@@ -21,13 +21,46 @@
    JS to build without requiring curl to be installed *)
 
 (*****************************************************************************)
+(* Types *)
+(*****************************************************************************)
+
+type analysis_flags = {
+  secrets_validators : bool;
+  historical_scan : bool;
+  allow_all_origins : bool;
+  deep_intra_file : bool;
+  deep_inter_file : bool;
+}
+
+type top_level_data = { version : string; analysis_flags : analysis_flags }
+
+(*****************************************************************************)
+(* Helpers *)
+(*****************************************************************************)
+
+let oss_analysis () =
+  {
+    secrets_validators = false;
+    historical_scan = false;
+    allow_all_origins = false;
+    deep_intra_file = false;
+    deep_inter_file = false;
+  }
+
+(*****************************************************************************)
 (* Code *)
 (*****************************************************************************)
 
+let enter_span = Trace_core.enter_span
+let exit_span = Trace_core.exit_span
 let with_span = Trace_core.with_span
 
 let add_data_to_span (_i : int64) (_data : (string * Trace_core.user_data) list)
     =
+  ()
+
+let add_data_to_opt_span (_i : int64 option)
+    (_data : (string * Trace_core.user_data) list) =
   ()
 
 (*****************************************************************************)
@@ -35,4 +68,4 @@ let add_data_to_span (_i : int64) (_data : (string * Trace_core.user_data) list)
 (*****************************************************************************)
 
 let configure_tracing (_service_name : string) = ()
-let with_setup f = f ()
+let with_setup f = f (Int64.of_int 0)

--- a/libs/tracing/js/Tracing.ml
+++ b/libs/tracing/js/Tracing.ml
@@ -25,38 +25,11 @@
 (*****************************************************************************)
 
 type span = Trace_core.span [@@deriving show]
-
-type analysis_flags = {
-  secrets_validators : bool;
-  historical_scan : bool;
-  allow_all_origins : bool;
-  deep_intra_file : bool;
-  deep_inter_file : bool;
-}
-[@@deriving show]
-
-type top_level_data = { version : string; analysis_flags : analysis_flags }
-[@@deriving show]
-
-(*****************************************************************************)
-(* Helpers *)
-(*****************************************************************************)
-
-let no_analysis_features () =
-  {
-    secrets_validators = false;
-    historical_scan = false;
-    allow_all_origins = false;
-    deep_intra_file = false;
-    deep_inter_file = false;
-  }
+type user_data = Trace_core.user_data
 
 (*****************************************************************************)
 (* Code *)
 (*****************************************************************************)
-
-let enter_span = Trace_core.enter_span
-let exit_span = Trace_core.exit_span
 let with_span = Trace_core.with_span
 
 let add_data_to_span (_i : span) (_data : (string * Trace_core.user_data) list)
@@ -72,4 +45,4 @@ let add_data_to_opt_span (_i : span option)
 (*****************************************************************************)
 
 let configure_tracing (_service_name : string) = ()
-let with_setup f = f (Int64.of_int 0)
+let with_tracing f = f (Int64.of_int 0)

--- a/libs/tracing/js/Tracing.ml
+++ b/libs/tracing/js/Tracing.ml
@@ -24,6 +24,8 @@
 (* Types *)
 (*****************************************************************************)
 
+type span = Trace_core.span [@@deriving show]
+
 type analysis_flags = {
   secrets_validators : bool;
   historical_scan : bool;
@@ -31,14 +33,16 @@ type analysis_flags = {
   deep_intra_file : bool;
   deep_inter_file : bool;
 }
+[@@deriving show]
 
 type top_level_data = { version : string; analysis_flags : analysis_flags }
+[@@deriving show]
 
 (*****************************************************************************)
 (* Helpers *)
 (*****************************************************************************)
 
-let oss_analysis () =
+let no_analysis_features () =
   {
     secrets_validators = false;
     historical_scan = false;
@@ -55,11 +59,11 @@ let enter_span = Trace_core.enter_span
 let exit_span = Trace_core.exit_span
 let with_span = Trace_core.with_span
 
-let add_data_to_span (_i : int64) (_data : (string * Trace_core.user_data) list)
+let add_data_to_span (_i : span) (_data : (string * Trace_core.user_data) list)
     =
   ()
 
-let add_data_to_opt_span (_i : int64 option)
+let add_data_to_opt_span (_i : span option)
     (_data : (string * Trace_core.user_data) list) =
   ()
 

--- a/libs/tracing/js/Tracing.ml
+++ b/libs/tracing/js/Tracing.ml
@@ -24,7 +24,7 @@
 (* Types *)
 (*****************************************************************************)
 
-type span = Trace_core.span [@@deriving show]
+type span = int64 [@@deriving show]
 type user_data = Trace_core.user_data
 
 (*****************************************************************************)
@@ -45,4 +45,4 @@ let add_data_to_opt_span (_i : span option)
 (*****************************************************************************)
 
 let configure_tracing (_service_name : string) = ()
-let with_tracing f = f (Int64.of_int 0)
+let with_tracing f = f 0L

--- a/libs/tracing/js/dune
+++ b/libs/tracing/js/dune
@@ -6,4 +6,7 @@
    trace
  )
  (implements tracing)
+  (preprocess (pps
+      ppx_deriving.show
+   ))
 )

--- a/libs/tracing/unix/Tracing.ml
+++ b/libs/tracing/unix/Tracing.ml
@@ -64,22 +64,37 @@ type top_level_data = { version : string }
 let default_endpoint = "https://telemetry.dev2.semgrep.dev"
 let endpoint_env_var = "SEMGREP_OTEL_ENDPOINT"
 
+(* TODO this isn't great because this doesn't make child spans properly,
+   since the span_id isn't actually real. *)
+let top_scope () =
+  {
+    Otel.Scope.span_id = Otel.Span_id.create ();
+    trace_id = Otel.Trace_id.create ();
+    events = [];
+    attrs = [];
+  }
+
 (*****************************************************************************)
 (* Wrapping functions Trace gives us to instrument the code *)
 (*****************************************************************************)
 
+let enter_span = Trace_core.enter_span
+let exit_span = Trace_core.exit_span
 let with_span = Trace_core.with_span
 let add_data_to_span = Trace_core.add_data_to_span
 
 let add_data_to_opt_span sp data =
   match sp with
-  | None -> ()
-  | Some sp -> Trace_core.add_data_to_span sp data
+  | None ->
+      UCommon.pr2 "no span";
+      ()
+  | Some sp ->
+      UCommon.pr2 "span found";
+      Trace_core.add_data_to_span sp data
 
 (*****************************************************************************)
 (* Entry points for setting up tracing *)
 (*****************************************************************************)
-
 (* Set according to README of https://github.com/imandra-ai/ocaml-opentelemetry/ *)
 let configure_tracing service_name =
   Otel.Globals.service_name := service_name;
@@ -105,7 +120,11 @@ let with_setup (config : top_level_data) f =
   let data () = [ ("version", `String config.version) ] in
   let config = Opentelemetry_client_ocurl.Config.make ~url () in
   Opentelemetry_client_ocurl.with_setup ~config () @@ fun () ->
-  with_span ~data ~__FILE__ ~__LINE__ "All time" @@ fun sp -> f sp
+  Opentelemetry.Scope.with_ambient_scope (top_scope ()) (fun () ->
+      let sp = enter_span ~data ~__FILE__ ~__LINE__ "All time" in
+      let res = f sp in
+      exit_span sp;
+      res)
 
 (* Alt: using cohttp_lwt
 

--- a/libs/tracing/unix/Tracing.ml
+++ b/libs/tracing/unix/Tracing.ml
@@ -52,6 +52,12 @@ module Otel = Opentelemetry
  *)
 
 (*****************************************************************************)
+(* Types *)
+(*****************************************************************************)
+
+type top_level_data = { version : string }
+
+(*****************************************************************************)
 (* Constants *)
 (*****************************************************************************)
 
@@ -64,6 +70,11 @@ let endpoint_env_var = "SEMGREP_OTEL_ENDPOINT"
 
 let with_span = Trace_core.with_span
 let add_data_to_span = Trace_core.add_data_to_span
+
+let add_data_to_opt_span sp data =
+  match sp with
+  | None -> ()
+  | Some sp -> Trace_core.add_data_to_span sp data
 
 (*****************************************************************************)
 (* Entry points for setting up tracing *)
@@ -78,7 +89,7 @@ let configure_tracing service_name =
   (* This forwards the spans from Trace to the Opentelemetry collector *)
   Opentelemetry_trace.setup_with_otel_backend otel_backend
 
-let with_setup f =
+let with_setup (config : top_level_data) f =
   (* This sets up the OTel collector and runs the given function.
    * Note that the function is traced by default. This makes sure we
      always trace the given function; it also ensures that all the spans from
@@ -91,9 +102,10 @@ let with_setup f =
     | Some url -> url
     | None -> default_endpoint
   in
+  let data () = [ ("version", `String config.version) ] in
   let config = Opentelemetry_client_ocurl.Config.make ~url () in
   Opentelemetry_client_ocurl.with_setup ~config () @@ fun () ->
-  with_span ~__FILE__ ~__LINE__ "All time" @@ fun _sp -> f ()
+  with_span ~data ~__FILE__ ~__LINE__ "All time" @@ fun sp -> f sp
 
 (* Alt: using cohttp_lwt
 

--- a/libs/tracing/unix/Tracing.ml
+++ b/libs/tracing/unix/Tracing.ml
@@ -55,7 +55,15 @@ module Otel = Opentelemetry
 (* Types *)
 (*****************************************************************************)
 
-type top_level_data = { version : string }
+type analysis_flags = {
+  secrets_validators : bool;
+  historical_scan : bool;
+  allow_all_origins : bool;
+  deep_intra_file : bool;
+  deep_inter_file : bool;
+}
+
+type top_level_data = { version : string; analysis_flags : analysis_flags }
 
 (*****************************************************************************)
 (* Constants *)
@@ -67,6 +75,21 @@ let endpoint_env_var = "SEMGREP_OTEL_ENDPOINT"
 (*****************************************************************************)
 (* Helpers *)
 (*****************************************************************************)
+
+let oss_analysis () =
+  {
+    secrets_validators = false;
+    historical_scan = false;
+    allow_all_origins = false;
+    deep_intra_file = false;
+    deep_inter_file = false;
+  }
+
+(* Set the descriptor for allowed origins. This is not simply
+   a boolean because we will likely include new origins in the
+   future *)
+let allowed_origins allow_all_origins =
+  if allow_all_origins then "all_origins" else "pro_rules_only"
 
 (* Poor man's Git repo detection. Running git repo detection again
    seems wasteful, but checking two env vars is pretty cheap.
@@ -130,7 +153,18 @@ let with_setup (config : top_level_data) f =
       ("version", `String config.version);
       ("folder", `String (current_working_folder ()));
       ("repo_name", `String (repo_name ()));
+      ("pro_secrets_validators", `Bool config.analysis_flags.secrets_validators);
+      ("pro_historical_scanning", `Bool config.analysis_flags.historical_scan);
+      ("pro_deep_intrafile", `Bool config.analysis_flags.deep_intra_file);
+      ("pro_deep_interfile", `Bool config.analysis_flags.deep_inter_file);
     ]
+    @
+    if config.analysis_flags.secrets_validators then
+      [
+        ( "pro_secrets_allowed_origins",
+          `String (allowed_origins config.analysis_flags.allow_all_origins) );
+      ]
+    else []
   in
   let config = Opentelemetry_client_ocurl.Config.make ~url () in
   Opentelemetry_client_ocurl.with_setup ~config () @@ fun () ->

--- a/libs/tracing/unix/Tracing.ml
+++ b/libs/tracing/unix/Tracing.ml
@@ -53,7 +53,13 @@ module Otel = Opentelemetry
 (* Types *)
 (*****************************************************************************)
 
-type span = Int64.t [@@deriving show]
+type span = Trace_core.span
+
+(* Implement the show and pp functions manually since we know
+   Trace_core.span is int64*)
+let show_span = Int64.to_string
+let pp_span fmt = Format.fprintf fmt "%Ldl"
+
 type user_data = Trace_core.user_data
 
 (*****************************************************************************)

--- a/libs/tracing/unix/dune
+++ b/libs/tracing/unix/dune
@@ -11,4 +11,7 @@
    ambient-context-lwt
  )
  (implements tracing)
+  (preprocess (pps
+      ppx_deriving.show
+   ))
 )

--- a/semgrep.opam
+++ b/semgrep.opam
@@ -57,7 +57,7 @@ depends: [
   "lsp" {= "1.15.1-5.0"}
   "trace"
   "ppx_trace"
-  "opentelemetry" {>= "0.6"}
+  "opentelemetry" {>= "0.8"}
   "opentelemetry-client-ocurl"
   "ambient-context-lwt"
   "conf-libcurl" {= "1"}

--- a/src/core/Trace_data.ml
+++ b/src/core/Trace_data.ml
@@ -71,9 +71,13 @@ let no_analysis_features () =
     deep_inter_file = false;
   }
 
-let get_top_level_data version analysis_flags =
+let data_of_languages (languages : Xlang.t list) =
+  languages |> List_.map (fun l -> (Xlang.to_string l, `Bool true))
+
+let get_top_level_data jobs version analysis_flags =
   [
     ("version", `String version);
+    ("jobs", `Int jobs);
     ("folder", `String (current_working_folder ()));
     ("repo_name", `String (repo_name ()));
     ("pro_secrets_validators", `Bool analysis_flags.secrets_validators);

--- a/src/core/Trace_data.ml
+++ b/src/core/Trace_data.ml
@@ -1,0 +1,90 @@
+(* Emma Jin
+ *
+ * Copyright (C) 2024 Semgrep Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * version 2.1 as published by the Free Software Foundation, with the
+ * special exception on linking described in file LICENSE.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
+ * LICENSE for more details.
+ *)
+
+(*****************************************************************************)
+(* Prelude *)
+(*****************************************************************************)
+(* Helpers to prepare data for Opentelemetry tracing *)
+
+(*****************************************************************************)
+(* Types *)
+(*****************************************************************************)
+
+type analysis_flags = {
+  secrets_validators : bool;
+  allow_all_origins : bool;
+  historical_scan : bool;
+  deep_intra_file : bool;
+  deep_inter_file : bool;
+}
+
+(*****************************************************************************)
+(* Helpers *)
+(*****************************************************************************)
+
+(* Set the descriptor for allowed origins. This is not simply
+   a boolean because we will likely include new origins in the
+   future *)
+let allowed_origins allow_all_origins =
+  if allow_all_origins then "all_origins" else "pro_rules_only"
+
+(* Poor man's Git repo detection. Running git repo detection again
+   seems wasteful, but checking two env vars is pretty cheap.
+
+   TODO the more we port of semgrep scan and semgrep ci, the more
+   of this information will already be in OCaml *)
+let repo_name () =
+  match Sys.getenv_opt "SEMGREP_REPO_DISPLAY_NAME" with
+  | Some name -> name
+  | None -> (
+      match Sys.getenv_opt "SEMGREP_REPO_NAME" with
+      | Some name -> name
+      | None -> "<local run>")
+
+(* In case we don't have a repo name, report the base folder where
+   semgrep was run. We report only the base name to avoid leaking
+   user information they may not have expected us to include. *)
+let current_working_folder () = Filename.basename (Sys.getcwd ())
+
+(*****************************************************************************)
+(* Shortcuts for Otel tracing *)
+(*****************************************************************************)
+
+let no_analysis_features () =
+  {
+    secrets_validators = false;
+    historical_scan = false;
+    allow_all_origins = false;
+    deep_intra_file = false;
+    deep_inter_file = false;
+  }
+
+let get_top_level_data version analysis_flags =
+  [
+    ("version", `String version);
+    ("folder", `String (current_working_folder ()));
+    ("repo_name", `String (repo_name ()));
+    ("pro_secrets_validators", `Bool analysis_flags.secrets_validators);
+    ("pro_historical_scanning", `Bool analysis_flags.historical_scan);
+    ("pro_deep_intrafile", `Bool analysis_flags.deep_intra_file);
+    ("pro_deep_interfile", `Bool analysis_flags.deep_inter_file);
+  ]
+  @
+  if analysis_flags.secrets_validators then
+    [
+      ( "pro_secrets_allowed_origins",
+        `String (allowed_origins analysis_flags.allow_all_origins) );
+    ]
+  else []

--- a/src/core/Trace_data.mli
+++ b/src/core/Trace_data.mli
@@ -3,17 +3,14 @@
 (* Types *)
 
 type analysis_flags = {
-  secrets_validators : bool;
-  (* True when secrets validators are enabled *)
+  secrets_validators : bool;  (** True when secrets validators are enabled *)
   allow_all_origins : bool;
-  (* True when secrets validators from any origin may be used.
-     This value is discarded if secrets_validators is false *)
-  historical_scan : bool;
-  (* True when historical scans are enabled *)
+      (** True when secrets validators from any origin may be used. This value is discarded if secrets_validators is false *)
+  historical_scan : bool;  (** True when historical scans are enabled *)
   deep_intra_file : bool;
-  (* True when deep intrafile scans (aka interproc taint) is enabled *)
+      (** True when deep intrafile scans (aka interproc taint) is enabled *)
   deep_inter_file : bool;
-      (* True when interfile scans are enabled. Only one of `deep_inter_file`
+      (** True when interfile scans are enabled. Only one of `deep_inter_file`
          and `deep_intra_file` should be true. *)
 }
 [@@derving show]

--- a/src/core/Trace_data.mli
+++ b/src/core/Trace_data.mli
@@ -21,7 +21,10 @@ type analysis_flags = {
 val no_analysis_features : unit -> analysis_flags
 (** For analysis run with the oss engine, we know all the flags will be false *)
 
+val data_of_languages : Xlang.t list -> (string * Tracing.user_data) list
+(** Convenience function to turn a list of interfile languages into otel data *)
+
 val get_top_level_data :
-  string -> analysis_flags -> (string * Tracing.user_data) list
+  int -> string -> analysis_flags -> (string * Tracing.user_data) list
 (** Create the tags for the top level span. These tags make it easy to see
     the traces we care about *)

--- a/src/core/Trace_data.mli
+++ b/src/core/Trace_data.mli
@@ -5,7 +5,8 @@
 type analysis_flags = {
   secrets_validators : bool;  (** True when secrets validators are enabled *)
   allow_all_origins : bool;
-      (** True when secrets validators from any origin may be used. This value is discarded if secrets_validators is false *)
+      (** True when secrets validators from any origin may be used. This value
+          is discarded if secrets_validators is false *)
   historical_scan : bool;  (** True when historical scans are enabled *)
   deep_intra_file : bool;
       (** True when deep intrafile scans (aka interproc taint) is enabled *)

--- a/src/core/Trace_data.mli
+++ b/src/core/Trace_data.mli
@@ -1,0 +1,19 @@
+(** Helpers to prepare data for Opentelemetry tracing *)
+
+(* Types *)
+
+type analysis_flags = {
+  secrets_validators : bool;
+  allow_all_origins : bool;
+  historical_scan : bool;
+  deep_intra_file : bool;
+  deep_inter_file : bool;
+}
+[@@derving show]
+
+(* Helpers *)
+
+val no_analysis_features : unit -> analysis_flags
+
+val get_top_level_data :
+  string -> analysis_flags -> (string * Tracing.user_data) list

--- a/src/core/Trace_data.mli
+++ b/src/core/Trace_data.mli
@@ -4,16 +4,26 @@
 
 type analysis_flags = {
   secrets_validators : bool;
+  (* True when secrets validators are enabled *)
   allow_all_origins : bool;
+  (* True when secrets validators from any origin may be used.
+     This value is discarded if secrets_validators is false *)
   historical_scan : bool;
+  (* True when historical scans are enabled *)
   deep_intra_file : bool;
+  (* True when deep intrafile scans (aka interproc taint) is enabled *)
   deep_inter_file : bool;
+      (* True when interfile scans are enabled. Only one of `deep_inter_file`
+         and `deep_intra_file` should be true. *)
 }
 [@@derving show]
 
 (* Helpers *)
 
 val no_analysis_features : unit -> analysis_flags
+(** For analysis run with the oss engine, we know all the flags will be false *)
 
 val get_top_level_data :
   string -> analysis_flags -> (string * Tracing.user_data) list
+(** Create the tags for the top level span. These tags make it easy to see
+    the traces we care about *)

--- a/src/core/dune
+++ b/src/core/dune
@@ -26,6 +26,7 @@
    glob
    lib_parsing
    ast_generic
+   tracing
 
    ; TODO ugly dependency to Ast_js.default_entity in Pattern.ml
    parser_javascript.ast

--- a/src/core_cli/Core_CLI.ml
+++ b/src/core_cli/Core_CLI.ml
@@ -759,7 +759,7 @@ let main_no_exn_handler (caps : Cap.all_caps) (sys_argv : string array) : unit =
              instrument the pre- and post-scan code in the same way. *)
           if config.trace then (
             let trace_data =
-              Trace_data.get_top_level_data config.version
+              Trace_data.get_top_level_data config.ncores config.version
                 (Trace_data.no_analysis_features ())
             in
             Tracing.configure_tracing "semgrep-oss";

--- a/src/core_cli/Core_CLI.ml
+++ b/src/core_cli/Core_CLI.ml
@@ -761,11 +761,12 @@ let main_no_exn_handler (caps : Cap.all_caps) (sys_argv : string array) : unit =
             let trace_data : Tracing.top_level_data =
               {
                 version = config.version;
-                analysis_flags = Tracing.oss_analysis ();
+                analysis_flags = Tracing.no_analysis_features ();
               }
             in
             Tracing.configure_tracing "semgrep-oss";
-            Tracing.with_setup trace_data (fun sp ->
+            Tracing.with_setup "Core_command.semgrep_core_dispatch" trace_data
+              (fun sp ->
                 Core_command.semgrep_core_dispatch caps
                   { config with top_level_span = Some sp }))
           else Core_command.semgrep_core_dispatch caps config)

--- a/src/core_cli/Core_CLI.ml
+++ b/src/core_cli/Core_CLI.ml
@@ -264,6 +264,7 @@ let mk_config () =
     action = !action;
     version = Version.version;
     roots = [] (* This will be set later in main () *);
+    top_level_span = None;
   }
 
 (*****************************************************************************)
@@ -757,9 +758,13 @@ let main_no_exn_handler (caps : Cap.all_caps) (sys_argv : string array) : unit =
            * TODO when osemgrep is the default entry point, we will also be able to
              instrument the pre- and post-scan code in the same way. *)
           if config.trace then (
-            Tracing.configure_tracing "semgrep";
-            Tracing.with_setup (fun () ->
-                Core_command.semgrep_core_dispatch caps config))
+            let trace_data : Tracing.top_level_data =
+              { version = config.version }
+            in
+            Tracing.configure_tracing "semgrep-oss";
+            Tracing.with_setup trace_data (fun sp ->
+                Core_command.semgrep_core_dispatch caps
+                  { config with top_level_span = Some sp }))
           else Core_command.semgrep_core_dispatch caps config)
 
 let with_exception_trace f =

--- a/src/core_cli/Core_CLI.ml
+++ b/src/core_cli/Core_CLI.ml
@@ -758,14 +758,12 @@ let main_no_exn_handler (caps : Cap.all_caps) (sys_argv : string array) : unit =
            * TODO when osemgrep is the default entry point, we will also be able to
              instrument the pre- and post-scan code in the same way. *)
           if config.trace then (
-            let trace_data : Tracing.top_level_data =
-              {
-                version = config.version;
-                analysis_flags = Tracing.no_analysis_features ();
-              }
+            let trace_data =
+              Trace_data.get_top_level_data config.version
+                (Trace_data.no_analysis_features ())
             in
             Tracing.configure_tracing "semgrep-oss";
-            Tracing.with_setup "Core_command.semgrep_core_dispatch" trace_data
+            Tracing.with_tracing "Core_command.semgrep_core_dispatch" trace_data
               (fun sp ->
                 Core_command.semgrep_core_dispatch caps
                   { config with top_level_span = Some sp }))

--- a/src/core_cli/Core_CLI.ml
+++ b/src/core_cli/Core_CLI.ml
@@ -759,7 +759,10 @@ let main_no_exn_handler (caps : Cap.all_caps) (sys_argv : string array) : unit =
              instrument the pre- and post-scan code in the same way. *)
           if config.trace then (
             let trace_data : Tracing.top_level_data =
-              { version = config.version }
+              {
+                version = config.version;
+                analysis_flags = Tracing.oss_analysis ();
+              }
             in
             Tracing.configure_tracing "semgrep-oss";
             Tracing.with_setup trace_data (fun sp ->

--- a/src/core_scan/Core_scan.ml
+++ b/src/core_scan/Core_scan.ml
@@ -1073,11 +1073,12 @@ let scan ?match_hook (caps : < Cap.tmp >) config
   (* Add information to the trace *)
   let num_targets = List.length all_targets in
   let num_skipped_targets = List.length skipped in
+  UCommon.pr2 "We're adding data to the span";
   Tracing.add_data_to_opt_span config.top_level_span
     [
-      ("num_rules", `Int (List.length valid_rules));
-      ("num_targets", `Int num_targets);
-      ("num_skipped_targets", `Int num_skipped_targets);
+      ("numrules", `Int (List.length valid_rules));
+      ("numtargets", `Int num_targets);
+      ("numskipped_targets", `Int num_skipped_targets);
     ];
 
   (* Let's go! *)
@@ -1120,7 +1121,7 @@ let scan ?match_hook (caps : < Cap.tmp >) config
   let num_matches = List.length res.processed_matches in
   let num_errors = List.length res.errors in
   Tracing.add_data_to_opt_span config.top_level_span
-    [ ("num_matches", `Int num_matches); ("num_errors", `Int num_errors) ];
+    [ ("nummatches", `Int num_matches); ("numerrors", `Int num_errors) ];
   Logs.info (fun m ->
       m ~tags "found %d matches, %d errors"
         (List.length res.processed_matches)

--- a/src/core_scan/Core_scan.ml
+++ b/src/core_scan/Core_scan.ml
@@ -1075,7 +1075,6 @@ let scan ?match_hook (caps : < Cap.tmp >) config
   let num_skipped_targets = List.length skipped in
   Tracing.add_data_to_opt_span config.top_level_span
     [
-      ("jobs", `Int config.ncores);
       ("num_rules", `Int (List.length valid_rules));
       ("num_targets", `Int num_targets);
       ("num_skipped_targets", `Int num_skipped_targets);
@@ -1123,9 +1122,7 @@ let scan ?match_hook (caps : < Cap.tmp >) config
   Tracing.add_data_to_opt_span config.top_level_span
     [ ("num_matches", `Int num_matches); ("num_errors", `Int num_errors) ];
   Logs.info (fun m ->
-      m ~tags "found %d matches, %d errors"
-        (List.length res.processed_matches)
-        (List.length res.errors));
+      m ~tags "found %d matches, %d errors" num_matches num_errors);
 
   let processed_matches, new_errors, new_skipped =
     filter_files_with_too_many_matches_and_transform_as_timeout

--- a/src/core_scan/Core_scan.ml
+++ b/src/core_scan/Core_scan.ml
@@ -1070,10 +1070,20 @@ let scan ?match_hook (caps : < Cap.tmp >) config
     else NoPrefiltering
   in
 
+  (* Add information to the trace *)
+  let num_targets = List.length all_targets in
+  let num_skipped_targets = List.length skipped in
+  Tracing.add_data_to_opt_span config.top_level_span
+    [
+      ("num_rules", `Int (List.length valid_rules));
+      ("num_targets", `Int num_targets);
+      ("num_skipped_targets", `Int num_skipped_targets);
+    ];
+
   (* Let's go! *)
   Logs.info (fun m ->
-      m ~tags "processing %d files, skipping %d files" (List.length all_targets)
-        (List.length skipped));
+      m ~tags "processing %d files, skipping %d files" num_targets
+        num_skipped_targets);
   let file_results, scanned_targets =
     all_targets
     |> iter_targets_and_get_matches_and_exn_to_errors config
@@ -1107,6 +1117,10 @@ let scan ?match_hook (caps : < Cap.tmp >) config
       (List_.map (fun r -> (r, `OSS)) valid_rules)
       invalid_rules scanned interfile_languages_used ~rules_parse_time
   in
+  let num_matches = List.length res.processed_matches in
+  let num_errors = List.length res.errors in
+  Tracing.add_data_to_opt_span config.top_level_span
+    [ ("num_matches", `Int num_matches); ("num_errors", `Int num_errors) ];
   Logs.info (fun m ->
       m ~tags "found %d matches, %d errors"
         (List.length res.processed_matches)

--- a/src/core_scan/Core_scan.ml
+++ b/src/core_scan/Core_scan.ml
@@ -1073,12 +1073,12 @@ let scan ?match_hook (caps : < Cap.tmp >) config
   (* Add information to the trace *)
   let num_targets = List.length all_targets in
   let num_skipped_targets = List.length skipped in
-  UCommon.pr2 "We're adding data to the span";
   Tracing.add_data_to_opt_span config.top_level_span
     [
-      ("numrules", `Int (List.length valid_rules));
-      ("numtargets", `Int num_targets);
-      ("numskipped_targets", `Int num_skipped_targets);
+      ("jobs", `Int config.ncores);
+      ("num_rules", `Int (List.length valid_rules));
+      ("num_targets", `Int num_targets);
+      ("num_skipped_targets", `Int num_skipped_targets);
     ];
 
   (* Let's go! *)
@@ -1121,7 +1121,7 @@ let scan ?match_hook (caps : < Cap.tmp >) config
   let num_matches = List.length res.processed_matches in
   let num_errors = List.length res.errors in
   Tracing.add_data_to_opt_span config.top_level_span
-    [ ("nummatches", `Int num_matches); ("numerrors", `Int num_errors) ];
+    [ ("num_matches", `Int num_matches); ("num_errors", `Int num_errors) ];
   Logs.info (fun m ->
       m ~tags "found %d matches, %d errors"
         (List.length res.processed_matches)

--- a/src/core_scan/Core_scan_config.ml
+++ b/src/core_scan/Core_scan_config.ml
@@ -72,6 +72,8 @@ type t = {
   action : string;
   (* Other *)
   version : string;
+  (* To add data to our opentelemetry top span, which makes it easier to filter *)
+  top_level_span : int64 option;
 }
 [@@deriving show]
 
@@ -129,4 +131,5 @@ let default =
     action = "";
     (* Other *)
     version = "";
+    top_level_span = None;
   }

--- a/src/core_scan/Core_scan_config.ml
+++ b/src/core_scan/Core_scan_config.ml
@@ -73,7 +73,7 @@ type t = {
   (* Other *)
   version : string;
   (* To add data to our opentelemetry top span, which makes it easier to filter *)
-  top_level_span : int64 option;
+  top_level_span : Tracing.span option;
 }
 [@@deriving show]
 


### PR DESCRIPTION
This will make it easier for us to understand the times

Unfortunately, a lot of information is hard to get by the point we enter semgrep-core. With osemgrep as the entry point, we would be able to add a lot more. Adding it during the migration is fairly difficult.

