### PR TITLE
feat(lsp): multiple pattern search

### DIFF
--- a/cli/tests/default/e2e/snapshots/test_misc/test_noextension_with_explicit_lang/results.json
+++ b/cli/tests/default/e2e/snapshots/test_misc/test_noextension_with_explicit_lang/results.json
@@ -19,7 +19,7 @@
         "fingerprint": "0x42",
         "is_ignored": false,
         "lines": "hello",
-        "message": "hello",
+        "message": "simple search rule",
         "metadata": {},
         "metavars": {},
         "severity": "ERROR",

--- a/cli/tests/default/e2e/snapshots/test_misc/test_noextension_with_explicit_lang/results.json
+++ b/cli/tests/default/e2e/snapshots/test_misc/test_noextension_with_explicit_lang/results.json
@@ -19,7 +19,7 @@
         "fingerprint": "0x42",
         "is_ignored": false,
         "lines": "hello",
-        "message": "simple search rule",
+        "message": "hello",
         "metadata": {},
         "metavars": {},
         "severity": "ERROR",

--- a/src/core/Rule.ml
+++ b/src/core/Rule.ml
@@ -955,15 +955,16 @@ let split_and (xs : formula list) : formula list * (tok * formula) list =
 (* create a fake rule when we only have a pattern and language.
  * This is used when someone calls `semgrep -e print -l python`
  *)
-let rule_of_xpattern (xlang : Xlang.t) (xpat : Xpattern.t) : rule =
+
+let rule_of_formula (xlang : Xlang.t) (formula : formula) : rule =
   let fk = Tok.unsafe_fake_tok "" in
   let target_selector, target_analyzer = selector_and_analyzer_of_xlang xlang in
   {
     id = (Rule_ID.of_string "-e", fk);
-    mode = `Search (f (P xpat));
+    mode = `Search formula;
     min_version = None;
     max_version = None;
-    message = fst xpat.pstr;
+    message = "simple search rule";
     severity = `Error;
     target_selector;
     target_analyzer;
@@ -977,6 +978,9 @@ let rule_of_xpattern (xlang : Xlang.t) (xpat : Xpattern.t) : rule =
     product = `SAST;
     dependency_formula = None;
   }
+
+let rule_of_xpattern (xlang : Xlang.t) (xpat : Xpattern.t) : rule =
+  rule_of_formula xlang (f (P xpat))
 
 (* TODO(dinosaure): Currently, on the Python side, we remove the metadatas and
    serialise the rule into JSON format, then produce the hash from this

--- a/src/core/Rule.ml
+++ b/src/core/Rule.ml
@@ -960,7 +960,8 @@ let rule_of_formula ?(fix = None) (xlang : Xlang.t) (formula : formula) : rule =
   let fk = Tok.unsafe_fake_tok "" in
   let target_selector, target_analyzer = selector_and_analyzer_of_xlang xlang in
   {
-    id = (Rule_ID.of_string "-e", fk);
+    (* Coupling: Constants.rule_id_for_dash_e *)
+    id = (Rule_ID.of_string "-", fk);
     mode = `Search formula;
     fix;
     (* default values *)

--- a/src/core/Rule.ml
+++ b/src/core/Rule.ml
@@ -967,7 +967,10 @@ let rule_of_formula ?(fix = None) (xlang : Xlang.t) (formula : formula) : rule =
     (* default values *)
     min_version = None;
     max_version = None;
-    message = "simple search rule";
+    message =
+      (match formula with
+      | { f = P xpat; focus = []; conditions = [] } -> fst xpat.Xpattern.pstr
+      | _ -> "simple search rule");
     severity = `Error;
     target_selector;
     target_analyzer;

--- a/src/core/Rule.ml
+++ b/src/core/Rule.ml
@@ -956,12 +956,14 @@ let split_and (xs : formula list) : formula list * (tok * formula) list =
  * This is used when someone calls `semgrep -e print -l python`
  *)
 
-let rule_of_formula (xlang : Xlang.t) (formula : formula) : rule =
+let rule_of_formula ?(fix = None) (xlang : Xlang.t) (formula : formula) : rule =
   let fk = Tok.unsafe_fake_tok "" in
   let target_selector, target_analyzer = selector_and_analyzer_of_xlang xlang in
   {
     id = (Rule_ID.of_string "-e", fk);
     mode = `Search formula;
+    fix;
+    (* default values *)
     min_version = None;
     max_version = None;
     message = "simple search rule";
@@ -970,7 +972,6 @@ let rule_of_formula (xlang : Xlang.t) (formula : formula) : rule =
     target_analyzer;
     options = None;
     equivalences = None;
-    fix = None;
     fix_regexp = None;
     paths = None;
     metadata = None;
@@ -979,8 +980,9 @@ let rule_of_formula (xlang : Xlang.t) (formula : formula) : rule =
     dependency_formula = None;
   }
 
-let rule_of_xpattern (xlang : Xlang.t) (xpat : Xpattern.t) : rule =
-  rule_of_formula xlang (f (P xpat))
+let rule_of_xpattern ?(fix = None) (xlang : Xlang.t) (xpat : Xpattern.t) : rule
+    =
+  rule_of_formula xlang ~fix (f (P xpat))
 
 (* TODO(dinosaure): Currently, on the Python side, we remove the metadatas and
    serialise the rule into JSON format, then produce the hash from this

--- a/src/osemgrep/networking/Rule_fetching.ml
+++ b/src/osemgrep/networking/Rule_fetching.ml
@@ -424,19 +424,34 @@ let rules_from_dashdash_config ~rewrite_rule_ids ~token_opt caps kind :
 (* Entry point *)
 (*****************************************************************************)
 
-let rules_from_pattern pattern : rules_and_origin list =
-  let pat, xlang_opt, fix = pattern in
+let rules_from_patterns (patterns, xlang_opt, fix) : rules_and_origin list =
   let fk = Tok.unsafe_fake_tok "" in
   let rules_and_origin_for_xlang xlang =
-    let xpat = Parse_rule.parse_xpattern xlang (pat, fk) in
-    (* force the parsing of the pattern to get the parse error if any *)
-    (match xpat.XP.pat with
-    | XP.Sem (lpat, _) -> Lazy.force lpat |> ignore
-    | XP.Spacegrep _
-    | XP.Aliengrep _
-    | XP.Regexp _ ->
-        ());
-    let rule = Rule.rule_of_xpattern xlang xpat in
+    let xpats =
+      List_.map
+        (fun (positive, pat) ->
+          let xpat = Parse_rule.parse_xpattern xlang (pat, fk) in
+          (* force the parsing of the pattern to get the parse error if any *)
+          (match xpat.XP.pat with
+          | XP.Sem (lpat, _) -> Lazy.force lpat |> ignore
+          | XP.Spacegrep _
+          | XP.Aliengrep _
+          | XP.Regexp _ ->
+              ());
+          (positive, xpat))
+        patterns
+    in
+    let of_xpat (positive, xpat) =
+      if positive then Rule.f (Rule.P xpat)
+      else Rule.f (Rule.Not (Tok.unsafe_fake_tok "", Rule.f (Rule.P xpat)))
+    in
+    let formula =
+      match xpats with
+      | [ (positive, xpat) ] -> of_xpat (positive, xpat)
+      | _ ->
+          Rule.And (Tok.unsafe_fake_tok "", List_.map of_xpat xpats) |> Rule.f
+    in
+    let rule = Rule.rule_of_formula xlang formula in
     let rule = { rule with id = (Constants.rule_id_for_dash_e, fk); fix } in
     { rules = [ rule ]; errors = []; origin = CLI_argument }
   in
@@ -521,7 +536,7 @@ let rules_from_rules_source_async ~token_opt ~rewrite_rule_ids ~strict caps
        * better: '-e foo -l generic' was not handled in semgrep-core
     *)
     | Pattern (pat, xlang_opt, fix) ->
-        Lwt.return (rules_from_pattern (pat, xlang_opt, fix), [])
+        Lwt.return (rules_from_patterns ([ (true, pat) ], xlang_opt, fix), [])
   in
 
   (* error handling: *)

--- a/src/osemgrep/networking/Rule_fetching.mli
+++ b/src/osemgrep/networking/Rule_fetching.mli
@@ -43,8 +43,8 @@ and origin =
 val partition_rules_and_errors :
   rules_and_origin list -> Rule.rules * Rule.invalid_rule_error list
 
-val rules_from_pattern :
-  string * Xlang.t option * string option -> rules_and_origin list
+val rules_from_patterns :
+  (bool * string) list * Xlang.t option * string option -> rules_and_origin list
 
 (* [rules_from_rules_source] returns rules from --config or -e.
  * If [rewrite_rule_ids] is true, it will add the path of the config

--- a/src/osemgrep/networking/Rule_fetching.mli
+++ b/src/osemgrep/networking/Rule_fetching.mli
@@ -43,8 +43,7 @@ and origin =
 val partition_rules_and_errors :
   rules_and_origin list -> Rule.rules * Rule.invalid_rule_error list
 
-val rules_from_patterns :
-  (bool * string) list * Xlang.t option * string option -> rules_and_origin list
+val langs_of_pattern : string * Xlang.t option -> Xlang.t list
 
 (* [rules_from_rules_source] returns rules from --config or -e.
  * If [rewrite_rule_ids] is true, it will add the path of the config

--- a/src/parsing/Parse_rule.ml
+++ b/src/parsing/Parse_rule.ml
@@ -1086,6 +1086,10 @@ let parse_xpattern xlang (str, tok) =
   in
   Parse_rule_formula.parse_rule_xpattern env (str, tok)
 
+let parse_fake_xpattern xlang str =
+  let fk = Tok.unsafe_fake_tok "" in
+  parse_xpattern xlang (str, fk)
+
 (*****************************************************************************)
 (* Useful for tests *)
 (*****************************************************************************)

--- a/src/parsing/Parse_rule.mli
+++ b/src/parsing/Parse_rule.mli
@@ -25,6 +25,7 @@ val parse_and_filter_invalid_rules :
  * force evaluate XPattern.Sem (lpat_lazy, _).
  *)
 val parse_xpattern : Xlang.t -> string Rule.wrap -> Xpattern.t
+val parse_fake_xpattern : Xlang.t -> string -> Xpattern.t
 
 (* This should be used mostly in testing code. Otherwise you should
  * use parse_and_filter_invalid_rules.


### PR DESCRIPTION
This is a stacked diff whose parent is https://github.com/semgrep/semgrep/pull/9949

## What:
This PR makes it so that the search commands accept a _list_ of patterns, each annotated with a Boolean denoting their "positivity", rather than a single pattern. This effectively simulates "simple mode", but via the LSP interface.

## Why:
Searching with a single pattern is reasonably limited. You can only search for things expressible in a single pattern, and you cannot filter anything out. This makes it rather difficult to use effectively, especially in the context of mass refactor, when you want to make sure you are only matching things which are relevant to you.

## Test plan: 
Tested manually.