### PR TITLE
Docker: remove the 'semgrep-dev' target, not needed anymore

### DIFF
--- a/.github/workflows/cron-parsing-stats.jsonnet
+++ b/.github/workflows/cron-parsing-stats.jsonnet
@@ -10,8 +10,8 @@ local semgrep = import 'libs/semgrep.libsonnet';
 // ----------------------------------------------------------------------------
 
 local job = {
-  // was 'ubuntu-latest' but we need a machine with lots of disk space to run the
-  // parsing stats as we clone many OSS repositories in './run-all ...' below
+  // was 'ubuntu-latest' but we need a machine with lots of disk space to run
+  // the parsing stats as we clone many OSS repos in './run-all ...' below
   'runs-on': 'ubuntu-latest-16-core',
   // we need semgrep-core in 'stats/parsing-stats/run-lang' called from run-all
   container: 'returntocorp/semgrep:develop',
@@ -20,6 +20,10 @@ local job = {
     // The packages below, which are needed by './run-all', used to be part of
     // the returntocorp/semgrep docker image but got removed to reduce its
     // attack surface, so we need to install them now.
+    // Here is why we need the apk packages below:
+    // - bash: run-all is a bash script
+    // - jq: used to filter JSON parsing statistics
+    // - curl: to upload data to our dashboard
     {
       name: 'Install dependencies',
       run: 'apk add bash jq curl',

--- a/Dockerfile
+++ b/Dockerfile
@@ -135,19 +135,21 @@ RUN apk upgrade --no-cache && \
 #
 # history: we used to install here various utilities (e.g., jq, curl) needed by
 # some of our bash (and python) scripts under scripts/. Indeed, those scripts are
-# run from CI jobs using the returntocorp/semgrep docker image as the container,
-# because they must test semgrep. Those scripts must also perform different
+# run from CI jobs using the returntocorp/semgrep docker image as the container
+# because they rely on semgrep(-core). Those scripts must also perform different
 # tasks that require utilities other than semgrep (e.g., compute parsing
 # statistics and then run 'jq' to filter the JSON). It was convenient to add
 # them to the docker image, especially because the addition of those packages
 # didn't add much to the size of the docker image (<1%). However, those utilities
-# can have CVEs associated, so better to not install them,
+# can have CVEs associated, so better to not install them.
 # alt:
 #  - we used to have an alternate semgrep-dev.Dockerfile container to use
 #    for our benchmarks, but it complicates things
-#  - just install those utilities in the workflow (see for example
-#    cron-parsing-stats.jsonnet).
-# See also https://docs.docker.com/develop/security-best-practices/
+#
+# If you need more utilities, just install them in the workflow instead
+# (see for example cron-parsing-stats.jsonnet).
+#
+# See https://docs.docker.com/develop/security-best-practices/ for more info.
 #
 # Here is why we need the apk packages below:
 # - git, git-lfs, openssh: so that the semgrep docker image can be used in

--- a/Dockerfile
+++ b/Dockerfile
@@ -107,7 +107,7 @@ RUN make install-deps-ALPINE-for-semgrep-core &&\
 
 # Let's build just semgrep-core
 WORKDIR /src/semgrep
-# An alternative to the eval is to use 'opam exec -- ...'
+#alt: use 'opam exec -- ...' instead of eval
 RUN eval "$(opam env)" &&\
     make minimal-build &&\
     # Sanity check
@@ -123,18 +123,37 @@ FROM python:3.11-alpine AS semgrep-oss
 
 WORKDIR /semgrep
 
-# Update to the latest packages for the base image.
-# This allows to get CVE fixes ASAP, without waiting for new builds of the base image.
+# Update to the latest packages for the base image. This allows to get CVE
+# fixes ASAP, without waiting for new builds of the base image.
 # See docker-library/python#761 for an example of such an issue in the past
-# where the time between the CVE was discovered and the package update was X days, but
-# the new base image was updated only after Y days.
-# See also https://docs.docker.com/develop/security-best-practices/
+# where the time between the CVE was discovered and the package update was
+# X days, but the new base image was updated only after Y days.
 RUN apk upgrade --no-cache && \
+    apk add --no-cache --virtual=.run-deps\
+# Try to limit to the minimum the number of packages to install; this reduces
+# the attack surface.
+#
+# history: we used to install here various utilities (e.g., jq, curl) needed by
+# some of our bash (and python) scripts under scripts/. Indeed, those scripts are
+# run from CI jobs using the returntocorp/semgrep docker image as the container,
+# because they must test semgrep. Those scripts must also perform different
+# tasks that require utilities other than semgrep (e.g., compute parsing
+# statistics and then run 'jq' to filter the JSON). It was convenient to add
+# them to the docker image, especially because the addition of those packages
+# didn't add much to the size of the docker image (<1%). However, those utilities
+# can have CVEs associated, so better to not install them,
+# alt:
+#  - we used to have an alternate semgrep-dev.Dockerfile container to use
+#    for our benchmarks, but it complicates things
+#  - just install those utilities in the workflow (see for example
+#    cron-parsing-stats.jsonnet).
+# See also https://docs.docker.com/develop/security-best-practices/
+#
 # Here is why we need the apk packages below:
 # - git, git-lfs, openssh: so that the semgrep docker image can be used in
-#   Github actions (GHA) and get git submodules and use ssh to get those submodules
-    apk add --no-cache --virtual=.run-deps\
-    git git-lfs openssh
+#   Github actions (GHA) and get git submodules and use ssh to get those
+#   submodules
+	git git-lfs openssh
 
 # We just need the Python code in cli/.
 # The semgrep-core stuff would be copied from the other container
@@ -173,10 +192,10 @@ ENV SEMGREP_IN_DOCKER=1 \
 
 # The command we tell people to run for testing semgrep in Docker is
 #   docker run --rm -v "${PWD}:/src" returntocorp/semgrep semgrep --config=auto
-# (see https://semgrep.dev/docs/getting-started/ ), hence the WORKDIR directive below
+# (see https://semgrep.dev/docs/getting-started/ ), hence this WORKDIR directive
 WORKDIR /src
 
-# Better to avoid running semgrep as root
+# It is better to avoid running semgrep as root
 # See https://stackoverflow.com/questions/49193283/why-it-is-unsafe-to-run-applications-as-root-in-docker-container
 # Note though that the actual USER directive is done in Step 3.
 RUN adduser -D -u 1000 -h /home/semgrep semgrep \
@@ -218,29 +237,29 @@ LABEL maintainer="support@semgrep.com"
 ###############################################################################
 # Step3: install semgrep-pro
 ###############################################################################
-# This step is valid only when run from Github Actions.
+# This builds a semgrep docker image with semgrep-pro already included,
+# to save time in CI as one does not need to wait 2min each time to
+# download it (it also reduces our cost to S3).
+# This step is valid only when run from Github Actions (it needs a secret)
 # See .github/workflows/build-test-docker.jsonnet and release.jsonnet
 
 #coupling: the 'semgrep-cli' name is used in release.jsonnet
 FROM semgrep-oss AS semgrep-cli
 
-# A semgrep docker image with semgrep-pro already included in the image,
-# to save time in CI as one does not need to wait 2min each time to
-# download it.
 RUN --mount=type=secret,id=SEMGREP_APP_TOKEN SEMGREP_APP_TOKEN=$(cat /run/secrets/SEMGREP_APP_TOKEN) semgrep install-semgrep-pro --debug
 
-# Clear out any detritus from the pro install
+# Clear out any detritus from the pro install (especially credentials)
 RUN rm -rf /root/.semgrep
 
 ###############################################################################
 # optional: nonroot variant
 ###############################################################################
-
 # Additional build stage that sets a non-root user.
 # We can't make this the default in the semgrep-cli stage above because of
 # permissions errors on the mounted volume when using instructions for running
 # semgrep with docker:
-# `docker run -v "${PWD}:/src" -i returntocorp/semgrep semgrep`
+#   `docker run -v "${PWD}:/src" -i returntocorp/semgrep semgrep`
+
 #coupling: the 'nonroot' name is used in release.jsonnet
 FROM semgrep-cli AS nonroot
 
@@ -260,46 +279,20 @@ ENV PATH="$PATH:/home/semgrep/bin"
 USER semgrep
 
 ###############################################################################
-# Other target: developer variant
-###############################################################################
-
-FROM semgrep-oss as semgrep-dev
-
-# Here we install various utilities needed by some of our bash and python
-# scripts (in scripts/). Indeed, those scripts are run from CI jobs that
-# use the returntocorp/semgrep docker image as the container, because
-# they must test semgrep, but those scripts must also perform different
-# tasks that require utilities other than semgrep (e.g., compute parsing
-# statistics and then run 'jq' to filter the JSON).
-# alt:
-#  - we used to have an alternate semgrep-dev.Dockerfile container to use
-#    for our benchmarks, but it complicates things
-#  - we used then to install those utilities as part of the semgrep-oss step.
-#    Indeed, the addition of those packages didn't add much to the size of
-#    the docker image (<1%), but those utilities can have CVEs associated
-#    with them so simpler to put them in a separate semgrep docker image
-#    to remove the attack surface of returntocorp/semgrep
-#
-# Here is why we need the apk packages below:
-# - bash: many scripts are bash scripts
-# - jq: used to filter JSON parsing statistics
-# - curl: used to upload data? also for telemetry?
-RUN apk add --no-cache bash curl jq
-
-###############################################################################
 # Other target: Build the semgrep Python wheel
 ###############################################################################
-# This is an intermediary stage used for building Python wheels. Semgrep users
+# This is a target used for building Python wheels. Semgrep users
 # don't need to use this.
+
 #coupling: 'semgrep-wheel' is used in build-test-manylinux-aarch64.jsonnet
 FROM python:3.11-alpine AS semgrep-wheel
 
 WORKDIR /semgrep
 
-# Install some deps (build-base because ruamel.yaml has native code)
-#
-# libffi-dev is needed for installing Python dependencies in
-# scripts/build-wheels.sh on arm64
+# Install some deps:
+#  - build-base because ruamel.yaml has native code
+#  - libffi-dev is needed for installing Python dependencies in
+#    scripts/build-wheels.sh on arm64
 RUN apk add --no-cache build-base zip bash libffi-dev
 
 # Copy in the CLI
@@ -313,7 +306,7 @@ COPY scripts/ ./scripts/
 
 # Build the source distribution and binary wheel, validate that the wheel
 # installs correctly. We're only checking the musllinux wheel because this is
-# an Alpine container. It shouldnt be a problem because the content of the
+# an Alpine container. It should not be a problem because the content of the
 # wheels are identical.
 RUN scripts/build-wheels.sh && scripts/validate-wheel.sh cli/dist/*musllinux*.whl
 


### PR DESCRIPTION
test plan:
make build-docker
wait for green CI checks