### PR TITLE
test: Autofix with non-ascii characters

### DIFF
--- a/cli/tests/default/e2e/rules/autofix/utf-8.yaml
+++ b/cli/tests/default/e2e/rules/autofix/utf-8.yaml
@@ -1,0 +1,11 @@
+rules:
+  - id: replace-with-smiley
+    patterns:
+      - pattern: |
+          print('a')
+    fix: |
+      print('😊')
+    message: Unnecessary parameter which matches the default
+    languages:
+      - python
+    severity: WARNING

--- a/cli/tests/default/e2e/snapshots/test_autofix/test_autofix/rulesautofixutf-8.yaml-autofixutf-8.py-json-dryrun/autofix/utf-8.py-dryrun
+++ b/cli/tests/default/e2e/snapshots/test_autofix/test_autofix/rulesautofixutf-8.yaml-autofixutf-8.py-json-dryrun/autofix/utf-8.py-dryrun
@@ -1,0 +1,16 @@
+# Tests autofixes when non-ascii characters are present in the source file and
+# the fix.
+#
+# In Python, strings are sequences of characters. In OCaml, they are sequences
+# of bytes. Because of this, we need to be particularly careful that we do not
+# conflate bytes with characters.
+
+# U+1F60A. Has a 4 byte encoding in utf-8. This is here to throw off offsets
+# later in the file if we are computing them incorrectly.
+x = '😊'
+
+print('a')
+
+# And this one is here at the beginning of a line to throw off columns later in
+# the line if we are computing them incorrectly.
+y = '😊'; print('a'); print('a')

--- a/cli/tests/default/e2e/snapshots/test_autofix/test_autofix/rulesautofixutf-8.yaml-autofixutf-8.py-json-dryrun/results.json
+++ b/cli/tests/default/e2e/snapshots/test_autofix/test_autofix/rulesautofixutf-8.yaml-autofixutf-8.py-json-dryrun/results.json
@@ -1,0 +1,100 @@
+{
+  "errors": [],
+  "interfile_languages_used": [],
+  "paths": {
+    "scanned": [
+      "targets/autofix/utf-8.py"
+    ]
+  },
+  "results": [
+    {
+      "check_id": "rules.autofix.replace-with-smiley",
+      "end": {
+        "col": 11,
+        "line": 12,
+        "offset": 442
+      },
+      "extra": {
+        "engine_kind": "OSS",
+        "fingerprint": "0x42",
+        "fix": "print('\ud83d\ude0a')",
+        "fixed_lines": [
+          "print('\ud83d\ude0a')"
+        ],
+        "is_ignored": false,
+        "lines": "print('a')",
+        "message": "Unnecessary parameter which matches the default",
+        "metadata": {},
+        "metavars": {},
+        "severity": "WARNING",
+        "validation_state": "NO_VALIDATOR"
+      },
+      "path": "targets/autofix/utf-8.py",
+      "start": {
+        "col": 1,
+        "line": 12,
+        "offset": 432
+      }
+    },
+    {
+      "check_id": "rules.autofix.replace-with-smiley",
+      "end": {
+        "col": 23,
+        "line": 16,
+        "offset": 595
+      },
+      "extra": {
+        "engine_kind": "OSS",
+        "fingerprint": "0x42",
+        "fix": "print('\ud83d\ude0a')",
+        "fixed_lines": [
+          "y = '\ud83d\ude0a'; priprint('\ud83d\ude0a')rint('a')"
+        ],
+        "is_ignored": false,
+        "lines": "y = '\ud83d\ude0a'; print('a'); print('a')",
+        "message": "Unnecessary parameter which matches the default",
+        "metadata": {},
+        "metavars": {},
+        "severity": "WARNING",
+        "validation_state": "NO_VALIDATOR"
+      },
+      "path": "targets/autofix/utf-8.py",
+      "start": {
+        "col": 13,
+        "line": 16,
+        "offset": 585
+      }
+    },
+    {
+      "check_id": "rules.autofix.replace-with-smiley",
+      "end": {
+        "col": 35,
+        "line": 16,
+        "offset": 607
+      },
+      "extra": {
+        "engine_kind": "OSS",
+        "fingerprint": "0x42",
+        "fix": "print('\ud83d\ude0a')",
+        "fixed_lines": [
+          "y = '\ud83d\ude0a'; print('a'); priprint('\ud83d\ude0a')"
+        ],
+        "is_ignored": false,
+        "lines": "y = '\ud83d\ude0a'; print('a'); print('a')",
+        "message": "Unnecessary parameter which matches the default",
+        "metadata": {},
+        "metavars": {},
+        "severity": "WARNING",
+        "validation_state": "NO_VALIDATOR"
+      },
+      "path": "targets/autofix/utf-8.py",
+      "start": {
+        "col": 25,
+        "line": 16,
+        "offset": 597
+      }
+    }
+  ],
+  "skipped_rules": [],
+  "version": "0.42"
+}

--- a/cli/tests/default/e2e/snapshots/test_autofix/test_autofix/rulesautofixutf-8.yaml-autofixutf-8.py-json-dryrun/stderr.txt
+++ b/cli/tests/default/e2e/snapshots/test_autofix/test_autofix/rulesautofixutf-8.yaml-autofixutf-8.py-json-dryrun/stderr.txt
@@ -1,0 +1,14 @@
+
+
+┌─────────────┐
+│ Scan Status │
+└─────────────┘
+  Scanning 1 file tracked by git with 1 Code rule:
+  Scanning 1 file.
+
+
+┌──────────────┐
+│ Scan Summary │
+└──────────────┘
+
+Ran 1 rule on 1 file: 3 findings.

--- a/cli/tests/default/e2e/snapshots/test_autofix/test_autofix/rulesautofixutf-8.yaml-autofixutf-8.py-json-not-dryrun/autofix/utf-8.py-fixed
+++ b/cli/tests/default/e2e/snapshots/test_autofix/test_autofix/rulesautofixutf-8.yaml-autofixutf-8.py-json-not-dryrun/autofix/utf-8.py-fixed
@@ -1,0 +1,16 @@
+# Tests autofixes when non-ascii characters are present in the source file and
+# the fix.
+#
+# In Python, strings are sequences of characters. In OCaml, they are sequences
+# of bytes. Because of this, we need to be particularly careful that we do not
+# conflate bytes with characters.
+
+# U+1F60A. Has a 4 byte encoding in utf-8. This is here to throw off offsets
+# later in the file if we are computing them incorrectly.
+x = '😊'
+
+print('😊')
+
+# And this one is here at the beginning of a line to throw off columns later in
+# the line if we are computing them incorrectly.
+y = '😊'; priprint('😊')riprint('😊')

--- a/cli/tests/default/e2e/snapshots/test_autofix/test_autofix/rulesautofixutf-8.yaml-autofixutf-8.py-json-not-dryrun/results.json
+++ b/cli/tests/default/e2e/snapshots/test_autofix/test_autofix/rulesautofixutf-8.yaml-autofixutf-8.py-json-not-dryrun/results.json
@@ -1,0 +1,91 @@
+{
+  "errors": [],
+  "interfile_languages_used": [],
+  "paths": {
+    "scanned": [
+      "targets/autofix/utf-8.py"
+    ]
+  },
+  "results": [
+    {
+      "check_id": "rules.autofix.replace-with-smiley",
+      "end": {
+        "col": 11,
+        "line": 12,
+        "offset": 442
+      },
+      "extra": {
+        "engine_kind": "OSS",
+        "fingerprint": "0x42",
+        "fix": "print('\ud83d\ude0a')",
+        "is_ignored": false,
+        "lines": "print('a')",
+        "message": "Unnecessary parameter which matches the default",
+        "metadata": {},
+        "metavars": {},
+        "severity": "WARNING",
+        "validation_state": "NO_VALIDATOR"
+      },
+      "path": "targets/autofix/utf-8.py",
+      "start": {
+        "col": 1,
+        "line": 12,
+        "offset": 432
+      }
+    },
+    {
+      "check_id": "rules.autofix.replace-with-smiley",
+      "end": {
+        "col": 23,
+        "line": 16,
+        "offset": 595
+      },
+      "extra": {
+        "engine_kind": "OSS",
+        "fingerprint": "0x42",
+        "fix": "print('\ud83d\ude0a')",
+        "is_ignored": false,
+        "lines": "y = '\ud83d\ude0a'; print('a'); print('a')",
+        "message": "Unnecessary parameter which matches the default",
+        "metadata": {},
+        "metavars": {},
+        "severity": "WARNING",
+        "validation_state": "NO_VALIDATOR"
+      },
+      "path": "targets/autofix/utf-8.py",
+      "start": {
+        "col": 13,
+        "line": 16,
+        "offset": 585
+      }
+    },
+    {
+      "check_id": "rules.autofix.replace-with-smiley",
+      "end": {
+        "col": 35,
+        "line": 16,
+        "offset": 607
+      },
+      "extra": {
+        "engine_kind": "OSS",
+        "fingerprint": "0x42",
+        "fix": "print('\ud83d\ude0a')",
+        "is_ignored": false,
+        "lines": "y = '\ud83d\ude0a'; print('a'); print('a')",
+        "message": "Unnecessary parameter which matches the default",
+        "metadata": {},
+        "metavars": {},
+        "severity": "WARNING",
+        "validation_state": "NO_VALIDATOR"
+      },
+      "path": "targets/autofix/utf-8.py",
+      "start": {
+        "col": 25,
+        "line": 16,
+        "offset": 597
+      }
+    }
+  ],
+  "skipped_rules": [],
+  "version": "0.42"
+}

--- a/cli/tests/default/e2e/snapshots/test_autofix/test_autofix/rulesautofixutf-8.yaml-autofixutf-8.py-json-not-dryrun/stderr.txt
+++ b/cli/tests/default/e2e/snapshots/test_autofix/test_autofix/rulesautofixutf-8.yaml-autofixutf-8.py-json-not-dryrun/stderr.txt
@@ -1,0 +1,15 @@
+
+
+┌─────────────┐
+│ Scan Status │
+└─────────────┘
+  Scanning 1 file tracked by git with 1 Code rule:
+  Scanning 1 file.
+successfully modified 1 file.
+
+
+┌──────────────┐
+│ Scan Summary │
+└──────────────┘
+
+Ran 1 rule on 1 file: 3 findings.

--- a/cli/tests/default/e2e/snapshots/test_autofix/test_autofix/rulesautofixutf-8.yaml-autofixutf-8.py-text-dryrun/autofix/utf-8.py-dryrun
+++ b/cli/tests/default/e2e/snapshots/test_autofix/test_autofix/rulesautofixutf-8.yaml-autofixutf-8.py-text-dryrun/autofix/utf-8.py-dryrun
@@ -1,0 +1,16 @@
+# Tests autofixes when non-ascii characters are present in the source file and
+# the fix.
+#
+# In Python, strings are sequences of characters. In OCaml, they are sequences
+# of bytes. Because of this, we need to be particularly careful that we do not
+# conflate bytes with characters.
+
+# U+1F60A. Has a 4 byte encoding in utf-8. This is here to throw off offsets
+# later in the file if we are computing them incorrectly.
+x = '😊'
+
+print('a')
+
+# And this one is here at the beginning of a line to throw off columns later in
+# the line if we are computing them incorrectly.
+y = '😊'; print('a'); print('a')

--- a/cli/tests/default/e2e/snapshots/test_autofix/test_autofix/rulesautofixutf-8.yaml-autofixutf-8.py-text-dryrun/results.txt
+++ b/cli/tests/default/e2e/snapshots/test_autofix/test_autofix/rulesautofixutf-8.yaml-autofixutf-8.py-text-dryrun/results.txt
@@ -1,0 +1,19 @@
+
+
+┌─────────────────┐
+│ 3 Code Findings │
+└─────────────────┘
+
+    targets/autofix/utf-8.py
+    ❯❱ rules.autofix.replace-with-smiley
+          Unnecessary parameter which matches the default
+
+           ▶▶┆ Autofix ▶ print('😊')
+           12┆ print('😊')
+            ⋮┆----------------------------------------
+           ▶▶┆ Autofix ▶ print('😊')
+           16┆ y = '😊'; priprint('😊')rint('a')
+            ⋮┆----------------------------------------
+           ▶▶┆ Autofix ▶ print('😊')
+           16┆ y = '😊'; print('a'); priprint('😊')
+

--- a/cli/tests/default/e2e/snapshots/test_autofix/test_autofix/rulesautofixutf-8.yaml-autofixutf-8.py-text-dryrun/stderr.txt
+++ b/cli/tests/default/e2e/snapshots/test_autofix/test_autofix/rulesautofixutf-8.yaml-autofixutf-8.py-text-dryrun/stderr.txt
@@ -1,0 +1,14 @@
+
+
+┌─────────────┐
+│ Scan Status │
+└─────────────┘
+  Scanning 1 file tracked by git with 1 Code rule:
+  Scanning 1 file.
+
+
+┌──────────────┐
+│ Scan Summary │
+└──────────────┘
+
+Ran 1 rule on 1 file: 3 findings.

--- a/cli/tests/default/e2e/snapshots/test_autofix/test_autofix/rulesautofixutf-8.yaml-autofixutf-8.py-text-not-dryrun/autofix/utf-8.py-fixed
+++ b/cli/tests/default/e2e/snapshots/test_autofix/test_autofix/rulesautofixutf-8.yaml-autofixutf-8.py-text-not-dryrun/autofix/utf-8.py-fixed
@@ -1,0 +1,16 @@
+# Tests autofixes when non-ascii characters are present in the source file and
+# the fix.
+#
+# In Python, strings are sequences of characters. In OCaml, they are sequences
+# of bytes. Because of this, we need to be particularly careful that we do not
+# conflate bytes with characters.
+
+# U+1F60A. Has a 4 byte encoding in utf-8. This is here to throw off offsets
+# later in the file if we are computing them incorrectly.
+x = '😊'
+
+print('😊')
+
+# And this one is here at the beginning of a line to throw off columns later in
+# the line if we are computing them incorrectly.
+y = '😊'; priprint('😊')riprint('😊')

--- a/cli/tests/default/e2e/snapshots/test_autofix/test_autofix/rulesautofixutf-8.yaml-autofixutf-8.py-text-not-dryrun/results.txt
+++ b/cli/tests/default/e2e/snapshots/test_autofix/test_autofix/rulesautofixutf-8.yaml-autofixutf-8.py-text-not-dryrun/results.txt
@@ -1,0 +1,19 @@
+
+
+┌─────────────────┐
+│ 3 Code Findings │
+└─────────────────┘
+
+    targets/autofix/utf-8.py
+    ❯❱ rules.autofix.replace-with-smiley
+          Unnecessary parameter which matches the default
+
+           ▶▶┆ Autofix ▶ print('😊')
+           12┆ print('a')
+            ⋮┆----------------------------------------
+           ▶▶┆ Autofix ▶ print('😊')
+           16┆ y = '😊'; print('a'); print('a')
+            ⋮┆----------------------------------------
+           ▶▶┆ Autofix ▶ print('😊')
+           16┆ y = '😊'; print('a'); print('a')
+

--- a/cli/tests/default/e2e/snapshots/test_autofix/test_autofix/rulesautofixutf-8.yaml-autofixutf-8.py-text-not-dryrun/stderr.txt
+++ b/cli/tests/default/e2e/snapshots/test_autofix/test_autofix/rulesautofixutf-8.yaml-autofixutf-8.py-text-not-dryrun/stderr.txt
@@ -1,0 +1,15 @@
+
+
+┌─────────────┐
+│ Scan Status │
+└─────────────┘
+  Scanning 1 file tracked by git with 1 Code rule:
+  Scanning 1 file.
+successfully modified 1 file.
+
+
+┌──────────────┐
+│ Scan Summary │
+└──────────────┘
+
+Ran 1 rule on 1 file: 3 findings.

--- a/cli/tests/default/e2e/targets/autofix/utf-8.py
+++ b/cli/tests/default/e2e/targets/autofix/utf-8.py
@@ -1,0 +1,16 @@
+# Tests autofixes when non-ascii characters are present in the source file and
+# the fix.
+#
+# In Python, strings are sequences of characters. In OCaml, they are sequences
+# of bytes. Because of this, we need to be particularly careful that we do not
+# conflate bytes with characters.
+
+# U+1F60A. Has a 4 byte encoding in utf-8. This is here to throw off offsets
+# later in the file if we are computing them incorrectly.
+x = '😊'
+
+print('a')
+
+# And this one is here at the beginning of a line to throw off columns later in
+# the line if we are computing them incorrectly.
+y = '😊'; print('a'); print('a')

--- a/cli/tests/default/e2e/test_autofix.py
+++ b/cli/tests/default/e2e/test_autofix.py
@@ -46,6 +46,7 @@ from semgrep.constants import OutputFormat
             "autofix/terraform-ec2-instance-metadata-options.hcl",
         ),
         ("rules/autofix/delete-partial-line.yaml", "autofix/delete-partial-line.py"),
+        ("rules/autofix/utf-8.yaml", "autofix/utf-8.py"),
     ],
 )
 def test_autofix(


### PR DESCRIPTION
We totally mangle this. For now, just documenting the current behavior.

Test plan: This is a test

