### PR TITLE
refactor(rules): rule IL

### DIFF
--- a/src/engine/Eval_generic.ml
+++ b/src/engine/Eval_generic.ml
@@ -520,12 +520,10 @@ let bindings_to_env (config : Rule_options.t) ~file bindings =
     bindings
     |> List_.map_filter (fun (mvar, mval) ->
            let try_bind_to_exp e =
-             UCommon.(pr2 (spf "try bind %s" ([%show: AST_generic.expr] e)));
              try
                let res =
                  eval { mvars = Hashtbl.create 0; constant_propagation; file } e
                in
-               UCommon.(pr2 (spf "res is %s" ([%show: value] res)));
                Some (mvar, res)
              with
              | NotHandled _
@@ -603,7 +601,6 @@ let eval_opt env e =
       None
 
 let eval_bool env e =
-  UCommon.(pr2 (spf "code %s" ([%show: AST_generic.expr] e)));
   let res = eval_opt env e in
   match res with
   | Some (Bool b) -> b

--- a/src/engine/Formula_internal.ml
+++ b/src/engine/Formula_internal.ml
@@ -1,0 +1,121 @@
+module MV = Metavariable
+open Ppx_hash_lib.Std.Hash.Builtin
+
+(*****************************************************************************)
+(* Types *)
+(*****************************************************************************)
+
+type tok = Tok.t_always_equal [@@deriving show, eq, hash]
+
+type formula =
+  | P of Xpattern.t (* a leaf pattern *)
+  | And of tok * formula list
+  | Or of tok * formula list
+  | Not of tok * formula
+  | Inside of tok * formula
+  | Anywhere of tok * formula
+  | Filter of tok * filter * formula
+  | Focus of tok * MV.mvar list * formula
+
+and filter =
+  | FilterEval of AST_generic.expr (* see Eval_generic.ml *)
+  | FilterRegexp of
+      MV.mvar * Xpattern.regexp_string * bool (* constant-propagation *)
+  | FilterType of
+      MV.mvar
+      * Xlang.t option
+      (* when the type expression is in different lang *)
+      * string list (* raw input string saved for regenerating rule yaml *)
+      * AST_generic.type_ list
+    (* LATER: could parse lazily, like the patterns *)
+  | FilterAnalysis of MV.mvar * metavar_analysis_kind
+  | FilterNestedFormula of MV.mvar * Xlang.t option * formula
+
+and metavar_analysis_kind = Rule.metavar_analysis_kind
+[@@deriving show, eq, hash]
+
+(*****************************************************************************)
+(* Helpers *)
+(*****************************************************************************)
+
+(*****************************************************************************)
+(* Prelude *)
+(*****************************************************************************)
+
+let rec of_rule_formula ({ f; conditions; focus } : Rule.formula) : formula =
+  let inner_formula = of_rule_formula_kind f in
+  let filtered_formula =
+    List.fold_left
+      (fun acc (tk, cond) ->
+        let filter = filter_of_rule_cond cond in
+        Filter (tk, filter, acc))
+      inner_formula conditions
+  in
+  let focused_formula =
+    List.fold_left
+      (fun acc (tk, mvars) -> Focus (tk, mvars, acc))
+      filtered_formula focus
+  in
+  focused_formula
+
+and of_rule_formula_kind (kind : Rule.formula_kind) : formula =
+  match kind with
+  | Rule.P pat -> P pat
+  | And (tk, fs) -> And (tk, List_.map of_rule_formula fs)
+  | Or (tk, fs) -> Or (tk, List_.map of_rule_formula fs)
+  | Not (tk, f) -> Not (tk, of_rule_formula f)
+  | Inside (tk, f) -> Inside (tk, of_rule_formula f)
+  | Anywhere (tk, f) -> Anywhere (tk, of_rule_formula f)
+
+and filter_of_rule_cond = function
+  | Rule.CondEval e -> FilterEval e
+  | CondRegexp (mvar, s, b) -> FilterRegexp (mvar, s, b)
+  | CondType (mv, xlang, ty_strs, tys) -> FilterType (mv, xlang, ty_strs, tys)
+  | CondAnalysis (mvar, analysis_kind) -> FilterAnalysis (mvar, analysis_kind)
+  | CondNestedFormula (mvar, xlang, f) ->
+      FilterNestedFormula (mvar, xlang, of_rule_formula f)
+
+let split_pos_neg f =
+  match f with
+  | P _
+  | And _
+  | Or _
+  | Anywhere _
+  | Inside _ ->
+      Either.Left f
+  (* TODO: This is actually not correct.
+     A `filter` or `focus` could be wrapping a `Not`,
+     which means that this is overall actually a negative
+     pattern.
+     This can be fixed by making evaluate_formula itself
+     bubble up the information of patterns being positive or
+     negative, which is a later change to make.
+  *)
+  | Filter _
+  | Focus _ ->
+      Left f
+  | Not (tk, f) -> Right (tk, f)
+
+(* OK, this is only a little disgusting, but...
+   Evaluation order means that we will only visit children after parents.
+   So we keep a reference cell around, and set it to true whenever we descend
+   under an inside.
+   That way, pattern leaves underneath an Inside/Anywhere will properly be
+   paired with a true boolean.
+*)
+let visit_formula func formula =
+  let bref = ref false in
+  let rec visit_formula func formula =
+    match formula with
+    | P p -> func p ~inside:!bref
+    | Anywhere (_, formula)
+    | Inside (_, formula)
+    | Filter (_, _, formula)
+    | Focus (_, _, formula) ->
+        Common.save_excursion bref true (fun () -> visit_formula func formula)
+    | Not (_, x) -> visit_formula func x
+    | Or (_, xs)
+    | And (_, xs) ->
+        xs |> List.iter (visit_formula func)
+  in
+  visit_formula func formula

--- a/src/engine/Match_search_mode.mli
+++ b/src/engine/Match_search_mode.mli
@@ -14,7 +14,7 @@ val matches_of_formula :
   Match_env.xconfig ->
   Rule.rule ->
   Xtarget.t ->
-  Rule.formula ->
+  Formula_internal.formula ->
   Range_with_metavars.t option ->
   Core_profiling.rule_profiling Core_result.match_result
   * Range_with_metavars.ranges

--- a/src/engine/Match_tainting_mode.ml
+++ b/src/engine/Match_tainting_mode.ml
@@ -133,9 +133,18 @@ let option_bind_list opt f =
 (* Finds all matches of a taint-spec pattern formula. *)
 let range_w_metas_of_formula (xconf : Match_env.xconfig) (xtarget : Xtarget.t)
     (rule : R.t) (formula : R.formula) : RM.ranges * ME.t list =
+  (* TODO: Ideally this should occur farther up, earlier on in the
+     Match_tainting_mode process.
+     But, this would run into trouble with the formula cache.
+     We'll leave that to a future PR so we don't change too much right now.
+  *)
+  let iformula =
+    if xconf.matching_explanations then Formula_internal.of_rule_formula formula
+    else Optimize_formula.optimize (Formula_internal.of_rule_formula formula)
+  in
   (* !! Calling Match_search_mode here !! *)
   let report, ranges =
-    Match_search_mode.matches_of_formula xconf rule xtarget formula None
+    Match_search_mode.matches_of_formula xconf rule xtarget iformula None
   in
   (ranges, report.explanations)
 

--- a/src/engine/Metavariable_pattern.ml
+++ b/src/engine/Metavariable_pattern.ml
@@ -109,7 +109,7 @@ let get_persistent_bindings revert_loc r nested_matches =
 (* Entry point *)
 (*****************************************************************************)
 let get_nested_metavar_pattern_bindings get_nested_formula_matches env r mvar
-    (opt_xlang : Xlang.t option) formula =
+    (opt_xlang : Xlang.t option) (formula : Formula_internal.formula) =
   let bindings = r.RM.mvars in
   (* If anything goes wrong the default is to filter out! *)
   match List.assoc_opt mvar bindings with

--- a/src/engine/Metavariable_pattern.mli
+++ b/src/engine/Metavariable_pattern.mli
@@ -8,7 +8,7 @@
  *)
 val get_nested_metavar_pattern_bindings :
   (Match_env.env ->
-  Rule.formula ->
+  Formula_internal.formula ->
   Range_with_metavars.t ->
   Range_with_metavars.t list) ->
   Match_env.env ->
@@ -16,5 +16,5 @@ val get_nested_metavar_pattern_bindings :
   (* The arguments in CondNestedFormula *)
   Metavariable.mvar ->
   Xlang.t option ->
-  Rule.formula ->
+  Formula_internal.formula ->
   Metavariable.bindings list

--- a/src/engine/Optimize_formula.ml
+++ b/src/engine/Optimize_formula.ml
@@ -1,0 +1,1 @@
+let optimize f = f

--- a/src/engine/Optimize_formula.mli
+++ b/src/engine/Optimize_formula.mli
@@ -1,0 +1,1 @@
+val optimize : Formula_internal.formula -> Formula_internal.formula

--- a/src/engine/dune
+++ b/src/engine/dune
@@ -28,5 +28,6 @@
    semgrep_reporting; for Test_engine.ml, we should split in tests/ separate dir
  )
  (inline_tests)
- (preprocess (pps ppx_deriving.show ppx_profiling ppx_inline_test))
+ (preprocess
+  (pps ppx_deriving.show ppx_deriving.eq ppx_profiling ppx_hash ppx_inline_test))
 )


### PR DESCRIPTION
## What:
This PR introduces the `Formula_internal` module, which defines a kind of "IL" (internal language) for rule formula. This allows us to have a separation between `Rule.formula`, which is a kind of "CST" for formulae, and `Formula_internal`, which is meant to be malleable (for optimization purposes). This is, importantly, witnessed by the existence of `Optimize_rule.optimize : Formula_internal.formula -> Formula_internal.formula`, which is a black-box method which optimizes a formula in an extensional-preserving way.

## Why:
We may be interested in optimizations on rules. For instance, take the case of:
```
any:
  - all:
      - A
      - B
  - all:
      - A
      - C
```
As it stands, we will compute the matches for both xpatterns `A`, meaning that we run it twice in total. This could instead, however, be written as:
```
all:
  - A
  - any:
    - B
    - C
```
which would run slightly more efficiently.

Lots of little optimizations like this are possible. Slightly more motivating is "regex fusion", where we could combine many `metavariable-regex`es into a single regex, separated by `|`s. 

This is harder to do on a type which is slightly more rigid in structure, such as `Rule.formula`. For instance, `Rule.formula` adheres more rigidly to the structure of a rule, because it separates out `where` clauses and such.

It would be nice to have a simple type which simple optimizations can be written on. That is the point of this PR.

## How:
This is what `Formula_internal` is. It has variants for each of the operations which it may perform, such as an `And`, `Or`, `Filter`, and whatnot.

## Test plan: 
Automated tests.