### PR TITLE
feat(lsp): search with includes/excludes

### DIFF
--- a/libs/git_wrapper/Git_wrapper.ml
+++ b/libs/git_wrapper/Git_wrapper.ml
@@ -648,7 +648,7 @@ let is_tracked_by_git ?cwd file =
   | Ok _ -> false
   | Error (`Msg e) -> raise (Error e)
 
-let dirty_files ?cwd () =
+let dirty_paths ?cwd () =
   let cmd =
     (git, cd cwd @ [ "status"; "--porcelain"; "--ignore-submodules" ])
   in

--- a/libs/git_wrapper/Git_wrapper.mli
+++ b/libs/git_wrapper/Git_wrapper.mli
@@ -135,11 +135,14 @@ val is_tracked_by_git : ?cwd:Fpath.t -> Fpath.t -> bool
 (** [is_tracked_by_git path] Returns true if the file is tracked by git *)
 
 (* precondition: cwd must be a directory *)
-val dirty_files : ?cwd:Fpath.t -> unit -> Fpath.t list
-(** [dirty_files ()] is the list of files which are dirty in a git repo, i.e.,
-    files which differ at all from the current index to the HEAD commit, plus
-    untracked files. Note that this means this list includes files which were
-    deleted. *)
+val dirty_paths : ?cwd:Fpath.t -> unit -> Fpath.t list
+(** [dirty_paths ()] is the list of paths which are dirty in a git repo, i.e.,
+    paths which differ at all from the current index to the HEAD commit, plus
+    untracked files. Note that this means this list includes paths which were
+    deleted.
+    We use "paths" instead of "files" here because it may include directories,
+    for newly created directories!
+  *)
 
 val init : ?cwd:Fpath.t -> ?branch:string -> unit -> unit
 (** [init ()] creates an empty git repository in the current directory. If

--- a/libs/paths/Ppath.ml
+++ b/libs/paths/Ppath.ml
@@ -294,8 +294,21 @@ let remove_prefix root path =
 *)
 let make_absolute path =
   if Fpath.is_rel path then Fpath.(v (Unix.getcwd ()) // path)
-  else (* save a syscall *)
-    path
+  else
+    (* Here, we must make a syscall, bceause we are making an unnormalized path absolute
+       so that we can compare it to a normalized path.
+       However, in the presence of symlinks, certain relationships like prefixes and
+       naive string operations do not work properly, because they are not cognizant of
+       how certain paths are actually related on the filesystem.
+       For instance, on Mac systems, `/var/` is actually the same as `/private/var`, so
+       our absolute form for `/var/` would prefer to be `/private/var`.
+       So we turn our path into an rpath. *)
+    match Rpath.of_fpath path with
+    | Ok path -> Rpath.to_fpath path
+    | Error err ->
+        failwith
+          (Common.spf "Failed to make path %s absolute: %s"
+             (Fpath.to_string path) err)
 
 let of_relative_fpath (fpath : Fpath.t) =
   if Fpath.is_rel fpath then create ("" :: Fpath.segs fpath)

--- a/src/osemgrep/language_server/Test_LS_e2e.ml
+++ b/src/osemgrep/language_server/Test_LS_e2e.ml
@@ -368,6 +368,20 @@ let mock_workspaces () =
 
   (workspace1, (Fpath.v workspace2_root, workspace2_files))
 
+let mock_search_files () : _ * Fpath.t list =
+  let git_tmp_path = git_tmp_path () in
+
+  let root = git_tmp_path in
+  let path1 = root / "a" / "b" / "c.py" in
+  let path2 = root / "test.py" in
+  (* should have preexisting matches that are committed *)
+  Unix.mkdir (root / "a" |> Fpath.to_string) 0o777;
+  Unix.mkdir (root / "a" / "b" |> Fpath.to_string) 0o777;
+  open_and_write_default_content ~mode:[ Open_wronly ] path1;
+  open_and_write_default_content ~mode:[ Open_wronly ] path2;
+
+  (root, [ path1; path2 ])
+
 (*****************************************************************************)
 (* Sending functions *)
 (*****************************************************************************)
@@ -528,8 +542,10 @@ let send_semgrep_scan_workspace ?(full = false) info =
 let _send_semgrep_refresh_rules info =
   send_custom_notification info ~meth:"semgrep/refreshRules"
 
-let send_semgrep_search info ?language pattern =
-  let params = Search.mk_params ~lang:language ~fix:None pattern in
+let send_semgrep_search info ?language ~includes ~excludes pattern =
+  let params =
+    Search.mk_params ~lang:language ~fix:None ~includes ~excludes pattern
+  in
   send_custom_request info ~meth:"semgrep/search" ~params
 
 let send_semgrep_search_ongoing info =
@@ -680,8 +696,8 @@ let check_startup info folders (files : Fpath.t list) =
 (* Tests *)
 (*****************************************************************************)
 
-let do_search info =
-  send_semgrep_search info "print(...)";
+let do_search ?(pattern = "print(...)") ?(includes = []) ?(excludes = []) info =
+  send_semgrep_search info pattern ~includes ~excludes;
   Lwt_seq.unfold_lwt
     (fun () ->
       let%lwt resp = receive_response info in
@@ -694,7 +710,7 @@ let do_search info =
           send_semgrep_search_ongoing info;
           Lwt.return (Some (matches, ())))
     ()
-  |> Lwt_seq.to_list
+  |> Lwt_seq.to_list |> Lwt.map List.concat
 
 let with_session caps (f : info -> unit Lwt.t) : unit Lwt.t =
   (* Not setting this means that really nasty errors happen when an exception
@@ -895,8 +911,8 @@ let test_ls_ext caps () =
           in
 
           (* search *)
-          let%lwt matches_of_files = do_search info in
-          assert (List.concat matches_of_files |> List.length = 3);
+          let%lwt matches = do_search info in
+          assert (matches |> List.length = 3);
 
           (* hover is on by default *)
           let%lwt () =
@@ -1018,6 +1034,76 @@ let test_ls_libev () =
   Lwt_platform.set_engine ();
   Lwt.return_unit
 
+let test_search_includes_excludes caps () =
+  with_session caps (fun info ->
+      let root, files = mock_search_files () in
+      let%lwt () = check_startup info [ root ] files in
+      let%lwt matches = do_search ~pattern:"x = 0" info in
+      assert (List.length matches = 2);
+
+      let assert_with_includes_excludes ?(includes = []) ?(excludes = [])
+          ~matches_test ~matches_c () =
+        let%lwt matches = do_search ~includes ~excludes ~pattern:"x = 0" info in
+        let num_matches =
+          (if matches_test then 1 else 0) + if matches_c then 1 else 0
+        in
+        assert (List.length matches = num_matches);
+        if matches_test then
+          assert (
+            List.exists
+              (fun m ->
+                YS.Util.(m |> member "uri" |> to_string) = "file://test.py")
+              matches);
+        if matches_c then
+          assert (
+            List.exists
+              (fun m ->
+                YS.Util.(m |> member "uri" |> to_string) = "file://a/b/c.py")
+              matches);
+        Lwt.return_unit
+      in
+
+      let%lwt () =
+        assert_with_includes_excludes ~includes:[ "c.py" ] ~matches_c:true
+          ~matches_test:false ()
+      in
+      let%lwt () =
+        assert_with_includes_excludes ~excludes:[ "c.py" ] ~matches_c:false
+          ~matches_test:true ()
+      in
+      let%lwt () =
+        assert_with_includes_excludes ~includes:[ "test.py" ] ~matches_c:false
+          ~matches_test:true ()
+      in
+      let%lwt () =
+        assert_with_includes_excludes ~excludes:[ "test.py" ] ~matches_c:true
+          ~matches_test:false ()
+      in
+
+      let%lwt () =
+        assert_with_includes_excludes ~includes:[ "py" ] ~matches_c:false
+          ~matches_test:false ()
+      in
+
+      let%lwt () =
+        assert_with_includes_excludes ~includes:[ "b" ] ~matches_c:true
+          ~matches_test:false ()
+      in
+      let%lwt () =
+        assert_with_includes_excludes ~includes:[ "a" ] ~matches_c:true
+          ~matches_test:false ()
+      in
+      let%lwt () =
+        assert_with_includes_excludes ~excludes:[ "a" ] ~matches_c:false
+          ~matches_test:true ()
+      in
+      let%lwt () =
+        assert_with_includes_excludes ~includes:[ "a/b/c.py" ] ~matches_c:true
+          ~matches_test:false ()
+      in
+
+      Lwt.return_unit)
+
 (*****************************************************************************)
 (* Entry point *)
 (*****************************************************************************)
@@ -1038,6 +1124,8 @@ let promise_tests caps =
        ~expected_outcome:
          (Should_fail "TODO: currently failing in js tests in CI"); *)
     Test_lwt.create "Test LS with no folders" (test_ls_no_folders caps);
+    Test_lwt.create "Test LS /semgrep/search includes/excludes"
+      (test_search_includes_excludes caps);
   ]
   |> List_.map (fun (test : _ Test.t) ->
          Test.update test ~func:(with_timeout test.func))

--- a/src/osemgrep/language_server/custom_requests/Search.ml
+++ b/src/osemgrep/language_server/custom_requests/Search.ml
@@ -175,15 +175,61 @@ let mk_env (server : RPC_server.t) (params : Request_params.t) =
     server.session.cached_workspace_targets |> Hashtbl.to_seq_values
     |> List.of_seq |> List.concat
   in
+  let project_root =
+    match
+      List.nth scanning_roots 0 |> Scanning_root.to_fpath |> Rfpath.of_fpath
+    with
+    | Error _ -> failwith "somehow unable to get project root from first root"
+    | Ok rfpath -> rfpath
+  in
+  (* TODO: This has a bug!!!
+     Suppose we exclude `test.py` and are given `tests2/test.py`.
+     This code will not exclude properly, on the basis that `test.py`
+     does not match `tests2/test.py`.
+     Essentially, we may need to look at every suffix of the file to see
+     if it matches.
+  *)
   let filtered_by_includes_excludes =
     files
-    |> List.filter (fun x ->
-           (* Must be included for all includes... *)
-           List.for_all (fun inc -> Glob.Match.run inc !!x) params.includes
-           (* and not excluded, for all excludes *)
-           && List.for_all
-                (fun exc -> not (Glob.Match.run exc !!x))
-                params.excludes)
+    |> List.filter (fun file ->
+           (* Why must we do this?
+               The paths that we receive are absolute paths in the machine.
+               This means something like /Users/brandonspark/test/test.py.
+               When we match it against a blob, like `test.py`, obviously this
+               will not match, because of the giant absolute prefix.
+               We actually want the path _relative to the project root_, which is
+               `test.py` for the project `test`.
+               So we use `Fpath.rem_prefix` here, which emulates that functionality.
+           *)
+           match Fpath.rem_prefix (Rfpath.to_fpath project_root) file with
+           | None ->
+               Logs.debug (fun m ->
+                   m "file not in project: %s" (Fpath.to_string file));
+               false
+           | Some file_relative_to_root ->
+               let is_not_included =
+                 match params.includes with
+                 | [] -> false
+                 (* if there wasn't a single included which included you, you are excluded *)
+                 | _ ->
+                     not
+                       (List.exists
+                          (fun inc ->
+                            Glob.Match.run inc !!file_relative_to_root)
+                          params.includes)
+               in
+               let is_not_excluded =
+                 match params.excludes with
+                 | [] -> true
+                 (* if there wasn't a single excluded which excluded you, you are included *)
+                 | _ ->
+                     not
+                       (List.exists
+                          (fun exc ->
+                            Glob.Match.run exc !!file_relative_to_root)
+                          params.excludes)
+               in
+               (not is_not_included) && is_not_excluded)
   in
   {
     roots = scanning_roots;
@@ -327,10 +373,6 @@ let rec search_single_target (server : RPC_server.t) =
     scan like normal, only returning the match ranges per file *)
 let start_search (server : RPC_server.t) (params : Jsonrpc.Structured.t option)
     =
-  UCommon.pr2
-    (Common.spf "got params %s"
-       (Common2.string_of_option Yojson.Safe.to_string
-          (Option.map Jsonrpc.Structured.yojson_of_t params)));
   match Request_params.of_jsonrpc_params params with
   | None ->
       Logs.debug (fun m -> m "no params received in semgrep/search");

--- a/src/osemgrep/language_server/custom_requests/Search.mli
+++ b/src/osemgrep/language_server/custom_requests/Search.mli
@@ -2,7 +2,12 @@ val start_meth : string
 (** method to match on: semgrep/search *)
 
 val mk_params :
-  lang:Xlang.t option -> fix:string option -> string -> Jsonrpc.Structured.t
+  lang:Xlang.t option ->
+  fix:string option ->
+  includes:string list ->
+  excludes:string list ->
+  string ->
+  Jsonrpc.Structured.t
 
 val ongoing_meth : string
 (** method to match on: semgrep/searchOngoing *)

--- a/src/osemgrep/language_server/custom_requests/dune
+++ b/src/osemgrep/language_server/custom_requests/dune
@@ -3,7 +3,10 @@
  (name osemgrep_language_server_custom_requests)
  (wrapped false)
  (libraries
-  semgrep.language_server.util
-  osemgrep_language_server_server
-  semgrep.osemgrep_cli_scan
-  semgrep.language_server.scan_helpers))
+   semgrep.language_server.util
+   osemgrep_language_server_server
+   semgrep.osemgrep_cli_scan
+   semgrep.language_server.scan_helpers
+   glob
+ )
+)

--- a/src/osemgrep/language_server/server/Session.ml
+++ b/src/osemgrep/language_server/server/Session.ml
@@ -69,11 +69,11 @@ let create caps capabilities =
     caps;
   }
 
-let dirty_files_of_folder folder =
+let dirty_paths_of_folder folder =
   let git_repo = Git_wrapper.is_git_repo ~cwd:folder () in
   if git_repo then
-    let dirty_files = Git_wrapper.dirty_files ~cwd:folder () in
-    Some (List_.map (fun x -> folder // x) dirty_files)
+    let dirty_paths = Git_wrapper.dirty_paths ~cwd:folder () in
+    Some (List_.map (fun x -> folder // x) dirty_paths)
   else None
 
 (* TODO: registry caching is not anymore in semgrep-OSS! *)
@@ -176,14 +176,21 @@ let cache_workspace_targets session =
 (* This is dynamic so if the targets file is updated we don't have to restart
  *)
 let targets session =
-  let dirty_files =
-    List_.map (fun f -> (f, dirty_files_of_folder f)) session.workspace_folders
+  (* These are "dirty paths" because they may not necessarily be files. They may also be folders.
+   *)
+  let dirty_paths_by_workspace =
+    List_.map (fun f -> (f, dirty_paths_of_folder f)) session.workspace_folders
   in
   let member_folder_dirty_files file folder =
-    let dirty_files = List.assoc folder dirty_files in
-    match dirty_files with
+    let dirty_paths_opt = List.assoc folder dirty_paths_by_workspace in
+    match dirty_paths_opt with
     | None -> true
-    | Some files -> List.mem file files
+    | Some dirty_paths ->
+        List.exists
+          (fun dirty_path ->
+            if Fpath.is_dir_path dirty_path then Fpath.is_prefix dirty_path file
+            else file = dirty_path)
+          dirty_paths
   in
   let member_workspace_folder file (folder : Fpath.t) =
     Fpath.is_prefix folder file


### PR DESCRIPTION
This is a stacked diff whose parent is #9944.

## What:
This PR adds the ability to specify paths to include/exclude from the search, which are written as a list of blobs.

## How:
Note I left a bug in -- we need to check every suffix of the file's path, essentially, because `test.py` should match `tests2/test.py`.

## Test plan:
Tested locally.

Closes CDX-301
