### PR TITLE
fix(secrets): validator rules should only respect validation state actions

### DIFF
--- a/cli/src/semgrep/rule_match.py
+++ b/cli/src/semgrep/rule_match.py
@@ -461,7 +461,10 @@ class RuleMatch:
                 return False
             else:
                 return blocking
-        elif self.validation_state is not None:
+        elif (
+            self.validation_state is not None
+            and type(self.validation_state.value) is not out.NoValidator
+        ):
             return self.is_validation_state_blocking
 
         return blocking

--- a/cli/src/semgrep/rule_match.py
+++ b/cli/src/semgrep/rule_match.py
@@ -431,14 +431,20 @@ class RuleMatch:
         if self.validation_state is None:
             return False
 
+        validation_state_type = type(self.validation_state.value)
+        if validation_state_type is out.NoValidator:
+            # If there is no validator, we should rely on original dev.semgrep.actions
+            return "block" in self.metadata.get("dev.semgrep.actions", ["block"])
+
         action_map = {
             out.ConfirmedValid: "valid",
             out.ConfirmedInvalid: "invalid",
             out.ValidationError: "error",
-            out.NoValidator: "valid",  # Fallback to valid action for no validator
+            # NOTE(sal): this exists purely for the sake of the type checker
+            out.NoValidator: "valid",
         }
 
-        validation_state = action_map.get(type(self.validation_state.value), "valid")
+        validation_state: str = action_map.get(validation_state_type, "valid")
 
         return (
             self.metadata.get("dev.semgrep.validation_state.actions", {}).get(
@@ -461,10 +467,7 @@ class RuleMatch:
                 return False
             else:
                 return blocking
-        elif (
-            self.validation_state is not None
-            and type(self.validation_state.value) is not out.NoValidator
-        ):
+        elif self.validation_state is not None:
             return self.is_validation_state_blocking
 
         return blocking

--- a/cli/src/semgrep/rule_match.py
+++ b/cli/src/semgrep/rule_match.py
@@ -438,7 +438,7 @@ class RuleMatch:
             out.NoValidator: "valid",  # Fallback to valid action for no validator
         }
 
-        validation_state = action_map.get(type(self.validation_state.value))
+        validation_state = action_map.get(type(self.validation_state.value), "valid")
 
         return (
             self.metadata.get("dev.semgrep.validation_state.actions", {}).get(
@@ -461,8 +461,10 @@ class RuleMatch:
                 return False
             else:
                 return blocking
-        else:
-            return self.is_validation_state_blocking or blocking
+        elif self.validation_state is not None:
+            return self.is_validation_state_blocking
+
+        return blocking
 
     @property
     def dataflow_trace(self) -> Optional[out.MatchDataflowTrace]:

--- a/cli/tests/default/unit/test_rule.py
+++ b/cli/tests/default/unit/test_rule.py
@@ -6,7 +6,12 @@ from semgrep.config_resolver import parse_config_string
 from semgrep.rule import Rule
 
 
-def create_validator_rule(validation_state_action: str) -> Rule:
+def create_validator_rule(
+    valid_action: str = "monitor",
+    invalid_action: str = "monitor",
+    error_action: str = "monitor",
+    action: str = "monitor",
+) -> Rule:
     config = parse_config_string(
         "testfile",
         dedent(
@@ -19,9 +24,11 @@ def create_validator_rule(validation_state_action: str) -> Rule:
           message: bad
           metadata:
             dev.semgrep.validation_state.actions:
-              valid: {validation_state_action}
-              invalid: comment
-              error: disabled
+              valid: {valid_action}
+              invalid: {invalid_action}
+              error: {error_action}
+            dev.semgrep.actions:
+              - {action}
           validators:
           - http:
               request:
@@ -88,7 +95,9 @@ def test_rule_full_hash_equivalency():
 
 
 @pytest.mark.quick
-@pytest.mark.parametrize(("action", "expected"), [("block", True), ("monitor", False)])
-def test_validator_rule_is_blocking(action, expected):
-    rule = create_validator_rule(action)
+@pytest.mark.parametrize(
+    ("valid_action", "expected"), [("block", True), ("monitor", False)]
+)
+def test_validator_rule_is_blocking(valid_action, expected):
+    rule = create_validator_rule(valid_action=valid_action, action="block")
     assert rule.is_blocking == expected

--- a/cli/tests/default/unit/test_rule_match.py
+++ b/cli/tests/default/unit/test_rule_match.py
@@ -548,11 +548,12 @@ def create_validator_rule_match(
     match_validation_state: Union[
         out.ConfirmedValid, out.ConfirmedInvalid, out.ValidationError, out.NoValidator
     ],
+    action: str = "monitor",
 ):
     return RuleMatch(
         message="message",
         metadata={
-            "dev.semgrep.actions": ["monitor"],
+            "dev.semgrep.actions": [action],
             "dev.semgrep.validation_state.actions": validation_state_actions,
         },
         severity=out.MatchSeverity(out.Error()),
@@ -573,49 +574,56 @@ def create_validator_rule_match(
 
 @pytest.mark.quick
 @pytest.mark.parametrize(
-    ("validation_state_actions", "match_validation_state", "is_blocking"),
+    ("validation_state_actions", "match_validation_state", "action", "is_blocking"),
     [
         (
             {"valid": "comment", "invalid": "monitor", "error": "block"},
             out.ConfirmedValid(),
+            "block",
             False,
         ),
         (
             {"valid": "comment", "invalid": "monitor", "error": "block"},
             out.ConfirmedInvalid(),
+            "block",
             False,
         ),
         (
             {"valid": "comment", "invalid": "monitor", "error": "block"},
             out.ValidationError(),
+            "monitor",
             True,
         ),
         (
             {"valid": "comment", "invalid": "monitor", "error": "block"},
             out.NoValidator(),
+            "block",
             False,
         ),
         (
             {"valid": "block", "invalid": "block", "error": "block"},
             out.ConfirmedValid(),
+            "monitor",
             True,
         ),
         (
             {"valid": "block", "invalid": "block", "error": "block"},
             out.ConfirmedInvalid(),
+            "monitor",
             True,
         ),
         (
             {"valid": "block", "invalid": "block", "error": "block"},
             out.NoValidator(),
+            "monitor",
             True,
         ),
     ],
 )
 def test_validator_rule_blocking(
-    validation_state_actions, match_validation_state, is_blocking
+    validation_state_actions, match_validation_state, action, is_blocking
 ):
     rule_match = create_validator_rule_match(
-        validation_state_actions, match_validation_state
+        validation_state_actions, match_validation_state, action
     )
     assert rule_match.is_blocking == is_blocking

--- a/cli/tests/default/unit/test_rule_match.py
+++ b/cli/tests/default/unit/test_rule_match.py
@@ -598,7 +598,7 @@ def create_validator_rule_match(
             {"valid": "comment", "invalid": "monitor", "error": "block"},
             out.NoValidator(),
             "block",
-            False,
+            True,
         ),
         (
             {"valid": "block", "invalid": "block", "error": "block"},
@@ -616,7 +616,7 @@ def create_validator_rule_match(
             {"valid": "block", "invalid": "block", "error": "block"},
             out.NoValidator(),
             "monitor",
-            True,
+            False,
         ),
     ],
 )

--- a/src/osemgrep/cli_ci/Ci_subcommand.ml
+++ b/src/osemgrep/cli_ci/Ci_subcommand.ml
@@ -336,6 +336,10 @@ let finding_is_blocking (m : OutJ.cli_match) =
 
   match metadata with
   | JSON.Object xs ->
+      let should_check_validation_state =
+        Option.is_some m.extra.validation_state
+      in
+
       let validation_state_should_block =
         match
           ( m.extra.validation_state,
@@ -347,12 +351,15 @@ let finding_is_blocking (m : OutJ.cli_match) =
             |> Option.value ~default:false
         | _ -> false
       in
-      let should_block =
-        match List.assoc_opt "dev.semgrep.actions" xs with
-        | Some (JSON.Array actions) -> contains_blocking actions
-        | _ -> false
-      in
-      validation_state_should_block || should_block
+
+      if should_check_validation_state then validation_state_should_block
+      else
+        let should_block =
+          match List.assoc_opt "dev.semgrep.actions" xs with
+          | Some (JSON.Array actions) -> contains_blocking actions
+          | _ -> false
+        in
+        should_block
   | _ -> false
 
 let rule_is_blocking (json : JSON.t) =

--- a/src/osemgrep/cli_ci/Ci_subcommand.ml
+++ b/src/osemgrep/cli_ci/Ci_subcommand.ml
@@ -76,7 +76,6 @@ module Http_helpers = Http_helpers.Make (Lwt_platform)
    --------------------
 
    TODO You can also inspect the backend logs in cloudwatch, and Metabase?
-
 *)
 
 (*****************************************************************************)
@@ -341,13 +340,11 @@ let finding_is_blocking (m : OutJ.cli_match) =
           List.assoc_opt "dev.semgrep.validation_state.actions" xs,
           List.assoc_opt "dev.semgrep.actions" xs )
       with
-      | Some validation_state, Some (JSON.Object vs), _
-        ->
+      | Some validation_state, Some (JSON.Object vs), _ ->
           List.assoc_opt (validation_state_to_action validation_state) vs
           |> Option.map (JSON.equal (JSON.String "block"))
           |> Option.value ~default:false
-      | None, _, Some (JSON.Array actions) ->
-          contains_blocking actions
+      | None, _, Some (JSON.Array actions) -> contains_blocking actions
       | _ -> false)
   | _ -> false
 

--- a/src/osemgrep/cli_ci/Ci_subcommand.ml
+++ b/src/osemgrep/cli_ci/Ci_subcommand.ml
@@ -341,7 +341,7 @@ let finding_is_blocking (m : OutJ.cli_match) =
           List.assoc_opt "dev.semgrep.validation_state.actions" xs,
           List.assoc_opt "dev.semgrep.actions" xs )
       with
-      | Some validation_state, Some (JSON.Object vs), Some (JSON.Array _actions)
+      | Some validation_state, Some (JSON.Object vs), _
         ->
           List.assoc_opt (validation_state_to_action validation_state) vs
           |> Option.map (JSON.equal (JSON.String "block"))

--- a/src/osemgrep/cli_ci/Ci_subcommand.ml
+++ b/src/osemgrep/cli_ci/Ci_subcommand.ml
@@ -346,7 +346,7 @@ let finding_is_blocking (m : OutJ.cli_match) =
           List.assoc_opt (validation_state_to_action validation_state) vs
           |> Option.map (JSON.equal (JSON.String "block"))
           |> Option.value ~default:false
-      | None, Some (JSON.Object _vs), Some (JSON.Array actions) ->
+      | None, _, Some (JSON.Array actions) ->
           contains_blocking actions
       | _ -> false)
   | _ -> false

--- a/src/osemgrep/cli_ci/Test_is_blocking_helpers.ml
+++ b/src/osemgrep/cli_ci/Test_is_blocking_helpers.ml
@@ -133,43 +133,41 @@ let tests =
                     cli_match_of_finding_with_actions
                       ~validation_state:`Confirmed_valid
                       ~direct_action:"monitor" ~valid:"block" ~invalid:"monitor"
-                      ~error:"comment",
+                      ~error:"comment" (),
                     true );
                   ( "confirmed invalid should block",
                     cli_match_of_finding_with_actions
                       ~validation_state:`Confirmed_invalid
                       ~direct_action:"monitor" ~valid:"monitor" ~invalid:"block"
-                      ~error:"comment",
+                      ~error:"comment" (),
                     true );
                   ( "validation error should block",
                     cli_match_of_finding_with_actions
                       ~validation_state:`Validation_error
                       ~direct_action:"monitor" ~valid:"monitor"
-                      ~invalid:"comment" ~error:"block",
+                      ~invalid:"comment" ~error:"block" (),
                     true );
                   ( "no validator (treated as valid) should block",
                     cli_match_of_finding_with_actions
                       ~validation_state:`No_validator ~direct_action:"monitor"
-                      ~valid:"block" ~invalid:"monitor" ~error:"comment",
+                      ~valid:"block" ~invalid:"monitor" ~error:"comment" (),
                     true );
                   ( "direct action for validated finding should not block",
                     cli_match_of_finding_with_actions
                       ~validation_state:`Confirmed_valid ~direct_action:"block"
-                      ~valid:"monitor" ~invalid:"monitor" ~error:"comment",
+                      ~valid:"monitor" ~invalid:"monitor" ~error:"comment" (),
                     false );
                   ( "no blocking action or state should not block",
                     cli_match_of_finding_with_actions
                       ~validation_state:`Confirmed_valid
                       ~direct_action:"monitor" ~valid:"monitor"
-                      ~invalid:"monitor" ~error:"comment",
+                      ~invalid:"monitor" ~error:"comment" (),
                     false );
                 ]
               in
               List.iter
                 (fun (name, m, expected) ->
-                  Alcotest.(check bool)
-                    name expected
-                    (finding_is_blocking (m ())))
+                  Alcotest.(check bool) name expected (finding_is_blocking m))
                 test_cases);
         ];
     ]


### PR DESCRIPTION
## Context

If a validator rule was set to blocking, every validation state will be blocked. For example, if we have an invalid finding and the rule is set to block for valid findings, then the invalid finding will block too. 

## Solution

If a finding has a validation state, then only respect actions in dev.semgrep.validation_state.actions. We made the mistake of taking `dev.semgrep.actions` into account.