### PR TITLE
refactor(lsp): explicit params to semgrep/search

### DIFF
--- a/src/osemgrep/language_server/Test_LS_e2e.ml
+++ b/src/osemgrep/language_server/Test_LS_e2e.ml
@@ -550,12 +550,12 @@ let _send_semgrep_refresh_rules info =
   send_custom_notification info ~meth:"semgrep/refreshRules"
 
 let send_semgrep_search info ?language pattern =
-  let params =
+  let lang =
     match language with
-    | None -> `Assoc [ ("pattern", `String pattern) ]
-    | Some lang ->
-        `Assoc [ ("pattern", `String pattern); ("language", `String lang) ]
+    | None -> `Null
+    | Some lang -> `String lang
   in
+  let params = `Assoc [ ("pattern", `String pattern); ("language", lang) ] in
   send_custom_request info ~meth:"semgrep/search" ~params
 
 let send_semgrep_show_ast info ?(named = false) (path : Fpath.t) =

--- a/src/osemgrep/language_server/custom_requests/Search.ml
+++ b/src/osemgrep/language_server/custom_requests/Search.ml
@@ -13,6 +13,11 @@ let meth = "semgrep/search"
 module Request_params = struct
   type t = { pattern : string; lang : Xlang.t option }
 
+  (* This schema means that it matters what order the arguments are in!
+     This is a little undesirable, but it's annoying to be truly
+     order-agnostic, and this is what `ocaml-lsp` also does.
+     https://github.com/ocaml/ocaml-lsp/blob/ad209576feb8127e921358f2e286e68fd60345e7/ocaml-lsp-server/src/custom_requests/req_wrapping_ast_node.ml#L8
+  *)
   let of_jsonrpc_params params : t option =
     match params with
     | Some (`Assoc [ ("pattern", `String pattern); ("language", lang) ]) ->
@@ -39,9 +44,7 @@ end
     scan like normal, only returning the match ranges per file *)
 let on_request runner params =
   match Request_params.of_jsonrpc_params params with
-  | None ->
-      Logs.debug (fun m -> m "no params received in semgrep/search");
-      None
+  | None -> None
   | Some params ->
       (* TODO: figure out why rules_from_rules_source_async hangs *)
       (* let src = Rules_source.(Pattern (pattern, xlang_opt, None)) in *)


### PR DESCRIPTION
## What:
This PR makes the parameters to the `semgrep/search` LSP command more explicit.

Before, we were destructuring the JSON manually, which is error-prone.

## How:
Introduced an explicit type for thep arams, and a `Request_params` module.

Caveat, this will matter on the order of the `Assoc` that we receive, but this is what `ocaml-lsp` does too:
https://github.com/ocaml/ocaml-lsp/blob/master/ocaml-lsp-server/src/custom_requests/req_wrapping_ast_node.ml#L8

## Test plan:
Tested that the LSP search capability works manually.