### PR TITLE
Add package url + reference to FoundDependency

### DIFF
--- a/changelog.d/sc-1218.added
+++ b/changelog.d/sc-1218.added
@@ -1,0 +1,1 @@
+SwiftPM parser will now report package url and reference.

--- a/cli/src/semdep/parsers/swiftpm.py
+++ b/cli/src/semdep/parsers/swiftpm.py
@@ -130,14 +130,18 @@ def parse_swiftpm_v2(
         if package is None:
             continue
         package_name = package.as_str().lower()
+        repository_url = fields.get("location")
 
         state = fields.get("state")
         if state is None:
             continue
 
-        version = state.as_dict().get("version")
+        state_dict = state.as_dict()
+        version = state_dict.get("version")
         if version is None:
             continue
+
+        revision = state_dict.get("revision")
 
         result.append(
             FoundDependency(
@@ -147,6 +151,8 @@ def parse_swiftpm_v2(
                 allowed_hashes={},
                 transitivity=transitivity(direct_deps, [package_name]),
                 line_number=version.line_number,
+                git_ref=revision.as_str() if revision else None,
+                resolved_url=repository_url.as_str() if repository_url else None,
             )
         )
 
@@ -171,13 +177,18 @@ def parse_swiftpm_v1(
             continue
 
         package_name = package.as_str().lower()
+        repository_url = fields.get("repositoryURL")
+
         state = fields.get("state")
         if state is None:
             continue
 
-        version = state.as_dict().get("version")
+        state_dict = state.as_dict()
+        version = state_dict.get("version")
         if version is None:
             continue
+
+        revision = state_dict.get("revision")
 
         result.append(
             FoundDependency(
@@ -187,6 +198,8 @@ def parse_swiftpm_v1(
                 allowed_hashes={},
                 transitivity=transitivity(direct_deps, [package_name]),
                 line_number=version.line_number,
+                git_ref=revision.as_str() if revision else None,
+                resolved_url=repository_url.as_str() if repository_url else None,
             )
         )
 

--- a/cli/tests/default/e2e-pro/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awareswift-sca.yaml-dependency_awareswiftpmv1/results.txt
+++ b/cli/tests/default/e2e-pro/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awareswift-sca.yaml-dependency_awareswiftpmv1/results.txt
@@ -42,8 +42,10 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
             "found_dependency": {
               "allowed_hashes": {},
               "ecosystem": "swiftpm",
+              "git_ref": "d029d9d39c87bed85b1c50adee7c41795261a192",
               "line_number": 28,
               "package": "swift-collections",
+              "resolved_url": "https://github.com/apple/swift-collections.git",
               "transitivity": "direct",
               "version": "1.0.6"
             },

--- a/cli/tests/default/e2e-pro/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awareswift-sca.yaml-dependency_awareswiftpmv2/results.txt
+++ b/cli/tests/default/e2e-pro/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awareswift-sca.yaml-dependency_awareswiftpmv2/results.txt
@@ -42,8 +42,10 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
             "found_dependency": {
               "allowed_hashes": {},
               "ecosystem": "swiftpm",
+              "git_ref": "d029d9d39c87bed85b1c50adee7c41795261a192",
               "line_number": 72,
               "package": "swift-collections",
+              "resolved_url": "https://github.com/apple/swift-collections.git",
               "transitivity": "transitive",
               "version": "1.0.6"
             },


### PR DESCRIPTION
When parsing SwiftPM lockfiles, we now extract the resolved url of the package, along with the git reference information, and store that with the `FoundDependency` 