### PR TITLE
fix: Cleanup unused functionality in remote code

### DIFF
--- a/changelog.d/cdx-remote.changed
+++ b/changelog.d/cdx-remote.changed
@@ -1,0 +1,1 @@
+osemgrep --remote will no longer clone into a tmp folder, but instead the CWD

--- a/libs/git_wrapper/Git_project.ml
+++ b/libs/git_wrapper/Git_project.ml
@@ -14,6 +14,9 @@ let force_project_root ?(project_root : Rfpath.t option) (path : Fpath.t) =
     | None -> Rfpath.getcwd ()
     | Some x -> x
   in
+  Logs.debug (fun m ->
+      m "project_root=%s path=%s" (Rfpath.show project_root)
+        (Fpath.to_string path));
   match Ppath.in_project ~root:project_root path with
   | Ok inproject_path -> { project_root; inproject_path }
   | Error msg -> failwith msg

--- a/libs/git_wrapper/Git_wrapper.ml
+++ b/libs/git_wrapper/Git_wrapper.ml
@@ -184,20 +184,6 @@ let remote_repo_name url =
   | Ok (Some substrings) -> Some (Pcre.get_substring substrings 1)
   | _ -> None
 
-let temporary_remote_checkout_path caps url =
-  let name =
-    match remote_repo_name url with
-    | Some name -> name
-    | None -> failwith "Could not get remote repo name"
-  in
-  let rand_prefix = Uuidm.v `V4 |> Uuidm.to_string in
-  let name = rand_prefix ^ "_" ^ name in
-  let tmp_dir = CapTmp.get_temp_dir_name caps#tmp in
-  let fpath = Fpath.add_seg tmp_dir name in
-  (* Make path *)
-  UUnix.mkdir !!fpath 0o777;
-  fpath
-
 let obj_type_of_string = function
   | "commit" -> Some Commit
   | "blob" -> Some Blob

--- a/libs/git_wrapper/Git_wrapper.ml
+++ b/libs/git_wrapper/Git_wrapper.ml
@@ -193,7 +193,10 @@ let temporary_remote_checkout_path caps url =
   let rand_prefix = Uuidm.v `V4 |> Uuidm.to_string in
   let name = rand_prefix ^ "_" ^ name in
   let tmp_dir = CapTmp.get_temp_dir_name caps#tmp in
-  Fpath.add_seg tmp_dir name
+  let fpath = Fpath.add_seg tmp_dir name in
+  (* Make path *)
+  UUnix.mkdir !!fpath 0o777;
+  fpath
 
 let obj_type_of_string = function
   | "commit" -> Some Commit

--- a/libs/git_wrapper/Git_wrapper.mli
+++ b/libs/git_wrapper/Git_wrapper.mli
@@ -262,11 +262,6 @@ val ls_tree :
 val remote_repo_name : string -> string option
 (** [remote_repo_name "https://github.com/semgrep/semgrep.git"] will return [Some "semgrep"] *)
 
-val temporary_remote_checkout_path : < Cap.tmp > -> string -> Fpath.t
-(** [temporary_remote_checkout_path "https://github.com/semgrep/semgrep.git"]
-    will return [Some "<TMPDIR>/RAND_UUID_semgrep"]. Expects url to be a valid
-    remote repo name *)
-
 (*****************************************************************************)
 (* For testing *)
 (*****************************************************************************)

--- a/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -792,7 +792,8 @@ let o_remote : string option Term.t =
       ~doc:
         {|Remote will quickly checkout and scan a remote git repository of
         the format "http[s]://<WEBSITE>/.../<REPO>.git". Must be run with
-        --pro Incompatible with --project-root|}
+        --pro Incompatible with --project-root. Note this requires an empty
+        CWD as this command will clone the repository into the CWD|}
   in
   Arg.value (Arg.opt Arg.(some string) None info)
 
@@ -899,7 +900,7 @@ let cmdline_term caps ~allow_empty_config : conf Term.t =
           Some (Find_targets.Filesystem (Rfpath.of_string_exn root))
       | None, Some url when is_git_repo url ->
           (* CWD must be empty for this to work *)
-          let has_files = List_files.list (Fpath.v ".") <> [] in
+          let has_files = not (List_.null (List_files.list (Fpath.v "."))) in
           if has_files then
             Error.abort
               "Cannot use --remote with a git remote when the current \

--- a/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -320,7 +320,7 @@ let mk_scan_func (caps : < Cap.tmp >) (conf : Scan_CLI.conf)
   in
   let core_run_for_osemgrep : Core_runner.core_run_for_osemgrep =
     match conf.targeting_conf.project_root with
-    | Some (Find_targets.Git_remote git_remote) -> (
+    | Some (Find_targets.Git_remote _) -> (
         match !Core_runner.hook_pro_git_remote_scan_setup with
         | None ->
             failwith
@@ -328,7 +328,7 @@ let mk_scan_func (caps : < Cap.tmp >) (conf : Scan_CLI.conf)
                the pro engine, but do not have the pro engine. You may need to \
                acquire a different binary."
         | Some pro_git_remote_scan_setup ->
-            pro_git_remote_scan_setup git_remote core_run_for_osemgrep)
+            pro_git_remote_scan_setup core_run_for_osemgrep)
     | _ -> core_run_for_osemgrep
   in
   core_run_for_osemgrep.run ~file_match_results_hook conf.core_runner_conf
@@ -873,17 +873,6 @@ let run_scan_conf (caps : caps) (conf : Scan_CLI.conf) : Exit_code.t =
   let targets_and_skipped =
     Find_targets.get_target_fpaths conf.targeting_conf conf.target_roots
   in
-  (* Change dir if project_root is a git_remote
-     note: sorry cooper, we gotta do this because
-     git sparse-checkout doesn't like absolute paths. - anonymous
-     Please try harder to not use chdir as it invalidates all relative paths.
-     'git -C dir' should work, no? - Martin
-  *)
-  (match conf.targeting_conf.project_root with
-  | Some (Find_targets.Git_remote { checkout_path; _ }) ->
-      Logs.debug (fun m -> m ~tags "chdir %s" (Rfpath.show checkout_path));
-      CapSys.chdir caps#chdir (Rpath.to_string checkout_path.rpath)
-  | _ -> ());
   (* step3: let's go *)
   let res =
     run_scan_files

--- a/src/osemgrep/configuring/Semgrep_envvars.ml
+++ b/src/osemgrep/configuring/Semgrep_envvars.ml
@@ -80,7 +80,6 @@ type t = {
   user_dot_semgrep_dir : Fpath.t;
   user_log_file : Fpath.t;
   user_settings_file : Fpath.t;
-  remote_clone_dir : Fpath.t option;
   no_color : bool;
   is_ci : bool;
   in_docker : bool;
@@ -146,7 +145,6 @@ let of_current_sys_env () : t =
     user_settings_file =
       env_or Fpath.v "SEMGREP_SETTINGS_FILE"
         (user_dot_semgrep_dir / settings_filename);
-    remote_clone_dir = env_opt "SEMGREP_REMOTE_CLONE_DIR" |> Option.map Fpath.v;
     no_color = env_truthy "NO_COLOR" || env_truthy "SEMGREP_COLOR_NO_COLOR";
     is_ci = in_env "CI";
     in_docker = in_env "SEMGREP_IN_DOCKER";

--- a/src/osemgrep/configuring/Semgrep_envvars.mli
+++ b/src/osemgrep/configuring/Semgrep_envvars.mli
@@ -36,7 +36,6 @@ type t = {
   user_log_file : Fpath.t;
   (* $SEMGREP_SETTINGS_FILE ~/.semgrep/settings.yml *)
   user_settings_file : Fpath.t;
-  remote_clone_dir : Fpath.t option;
   (* TODO: Reconcile $SEMGREP_FORCE_COLOR via o_force_color *)
   (* ($NO_COLOR | $SEMGREP_COLOR_NO_COLOR) *)
   no_color : bool;

--- a/src/osemgrep/core_runner/Core_runner.ml
+++ b/src/osemgrep/core_runner/Core_runner.ml
@@ -114,11 +114,7 @@ let (hook_pro_core_run_for_osemgrep :
  * that are needed for the scan.
  *)
 let (hook_pro_git_remote_scan_setup :
-      (Find_targets.git_remote ->
-      core_run_for_osemgrep ->
-      core_run_for_osemgrep)
-      option
-      ref) =
+      (core_run_for_osemgrep -> core_run_for_osemgrep) option ref) =
   ref None
 
 (*************************************************************************)

--- a/src/osemgrep/core_runner/Core_runner.mli
+++ b/src/osemgrep/core_runner/Core_runner.mli
@@ -50,9 +50,7 @@ val hook_pro_core_run_for_osemgrep :
   ref
 
 val hook_pro_git_remote_scan_setup :
-  (Find_targets.git_remote -> core_run_for_osemgrep -> core_run_for_osemgrep)
-  option
-  ref
+  (core_run_for_osemgrep -> core_run_for_osemgrep) option ref
 
 val create_core_result : Rule.rule list -> Core_result.result_or_exn -> result
 

--- a/src/targeting/Find_targets.ml
+++ b/src/targeting/Find_targets.ml
@@ -67,7 +67,7 @@ end
          and have the exclusions apply only to the files that aren't tracked.
 *)
 
-type git_remote = { url : Uri.t; checkout_path : Rfpath.t } [@@deriving show]
+type git_remote = { url : Uri.t } [@@deriving show]
 
 type project_root = Git_remote of git_remote | Filesystem of Rfpath.t
 [@@deriving show]
@@ -104,6 +104,12 @@ type project_roots = {
   (* scanning roots that belong to the project *)
   scanning_roots : Fppath.t list;
 }
+
+type force_root = (Project.kind * Rfpath.t) option
+
+(*************************************************************************)
+(* Defaults *)
+(*************************************************************************)
 
 let default_conf : conf =
   {
@@ -348,6 +354,19 @@ let git_list_untracked_files (project_roots : project_roots) :
 (* Grouping *)
 (*************************************************************************)
 
+let scanning_root_by_project (force_root : force_root)
+    (scanning_root : Scanning_root.t) : Project.t * Fppath.t =
+  let kind, { Git_project.project_root; inproject_path = scanning_root_ppath } =
+    Git_project.find_any_project_root ?force_root
+      (Scanning_root.to_fpath scanning_root)
+  in
+  ( ({ kind; path = project_root } : Project.t),
+    ({
+       fpath = Scanning_root.to_fpath scanning_root;
+       ppath = scanning_root_ppath;
+     }
+      : Fppath.t) )
+
 (*
    Identify the project root for each scanning root and group them
    by project root. If the project_root is specified, then we use that.
@@ -373,11 +392,6 @@ let group_scanning_roots_by_project (conf : conf)
         (Logs_.list Scanning_root.to_string scanning_roots));
   let force_root =
     match conf.project_root with
-    | Some (Git_remote { checkout_path; _ }) ->
-        Some (Project.Git_project, checkout_path)
-    | None ->
-        (* Usual case when scanning the local file system *)
-        None
     | Some (Filesystem proj_root) ->
         (* This is when --project-root is specified on the command line.
            It doesn't use 'git ls-files' to list files. This is required
@@ -385,29 +399,18 @@ let group_scanning_roots_by_project (conf : conf)
            why it's like this.
            TODO: make tests work without requiring --project-root? *)
         Some (Project.Gitignore_project, proj_root)
+    | Some (Git_remote _)
+    | None ->
+        (* Usual case when scanning the local file system *)
+        None
   in
   scanning_roots
-  |> List_.map (fun (scanning_root : Scanning_root.t) ->
-         let ( kind,
-               {
-                 Git_project.project_root;
-                 inproject_path = scanning_root_ppath;
-               } ) =
-           Git_project.find_any_project_root ?force_root
-             (Scanning_root.to_fpath scanning_root)
-         in
-         ( ({ kind; path = project_root } : Project.t),
-           ({
-              fpath = Scanning_root.to_fpath scanning_root;
-              ppath = scanning_root_ppath;
-            }
-             : Fppath.t) ))
+  |> List_.map (scanning_root_by_project force_root)
   (* Using a realpath (physical path) in Project.t ensures we group
      correctly even if the scanning_roots went through different symlink paths.
   *)
-  |> Assoc.group_by fst
-  |> List_.map (fun (project, xs) ->
-         { project; scanning_roots = xs |> List_.map snd })
+  |> Assoc.group_assoc_bykey_eff
+  |> List_.map (fun (project, scanning_roots) -> { project; scanning_roots })
 
 (*************************************************************************)
 (* Work on a single project *)
@@ -530,17 +533,17 @@ let get_targets_for_project conf (project_roots : project_roots) =
 (* for semgrep query console *)
 let clone_if_remote_project_root conf =
   match conf.project_root with
-  | Some (Git_remote { url; checkout_path }) ->
-      let checkout_path = Rfpath.to_fpath checkout_path in
+  | Some (Git_remote { url }) ->
+      let cwd = Fpath.v (Unix.getcwd ()) in
       Logs.debug (fun m ->
-          m "Sparse cloning %a into %a" Uri.pp url Fpath.pp checkout_path);
-      (match Git_wrapper.sparse_shallow_filtered_checkout url checkout_path with
+          m "Sparse cloning %a into CWD: %a" Uri.pp url Fpath.pp cwd);
+      (match Git_wrapper.sparse_shallow_filtered_checkout url (Fpath.v ".") with
       | Ok () -> ()
       | Error msg ->
           failwith
             (spf "Error while sparse cloning %s into %s: %s" (Uri.to_string url)
-               !!checkout_path msg));
-      Git_wrapper.checkout ~cwd:checkout_path ();
+               (Fpath.to_string cwd) msg));
+      Git_wrapper.checkout ();
       Logs.debug (fun m -> m "Sparse cloning done")
   | Some (Filesystem _)
   | None ->

--- a/src/targeting/Find_targets.mli
+++ b/src/targeting/Find_targets.mli
@@ -3,8 +3,7 @@
    regardless of rules or languages.
  *)
 
-(* Git_remote should really be a URI *)
-type git_remote = { url : Uri.t; checkout_path : Rfpath.t } [@@deriving show]
+type git_remote = { url : Uri.t } [@@deriving show]
 
 type project_root = Git_remote of git_remote | Filesystem of Rfpath.t
 [@@deriving show]


### PR DESCRIPTION
Previously, when a user used --remote, it'd clone the folder into a tmp folder without changing the cwd and scan it there. This was fragile and useless beyond making the command a little cleaner. The cleanliness to the user was not worth the ugliness to our code. So now --remote will just clone the folder into the cwd (assuming it's empty). Now we don't do some weird conditional cwd change either (sorry @kopecs and @mjambon, yall were right).

Downside is that users have to cleanup after themselves but oh well

## Test plan
```bash
mkdir empty
cd empty
semgrep --develop --pro --config ~/tmp.yaml --remote https://github.com/semgrep/semgrep.git
```