### PR TITLE
Update interfile max memory help to mention pre-processing

### DIFF
--- a/changelog.d/gh-9932.added
+++ b/changelog.d/gh-9932.added
@@ -1,0 +1,1 @@
+Added information about interfile pre-processing to --max-memory help.

--- a/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -289,9 +289,10 @@ let o_max_memory_mb : int Term.t =
   let info =
     Arg.info [ "max-memory" ]
       ~doc:
-        {|Maximum system memory to use running a rule on a single file in MiB.
-If set to 0 will not have memory limit. Defaults to 0. For CI scans
-that use the Pro Engine, it defaults to 5000 MiB.
+        {|Maximum system memory to use during pre-processing, or when
+running a rule on a single file in MiB. If set to 0 will not have memory
+limit. Defaults to 0. For CI scans that use the Pro Engine, it defaults
+to 5000 MiB.
 |}
   in
   Arg.value (Arg.opt Arg.int default info)

--- a/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -289,10 +289,10 @@ let o_max_memory_mb : int Term.t =
   let info =
     Arg.info [ "max-memory" ]
       ~doc:
-        {|Maximum system memory to use during pre-processing, or when
-running a rule on a single file in MiB. If set to 0 will not have memory
-limit. Defaults to 0. For CI scans that use the Pro Engine, it defaults
-to 5000 MiB.
+        {|Maximum system memory in MiB to use during the interfile pre-processing
+phase, or when running a rule on a single file. If set to 0, will
+not have memory limit. Defaults to 0. For CI scans that use the Pro Engine,
+defaults to 5000 MiB.
 |}
   in
   Arg.value (Arg.opt Arg.int default info)


### PR DESCRIPTION
It wasn't very clear from the help that this limit will also be applied during the interfile pre-processing phase, so add that explicitly.

To test:
`pipenv run semgrep ci --help` and search/scroll to `--max-memory`:

```
       --max-memory=VAL (absent=0)
           Maximum system memory in MiB to use during the interfile
           pre-processing phase, or when running a rule on a single file. If
           set to 0, will not have memory limit. Defaults to 0. For CI scans
           that use the Pro Engine, defaults to 5000 MiB.
```