### PR TITLE
feat: respect http_proxy and https_proxy

### DIFF
--- a/changelog.d/cdx-253.added
+++ b/changelog.d/cdx-253.added
@@ -1,0 +1,1 @@
+osemgrep now respects HTTP_PROXY and HTTPS_PROXY when making network requests

--- a/libs/networking/http_helpers/http_helpers.ml
+++ b/libs/networking/http_helpers/http_helpers.ml
@@ -103,6 +103,7 @@ struct
       | None -> (req, url)
     in
     let stream_req = Lwt_stream.of_list [ (req, body) ] in
+    (* callv is deprecated in 6.0.0 of cohttp, but that's not released yet as of this comment *)
     let%lwt responses_stream = Client.callv url stream_req in
     (* Assume that we only get one response back *)
     (* MUST USE GET HERE *)

--- a/libs/networking/http_helpers/http_helpers.mli
+++ b/libs/networking/http_helpers/http_helpers.mli
@@ -1,11 +1,7 @@
 (* Small wrapper around Cohttp data structures to access conveniently
  * all results (body, http code) from a GET http request.
  *)
-type get_info = {
-  response : Cohttp.Response.t;
-  body : Cohttp_lwt.Body.t;
-  code : int;
-}
+type get_info = { response : Cohttp.Response.t; code : int }
 
 (* This is functorized because we must run http requests differently
  * depending on the platform (native vs jsoo). To use this module do:

--- a/libs/networking/http_mock_client/Http_mock_client.ml
+++ b/libs/networking/http_mock_client/Http_mock_client.ml
@@ -37,23 +37,45 @@ module Make (M : S) : Cohttp_lwt.S.Client = struct
 
   type ctx = unit
 
-  let callv ?ctx _ _ =
+  let mock_response_of_request (req : Cohttp.Request.t) (body : Body.t) =
+    Logs.debug (fun m ->
+        m "[Testing client] Request: %s"
+          (Request.sexp_of_t req |> Sexplib.Sexp.to_string_hum));
+    let%lwt _body = Body.to_string body in
+    Logs.debug (fun m -> m "[Testing client] Body: %s" _body);
+    let%lwt response = make_response req body in
+    Lwt.return (response.response, response.body)
+
+  let callv ?ctx uri (reqs : (Cohttp.Request.t * Body.t) Lwt_stream.t) =
     ignore ctx;
-    failwith "Not implemented"
+    Logs.debug (fun m ->
+        m "[Testing client] Request URI: %s" (Uri.to_string uri));
+    let response_stream =
+      Lwt_stream.map_s
+        (fun (req, body) -> mock_response_of_request req body)
+        reqs
+    in
+    Lwt.return response_stream
 
   let head ?ctx ?headers _ =
     ignore ctx;
     ignore headers;
-    failwith "Not implemented"
+    failwith
+      "head is not implemented in the HTTP mock client. If you need this \
+       functionality, please implement it."
 
   let post_form ?ctx ?headers ~params _ =
     ignore ctx;
     ignore headers;
     ignore params;
-    failwith "Not implemented"
+    failwith
+      "post_form is not implemented in the HTTP mock client. If you need this \
+       functionality, please implement it."
 
   let call ?ctx ?headers ?(body = `Empty) ?chunked meth uri =
     ignore ctx;
+    Logs.debug (fun m ->
+        m "[Testing client] Request URI: %s" (Uri.to_string uri));
     let headers =
       match headers with
       | None -> Header.init ()
@@ -65,13 +87,7 @@ module Make (M : S) : Cohttp_lwt.S.Client = struct
       | None -> false
     in
     let req = Request.make_for_client ~headers ~chunked meth uri in
-    Logs.debug (fun m ->
-        m "[Testing client] Request: %s"
-          (Request.sexp_of_t req |> Sexplib.Sexp.to_string_hum));
-    let%lwt _body = Body.to_string body in
-    Logs.debug (fun m -> m "[Testing client] Body: %s" _body);
-    let%lwt response = make_response req body in
-    Lwt.return (response.response, response.body)
+    mock_response_of_request req body
 
   let get ?ctx ?headers uri = call ?ctx ?headers `GET uri
 


### PR DESCRIPTION
Cohttp doesn't respect HTTP_PROXY and HTTPS_PROXY. Now it does!

## Test plan
using mitmproxy
```bash
mitmproxy &
make core
HTTPS_PROXY=localhost:8080 ./bin/osemgrep --experimental --config auto
fg 1
```
then see that it makes the request on mitmproxy