### PR TITLE
test: e2e tests for autofixes deleting the match

### DIFF
--- a/cli/tests/default/e2e/rules/autofix/delete-partial-line.yaml
+++ b/cli/tests/default/e2e/rules/autofix/delete-partial-line.yaml
@@ -1,0 +1,27 @@
+# This test is designed to test autofixes that remove text, both on entire lines
+# and on partial lines. The example here is a bit contrived so as to ensure that
+# the program after autofix application remains valid code.
+#
+# The purpose of this test is primarily to exercise the behavior of the code
+# that generates the `fixed_lines` part of the JSON result. It has different
+# behavior depending on whether part of a line or a whole line has been deleted.
+#
+# I (nmote) am not sure whether this difference in behavior is really desirable.
+# If you are reading this and want to change it to be more consistent, go ahead.
+# I'm just documenting the current behavior and making sure that we don't
+# accidentally make a potentially breaking change.
+rules:
+  - id: delete-default
+    patterns:
+      - pattern: |
+          foo($X)
+      - metavariable-pattern:
+          metavariable: $X
+          pattern: |
+            42
+      - focus-metavariable: $X
+    fix: ""
+    message: Unnecessary parameter which matches the default
+    languages:
+      - python
+    severity: WARNING

--- a/cli/tests/default/e2e/snapshots/test_autofix/test_autofix/rulesautofixdelete-partial-line.yaml-autofixdelete-partial-line.py-json-dryrun/autofix/delete-partial-line.py-dryrun
+++ b/cli/tests/default/e2e/snapshots/test_autofix/test_autofix/rulesautofixdelete-partial-line.yaml-autofixdelete-partial-line.py-json-dryrun/autofix/delete-partial-line.py-dryrun
@@ -1,0 +1,23 @@
+def foo(x=42):
+    print(x)
+
+# No autofix
+foo()
+foo(
+)
+foo(43)
+foo(
+43
+)
+
+# Autofix of a partial line
+foo(42)
+foo(
+42)
+foo(42
+)
+
+# Autofix of an entire line
+foo(
+42
+)

--- a/cli/tests/default/e2e/snapshots/test_autofix/test_autofix/rulesautofixdelete-partial-line.yaml-autofixdelete-partial-line.py-json-dryrun/results.json
+++ b/cli/tests/default/e2e/snapshots/test_autofix/test_autofix/rulesautofixdelete-partial-line.yaml-autofixdelete-partial-line.py-json-dryrun/results.json
@@ -1,0 +1,182 @@
+{
+  "errors": [],
+  "interfile_languages_used": [],
+  "paths": {
+    "scanned": [
+      "targets/autofix/delete-partial-line.py"
+    ]
+  },
+  "results": [
+    {
+      "check_id": "rules.autofix.delete-default",
+      "end": {
+        "col": 7,
+        "line": 14,
+        "offset": 108
+      },
+      "extra": {
+        "engine_kind": "OSS",
+        "fingerprint": "0x42",
+        "fix": "",
+        "fixed_lines": [
+          "foo()"
+        ],
+        "is_ignored": false,
+        "lines": "foo(42)",
+        "message": "Unnecessary parameter which matches the default",
+        "metadata": {},
+        "metavars": {
+          "$X": {
+            "abstract_content": "42",
+            "end": {
+              "col": 7,
+              "line": 14,
+              "offset": 108
+            },
+            "start": {
+              "col": 5,
+              "line": 14,
+              "offset": 106
+            }
+          }
+        },
+        "severity": "WARNING",
+        "validation_state": "NO_VALIDATOR"
+      },
+      "path": "targets/autofix/delete-partial-line.py",
+      "start": {
+        "col": 5,
+        "line": 14,
+        "offset": 106
+      }
+    },
+    {
+      "check_id": "rules.autofix.delete-default",
+      "end": {
+        "col": 3,
+        "line": 16,
+        "offset": 117
+      },
+      "extra": {
+        "engine_kind": "OSS",
+        "fingerprint": "0x42",
+        "fix": "",
+        "fixed_lines": [
+          ")"
+        ],
+        "is_ignored": false,
+        "lines": "42)",
+        "message": "Unnecessary parameter which matches the default",
+        "metadata": {},
+        "metavars": {
+          "$X": {
+            "abstract_content": "42",
+            "end": {
+              "col": 3,
+              "line": 16,
+              "offset": 117
+            },
+            "start": {
+              "col": 1,
+              "line": 16,
+              "offset": 115
+            }
+          }
+        },
+        "severity": "WARNING",
+        "validation_state": "NO_VALIDATOR"
+      },
+      "path": "targets/autofix/delete-partial-line.py",
+      "start": {
+        "col": 1,
+        "line": 16,
+        "offset": 115
+      }
+    },
+    {
+      "check_id": "rules.autofix.delete-default",
+      "end": {
+        "col": 7,
+        "line": 17,
+        "offset": 125
+      },
+      "extra": {
+        "engine_kind": "OSS",
+        "fingerprint": "0x42",
+        "fix": "",
+        "fixed_lines": [
+          "foo("
+        ],
+        "is_ignored": false,
+        "lines": "foo(42",
+        "message": "Unnecessary parameter which matches the default",
+        "metadata": {},
+        "metavars": {
+          "$X": {
+            "abstract_content": "42",
+            "end": {
+              "col": 7,
+              "line": 17,
+              "offset": 125
+            },
+            "start": {
+              "col": 5,
+              "line": 17,
+              "offset": 123
+            }
+          }
+        },
+        "severity": "WARNING",
+        "validation_state": "NO_VALIDATOR"
+      },
+      "path": "targets/autofix/delete-partial-line.py",
+      "start": {
+        "col": 5,
+        "line": 17,
+        "offset": 123
+      }
+    },
+    {
+      "check_id": "rules.autofix.delete-default",
+      "end": {
+        "col": 3,
+        "line": 22,
+        "offset": 164
+      },
+      "extra": {
+        "engine_kind": "OSS",
+        "fingerprint": "0x42",
+        "fix": "",
+        "is_ignored": false,
+        "lines": "42",
+        "message": "Unnecessary parameter which matches the default",
+        "metadata": {},
+        "metavars": {
+          "$X": {
+            "abstract_content": "42",
+            "end": {
+              "col": 3,
+              "line": 22,
+              "offset": 164
+            },
+            "start": {
+              "col": 1,
+              "line": 22,
+              "offset": 162
+            }
+          }
+        },
+        "severity": "WARNING",
+        "validation_state": "NO_VALIDATOR"
+      },
+      "path": "targets/autofix/delete-partial-line.py",
+      "start": {
+        "col": 1,
+        "line": 22,
+        "offset": 162
+      }
+    }
+  ],
+  "skipped_rules": [],
+  "version": "0.42"
+}

--- a/cli/tests/default/e2e/snapshots/test_autofix/test_autofix/rulesautofixdelete-partial-line.yaml-autofixdelete-partial-line.py-json-dryrun/stderr.txt
+++ b/cli/tests/default/e2e/snapshots/test_autofix/test_autofix/rulesautofixdelete-partial-line.yaml-autofixdelete-partial-line.py-json-dryrun/stderr.txt
@@ -1,0 +1,14 @@
+
+
+┌─────────────┐
+│ Scan Status │
+└─────────────┘
+  Scanning 1 file tracked by git with 1 Code rule:
+  Scanning 1 file.
+
+
+┌──────────────┐
+│ Scan Summary │
+└──────────────┘
+
+Ran 1 rule on 1 file: 4 findings.

--- a/cli/tests/default/e2e/snapshots/test_autofix/test_autofix/rulesautofixdelete-partial-line.yaml-autofixdelete-partial-line.py-json-not-dryrun/autofix/delete-partial-line.py-fixed
+++ b/cli/tests/default/e2e/snapshots/test_autofix/test_autofix/rulesautofixdelete-partial-line.yaml-autofixdelete-partial-line.py-json-not-dryrun/autofix/delete-partial-line.py-fixed
@@ -1,0 +1,22 @@
+def foo(x=42):
+    print(x)
+
+# No autofix
+foo()
+foo(
+)
+foo(43)
+foo(
+43
+)
+
+# Autofix of a partial line
+foo()
+foo(
+)
+foo(
+)
+
+# Autofix of an entire line
+foo(
+)

--- a/cli/tests/default/e2e/snapshots/test_autofix/test_autofix/rulesautofixdelete-partial-line.yaml-autofixdelete-partial-line.py-json-not-dryrun/results.json
+++ b/cli/tests/default/e2e/snapshots/test_autofix/test_autofix/rulesautofixdelete-partial-line.yaml-autofixdelete-partial-line.py-json-not-dryrun/results.json
@@ -1,0 +1,173 @@
+{
+  "errors": [],
+  "interfile_languages_used": [],
+  "paths": {
+    "scanned": [
+      "targets/autofix/delete-partial-line.py"
+    ]
+  },
+  "results": [
+    {
+      "check_id": "rules.autofix.delete-default",
+      "end": {
+        "col": 7,
+        "line": 14,
+        "offset": 108
+      },
+      "extra": {
+        "engine_kind": "OSS",
+        "fingerprint": "0x42",
+        "fix": "",
+        "is_ignored": false,
+        "lines": "foo(42)",
+        "message": "Unnecessary parameter which matches the default",
+        "metadata": {},
+        "metavars": {
+          "$X": {
+            "abstract_content": "42",
+            "end": {
+              "col": 7,
+              "line": 14,
+              "offset": 108
+            },
+            "start": {
+              "col": 5,
+              "line": 14,
+              "offset": 106
+            }
+          }
+        },
+        "severity": "WARNING",
+        "validation_state": "NO_VALIDATOR"
+      },
+      "path": "targets/autofix/delete-partial-line.py",
+      "start": {
+        "col": 5,
+        "line": 14,
+        "offset": 106
+      }
+    },
+    {
+      "check_id": "rules.autofix.delete-default",
+      "end": {
+        "col": 3,
+        "line": 16,
+        "offset": 117
+      },
+      "extra": {
+        "engine_kind": "OSS",
+        "fingerprint": "0x42",
+        "fix": "",
+        "is_ignored": false,
+        "lines": "42)",
+        "message": "Unnecessary parameter which matches the default",
+        "metadata": {},
+        "metavars": {
+          "$X": {
+            "abstract_content": "42",
+            "end": {
+              "col": 3,
+              "line": 16,
+              "offset": 117
+            },
+            "start": {
+              "col": 1,
+              "line": 16,
+              "offset": 115
+            }
+          }
+        },
+        "severity": "WARNING",
+        "validation_state": "NO_VALIDATOR"
+      },
+      "path": "targets/autofix/delete-partial-line.py",
+      "start": {
+        "col": 1,
+        "line": 16,
+        "offset": 115
+      }
+    },
+    {
+      "check_id": "rules.autofix.delete-default",
+      "end": {
+        "col": 7,
+        "line": 17,
+        "offset": 125
+      },
+      "extra": {
+        "engine_kind": "OSS",
+        "fingerprint": "0x42",
+        "fix": "",
+        "is_ignored": false,
+        "lines": "foo(42",
+        "message": "Unnecessary parameter which matches the default",
+        "metadata": {},
+        "metavars": {
+          "$X": {
+            "abstract_content": "42",
+            "end": {
+              "col": 7,
+              "line": 17,
+              "offset": 125
+            },
+            "start": {
+              "col": 5,
+              "line": 17,
+              "offset": 123
+            }
+          }
+        },
+        "severity": "WARNING",
+        "validation_state": "NO_VALIDATOR"
+      },
+      "path": "targets/autofix/delete-partial-line.py",
+      "start": {
+        "col": 5,
+        "line": 17,
+        "offset": 123
+      }
+    },
+    {
+      "check_id": "rules.autofix.delete-default",
+      "end": {
+        "col": 3,
+        "line": 22,
+        "offset": 164
+      },
+      "extra": {
+        "engine_kind": "OSS",
+        "fingerprint": "0x42",
+        "fix": "",
+        "is_ignored": false,
+        "lines": "42",
+        "message": "Unnecessary parameter which matches the default",
+        "metadata": {},
+        "metavars": {
+          "$X": {
+            "abstract_content": "42",
+            "end": {
+              "col": 3,
+              "line": 22,
+              "offset": 164
+            },
+            "start": {
+              "col": 1,
+              "line": 22,
+              "offset": 162
+            }
+          }
+        },
+        "severity": "WARNING",
+        "validation_state": "NO_VALIDATOR"
+      },
+      "path": "targets/autofix/delete-partial-line.py",
+      "start": {
+        "col": 1,
+        "line": 22,
+        "offset": 162
+      }
+    }
+  ],
+  "skipped_rules": [],
+  "version": "0.42"
+}

--- a/cli/tests/default/e2e/snapshots/test_autofix/test_autofix/rulesautofixdelete-partial-line.yaml-autofixdelete-partial-line.py-json-not-dryrun/stderr.txt
+++ b/cli/tests/default/e2e/snapshots/test_autofix/test_autofix/rulesautofixdelete-partial-line.yaml-autofixdelete-partial-line.py-json-not-dryrun/stderr.txt
@@ -1,0 +1,15 @@
+
+
+┌─────────────┐
+│ Scan Status │
+└─────────────┘
+  Scanning 1 file tracked by git with 1 Code rule:
+  Scanning 1 file.
+successfully modified 1 file.
+
+
+┌──────────────┐
+│ Scan Summary │
+└──────────────┘
+
+Ran 1 rule on 1 file: 4 findings.

--- a/cli/tests/default/e2e/snapshots/test_autofix/test_autofix/rulesautofixdelete-partial-line.yaml-autofixdelete-partial-line.py-text-dryrun/autofix/delete-partial-line.py-dryrun
+++ b/cli/tests/default/e2e/snapshots/test_autofix/test_autofix/rulesautofixdelete-partial-line.yaml-autofixdelete-partial-line.py-text-dryrun/autofix/delete-partial-line.py-dryrun
@@ -1,0 +1,23 @@
+def foo(x=42):
+    print(x)
+
+# No autofix
+foo()
+foo(
+)
+foo(43)
+foo(
+43
+)
+
+# Autofix of a partial line
+foo(42)
+foo(
+42)
+foo(42
+)
+
+# Autofix of an entire line
+foo(
+42
+)

--- a/cli/tests/default/e2e/snapshots/test_autofix/test_autofix/rulesautofixdelete-partial-line.yaml-autofixdelete-partial-line.py-text-dryrun/results.txt
+++ b/cli/tests/default/e2e/snapshots/test_autofix/test_autofix/rulesautofixdelete-partial-line.yaml-autofixdelete-partial-line.py-text-dryrun/results.txt
@@ -1,0 +1,22 @@
+
+
+┌─────────────────┐
+│ 4 Code Findings │
+└─────────────────┘
+
+    targets/autofix/delete-partial-line.py
+    ❯❱ rules.autofix.delete-default
+          Unnecessary parameter which matches the default
+
+           ▶▶┆ Autofix ▶ delete
+           14┆ foo()
+            ⋮┆----------------------------------------
+           ▶▶┆ Autofix ▶ delete
+           16┆ )
+            ⋮┆----------------------------------------
+           ▶▶┆ Autofix ▶ delete
+           17┆ foo(
+            ⋮┆----------------------------------------
+           ▶▶┆ Autofix ▶ delete
+           22┆ 42
+

--- a/cli/tests/default/e2e/snapshots/test_autofix/test_autofix/rulesautofixdelete-partial-line.yaml-autofixdelete-partial-line.py-text-dryrun/stderr.txt
+++ b/cli/tests/default/e2e/snapshots/test_autofix/test_autofix/rulesautofixdelete-partial-line.yaml-autofixdelete-partial-line.py-text-dryrun/stderr.txt
@@ -1,0 +1,14 @@
+
+
+┌─────────────┐
+│ Scan Status │
+└─────────────┘
+  Scanning 1 file tracked by git with 1 Code rule:
+  Scanning 1 file.
+
+
+┌──────────────┐
+│ Scan Summary │
+└──────────────┘
+
+Ran 1 rule on 1 file: 4 findings.

--- a/cli/tests/default/e2e/snapshots/test_autofix/test_autofix/rulesautofixdelete-partial-line.yaml-autofixdelete-partial-line.py-text-not-dryrun/autofix/delete-partial-line.py-fixed
+++ b/cli/tests/default/e2e/snapshots/test_autofix/test_autofix/rulesautofixdelete-partial-line.yaml-autofixdelete-partial-line.py-text-not-dryrun/autofix/delete-partial-line.py-fixed
@@ -1,0 +1,22 @@
+def foo(x=42):
+    print(x)
+
+# No autofix
+foo()
+foo(
+)
+foo(43)
+foo(
+43
+)
+
+# Autofix of a partial line
+foo()
+foo(
+)
+foo(
+)
+
+# Autofix of an entire line
+foo(
+)

--- a/cli/tests/default/e2e/snapshots/test_autofix/test_autofix/rulesautofixdelete-partial-line.yaml-autofixdelete-partial-line.py-text-not-dryrun/results.txt
+++ b/cli/tests/default/e2e/snapshots/test_autofix/test_autofix/rulesautofixdelete-partial-line.yaml-autofixdelete-partial-line.py-text-not-dryrun/results.txt
@@ -1,0 +1,22 @@
+
+
+┌─────────────────┐
+│ 4 Code Findings │
+└─────────────────┘
+
+    targets/autofix/delete-partial-line.py
+    ❯❱ rules.autofix.delete-default
+          Unnecessary parameter which matches the default
+
+           ▶▶┆ Autofix ▶ delete
+           14┆ foo(42)
+            ⋮┆----------------------------------------
+           ▶▶┆ Autofix ▶ delete
+           16┆ 42)
+            ⋮┆----------------------------------------
+           ▶▶┆ Autofix ▶ delete
+           17┆ foo(42
+            ⋮┆----------------------------------------
+           ▶▶┆ Autofix ▶ delete
+           22┆ 42
+

--- a/cli/tests/default/e2e/snapshots/test_autofix/test_autofix/rulesautofixdelete-partial-line.yaml-autofixdelete-partial-line.py-text-not-dryrun/stderr.txt
+++ b/cli/tests/default/e2e/snapshots/test_autofix/test_autofix/rulesautofixdelete-partial-line.yaml-autofixdelete-partial-line.py-text-not-dryrun/stderr.txt
@@ -1,0 +1,15 @@
+
+
+┌─────────────┐
+│ Scan Status │
+└─────────────┘
+  Scanning 1 file tracked by git with 1 Code rule:
+  Scanning 1 file.
+successfully modified 1 file.
+
+
+┌──────────────┐
+│ Scan Summary │
+└──────────────┘
+
+Ran 1 rule on 1 file: 4 findings.

--- a/cli/tests/default/e2e/targets/autofix/delete-partial-line.py
+++ b/cli/tests/default/e2e/targets/autofix/delete-partial-line.py
@@ -1,0 +1,23 @@
+def foo(x=42):
+    print(x)
+
+# No autofix
+foo()
+foo(
+)
+foo(43)
+foo(
+43
+)
+
+# Autofix of a partial line
+foo(42)
+foo(
+42)
+foo(42
+)
+
+# Autofix of an entire line
+foo(
+42
+)

--- a/cli/tests/default/e2e/test_autofix.py
+++ b/cli/tests/default/e2e/test_autofix.py
@@ -45,6 +45,7 @@ from semgrep.constants import OutputFormat
             "rules/autofix/terraform-ec2-instance-metadata-options.yaml",
             "autofix/terraform-ec2-instance-metadata-options.hcl",
         ),
+        ("rules/autofix/delete-partial-line.yaml", "autofix/delete-partial-line.py"),
     ],
 )
 def test_autofix(


### PR DESCRIPTION
There's some peculiar behavior around reporting `fixed_lines` when deleting full lines. I'm not sure if it's the behavior that we want, but either way it should be tested and we should be deliberate if we change it.

Test plan: Run this test

