### PR TITLE
refactor: Refactor how osemgrep creates `fixed_lines`

### DIFF
--- a/src/fixing/Autofix.mli
+++ b/src/fixing/Autofix.mli
@@ -16,3 +16,28 @@ val apply_fixes_of_core_matches :
    Raises an exception in case of a conflict.
 *)
 val apply_fixes_to_file_exn : Fpath.t -> Textedit.t list -> string
+
+(* See make_fixed_lines for an explanation *)
+type fixed_lines_env
+
+(* See make_fixed_lines for an explanation *)
+val make_fixed_lines_env : unit -> fixed_lines_env
+
+(* Does a dry-run of applying the given Textedit.t and returns the affected
+ * lines after the fix has been applied, if any. The mutable env is used to
+ * track whether or not we have previously applied a Textedit.t to the location
+ * in question. If we have, we do not apply the fix and instead return None.
+ *
+ * This could potentially go into Textedit.ml but it's somewhat peculiar
+ * business logic which I (nmote) do not think belongs in a general-purpose
+ * library. *)
+val make_fixed_lines : fixed_lines_env -> Textedit.t -> string list option
+
+(* Like the above but uses the given contents for the file instead of reading
+ * from the filesystem. Exposed for testing but might be useful in other
+ * contexts. *)
+val make_fixed_lines_of_string :
+  fixed_lines_env ->
+  (* file contents *) string ->
+  Textedit.t ->
+  string list option

--- a/src/fixing/tests/Unit_autofix.ml
+++ b/src/fixing/tests/Unit_autofix.ml
@@ -1,0 +1,105 @@
+type make_fixed_lines_case = {
+  test_name : string;
+  contents : string;
+  (* start, end, replacement *)
+  fixes : (int * int * string) list;
+  expected : string list option list;
+}
+
+let make_fixed_lines_cases =
+  [
+    {
+      test_name = "Ordinary case with one overlapping fix";
+      contents = "foo\nbar\n";
+      fixes = [ (1, 5, "1\n2"); (1, 2, "1") ];
+      expected = [ Some [ "f1"; "2ar" ]; None ];
+    };
+    {
+      test_name = "Ordinary case with no overlapping fixes";
+      contents = "foo\nbar\n";
+      fixes = [ (1, 2, "1"); (5, 6, "2") ];
+      expected = [ Some [ "f1o" ]; Some [ "b2r" ] ];
+    };
+    {
+      test_name = "Two lines entirely deleted";
+      contents = "foo\nbar\nbaz\n";
+      fixes = [ (0, 7, "") ];
+      expected = [ None ];
+    };
+    {
+      test_name = "One line entirely deleted";
+      contents = "foo\nbar\nbaz\n";
+      fixes = [ (4, 7, "") ];
+      expected = [ None ];
+    };
+    {
+      test_name = "One line partially deleted";
+      contents = "foo\nbar\nbaz\n";
+      fixes = [ (5, 7, "") ];
+      expected = [ Some [ "b" ] ];
+    };
+    {
+      test_name = "Two lines partially deleted";
+      contents = "foo\nbar\nbaz\n";
+      fixes = [ (1, 7, "") ];
+      expected = [ Some [ "f" ] ];
+    };
+    {
+      test_name = "Second fix contained entirely in first";
+      contents = "0123456789";
+      fixes = [ (1, 4, "a"); (2, 3, "b") ];
+      expected = [ Some [ "0a456789" ]; None ];
+    };
+    {
+      test_name = "First fix contained entirely in second";
+      contents = "0123456789";
+      fixes = [ (2, 3, "a"); (1, 4, "b") ];
+      expected = [ Some [ "01a3456789" ]; None ];
+    };
+    {
+      test_name = "End of first fix overlaps with start of second";
+      contents = "0123456789";
+      fixes = [ (1, 4, "a"); (3, 6, "b") ];
+      expected = [ Some [ "0a456789" ]; None ];
+    };
+    {
+      test_name = "End of second fix overlaps with start of first";
+      contents = "0123456789";
+      fixes = [ (3, 6, "b"); (1, 4, "a") ];
+      expected = [ Some [ "012b6789" ]; None ];
+    };
+    {
+      test_name = "Start of second fix is adjacent to end of first";
+      contents = "0123456789";
+      fixes = [ (1, 4, "a"); (4, 6, "b") ];
+      expected = [ Some [ "0a456789" ]; Some [ "0123b6789" ] ];
+    };
+    {
+      test_name = "Start of first fix is adjacent to end of second";
+      contents = "0123456789";
+      fixes = [ (4, 6, "b"); (1, 4, "a") ];
+      expected = [ Some [ "0123b6789" ]; Some [ "0a456789" ] ];
+    };
+  ]
+
+let fakepath = Fpath.v (Filename.get_temp_dir_name () ^ "/fake.txt")
+
+let create_make_fixed_lines_test { test_name; contents; fixes; expected } =
+  Testo.create test_name (fun () ->
+      let edits =
+        List_.map
+          (fun (start, end_, replacement_text) ->
+            Textedit.{ start; end_; replacement_text; path = fakepath })
+          fixes
+      in
+      let env = Autofix.make_fixed_lines_env () in
+      let all_fixed_lines : string list option list =
+        List_.map (Autofix.make_fixed_lines_of_string env contents) edits
+      in
+      Alcotest.(check (string |> list |> option |> list))
+        "fixed_lines" expected all_fixed_lines)
+
+let tests =
+  Testo.categorize "autofix"
+    (Testo.categorize "make_fixed_lines"
+       (List_.map create_make_fixed_lines_test make_fixed_lines_cases))

--- a/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -136,10 +136,11 @@ let mk_file_match_results_hook (conf : Scan_CLI.conf) (rules : Rule.rules)
       |> fst |> Core_json_output.dedup_and_sort
     in
     let hrules = Rule.hrules_of_rules rules in
+    let fixes_env = Autofix.make_fixed_lines_env () in
     core_matches
     |> List_.map
          (Cli_json_output.cli_match_of_core_match
-            ~dryrun:conf.output_conf.dryrun hrules)
+            ~dryrun:conf.output_conf.dryrun fixes_env hrules)
   in
   let cli_matches =
     cli_matches

--- a/src/osemgrep/reporting/Cli_json_output.mli
+++ b/src/osemgrep/reporting/Cli_json_output.mli
@@ -11,15 +11,13 @@ val cli_output_of_core_results :
 (* internals used in Scan_subcommant.ml *)
 val exit_code_of_error_type : Semgrep_output_v1_t.error_type -> Exit_code.t
 
-(* internals used also for incremental display of matches
-   The [applied_fixes] hash table is both in and out parameter, it is used for
-   deciding whether a fixed_lines elements is included in the cli_match. This
-   depends on whether an overlapping fix was already included in an earlier
-   cli_match in the same list of matches.
-*)
+(* internals used also for incremental display of matches The fixed_lines_env is
+ * used for deciding whether a fixed_lines elements is included in the
+ * cli_match. This depends on whether an overlapping fix was already included in
+ * an earlier cli_match in the same list of matches. *)
 val cli_match_of_core_match :
   dryrun:bool ->
-  ?applied_fixes:(string, (int * int) list) Hashtbl.t ->
+  Autofix.fixed_lines_env ->
   Rule.hrules ->
   Semgrep_output_v1_t.core_match ->
   Semgrep_output_v1_t.cli_match

--- a/src/tests/Test.ml
+++ b/src/tests/Test.ml
@@ -52,6 +52,7 @@ let tests (caps : Cap.all_caps) =
       Unit_Rpath.tests;
       Unit_git_wrapper.tests;
       Unit_ugly_print_AST.tests;
+      Unit_autofix.tests;
       Unit_autofix_printer.tests;
       Unit_synthesizer.tests;
       Unit_synthesizer_targets.tests;


### PR DESCRIPTION
The way this was implemented was confusing and not reusable.

This is mostly a refactor, though I did also address some behaviors in osemgrep that were inconsistent with pysemgrep. But, I don't think it's worth a changelog entry since it only affects osemgrep.

Test plan:
- Unit tests
- I'm using this utility in my in-progress work to replace the Python autofix application code with an RPC call. It currently passes all autofix e2e tests.

