### PR TITLE
fix(paths): normalize absolute paths

### DIFF
--- a/libs/paths/Ppath.ml
+++ b/libs/paths/Ppath.ml
@@ -256,11 +256,13 @@ let make_absolute path =
        our absolute form for `/var/` would prefer to be `/private/var`.
        So we turn our path into an rpath. *)
     match Rpath.of_fpath path with
-    | Ok path -> Rpath.to_fpath path
+    | Ok path ->
+        Rpath.to_fpath path
+        (* Only warn here, since we don't guarantee Ppath exists  *)
     | Error err ->
-        failwith
-          (Common.spf "Failed to make path %s absolute: %s"
-             (Fpath.to_string path) err)
+        Logs.warn (fun m ->
+            m "Failed to make path %s absolute: %s" (Fpath.to_string path) err);
+        path
 
 (*
    This assumes the input paths are normalized. We use this

--- a/src/osemgrep/tests/Test_target_selection.ml
+++ b/src/osemgrep/tests/Test_target_selection.ml
@@ -106,7 +106,7 @@ let normalize =
   [
     Testo.mask_line ~after:"Initialized empty Git repository in" ();
     Testo.mask_line ~after:"[main (root-commit) " ~before:"]" ();
-    Testo.mask_pcre_pattern "/test-[a-f0-9]+";
+    Testo.mask_temp_paths ();
   ]
 
 (*

--- a/tests/snapshots/semgrep-core/0307ab87fd4c/stdout
+++ b/tests/snapshots/semgrep-core/0307ab87fd4c/stdout
@@ -4,6 +4,6 @@ Initialized empty Git repository in<MASKED>
  create mode 100644 a/b/target
 Input files:
 a/b/target
-cwd: /tmp<MASKED>/a
+cwd: <TMP>/<MASKED>/a
 Target files:
   b/target

--- a/tests/snapshots/semgrep-core/7c0c5fe922a0/stdout
+++ b/tests/snapshots/semgrep-core/7c0c5fe922a0/stdout
@@ -4,6 +4,6 @@ Initialized empty Git repository in<MASKED>
  create mode 100644 a/b/target
 Input files:
 a/b/target
-cwd: /tmp<MASKED>/a/b
+cwd: <TMP>/<MASKED>/a/b
 Target files:
   target


### PR DESCRIPTION
## What:
This PR fixes a bug which was causing some LS e2e tests to fail.

## Why:
In `Git_project.ml`, we would accidentally try to check whether an unnormalized path were present in a given project root, which would be problematic when the unnormalized path contained a symlink. For instance, we would check if the path `/var/.../a` were contained in the project root `/private/var/.../a`, not knowing that `/var/` and `/private/var/` represent the same directory.

## How:
In the logic for `Ppath.in_project`, we inserted a syscall which makes sure that the `Rfpath` is only compared to the _real_ version of the `Fpath`, so we are on the same page regarding symlinks.

Ideally, we would have been holding a real path from the beginning, but this would take a lot more refactoring, to obtain `Rpath`s where we need them to be. This unblocks us from landing other PRs.

## Test plan:
LS e2e tests now pass. 