### PR TITLE
Small cleanup of the recently jsonnetized workflow push-docker and

### DIFF
--- a/.github/workflows/promote-canary-to-latest.yml
+++ b/.github/workflows/promote-canary-to-latest.yml
@@ -13,28 +13,6 @@ jobs:
           docker_image: ${{ inputs.docker_image }}
         name: promote-canary-to-latest
         run: |
-          #
-          # Promoting an image via Docker tags is typically done via:
-          # docker pull source-image
-          # docker tag source-image target-image
-          # docker push target-image
-          #
-          # Sadly, this falls apart when dealing with multi-arch docker images. This is
-          # because a multi-arch image (e.g. returntocorp/semgrep:latest) doesn't actually
-          # point to a specific docker image manifest, but rather, a "manifest list" which
-          # is effectively a mapping of OS architectures to actual docker image manifests.
-          #
-          # When `docker pull` encounters a manifest list, it implicitly grabs the
-          # arch-specific image for the machine that's docker is running on, which means
-          # that the subsequent tag and push will never push the multi-arch image.
-          #
-          # Instead, we use `docker buildx imagetools create` which only operates on
-          # manifest lists. This allows us to point to a manifest list successfully
-          #
-          # For more info:
-          # - manifest lists: https://docs.docker.com/registry/spec/manifest-v2-2/
-          # - imagetools create: https://docs.docker.com/engine/reference/commandline/buildx_imagetools_create/
-
           if [[ "${debug}" == "true" ]]; then
             echo "Enabling debug logging..."
             set -x

--- a/.github/workflows/push-docker.yml
+++ b/.github/workflows/push-docker.yml
@@ -22,7 +22,8 @@ jobs:
             echo "Found images: ${image_filenames[@]}"
           fi
 
-          # Create an empty manifest list. This will ultimately be the union of all the arch-specific image manifests we intend to publish.
+          # Create an empty manifest list. This will ultimately be the union of
+          # all the arch-specific image manifests we intend to publish.
           cat << "EOF" > ${MERGED_IMAGE_PATH}/index.json
           {
             "schemaVersion": 2,
@@ -32,13 +33,15 @@ jobs:
           EOF
           echo "Wrote empty manifest list to ${MERGED_IMAGE_PATH}/index.json"
 
-          # Merge the contents (blobs and manifest) of each docker image into one big multi-arch image
+          # Merge the contents (blobs and manifest) of each docker image into one
+          # big multi-arch image
           for image_filename in ${image_filenames[@]}; do
             echo "Merging contents of ${image_filename}"
             cd $(dirname $image_filename)
             tar xvf image.tar
 
-            # Copy image's blobs into merged blobs folder (overwrite is fine since this is content-addressable storage)
+            # Copy image's blobs into merged blobs folder (overwrite is fine
+            # since this is content-addressable storage)
             cp -rvf blobs/sha256/* ${MERGED_IMAGE_PATH}/blobs/sha256/
 
             # Merge image's manifest list into our merged manifest list
@@ -84,7 +87,7 @@ on:
   workflow_call:
     inputs:
       artifact-name:
-        description: Name (key) to use when uploading the docker image tarball as a artifact
+        description: Name (key) to use when uploading the docker image tarball as an artifact
         required: true
         type: string
       dry-run:
@@ -92,13 +95,13 @@ on:
         required: true
         type: boolean
       repository-name:
-        description: The repository/name of the docker image to push, e.g., returntocorp/semgrep
+        description: The repository/name of the docker image to push, e.g., semgrep/semgrep
         required: true
         type: string
   workflow_dispatch:
     inputs:
       artifact-name:
-        description: Name (key) to use when uploading the docker image tarball as a artifact
+        description: Name (key) to use when uploading the docker image tarball as an artifact
         required: true
         type: string
       dry-run:
@@ -106,6 +109,6 @@ on:
         required: true
         type: boolean
       repository-name:
-        description: The repository/name of the docker image to push, e.g., returntocorp/semgrep
+        description: The repository/name of the docker image to push, e.g., semgrep/semgrep
         required: true
         type: string


### PR DESCRIPTION
promote

test plan:
wait for green CI checks (tests.jsonnet is exercising push-docker)
and trigger manually from this branch a promote-to-canary dry-run
test