### PR TITLE
Remove max parse iterations on swift package parser

### DIFF
--- a/changelog.d/sc-1364.fixed
+++ b/changelog.d/sc-1364.fixed
@@ -1,0 +1,1 @@
+Fixed swiftpm parser to no longer limit the amount of found packages in manifest file.

--- a/cli/src/semdep/parsers/swiftpm.py
+++ b/cli/src/semdep/parsers/swiftpm.py
@@ -95,7 +95,7 @@ package_block = (
 
 comment = whitespace >> regex(r" *//") >> line
 
-multiple_package_blocks = (comment | package_block).sep_by(new_lines, max=5)
+multiple_package_blocks = (comment | package_block).sep_by(new_lines)
 
 dependencies_block = (
     regex(r"dependencies:\s*\[")


### PR DESCRIPTION
The `max=5` was not removed during initial manual testing. We should not limit the amount of iterations of the parser.