### PR TITLE
chore(secrets): modify secrets flags for ci and scan commands

### DIFF
--- a/changelog.d/gh-9987.changed
+++ b/changelog.d/gh-9987.changed
@@ -1,0 +1,1 @@
+The `--beta-testing-secrets-enabled` option, deprecated for several months, is now removed. Use `--secrets` as its replacement.

--- a/cli/src/semgrep/commands/ci.py
+++ b/cli/src/semgrep/commands/ci.py
@@ -142,12 +142,11 @@ def fix_head_if_github_action(metadata: GitMeta) -> None:
     is_flag=True,
 )
 @click.option("--code", is_flag=True, hidden=True)
-@click.option("--beta-testing-secrets", is_flag=True, hidden=True)
 @click.option(
     "--secrets",
     "run_secrets_flag",
     is_flag=True,
-    hidden=True,
+    help="Run Semgrep Secrets product, including support for secret validation. Requires access to Secrets, contact support@semgrep.com for more information.",
 )
 @click.option(
     "--suppress-errors/--no-suppress-errors",
@@ -168,9 +167,6 @@ def ci(
     audit_on: Sequence[str],
     autofix: bool,
     baseline_commit: Optional[str],
-    # TODO: Remove after October 2023. Left for a error message
-    # redirect to `--secrets` aka run_secrets_flag.
-    beta_testing_secrets: bool,
     historical_secrets: bool,
     internal_ci_scan_results: bool,
     code: bool,
@@ -255,10 +251,6 @@ def ci(
         scan_handler = ScanHandler(dry_run=dry_run)
     else:  # impossible state… until we break the code above
         raise RuntimeError("The token and/or config are misconfigured")
-
-    if beta_testing_secrets:
-        logger.info("Please use --secrets instead of --beta-testing-secrets")
-        sys.exit(FATAL_EXIT_CODE)
 
     metadata = generate_meta_from_environment(baseline_commit)
 

--- a/cli/src/semgrep/commands/scan.py
+++ b/cli/src/semgrep/commands/scan.py
@@ -475,11 +475,10 @@ def scan_options(func: Callable) -> Callable:
 # rely on their existence, or their output being stable
 @click.option("--dump-engine-path", is_flag=True, hidden=True)
 @click.option(
-    "--beta-testing-secrets-enabled",
+    "--secrets",
     "run_secrets_flag",
     is_flag=True,
-    hidden=True,
-    help="Contact support@semgrep.com for more informationon this.",
+    help="Run Semgrep Secrets product, including support for secret validation. Requires access to Secrets, contact support@semgrep.com for more information.",
 )
 @optgroup.group("Osemgrep migration options")
 @optgroup.option(
@@ -575,7 +574,7 @@ def scan(
     # Handled error outside engine type for more actionable advice.
     if run_secrets_flag and requested_engine is EngineType.OSS:
         abort(
-            "The flags --beta-testing-secrets-enabled and --oss-only are incompatible. Semgrep Secrets is a proprietary extension."
+            "Cannot run secrets scan with OSS engine (--oss specified). Semgrep Secrets is a proprietary extension."
         )
 
     state = get_state()

--- a/src/osemgrep/cli_ci/Ci_CLI.ml
+++ b/src/osemgrep/cli_ci/Ci_CLI.ml
@@ -83,23 +83,6 @@ let o_code : bool Term.t =
   let info = Arg.info [ "code" ] ~doc:{|Run Semgrep Code (SAST) product.|} in
   Arg.value (Arg.flag info)
 
-let o_beta_testing_secrets : bool Term.t =
-  let info =
-    Arg.info [ "beta-testing-secrets" ]
-      ~doc:{|Please use --secrets instead of --beta-testing-secrets.|}
-  in
-  Arg.value (Arg.flag info)
-
-let o_secrets : bool Term.t =
-  let info =
-    Arg.info [ "secrets" ]
-      ~doc:
-        {|Run Semgrep Secrets product, including support for secret validation.
-          Requires access to Secrets, contact support@semgrep.com for more
-          information.|}
-  in
-  Arg.value (Arg.flag info)
-
 let o_suppress_errors : bool Term.t =
   H.negatable_flag_with_env [ "suppress-errors" ]
     ~neg_options:[ "no-suppress-errors" ]
@@ -121,11 +104,10 @@ let cmdline_term caps : conf Term.t =
    * it below so we can get a nice man page documenting those environment
    * variables (Romain's idea).
    *)
-  let combine scan_conf audit_on beta_testing_secrets code dry_run
-      _internal_ci_scan_results secrets supply_chain suppress_errors _git_meta
-      _github_meta =
+  let combine scan_conf audit_on code secrets dry_run _internal_ci_scan_results
+      supply_chain suppress_errors _git_meta _github_meta =
     let products =
-      (if beta_testing_secrets || secrets then [ `Secrets ] else [])
+      (if secrets then [ `Secrets ] else [])
       @ (if code then [ `SAST ] else [])
       @ if supply_chain then [ `SCA ] else []
     in
@@ -134,9 +116,9 @@ let cmdline_term caps : conf Term.t =
   Term.(
     const combine
     $ Scan_CLI.cmdline_term caps ~allow_empty_config:true
-    $ o_audit_on $ o_beta_testing_secrets $ o_code $ o_dry_run
-    $ o_internal_ci_scan_results $ o_secrets $ o_supply_chain
-    $ o_suppress_errors $ Git_metadata.env $ Github_metadata.env)
+    $ o_audit_on $ o_code $ Scan_CLI.o_secrets $ o_dry_run
+    $ o_internal_ci_scan_results $ o_supply_chain $ o_suppress_errors
+    $ Git_metadata.env $ Github_metadata.env)
 
 let doc = "the recommended way to run semgrep in CI"
 

--- a/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -587,12 +587,11 @@ let o_junit_xml_outputs = make_o_format_outputs ~fancy:"JUnit XML" "junit-xml"
 
 let o_secrets : bool Term.t =
   let info =
-    Arg.info
-      [ "beta-testing-secrets-enabled" ]
+    Arg.info [ "secrets" ]
       ~doc:
-        {|Please use --secrets instead of --beta-testing-secrets.
-          Requires Semgrep Secrets, contact support@semgrep.com for more
-          information on this.|}
+        {|Run Semgrep Secrets product, including support for secret validation.
+          Requires access to Secrets, contact support@semgrep.com for more
+          information.|}
   in
   Arg.value (Arg.flag info)
 
@@ -1076,8 +1075,7 @@ let cmdline_term caps ~allow_empty_config : conf Term.t =
     let engine_type =
       (* This first bit just rules out mutually exclusive options. *)
       if oss && secrets then
-        Error.abort
-          "Mutually exclusive options --oss/--beta-testing-secrets-enabled";
+        Error.abort "Cannot run secrets scan with OSS engine (--oss specified).";
       if
         [ oss; pro_lang; pro_intrafile; pro ]
         |> List.filter Fun.id |> List.length > 1

--- a/src/osemgrep/cli_scan/Scan_CLI.mli
+++ b/src/osemgrep/cli_scan/Scan_CLI.mli
@@ -69,3 +69,4 @@ val o_lang : string option Cmdliner.Term.t
 val o_target_roots : string list Cmdliner.Term.t
 val o_include : string list Cmdliner.Term.t
 val o_exclude : string list Cmdliner.Term.t
+val o_secrets : bool Cmdliner.Term.t


### PR DESCRIPTION
This PR introduces some changes to secrets related CLI flags.
* `beta-testing-secrets-enabled` has been deprecated for a couple months and will now be removed. `--secrets` replaces it