### PR TITLE
Update Testo

### DIFF
--- a/libs/commons/Logs_.ml
+++ b/libs/commons/Logs_.ml
@@ -319,11 +319,13 @@ let swarn ?src ?tags str = Logs.warn ?src (fun m -> m ?tags "%s" str)
 let serr ?src ?tags str = Logs.err ?src (fun m -> m ?tags "%s" str)
 
 let mask_time =
-  Testo.mask_pcre_pattern ~mask:"<MASKED TIMESTAMP>"
+  Testo.mask_pcre_pattern
+    ~replace:(fun _ -> "<MASKED TIMESTAMP>")
     {|\[([0-9]{2}\.[0-9]{2})\]|}
 
 let mask_log_lines =
-  Testo.mask_pcre_pattern ~mask:"<MASKED LOG LINE>"
+  Testo.mask_pcre_pattern
+    ~replace:(fun _ -> "<MASKED LOG LINE>")
     {|\[[0-9]{2}\.[0-9]{2}\][^\n]*|}
 
 let list to_string xs =

--- a/libs/git_wrapper/Unit_git_wrapper.ml
+++ b/libs/git_wrapper/Unit_git_wrapper.ml
@@ -13,12 +13,13 @@ let mask_temp_git_hash =
   Testo.mask_line ~after:"[main (root-commit) " ~before:"]" ()
 
 (* Precisely mask the hexadecimal part in a temp folder name
-   such as 'test-1e92745e' *)
+   such as 'test-1e92745e'. This is printed by some tests as a relative
+   path that is not automatically detected by Testo.mask_temp_paths. *)
 let mask_test_dirname =
-  Testo.mask_pcre_pattern ~mask:"test-<HEX>" "test-[a-f0-9]{1,8}"
+  Testo.mask_pcre_pattern ~replace:(fun _ -> "<HEX>") "test-([a-f0-9]{1,8})"
 
 let normalize =
-  [ mask_temp_git_hash; mask_test_dirname; Testo.mask_temp_paths () ]
+  [ mask_temp_git_hash; Testo.mask_temp_paths (); mask_test_dirname ]
 
 let t = Testo.create
 let capture = Testo.create ~checked_output:Stdout ~normalize

--- a/tests/snapshots/semgrep-core/17c29a0136d9/stdout
+++ b/tests/snapshots/semgrep-core/17c29a0136d9/stdout
@@ -1,4 +1,4 @@
-Initialized empty Git repository in <TEMPORARY FILE PATH><HEX>/.git/
+Initialized empty Git repository in <TMP>/<MASKED>/.git/
 [main (root-commit) <MASKED>] Add all the files
  2 files changed, 0 insertions(+), 0 deletions(-)
  create mode 100644 a/b/target
@@ -6,9 +6,9 @@ Initialized empty Git repository in <TEMPORARY FILE PATH><HEX>/.git/
 Input files:
 a/b/target
 x/y/z
-project root: <TEMPORARY FILE PATH><HEX>
-cwd: <TEMPORARY FILE PATH>
-scanning root: <TEMPORARY FILE PATH><HEX>
+project root: <TMP>/<MASKED>
+cwd: <TMP>
+scanning root: <TMP>/<MASKED>
 file list:
   test-<HEX>/a/b/target
   test-<HEX>/x/y/z

--- a/tests/snapshots/semgrep-core/2e75b85cd1f4/stdout
+++ b/tests/snapshots/semgrep-core/2e75b85cd1f4/stdout
@@ -6,8 +6,8 @@ dir/a
 Selection events for path .gitignore:
 SEL .gitignore
 Selection events for path a:
-ignored at <TEMPORARY FILE PATH>.gitignore, line 1: a
+ignored at <TMP>/<MASKED>/.gitignore, line 1: a
 IGN a
 Selection events for path dir/a:
-ignored at <TEMPORARY FILE PATH>.gitignore, line 1: a
+ignored at <TMP>/<MASKED>/.gitignore, line 1: a
 IGN dir/a

--- a/tests/snapshots/semgrep-core/343da82ffbcb/stdout
+++ b/tests/snapshots/semgrep-core/343da82ffbcb/stdout
@@ -1,4 +1,4 @@
-Initialized empty Git repository in <TEMPORARY FILE PATH><HEX>/.git/
+Initialized empty Git repository in <TMP>/<MASKED>/.git/
 [main (root-commit) <MASKED>] Add all the files
  2 files changed, 0 insertions(+), 0 deletions(-)
  create mode 100644 a/b/target
@@ -6,8 +6,8 @@ Initialized empty Git repository in <TEMPORARY FILE PATH><HEX>/.git/
 Input files:
 a/b/target
 x/y/z
-project root: <TEMPORARY FILE PATH><HEX>
-cwd: <TEMPORARY FILE PATH><HEX>
+project root: <TMP>/<MASKED>
+cwd: <TMP>/<MASKED>
 scanning root: .
 file list:
   a/b/target

--- a/tests/snapshots/semgrep-core/36408fbb6ab3/stdout
+++ b/tests/snapshots/semgrep-core/36408fbb6ab3/stdout
@@ -1,4 +1,4 @@
-Initialized empty Git repository in <TEMPORARY FILE PATH><HEX>/.git/
+Initialized empty Git repository in <TMP>/<MASKED>/.git/
 [main (root-commit) <MASKED>] Add all the files
  2 files changed, 0 insertions(+), 0 deletions(-)
  create mode 100644 a/b/target
@@ -6,8 +6,8 @@ Initialized empty Git repository in <TEMPORARY FILE PATH><HEX>/.git/
 Input files:
 a/b/target
 x/y/z
-project root: <TEMPORARY FILE PATH><HEX>
-cwd: <TEMPORARY FILE PATH><HEX>/a
+project root: <TMP>/<MASKED>
+cwd: <TMP>/<MASKED>/a
 scanning root: .
 file list:
   b/target

--- a/tests/snapshots/semgrep-core/551857e0cb97/stdout
+++ b/tests/snapshots/semgrep-core/551857e0cb97/stdout
@@ -8,5 +8,5 @@ SEL a
 Selection events for path dir/.gitignore:
 SEL dir/.gitignore
 Selection events for path dir/a:
-ignored at <TEMPORARY FILE PATH>dir/.gitignore, line 1: a
+ignored at <TMP>/<MASKED>/dir/.gitignore, line 1: a
 IGN dir/a

--- a/tests/snapshots/semgrep-core/5722008e9775/stdout
+++ b/tests/snapshots/semgrep-core/5722008e9775/stdout
@@ -6,7 +6,7 @@ sub/dir/ignore-me-not
 Selection events for path .gitignore:
 SEL .gitignore
 Selection events for path dir/ignore-me:
-ignored at <TEMPORARY FILE PATH>.gitignore, line 1: dir/*
+ignored at <TMP>/<MASKED>/.gitignore, line 1: dir/*
 IGN dir/ignore-me
 Selection events for path sub/dir/ignore-me-not:
 SEL sub/dir/ignore-me-not

--- a/tests/snapshots/semgrep-core/68ddf7069d0b/stdout
+++ b/tests/snapshots/semgrep-core/68ddf7069d0b/stdout
@@ -6,7 +6,7 @@ dir/a
 Selection events for path .gitignore:
 SEL .gitignore
 Selection events for path a/b:
-ignored at <TEMPORARY FILE PATH>.gitignore, line 1: a/
+ignored at <TMP>/<MASKED>/.gitignore, line 1: a/
 IGN a/b
 Selection events for path dir/a:
 SEL dir/a

--- a/tests/snapshots/semgrep-core/917142b5cdf9/stdout
+++ b/tests/snapshots/semgrep-core/917142b5cdf9/stdout
@@ -6,7 +6,7 @@ hello.ml
 Selection events for path .gitignore:
 SEL .gitignore
 Selection events for path hello.c:
-ignored at <TEMPORARY FILE PATH>.gitignore, line 1: *.c
+ignored at <TMP>/<MASKED>/.gitignore, line 1: *.c
 IGN hello.c
 Selection events for path hello.ml:
 SEL hello.ml

--- a/tests/snapshots/semgrep-core/928cede2578e/stdout
+++ b/tests/snapshots/semgrep-core/928cede2578e/stdout
@@ -6,9 +6,9 @@ dir/ignore-me-not
 Selection events for path .gitignore:
 SEL .gitignore
 Selection events for path dir/ignore-me:
-ignored at <TEMPORARY FILE PATH>.gitignore, line 1: dir/*
+ignored at <TMP>/<MASKED>/.gitignore, line 1: dir/*
 IGN dir/ignore-me
 Selection events for path dir/ignore-me-not:
-ignored at <TEMPORARY FILE PATH>.gitignore, line 1: dir/*
-de-ignored at <TEMPORARY FILE PATH>.gitignore, line 2: !dir/ignore-me-not
+ignored at <TMP>/<MASKED>/.gitignore, line 1: dir/*
+de-ignored at <TMP>/<MASKED>/.gitignore, line 2: !dir/ignore-me-not
 SEL dir/ignore-me-not

--- a/tests/snapshots/semgrep-core/946b937b8376/stdout
+++ b/tests/snapshots/semgrep-core/946b937b8376/stdout
@@ -1,4 +1,4 @@
-Initialized empty Git repository in <TEMPORARY FILE PATH><HEX>/.git/
+Initialized empty Git repository in <TMP>/<MASKED>/.git/
 [main (root-commit) <MASKED>] Add all the files
  2 files changed, 0 insertions(+), 0 deletions(-)
  create mode 100644 a/b/target
@@ -6,8 +6,8 @@ Initialized empty Git repository in <TEMPORARY FILE PATH><HEX>/.git/
 Input files:
 a/b/target
 x/y/z
-project root: <TEMPORARY FILE PATH><HEX>
-cwd: <TEMPORARY FILE PATH>
+project root: <TMP>/<MASKED>
+cwd: <TMP>
 scanning root: test-<HEX>
 file list:
   test-<HEX>/a/b/target

--- a/tests/snapshots/semgrep-core/aaadc9ccf052/stdout
+++ b/tests/snapshots/semgrep-core/aaadc9ccf052/stdout
@@ -6,8 +6,8 @@ dir/a/b
 Selection events for path .gitignore:
 SEL .gitignore
 Selection events for path a/b:
-ignored at <TEMPORARY FILE PATH>.gitignore, line 1: a/
+ignored at <TMP>/<MASKED>/.gitignore, line 1: a/
 IGN a/b
 Selection events for path dir/a/b:
-de-ignored at <TEMPORARY FILE PATH>.gitignore, line 2: !dir/a
+de-ignored at <TMP>/<MASKED>/.gitignore, line 2: !dir/a
 SEL dir/a/b

--- a/tests/snapshots/semgrep-core/bbb375beed7d/stdout
+++ b/tests/snapshots/semgrep-core/bbb375beed7d/stdout
@@ -1,4 +1,4 @@
-Initialized empty Git repository in <TEMPORARY FILE PATH><HEX>/.git/
+Initialized empty Git repository in <TMP>/<MASKED>/.git/
 [main (root-commit) <MASKED>] Add all the files
  2 files changed, 0 insertions(+), 0 deletions(-)
  create mode 100644 a/b/target
@@ -6,8 +6,8 @@ Initialized empty Git repository in <TEMPORARY FILE PATH><HEX>/.git/
 Input files:
 a/b/target
 x/y/z
-project root: <TEMPORARY FILE PATH><HEX>
-cwd: <TEMPORARY FILE PATH><HEX>/x
+project root: <TMP>/<MASKED>
+cwd: <TMP>/<MASKED>/x
 scanning root: ../a
 file list:
   ../a/b/target

--- a/tests/snapshots/semgrep-core/ec0b6d8d3aac/stdout
+++ b/tests/snapshots/semgrep-core/ec0b6d8d3aac/stdout
@@ -9,14 +9,14 @@ b/d
 Selection events for path .gitignore:
 SEL .gitignore
 Selection events for path a/b:
-ignored at <TEMPORARY FILE PATH>.gitignore, line 1: /a
+ignored at <TMP>/<MASKED>/.gitignore, line 1: /a
 IGN a/b
 Selection events for path b/a:
 SEL b/a
 Selection events for path b/b/c:
 SEL b/b/c
 Selection events for path b/c:
-ignored at <TEMPORARY FILE PATH>.gitignore, line 2: b/c
+ignored at <TMP>/<MASKED>/.gitignore, line 2: b/c
 IGN b/c
 Selection events for path b/d:
 SEL b/d

--- a/tests/snapshots/semgrep-core/f4ba77a8739a/stdout
+++ b/tests/snapshots/semgrep-core/f4ba77a8739a/stdout
@@ -1,4 +1,4 @@
-Initialized empty Git repository in <TEMPORARY FILE PATH><HEX>/.git/
+Initialized empty Git repository in <TMP>/<MASKED>/.git/
 [main (root-commit) <MASKED>] Add all the files
  2 files changed, 0 insertions(+), 0 deletions(-)
  create mode 100644 a/b/target
@@ -6,8 +6,8 @@ Initialized empty Git repository in <TEMPORARY FILE PATH><HEX>/.git/
 Input files:
 a/b/target
 x/y/z
-project root: <TEMPORARY FILE PATH><HEX>
-cwd: <TEMPORARY FILE PATH><HEX>/x
-scanning root: <TEMPORARY FILE PATH><HEX>/a
+project root: <TMP>/<MASKED>
+cwd: <TMP>/<MASKED>/x
+scanning root: <TMP>/<MASKED>/a
 file list:
   ../a/b/target

--- a/tests/snapshots/semgrep-core/fc0ccdecb184/stdout
+++ b/tests/snapshots/semgrep-core/fc0ccdecb184/stdout
@@ -6,7 +6,7 @@ hello.ml
 Selection events for path .gitignore:
 SEL .gitignore
 Selection events for path hello.c:
-ignored at <TEMPORARY FILE PATH>.gitignore, line 1: *.c
+ignored at <TMP>/<MASKED>/.gitignore, line 1: *.c
 IGN hello.c
 Selection events for path hello.ml:
 SEL hello.ml


### PR DESCRIPTION
This makes the default output of `./test status` compact. See https://github.com/semgrep/testo/pull/40