### PR TITLE
Docker: remove jq, bash, curl from the default docker image (move those utilities to a semgrep-dev step)

### DIFF
--- a/.github/workflows/test-semgrep-pro.jsonnet
+++ b/.github/workflows/test-semgrep-pro.jsonnet
@@ -90,10 +90,10 @@ local test_semgrep_pro_job = {
     },
     {
       name: 'Run Semgrep Pro Engine!',
-      // old:  we used to also pass --entrypoint=bash, but bash is not anymore
-      // in the official docker image, and anyway there is no need for
-      // --entrypoint to override an entrypoint because the semgrep Dockerfiles
-      // does not define one.
+      // old: we used to also pass '--entrypoint=bash' below, but bash is not anymore
+      // in the semgrep docker image. Moreover, there was no need for --entrypoint,
+      // which is used to override an existing entrypoint, because the semgrep
+      // Dockerfile does not have an ENTRYPOINT.
       run: 'docker run --rm -v "$(pwd):/root" -e SEMGREP_APP_TOKEN=${{ secrets.SEMGREP_APP_TOKEN }} "${{ inputs.repository-name }}:${{ needs.setup-docker-tag.outputs.docker-tag }}" /root/scripts/test-pro.sh',
     },
   ],

--- a/.github/workflows/test-semgrep-pro.jsonnet
+++ b/.github/workflows/test-semgrep-pro.jsonnet
@@ -90,7 +90,11 @@ local test_semgrep_pro_job = {
     },
     {
       name: 'Run Semgrep Pro Engine!',
-      run: 'docker run --rm -v "$(pwd):/root" -e SEMGREP_APP_TOKEN=${{ secrets.SEMGREP_APP_TOKEN }} --entrypoint=bash "${{ inputs.repository-name }}:${{ needs.setup-docker-tag.outputs.docker-tag }}" /root/scripts/test-pro.sh',
+      // old:  we used to also pass --entrypoint=bash, but bash is not anymore
+      // in the official docker image, and anyway there is no need for
+      // --entrypoint to override an entrypoint because the semgrep Dockerfiles
+      // does not define one.
+      run: 'docker run --rm -v "$(pwd):/root" -e SEMGREP_APP_TOKEN=${{ secrets.SEMGREP_APP_TOKEN }} "${{ inputs.repository-name }}:${{ needs.setup-docker-tag.outputs.docker-tag }}" /root/scripts/test-pro.sh',
     },
   ],
 };

--- a/.github/workflows/test-semgrep-pro.yml
+++ b/.github/workflows/test-semgrep-pro.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Download Semgrep Pro `develop` binary
         run: aws s3 cp s3://web-assets.r2c.dev/assets/semgrep-core-proprietary-manylinux-develop ./semgrep-core-proprietary
       - name: Run Semgrep Pro Engine!
-        run: docker run --rm -v "$(pwd):/root" -e SEMGREP_APP_TOKEN=${{ secrets.SEMGREP_APP_TOKEN }} --entrypoint=bash "${{ inputs.repository-name }}:${{ needs.setup-docker-tag.outputs.docker-tag }}" /root/scripts/test-pro.sh
+        run: docker run --rm -v "$(pwd):/root" -e SEMGREP_APP_TOKEN=${{ secrets.SEMGREP_APP_TOKEN }} "${{ inputs.repository-name }}:${{ needs.setup-docker-tag.outputs.docker-tag }}" /root/scripts/test-pro.sh
 name: test-semgrep-pro
 on:
   workflow_call:

--- a/Dockerfile
+++ b/Dockerfile
@@ -251,21 +251,25 @@ LABEL maintainer="support@semgrep.com"
 
 FROM semgrep-oss as semgrep-dev
 
-# Here we install various utilities useful in our CI jobs (e.g., our benchmark,
-# job) which need to use the latest semgrep docker image but also need a few
-# utilities called in some of our bash and python scripts/.
+# Here we install various utilities needed by some of our bash and python
+# scripts (in scripts/). Indeed, those scripts are run from CI jobs that
+# use the returntocorp/semgrep docker image as the container, because
+# they must test semgrep, but those scripts must also perform different
+# tasks that require utilities other than semgrep (e.g., compute parsing
+# statistics and then run 'jq' to filter the JSON).
 # alt:
 #  - we used to have an alternate semgrep-dev.Dockerfile container to use
 #    for our benchmarks, but it complicates things
-#  - we used then to install those utiliies as part of semgrep-oss. Indeed,
-#    the addition of those packages do not add much to the size of the docker
-#    image (<1%), but those utilities can have CVEs associated with them so
-#    simpler to put them in a separate semgrep docker image.
+#  - we used then to install those utilities as part of the semgrep-oss step.
+#    Indeed, the addition of those packages didn't add much to the size of
+#    the docker image (<1%), but those utilities can have CVEs associated
+#    with them so simpler to put them in a separate semgrep docker image
+#    to remove the attack surface of returntocorp/semgrep
 #
 # Here is why we need the apk packages below:
-# - bash: useful to debug the container
-# - jq: used in many of our scripts
-# - curl: use in our scripts?
+# - bash: many scripts are bash scripts
+# - jq: used to filter JSON parsing statistics
+# - curl: used to upload data? also for telemetry?
 RUN apk add --no-cache bash curl jq
 
 ###############################################################################

--- a/Dockerfile
+++ b/Dockerfile
@@ -144,7 +144,7 @@ COPY scripts/ ./scripts/
 RUN scripts/build-wheels.sh && scripts/validate-wheel.sh cli/dist/*musllinux*.whl
 
 ###############################################################################
-# Step3: Build the final docker image with Python wrapper and semgrep-core bin
+# Step3: Combine the Python wrapper (pysemgrep) and semgrep-core bin
 ###############################################################################
 # We change container, bringing the 'semgrep-core' binary with us.
 
@@ -163,15 +163,8 @@ RUN apk upgrade --no-cache && \
 # Here is why we need the apk packages below:
 # - git, git-lfs, openssh: so that the semgrep docker image can be used in
 #   Github actions (GHA) and get git submodules and use ssh to get those submodules
-# - bash, curl, jq: various utilities useful in CI jobs (e.g., our benchmark jobs,
-#   which needs to use the latest semgrep docker image, also need a few utilities called
-#   in some of our bash and python scripts/)
-#   alt: we used to have an alternate semgrep-dev.Dockerfile container to use
-#   for our benchmarks, but it complicates things and the addition of those
-#   packages do not add much to the size of the docker image (<1%).
     apk add --no-cache --virtual=.run-deps\
-    git git-lfs openssh\
-    bash curl jq
+    git git-lfs openssh
 
 # We just need the Python code in cli/.
 # The semgrep-core stuff would be copied from the other container
@@ -253,6 +246,29 @@ CMD ["semgrep", "--help"]
 LABEL maintainer="support@semgrep.com"
 
 ###############################################################################
+# optional: developer variant
+###############################################################################
+
+FROM semgrep-oss as semgrep-dev
+
+# Here we install various utilities useful in our CI jobs (e.g., our benchmark,
+# job) which need to use the latest semgrep docker image but also need a few
+# utilities called in some of our bash and python scripts/.
+# alt:
+#  - we used to have an alternate semgrep-dev.Dockerfile container to use
+#    for our benchmarks, but it complicates things
+#  - we used then to install those utiliies as part of semgrep-oss. Indeed,
+#    the addition of those packages do not add much to the size of the docker
+#    image (<1%), but those utilities can have CVEs associated with them so
+#    simpler to put them in a separate semgrep docker image.
+#
+# Here is why we need the apk packages below:
+# - bash: useful to debug the container
+# - jq: used in many of our scripts
+# - curl: use in our scripts?
+RUN apk add --no-cache bash curl jq
+
+###############################################################################
 # Step4: install semgrep-pro
 ###############################################################################
 # This step is valid only when run from Github Actions.
@@ -270,7 +286,7 @@ RUN --mount=type=secret,id=SEMGREP_APP_TOKEN SEMGREP_APP_TOKEN=$(cat /run/secret
 RUN rm -rf /root/.semgrep
 
 ###############################################################################
-# Step5: (optional) nonroot variant
+# optional: nonroot variant
 ###############################################################################
 
 # Additional build stage that sets a non-root user.
@@ -296,7 +312,7 @@ ENV PATH="$PATH:/home/semgrep/bin"
 USER semgrep
 
 ###############################################################################
-# Step6: (optional) performance testing
+# optional: performance testing
 ###############################################################################
 
 # Build target that exposes the performance benchmark tests in perf/ for

--- a/changelog.d/saf-861.fixed
+++ b/changelog.d/saf-861.fixed
@@ -1,0 +1,2 @@
+The official semgrep docker image does not contain anymore the
+bash, jq, and curl utilities, to reduce its attack surface.

--- a/scripts/test-pro.sh
+++ b/scripts/test-pro.sh
@@ -1,4 +1,9 @@
-#! /usr/bin/env bash
+#! /usr/bin/env sh
+# This script is called from the test-semgrep-pro.jsonnet workflow.
+# We now use 'sh' and not 'bash' above because we removed bash
+# from the returntocorp/semgrep docker image to remain as small
+# as possible (and to avoid CVEs on programs we actually don't really
+# need in the image).
 
 set -e
 


### PR DESCRIPTION
test plan:
docker build -t semgrep --target semgrep-oss
```
$ docker run -it semgrep:latest apk list | grep jq
$ 
```