### PR TITLE
feat(lsp): default search to regex

### DIFF
--- a/src/osemgrep/language_server/custom_requests/Search.ml
+++ b/src/osemgrep/language_server/custom_requests/Search.ml
@@ -65,24 +65,86 @@ module Request_params = struct
 end
 
 (*****************************************************************************)
+(* Helpers *)
+(*****************************************************************************)
+
+(* Get the languages that are in play in this workspace, by consulting all the
+   current targets' languages.
+   TODO: Maybe buggy if cached_workspace_targets only has dirty files or
+   whatever, I don't think it's always all of the targets in the workspace.
+   I tried Find_targets.get_targets, but this ran into an error because of some
+   path relativity stuff, I think.
+*)
+let get_relevant_xlangs (server : RPC_server.t) : Xlang.t list =
+  let files =
+    server.session.cached_workspace_targets |> Hashtbl.to_seq_values
+    |> List.of_seq |> List.concat
+  in
+  let lang_set = Hashtbl.create 10 in
+  List.iter
+    (fun file ->
+      let file_langs = Lang.langs_of_filename file in
+      List.iter (fun lang -> Hashtbl.replace lang_set lang ()) file_langs)
+    files;
+  Hashtbl.to_seq_keys lang_set |> List.of_seq |> List_.map Xlang.of_lang
+
+(* Get the rules to run based on the pattern and state of the LSP. *)
+let get_relevant_rules (params : Request_params.t) (server : RPC_server.t) :
+    Rule.t list =
+  (* TODO: figure out why rules_from_rules_source_async hangs *)
+  (* let src = Rules_source.(Pattern (pattern, xlang_opt, None)) in *)
+  let rules_and_origins =
+    Rule_fetching.rules_from_pattern (params.pattern, params.lang, None)
+  in
+  let rules, _ = Rule_fetching.partition_rules_and_errors rules_and_origins in
+  let xlangs = get_relevant_xlangs server in
+  let rules_with_relevant_xlang =
+    List.filter
+      (fun (rule : Rule.t) -> List.mem rule.target_analyzer xlangs)
+      rules
+  in
+  match rules_with_relevant_xlang with
+  (* Unfortunately, almost everything parses as YAML, because you can specify
+     no quotes and it will be interpreted as a YAML string
+     So if we are getting a pattern which only parses as YAML, it's probably
+     safe to say it's a non-language-specific pattern.
+  *)
+  | []
+  | [ { target_analyzer = Xlang.L (Yaml, _); _ } ] ->
+      (* should be a singleton *)
+      let rules_and_origins =
+        Rule_fetching.rules_from_pattern
+          (params.pattern, Some Xlang.LRegex, None)
+      in
+      Rule_fetching.partition_rules_and_errors rules_and_origins |> fst
+  | other -> other
+
+(*
+  let relevant_xtargets_for_lang (files: Fpath.t list) (xlang: Xlang.t) : Xtarget.t list =
+    let filtered_files: Fpath.t list =
+      files
+      |> List.filter (fun target ->
+          Filter_target.filter_target_for_xlang xlang target)
+    in
+    filtered_files
+    |> List_.map (fun (file) ->
+      Xtarget.resolve parse_and_resolve_name
+      (Target.mk_regular xlang Product.all (File file))
+    )
+   *)
+
+(*****************************************************************************)
 (* Entry point *)
 (*****************************************************************************)
 
 (** on a semgrep/search request, get the pattern and (optional) language params.
     We then try and parse the pattern in every language (or specified lang), and
     scan like normal, only returning the match ranges per file *)
-let on_request runner params =
+let on_request server runner params =
   match Request_params.of_jsonrpc_params params with
   | None -> None
   | Some params ->
-      (* TODO: figure out why rules_from_rules_source_async hangs *)
-      (* let src = Rules_source.(Pattern (pattern, xlang_opt, None)) in *)
-      let rules_and_origins =
-        Rule_fetching.rules_from_pattern (params.pattern, params.lang, None)
-      in
-      let rules, _ =
-        Rule_fetching.partition_rules_and_errors rules_and_origins
-      in
+      let rules = get_relevant_rules params server in
       let rules_with_fixes =
         rules |> List_.map (fun rule -> { rule with Rule.fix = params.fix })
       in

--- a/src/osemgrep/language_server/custom_requests/Search.ml
+++ b/src/osemgrep/language_server/custom_requests/Search.ml
@@ -91,8 +91,6 @@ let get_relevant_xlangs (server : RPC_server.t) : Xlang.t list =
 (* Get the rules to run based on the pattern and state of the LSP. *)
 let get_relevant_rules (params : Request_params.t) (server : RPC_server.t) :
     Rule.t list =
-  (* TODO: figure out why rules_from_rules_source_async hangs *)
-  (* let src = Rules_source.(Pattern (pattern, xlang_opt, None)) in *)
   let rules_and_origins =
     Rule_fetching.rules_from_pattern (params.pattern, params.lang, None)
   in
@@ -118,20 +116,6 @@ let get_relevant_rules (params : Request_params.t) (server : RPC_server.t) :
       in
       Rule_fetching.partition_rules_and_errors rules_and_origins |> fst
   | other -> other
-
-(*
-  let relevant_xtargets_for_lang (files: Fpath.t list) (xlang: Xlang.t) : Xtarget.t list =
-    let filtered_files: Fpath.t list =
-      files
-      |> List.filter (fun target ->
-          Filter_target.filter_target_for_xlang xlang target)
-    in
-    filtered_files
-    |> List_.map (fun (file) ->
-      Xtarget.resolve parse_and_resolve_name
-      (Target.mk_regular xlang Product.all (File file))
-    )
-   *)
 
 (*****************************************************************************)
 (* Entry point *)

--- a/src/osemgrep/language_server/custom_requests/Search.mli
+++ b/src/osemgrep/language_server/custom_requests/Search.mli
@@ -5,6 +5,7 @@ val mk_params :
   lang:Xlang.t option -> fix:string option -> string -> Jsonrpc.Structured.t
 
 val on_request :
+  RPC_server.t ->
   (Rule.rules -> Semgrep_output_v1_t.cli_match list) ->
   Jsonrpc.Structured.t option ->
   Yojson.Safe.t option

--- a/src/osemgrep/language_server/custom_requests/dune
+++ b/src/osemgrep/language_server/custom_requests/dune
@@ -5,5 +5,6 @@
  (libraries
    semgrep.language_server.util
    osemgrep_language_server_server
+   semgrep.osemgrep_cli_scan
  )
 )

--- a/src/osemgrep/language_server/requests/Request_handler.ml
+++ b/src/osemgrep/language_server/requests/Request_handler.ml
@@ -41,7 +41,7 @@ let search_handler (server : RPC_server.t) params =
     { server with session }
   in
   let runner rules = Scan_helpers.run_semgrep server ~rules |> fst in
-  Search.on_request runner params
+  Search.on_request server runner params
 
 (* Dispatch to the various custom request handlers. *)
 let handle_custom_request server (meth : string)


### PR DESCRIPTION
This is a stacked diff whose parent is https://github.com/semgrep/semgrep/pull/9920.

## What:
This PR makes it so if we cannot parse a pattern in a particular language, we will default it to a regex rule, so that we maintain rough parity with regular textual search.

## Why:
This is nice for usability.

## How:
This PR makes it so we narrow the scope of rules we can produce to only those with languages that are present in files in the workspace. If we are unable to parse in any of those languages, then we default to a regex rule.

## Test plan:
Tested manually.

Closes CDX-280
Closes CDX-279