### PR TITLE
fix(lsp): restore search fixes

### DIFF
--- a/src/osemgrep/language_server/custom_requests/Search.ml
+++ b/src/osemgrep/language_server/custom_requests/Search.ml
@@ -321,8 +321,9 @@ let rec search_single_target (server : RPC_server.t) =
       | GitBlob _ -> search_single_target server
       | File path ->
           let is_relevant_rule =
-            true
-            (* Match_rules.is_relevant_rule_for_xtarget (rule :> Rule.rule) conf.xconf xtarget *)
+            Match_rules.is_relevant_rule_for_xtarget
+              (rule :> Rule.rule)
+              conf.xconf xtarget
           in
           if is_relevant_rule then
             try

--- a/src/osemgrep/language_server/custom_requests/Search.ml
+++ b/src/osemgrep/language_server/custom_requests/Search.ml
@@ -19,7 +19,8 @@ open Fpath_.Operators
 module Conv = Convert_utils
 module OutJ = Semgrep_output_v1_t
 
-let meth = "semgrep/search"
+let start_meth = "semgrep/search"
+let ongoing_meth = "semgrep/searchOngoing"
 
 (*****************************************************************************)
 (* Prelude *)
@@ -27,6 +28,27 @@ let meth = "semgrep/search"
 
 (* The main logic for the /semgrep/search LSP command, which is meant to be
    run on a manual search.
+
+   This is a _streaming_ search, meaning that we service partial results. In
+   particular, we choose to service results within the RPC_server loop as
+   _one file per request_.
+
+   As such, we have two different commands: /semgrep/search, and /semgrep/searchOngoing.
+   Our protocol with them are as follows:
+   - when starting a search, the LS receives /semgrep/search and stores some
+     information of what to do next in the `server` value
+   - the server then receives /semgrep/searchOngoing until either a new search
+     is started, or the search is finished.
+   - both searches will return the matches found in the next file in the queue
+
+   Effectively, think of `Search.ml` as a pinata, which is consistently hit by
+   /semgrep/search and /semgrep/searchOngoing until it runs out of files to
+   search.
+
+   TODO: Things that would be nice:
+   - AST caching
+   - Parallelism (Parmap or threads?)
+   - Moving work up to folder-open time rather than search-time
 *)
 
 (*****************************************************************************)
@@ -170,48 +192,113 @@ let get_relevant_rules ({ params = { pattern; fix; _ }; _ } as env : env) :
       search_rules_of_langs (Some Xlang.LRegex)
   | other -> other
 
-(*****************************************************************************)
-(* Running Semgrep! *)
-(*****************************************************************************)
-
-let runner (env : env) rules =
+let get_rules_and_targets (env : env) =
+  let rules = get_relevant_rules env in
   (* Ideally we would just use this, but it seems to err.
      I suspect that Find_targets.git_list_files is not quite correct.
   *)
   (* let _res = Find_targets.get_target_fpaths Scan_CLI.default.targeting_conf env.roots in *)
-  (* TODO: Streaming matches!! *)
+  let rules_and_targets =
+    rules
+    |> List_.map (fun (rule : Rule.search_rule) ->
+           let xlang = rule.target_analyzer in
+           (* We have to look at all the initial files again when we do this.
+               TODO: Maybe could be better to infer languages from each file,
+               so we only have to look at each file once.
+           *)
+           let filtered_files : Fpath.t list =
+             env.initial_files
+             |> List.filter (fun target ->
+                    Filter_target.filter_target_for_xlang xlang target)
+           in
+           ( rule,
+             filtered_files
+             |> List_.map (fun file ->
+                    Xtarget.resolve parse_and_resolve_name
+                      (Target.mk_regular xlang Product.all (File file))) ))
+  in
+  rules_and_targets
+
+(*****************************************************************************)
+(* Output *)
+(*****************************************************************************)
+
+let json_of_matches (matches_by_file : (Fpath.t * Pattern_match.t list) list) =
+  let json =
+    List_.map
+      (fun (path, matches) ->
+        let uri = !!path |> Uri.of_path |> Uri.to_string in
+        let matches =
+          matches
+          |> List_.map (fun (m : Pattern_match.t) ->
+                 let range_json =
+                   Range.yojson_of_t (Conv.range_of_toks m.range_loc)
+                 in
+                 let fix_json =
+                   match m.rule_id.fix with
+                   | None -> `Null
+                   | Some s -> `String s
+                 in
+                 `Assoc [ ("range", range_json); ("fix", fix_json) ])
+        in
+        `Assoc [ ("uri", `String uri); ("matches", `List matches) ])
+      matches_by_file
+  in
+  Some (`Assoc [ ("locations", `List json) ])
+
+(*****************************************************************************)
+(* Running Semgrep! *)
+(*****************************************************************************)
+
+let rec next_rule_and_xtarget (server : RPC_server.t) =
+  match server.session.search_config with
+  | None
+  | Some { rules_and_targets = [] } ->
+      None
+  | Some { rules_and_targets = (_rule, []) :: rest } ->
+      let new_session =
+        {
+          server.session with
+          search_config = Some { rules_and_targets = rest };
+        }
+      in
+      next_rule_and_xtarget { server with session = new_session }
+  | Some { rules_and_targets = (rule, xtarget :: rest_xtargets) :: rest } ->
+      let new_session =
+        {
+          server.session with
+          search_config =
+            Some { rules_and_targets = (rule, rest_xtargets) :: rest };
+        }
+      in
+      Some ((rule, xtarget), { server with session = new_session })
+
+let rec search_single_target (server : RPC_server.t) =
   let hook _file _pm = () in
-  rules
-  |> List.concat_map (fun (rule : Rule.search_rule) ->
-         let xlang = rule.target_analyzer in
-         (* We have to look at all the initial files again when we do this.
-            TODO: Maybe could be better to infer languages from each file,
-            so we only have to look at each file once.
-         *)
-         let filtered_files : Fpath.t list =
-           env.initial_files
-           |> List.filter (fun target ->
-                  Filter_target.filter_target_for_xlang xlang target)
-         in
-         filtered_files
-         |> List_.map (fun file ->
-                Xtarget.resolve parse_and_resolve_name
-                  (Target.mk_regular xlang Product.all (File file)))
-         |> List_.map_filter (fun xtarget ->
-                try
-                  (* !!calling the engine!! *)
-                  let ({ Core_result.matches; _ } : _ Core_result.match_result)
-                      =
-                    Match_search_mode.check_rule rule hook
-                      Match_env.default_xconfig xtarget
-                  in
-                  match (matches, xtarget.path.origin) with
-                  | [], _ -> None
-                  | _, File path -> Some (path, matches)
-                  (* This shouldn't happen. *)
-                  | _, GitBlob _ -> None
-                with
-                | Parsing_error.Syntax_error _ -> None))
+  match next_rule_and_xtarget server with
+  | None ->
+      (* Since we are done with our searches (no more targets), reset our internal state to
+         no longer have this scan config.
+      *)
+      ( json_of_matches [],
+        { server with session = { server.session with search_config = None } }
+      )
+  | Some ((rule, xtarget), server) -> (
+      try
+        (* !!calling the engine!! *)
+        let ({ Core_result.matches; _ } : _ Core_result.match_result) =
+          Match_search_mode.check_rule rule hook Match_env.default_xconfig
+            xtarget
+        in
+        match (matches, xtarget.path.origin) with
+        | [], _ -> search_single_target server
+        | _, File path ->
+            let json = json_of_matches [ (path, matches) ] in
+            (json, server)
+        (* This shouldn't happen. *)
+        | _, GitBlob _ -> search_single_target server
+      with
+      | Parsing_error.Syntax_error _ -> search_single_target server)
 
 (*****************************************************************************)
 (* Entry point *)
@@ -220,32 +307,22 @@ let runner (env : env) rules =
 (** on a semgrep/search request, get the pattern and (optional) language params.
     We then try and parse the pattern in every language (or specified lang), and
     scan like normal, only returning the match ranges per file *)
-let on_request (server : RPC_server.t) params =
+let start_search (server : RPC_server.t) params =
   match Request_params.of_jsonrpc_params params with
-  | None -> None
+  | None ->
+      Logs.debug (fun m -> m "no params received in semgrep/search");
+      (None, server)
   | Some params ->
       let env = mk_env server params in
-      let rules = get_relevant_rules env in
+      let rules_and_targets = get_rules_and_targets env in
       (* !!calling the engine!! *)
-      let matches_by_file = runner env rules in
-      let json =
-        List_.map
-          (fun (path, matches) ->
-            let uri = !!path |> Uri.of_path |> Uri.to_string in
-            let matches =
-              matches
-              |> List_.map (fun (m : Pattern_match.t) ->
-                     let range_json =
-                       Range.yojson_of_t (Conv.range_of_toks m.range_loc)
-                     in
-                     let fix_json =
-                       match m.rule_id.fix with
-                       | None -> `Null
-                       | Some s -> `String s
-                     in
-                     `Assoc [ ("range", range_json); ("fix", fix_json) ])
-            in
-            `Assoc [ ("uri", `String uri); ("matches", `List matches) ])
-          matches_by_file
-      in
-      Some (`Assoc [ ("locations", `List json) ])
+      search_single_target
+        {
+          server with
+          session =
+            { server.session with search_config = Some { rules_and_targets } };
+        }
+
+let search_next_file (server : RPC_server.t) _params =
+  (* The params are nullary, so we don't actually need to check them. *)
+  search_single_target server

--- a/src/osemgrep/language_server/custom_requests/Search.ml
+++ b/src/osemgrep/language_server/custom_requests/Search.ml
@@ -130,6 +130,28 @@ let parse_and_resolve_name (lang : Lang.t) (fpath : Fpath.t) :
   in
   (ast, skipped_tokens)
 
+let filter_by_gitignore (files : Fpath.t list)
+    (scanning_roots : Scanning_root.t list) : Fpath.t list =
+  (* Filter all files by gitignores *)
+  let project_root =
+    match
+      List.nth scanning_roots 0 |> Scanning_root.to_fpath |> Rfpath.of_fpath
+    with
+    | Error _ -> failwith "somehow unable to get project root from first root"
+    | Ok rfpath -> rfpath
+  in
+  let gitignore_filter =
+    Gitignore_filter.create ~project_root:(Rfpath.to_fpath project_root) ()
+  in
+  files
+  |> List.filter (fun file ->
+         match Ppath.in_project ~root:project_root file with
+         | Error _ -> failwith "err"
+         | Ok ppath -> (
+             match Gitignore_filter.select gitignore_filter [] ppath with
+             | Gitignore.Ignored, _ -> false
+             | _ -> true))
+
 (*****************************************************************************)
 (* Information gathering *)
 (*****************************************************************************)
@@ -148,26 +170,7 @@ let mk_env (server : RPC_server.t) params =
        This adds 10s to startup time in `semgrep-app` on my machine.
        Gitignore is expensive! I don't know why.
     *)
-    if false then
-      let project_root =
-        match
-          List.nth scanning_roots 0 |> Scanning_root.to_fpath |> Rfpath.of_fpath
-        with
-        | Error _ -> failwith "wtf"
-        | Ok rfpath -> rfpath
-      in
-      let gitignore_filter =
-        Gitignore_filter.create ~project_root:(Rfpath.to_fpath project_root) ()
-      in
-      files
-      |> List.filter (fun file ->
-             match Ppath.in_project ~root:project_root file with
-             | Error _ -> failwith "err"
-             | Ok ppath -> (
-                 match Gitignore_filter.select gitignore_filter [] ppath with
-                 | Gitignore.Ignored, _ -> false
-                 | _ -> true))
-    else files
+    if false then filter_by_gitignore files scanning_roots else files
   in
   { roots = scanning_roots; initial_files = filtered_files; params }
 
@@ -319,7 +322,7 @@ let rec search_single_target (server : RPC_server.t) =
       | File path ->
           let is_relevant_rule =
             true
-            (* Match_rules.is_relevant_rule_for_xtarget (rule :> Rule.rule) conf.xconf xtarget  *)
+            (* Match_rules.is_relevant_rule_for_xtarget (rule :> Rule.rule) conf.xconf xtarget *)
           in
           if is_relevant_rule then
             try
@@ -349,17 +352,14 @@ let start_search (server : RPC_server.t) params =
       Logs.debug (fun m -> m "no params received in semgrep/search");
       (None, server)
   | Some params ->
-      let env, t1 = Common.with_time (fun () -> mk_env server params) in
-      let rules_and_targets, t2 =
-        Common.with_time (fun () -> get_rules_and_targets env)
-      in
+      let env = mk_env server params in
+      let rules_and_targets = get_rules_and_targets env in
       let xconf =
         {
           Match_env.default_xconfig with
           filter_irrelevant_rules = PrefilterWithCache (Hashtbl.create 10);
         }
       in
-      UCommon.pr2 (Common.spf "env time: %f, rules time %f" t1 t2);
       (* !!calling the engine!! *)
       search_single_target
         {

--- a/src/osemgrep/language_server/custom_requests/Search.ml
+++ b/src/osemgrep/language_server/custom_requests/Search.ml
@@ -65,24 +65,86 @@ module Request_params = struct
 end
 
 (*****************************************************************************)
+(* Helpers *)
+(*****************************************************************************)
+
+(* Get the languages that are in play in this workspace, by consulting all the
+   current targets' languages.
+   TODO: Maybe buggy if cached_workspace_targets only has dirty files or
+   whatever, I don't think it's always all of the targets in the workspace.
+   I tried Find_targets.get_targets, but this ran into an error because of some
+   path relativity stuff, I think.
+*)
+let get_relevant_xlangs (server : RPC_server.t) : Xlang.t list =
+  let files =
+    server.session.cached_workspace_targets |> Hashtbl.to_seq_values
+    |> List.of_seq |> List.concat
+  in
+  let lang_set = Hashtbl.create 10 in
+  List.iter
+    (fun file ->
+      let file_langs = Lang.langs_of_filename file in
+      List.iter (fun lang -> Hashtbl.replace lang_set lang ()) file_langs)
+    files;
+  Hashtbl.to_seq_keys lang_set |> List.of_seq |> List_.map Xlang.of_lang
+
+(* Get the rules to run based on the pattern and state of the LSP. *)
+let get_relevant_rules (params : Request_params.t) (server : RPC_server.t) :
+    Rule.t list =
+  (* TODO: figure out why rules_from_rules_source_async hangs *)
+  (* let src = Rules_source.(Pattern (pattern, xlang_opt, None)) in *)
+  let rules_and_origins =
+    Rule_fetching.rules_from_pattern (params.pattern, params.lang, None)
+  in
+  let rules, _ = Rule_fetching.partition_rules_and_errors rules_and_origins in
+  let xlangs = get_relevant_xlangs server in
+  let rules_with_relevant_xlang =
+    List.filter
+      (fun (rule : Rule.t) -> List.mem rule.target_analyzer xlangs)
+      rules
+  in
+  match rules_with_relevant_xlang with
+  (* Unfortunately, almost everything parses as YAML, because you can specify
+     no quotes and it will be interpreted as a YAML string
+     So if we are getting a pattern which only parses as YAML, it's probably
+     safe to say it's a non-language-specific pattern.
+  *)
+  | []
+  | [ { target_analyzer = Xlang.L (Yaml, _); _ } ] ->
+      (* should be a singleton *)
+      let rules_and_origins =
+        Rule_fetching.rules_from_pattern
+          (params.pattern, Some Xlang.LRegex, None)
+      in
+      Rule_fetching.partition_rules_and_errors rules_and_origins |> fst
+  | other -> other
+
+(*
+  let relevant_xtargets_for_lang (files: Fpath.t list) (xlang: Xlang.t) : Xtarget.t list =
+    let filtered_files: Fpath.t list =
+      files
+      |> List.filter (fun target ->
+          Filter_target.filter_target_for_xlang xlang target)
+    in
+    filtered_files
+    |> List_.map (fun (file) ->
+      Xtarget.resolve parse_and_resolve_name
+      (Target.mk_regular xlang Product.all (File file))
+    )
+   *)
+
+(*****************************************************************************)
 (* Entry point *)
 (*****************************************************************************)
 
 (** on a semgrep/search request, get the pattern and (optional) language params.
     We then try and parse the pattern in every language (or specified lang), and
     scan like normal, only returning the match ranges per file *)
-let on_request runner params =
+let on_request server runner params =
   match Request_params.of_jsonrpc_params params with
   | None -> None
   | Some params ->
-      (* TODO: figure out why rules_from_rules_source_async hangs *)
-      (* let src = Rules_source.(Pattern (pattern, xlang_opt, None)) in *)
-      let rules_and_origins =
-        Rule_fetching.rules_from_pattern (params.pattern, params.lang, None)
-      in
-      let rules, _ =
-        Rule_fetching.partition_rules_and_errors rules_and_origins
-      in
+      let rules = get_relevant_rules params server in
       let rules_with_fixes =
         rules |> List_.map (fun rule -> { rule with Rule.fix = params.fix })
       in

--- a/src/osemgrep/language_server/custom_requests/Search.ml
+++ b/src/osemgrep/language_server/custom_requests/Search.ml
@@ -1,3 +1,18 @@
+(* Brandon Wu
+ *
+ * Copyright (C) 2019-2024 Semgrep, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * version 2.1 as published by the Free Software Foundation, with the
+ * special exception on linking described in file LICENSE.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
+ * LICENSE for more details.
+ *)
+
 open Lsp
 open Lsp.Types
 open Fpath_.Operators
@@ -5,6 +20,14 @@ module Conv = Convert_utils
 module OutJ = Semgrep_output_v1_t
 
 let meth = "semgrep/search"
+
+(*****************************************************************************)
+(* Prelude *)
+(*****************************************************************************)
+
+(* The main logic for the /semgrep/search LSP command, which is meant to be
+   run on a manual search.
+*)
 
 (*****************************************************************************)
 (* Parameters *)
@@ -65,8 +88,39 @@ module Request_params = struct
 end
 
 (*****************************************************************************)
+(* Types *)
+(*****************************************************************************)
+
+type env = {
+  params : Request_params.t;
+  initial_files : Fpath.t list;
+  roots : Scanning_root.t list;
+}
+
+(*****************************************************************************)
 (* Helpers *)
 (*****************************************************************************)
+
+let parse_and_resolve_name (lang : Lang.t) (fpath : Fpath.t) :
+    AST_generic.program * Tok.location list =
+  let { Parsing_result2.ast; skipped_tokens; _ } =
+    Parse_target.parse_and_resolve_name lang fpath
+  in
+  (ast, skipped_tokens)
+
+(*****************************************************************************)
+(* Information gathering *)
+(*****************************************************************************)
+
+let mk_env (server : RPC_server.t) params =
+  let scanning_roots =
+    List_.map Scanning_root.of_fpath server.session.workspace_folders
+  in
+  let files =
+    server.session.cached_workspace_targets |> Hashtbl.to_seq_values
+    |> List.of_seq |> List.concat
+  in
+  { roots = scanning_roots; initial_files = files; params }
 
 (* Get the languages that are in play in this workspace, by consulting all the
    current targets' languages.
@@ -75,33 +129,34 @@ end
    I tried Find_targets.get_targets, but this ran into an error because of some
    path relativity stuff, I think.
 *)
-let get_relevant_xlangs (server : RPC_server.t) : Xlang.t list =
-  let files =
-    server.session.cached_workspace_targets |> Hashtbl.to_seq_values
-    |> List.of_seq |> List.concat
-  in
+let get_relevant_xlangs (env : env) : Xlang.t list =
   let lang_set = Hashtbl.create 10 in
   List.iter
     (fun file ->
       let file_langs = Lang.langs_of_filename file in
       List.iter (fun lang -> Hashtbl.replace lang_set lang ()) file_langs)
-    files;
+    env.initial_files;
   Hashtbl.to_seq_keys lang_set |> List.of_seq |> List_.map Xlang.of_lang
 
 (* Get the rules to run based on the pattern and state of the LSP. *)
-let get_relevant_rules (params : Request_params.t) (server : RPC_server.t) :
-    Rule.t list =
+let get_relevant_rules ({ params = { pattern; fix; _ }; _ } as env : env) :
+    Rule.search_rule list =
   (* TODO: figure out why rules_from_rules_source_async hangs *)
   (* let src = Rules_source.(Pattern (pattern, xlang_opt, None)) in *)
-  let rules_and_origins =
-    Rule_fetching.rules_from_pattern (params.pattern, params.lang, None)
+  let search_rules_of_langs (lang_opt : Xlang.t option) : Rule.search_rule list
+      =
+    let rules_and_origins =
+      Rule_fetching.rules_from_pattern (pattern, lang_opt, fix)
+    in
+    let rules, _ = Rule_fetching.partition_rules_and_errors rules_and_origins in
+    let search_rules, _, _, _ = Rule.partition_rules rules in
+    search_rules
   in
-  let rules, _ = Rule_fetching.partition_rules_and_errors rules_and_origins in
-  let xlangs = get_relevant_xlangs server in
+  let xlangs = get_relevant_xlangs env in
   let rules_with_relevant_xlang =
-    List.filter
-      (fun (rule : Rule.t) -> List.mem rule.target_analyzer xlangs)
-      rules
+    search_rules_of_langs None
+    |> List.filter (fun (rule : Rule.search_rule) ->
+           List.mem rule.target_analyzer xlangs)
   in
   match rules_with_relevant_xlang with
   (* Unfortunately, almost everything parses as YAML, because you can specify
@@ -112,26 +167,51 @@ let get_relevant_rules (params : Request_params.t) (server : RPC_server.t) :
   | []
   | [ { target_analyzer = Xlang.L (Yaml, _); _ } ] ->
       (* should be a singleton *)
-      let rules_and_origins =
-        Rule_fetching.rules_from_pattern
-          (params.pattern, Some Xlang.LRegex, None)
-      in
-      Rule_fetching.partition_rules_and_errors rules_and_origins |> fst
+      search_rules_of_langs (Some Xlang.LRegex)
   | other -> other
 
-(*
-  let relevant_xtargets_for_lang (files: Fpath.t list) (xlang: Xlang.t) : Xtarget.t list =
-    let filtered_files: Fpath.t list =
-      files
-      |> List.filter (fun target ->
-          Filter_target.filter_target_for_xlang xlang target)
-    in
-    filtered_files
-    |> List_.map (fun (file) ->
-      Xtarget.resolve parse_and_resolve_name
-      (Target.mk_regular xlang Product.all (File file))
-    )
-   *)
+(*****************************************************************************)
+(* Running Semgrep! *)
+(*****************************************************************************)
+
+let runner (env : env) rules =
+  (* Ideally we would just use this, but it seems to err.
+     I suspect that Find_targets.git_list_files is not quite correct.
+  *)
+  (* let _res = Find_targets.get_target_fpaths Scan_CLI.default.targeting_conf env.roots in *)
+  (* TODO: Streaming matches!! *)
+  let hook _file _pm = () in
+  rules
+  |> List.concat_map (fun (rule : Rule.search_rule) ->
+         let xlang = rule.target_analyzer in
+         (* We have to look at all the initial files again when we do this.
+            TODO: Maybe could be better to infer languages from each file,
+            so we only have to look at each file once.
+         *)
+         let filtered_files : Fpath.t list =
+           env.initial_files
+           |> List.filter (fun target ->
+                  Filter_target.filter_target_for_xlang xlang target)
+         in
+         filtered_files
+         |> List_.map (fun file ->
+                Xtarget.resolve parse_and_resolve_name
+                  (Target.mk_regular xlang Product.all (File file)))
+         |> List_.map_filter (fun xtarget ->
+                try
+                  (* !!calling the engine!! *)
+                  let ({ Core_result.matches; _ } : _ Core_result.match_result)
+                      =
+                    Match_search_mode.check_rule rule hook
+                      Match_env.default_xconfig xtarget
+                  in
+                  match (matches, xtarget.path.origin) with
+                  | [], _ -> None
+                  | _, File path -> Some (path, matches)
+                  (* This shouldn't happen. *)
+                  | _, GitBlob _ -> None
+                with
+                | Parsing_error.Syntax_error _ -> None))
 
 (*****************************************************************************)
 (* Entry point *)
@@ -140,30 +220,26 @@ let get_relevant_rules (params : Request_params.t) (server : RPC_server.t) :
 (** on a semgrep/search request, get the pattern and (optional) language params.
     We then try and parse the pattern in every language (or specified lang), and
     scan like normal, only returning the match ranges per file *)
-let on_request server runner params =
+let on_request (server : RPC_server.t) params =
   match Request_params.of_jsonrpc_params params with
   | None -> None
   | Some params ->
-      let rules = get_relevant_rules params server in
-      let rules_with_fixes =
-        rules |> List_.map (fun rule -> { rule with Rule.fix = params.fix })
-      in
-      let matches = runner rules_with_fixes in
-      let matches_by_file =
-        Assoc.group_by (fun (m : OutJ.cli_match) -> !!(m.path)) matches
-      in
+      let env = mk_env server params in
+      let rules = get_relevant_rules env in
+      (* !!calling the engine!! *)
+      let matches_by_file = runner env rules in
       let json =
         List_.map
-          (fun (file, matches) ->
-            let uri = file |> Uri.of_path |> Uri.to_string in
+          (fun (path, matches) ->
+            let uri = !!path |> Uri.of_path |> Uri.to_string in
             let matches =
               matches
-              |> List_.map (fun m ->
+              |> List_.map (fun (m : Pattern_match.t) ->
                      let range_json =
-                       Range.yojson_of_t (Conv.range_of_cli_match m)
+                       Range.yojson_of_t (Conv.range_of_toks m.range_loc)
                      in
                      let fix_json =
-                       match m.extra.fix with
+                       match m.rule_id.fix with
                        | None -> `Null
                        | Some s -> `String s
                      in

--- a/src/osemgrep/language_server/custom_requests/Search.ml
+++ b/src/osemgrep/language_server/custom_requests/Search.ml
@@ -271,21 +271,22 @@ let get_rules_and_targets (env : env) =
 (* Output *)
 (*****************************************************************************)
 
-let json_of_matches (matches_by_file : (Fpath.t * Pattern_match.t list) list) =
+let json_of_matches
+    (matches_by_file : (Fpath.t * Core_result.processed_match list) list) =
   let json =
     List_.map
       (fun (path, matches) ->
         let uri = !!path |> Uri.of_path |> Uri.to_string in
         let matches =
           matches
-          |> List_.map (fun (m : Pattern_match.t) ->
+          |> List_.map (fun (m : Core_result.processed_match) ->
                  let range_json =
-                   Range.yojson_of_t (Conv.range_of_toks m.range_loc)
+                   Range.yojson_of_t (Conv.range_of_toks m.pm.range_loc)
                  in
                  let fix_json =
-                   match m.rule_id.fix with
+                   match m.autofix_edit with
                    | None -> `Null
-                   | Some s -> `String s
+                   | Some edit -> `String edit.replacement_text
                  in
                  `Assoc [ ("range", range_json); ("fix", fix_json) ])
         in
@@ -349,10 +350,15 @@ let rec search_single_target (server : RPC_server.t) =
               let ({ Core_result.matches; _ } : _ Core_result.match_result) =
                 Match_search_mode.check_rule rule hook conf.xconf xtarget
               in
+              let matches_with_fixes =
+                matches
+                |> List_.map Core_result.mk_processed_match
+                |> Autofix.produce_autofixes
+              in
               match matches with
               | [] -> search_single_target server
               | _ ->
-                  let json = json_of_matches [ (path, matches) ] in
+                  let json = json_of_matches [ (path, matches_with_fixes) ] in
                   (json, server)
             with
             | Parsing_error.Syntax_error _ -> search_single_target server

--- a/src/osemgrep/language_server/custom_requests/Search.ml
+++ b/src/osemgrep/language_server/custom_requests/Search.ml
@@ -220,7 +220,25 @@ let get_relevant_rules ({ params = { pattern; fix; _ }; _ } as env : env) :
   | [ { target_analyzer = Xlang.L (Yaml, _); _ } ] ->
       (* should be a singleton *)
       search_rules_of_langs (Some Xlang.LRegex)
-  | other -> other
+  | other ->
+      let has_python3 =
+        List.exists
+          (fun x ->
+            match x.Rule.target_analyzer with
+            | Xlang.L (Python3, _) -> true
+            | _ -> false)
+          other
+      in
+      (* If a pattern parses with python3, don't run any more Python rules. *)
+      if has_python3 then
+        List.filter
+          (fun x ->
+            match x.Rule.target_analyzer with
+            | Xlang.L (Python2, _) -> false
+            | Xlang.L (Python, _) -> false
+            | _ -> true)
+          other
+      else other
 
 let get_rules_and_targets (env : env) =
   let rules = get_relevant_rules env in

--- a/src/osemgrep/language_server/custom_requests/Search.ml
+++ b/src/osemgrep/language_server/custom_requests/Search.ml
@@ -142,7 +142,34 @@ let mk_env (server : RPC_server.t) params =
     server.session.cached_workspace_targets |> Hashtbl.to_seq_values
     |> List.of_seq |> List.concat
   in
-  { roots = scanning_roots; initial_files = files; params }
+  (* Filter all files by gitignores *)
+  let filtered_files =
+    (* Gitignore code. We hard-code it to be false for now.
+       This adds 10s to startup time in `semgrep-app` on my machine.
+       Gitignore is expensive! I don't know why.
+    *)
+    if false then
+      let project_root =
+        match
+          List.nth scanning_roots 0 |> Scanning_root.to_fpath |> Rfpath.of_fpath
+        with
+        | Error _ -> failwith "wtf"
+        | Ok rfpath -> rfpath
+      in
+      let gitignore_filter =
+        Gitignore_filter.create ~project_root:(Rfpath.to_fpath project_root) ()
+      in
+      files
+      |> List.filter (fun file ->
+             match Ppath.in_project ~root:project_root file with
+             | Error _ -> failwith "err"
+             | Ok ppath -> (
+                 match Gitignore_filter.select gitignore_filter [] ppath with
+                 | Gitignore.Ignored, _ -> false
+                 | _ -> true))
+    else files
+  in
+  { roots = scanning_roots; initial_files = filtered_files; params }
 
 (* Get the languages that are in play in this workspace, by consulting all the
    current targets' languages.
@@ -253,25 +280,27 @@ let json_of_matches (matches_by_file : (Fpath.t * Pattern_match.t list) list) =
 let rec next_rule_and_xtarget (server : RPC_server.t) =
   match server.session.search_config with
   | None
-  | Some { rules_and_targets = [] } ->
+  | Some { rules_and_targets = []; _ } ->
       None
-  | Some { rules_and_targets = (_rule, []) :: rest } ->
+  | Some ({ rules_and_targets = (_rule, []) :: rest; _ } as conf) ->
       let new_session =
         {
           server.session with
-          search_config = Some { rules_and_targets = rest };
+          search_config = Some { conf with rules_and_targets = rest };
         }
       in
       next_rule_and_xtarget { server with session = new_session }
-  | Some { rules_and_targets = (rule, xtarget :: rest_xtargets) :: rest } ->
+  | Some
+      ({ rules_and_targets = (rule, xtarget :: rest_xtargets) :: rest; _ } as
+       conf) ->
       let new_session =
         {
           server.session with
           search_config =
-            Some { rules_and_targets = (rule, rest_xtargets) :: rest };
+            Some { conf with rules_and_targets = (rule, rest_xtargets) :: rest };
         }
       in
-      Some ((rule, xtarget), { server with session = new_session })
+      Some ((rule, xtarget, conf), { server with session = new_session })
 
 let rec search_single_target (server : RPC_server.t) =
   let hook _file _pm = () in
@@ -283,22 +312,29 @@ let rec search_single_target (server : RPC_server.t) =
       ( json_of_matches [],
         { server with session = { server.session with search_config = None } }
       )
-  | Some ((rule, xtarget), server) -> (
-      try
-        (* !!calling the engine!! *)
-        let ({ Core_result.matches; _ } : _ Core_result.match_result) =
-          Match_search_mode.check_rule rule hook Match_env.default_xconfig
-            xtarget
-        in
-        match (matches, xtarget.path.origin) with
-        | [], _ -> search_single_target server
-        | _, File path ->
-            let json = json_of_matches [ (path, matches) ] in
-            (json, server)
-        (* This shouldn't happen. *)
-        | _, GitBlob _ -> search_single_target server
-      with
-      | Parsing_error.Syntax_error _ -> search_single_target server)
+  | Some ((rule, xtarget, conf), server) -> (
+      match xtarget.path.origin with
+      (* This shouldn't happen. *)
+      | GitBlob _ -> search_single_target server
+      | File path ->
+          let is_relevant_rule =
+            true
+            (* Match_rules.is_relevant_rule_for_xtarget (rule :> Rule.rule) conf.xconf xtarget  *)
+          in
+          if is_relevant_rule then
+            try
+              (* !!calling the engine!! *)
+              let ({ Core_result.matches; _ } : _ Core_result.match_result) =
+                Match_search_mode.check_rule rule hook conf.xconf xtarget
+              in
+              match matches with
+              | [] -> search_single_target server
+              | _ ->
+                  let json = json_of_matches [ (path, matches) ] in
+                  (json, server)
+            with
+            | Parsing_error.Syntax_error _ -> search_single_target server
+          else search_single_target server)
 
 (*****************************************************************************)
 (* Entry point *)
@@ -313,14 +349,26 @@ let start_search (server : RPC_server.t) params =
       Logs.debug (fun m -> m "no params received in semgrep/search");
       (None, server)
   | Some params ->
-      let env = mk_env server params in
-      let rules_and_targets = get_rules_and_targets env in
+      let env, t1 = Common.with_time (fun () -> mk_env server params) in
+      let rules_and_targets, t2 =
+        Common.with_time (fun () -> get_rules_and_targets env)
+      in
+      let xconf =
+        {
+          Match_env.default_xconfig with
+          filter_irrelevant_rules = PrefilterWithCache (Hashtbl.create 10);
+        }
+      in
+      UCommon.pr2 (Common.spf "env time: %f, rules time %f" t1 t2);
       (* !!calling the engine!! *)
       search_single_target
         {
           server with
           session =
-            { server.session with search_config = Some { rules_and_targets } };
+            {
+              server.session with
+              search_config = Some { rules_and_targets; xconf };
+            };
         }
 
 let search_next_file (server : RPC_server.t) _params =

--- a/src/osemgrep/language_server/custom_requests/Search.mli
+++ b/src/osemgrep/language_server/custom_requests/Search.mli
@@ -5,6 +5,7 @@ val mk_params :
   lang:Xlang.t option -> fix:string option -> string -> Jsonrpc.Structured.t
 
 val on_request :
+  RPC_server.t ->
   (Rule.rules -> Semgrep_output_v1_t.cli_match list) ->
   Jsonrpc.Structured.t option ->
   Yojson.Safe.t option

--- a/src/osemgrep/language_server/custom_requests/Search.mli
+++ b/src/osemgrep/language_server/custom_requests/Search.mli
@@ -5,10 +5,7 @@ val mk_params :
   lang:Xlang.t option -> fix:string option -> string -> Jsonrpc.Structured.t
 
 val on_request :
-  RPC_server.t ->
-  (Rule.rules -> Semgrep_output_v1_t.cli_match list) ->
-  Jsonrpc.Structured.t option ->
-  Yojson.Safe.t option
+  RPC_server.t -> Jsonrpc.Structured.t option -> Yojson.Safe.t option
 (** [on_request runner request] will run [runner] on the given pattern and optional
     language params. If the request is None, we return None. Otherwise, we return
     [Some (JSON response)] that contains the ranges of all matches *)

--- a/src/osemgrep/language_server/custom_requests/Search.mli
+++ b/src/osemgrep/language_server/custom_requests/Search.mli
@@ -1,11 +1,28 @@
-val meth : string
+val start_meth : string
 (** method to match on: semgrep/search *)
 
 val mk_params :
   lang:Xlang.t option -> fix:string option -> string -> Jsonrpc.Structured.t
 
-val on_request :
-  RPC_server.t -> Jsonrpc.Structured.t option -> Yojson.Safe.t option
-(** [on_request runner request] will run [runner] on the given pattern and optional
-    language params. If the request is None, we return None. Otherwise, we return
-    [Some (JSON response)] that contains the ranges of all matches *)
+val ongoing_meth : string
+(** method to match on: semgrep/searchOngoing *)
+
+val start_search :
+  RPC_server.t ->
+  Jsonrpc.Structured.t option ->
+  Yojson.Safe.t option * RPC_server.t
+(** [start_search server params] will cause a search to start with the given parameters,
+    storing the information of remaining rules/targets to search in the server session.
+    It will then return the matches in the first file with matches.
+    Will return `Assoc ["locations": `List []] when the search has concluded.
+  *)
+
+val search_next_file :
+  RPC_server.t ->
+  Jsonrpc.Structured.t option ->
+  Yojson.Safe.t option * RPC_server.t
+(** [search_next_file server params] is used during an ongoing search, and will
+    return the matches in the first file with matches, based on the remaining
+    rules/targets to search in the server session state.
+    Will return `Assoc ["locations": `List []] when the search has concluded.
+  *)

--- a/src/osemgrep/language_server/custom_requests/dune
+++ b/src/osemgrep/language_server/custom_requests/dune
@@ -5,5 +5,6 @@
  (libraries
    semgrep.language_server.util
    osemgrep_language_server_server
+   semgrep.osemgrep_cli_scan
  )
 )

--- a/src/osemgrep/language_server/requests/Request_handler.ml
+++ b/src/osemgrep/language_server/requests/Request_handler.ml
@@ -28,27 +28,33 @@ module CR = Client_request
 (* Code *)
 (*****************************************************************************)
 
-(* Specifically for custom requests for searching. *)
-let search_handler (server : RPC_server.t) params =
-  Search.on_request server params
-
 (* Dispatch to the various custom request handlers. *)
 let handle_custom_request server (meth : string)
     (params : Jsonrpc.Structured.t option) : Yojson.Safe.t option * RPC_server.t
     =
   match
+    (* Methods which can alter the server *)
     [
-      (Search.meth, search_handler);
-      (ShowAst.meth, ShowAst.on_request);
-      (Login.meth, Login.on_request);
-      (LoginStatus.meth, LoginStatus.on_request);
+      (Search.start_meth, Search.start_search);
+      (Search.ongoing_meth, Search.search_next_file);
     ]
     |> List.assoc_opt meth
   with
-  | None ->
-      Logs.warn (fun m -> m "Unhandled custom request %s" meth);
-      (None, server)
-  | Some handler -> (handler server params, server)
+  | Some handler -> handler server params
+  | None -> (
+      match
+        (* Methods which cannot alter the server. *)
+        [
+          (ShowAst.meth, ShowAst.on_request);
+          (Login.meth, Login.on_request);
+          (LoginStatus.meth, LoginStatus.on_request);
+        ]
+        |> List.assoc_opt meth
+      with
+      | None ->
+          Logs.warn (fun m -> m "Unhandled custom request %s" meth);
+          (None, server)
+      | Some handler -> (handler server params, server))
 
 let on_request (type r) (request : r CR.t) server =
   let process_result (r, server) =

--- a/src/osemgrep/language_server/requests/Request_handler.ml
+++ b/src/osemgrep/language_server/requests/Request_handler.ml
@@ -41,7 +41,7 @@ let search_handler (server : RPC_server.t) params =
     { server with session }
   in
   let runner rules = Scan_helpers.run_semgrep server ~rules |> fst in
-  Search.on_request runner params
+  Search.on_request server runner params
 
 (* Dispatch to the various custom request handlers. *)
 let handle_custom_request server (meth : string)

--- a/src/osemgrep/language_server/requests/Request_handler.ml
+++ b/src/osemgrep/language_server/requests/Request_handler.ml
@@ -30,18 +30,7 @@ module CR = Client_request
 
 (* Specifically for custom requests for searching. *)
 let search_handler (server : RPC_server.t) params =
-  let server =
-    let session = server.session in
-    let session =
-      {
-        session with
-        user_settings = { session.user_settings with only_git_dirty = false };
-      }
-    in
-    { server with session }
-  in
-  let runner rules = Scan_helpers.run_semgrep server ~rules |> fst in
-  Search.on_request server runner params
+  Search.on_request server params
 
 (* Dispatch to the various custom request handlers. *)
 let handle_custom_request server (meth : string)

--- a/src/osemgrep/language_server/server/Search_config.ml
+++ b/src/osemgrep/language_server/server/Search_config.ml
@@ -1,0 +1,34 @@
+(* Brandon Wu
+ *
+ * Copyright (C) 2019-2024 Semgrep, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * version 2.1 as published by the Free Software Foundation, with the
+ * special exception on linking described in file LICENSE.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
+ * LICENSE for more details.
+ *)
+
+module OutJ = Semgrep_output_v1_t
+
+(*****************************************************************************)
+(* Prelude *)
+(*****************************************************************************)
+
+(* The internal state associated with the /semgrep/search command, which
+   starts a streaming search process with the LSP.
+   Will be reset on every new search request!
+*)
+
+(*****************************************************************************)
+(* Types *)
+(*****************************************************************************)
+
+type t = {
+  rules_and_targets : (Rule.search_rule * (Xtarget.t[@opaque]) list) list;
+}
+[@@deriving show]

--- a/src/osemgrep/language_server/server/Search_config.ml
+++ b/src/osemgrep/language_server/server/Search_config.ml
@@ -30,5 +30,6 @@ module OutJ = Semgrep_output_v1_t
 
 type t = {
   rules_and_targets : (Rule.search_rule * (Xtarget.t[@opaque]) list) list;
+  xconf : Match_env.xconfig; [@opaque]
 }
 [@@deriving show]

--- a/src/osemgrep/language_server/server/Session.ml
+++ b/src/osemgrep/language_server/server/Session.ml
@@ -35,6 +35,7 @@ type t = {
   cached_session : session_cache;
   skipped_local_fingerprints : string list;
   user_settings : User_settings.t;
+  search_config : Search_config.t option;
   metrics : LS_metrics.t;
   is_intellij : bool;
   caps : < Cap.random ; Cap.network ; Cap.tmp >; [@opaque]
@@ -62,6 +63,7 @@ let create caps capabilities =
     cached_session;
     skipped_local_fingerprints = [];
     user_settings = User_settings.default;
+    search_config = None;
     metrics = LS_metrics.default;
     is_intellij = false;
     caps;

--- a/src/osemgrep/language_server/server/Session.mli
+++ b/src/osemgrep/language_server/server/Session.mli
@@ -27,6 +27,7 @@ type t = {
   cached_session : session_cache;
   skipped_local_fingerprints : string list;
   user_settings : User_settings.t;
+  search_config : Search_config.t option;
   metrics : LS_metrics.t;
   is_intellij : bool;
   caps : < Cap.random ; Cap.network ; Cap.tmp >; [@opaque]

--- a/src/osemgrep/language_server/util/Convert_utils.ml
+++ b/src/osemgrep/language_server/util/Convert_utils.ml
@@ -8,6 +8,12 @@ let range_of_cli_match (m : OutJ.cli_match) =
       (Position.create ~line:(m.start.line - 1) ~character:(m.start.col - 1))
     ~end_:(Position.create ~line:(m.end_.line - 1) ~character:(m.end_.col - 1))
 
+let range_of_toks ((l1 : Tok.location), (l2 : Tok.location)) =
+  let line, col, _ = Tok.end_pos_of_loc l2 in
+  Range.create
+    ~start:(Position.create ~line:(l1.pos.line - 1) ~character:l1.pos.column)
+    ~end_:(Position.create ~line:(line - 1) ~character:col)
+
 let convert_severity (severity : OutJ.match_severity) : DiagnosticSeverity.t =
   match severity with
   | `Error -> Error

--- a/src/osemgrep/language_server/util/Convert_utils.mli
+++ b/src/osemgrep/language_server/util/Convert_utils.mli
@@ -1,6 +1,11 @@
 val range_of_cli_match : Semgrep_output_v1_t.cli_match -> Lsp.Types.Range.t
 (** [range_of_cli_match cli_match] returns the lsp range of the given cli_match. *)
 
+(* This is meant to be used with Pattern_match.range_locs, where these two tokens
+   may be the same.
+*)
+val range_of_toks : Tok.location * Tok.location -> Lsp.Types.Range.t
+
 val convert_severity :
   Semgrep_output_v1_t.match_severity -> Lsp.Types.DiagnosticSeverity.t
 (** [convert_severity s] returns the lsp severity corresponding to the semgrep severity [s]. *)


### PR DESCRIPTION
This is a stacked diff whose parent is https://github.com/semgrep/semgrep/pull/9941.

## What:
This PR fixes autofixing in `/semgrep/search` for LSP, which was broken by https://github.com/semgrep/semgrep/pull/9930

## How:
The aforementioned PR hooked into `Match_search_mode.check_rule`, which is prior to autofixing.

We just manually invoked the logic in `Autofix.ml` by going through `Core_result.processed_match`.

## Test plan:
Tested locally.

Closes CDX-303