### PR TITLE
feat(lsp): streaming search

### DIFF
--- a/src/osemgrep/language_server/Test_LS_e2e.ml
+++ b/src/osemgrep/language_server/Test_LS_e2e.ml
@@ -689,7 +689,10 @@ let do_search info =
         YS.Util.(resp.result |> Result.get_ok |> member "locations" |> to_list)
       with
       | [] -> Lwt.return None
-      | matches -> Lwt.return (Some (matches, ())))
+      | matches ->
+          (* Send the searchOngoing so we get the next response *)
+          send_semgrep_search_ongoing info;
+          Lwt.return (Some (matches, ())))
     ()
   |> Lwt_seq.to_list
 
@@ -893,7 +896,7 @@ let test_ls_ext caps () =
 
           (* search *)
           let%lwt matches_of_files = do_search info in
-          assert (YS.Util.(List.concat matches_of_files |> List.length = 3));
+          assert (List.concat matches_of_files |> List.length = 3);
 
           (* hover is on by default *)
           let%lwt () =

--- a/src/osemgrep/language_server/Test_LS_e2e.ml
+++ b/src/osemgrep/language_server/Test_LS_e2e.ml
@@ -534,7 +534,7 @@ let send_semgrep_search info ?language pattern =
 
 let send_semgrep_search_ongoing info =
   send_custom_request info ~meth:"semgrep/searchOngoing"
-    ~params:(Jsonrpc.Structured.t_of_yojson `Null)
+    ~params:(Jsonrpc.Structured.t_of_yojson (`Assoc []))
 
 let send_semgrep_show_ast info ?(named = false) (path : Fpath.t) =
   let uri = Uri.of_path (Fpath.to_string path) |> Uri.yojson_of_t in

--- a/src/osemgrep/language_server/custom_requests/Search.ml
+++ b/src/osemgrep/language_server/custom_requests/Search.ml
@@ -182,7 +182,8 @@ let get_relevant_rules ({ params = { pattern; fix; _ }; _ } as env : env) :
 (* Output *)
 (*****************************************************************************)
 
-let json_of_matches (matches_by_file : (Fpath.t * OutJ.cli_match list) list) =
+let json_of_matches (matches_by_file : (Fpath.t * OutJ.cli_match list) list) :
+    Yojson.Safe.t option =
   let json =
     List_.map
       (fun (path, matches) ->

--- a/src/osemgrep/language_server/custom_requests/Search.ml
+++ b/src/osemgrep/language_server/custom_requests/Search.ml
@@ -17,8 +17,10 @@ open Lsp
 open Lsp.Types
 module Conv = Convert_utils
 module OutJ = Semgrep_output_v1_t
+open Fpath_.Operators
 
-let meth = "semgrep/search"
+let start_meth = "semgrep/search"
+let ongoing_meth = "semgrep/searchOngoing"
 
 (*****************************************************************************)
 (* Prelude *)
@@ -26,6 +28,27 @@ let meth = "semgrep/search"
 
 (* The main logic for the /semgrep/search LSP command, which is meant to be
    run on a manual search.
+
+   This is a _streaming_ search, meaning that we service partial results. In
+   particular, we choose to service results within the RPC_server loop as
+   _one file per request_.
+
+   As such, we have two different commands: /semgrep/search, and /semgrep/searchOngoing.
+   Our protocol with them are as follows:
+   - when starting a search, the LS receives /semgrep/search and stores some
+     information of what to do next in the `server` value
+   - the server then receives /semgrep/searchOngoing until either a new search
+     is started, or the search is finished.
+   - both searches will return the matches found in the next file in the queue
+
+   Effectively, think of `Search.ml` as a pinata, which is consistently hit by
+   /semgrep/search and /semgrep/searchOngoing until it runs out of files to
+   search.
+
+   TODO: Things that would be nice:
+   - AST caching
+   - Parallelism (Parmap or threads?)
+   - Moving work up to folder-open time rather than search-time
 *)
 
 (*****************************************************************************)
@@ -155,53 +178,97 @@ let get_relevant_rules ({ params = { pattern; fix; _ }; _ } as env : env) :
   | other -> other
 
 (*****************************************************************************)
+(* Output *)
+(*****************************************************************************)
+
+let json_of_matches (matches_by_file : (Fpath.t * Pattern_match.t list) list) =
+  let json =
+    List_.map
+      (fun (path, matches) ->
+        let uri = !!path |> Uri.of_path |> Uri.to_string in
+        let matches =
+          matches
+          |> List_.map (fun (m : Pattern_match.t) ->
+                 let range_json =
+                   Range.yojson_of_t (Conv.range_of_toks m.range_loc)
+                 in
+                 let fix_json =
+                   match m.rule_id.fix with
+                   | None -> `Null
+                   | Some s -> `String s
+                 in
+                 `Assoc [ ("range", range_json); ("fix", fix_json) ])
+        in
+        `Assoc [ ("uri", `String uri); ("matches", `List matches) ])
+      matches_by_file
+  in
+  Some (`Assoc [ ("locations", `List json) ])
+
+(*****************************************************************************)
+(* Running Semgrep! *)
+(*****************************************************************************)
+
+let rec next_rules_and_file (server : RPC_server.t) =
+  match server.session.search_config with
+  | None
+  | Some { files = []; _ } ->
+      None
+  | Some ({ files = file :: rest; _ } as config) ->
+      let new_session =
+        {
+          server.session with
+          search_config = Some { config with files = rest };
+        }
+      in
+      Some ((config.rules, file), { server with session = new_session })
+
+let rec search_single_target (server : RPC_server.t) =
+  let hook _file _pm = () in
+  match next_rule_and_file server with
+  | None ->
+      (* Since we are done with our searches (no more targets), reset our internal state to
+         no longer have this scan config.
+      *)
+      ( json_of_matches [],
+        { server with session = { server.session with search_config = None } }
+      )
+  | Some ((rule, file), server) -> (
+      try
+        (* !!calling the engine!! *)
+        let ({ Core_result.matches; _ } : _ Core_result.match_result) =
+          Scan_helpers.run_core_search rule file
+        in
+        let json = json_of_matches [ (file, matches) ] in
+        (json, server)
+      with
+      | Parsing_error.Syntax_error _ -> search_single_target server)
+
+(*****************************************************************************)
 (* Entry point *)
 (*****************************************************************************)
 
 (** on a semgrep/search request, get the pattern and (optional) language params.
     We then try and parse the pattern in every language (or specified lang), and
     scan like normal, only returning the match ranges per file *)
-let on_request (server : RPC_server.t) params =
+let start_search (server : RPC_server.t) params =
   match Request_params.of_jsonrpc_params params with
-  | None -> None
+  | None ->
+      Logs.debug (fun m -> m "no params received in semgrep/search");
+      (None, server)
   | Some params ->
       let env = mk_env server params in
       let rules = get_relevant_rules env in
       (* !!calling the engine!! *)
-      let matches, _scanned =
-        let session =
-          {
-            server.session with
-            user_settings =
-              { server.session.user_settings with only_git_dirty = false };
-          }
-        in
-        Scan_helpers.run_semgrep ~targets:env.initial_files
-          { server with session } ~rules
-      in
-      let matches_by_file =
-        matches
-        |> List_.map (fun (m : OutJ.cli_match) -> (Fpath.to_string m.path, m))
-        |> Common2.group_assoc_bykey_eff
-      in
-      let json =
-        List_.map
-          (fun (path, matches) ->
-            let uri = path |> Uri.of_path |> Uri.to_string in
-            let matches =
-              matches
-              |> List_.map (fun (m : OutJ.cli_match) ->
-                     let range_json =
-                       Range.yojson_of_t (Conv.range_of_cli_match m)
-                     in
-                     let fix_json =
-                       match m.extra.fix with
-                       | None -> `Null
-                       | Some s -> `String s
-                     in
-                     `Assoc [ ("range", range_json); ("fix", fix_json) ])
-            in
-            `Assoc [ ("uri", `String uri); ("matches", `List matches) ])
-          matches_by_file
-      in
-      Some (`Assoc [ ("locations", `List json) ])
+      search_single_target
+        {
+          server with
+          session =
+            {
+              server.session with
+              search_config = Some { rules; files = env.initial_files };
+            };
+        }
+
+let search_next_file (server : RPC_server.t) _params =
+  (* The params are nullary, so we don't actually need to check them. *)
+  search_single_target server

--- a/src/osemgrep/language_server/custom_requests/Search.mli
+++ b/src/osemgrep/language_server/custom_requests/Search.mli
@@ -1,11 +1,28 @@
-val meth : string
+val start_meth : string
 (** method to match on: semgrep/search *)
 
 val mk_params :
   lang:Xlang.t option -> fix:string option -> string -> Jsonrpc.Structured.t
 
-val on_request :
-  RPC_server.t -> Jsonrpc.Structured.t option -> Yojson.Safe.t option
-(** [on_request runner request] will run [runner] on the given pattern and optional
-    language params. If the request is None, we return None. Otherwise, we return
-    [Some (JSON response)] that contains the ranges of all matches *)
+val ongoing_meth : string
+(** method to match on: semgrep/searchOngoing *)
+
+val start_search :
+  RPC_server.t ->
+  Jsonrpc.Structured.t option ->
+  Yojson.Safe.t option * RPC_server.t
+(** [start_search server params] will cause a search to start with the given parameters,
+    storing the information of remaining rules/targets to search in the server session.
+    It will then return the matches in the first file with matches.
+    Will return `Assoc ["locations": `List []] when the search has concluded.
+  *)
+
+val search_next_file :
+  RPC_server.t ->
+  Jsonrpc.Structured.t option ->
+  Yojson.Safe.t option * RPC_server.t
+(** [search_next_file server params] is used during an ongoing search, and will
+    return the matches in the first file with matches, based on the remaining
+    rules/targets to search in the server session state.
+    Will return `Assoc ["locations": `List []] when the search has concluded.
+  *)

--- a/src/osemgrep/language_server/requests/Request_handler.ml
+++ b/src/osemgrep/language_server/requests/Request_handler.ml
@@ -28,27 +28,33 @@ module CR = Client_request
 (* Code *)
 (*****************************************************************************)
 
-(* Specifically for custom requests for searching. *)
-let search_handler (server : RPC_server.t) params =
-  Search.on_request server params
-
 (* Dispatch to the various custom request handlers. *)
 let handle_custom_request server (meth : string)
     (params : Jsonrpc.Structured.t option) : Yojson.Safe.t option * RPC_server.t
     =
   match
+    (* Methods which can alter the server *)
     [
-      (Search.meth, search_handler);
-      (ShowAst.meth, ShowAst.on_request);
-      (Login.meth, Login.on_request);
-      (LoginStatus.meth, LoginStatus.on_request);
+      (Search.start_meth, Search.start_search);
+      (Search.ongoing_meth, Search.search_next_file);
     ]
     |> List.assoc_opt meth
   with
-  | None ->
-      Logs.warn (fun m -> m "Unhandled custom request %s" meth);
-      (None, server)
-  | Some handler -> (handler server params, server)
+  | Some handler -> handler server params
+  | None -> (
+      match
+        (* Methods which cannot alter the server. *)
+        [
+          (ShowAst.meth, ShowAst.on_request);
+          (Login.meth, Login.on_request);
+          (LoginStatus.meth, LoginStatus.on_request);
+        ]
+        |> List.assoc_opt meth
+      with
+      | None ->
+          Logs.warn (fun m -> m "Unhandled custom request %s" meth);
+          (None, server)
+      | Some handler -> (handler server params, server))
 
 let on_request (type r) (request : r CR.t) server =
   let process_result (r, server) =

--- a/src/osemgrep/language_server/scan_helpers/Scan_helpers.mli
+++ b/src/osemgrep/language_server/scan_helpers/Scan_helpers.mli
@@ -11,6 +11,12 @@ val run_semgrep :
   * used as the git ref for what matches are filtered out based on git diff.
   *)
 
+val run_core_search : Fpath.t -> Rule.search_rule -> Pattern_match.t list
+(** [run_core_search] runs a search intended for the /semgrep/search IDE
+    search command, by hooking lower into the Match_search_mode matching
+    process, bypassing the CLI.
+  *)
+
 val scan_workspace : RPC_server.t -> unit
 (** [scan_workspace server] scans the workspace of the given session. *)
 

--- a/src/osemgrep/language_server/scan_helpers/Scan_helpers.mli
+++ b/src/osemgrep/language_server/scan_helpers/Scan_helpers.mli
@@ -11,7 +11,7 @@ val run_semgrep :
   * used as the git ref for what matches are filtered out based on git diff.
   *)
 
-val run_core_search : Fpath.t -> Rule.search_rule -> Pattern_match.t list
+val run_core_search : Rule.search_rule -> Fpath.t -> Pattern_match.t list option
 (** [run_core_search] runs a search intended for the /semgrep/search IDE
     search command, by hooking lower into the Match_search_mode matching
     process, bypassing the CLI.

--- a/src/osemgrep/language_server/server/Search_config.ml
+++ b/src/osemgrep/language_server/server/Search_config.ml
@@ -1,0 +1,32 @@
+(* Brandon Wu
+ *
+ * Copyright (C) 2019-2024 Semgrep, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * version 2.1 as published by the Free Software Foundation, with the
+ * special exception on linking described in file LICENSE.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
+ * LICENSE for more details.
+ *)
+
+module OutJ = Semgrep_output_v1_t
+
+(*****************************************************************************)
+(* Prelude *)
+(*****************************************************************************)
+
+(* The internal state associated with the /semgrep/search command, which
+   starts a streaming search process with the LSP.
+   Will be reset on every new search request!
+*)
+
+(*****************************************************************************)
+(* Types *)
+(*****************************************************************************)
+
+type t = { rules : Rule.search_rule list; files : Fpath.t list }
+[@@deriving show]

--- a/src/osemgrep/language_server/server/Session.ml
+++ b/src/osemgrep/language_server/server/Session.ml
@@ -35,6 +35,7 @@ type t = {
   cached_session : session_cache;
   skipped_local_fingerprints : string list;
   user_settings : User_settings.t;
+  search_config : Search_config.t option;
   metrics : LS_metrics.t;
   is_intellij : bool;
   caps : < Cap.random ; Cap.network ; Cap.tmp >; [@opaque]
@@ -62,6 +63,7 @@ let create caps capabilities =
     cached_session;
     skipped_local_fingerprints = [];
     user_settings = User_settings.default;
+    search_config = None;
     metrics = LS_metrics.default;
     is_intellij = false;
     caps;

--- a/src/osemgrep/language_server/server/Session.mli
+++ b/src/osemgrep/language_server/server/Session.mli
@@ -27,6 +27,7 @@ type t = {
   cached_session : session_cache;
   skipped_local_fingerprints : string list;
   user_settings : User_settings.t;
+  search_config : Search_config.t option;
   metrics : LS_metrics.t;
   is_intellij : bool;
   caps : < Cap.random ; Cap.network ; Cap.tmp >; [@opaque]

--- a/src/osemgrep/language_server/util/Convert_utils.ml
+++ b/src/osemgrep/language_server/util/Convert_utils.ml
@@ -8,6 +8,12 @@ let range_of_cli_match (m : OutJ.cli_match) =
       (Position.create ~line:(m.start.line - 1) ~character:(m.start.col - 1))
     ~end_:(Position.create ~line:(m.end_.line - 1) ~character:(m.end_.col - 1))
 
+let range_of_toks ((l1 : Tok.location), (l2 : Tok.location)) =
+  let line, col, _ = Tok.end_pos_of_loc l2 in
+  Range.create
+    ~start:(Position.create ~line:(l1.pos.line - 1) ~character:l1.pos.column)
+    ~end_:(Position.create ~line:(line - 1) ~character:col)
+
 let convert_severity (severity : OutJ.match_severity) : DiagnosticSeverity.t =
   match severity with
   | `Error -> Error

--- a/src/osemgrep/language_server/util/Convert_utils.mli
+++ b/src/osemgrep/language_server/util/Convert_utils.mli
@@ -1,6 +1,11 @@
 val range_of_cli_match : Semgrep_output_v1_t.cli_match -> Lsp.Types.Range.t
 (** [range_of_cli_match cli_match] returns the lsp range of the given cli_match. *)
 
+(* This is meant to be used with Pattern_match.range_locs, where these two tokens
+   may be the same.
+*)
+val range_of_toks : Tok.location * Tok.location -> Lsp.Types.Range.t
+
 val convert_severity :
   Semgrep_output_v1_t.match_severity -> Lsp.Types.DiagnosticSeverity.t
 (** [convert_severity s] returns the lsp severity corresponding to the semgrep severity [s]. *)


### PR DESCRIPTION
This is a stacked diff whose parent is #9930.

## What:
This PR implements _streaming search_ for the LSP, by making it so that searches now take place over many rounds of requests in the `RPC_server` loop.

## Why:
This lets the IDE search be way more responsive, and not block the user to wait for all the files to conclude.

## How:
We invent two commands, `/semgrep/search` and `/semgrep/searchOngoing`.

The first one starts a search. The second requests the next round of results from an ongoing search. Both commands decide that a single request always means getting only the next file's matches.

## Test plan:
Tested manually.

Closes CDX-290