### PR TITLE
Promote also the -nonroot variant when promoting the canary

### DIFF
--- a/.github/workflows/promote-canary-to-latest.jsonnet
+++ b/.github/workflows/promote-canary-to-latest.jsonnet
@@ -1,5 +1,7 @@
-// Workflow to manually promote the semgrep/semgrep:canary docker image
-// to semgrep/semgrep:latest that most customers are using.
+// Workflow to manually promote the returntocorp/semgrep:canary docker image
+// to returntocorp/semgrep:latest that most customers are using.
+// See https://www.notion.so/semgrep/returntocorp-semgrep-canary-docker-canary-45e4927fb1f847429f6064a96bf9dffd
+// for more context.
 //
 // Promoting an image via Docker tags is typically done via:
 //    $ docker pull source-image
@@ -7,7 +9,7 @@
 //    $ docker push target-image
 //
 // Sadly, this falls apart when dealing with multi-arch docker images. This is
-// because a multi-arch image (e.g. semgrep/semgrep:latest) doesn't actually
+// because a multi-arch image (e.g. returntocorp/semgrep:latest) doesn't actually
 // point to a specific docker image manifest, but rather, a "manifest list" which
 // is effectively a mapping of OS architectures to actual docker image manifests.
 //
@@ -35,14 +37,25 @@ local inputs = {
         // testing image
         'returntocorp/semgrep-test',
         'returntocorp/semgrep',
-        'semgrep/semgrep',
       ],
-      description: 'Semgrep docker image to update',
+      description: 'Semgrep docker image to promote',
       required: true,
     },
     debug: {
       type: 'boolean',
       description: 'Check to enable verbose logging of bash commands',
+      required: true,
+      default: false,
+    },
+    update_also_semgrep_semgrep: {
+      type: 'boolean',
+      description: 'Check to also promote semgrep/semgrep:canary to :latest',
+      required: true,
+      default: false,
+    },
+    update_also_nonroot: {
+      type: 'boolean',
+      description: 'Check to also promote returntocorp/semgrep:canary-nonroot to :latest-nonroot',
       required: true,
       default: false,
     },
@@ -58,47 +71,56 @@ local inputs = {
 // ----------------------------------------------------------------------------
 // The Job
 // ----------------------------------------------------------------------------
+
+//ex: promote("returntocorp/semgrep", "-nonroot")
+local promote_step(image, suffix='') = {
+  name: "Promoting %(img)s:canary%(suffix)s to %(img)s:latest%(suffix)s" %
+     { img: image, suffix: suffix },
+  run: |||
+    if [[ "${{ inputs.debug }}" == "true" ]]; then
+      echo "Enabling debug logging..."
+      set -x
+    fi
+
+    canary_digest=$(docker buildx imagetools inspect --format '{{printf "%%s" .Manifest.Digest}}' %(image)s:canary%(suffix)s || echo "")
+    latest_digest=$(docker buildx imagetools inspect --format '{{printf "%%s" .Manifest.Digest}}' %(image)s:latest%(suffix)s || echo "(not set)")
+
+    if [[ "${canary_digest}" == "" ]]; then
+      echo "Error: %(image)s:canary%(suffix)s did not resolve to a manifest list"
+      echo "If this is urgent, you can manually login to our Docker Hub account and then run these commands to promote an arch-specific image:"
+      echo "docker pull %(image)s:canary%(suffix)s"
+      echo "docker tag %(image)s:canary%(suffix)s %(image)s:latest%(suffix)s"
+      echo "docker push %(image)s:latest%(suffix)s"
+      exit 1
+    fi
+
+    echo "Promoting %(image)s:canary%(suffix)s (${canary_digest}) to %(image)s:latest%(suffix)s (was ${latest_digest})"
+    echo ""
+
+    if [[ "${{ inputs.confirmed }}" == "true" ]]; then
+      docker buildx imagetools create -t %(image)s:latest%(suffix)s %(image)s:canary%(suffix)s
+    else
+      echo "(dry run)"
+      docker buildx imagetools create --dry-run -t %(image)s:latest%(suffix)s %(image)s:canary%(suffix)s
+      echo "(dry run)"
+    fi
+  ||| % { image: image, suffix: suffix },
+}
+;
+
 local job = {
   'runs-on': 'ubuntu-22.04',
   steps: [
     actions.docker_login_step,
-    {
-      name: 'promote-canary-to-latest',
-      env: {
-        docker_image: '${{ inputs.docker_image }}',
-        confirmed: '${{ inputs.confirmed }}',
-        debug: '${{ inputs.debug }}',
-      },
-
-      run: |||
-        if [[ "${debug}" == "true" ]]; then
-          echo "Enabling debug logging..."
-          set -x
-        fi
-
-        canary_digest=$(docker buildx imagetools inspect --format '{{printf "%s" .Manifest.Digest}}' ${docker_image}:canary || echo "")
-        latest_digest=$(docker buildx imagetools inspect --format '{{printf "%s" .Manifest.Digest}}' ${docker_image}:latest || echo "(not set)")
-
-        if [[ "${canary_digest}" == "" ]]; then
-          echo "Error: ${docker_image}:canary did not resolve to a manifest list"
-          echo "If this is urgent, you can manually login to our Docker Hub account and then run these commands to promote an arch-specific image:"
-          echo "docker pull ${docker_image}:canary"
-          echo "docker tag ${docker_image}:canary ${docker_image}:latest"
-          echo "docker push ${docker_image}:latest"
-          exit 1
-        fi
-
-        echo "Promoting ${docker_image}:canary (${canary_digest}) to ${docker_image}:latest (was ${latest_digest})"
-        echo ""
-
-        if [[ "${confirmed}" == "true" ]]; then
-          docker buildx imagetools create -t ${docker_image}:latest ${docker_image}:canary
-        else
-          echo "(dry run)"
-          docker buildx imagetools create --dry-run -t ${docker_image}:latest ${docker_image}:canary
-          echo "(dry run)"
-        fi
-      |||,
+    promote_step('${{ inputs.docker_image }}', ''),
+    promote_step('${{ inputs.docker_image }}', '-nonroot') + {
+      'if': '${{ inputs.update_also_nonroot }}',
+    },
+    promote_step('semgrep/semgrep', '') + {
+      'if': '${{ inputs.update_also_semgrep_semgrep }}',
+    },
+    promote_step('semgrep/semgrep', '-nonroot') + {
+      'if': '${{ inputs.update_also_semgrep_semgrep && inputs.update_also_nonroot }}',
     },
   ],
 };

--- a/.github/workflows/promote-canary-to-latest.yml
+++ b/.github/workflows/promote-canary-to-latest.yml
@@ -7,37 +7,123 @@ jobs:
         with:
           password: ${{ secrets.DOCKER_PASSWORD }}
           username: ${{ secrets.DOCKER_USERNAME }}
-      - env:
-          confirmed: ${{ inputs.confirmed }}
-          debug: ${{ inputs.debug }}
-          docker_image: ${{ inputs.docker_image }}
-        name: promote-canary-to-latest
+      - name: Promoting ${{ inputs.docker_image }}:canary to ${{ inputs.docker_image }}:latest
         run: |
-          if [[ "${debug}" == "true" ]]; then
+          if [[ "${{ inputs.debug }}" == "true" ]]; then
             echo "Enabling debug logging..."
             set -x
           fi
 
-          canary_digest=$(docker buildx imagetools inspect --format '{{printf "%s" .Manifest.Digest}}' ${docker_image}:canary || echo "")
-          latest_digest=$(docker buildx imagetools inspect --format '{{printf "%s" .Manifest.Digest}}' ${docker_image}:latest || echo "(not set)")
+          canary_digest=$(docker buildx imagetools inspect --format '{{printf "%s" .Manifest.Digest}}' ${{ inputs.docker_image }}:canary || echo "")
+          latest_digest=$(docker buildx imagetools inspect --format '{{printf "%s" .Manifest.Digest}}' ${{ inputs.docker_image }}:latest || echo "(not set)")
 
           if [[ "${canary_digest}" == "" ]]; then
-            echo "Error: ${docker_image}:canary did not resolve to a manifest list"
+            echo "Error: ${{ inputs.docker_image }}:canary did not resolve to a manifest list"
             echo "If this is urgent, you can manually login to our Docker Hub account and then run these commands to promote an arch-specific image:"
-            echo "docker pull ${docker_image}:canary"
-            echo "docker tag ${docker_image}:canary ${docker_image}:latest"
-            echo "docker push ${docker_image}:latest"
+            echo "docker pull ${{ inputs.docker_image }}:canary"
+            echo "docker tag ${{ inputs.docker_image }}:canary ${{ inputs.docker_image }}:latest"
+            echo "docker push ${{ inputs.docker_image }}:latest"
             exit 1
           fi
 
-          echo "Promoting ${docker_image}:canary (${canary_digest}) to ${docker_image}:latest (was ${latest_digest})"
+          echo "Promoting ${{ inputs.docker_image }}:canary (${canary_digest}) to ${{ inputs.docker_image }}:latest (was ${latest_digest})"
           echo ""
 
-          if [[ "${confirmed}" == "true" ]]; then
-            docker buildx imagetools create -t ${docker_image}:latest ${docker_image}:canary
+          if [[ "${{ inputs.confirmed }}" == "true" ]]; then
+            docker buildx imagetools create -t ${{ inputs.docker_image }}:latest ${{ inputs.docker_image }}:canary
           else
             echo "(dry run)"
-            docker buildx imagetools create --dry-run -t ${docker_image}:latest ${docker_image}:canary
+            docker buildx imagetools create --dry-run -t ${{ inputs.docker_image }}:latest ${{ inputs.docker_image }}:canary
+            echo "(dry run)"
+          fi
+      - if: ${{ inputs.update_also_nonroot }}
+        name: Promoting ${{ inputs.docker_image }}:canary-nonroot to ${{ inputs.docker_image }}:latest-nonroot
+        run: |
+          if [[ "${{ inputs.debug }}" == "true" ]]; then
+            echo "Enabling debug logging..."
+            set -x
+          fi
+
+          canary_digest=$(docker buildx imagetools inspect --format '{{printf "%s" .Manifest.Digest}}' ${{ inputs.docker_image }}:canary-nonroot || echo "")
+          latest_digest=$(docker buildx imagetools inspect --format '{{printf "%s" .Manifest.Digest}}' ${{ inputs.docker_image }}:latest-nonroot || echo "(not set)")
+
+          if [[ "${canary_digest}" == "" ]]; then
+            echo "Error: ${{ inputs.docker_image }}:canary-nonroot did not resolve to a manifest list"
+            echo "If this is urgent, you can manually login to our Docker Hub account and then run these commands to promote an arch-specific image:"
+            echo "docker pull ${{ inputs.docker_image }}:canary-nonroot"
+            echo "docker tag ${{ inputs.docker_image }}:canary-nonroot ${{ inputs.docker_image }}:latest-nonroot"
+            echo "docker push ${{ inputs.docker_image }}:latest-nonroot"
+            exit 1
+          fi
+
+          echo "Promoting ${{ inputs.docker_image }}:canary-nonroot (${canary_digest}) to ${{ inputs.docker_image }}:latest-nonroot (was ${latest_digest})"
+          echo ""
+
+          if [[ "${{ inputs.confirmed }}" == "true" ]]; then
+            docker buildx imagetools create -t ${{ inputs.docker_image }}:latest-nonroot ${{ inputs.docker_image }}:canary-nonroot
+          else
+            echo "(dry run)"
+            docker buildx imagetools create --dry-run -t ${{ inputs.docker_image }}:latest-nonroot ${{ inputs.docker_image }}:canary-nonroot
+            echo "(dry run)"
+          fi
+      - if: ${{ inputs.update_also_semgrep_semgrep }}
+        name: Promoting semgrep/semgrep:canary to semgrep/semgrep:latest
+        run: |
+          if [[ "${{ inputs.debug }}" == "true" ]]; then
+            echo "Enabling debug logging..."
+            set -x
+          fi
+
+          canary_digest=$(docker buildx imagetools inspect --format '{{printf "%s" .Manifest.Digest}}' semgrep/semgrep:canary || echo "")
+          latest_digest=$(docker buildx imagetools inspect --format '{{printf "%s" .Manifest.Digest}}' semgrep/semgrep:latest || echo "(not set)")
+
+          if [[ "${canary_digest}" == "" ]]; then
+            echo "Error: semgrep/semgrep:canary did not resolve to a manifest list"
+            echo "If this is urgent, you can manually login to our Docker Hub account and then run these commands to promote an arch-specific image:"
+            echo "docker pull semgrep/semgrep:canary"
+            echo "docker tag semgrep/semgrep:canary semgrep/semgrep:latest"
+            echo "docker push semgrep/semgrep:latest"
+            exit 1
+          fi
+
+          echo "Promoting semgrep/semgrep:canary (${canary_digest}) to semgrep/semgrep:latest (was ${latest_digest})"
+          echo ""
+
+          if [[ "${{ inputs.confirmed }}" == "true" ]]; then
+            docker buildx imagetools create -t semgrep/semgrep:latest semgrep/semgrep:canary
+          else
+            echo "(dry run)"
+            docker buildx imagetools create --dry-run -t semgrep/semgrep:latest semgrep/semgrep:canary
+            echo "(dry run)"
+          fi
+      - if: ${{ inputs.update_also_semgrep_semgrep && inputs.update_also_nonroot }}
+        name: Promoting semgrep/semgrep:canary-nonroot to semgrep/semgrep:latest-nonroot
+        run: |
+          if [[ "${{ inputs.debug }}" == "true" ]]; then
+            echo "Enabling debug logging..."
+            set -x
+          fi
+
+          canary_digest=$(docker buildx imagetools inspect --format '{{printf "%s" .Manifest.Digest}}' semgrep/semgrep:canary-nonroot || echo "")
+          latest_digest=$(docker buildx imagetools inspect --format '{{printf "%s" .Manifest.Digest}}' semgrep/semgrep:latest-nonroot || echo "(not set)")
+
+          if [[ "${canary_digest}" == "" ]]; then
+            echo "Error: semgrep/semgrep:canary-nonroot did not resolve to a manifest list"
+            echo "If this is urgent, you can manually login to our Docker Hub account and then run these commands to promote an arch-specific image:"
+            echo "docker pull semgrep/semgrep:canary-nonroot"
+            echo "docker tag semgrep/semgrep:canary-nonroot semgrep/semgrep:latest-nonroot"
+            echo "docker push semgrep/semgrep:latest-nonroot"
+            exit 1
+          fi
+
+          echo "Promoting semgrep/semgrep:canary-nonroot (${canary_digest}) to semgrep/semgrep:latest-nonroot (was ${latest_digest})"
+          echo ""
+
+          if [[ "${{ inputs.confirmed }}" == "true" ]]; then
+            docker buildx imagetools create -t semgrep/semgrep:latest-nonroot semgrep/semgrep:canary-nonroot
+          else
+            echo "(dry run)"
+            docker buildx imagetools create --dry-run -t semgrep/semgrep:latest-nonroot semgrep/semgrep:canary-nonroot
             echo "(dry run)"
           fi
 name: promote-canary-to-latest
@@ -55,10 +141,19 @@ on:
         required: true
         type: boolean
       docker_image:
-        description: Semgrep docker image to update
+        description: Semgrep docker image to promote
         options:
           - returntocorp/semgrep-test
           - returntocorp/semgrep
-          - semgrep/semgrep
         required: true
         type: choice
+      update_also_nonroot:
+        default: false
+        description: Check to also promote returntocorp/semgrep:canary-nonroot to :latest-nonroot
+        required: true
+        type: boolean
+      update_also_semgrep_semgrep:
+        default: false
+        description: Check to also promote semgrep/semgrep:canary to :latest
+        required: true
+        type: boolean


### PR DESCRIPTION
test plan:
run promote workflow from this branch with the semgrep-test repo
and see what is executed