### PR TITLE
Add semicolon token for variable definition in AST_generic

### DIFF
--- a/changelog.d/autofix_stmt.fixed
+++ b/changelog.d/autofix_stmt.fixed
@@ -1,0 +1,2 @@
+Autofix on variable definitions should now handle the semicolon
+in Rust, Cairo, Solidity.

--- a/languages/c/generic/c_to_generic.ml
+++ b/languages/c/generic/c_to_generic.ml
@@ -463,7 +463,7 @@ and var_decl
   let v3 = storage (snd v1) xstorage in
   let v4 = option initialiser init in
   let entity = G.basic_entity v1 ~attrs:v3 in
-  (entity, G.VarDef { G.vinit = v4; vtype = Some v2 })
+  (entity, G.VarDef { G.vinit = v4; vtype = Some v2; vtok = G.no_sc })
 
 and initialiser x =
   match x with

--- a/languages/cairo/generic/Parse_cairo_tree_sitter.ml
+++ b/languages/cairo/generic/Parse_cairo_tree_sitter.ml
@@ -19,16 +19,17 @@ module H = Parse_tree_sitter_helpers
 module H2 = AST_generic_helpers
 module G = AST_generic
 
+(*****************************************************************************)
 (* Prelude *)
 (*****************************************************************************)
 (* Cairo parser using tree-sitter-lang/semgrep-cairo and converting directly
  * to AST_generic.ml
  *
- * Cairo is a language based on Rust, therefore this transformer has been inspired
- * by the Rust transformer The code below "entry points" has been copy-pasted from
- * the Rust transformer but everything else has been rewritten to accomodate the syntax
- * and semantic of the language which differ from Rust's.
- *
+ * Cairo is a language based on Rust, therefore this transformer has been
+ * inspired by the Rust transformer The code below "entry points" has been
+ * copy-pasted from the Rust transformer but everything else has been rewritten
+ * to accomodate the syntax and semantic of the language which differ from
+ * Rust's.
  *)
 
 type mode = Pattern | Target
@@ -696,8 +697,7 @@ and map_module_declaration (env : env) (x : CST.module_declaration) :
 
 and map_const_declaration (env : env) (x : CST.const_declaration) : G.definition
     =
-  let attributes, _, name, _, ttype, _, value, _ = x in
-
+  let attributes, _, name, _, ttype, _, value, sc = x in
   let name : G.entity =
     {
       name = G.EN (H2.name_of_id (map_name env name));
@@ -705,17 +705,14 @@ and map_const_declaration (env : env) (x : CST.const_declaration) : G.definition
       tparams = None;
     }
   in
-
   let value = map_expression env value in
-
   let ttype = map_type env ttype in
-
-  (name, G.VarDef { vinit = Some value; vtype = Some ttype })
+  let sc = token env sc in
+  (name, G.VarDef { vinit = Some value; vtype = Some ttype; vtok = Some sc })
 
 and map_typealias_declaration (env : env) (x : CST.typealias_declaration) :
     G.definition =
-  let _, name, tparams, _, ttype, _ = x in
-
+  let _, name, tparams, _, ttype, sc = x in
   let name : G.entity =
     {
       name = map_name_to_entity_name env name;
@@ -723,9 +720,8 @@ and map_typealias_declaration (env : env) (x : CST.typealias_declaration) :
       tparams = Option.map (map_type_parameters env) tparams;
     }
   in
-
   let ttype = map_type env ttype in
-
+  let _sc = token env sc in
   (name, G.TypeDef { tbody = G.AliasType ttype })
 
 and map_trait_declaration (env : env) (x : CST.trait_declaration) : G.definition
@@ -803,7 +799,11 @@ and map_struct_declaration (env : env) (x : CST.struct_declaration) :
           let definition =
             ( entity,
               G.FieldDefColon
-                { vinit = None; vtype = Some (map_type env ttype) } )
+                {
+                  vinit = None;
+                  vtype = Some (map_type env ttype);
+                  vtok = G.no_sc;
+                } )
           in
 
           G.F (G.s (G.DefStmt definition))

--- a/languages/cpp/generic/cpp_to_generic.ml
+++ b/languages/cpp/generic/cpp_to_generic.ml
@@ -1425,6 +1425,7 @@ and map_decl env x : G.stmt list =
 
 and map_vars_decl env (v1, v2) : G.definition list =
   let v1 = map_of_list (map_onedecl env) v1 |> List.flatten
+  (* TODO: inject back the sc in the last decl in v1 in vtok *)
   and _v2 = map_sc env v2 in
   v1
 
@@ -1474,7 +1475,7 @@ and map_onedecl env x : G.definition list =
       let pat = G.PatTyped (pat, v1) in
       let ent = { G.name = G.EPattern pat; attrs = []; tparams = None } in
       (* TODO? use v1 for vtype? *)
-      let def = G.VarDef { G.vinit = Some v3; vtype = None } in
+      let def = G.VarDef { G.vinit = Some v3; vtype = None; vtok = G.no_sc } in
       [ (ent, def) ]
   | BitField (v1, v2, v3, v4) ->
       let v1 = map_of_option (map_ident env) v1
@@ -1499,7 +1500,7 @@ and map_var_decl env (ent, { v_init = v_v_init; v_type = v_v_type }) =
     let ent = map_entity env ent in
     let v_v_type = map_type_ env v_v_type in
     let v_v_init = map_of_option (map_init env) v_v_init in
-    (ent, { G.vtype = Some v_v_type; vinit = v_v_init })
+    (ent, { G.vtype = Some v_v_type; vinit = v_v_init; vtok = G.no_sc })
   in
   let fun_def_as_var_def_with_ctor () =
     match (v_v_init, v_v_type) with
@@ -1522,7 +1523,10 @@ and map_var_decl env (ent, { v_init = v_v_init; v_type = v_v_type }) =
         if List.length params <> List.length args then None
         else
           let v_v_init = map_init env (ObjInit (Args (p1, args, p2))) in
-          Some (ent, { G.vtype = Some v_v_type; vinit = Some v_v_init })
+          Some
+            ( ent,
+              { G.vtype = Some v_v_type; vinit = Some v_v_init; vtok = G.no_sc }
+            )
     | _ -> None
   in
   let var_def_with_ctor_as_fun_def () =
@@ -1558,7 +1562,7 @@ and map_var_decl env (ent, { v_init = v_v_init; v_type = v_v_type }) =
                     ft_requires = None;
                   } )
           in
-          Some (ent, { G.vtype = Some v_v_type; vinit = None })
+          Some (ent, { G.vtype = Some v_v_type; vinit = None; vtok = G.no_sc })
     | _ -> None
   in
   let result =

--- a/languages/dart/generic/Parse_dart_tree_sitter.ml
+++ b/languages/dart/generic/Parse_dart_tree_sitter.ml
@@ -990,9 +990,9 @@ and map_expression (env : env) (x : CST.expression) : G.expr =
 and map_expression_statement (env : env) (x : CST.expression_statement) : stmt =
   match x with
   | `Exp_semi (v1, v2) ->
-      let v1 = map_expression env v1 in
-      let v2 = map_semicolon env v2 in
-      ExprStmt (v1, v2) |> G.s
+      let e = map_expression env v1 in
+      let sc = map_semicolon env v2 in
+      ExprStmt (e, sc) |> G.s
   | `Semg_ellips tok ->
       ExprStmt (Ellipsis (* "..." *) (token env tok) |> G.e, G.sc) |> G.s
 
@@ -1362,7 +1362,8 @@ and map_initialized_variable_definition_unwrapped (env : env)
         v3
   in
   List_.map
-    (fun (id, vinit) -> (basic_entity ~attrs id, { vtype; vinit }))
+    (fun (id, vinit) ->
+      (basic_entity ~attrs id, { vtype; vinit; vtok = G.no_sc }))
     inits
 
 and map_initialized_variable_definition (env : env)
@@ -1459,13 +1460,14 @@ and map_literal (env : env) (x : CST.literal) =
       Container (Dict, (v3, v4, v5)) |> G.e
 
 and map_local_variable_declaration (env : env)
-    ((v1, v2) : CST.local_variable_declaration) =
+    ((v1, v2) : CST.local_variable_declaration) : G.stmt list =
   let v1 = map_initialized_variable_definition env v1 in
   let _v2 = map_semicolon env v2 in
   v1
 
 and map_local_variable_declaration_unwrapped (env : env)
-    ((v1, v2) : CST.local_variable_declaration) =
+    ((v1, v2) : CST.local_variable_declaration) :
+    (G.entity * G.variable_definition) list =
   let v1 = map_initialized_variable_definition_unwrapped env v1 in
   let _v2 = map_semicolon env v2 in
   v1
@@ -2050,8 +2052,8 @@ and map_statement (env : env) (x : CST.statement) : stmt list =
         | Some tok -> LId ((* pattern [a-zA-Z_$][\w$]* *) str env tok)
         | None -> LNone
       in
-      let v3 = map_semicolon env v3 in
-      [ Break (v1, v2, v3) |> G.s ]
+      let sc = map_semicolon env v3 in
+      [ Break (v1, v2, sc) |> G.s ]
   | `Cont_stmt (v1, v2, v3) ->
       let v1 = (* "continue" *) token env v1 in
       let v2 =
@@ -2059,8 +2061,8 @@ and map_statement (env : env) (x : CST.statement) : stmt list =
         | Some tok -> LId ((* pattern [a-zA-Z_$][\w$]* *) str env tok)
         | None -> LNone
       in
-      let v3 = map_semicolon env v3 in
-      [ Continue (v1, v2, v3) |> G.s ]
+      let sc = map_semicolon env v3 in
+      [ Continue (v1, v2, sc) |> G.s ]
   | `Ret_stmt (v1, v2, v3) ->
       let v1 = (* "return" *) token env v1 in
       let v2 =
@@ -2068,12 +2070,12 @@ and map_statement (env : env) (x : CST.statement) : stmt list =
         | Some x -> Some (map_expression env x)
         | None -> None
       in
-      let v3 = map_semicolon env v3 in
-      [ Return (v1, v2, v3) |> G.s ]
+      let sc = map_semicolon env v3 in
+      [ Return (v1, v2, sc) |> G.s ]
   | `Yield_stmt (v1, v2, v3) ->
       let v1 = (* "yield" *) token env v1 in
       let v2 = map_expression env v2 in
-      let _v3 = map_semicolon env v3 in
+      let _sc = map_semicolon env v3 in
       [ G.exprstmt (Yield (v1, Some v2, false) |> G.e) ]
   | `Yield_each_stmt (v1, v2, v3, v4) ->
       (* Dart docs are incredibly unhelpful on what this is.
@@ -2083,7 +2085,7 @@ and map_statement (env : env) (x : CST.statement) : stmt list =
       let v1 = (* "yield" *) token env v1 in
       let _v2 = (* "*" *) token env v2 in
       let v3 = map_expression env v3 in
-      let _v4 = map_semicolon env v4 in
+      let _sc = map_semicolon env v4 in
       [ G.exprstmt (Yield (v1, Some v3, false) |> G.e) ]
   | `Exp_stmt x -> [ map_expression_statement env x ]
   | `Assert_stmt (v1, v2) ->
@@ -2559,7 +2561,7 @@ let map_part_directive (env : env) ((v1, v2, v3, v4) : CST.part_directive) =
   in
   let v2 = (* "part" *) str env v2 in
   let v3 = map_uri env v3 in
-  let _v4 = map_semicolon env v4 in
+  let _sc = map_semicolon env v4 in
   let d = OtherDirective (v2, [ G.Modn v3 ]) |> G.d in
   DirectiveStmt { d with d_attrs = v1 } |> G.s
 
@@ -2709,7 +2711,7 @@ let map_library_name (env : env) ((v1, v2, v3, v4) : CST.library_name) : stmt =
   in
   let v2 = (* "library" *) token env v2 in
   let v3 = map_dotted_identifier_list env v3 in
-  let _v4 = map_semicolon env v4 in
+  let _sc = map_semicolon env v4 in
   let dk = Package (v2, v3) in
   DirectiveStmt { d = dk; d_attrs = v1 } |> G.s
 
@@ -2769,7 +2771,7 @@ let map_part_of_directive (env : env)
     | `Dotted_id_list x -> DottedName (map_dotted_identifier_list env x)
     | `Uri x -> map_uri env x
   in
-  let _v5 = map_semicolon env v5 in
+  let _sc = map_semicolon env v5 in
   let d = OtherDirective (v3, [ G.Modn v4 ]) |> G.d in
   DirectiveStmt { d with d_attrs = v1 } |> G.s
 
@@ -2976,12 +2978,13 @@ let map_configurable_uri (env : env) ((v1, v2) : CST.configurable_uri) :
 
 let map_mixin_application_class ~attrs ~class_tok (env : env)
     ((v1, v2, v3, v4, v5) : CST.mixin_application_class) =
-  let v1 = (* pattern [a-zA-Z_$][\w$]* *) str env v1 in
+  let id = (* pattern [a-zA-Z_$][\w$]* *) str env v1 in
   let tparams = Option.map (map_type_parameters env) v2 in
-  let _v3 = (* "=" *) token env v3 in
+  let _teq = (* "=" *) token env v3 in
   let cdef = map_mixin_application ~class_tok env v4 in
-  let _v5 = map_semicolon env v5 in
-  DefStmt (basic_entity v1 ~attrs ~tparams, cdef) |> G.s
+  (* TODO: add sc to cdef *)
+  let _sc = map_semicolon env v5 in
+  DefStmt (basic_entity id ~attrs ~tparams, cdef) |> G.s
 
 (* For use to augment the body of a function with "initializers", which are
    code that runs prior to the body of the constructor, on invocation.
@@ -3093,7 +3096,7 @@ let map_import_specification (env : env) (x : CST.import_specification) =
   | `Import_conf_uri_opt_as_id_rep_comb_semi (v1, v2, v3, v4, v5) -> (
       let v1 = (* "import" *) token env v1 in
       let uri = map_configurable_uri env v2 in
-      let v5 = map_semicolon env v5 in
+      let sc = map_semicolon env v5 in
       (* brandon: I'm not convinced it's possible to have both a package
          alias and to do selective importing.
          If it is, the package alias should be more important, anyways.
@@ -3108,7 +3111,7 @@ let map_import_specification (env : env) (x : CST.import_specification) =
           match v4 with
           | [] ->
               (* No selective imports, so remain a wildcard import. *)
-              ImportAll (v1, uri, v5)
+              ImportAll (v1, uri, sc)
           | _ ->
               (* If there are selective imports, convert to an ImportFrom. *)
               let selected = List_.map (fun id -> (id, None)) v4 in
@@ -3403,7 +3406,9 @@ let map_declaration_ ?(attrs = []) (env : env) (x : CST.declaration_) :
       let attrs = (static_attr :: new_attrs) @ attrs in
       List_.map
         (fun (id, vinit) ->
-          DefStmt (basic_entity ~attrs id, VarDef { vinit; vtype }) |> G.s)
+          DefStmt
+            (basic_entity ~attrs id, VarDef { vinit; vtype; vtok = G.no_sc })
+          |> G.s)
         inits
   | `Cova_choice_late_buil_choice_final_buil_opt_type_id_list_ (v1, v2) ->
       let cov_attr = unhandled_keywordattr ((* "covariant" *) str env v1) in
@@ -3441,7 +3446,9 @@ let map_declaration_ ?(attrs = []) (env : env) (x : CST.declaration_) :
       let attrs = (cov_attr :: new_attrs) @ attrs in
       List_.map
         (fun (id, vinit) ->
-          DefStmt (basic_entity ~attrs id, VarDef { vinit; vtype }) |> G.s)
+          DefStmt
+            (basic_entity ~attrs id, VarDef { vinit; vtype; vtok = G.no_sc })
+          |> G.s)
         inits
   | `Opt_late_buil_final_buil_opt_type_init_id_list (v1, v2, v3, v4) ->
       let v1 =
@@ -3459,7 +3466,9 @@ let map_declaration_ ?(attrs = []) (env : env) (x : CST.declaration_) :
       let inits = map_initialized_identifier_list env v4 in
       List_.map
         (fun (id, vinit) ->
-          DefStmt (basic_entity ~attrs id, VarDef { vinit; vtype }) |> G.s)
+          DefStmt
+            (basic_entity ~attrs id, VarDef { vinit; vtype; vtok = G.no_sc })
+          |> G.s)
         inits
   | `Opt_late_buil_var_or_type_init_id_list (v1, v2, v3) ->
       let attrs =
@@ -3472,7 +3481,9 @@ let map_declaration_ ?(attrs = []) (env : env) (x : CST.declaration_) :
       let inits = map_initialized_identifier_list env v3 in
       List_.map
         (fun (id, vinit) ->
-          DefStmt (basic_entity ~attrs id, VarDef { vinit; vtype = Some v2 })
+          DefStmt
+            ( basic_entity ~attrs id,
+              VarDef { vinit; vtype = Some v2; vtok = G.no_sc } )
           |> G.s)
         inits
 
@@ -3742,12 +3753,14 @@ let map_top_level_definition ~attrs (env : env) (x : CST.top_level_definition) :
         | None -> None
       in
       let v3 = map_static_final_declaration_list env v3 in
+      (* TODO: inject it at least in the last decl in v3? *)
       let _v4 = map_semicolon env v4 in
-      List_.map
-        (fun (id, expr) ->
-          G.DefStmt (basic_entity ~attrs id, VarDef { vinit = Some expr; vtype })
-          |> G.s)
-        v3
+      v3
+      |> List_.map (fun (id, expr) ->
+             G.DefStmt
+               ( basic_entity ~attrs id,
+                 VarDef { vinit = Some expr; vtype; vtok = G.no_sc } )
+             |> G.s)
   | `Late_buil_final_buil_opt_type_init_id_list_semi (v1, v2, v3, v4, v5) ->
       let attrs =
         let v1 = G.unhandled_keywordattr ((* "late" *) str env v1) in
@@ -3759,12 +3772,12 @@ let map_top_level_definition ~attrs (env : env) (x : CST.top_level_definition) :
         | Some x -> Some (map_type_ env x)
         | None -> None
       in
-      let v4 = map_initialized_identifier_list env v4 in
-      let _v5 = map_semicolon env v5 in
-      List_.map
-        (fun (id, vinit) ->
-          G.DefStmt (basic_entity ~attrs id, VarDef { vinit; vtype }) |> G.s)
-        v4
+      let inits = map_initialized_identifier_list env v4 in
+      let sc = map_semicolon env v5 in
+      inits
+      |> List_.map (fun (id, vinit) ->
+             (basic_entity ~attrs id, { vinit; vtype; vtok = G.no_sc }))
+      |> H2.add_semicolon_to_last_var_def_and_convert_to_stmts sc
   | `Opt_late_buil_choice_type_init_id_list_semi (v1, v2, v3, v4) ->
       let attrs =
         match v1 with
@@ -3773,14 +3786,13 @@ let map_top_level_definition ~attrs (env : env) (x : CST.top_level_definition) :
         | None -> attrs
       in
       let vtype = map_var_or_type env v2 in
-      let v3 = map_initialized_identifier_list env v3 in
-      let _v4 = map_semicolon env v4 in
-      List_.map
-        (fun (id, vinit) ->
-          G.DefStmt
-            (basic_entity ~attrs id, VarDef { vinit; vtype = Some vtype })
-          |> G.s)
-        v3
+      let inits = map_initialized_identifier_list env v3 in
+      let sc = map_semicolon env v4 in
+      inits
+      |> List_.map (fun (id, vinit) ->
+             ( basic_entity ~attrs id,
+               { vinit; vtype = Some vtype; vtok = G.no_sc } ))
+      |> H2.add_semicolon_to_last_var_def_and_convert_to_stmts sc
 
 let map_program (env : env) (prog : CST.program) =
   match prog with

--- a/languages/dockerfile/generic/Dockerfile_to_generic.ml
+++ b/languages/dockerfile/generic/Dockerfile_to_generic.ml
@@ -326,7 +326,7 @@ let env_decl pairs =
     pairs
     |> List_.map (function
          | Label_semgrep_ellipsis tok ->
-             G.ExprStmt (G.Ellipsis tok |> G.e, Tok.unsafe_sc) |> G.s
+             G.ExprStmt (G.Ellipsis tok |> G.e, G.sc) |> G.s
          | Label_pair (_loc, key, _eq, value) -> (
              match key with
              | Var_ident v
@@ -334,7 +334,11 @@ let env_decl pairs =
                  let entity = G.basic_entity v in
                  let vardef =
                    G.VarDef
-                     { vinit = Some (docker_string_expr value); vtype = None }
+                     {
+                       vinit = Some (docker_string_expr value);
+                       vtype = None;
+                       vtok = G.no_sc;
+                     }
                  in
                  G.DefStmt (entity, vardef) |> G.s))
   in

--- a/languages/go/generic/go_to_generic.ml
+++ b/languages/go/generic/go_to_generic.ml
@@ -607,13 +607,15 @@ let top_func () =
         let ent =
           G.basic_entity v1 ~attrs:[ G.attr G.Const (fake (snd v1) "const") ]
         in
-        G.DefStmt (ent, G.VarDef { G.vinit = v3; vtype = v2 }) |> G.s
+        G.DefStmt (ent, G.VarDef { G.vinit = v3; vtype = v2; vtok = G.no_sc })
+        |> G.s
     | DVar (v1, v2, v3) ->
         let v1 = ident v1 and v2 = option type_ v2 and v3 = option expr v3 in
         let ent =
           G.basic_entity v1 ~attrs:[ G.attr G.Var (fake (snd v1) "var") ]
         in
-        G.DefStmt (ent, G.VarDef { G.vinit = v3; vtype = v2 }) |> G.s
+        G.DefStmt (ent, G.VarDef { G.vinit = v3; vtype = v2; vtok = G.no_sc })
+        |> G.s
     | DTypeAlias (v1, v2, v3) ->
         let v1 = ident v1 and _v2 = tok v2 and v3 = type_ v3 in
         let ent = G.basic_entity v1 in

--- a/languages/java/ast/ast_java.ml
+++ b/languages/java/ast/ast_java.ml
@@ -13,7 +13,7 @@
  *
  * Extended by Yoann Padioleau to support more recent versions of Java.
  * Copyright (C) 2011 Facebook
- * Copyright (C) 2020-2022 r2c
+ * Copyright (C) 2020-2024 Semgrep Inc.
  *)
 
 (*****************************************************************************)
@@ -320,6 +320,8 @@ and entity = {
 (* variable (local var, parameter) declaration *)
 (* ------------------------------------------------------------------------- *)
 and var_definition = entity
+
+(* TODO: add semicolon *)
 and vars = var_definition list
 
 (* less: could be merged with var *)

--- a/languages/java/generic/java_to_generic.ml
+++ b/languages/java/generic/java_to_generic.ml
@@ -1,6 +1,6 @@
 (* Yoann Padioleau
  *
- * Copyright (C) 2019 r2c
+ * Copyright (C) 2019 Semgrep Inc.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
@@ -575,7 +575,7 @@ and catches v = list catch v
 and var_with_init { f_var; f_init } =
   let ent, t = var f_var in
   let init = option init f_init in
-  (ent, { G.vinit = init; vtype = t })
+  (ent, { G.vinit = init; vtype = t; vtok = G.no_sc })
 
 and init = function
   | ExprInit v1 ->
@@ -791,7 +791,7 @@ let any = function
       G.T v1
   | AVar v1 ->
       let ent, t = var v1 in
-      G.Def (ent, G.VarDef { G.vtype = t; vinit = None })
+      G.Def (ent, G.VarDef { G.vtype = t; vinit = None; vtok = G.no_sc })
   | AInit v1 ->
       let v1 = init v1 in
       G.E v1

--- a/languages/javascript/generic/js_to_generic.ml
+++ b/languages/javascript/generic/js_to_generic.ml
@@ -533,7 +533,7 @@ and definition (ent, def) =
       let ty = option type_ ty in
       let v3 = option expr x_init in
       ( { ent with G.attrs = v2 :: ent.G.attrs },
-        G.VarDef { G.vinit = v3; G.vtype = ty } )
+        G.VarDef { G.vinit = v3; vtype = ty; vtok = G.no_sc } )
   | FuncDef def ->
       let def, more_attrs = fun_ def in
       ({ ent with G.attrs = ent.G.attrs @ more_attrs }, G.FuncDef def)
@@ -552,7 +552,7 @@ and var_of_var
   let ent = G.basic_entity v1 ~attrs:(v2 :: attrs) in
   let v3 = option expr x_init in
   let v_type = option type_ v_type in
-  (ent, { G.vinit = v3; vtype = v_type })
+  (ent, { G.vinit = v3; vtype = v_type; vtok = G.no_sc })
 
 and var_kind (x, tok) =
   match x with
@@ -681,7 +681,7 @@ and field_classic
         G.FuncDef { def with G.fkind = (fkind, tok) } )
   | _ ->
       let v3 = option expr v3 in
-      (ent, G.VarDef { G.vinit = v3; vtype = vt })
+      (ent, G.VarDef { G.vinit = v3; vtype = vt; vtok = G.no_sc })
 
 and property x =
   match x with

--- a/languages/jsonnet/generic/Jsonnet_to_generic.ml
+++ b/languages/jsonnet/generic/Jsonnet_to_generic.ml
@@ -295,7 +295,7 @@ and map_bind env v : G.definition =
       let _teq = map_tok env v2 in
       let e = map_expr env v3 in
       let ent = G.basic_entity id in
-      let def = G.VarDef { G.vinit = Some e; vtype = None } in
+      let def = G.VarDef { G.vinit = Some e; vtype = None; vtok = G.no_sc } in
       (ent, def)
 
 and map_function_definition env v : G.function_definition =
@@ -358,7 +358,9 @@ and map_field env v : G.definition =
   let fld_value = map_expr env fld_value in
   let ent = { G.name = entname; tparams = None; attrs = [] } in
   (* alt? FldDefColon? *)
-  let def = G.VarDef { G.vinit = Some fld_value; vtype = None } in
+  let def =
+    G.VarDef { G.vinit = Some fld_value; vtype = None; vtok = G.no_sc }
+  in
   (ent, def)
 
 and map_field_name env v : G.entity_name =
@@ -401,7 +403,7 @@ and map_obj_comprehension env v =
     let e = map_expr env v3 in
     let entname = G.EDynamic e1 in
     let ent = { G.name = entname; tparams = None; attrs = [] } in
-    let def = G.VarDef { G.vinit = Some e; vtype = None } in
+    let def = G.VarDef { G.vinit = Some e; vtype = None; vtok = G.no_sc } in
     (ent, def)
   in
   let def, for_if_comps = (map_comprehension2 map_tuple) env oc_comp in

--- a/languages/julia/generic/Parse_julia_tree_sitter.ml
+++ b/languages/julia/generic/Parse_julia_tree_sitter.ml
@@ -359,23 +359,20 @@ and map_multi_assign ?(attrs = []) (env : env) x =
       let l_exp, _, r_exp = map_assignment env x in
       DefStmt
         ( { name = EDynamic l_exp; attrs; tparams = None },
-          VarDef { vinit = Some r_exp; vtype = None } )
+          VarDef { vinit = Some r_exp; vtype = None; vtok = G.no_sc } )
       |> G.s
   | `Id tok ->
       let id = map_identifier env tok in
-      DefStmt (basic_entity ~attrs id, VarDef { vinit = None; vtype = None })
-      |> G.s
+      DefStmt (basic_entity ~attrs id, VarDef G.empty_var) |> G.s
   | `Typed_exp x ->
       let l_exp, _, ty = map_typed_expression env x in
       DefStmt
         ( { name = EDynamic l_exp; attrs; tparams = None },
-          VarDef { vinit = None; vtype = Some ty } )
+          VarDef { vinit = None; vtype = Some ty; vtok = G.no_sc } )
       |> G.s
   | `Bare_tuple x ->
       let e = map_bare_tuple_exp env x in
-      DefStmt
-        ( { name = EDynamic e; attrs; tparams = None },
-          VarDef { vinit = None; vtype = None } )
+      DefStmt ({ name = EDynamic e; attrs; tparams = None }, VarDef G.empty_var)
       |> G.s
   | `Func_defi x -> map_function_definition env x
   | `Short_func_defi x -> map_short_function_definition env x
@@ -597,7 +594,7 @@ and map_anon_choice_id_c313bb1 (env : env) (x : CST.anon_choice_id_c313bb1) =
   | `Id tok ->
       let id = map_identifier env tok in
       let ent = basic_entity id in
-      DefStmt (ent, VarDef { vinit = None; vtype = None }) |> G.s
+      DefStmt (ent, VarDef G.empty_var) |> G.s
   | `Named_field x ->
       let either, _tok, exp = map_named_field env x in
       let ent =
@@ -605,7 +602,8 @@ and map_anon_choice_id_c313bb1 (env : env) (x : CST.anon_choice_id_c313bb1) =
         | Left id -> basic_entity id
         | Right e -> { name = EDynamic e; attrs = []; tparams = None }
       in
-      DefStmt (ent, VarDef { vinit = Some exp; vtype = None }) |> G.s
+      DefStmt (ent, VarDef { vinit = Some exp; vtype = None; vtok = G.no_sc })
+      |> G.s
 
 and map_anon_choice_id_f1f5a37 (env : env) (x : CST.anon_choice_id_f1f5a37) =
   match x with
@@ -2189,22 +2187,19 @@ and map_statement (env : env) (x : CST.statement) : stmt list =
               [
                 DefStmt
                   ( { name = EDynamic l_exp; attrs; tparams = None },
-                    VarDef { vinit = Some r_exp; vtype = None } )
+                    VarDef { vinit = Some r_exp; vtype = None; vtok = G.no_sc }
+                  )
                 |> G.s;
               ]
           | `Id tok ->
               let id = map_identifier env tok in
-              [
-                DefStmt
-                  (basic_entity ~attrs id, VarDef { vinit = None; vtype = None })
-                |> G.s;
-              ]
+              [ DefStmt (basic_entity ~attrs id, VarDef G.empty_var) |> G.s ]
           | `Typed_exp x ->
               let l_exp, _, ty = map_typed_expression env x in
               [
                 DefStmt
                   ( { name = EDynamic l_exp; attrs; tparams = None },
-                    VarDef { vinit = None; vtype = Some ty } )
+                    VarDef { vinit = None; vtype = Some ty; vtok = G.no_sc } )
                 |> G.s;
               ])
       | `Local_stmt (v1, v2) ->

--- a/languages/kotlin/generic/Parse_kotlin_tree_sitter.ml
+++ b/languages/kotlin/generic/Parse_kotlin_tree_sitter.ml
@@ -1,7 +1,7 @@
 (* Colleen Dai
  * Yoann Padioleau
  *
- * Copyright (c) 2021, 2022 R2C
+ * Copyright (c) 2021, 2022 Semgrep Inc.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
@@ -76,21 +76,18 @@ let equality_operator (env : env) (x : CST.equality_operator) =
   | `BANGEQEQ tok -> (NotPhysEq, token env tok) (* "!==" *)
   | `EQEQ tok -> (Eq, token env tok) (* "==" *)
   | `EQEQEQ tok -> (PhysEq, token env tok)
-
 (* "===" *)
 
 let anon_choice_val_2833752 (env : env) (x : CST.anon_choice_val_2833752) =
   match x with
   | `Val tok -> (Const, token env tok) (* "val" *)
   | `Var tok -> (Mutable, token env tok)
-
 (* "var" *)
 
 let platform_modifier (env : env) (x : CST.platform_modifier) =
   match x with
   | `Expect tok -> G.unhandled_keywordattr (str env tok) (* "expect" *)
   | `Actual tok -> G.unhandled_keywordattr (str env tok)
-
 (* "actual" *)
 
 let real_literal (env : env) (tok : CST.real_literal) =
@@ -104,7 +101,6 @@ let comparison_operator (env : env) (x : CST.comparison_operator) =
   | `GT tok -> (Gt, token env tok) (* ">" *)
   | `LTEQ tok -> (LtE, token env tok) (* "<=" *)
   | `GTEQ tok -> (GtE, token env tok)
-
 (* ">=" *)
 
 let assignment_and_operator (env : env) (x : CST.assignment_and_operator) =
@@ -114,7 +110,6 @@ let assignment_and_operator (env : env) (x : CST.assignment_and_operator) =
   | `STAREQ tok -> (Mult, token env tok) (* "*=" *)
   | `SLASHEQ tok -> (Div, token env tok) (* "/=" *)
   | `PERCEQ tok -> (Mod, token env tok)
-
 (* "%=" *)
 
 let inheritance_modifier (env : env) (x : CST.inheritance_modifier) =
@@ -122,7 +117,6 @@ let inheritance_modifier (env : env) (x : CST.inheritance_modifier) =
   | `Abst tok -> KeywordAttr (Abstract, token env tok) (* "abstract" *)
   | `Final tok -> KeywordAttr (Final, token env tok) (* "final" *)
   | `Open tok -> G.unhandled_keywordattr (str env tok)
-
 (* "open" *)
 
 let postfix_unary_operator (env : env) (x : CST.postfix_unary_operator) =
@@ -999,7 +993,7 @@ and declaration (env : env) (x : CST.declaration) : definition =
         | Some x -> type_constraints env x
         | None -> []
       in
-      let v7 =
+      let vinit =
         match v7 with
         | Some x -> (
             match x with
@@ -1010,7 +1004,7 @@ and declaration (env : env) (x : CST.declaration) : definition =
             | `Prop_dele x -> property_delegate env x)
         | None -> None
       in
-      let _v8 =
+      let vtok =
         match v8 with
         | Some tok -> (* ";" *) Some (token env tok)
         | None -> None
@@ -1030,7 +1024,7 @@ and declaration (env : env) (x : CST.declaration) : definition =
                 Some (Either.Right x)
             | None -> None)
       in
-      let vdef = { vinit = v7; vtype = typopt } in
+      let vdef = { vinit; vtype = typopt; vtok } in
       let ent = { name = entname; attrs = v2 :: v1; tparams = v3 } in
       (ent, VarDef vdef)
   | `Type_alias (v0, v1, v2, v3, v4, v5) ->

--- a/languages/lua/generic/Parse_lua_tree_sitter.ml
+++ b/languages/lua/generic/Parse_lua_tree_sitter.ml
@@ -60,10 +60,10 @@ let mk_vars xs ys =
   let rec aux xs ys =
     match (xs, ys) with
     | [], [] -> []
-    | x :: xs, [] ->
-        (x, G.VarDef { G.vinit = None; G.vtype = None }) :: aux xs ys
+    | x :: xs, [] -> (x, G.VarDef G.empty_var) :: aux xs ys
     | x :: xs, y :: ys ->
-        (x, G.VarDef { G.vinit = Some y; G.vtype = None }) :: aux xs ys
+        (x, G.VarDef { G.vinit = Some y; vtype = None; vtok = G.no_sc })
+        :: aux xs ys
     | [], _y :: _ys -> []
   in
   aux xs ys
@@ -549,7 +549,7 @@ and map_loop_expression (env : env)
   let v1 = identifier env v1 (* pattern [a-zA-Z_][a-zA-Z0-9_]* *) in
   let _v2 = token env v2 (* "=" *) in
   let _v3 = map_expression env v3 in
-  let var : G.variable_definition = { vinit = None; vtype = None } in
+  let var : G.variable_definition = G.empty_var in
   let for_init_var = G.ForInitVar (G.basic_entity v1, var) in
   let _v4 = token env v4 (* "," *) in
   let v5 = map_expression env v5 in

--- a/languages/php/ast/cst_php.ml
+++ b/languages/php/ast/cst_php.ml
@@ -1,7 +1,7 @@
 (* Yoann Padioleau
  *
  * Copyright (C) 2009-2013 Facebook
- * Copyright (C) 2020 R2C
+ * Copyright (C) 2020 Semgrep Inc.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License

--- a/languages/php/generic/php_to_generic.ml
+++ b/languages/php/generic/php_to_generic.ml
@@ -1,6 +1,6 @@
 (* Yoann Padioleau
  *
- * Copyright (C) 2020 r2c
+ * Copyright (C) 2020 Semgrep Inc.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
@@ -193,7 +193,7 @@ let rec stmt_aux = function
              let v1 = var v1 and v2 = option expr v2 in
              let attrs = [ G.KeywordAttr (G.Static, t) ] in
              let ent = G.basic_entity v1 ~case_insensitive:false ~attrs in
-             let def = { G.vinit = v2; vtype = None } in
+             let def = { G.vinit = v2; vtype = None; vtok = G.no_sc } in
              G.DefStmt (ent, G.VarDef def) |> G.s)
   | Global (t, v1) ->
       v1
@@ -609,7 +609,7 @@ and constant_def { cst_name; cst_body; cst_tok = tok } =
   let body = expr cst_body in
   let attr = [ G.KeywordAttr (G.Const, tok) ] in
   let ent = G.basic_entity id ~case_insensitive:false ~attrs:attr in
-  (ent, { G.vinit = Some body; vtype = None })
+  (ent, { G.vinit = Some body; vtype = None; vtok = G.no_sc })
 
 and enum_type _tok { e_base; e_constraint } =
   let t = hint_type e_base in
@@ -698,7 +698,7 @@ and class_var
     list modifier cmodifiers |> List_.map (fun m -> G.KeywordAttr m)
   in
   let ent = G.basic_entity id ~case_insensitive:false ~attrs:modifiers in
-  let def = { G.vtype = typ; vinit = value } in
+  let def = { G.vtype = typ; vinit = value; vtok = G.no_sc } in
   (ent, def)
 
 and method_def v = func_def v

--- a/languages/python/generic/Python_to_generic.ml
+++ b/languages/python/generic/Python_to_generic.ml
@@ -552,7 +552,7 @@ and fieldstmt x =
    G.s = G.ExprStmt ({ e = G.Assign ({ e = G.N name; _ }, _teq, e); _ }, _sc);
    _;
   } ->
-      let vdef = { G.vinit = Some e; vtype = None } in
+      let vdef = { G.vinit = Some e; vtype = None; vtok = G.no_sc } in
       let ent = { G.name = G.EN name; attrs = []; tparams = None } in
       G.fld (ent, G.VarDef vdef)
   | _ -> G.F x
@@ -693,7 +693,9 @@ and stmt_aux env x =
             let ent =
               { G.name = G.EN (G.Id (id, idinfo)); attrs = []; tparams = None }
             in
-            let var = G.VarDef { G.vinit = Some v3; vtype = topt } in
+            let var =
+              G.VarDef { G.vinit = Some v3; vtype = topt; vtok = G.no_sc }
+            in
             [ G.DefStmt (ent, var) |> G.s ]
           in
           let default_res = [ G.exprstmt (G.Assign (a, v2, v3) |> G.e) ] in
@@ -748,7 +750,7 @@ and stmt_aux env x =
       let id = name env id in
       let ty = type_ env ty in
       let ent = G.basic_entity id in
-      let def = G.VarDef { G.vtype = Some ty; vinit = None } in
+      let def = G.VarDef { G.vtype = Some ty; vinit = None; vtok = G.no_sc } in
       [ G.DefStmt (ent, def) |> G.s ]
   | Cast (e, tok, ty) ->
       [ G.exprstmt (G.Cast (type_ env ty, info tok, expr env e) |> G.e) ]

--- a/languages/rust/generic/Parse_rust_tree_sitter.ml
+++ b/languages/rust/generic/Parse_rust_tree_sitter.ml
@@ -1216,11 +1216,11 @@ and map_const_block (env : env) ((v1, v2) : CST.const_block) : G.expr =
 and map_const_item (env : env) outer_attrs
     ((_v0TODO, v1, v2, v3, v4, v5, v6) : CST.const_item) : G.stmt =
   (* TODO v0 optional visibility modif *)
-  let const = token env v1 (* "const" *) in
-  let attrs = G.KeywordAttr (G.Const, const) :: outer_attrs in
-  let ident = ident env v2 in
+  let tconst = token env v1 (* "const" *) in
+  let attrs = G.KeywordAttr (G.Const, tconst) :: outer_attrs in
+  let id = ident env v2 in
   (* pattern (r#)?[a-zA-Zα-ωΑ-Ωµ_][a-zA-Zα-ωΑ-Ωµ\d_]* *)
-  let _colon = token env v3 (* ":" *) in
+  let _tcolon = token env v3 (* ":" *) in
   let type_ = map_type_ env v4 in
   let init =
     Option.map
@@ -1230,14 +1230,10 @@ and map_const_item (env : env) outer_attrs
         expr)
       v5
   in
-  let _semicolon = token env v6 (* ";" *) in
-  let var_def = { G.vinit = init; G.vtype = Some type_ } in
+  let sc = token env v6 (* ";" *) in
+  let var_def = { G.vinit = init; G.vtype = Some type_; vtok = Some sc } in
   let ent =
-    {
-      G.name = G.EN (G.Id (ident, G.empty_id_info ()));
-      G.attrs;
-      G.tparams = None;
-    }
+    { G.name = G.EN (G.Id (id, G.empty_id_info ())); G.attrs; G.tparams = None }
   in
   G.DefStmt (ent, G.VarDef var_def) |> G.s
 
@@ -1777,7 +1773,7 @@ and map_field_declaration (env : env) (x : CST.field_declaration) : G.field =
       (* pattern (r#)?[a-zA-Zα-ωΑ-Ωµ_][a-zA-Zα-ωΑ-Ωµ\d_]* *)
       let _colon = token env v3 (* ":" *) in
       let ty = map_type_ env v4 in
-      let var_def = { G.vinit = None; G.vtype = Some ty } in
+      let var_def = { G.vinit = None; G.vtype = Some ty; vtok = G.no_sc } in
       let ent =
         {
           G.name = G.EN (G.Id (ident, G.empty_id_info ()));
@@ -2315,7 +2311,7 @@ and map_declaration_list env (v1, v2, v3) : G.stmt list G.bracket =
 
 and map_ordered_field (_env : env) _outer_attrsTODO
     (_attrsTODO : G.attribute list) (type_ : G.type_) (index : int) : G.field =
-  let var_def = { G.vinit = None; G.vtype = Some type_ } in
+  let var_def = { G.vinit = None; G.vtype = Some type_; vtok = G.no_sc } in
   let ent =
     {
       G.name = G.EDynamic (G.L (G.Int (Parsed_int.of_int index)) |> G.e);
@@ -3208,8 +3204,8 @@ and map_declaration_statement_bis (env : env) outer_attrs (*_visibility*) x :
             ()
         | None -> ()
       in
-      let _semicolon = token env v7 (* ";" *) in
-      let var_def = { G.vinit = expr; G.vtype = type_ } in
+      let sc = token env v7 (* ";" *) in
+      let var_def = { G.vinit = expr; G.vtype = type_; vtok = Some sc } in
       let ent =
         {
           (* Patterns are difficult to convert to expressions, so wrap it *)
@@ -3561,8 +3557,8 @@ and map_declaration_statement_bis (env : env) outer_attrs (*_visibility*) x :
             expr)
           v7
       in
-      let _semicolon = token env v8 (* ";" *) in
-      let var_def = { G.vinit = init; G.vtype = Some type_ } in
+      let sc = token env v8 (* ";" *) in
+      let var_def = { G.vinit = init; G.vtype = Some type_; vtok = Some sc } in
       let ent =
         {
           G.name = G.EN (G.Id (ident, G.empty_id_info ()));

--- a/languages/scala/generic/scala_to_generic.ml
+++ b/languages/scala/generic/scala_to_generic.ml
@@ -1022,14 +1022,14 @@ and v_variable_definitions
          | PatVarid id
          | PatName (Id id, []) ->
              let ent = G.basic_entity id ~attrs in
-             let vdef = { G.vinit = eopt; vtype = topt } in
+             let vdef = { G.vinit = eopt; vtype = topt; vtok = G.no_sc } in
              Some (ent, G.VarDef vdef)
          | _ ->
              (* TODO: some patterns may have tparams? *)
              let ent =
                { G.name = EPattern (v_pattern pat); attrs; tparams = None }
              in
-             let vdef = { G.vinit = eopt; vtype = topt } in
+             let vdef = { G.vinit = eopt; vtype = topt; vtok = G.no_sc } in
              Some (ent, G.VarDef vdef))
 
 and v_entity { name = v_name; attrs = v_attrs; tparams = v_tparams } =

--- a/languages/solidity/generic/Parse_solidity_tree_sitter.ml
+++ b/languages/solidity/generic/Parse_solidity_tree_sitter.ml
@@ -1,6 +1,6 @@
 (* Yoann Padioleau
  *
- * Copyright (c) 2021-2022 R2C
+ * Copyright (c) 2021-2022 Semgrep Inc.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
@@ -866,7 +866,7 @@ let map_yul_variable_declaration (env : env) (x : CST.yul_variable_declaration)
         | None -> None
       in
       let ent = G.basic_entity id in
-      let vdef = { vinit = eopt; vtype = None } in
+      let vdef = { vinit = eopt; vtype = None; vtok = None } in
       (ent, VarDef vdef)
   | `Let_choice_yul_id_rep_COMMA_yul_id_opt_COMMA_opt_COLONEQ_yul_func_call
       (v1, v2, v3) ->
@@ -905,7 +905,7 @@ let map_yul_variable_declaration (env : env) (x : CST.yul_variable_declaration)
         |> G.p
       in
       let ent = { name = EPattern pat; attrs = []; tparams = None } in
-      let def = { vinit = eopt; vtype = None } in
+      let def = { vinit = eopt; vtype = None; vtok = G.no_sc } in
       (ent, VarDef def)
 
 let map_yul_assignment_operator (env : env) (x : CST.yul_assignment_operator) =
@@ -1713,9 +1713,9 @@ let map_state_variable_declaration (env : env)
         Some v2
     | None -> None
   in
-  let _sc = (* ";" *) token env v5 in
+  let sc = (* ";" *) token env v5 in
   let ent = G.basic_entity ~attrs id in
-  let def = { vinit; vtype = Some ty } in
+  let def = { vinit; vtype = Some ty; vtok = Some sc } in
   (ent, VarDef def)
 
 let map_modifier_invocation (env : env) ((v1, v2) : CST.modifier_invocation) :
@@ -1964,14 +1964,14 @@ let map_variable_declaration_statement (env : env)
           | None -> None
         in
         let ent = G.basic_entity id ~attrs in
-        let vdef = { vinit; vtype = Some ty } in
+        let vdef = { vinit; vtype = Some ty; vtok = G.no_sc } in
         (ent, vdef)
     | `Var_decl_tuple_EQ_exp (v1, v2, v3) ->
         let pat = map_variable_declaration_tuple env v1 in
         let _teq = (* "=" *) token env v2 in
         let e = map_expression env v3 in
         let ent = { name = EPattern pat; attrs = []; tparams = None } in
-        let vdef = { vinit = Some e; vtype = None } in
+        let vdef = { vinit = Some e; vtype = None; vtok = G.no_sc } in
         (ent, vdef)
   in
   let _sc = (* ";" *) token env v2 in
@@ -2452,10 +2452,10 @@ let map_declaration (env : env) (x : CST.declaration) : definition =
       let id = (* pattern [a-zA-Z$_][a-zA-Z0-9$_]* *) str env v3 in
       let _teq = (* "=" *) token env v4 in
       let e = map_expression env v5 in
-      let _sc = (* ";" *) token env v6 in
+      let sc = (* ";" *) token env v6 in
       let attr = G.attr Const tconst in
       let ent = G.basic_entity id ~attrs:[ attr ] in
-      let def = { vtype = Some ty; vinit = Some e } in
+      let def = { vtype = Some ty; vinit = Some e; vtok = Some sc } in
       (ent, VarDef def)
   | `User_defi_type_defi x -> map_user_defined_type_definition env x
   | `Error_decl x -> map_error_declaration env x

--- a/languages/swift/generic/Parse_swift_tree_sitter.ml
+++ b/languages/swift/generic/Parse_swift_tree_sitter.ml
@@ -757,7 +757,10 @@ and map_enum_entry_suffix (env : env) (ent : G.entity)
               in
               let ty = map_type_ env ty in
               let ent = { G.name; attrs = []; tparams = None } in
-              G.DefStmt (ent, G.FieldDefColon { vinit = None; vtype = Some ty })
+              G.DefStmt
+                ( ent,
+                  G.FieldDefColon
+                    { vinit = None; vtype = Some ty; vtok = G.no_sc } )
             in
             let field_first = mk_field v1 v2 v3 in
             let field_rest =
@@ -2162,7 +2165,8 @@ and map_single_modifierless_property_declaration (env : env)
            in
            x)
   in
-  G.DefStmt (entity, G.VarDef { vinit = init; vtype = tannot }) |> G.s
+  G.DefStmt (entity, G.VarDef { vinit = init; vtype = tannot; vtok = G.no_sc })
+  |> G.s
 
 and map_modifierless_property_declaration (env : env) (attrs : G.attribute list)
     ((v1, v2, v3) : CST.modifierless_property_declaration) : G.stmt list =
@@ -2551,7 +2555,8 @@ and map_protocol_member_declaration (env : env)
       let _v5TODO = map_protocol_property_requirements env v5 in
       (* TODO desugar PatID? *)
       let stmt =
-        G.DefStmt (entity, G.VarDef { vinit = None; vtype = v3 }) |> G.s
+        G.DefStmt (entity, G.VarDef { vinit = None; vtype = v3; vtok = G.no_sc })
+        |> G.s
       in
       G.F stmt
   | `Typeas_decl x -> G.F (map_typealias_declaration env x)
@@ -2890,7 +2895,9 @@ and map_tuple_type_item (env : env) ((v1, v2, v3) : CST.tuple_type_item) =
   in
   let _v2TODO = map_parameter_modifiers_opt env v2 in
   let v3 = map_type_ env v3 in
-  G.DefStmt (ent, G.FieldDefColon { vinit = None; vtype = Some v3 }) |> G.s
+  G.DefStmt
+    (ent, G.FieldDefColon { vinit = None; vtype = Some v3; vtok = G.no_sc })
+  |> G.s
 
 and map_type_ (env : env) (x : CST.type_) : G.type_ =
   match x with

--- a/languages/terraform/generic/Terraform_to_generic.ml
+++ b/languages/terraform/generic/Terraform_to_generic.ml
@@ -30,7 +30,7 @@ let fb = Tok.unsafe_fake_bracket
 let map_argument (arg : argument) : G.definition =
   let id, _teq, e = arg in
   let ent = G.basic_entity id in
-  let def = { G.vinit = Some e; vtype = None } in
+  let def = { G.vinit = Some e; vtype = None; vtok = G.no_sc } in
   (ent, G.VarDef def)
 
 (* We convert to a field, to be similar to Parse_terraform_xxx.map_object,

--- a/languages/terraform/tree-sitter/Parse_terraform_tree_sitter.ml
+++ b/languages/terraform/tree-sitter/Parse_terraform_tree_sitter.ml
@@ -451,7 +451,7 @@ and map_object_elem (env : env) (x : CST.object_elem) : G.field =
         | _ -> G.EDynamic v1
       in
       let ent = { G.name = n_or_dyn; attrs = []; tparams = None } in
-      let vdef = { G.vinit = Some v3; vtype = None } in
+      let vdef = { G.vinit = Some v3; vtype = None; vtok = G.no_sc } in
       let def =
         match v2 with
         | Left _teq -> G.VarDef vdef

--- a/languages/tree-sitter-to-generic/Parse_hack_tree_sitter.ml
+++ b/languages/tree-sitter-to-generic/Parse_hack_tree_sitter.ml
@@ -564,6 +564,7 @@ and shape_field_specifier (env : env) (x : CST.anon_choice_field_spec_0e0e023) =
           (* Note: This could never exist. Am I using the wrong type here? *)
           vinit = None;
           vtype = Some v4;
+          vtok = G.no_sc;
         }
       in
       G.DefStmt (ent, FieldDefColon def)
@@ -1025,7 +1026,7 @@ and class_const_declarator (env : env) ((v1, v2) : CST.class_const_declarator)
     | None -> None
   in
   let ent = G.basic_entity v1 ~attrs in
-  let def : G.variable_definition = { vinit = v2; vtype } in
+  let def : G.variable_definition = { vinit = v2; vtype; vtok = G.no_sc } in
   G.DefStmt (ent, G.VarDef def) |> G.s
 
 and compound_statement (env : env) ((v1, v2, v3) : CST.compound_statement) :
@@ -1040,7 +1041,8 @@ and const_declarator (env : env) ((v1, v2, v3) : CST.const_declarator) attrs
   let v1 = const_declarator_id env v1 in
   let _v2 = (* "=" *) token env v2 in
   let v3 = expression env v3 in
-  G.DefStmt (G.basic_entity v1 ~attrs, VarDef { vinit = Some v3; vtype })
+  G.DefStmt
+    (G.basic_entity v1 ~attrs, VarDef { vinit = Some v3; vtype; vtok = G.no_sc })
 
 and declaration (env : env) (x : CST.declaration) =
   match x with
@@ -1681,6 +1683,7 @@ and field_initializer (env : env) ((v1, v2, v3) : CST.field_initializer) =
       vtype = None;
       (* Do we want to represent that this must be a string? *)
       vinit = Some v3;
+      vtok = G.no_sc;
     }
   in
   G.DefStmt (v1, FieldDefColon def)
@@ -1995,7 +1998,7 @@ and property_declarator (env : env) ((v1, v2) : CST.property_declarator) attrs
     | None -> None
   in
   let ent = G.basic_entity v1 ~attrs in
-  let def : G.variable_definition = { vinit = v2; vtype } in
+  let def : G.variable_definition = { vinit = v2; vtype; vtok = G.no_sc } in
   G.DefStmt (ent, G.VarDef def) |> G.s
 
 and require_extends_clause (env : env)
@@ -2863,7 +2866,7 @@ and xhp_class_attribute (env : env) ((v1, v2, v3, v4) : CST.xhp_class_attribute)
   (* Q: Something feels off here... Originally did VarDef with init...*)
   (* But then it had to be enum... So did TypeDef, but then went back... *)
   let ent = G.basic_entity v2 ~attrs:(attr_tok :: v4) in
-  let def = (ent, G.VarDef { vinit = v3; vtype = Some v1 }) in
+  let def = (ent, G.VarDef { vinit = v3; vtype = Some v1; vtok = G.no_sc }) in
   G.fld def
 
 and xhp_expression (env : env) (x : CST.xhp_expression) : G.xml =

--- a/libs/ast_generic/AST_generic.ml
+++ b/libs/ast_generic/AST_generic.ml
@@ -174,7 +174,7 @@
  * convenient to correspond mostly to Semgrep versions. So version below
  * can jump from "1.12.1" to "1.20.0" and that's fine.
  *)
-let version = "1.62.0"
+let version = "1.66.1"
 
 (*****************************************************************************)
 (* Some notes on deriving *)
@@ -232,6 +232,8 @@ type 'a bracket = tok * 'a * tok [@@deriving show, eq, hash]
 
 (* semicolon, a FakeTok in languages that do not require them (e.g., Python).
  * alt: tok option.
+ * TODO: use a tok option, or maybe better is to do like for vtok in
+ * variable_definition and use `sc option` in more places (e.g., ExprStmt)
  * See the sc value also at the end of this file to build an sc.
  *)
 type sc = tok [@@deriving show, eq, hash]
@@ -1814,6 +1816,14 @@ and variable_definition = {
   vinit : expr option;
   (* less: (tok * expr) option? *)
   vtype : type_ option;
+  (* Note that this is None for most languages. Even in C-like languages, this
+   * is also often None because one statement can contain multiple definitions
+   * as in `int a, b = 1, c;` but there is just one semicolon. We could use
+   * the ',' for the other declarations but anyway to be really correct we would
+   * need to change the `entity x VarDef` in an `entities x VarDefs` which is a
+   * complex refactoring.
+   *)
+  vtok : sc option;
 }
 
 (* ------------------------------------------------------------------------- *)
@@ -2148,9 +2158,14 @@ let error tok msg = raise (Error (msg, tok))
 let fake s = Tok.unsafe_fake_tok s
 
 (* bugfix: I used to put ";" but now Parse_info.str_of_info prints
- * the string of a fake info
+ * the string of a fake info.
+ * TODO: try to put back ";", but in many languages like Python we still use
+ * G.sc even if we know there is no semicolon, so for those we need to refactor
+ * the code to use G.no_sc instead
+ * TODO: factorize with Tok.unsafe_sc
  *)
-let sc = Tok.unsafe_fake_tok ""
+let sc : Tok.t = Tok.unsafe_fake_tok ""
+let no_sc : Tok.t option = None
 
 (*****************************************************************************)
 (* AST builder helpers *)
@@ -2188,7 +2203,7 @@ let p x = x
  * not matter as the couple (filename, id_info_id) is unique.
  *)
 let id_info_id = IdInfoId.mk
-let empty_var = { vinit = None; vtype = None }
+let empty_var = { vinit = None; vtype = None; vtok = no_sc }
 
 let empty_id_info ?(hidden = false) ?(case_insensitive = false)
     ?(id = id_info_id ()) () =
@@ -2348,9 +2363,9 @@ let stmt1 xs =
 (* this should be simpler at some point if we get rid of FieldStmt *)
 let fld (ent, def) = F (s (DefStmt (ent, def)))
 
-let basic_field id vopt typeopt =
+let basic_field ?(vtok = no_sc) id vopt typeopt =
   let entity = basic_entity id in
-  fld (entity, VarDef { vinit = vopt; vtype = typeopt })
+  fld (entity, VarDef { vinit = vopt; vtype = typeopt; vtok })
 
 let fieldEllipsis t = F (exprstmt (e (Ellipsis t)))
 

--- a/libs/ast_generic/AST_generic_helpers.ml
+++ b/libs/ast_generic/AST_generic_helpers.ml
@@ -314,16 +314,21 @@ let vardef_to_assign (ent, def) =
   in
   Assign (name_or_expr, Tok.unsafe_fake_tok "=", v) |> G.e
 
-let assign_to_vardef_opt ((e1, _tk, e2) : G.expr * G.tok * G.expr) =
+(* TODO: pass also semicolon tok? not just the equal tok *)
+let assign_to_vardef_opt ((e1, _teq, e2) : G.expr * G.tok * G.expr) =
   match e1.G.e with
   | Cast (ty, _, e) ->
       let* name = expr_to_entity_name_opt e in
       let ent = { name; attrs = []; tparams = None } in
-      Some (DefStmt (ent, VarDef { vinit = Some e2; vtype = Some ty }) |> G.s)
+      Some
+        (DefStmt (ent, VarDef { vinit = Some e2; vtype = Some ty; vtok = no_sc })
+        |> G.s)
   | _ ->
       let* name = expr_to_entity_name_opt e1 in
       let ent = { name; attrs = []; tparams = None } in
-      Some (DefStmt (ent, VarDef { vinit = Some e2; vtype = None }) |> G.s)
+      Some
+        (DefStmt (ent, VarDef { vinit = Some e2; vtype = None; vtok = no_sc })
+        |> G.s)
 
 (* used in controlflow_build *)
 let funcdef_to_lambda (ent, def) resolved =
@@ -715,3 +720,17 @@ let fix_token_locations_visitor =
  * an mli and allowing direct access to it. *)
 let fix_token_locations_any = fix_token_locations_visitor#visit_any
 let fix_token_locations_program = fix_token_locations_visitor#visit_program
+
+(*****************************************************************************)
+(* Add semicolons *)
+(*****************************************************************************)
+
+let add_semicolon_to_last_var_def_and_convert_to_stmts (sc : sc)
+    (xs : (entity * variable_definition) list) : stmt list =
+  let ys =
+    match List.rev xs with
+    (* Impossible in principle *)
+    | [] -> []
+    | (ent, vardef) :: xs -> (ent, { vardef with vtok = Some sc }) :: xs
+  in
+  ys |> List_.map (fun (ent, vardef) -> DefStmt (ent, VarDef vardef) |> G.s)

--- a/libs/ast_generic/AST_generic_helpers.mli
+++ b/libs/ast_generic/AST_generic_helpers.mli
@@ -150,3 +150,8 @@ val fix_token_locations_any :
 
 val fix_token_locations_program :
   (Tok.location -> Tok.location) -> AST_generic.program -> AST_generic.program
+
+val add_semicolon_to_last_var_def_and_convert_to_stmts :
+  AST_generic.sc ->
+  (AST_generic.entity * AST_generic.variable_definition) list ->
+  AST_generic.stmt list

--- a/libs/ast_generic/AST_generic_to_v1.ml
+++ b/libs/ast_generic/AST_generic_to_v1.ml
@@ -1167,7 +1167,7 @@ and map_parameter_classic
     pinfo = v_pinfo;
   }
 
-and map_variable_definition { G.vinit = v_vinit; vtype = v_vtype } =
+and map_variable_definition { G.vinit = v_vinit; vtype = v_vtype; vtok = _sc } =
   let v_vtype = map_of_option map_type_ v_vtype in
   let v_vinit = map_of_option map_expr v_vinit in
   { B.vinit = v_vinit; vtype = v_vtype }

--- a/libs/ast_generic/Meta_AST.ml
+++ b/libs/ast_generic/Meta_AST.ml
@@ -1324,8 +1324,11 @@ and vof_function_body = function
       OCaml.VSum ("FBDecl", [ v1 ])
   | FBNothing -> OCaml.VSum ("FBNothing", [])
 
-and vof_variable_definition { vinit = v_vinit; vtype = v_vtype } =
+and vof_variable_definition { vinit = v_vinit; vtype = v_vtype; vtok } =
   let bnds = [] in
+  let arg = OCaml.vof_option vof_tok vtok in
+  let bnd = ("vtok", arg) in
+  let bnds = bnd :: bnds in
   let arg = OCaml.vof_option vof_type_ v_vtype in
   let bnd = ("vtype", arg) in
   let bnds = bnd :: bnds in

--- a/src/analyzing/Constant_propagation.ml
+++ b/src/analyzing/Constant_propagation.ml
@@ -355,7 +355,7 @@ let (terraform_stmt_to_vardefs : item -> (ident * expr) list) =
                          attrs = [];
                          tparams = None;
                        },
-                       VarDef { vinit = Some v; vtype = None } );
+                       VarDef { vinit = Some v; vtype = None; vtok = _ } );
                  _;
                } ->
                Some (("local." ^ str, tk), v)
@@ -386,7 +386,7 @@ let (terraform_stmt_to_vardefs : item -> (ident * expr) list) =
                          attrs = [];
                          tparams = None;
                        },
-                       VarDef { vinit = Some v; vtype = None } );
+                       VarDef { vinit = Some v; vtype = None; vtok = _ } );
                  _;
                } ->
                let str, tk = id in

--- a/src/matching/Generic_vs_generic.ml
+++ b/src/matching/Generic_vs_generic.ml
@@ -3161,9 +3161,11 @@ and m_parameter_classic a b =
 and m_variable_definition a b =
   match (a, b) with
   (* boilerplate *)
-  | { G.vinit = a1; vtype = a2 }, { B.vinit = b1; vtype = b2 } ->
-      (m_option m_expr) a1 b1 >>= fun () ->
-      (m_option_none_can_match_some m_type_) a2 b2
+  | ( { G.vinit = a1; vtype = a2; vtok = _a3 },
+      { B.vinit = b1; vtype = b2; vtok = _b3 } ) ->
+      let* () = (m_option m_expr) a1 b1 in
+      let* () = (m_option_none_can_match_some m_type_) a2 b2 in
+      return ()
 
 (* ------------------------------------------------------------------------- *)
 (* Field definition and use *)
@@ -3543,7 +3545,7 @@ and m_directive_vs_def a b =
                             _ ) );
                     _;
                   };
-              vtype = _;
+              _;
             } ) ) ->
         (* Match the pattern `import "foo"` against `const x = require("foo")` *)
         m_wrap m_string filea fileb
@@ -3575,7 +3577,7 @@ and m_directive_vs_def a b =
                           } );
                     _;
                   };
-              vtype = _;
+              _;
             } ) )
       when id_str = B.special_multivardef_pattern ->
         let* () = m_wrap m_string filea fileb in

--- a/src/naming/Naming_AST.ml
+++ b/src/naming/Naming_AST.ml
@@ -552,7 +552,7 @@ let resolve lang prog =
                           );
                       _;
                     };
-                vtype = _;
+                _;
               } )
           when lang =*= Lang.Js || lang =*= Lang.Ts ->
             let sid = SId.mk () in
@@ -585,7 +585,7 @@ let resolve lang prog =
                             } );
                       _;
                     };
-                vtype = _;
+                _;
               } )
           when id_str = special_multivardef_pattern
                && (lang =*= Lang.Js || lang =*= Lang.Ts) ->
@@ -622,8 +622,9 @@ let resolve lang prog =
         (* In Rust, the left-hand side (lhs) of the let variable definition is
          * parsed as a pattern.
          * TODO handle more cases than just the simple identifier pattern. *)
-        | { name = EPattern (PatId (id, id_info)); _ }, VarDef { vinit; vtype }
-        | { name = EN (Id (id, id_info)); _ }, VarDef { vinit; vtype }
+        | ( { name = EPattern (PatId (id, id_info)); _ },
+            VarDef { vinit; vtype; vtok = _ } )
+        | { name = EN (Id (id, id_info)); _ }, VarDef { vinit; vtype; vtok = _ }
         (* note that some languages such as Python do not have VarDef
          * construct
          * todo? should add those somewhere instead of in_lvalue detection? *)


### PR DESCRIPTION
This should also fix autofix on var defs in a few languages.
The motivation for this PR is romain's stubber
https://github.com/semgrep/semgrep-proprietary/pull/1397
which currently don't work well because the range of vardef
is not correct and so can't really be removed because the semicolon
is not present in the AST (CST really).

A different PR will fix the issue for Java.
This will help SAF-928

test plan:
make
make test