### PR TITLE
chore(secrets): rename secrets related flags

### DIFF
--- a/cli/src/semgrep/commands/scan.py
+++ b/cli/src/semgrep/commands/scan.py
@@ -329,7 +329,12 @@ _scan_options: List[Callable] = [
         is_flag=True,
         hidden=True,
     ),
-    optgroup.option("--allow-untrusted-validators", is_flag=True, hidden=True),
+    optgroup.option(
+        "--allow-custom-validators",
+        "allow_untrusted_validators",
+        is_flag=True,
+        hidden=True,
+    ),
 ]
 
 
@@ -410,7 +415,7 @@ def scan_options(func: Callable) -> Callable:
     help="Contact support@semgrep.com for more informationon this.",
 )
 @click.option(
-    "--historical-secrets-targets",
+    "--historical-secrets",
     "historical_secrets",
     is_flag=True,
 )

--- a/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -533,8 +533,8 @@ let o_no_secrets_validation : bool Term.t =
 let o_allow_untrusted_validators : bool Term.t =
   let info =
     Arg.info
-      [ "allow-untrusted-validators" ]
-      ~doc:{|Run postprocessors from untrusted sources.|}
+      [ "allow-custom-validators" ]
+      ~doc:{|Run postprocessors from custom rules.|}
   in
   Arg.value (Arg.flag info)
 


### PR DESCRIPTION
Related to https://github.com/semgrep/semgrep/pull/9987 (decided to break out changes from that PR since it's becoming more complex).

This PR introduces some changes to secrets related CLI flags.

* `allow-untrusted-validators` renamed to `allow-custom-validators`
* `semgrep scan --historical-secrets-targets` renamed to `--historical-secrets` to match semgrep ci.