### PR TITLE
feat(lsp): match previews for `/semgrep/search`

### DIFF
--- a/src/osemgrep/language_server/custom_requests/Search.ml
+++ b/src/osemgrep/language_server/custom_requests/Search.ml
@@ -320,7 +320,7 @@ let preview_of_line ?(before_length = 12) line ~col_range:(begin_col, end_col) =
     else
       (* The picture looks like this:
          xxxxxoooooxxxxxoooooxxxxxoooooxxxxx
-                                      ^  ^
+                                      ^--^ match
                           ^ ideal_end
               ^ ideal_start
               |___________| ideal range
@@ -345,10 +345,12 @@ let preview_of_line ?(before_length = 12) line ~col_range:(begin_col, end_col) =
          this index is right after the closest whitespace to ideal_end.
       *)
       | Some idx when idx > ideal_start -> (idx + 1, false)
-      (* If we didn't find a good starting point, let's just take the ideal
-         start.
+      (* This means our preview is currently on whitespace, let's skip ahead if possible.
       *)
-      | _ -> (first_non_whitespace_after line ideal_start, true)
+      | _ when String.get line ideal_start = ' ' ->
+          (first_non_whitespace_after line ideal_start, false)
+      (* if we're not on whitespace, we can't do better. Just cut the word in half. *)
+      | _ -> (ideal_start, true)
   in
   let before = String.sub line before_col (begin_col - before_col) in
   let inside = String.sub line begin_col (end_col - begin_col) in

--- a/src/osemgrep/language_server/custom_requests/Search.ml
+++ b/src/osemgrep/language_server/custom_requests/Search.ml
@@ -357,8 +357,7 @@ let preview_of_line ?(before_length = 12) line ~col_range:(begin_col, end_col) =
   let after = Str.string_after line end_col in
   ((if is_cut_off then "..." ^ before else before), inside, after)
 
-let json_of_matches (xtarget : Xtarget.t)
-    (matches_by_file : (Fpath.t * Core_result.processed_match list) list) =
+let json_of_matches (matches_by_file : (Fpath.t * OutJ.cli_match list) list) =
   let json =
     List_.map
       (fun (path, matches) ->
@@ -367,12 +366,8 @@ let json_of_matches (xtarget : Xtarget.t)
           matches
           |> List_.map (fun (m : OutJ.cli_match) ->
                  let range = Conv.range_of_cli_match m in
-                 let range_json = Range.yojson_of_t in
-                 let line =
-                   List.nth
-                     (Common2.lines (Lazy.force xtarget.lazy_content))
-                     range.start.line
-                 in
+                 let range_json = Range.yojson_of_t range in
+                 let line = List.nth (UFile.cat path) range.start.line in
                  let before, inside, after =
                    if range.start.line = range.end_.line then
                      preview_of_line line

--- a/src/osemgrep/language_server/custom_requests/Search.ml
+++ b/src/osemgrep/language_server/custom_requests/Search.ml
@@ -305,13 +305,11 @@ let get_relevant_rules ({ params = { pattern; fix; _ }; _ } as env : env) :
 (* Output *)
 (*****************************************************************************)
 
-let go line begin_col end_col =
+let preview_of_line line ~col_range:(begin_col, end_col) =
   let before_col = Int.max 0 (begin_col - 8) in
   let before = String.sub line before_col (begin_col - before_col) in
   let inside = String.sub line begin_col (end_col - begin_col) in
-  let after =
-    String.sub line end_col (Int.min 8 (String.length line - end_col))
-  in
+  let after = Str.string_after line end_col in
   (before, inside, after)
 
 let json_of_matches (xtarget : Xtarget.t)
@@ -332,8 +330,13 @@ let json_of_matches (xtarget : Xtarget.t)
                  in
                  let before, inside, after =
                    if range.start.line = range.end_.line then
-                     go line range.start.character range.end_.character
-                   else go line range.start.character (String.length line)
+                     preview_of_line line
+                       ~col_range:(range.start.character, range.end_.character)
+                   else
+                     preview_of_line line
+                       ~col_range:
+                         ( range.start.character,
+                           String.length line - range.start.character )
                  in
                  let fix_json =
                    match m.extra.fix with

--- a/src/osemgrep/language_server/custom_requests/Search.ml
+++ b/src/osemgrep/language_server/custom_requests/Search.ml
@@ -305,12 +305,55 @@ let get_relevant_rules ({ params = { pattern; fix; _ }; _ } as env : env) :
 (* Output *)
 (*****************************************************************************)
 
-let preview_of_line line ~col_range:(begin_col, end_col) =
-  let before_col = Int.max 0 (begin_col - 8) in
+(* [first_non_whitespace_after s start] finds the first occurrence
+   of a non-whitespace character after index [start] in string [s]*)
+let first_non_whitespace_after s start =
+  try Str.search_forward (Str.regexp "[^ ]") s start with
+  | Not_found -> start
+
+(* TODO: unit tests would be nice *)
+let preview_of_line ?(before_length = 12) line ~col_range:(begin_col, end_col) =
+  let before_col, is_cut_off =
+    let ideal_start = Int.max 0 (begin_col - before_length) in
+    let ideal_end = Int.max 0 (begin_col - (before_length * 2)) in
+    if ideal_start = 0 then (first_non_whitespace_after line 0, false)
+    else
+      (* The picture looks like this:
+         xxxxxoooooxxxxxoooooxxxxxoooooxxxxx
+                                      ^  ^
+                          ^ ideal_end
+              ^ ideal_start
+              |___________| ideal range
+
+         the "ideal_start" and "ideal_end" indices denote the ends of the
+         "ideal range", which is by default 12-24 characters before the
+         start of the match.
+         We want to find a "natural beginning" of the preview, such as a space.
+         If at all possible, though, it should exist in the ideal range, because
+         if our preview starts too early, we won't be able to see the match.
+         So we'll look to the left from the ideal end, and hopefully find a good
+         place to the right of the ideal start.
+         If we don't find a nice starting point, then we'll just go with the ideal start.
+      *)
+      (* Find the nearest space that occurred before the match
+         This is in the hopes of finding a "natural" stopping point.
+      *)
+      match String.rindex_from_opt line ideal_end ' ' with
+      (* We don't want the preview to be too far, though.
+         It needs to be at most as early as the ideal start.
+         We don't need to call `first_non_whitespace_after` because we know
+         this index is right after the closest whitespace to ideal_end.
+      *)
+      | Some idx when idx > ideal_start -> (idx + 1, false)
+      (* If we didn't find a good starting point, let's just take the ideal
+         start.
+      *)
+      | _ -> (first_non_whitespace_after line ideal_start, true)
+  in
   let before = String.sub line before_col (begin_col - before_col) in
   let inside = String.sub line begin_col (end_col - begin_col) in
   let after = Str.string_after line end_col in
-  (before, inside, after)
+  ((if is_cut_off then "..." ^ before else before), inside, after)
 
 let json_of_matches (xtarget : Xtarget.t)
     (matches_by_file : (Fpath.t * Core_result.processed_match list) list) =
@@ -334,9 +377,7 @@ let json_of_matches (xtarget : Xtarget.t)
                        ~col_range:(range.start.character, range.end_.character)
                    else
                      preview_of_line line
-                       ~col_range:
-                         ( range.start.character,
-                           String.length line - range.start.character )
+                       ~col_range:(range.start.character, String.length line)
                  in
                  let fix_json =
                    match m.extra.fix with

--- a/src/osemgrep/language_server/custom_requests/Search.ml
+++ b/src/osemgrep/language_server/custom_requests/Search.ml
@@ -273,8 +273,8 @@ let get_relevant_xlangs (env : env) : Xlang.t list =
   Hashtbl.to_seq_keys lang_set |> List.of_seq |> List_.map Xlang.of_lang
 
 (* Get the rules to run based on the pattern and state of the LSP. *)
-let get_relevant_rules ({ params = { pattern; fix; _ }; _ } as env : env) :
-    Rule.search_rule list =
+let get_relevant_rules ({ params = { pattern; fix; lang; _ }; _ } as env : env)
+    : Rule.search_rule list =
   let rules_of_langs (lang_opt : Xlang.t option) : Rule.search_rule list =
     let rules_and_origins =
       Rule_fetching.rules_from_pattern (pattern, lang_opt, fix)
@@ -285,7 +285,7 @@ let get_relevant_rules ({ params = { pattern; fix; _ }; _ } as env : env) :
   in
   let xlangs = get_relevant_xlangs env in
   let rules_with_relevant_xlang =
-    rules_of_langs None
+    rules_of_langs lang
     |> List.filter (fun (rule : Rule.search_rule) ->
            List.mem rule.target_analyzer xlangs)
   in

--- a/src/osemgrep/language_server/custom_requests/dune
+++ b/src/osemgrep/language_server/custom_requests/dune
@@ -8,5 +8,6 @@
    semgrep.osemgrep_cli_scan
    semgrep.language_server.scan_helpers
    glob
+   semgrep_core
  )
 )


### PR DESCRIPTION
This is a stacked diff whose parent is #9945 

## What:
This PR generates the match previews for the VS Code extension via the LSP, instead of grabbing the text later in the extension.

## Why:
Each time we touch the files in the extension, this generates a `onTextDocumentOpen`, which the LSP then needs to handle. These can build up and cause slowdowns.

## How:
We implement a "best effort" preview showing logic, which tries to find the nearest "natural" place to start the match (currently a space). If there is not such a location which leaves the match still acceptably visible, we just intercept in the middle of some phrase.

## Test plan:
<img width="458" alt="image" src="https://github.com/semgrep/semgrep/assets/49291449/86b30b9c-50eb-4a8f-a4df-56370fbb1014">
