### PR TITLE
feat(secrets): add historical scanning flag

### DIFF
--- a/cli/src/semgrep/commands/ci.py
+++ b/cli/src/semgrep/commands/ci.py
@@ -142,6 +142,7 @@ def fix_head_if_github_action(metadata: GitMeta) -> None:
 )
 @click.option("--code", is_flag=True, hidden=True)
 @click.option("--beta-testing-secrets", is_flag=True, hidden=True)
+@click.option("--historical-secrets", is_flag=True, hidden=True)
 @click.option(
     "--secrets",
     "run_secrets_flag",
@@ -170,6 +171,7 @@ def ci(
     # TODO: Remove after October 2023. Left for a error message
     # redirect to `--secrets` aka run_secrets_flag.
     beta_testing_secrets: bool,
+    historical_secrets: bool,
     internal_ci_scan_results: bool,
     code: bool,
     config: Optional[Tuple[str, ...]],
@@ -501,7 +503,15 @@ def ci(
     # place we wouldn't need this seprarately. There are some benefits
     # (e.g., separate progress bar), but it would simplify output logic if we
     # simply had one "scan".
-    if run_secrets and scan_handler and scan_handler.historical_config.enabled:
+    if not run_secrets and historical_secrets:
+        logger.info("Cannot run historical secrets scan without secrets enabled.")
+        sys.exit(FATAL_EXIT_CODE)
+
+    run_historical_secrets_scan = (
+        run_secrets and scan_handler and scan_handler.historical_config.enabled
+    ) or historical_secrets
+
+    if run_historical_secrets_scan:
         try:
             console.print(Title("Secrets Historical Scan"))
 

--- a/cli/src/semgrep/commands/ci.py
+++ b/cli/src/semgrep/commands/ci.py
@@ -377,6 +377,10 @@ def ci(
         scan_handler and "secrets" in scan_handler.enabled_products
     )
 
+    if not run_secrets and historical_secrets:
+        logger.info("Cannot run historical secrets scan without secrets enabled.")
+        sys.exit(FATAL_EXIT_CODE)
+
     supply_chain_only = supply_chain and not code and not run_secrets
     engine_type = EngineType.decide_engine_type(
         requested_engine=requested_engine,
@@ -503,10 +507,6 @@ def ci(
     # place we wouldn't need this seprarately. There are some benefits
     # (e.g., separate progress bar), but it would simplify output logic if we
     # simply had one "scan".
-    if not run_secrets and historical_secrets:
-        logger.info("Cannot run historical secrets scan without secrets enabled.")
-        sys.exit(FATAL_EXIT_CODE)
-
     run_historical_secrets_scan = (
         run_secrets and scan_handler and scan_handler.historical_config.enabled
     ) or historical_secrets

--- a/cli/tests/default/e2e-pro/snapshots/test_ci/test_fail_on_historical_scan_without_secrets/output.txt
+++ b/cli/tests/default/e2e-pro/snapshots/test_ci/test_fail_on_historical_scan_without_secrets/output.txt
@@ -1,0 +1,36 @@
+=== command
+SEMGREP_APP_TOKEN="fake-key-from-tests" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERSION_CACHE_PATH="<MASKED>" SEMGREP_ENABLE_VERSION_CHECK="0" SEMGREP_SEND_METRICS="off" semgrep ci --historical-secrets --no-suppress-errors
+=== end of command
+
+=== exit code
+2
+=== end of exit code
+
+=== stdout - plain
+
+=== end of stdout - plain
+
+=== stderr - plain
+
+
+┌────────────────┐
+│ Debugging Info │
+└────────────────┘
+
+  SCAN ENVIRONMENT
+  versions    - semgrep <MASKED> on python <MASKED>
+  environment - running in environment git, triggering event is unknown
+
+  CONNECTION
+  Initializing scan (deployment=org_name, scan_id=12345)
+  Enabled products: Code, Supply Chain                    Cannot run historical secrets scan without secrets enabled.
+
+=== end of stderr - plain
+
+=== stdout - color
+<same as above: stdout - plain>
+=== end of stdout - color
+
+=== stderr - color
+<same as above: stderr - plain>
+=== end of stderr - color

--- a/cli/tests/default/e2e-pro/test_ci.py
+++ b/cli/tests/default/e2e-pro/test_ci.py
@@ -2249,3 +2249,30 @@ def test_ci_uuid(
     assert (
         found_uuid == expected_uuid
     ), f"Expected {expected_uuid} but found {found_uuid}"
+
+
+@pytest.mark.osemfail
+def test_fail_on_historical_scan_without_secrets(
+    run_semgrep: RunSemgrep,
+    snapshot,
+    start_scan_mock_maker,
+    complete_scan_mock_maker,
+    upload_results_mock_maker,
+):
+    start_scan_mock = start_scan_mock_maker("https://semgrep.dev")
+    complete_scan_mock = complete_scan_mock_maker("https://semgrep.dev")
+    upload_results_mock = upload_results_mock_maker("https://semgrep.dev")
+
+    result = run_semgrep(
+        subcommand="ci",
+        options=["--historical-secrets", "--no-suppress-errors"],
+        strict=False,
+        env={"SEMGREP_APP_TOKEN": "fake-key-from-tests"},
+        assert_exit_code=2,
+        target_name=None,
+        use_click_runner=True,
+    )
+    snapshot.assert_match(
+        result.as_snapshot(),
+        "output.txt",
+    )

--- a/src/osemgrep/cli_ci/Ci_CLI.ml
+++ b/src/osemgrep/cli_ci/Ci_CLI.ml
@@ -100,6 +100,10 @@ let o_secrets : bool Term.t =
   in
   Arg.value (Arg.flag info)
 
+let o_historical_secrets : bool Term.t =
+  let info = Arg.info [ "historical-secrets" ] in
+  Arg.value (Arg.flag info)
+
 let o_suppress_errors : bool Term.t =
   H.negatable_flag_with_env [ "suppress-errors" ]
     ~neg_options:[ "no-suppress-errors" ]
@@ -123,7 +127,7 @@ let cmdline_term caps : conf Term.t =
    *)
   let combine scan_conf audit_on beta_testing_secrets code dry_run
       _internal_ci_scan_results secrets supply_chain suppress_errors _git_meta
-      _github_meta =
+      _github_meta historical_secrets =
     let products =
       (if beta_testing_secrets || secrets then [ `Secrets ] else [])
       @ (if code then [ `SAST ] else [])
@@ -136,7 +140,8 @@ let cmdline_term caps : conf Term.t =
     $ Scan_CLI.cmdline_term caps ~allow_empty_config:true
     $ o_audit_on $ o_beta_testing_secrets $ o_code $ o_dry_run
     $ o_internal_ci_scan_results $ o_secrets $ o_supply_chain
-    $ o_suppress_errors $ Git_metadata.env $ Github_metadata.env)
+    $ o_suppress_errors $ Git_metadata.env $ Github_metadata.env
+    $ o_historical_secrets)
 
 let doc = "the recommended way to run semgrep in CI"
 

--- a/src/osemgrep/cli_ci/Ci_CLI.ml
+++ b/src/osemgrep/cli_ci/Ci_CLI.ml
@@ -127,7 +127,7 @@ let cmdline_term caps : conf Term.t =
    *)
   let combine scan_conf audit_on beta_testing_secrets code dry_run
       _internal_ci_scan_results secrets supply_chain suppress_errors _git_meta
-      _github_meta historical_secrets =
+      _github_meta _historical_secrets =
     let products =
       (if beta_testing_secrets || secrets then [ `Secrets ] else [])
       @ (if code then [ `SAST ] else [])


### PR DESCRIPTION
This PR adds a new experimental flag to run a historical secrets scan. This functionality requires enabling secrets.

Example usage:
```
$ semgrep ci --secrets --historical-secrets
```