### PR TITLE
cleanup: extract Eval_il_partial.ml out of Dataflow_svalue

### DIFF
--- a/libs/ast_generic/AST_generic.ml
+++ b/libs/ast_generic/AST_generic.ml
@@ -1,6 +1,6 @@
 (* Yoann Padioleau
  *
- * Copyright (C) 2019-2023 Semgrep Inc.
+ * Copyright (C) 2019-2024 Semgrep Inc.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
@@ -690,8 +690,7 @@ and expr_kind =
   | RegexpTemplate of expr bracket (* // *) * string wrap option (* modifiers *)
   (* see also New(...) for other values *)
   | N of name
-  | IdSpecial of
-      special wrap (*e: [[AST_generic.expr]] other identifier cases *)
+  | IdSpecial of special wrap
   (* operators and function application *)
   | Call of expr * arguments
   (* 'type_' below is usually a TyN or TyArray (or TyExpr).
@@ -728,7 +727,7 @@ and expr_kind =
   (* less: could desugar in Assign, should be only binary_operator *)
   | AssignOp of expr * operator wrap * expr
   (* newvar:! newscope:? in OCaml yes but we miss the 'in' part here  *)
-  | LetPattern of pattern * expr (*e: [[AST_generic.expr]] other assign cases *)
+  | LetPattern of pattern * expr
   (* can be used for Record, Class, or Module access depending on expr.
    * In the last case it should be rewritten as a (N IdQualified) with a
    * qualifier though.

--- a/src/analyzing/Dataflow_svalue.ml
+++ b/src/analyzing/Dataflow_svalue.ml
@@ -21,10 +21,10 @@ module D = Dataflow_core
 module Var_env = Dataflow_var_env
 module VarMap = Var_env.VarMap
 module LV = IL_helpers
+module Eval = Eval_il_partial
 
 let base_tag_strings = [ __MODULE__; "svalue" ]
 let tags = Logs_.create_tags base_tag_strings
-let warning = Logs_.create_tags (base_tag_strings @ [ "warning" ])
 
 (*****************************************************************************)
 (* Types *)
@@ -51,22 +51,42 @@ let hook_constness_of_function = ref None
 let hook_transfer_of_assume = ref None
 
 (*****************************************************************************)
-(* Error management *)
-(*****************************************************************************)
-
-let warning _tok s =
-  (* TODO: Report these errors as matches of a builtin_div_by_zero rule. *)
-  Logs.debug (fun m -> m ~tags:warning "CFGError: %s" s)
-
-(*****************************************************************************)
-(* Helpers *)
-(*****************************************************************************)
-
-let fb = Tok.unsafe_fake_bracket
-
-(*****************************************************************************)
 (* Constness *)
 (*****************************************************************************)
+
+let eval_format env args =
+  let cs = List_.map (Eval.eval env) args in
+  if
+    cs
+    |> List.for_all (function
+         | G.Lit _
+         | G.Cst _ ->
+             true
+         | _ -> false)
+  then G.Cst G.Cstr
+  else G.NotCst
+
+let eval_builtin_func lang env func args =
+  let args = List_.map IL_helpers.exp_of_arg args in
+  match func with
+  | { e = _; eorig = SameAs eorig } -> (
+      let* gname = H.name_of_dot_access eorig in
+      match (lang, gname) with
+      | ( Lang.Java,
+          G.IdQualified
+            {
+              name_last = ("format", _), _;
+              name_middle =
+                Some
+                  (QDots
+                    ( [ (("String", _), _) ]
+                    | [ (("java", _), _); (("lang", _), _); (("String", _), _) ]
+                      ));
+              _;
+            } ) ->
+          Some (eval_format env args)
+      | __else__ -> None)
+  | __else__ -> None
 
 let result_of_function_call_constant lang f args =
   match (lang, f, args) with
@@ -99,293 +119,6 @@ let result_of_function_call_constant lang f args =
           | None ->
               None)
       | None -> None)
-  | __else__ -> None
-
-let eq_literal l1 l2 = G.equal_literal l1 l2
-let eq_ctype t1 t2 = t1 =*= t2
-
-let eq c1 c2 =
-  match (c1, c2) with
-  | G.Lit l1, G.Lit l2 -> eq_literal l1 l2
-  | G.Cst t1, G.Cst t2 -> eq_ctype t1 t2
-  | G.Sym e1, G.Sym e2 ->
-      (* We only consider two `Sym`s equal when they are exactly the same. If two
-       * `Sym`s are structuraly equal but their `id_svalue` pointers are different
-       * it may not be safe to use them interchangeably. (TBH I'm not sure if/when
-       * it's safe so I'm erring on the side of caution!) *)
-      phys_equal e1 e2
-  | G.NotCst, G.NotCst -> true
-  | G.Lit _, _
-  | G.Cst _, _
-  | G.Sym _, _
-  | G.NotCst, _ ->
-      false
-
-let union_ctype t1 t2 = if eq_ctype t1 t2 then t1 else G.Cany
-
-(* aka merge *)
-let union c1 c2 =
-  match (c1, c2) with
-  | _any, G.NotCst
-  | G.NotCst, _any ->
-      G.NotCst
-  | c1, c2 when eq c1 c2 -> c1
-  (* Note that merging symbolic expressions can be tricky.
-   *
-   * Example: Both branches assign `y = x.foo`, but `x` may have a different
-   * value in each branch. When merging symbolic expressions like `x.foo` we
-   * must first merge their dependencies (in our example, `x`).
-   *
-   *     if c:
-   *       x = a
-   *       y = x.foo
-   *     else:
-   *       x = b
-   *       y = x.foo
-   *
-   * Example: If we are not careful, when analyzing loops, we could introduce
-   * circular dependencies! (See tests/rules/sym_prop_no_merge1.go)
-   *
-   *     for cond {
-   *       x = f(x)
-   *     }
-   *)
-  | _any, G.Sym _
-  | G.Sym _, _any ->
-      G.NotCst
-  | G.Lit l1, G.Lit l2 ->
-      let t1 = H.ctype_of_literal l1 and t2 = H.ctype_of_literal l2 in
-      G.Cst (union_ctype t1 t2)
-  | G.Lit l1, G.Cst t2
-  | G.Cst t2, G.Lit l1 ->
-      let t1 = H.ctype_of_literal l1 in
-      G.Cst (union_ctype t1 t2)
-  | G.Cst t1, G.Cst t2 -> G.Cst (union_ctype t1 t2)
-
-(* THINK: This assumes that analyses are sound... but they are not
-   (e.g. due to aliasing). *)
-let refine c1 c2 =
-  match (c1, c2) with
-  | _ when eq c1 c2 -> c1
-  | c, G.NotCst
-  | G.NotCst, c ->
-      c
-  | G.Lit _, _
-  | G.Cst _, G.Cst _
-  | G.Sym _, G.Sym _ ->
-      c1
-  | G.Cst _, G.Sym _ -> c1
-  | G.Cst _, G.Lit _ -> c2
-  | G.Sym _, G.Lit _
-  | G.Sym _, G.Cst _ ->
-      c2
-
-(*****************************************************************************)
-(* Constness evaluation *)
-(*****************************************************************************)
-
-let literal_of_bool b =
-  let b_str = string_of_bool b in
-  (* TODO: use proper token when possible? *)
-  let tok = Tok.unsafe_fake_tok b_str in
-  G.Bool (b, tok)
-
-let literal_of_int i64 =
-  (* TODO: use proper token when possible? *)
-  G.Int (Parsed_int.of_int64 i64)
-
-let int_of_literal = function
-  | G.Int (opt, _) -> opt
-  | ___else___ -> None
-
-let literal_of_string ?tok s : G.literal =
-  let tok =
-    match tok with
-    | None -> Tok.unsafe_fake_tok s
-    | Some tok ->
-        (* THIHK: IMO this should be `Parse_info.fake_info tok s`. Yet right now
-         * we are picking an arbitrary token from one of the strings involved in
-         * computing `s` and prentending it is a real token for `s`, but it's NOT.
-         * This may not interact well with Autofix (?). Anyways for now we have
-         * to do this because an $MVAR could match `s` and Semgrep assumes that
-         * an $MVAR always has a source location. *)
-        tok
-  in
-  G.String (fb (s, tok))
-
-let eval_unop_bool op b =
-  match op with
-  | G.Not -> G.Lit (literal_of_bool (not b))
-  | _else -> G.Cst G.Cbool
-
-let eval_binop_bool op b1 b2 =
-  match op with
-  | G.Or -> G.Lit (literal_of_bool (b1 || b2))
-  | G.And -> G.Lit (literal_of_bool (b1 && b2))
-  | _else -> G.Cst G.Cbool
-
-let eval_unop_int op opt_i =
-  match (op, opt_i) with
-  | G.Plus, Some i -> G.Lit (literal_of_int i)
-  | G.Minus, Some i -> G.Lit (literal_of_int (Int64.neg i))
-  | ___else____ -> G.Cst G.Cint
-
-(* This reduces arithmetic "exceptions" to `G.Cst G.Cint`, it does NOT
- * detect overflows for any other language than OCaml. Note that OCaml
- * integers have just 63-bits in 64-bit architectures!
- *)
-let eval_binop_int tok op opt_i1 opt_i2 =
-  let open Int64_ in
-  let sign_bit i = i asr Int.sub Sys.int_size 1 =|= 1L in
-  match (op, opt_i1, opt_i2) with
-  | G.Plus, Some i1, Some i2 ->
-      let r = i1 + i2 in
-      if sign_bit i1 =:= sign_bit i2 && sign_bit r <> sign_bit i1 then
-        G.Cst G.Cint (* overflow *)
-      else G.Lit (literal_of_int (i1 + i2))
-  | G.Minus, Some i1, Some i2 ->
-      let r = i1 - i2 in
-      if sign_bit i1 <> sign_bit i2 && sign_bit r <> sign_bit i1 then
-        G.Cst G.Cint (* overflow *)
-      else G.Lit (literal_of_int (i1 - i2))
-  | G.Mult, Some i1, Some i2 ->
-      let overflow =
-        i1 <> 0L && i2 <> 0L
-        && ((i1 < 0L && i2 =|= min_int) (* >max_int *)
-           || (i1 =|= min_int && i2 < 0L) (* >max_int *)
-           ||
-           if sign_bit i1 =:= sign_bit i2 then abs i1 > abs (max_int / i2)
-             (* >max_int *)
-           else abs i1 > abs (min_int / i2) (* <min_int *))
-      in
-      if overflow then G.Cst G.Cint else G.Lit (literal_of_int (i1 * i2))
-  | G.Div, Some i1, Some i2 -> (
-      if i1 =|= min_int && i2 =|= -1L then
-        G.Cst G.Cint (* = max_int+1, overflow *)
-      else
-        try G.Lit (literal_of_int (i1 / i2)) with
-        | Division_by_zero ->
-            warning tok "Found division by zero";
-            G.Cst G.Cint)
-  | ___else____ -> G.Cst G.Cint
-
-let eval_binop_string ?tok op s1 s2 =
-  match op with
-  | G.Plus
-  | G.Concat ->
-      G.Lit (literal_of_string ?tok (s1 ^ s2))
-  | __else__ -> G.Cst G.Cstr
-
-let rec eval (env : G.svalue Var_env.t) exp : G.svalue =
-  match exp.e with
-  | Fetch lval -> eval_lval env lval
-  | Literal li -> G.Lit li
-  (* Python: cond and <then-exp> or <else-exp> *)
-  | Operator
-      ( ((Or, _) as op),
-        ([
-           Unnamed { e = Operator ((And, _), [ _cond; Unnamed a_then ]); _ };
-           Unnamed a_else;
-         ] as args) ) -> (
-      let c_then = eval env a_then in
-      let c_else = eval env a_else in
-      match (c_then, c_else) with
-      | G.Lit (G.String _), G.Lit (G.String _) -> G.Cst G.Cstr
-      | G.Lit (G.Int _), G.Lit (G.Int _) -> G.Cst G.Cstr
-      (* Fall-back to default evaluation strategy. *)
-      | __else__ -> eval_op env op args)
-  | Operator (op, args) -> eval_op env op args
-  | Composite _
-  | Record _
-  | Cast _
-  | FixmeExp _ ->
-      G.NotCst
-
-and eval_lval env lval =
-  match lval with
-  | { base = Var x; rev_offset = [] } -> (
-      let opt_c = VarMap.find_opt (IL.str_of_name x) env in
-      match (!(x.id_info.id_svalue), opt_c) with
-      | None, None -> G.NotCst
-      | Some c, None
-      | None, Some c ->
-          c
-      | Some c1, Some c2 -> refine c1 c2)
-  | ___else___ -> G.NotCst
-
-and eval_op env wop args =
-  let op, tok = wop in
-  let cs = args |> List_.map IL_helpers.exp_of_arg |> List_.map (eval env) in
-  match (op, cs) with
-  | G.Plus, [ c1 ] -> c1
-  | op, [ G.Lit (G.Bool (b, _)) ] -> eval_unop_bool op b
-  | op, [ G.Lit (G.Int _ as li) ] -> eval_unop_int op (int_of_literal li)
-  | G.And, [ G.Lit (G.Bool (true, _)); c ] -> c (* Python: True and 42 -> 42 *)
-  | G.Or, [ G.Lit (G.Bool (false, _)); c ] -> c (* Python: False or 42 -> 42 *)
-  | op, [ G.Lit (G.Bool (b1, _)); G.Lit (G.Bool (b2, _)) ] ->
-      eval_binop_bool op b1 b2
-  | op, [ G.Lit (G.Int _ as li1); G.Lit (G.Int _ as li2) ] ->
-      eval_binop_int tok op (int_of_literal li1) (int_of_literal li2)
-  | op, [ G.Lit (G.String (_, (s1, _), _)); G.Lit (G.String (_, (s2, _), _)) ]
-    ->
-      eval_binop_string ~tok op s1 s2
-  | _op, [ (G.Cst _ as c1) ] -> c1
-  | _op, [ G.Cst t1; G.Cst t2 ] -> G.Cst (union_ctype t1 t2)
-  | _op, [ G.Lit l1; G.Cst t2 ]
-  | _op, [ G.Cst t2; G.Lit l1 ] ->
-      let t1 = H.ctype_of_literal l1 in
-      G.Cst (union_ctype t1 t2)
-  | ___else___ -> G.NotCst
-
-and eval_concat env args =
-  match List_.map (eval env) args with
-  | [] -> G.Lit (literal_of_string "")
-  | G.Lit (G.String (_, (r, tok), _)) :: args' ->
-      List.fold_left
-        (fun res e ->
-          match (res, e) with
-          | G.Lit (G.String (_l, (x, tok), _r)), G.Lit (G.String (_, (s, _), _))
-            ->
-              (* should reuse l/r? *)
-              G.Lit (literal_of_string ~tok (x ^ s))
-          | (G.Lit _ | G.Cst _), G.Cst G.Cstr -> G.Cst G.Cstr
-          | _____else_____ -> G.NotCst)
-        (G.Lit (literal_of_string ~tok r))
-        args'
-  | ___else___ -> G.NotCst
-
-let eval_format env args =
-  let cs = List_.map (eval env) args in
-  if
-    cs
-    |> List.for_all (function
-         | G.Lit _
-         | G.Cst _ ->
-             true
-         | _ -> false)
-  then G.Cst G.Cstr
-  else G.NotCst
-
-let eval_builtin_func lang env func args =
-  let args = List_.map IL_helpers.exp_of_arg args in
-  match func with
-  | { e = _; eorig = SameAs eorig } -> (
-      let* gname = H.name_of_dot_access eorig in
-      match (lang, gname) with
-      | ( Lang.Java,
-          G.IdQualified
-            {
-              name_last = ("format", _), _;
-              name_middle =
-                Some
-                  (QDots
-                    ( [ (("String", _), _) ]
-                    | [ (("java", _), _); (("lang", _), _); (("String", _), _) ]
-                      ));
-              _;
-            } ) ->
-          Some (eval_format env args)
-      | __else__ -> None)
   | __else__ -> None
 
 (*****************************************************************************)
@@ -430,7 +163,7 @@ let sym_prop eorig =
   | ___else___ -> G.NotCst
 
 let eval_or_sym_prop env exp =
-  match eval env exp with
+  match Eval.eval env exp with
   | G.NotCst -> sym_prop exp.eorig
   | c -> c
 
@@ -497,7 +230,7 @@ let set_svalue_ref id_info c' =
   if no_cycles_in_svalue id_info c' then
     match !(id_info.id_svalue) with
     | None -> id_info.id_svalue := Some c'
-    | Some c -> id_info.id_svalue := Some (refine c c')
+    | Some c -> id_info.id_svalue := Some (Eval.refine c c')
   else
     Logs.debug (fun m ->
         m ~tags "Cycle check failed for %s := ..." (G.show_id_info id_info))
@@ -531,7 +264,7 @@ let union_env =
   VarMap.merge (fun _ c1_opt c2_opt ->
       let* c1 = c1_opt in
       let* c2 = c2_opt in
-      Some (union c1 c2))
+      Some (Eval.union c1 c2))
 
 let input_env ~enter_env ~(flow : F.cfg) mapping ni =
   let node = flow.graph#nodes#assoc ni in
@@ -612,7 +345,9 @@ let transfer :
             update_env_with inp' var cexp
         | Call (Some { base = Var var; rev_offset = [] }, func, args) -> (
             let args_val =
-              List_.map (fun arg -> eval inp' (IL_helpers.exp_of_arg arg)) args
+              List_.map
+                (fun arg -> Eval.eval inp' (IL_helpers.exp_of_arg arg))
+                args
             in
             match result_of_function_call_constant lang func args_val with
             | Some kind -> VarMap.add (IL.str_of_name var) (G.Cst kind) inp'
@@ -636,7 +371,7 @@ let transfer :
               (* We try to evaluate the special function, if we know how. *)
               if special =*= Concat then
                 (* var = concat(args) *)
-                eval_concat inp' args
+                Eval.eval_concat inp' args
               else G.NotCst
             in
             let cexp =
@@ -678,7 +413,7 @@ let (fixpoint : Lang.t -> IL.name list -> F.cfg -> mapping) =
  fun lang _inputs flow ->
   let enter_env = VarMap.empty in
   DataflowX.fixpoint ~timeout:Limits_semgrep.svalue_prop_FIXPOINT_TIMEOUT
-    ~eq_env:(Var_env.eq_env eq)
+    ~eq_env:(Var_env.eq_env Eval.eq)
     ~init:(DataflowX.new_node_array flow (Var_env.empty_inout ()))
     ~trans:(transfer ~lang ~enter_env ~flow) (* svalue is a forward analysis! *)
     ~forward:true ~flow

--- a/src/analyzing/Dataflow_svalue.mli
+++ b/src/analyzing/Dataflow_svalue.mli
@@ -20,8 +20,10 @@ val hook_transfer_of_assume :
   ref
 
 val is_symbolic_expr : AST_generic.expr -> bool
+(*
 val eq : AST_generic.svalue -> AST_generic.svalue -> bool
 val union : AST_generic.svalue -> AST_generic.svalue -> AST_generic.svalue
+*)
 
 val fixpoint : Lang.t -> IL.name list -> IL.cfg -> mapping
 (** Flow-sensitive constant-propagation.

--- a/src/analyzing/Eval_generic_partial.ml
+++ b/src/analyzing/Eval_generic_partial.ml
@@ -190,7 +190,7 @@ let rec eval (env : env) (x : G.expr) : G.svalue option =
   | Conditional (_e1, e2, e3) ->
       let* v2 = eval env e2 in
       let* v3 = eval env e3 in
-      Some (Dataflow_svalue.union v2 v3)
+      Some (Eval_il_partial.union v2 v3)
   | Call
       ( { e = IdSpecial (EncodedString str_kind, _); _ },
         (_, [ Arg { e = L (String (_, (str, str_tok), _) as str_lit); _ } ], _)

--- a/src/analyzing/Eval_il_partial.ml
+++ b/src/analyzing/Eval_il_partial.ml
@@ -1,0 +1,305 @@
+(* Iago Abal
+ *
+ * Copyright (C) 2020 Semgrep Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * version 2.1 as published by the Free Software Foundation, with the
+ * special exception on linking described in file LICENSE.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
+ * LICENSE for more details.
+ *)
+open Common
+module G = AST_generic
+module H = AST_generic_helpers
+
+(*****************************************************************************)
+(* Prelude *)
+(*****************************************************************************)
+(* Constness evaluation on the IL.
+ *
+ * See Eval_generic_partial.ml for similar code but operating on the generic
+ * AST.
+ * See also Eval_generic.ml
+ *)
+
+(*****************************************************************************)
+(* Types *)
+(*****************************************************************************)
+type env = G.svalue Dataflow_var_env.t
+
+(*****************************************************************************)
+(* Helpers *)
+(*****************************************************************************)
+let fb = Tok.unsafe_fake_bracket
+
+(*****************************************************************************)
+(* Error management *)
+(*****************************************************************************)
+
+let warning _tok s =
+  (* TODO: Report these errors as matches of a builtin_div_by_zero rule. *)
+  Logs.debug (fun m -> m "CFGError: %s" s)
+
+(*****************************************************************************)
+(* Svalue Lattice *)
+(*****************************************************************************)
+let eq_literal l1 l2 = G.equal_literal l1 l2
+let eq_ctype t1 t2 = t1 =*= t2
+
+let eq (c1 : G.svalue) (c2 : G.svalue) : bool =
+  match (c1, c2) with
+  | G.Lit l1, G.Lit l2 -> eq_literal l1 l2
+  | G.Cst t1, G.Cst t2 -> eq_ctype t1 t2
+  | G.Sym e1, G.Sym e2 ->
+      (* We only consider two `Sym`s equal when they are exactly the same. If two
+       * `Sym`s are structuraly equal but their `id_svalue` pointers are different
+       * it may not be safe to use them interchangeably. (TBH I'm not sure if/when
+       * it's safe so I'm erring on the side of caution!) *)
+      phys_equal e1 e2
+  | G.NotCst, G.NotCst -> true
+  | G.Lit _, _
+  | G.Cst _, _
+  | G.Sym _, _
+  | G.NotCst, _ ->
+      false
+
+let union_ctype t1 t2 = if eq_ctype t1 t2 then t1 else G.Cany
+
+(* aka merge *)
+let union c1 c2 =
+  match (c1, c2) with
+  | _any, G.NotCst
+  | G.NotCst, _any ->
+      G.NotCst
+  | c1, c2 when eq c1 c2 -> c1
+  (* Note that merging symbolic expressions can be tricky.
+   *
+   * Example: Both branches assign `y = x.foo`, but `x` may have a different
+   * value in each branch. When merging symbolic expressions like `x.foo` we
+   * must first merge their dependencies (in our example, `x`).
+   *
+   *     if c:
+   *       x = a
+   *       y = x.foo
+   *     else:
+   *       x = b
+   *       y = x.foo
+   *
+   * Example: If we are not careful, when analyzing loops, we could introduce
+   * circular dependencies! (See tests/rules/sym_prop_no_merge1.go)
+   *
+   *     for cond {
+   *       x = f(x)
+   *     }
+   *)
+  | _any, G.Sym _
+  | G.Sym _, _any ->
+      G.NotCst
+  | G.Lit l1, G.Lit l2 ->
+      let t1 = H.ctype_of_literal l1 and t2 = H.ctype_of_literal l2 in
+      G.Cst (union_ctype t1 t2)
+  | G.Lit l1, G.Cst t2
+  | G.Cst t2, G.Lit l1 ->
+      let t1 = H.ctype_of_literal l1 in
+      G.Cst (union_ctype t1 t2)
+  | G.Cst t1, G.Cst t2 -> G.Cst (union_ctype t1 t2)
+
+(* THINK: This assumes that analyses are sound... but they are not
+   (e.g. due to aliasing). *)
+let refine (c1 : G.svalue) (c2 : G.svalue) : G.svalue =
+  match (c1, c2) with
+  | _ when eq c1 c2 -> c1
+  | c, G.NotCst
+  | G.NotCst, c ->
+      c
+  | G.Lit _, _
+  | G.Cst _, G.Cst _
+  | G.Sym _, G.Sym _ ->
+      c1
+  | G.Cst _, G.Sym _ -> c1
+  | G.Cst _, G.Lit _ -> c2
+  | G.Sym _, G.Lit _
+  | G.Sym _, G.Cst _ ->
+      c2
+
+(*****************************************************************************)
+(* Eval helpers *)
+(*****************************************************************************)
+
+let literal_of_bool b =
+  let b_str = string_of_bool b in
+  (* TODO: use proper token when possible? *)
+  let tok = Tok.unsafe_fake_tok b_str in
+  G.Bool (b, tok)
+
+let literal_of_int i64 =
+  (* TODO: use proper token when possible? *)
+  G.Int (Parsed_int.of_int64 i64)
+
+let int_of_literal = function
+  | G.Int (opt, _) -> opt
+  | ___else___ -> None
+
+let literal_of_string ?tok s : G.literal =
+  let tok =
+    match tok with
+    | None -> Tok.unsafe_fake_tok s
+    | Some tok ->
+        (* THIHK: IMO this should be `Parse_info.fake_info tok s`. Yet right now
+         * we are picking an arbitrary token from one of the strings involved in
+         * computing `s` and prentending it is a real token for `s`, but it's NOT.
+         * This may not interact well with Autofix (?). Anyways for now we have
+         * to do this because an $MVAR could match `s` and Semgrep assumes that
+         * an $MVAR always has a source location. *)
+        tok
+  in
+  G.String (fb (s, tok))
+
+let eval_unop_bool op b =
+  match op with
+  | G.Not -> G.Lit (literal_of_bool (not b))
+  | _else -> G.Cst G.Cbool
+
+let eval_binop_bool op b1 b2 =
+  match op with
+  | G.Or -> G.Lit (literal_of_bool (b1 || b2))
+  | G.And -> G.Lit (literal_of_bool (b1 && b2))
+  | _else -> G.Cst G.Cbool
+
+let eval_unop_int op opt_i =
+  match (op, opt_i) with
+  | G.Plus, Some i -> G.Lit (literal_of_int i)
+  | G.Minus, Some i -> G.Lit (literal_of_int (Int64.neg i))
+  | ___else____ -> G.Cst G.Cint
+
+(* This reduces arithmetic "exceptions" to `G.Cst G.Cint`, it does NOT
+ * detect overflows for any other language than OCaml. Note that OCaml
+ * integers have just 63-bits in 64-bit architectures!
+ *)
+let eval_binop_int tok op opt_i1 opt_i2 =
+  let open Int64_ in
+  let sign_bit i = i asr Int.sub Sys.int_size 1 =|= 1L in
+  match (op, opt_i1, opt_i2) with
+  | G.Plus, Some i1, Some i2 ->
+      let r = i1 + i2 in
+      if sign_bit i1 =:= sign_bit i2 && sign_bit r <> sign_bit i1 then
+        G.Cst G.Cint (* overflow *)
+      else G.Lit (literal_of_int (i1 + i2))
+  | G.Minus, Some i1, Some i2 ->
+      let r = i1 - i2 in
+      if sign_bit i1 <> sign_bit i2 && sign_bit r <> sign_bit i1 then
+        G.Cst G.Cint (* overflow *)
+      else G.Lit (literal_of_int (i1 - i2))
+  | G.Mult, Some i1, Some i2 ->
+      let overflow =
+        i1 <> 0L && i2 <> 0L
+        && ((i1 < 0L && i2 =|= min_int) (* >max_int *)
+           || (i1 =|= min_int && i2 < 0L) (* >max_int *)
+           ||
+           if sign_bit i1 =:= sign_bit i2 then abs i1 > abs (max_int / i2)
+             (* >max_int *)
+           else abs i1 > abs (min_int / i2) (* <min_int *))
+      in
+      if overflow then G.Cst G.Cint else G.Lit (literal_of_int (i1 * i2))
+  | G.Div, Some i1, Some i2 -> (
+      if i1 =|= min_int && i2 =|= -1L then
+        G.Cst G.Cint (* = max_int+1, overflow *)
+      else
+        try G.Lit (literal_of_int (i1 / i2)) with
+        | Division_by_zero ->
+            warning tok "Found division by zero";
+            G.Cst G.Cint)
+  | ___else____ -> G.Cst G.Cint
+
+let eval_binop_string ?tok op s1 s2 =
+  match op with
+  | G.Plus
+  | G.Concat ->
+      G.Lit (literal_of_string ?tok (s1 ^ s2))
+  | __else__ -> G.Cst G.Cstr
+
+(*****************************************************************************)
+(* Entry point *)
+(*****************************************************************************)
+
+let rec eval (env : G.svalue Dataflow_var_env.t) (exp : IL.exp) : G.svalue =
+  match exp.e with
+  | Fetch lval -> eval_lval env lval
+  | Literal li -> G.Lit li
+  (* Python: cond and <then-exp> or <else-exp> *)
+  | Operator
+      ( ((Or, _) as op),
+        ([
+           Unnamed { e = Operator ((And, _), [ _cond; Unnamed a_then ]); _ };
+           Unnamed a_else;
+         ] as args) ) -> (
+      let c_then = eval env a_then in
+      let c_else = eval env a_else in
+      match (c_then, c_else) with
+      | G.Lit (G.String _), G.Lit (G.String _) -> G.Cst G.Cstr
+      | G.Lit (G.Int _), G.Lit (G.Int _) -> G.Cst G.Cstr
+      (* Fall-back to default evaluation strategy. *)
+      | __else__ -> eval_op env op args)
+  | Operator (op, args) -> eval_op env op args
+  | Composite _
+  | Record _
+  | Cast _
+  | FixmeExp _ ->
+      G.NotCst
+
+and eval_lval env lval =
+  match lval with
+  | { base = Var x; rev_offset = [] } -> (
+      let opt_c = Dataflow_var_env.VarMap.find_opt (IL.str_of_name x) env in
+      match (!(x.id_info.id_svalue), opt_c) with
+      | None, None -> G.NotCst
+      | Some c, None
+      | None, Some c ->
+          c
+      | Some c1, Some c2 -> refine c1 c2)
+  | ___else___ -> G.NotCst
+
+and eval_op env wop args =
+  let op, tok = wop in
+  let cs = args |> List_.map IL_helpers.exp_of_arg |> List_.map (eval env) in
+  match (op, cs) with
+  | G.Plus, [ c1 ] -> c1
+  | op, [ G.Lit (G.Bool (b, _)) ] -> eval_unop_bool op b
+  | op, [ G.Lit (G.Int _ as li) ] -> eval_unop_int op (int_of_literal li)
+  | G.And, [ G.Lit (G.Bool (true, _)); c ] -> c (* Python: True and 42 -> 42 *)
+  | G.Or, [ G.Lit (G.Bool (false, _)); c ] -> c (* Python: False or 42 -> 42 *)
+  | op, [ G.Lit (G.Bool (b1, _)); G.Lit (G.Bool (b2, _)) ] ->
+      eval_binop_bool op b1 b2
+  | op, [ G.Lit (G.Int _ as li1); G.Lit (G.Int _ as li2) ] ->
+      eval_binop_int tok op (int_of_literal li1) (int_of_literal li2)
+  | op, [ G.Lit (G.String (_, (s1, _), _)); G.Lit (G.String (_, (s2, _), _)) ]
+    ->
+      eval_binop_string ~tok op s1 s2
+  | _op, [ (G.Cst _ as c1) ] -> c1
+  | _op, [ G.Cst t1; G.Cst t2 ] -> G.Cst (union_ctype t1 t2)
+  | _op, [ G.Lit l1; G.Cst t2 ]
+  | _op, [ G.Cst t2; G.Lit l1 ] ->
+      let t1 = H.ctype_of_literal l1 in
+      G.Cst (union_ctype t1 t2)
+  | ___else___ -> G.NotCst
+
+let eval_concat (env : env) args =
+  match List_.map (eval env) args with
+  | [] -> G.Lit (literal_of_string "")
+  | G.Lit (G.String (_, (r, tok), _)) :: args' ->
+      List.fold_left
+        (fun res e ->
+          match (res, e) with
+          | G.Lit (G.String (_l, (x, tok), _r)), G.Lit (G.String (_, (s, _), _))
+            ->
+              (* should reuse l/r? *)
+              G.Lit (literal_of_string ~tok (x ^ s))
+          | (G.Lit _ | G.Cst _), G.Cst G.Cstr -> G.Cst G.Cstr
+          | _____else_____ -> G.NotCst)
+        (G.Lit (literal_of_string ~tok r))
+        args'
+  | ___else___ -> G.NotCst

--- a/src/analyzing/Eval_il_partial.mli
+++ b/src/analyzing/Eval_il_partial.mli
@@ -1,0 +1,11 @@
+type env = AST_generic.svalue Dataflow_var_env.t
+
+val eval : env -> IL.exp -> AST_generic.svalue
+
+(* internals used also in Dataflow_svalue.ml *)
+val eval_concat : env -> IL.exp list -> AST_generic.svalue
+
+(* lattice ops *)
+val refine : AST_generic.svalue -> AST_generic.svalue -> AST_generic.svalue
+val union : AST_generic.svalue -> AST_generic.svalue -> AST_generic.svalue
+val eq : AST_generic.svalue -> AST_generic.svalue -> bool


### PR DESCRIPTION
This gives more flexibility to this file, and also
to the fact that maybe we should factorize code between
Eval_generic_partial.ml and Eval_il_partial.ml

test plan:
make
make test