### PR TITLE
Update file targeting for the second run of inter-file diff scan

### DIFF
--- a/changelog.d/saf-897.fixed
+++ b/changelog.d/saf-897.fixed
@@ -1,0 +1,3 @@
+Improved removal of pre-existing findings in inter-file diff scan: We've
+implemented a more effective method for removing pre-existing findings from
+intra-file rules in the inter-file diff scan.

--- a/changelog.d/saf-897.fixed
+++ b/changelog.d/saf-897.fixed
@@ -1,3 +1,2 @@
-Improved removal of pre-existing findings in inter-file diff scan: We've
-implemented a more effective method for removing pre-existing findings from
-intra-file rules in the inter-file diff scan.
+Fixed the inter-file diff scan issue where the removal of pre-existing findings
+didn't work properly when adding a new file or renaming an existing file.

--- a/cli/src/semgrep/run_scan.py
+++ b/cli/src/semgrep/run_scan.py
@@ -637,13 +637,15 @@ def run_scan(
                     baseline_target_strings = target_strings
                     baseline_target_mode_config = target_mode_config
                     if target_mode_config.is_pro_diff_scan:
+                        scanned = [
+                            Path(t.value) for t in output_extra.core.paths.scanned
+                        ]
+                        scanned.extend(baseline_handler.status.renamed.values())
                         baseline_target_mode_config = TargetModeConfig.pro_diff_scan(
                             frozenset(
-                                Path(t)
-                                for t in target_mode_config.get_diff_targets()
-                                if t.exists() and not t.is_symlink()
+                                t for t in scanned if t.exists() and not t.is_symlink()
                             ),
-                            target_mode_config.get_diff_depth(),
+                            0,  # scanning the same set of files in the second run
                         )
                     else:
                         baseline_target_strings = frozenset(

--- a/cli/src/semgrep/run_scan.py
+++ b/cli/src/semgrep/run_scan.py
@@ -638,7 +638,16 @@ def run_scan(
                     baseline_target_mode_config = target_mode_config
                     if target_mode_config.is_pro_diff_scan:
                         scanned = [
-                            Path(t.value) for t in output_extra.core.paths.scanned
+                            # Conducting the inter-file diff scan twice with the exact same configuration,
+                            # both on the current commit and the baseline commit, could result in the absence
+                            # of a newly added file and its dependencies from the baseline run. Consequently,
+                            # this may lead to the failure to remove pre-existing findings. A more effective
+                            # approach would involve utilizing the same set of scanned diff targets from the
+                            # first run in the baseline run. This approach ensures the safe elimination of any
+                            # existing findings in the dependency files, even if the original file does not
+                            # exist in the baseline commit.
+                            Path(t.value)
+                            for t in output_extra.core.paths.scanned
                         ]
                         scanned.extend(baseline_handler.status.renamed.values())
                         baseline_target_mode_config = TargetModeConfig.pro_diff_scan(

--- a/cli/src/semgrep/scan_report.py
+++ b/cli/src/semgrep/scan_report.py
@@ -116,7 +116,9 @@ def _print_scan_plan_header(
             evolve(target_manager, baseline_handler=None).get_all_files()
         )
         diff_file_count = len(target_mode_config.get_diff_targets())
-        summary_line = f"Pro Differential Scanning {diff_file_count}/{unit_str(total_file_count, 'file')}"
+        summary_line = (
+            f"Inter-file Differential Scanning {unit_str(diff_file_count, 'file')}"
+        )
     else:
         file_count = len(target_manager.get_all_files())
         summary_line = f"Scanning {unit_str(file_count, 'file')}"

--- a/cli/src/semgrep/target_mode.py
+++ b/cli/src/semgrep/target_mode.py
@@ -41,6 +41,7 @@ class DiffScan:
 
 @frozen
 class ProDiffScan:
+    # TODO: rename this class to InterfileDiffScan
     diff_targets: FrozenSet[Path] = field()
     diff_depth: int = field()
 

--- a/src/reporting/Core_json_output.ml
+++ b/src/reporting/Core_json_output.ml
@@ -591,11 +591,12 @@ let core_output_of_matches_and_errors (res : Core_result.t) : OutJ.core_output =
     errors = errs |> List_.map error_to_error;
     paths =
       {
-        (* TODO: those are set later in Cli_json_output.ml,
-         * but should we compute skipped and scanned here instead?
-         *)
+        (* It seems that we have two separate paths, one for osemgrep
+           (Cli_json_output.ml) and another for pysemgrep here. We
+           should update this section to output the results
+           specifically for pysemgrep. *)
         skipped = None;
-        scanned = [];
+        scanned = res.scanned;
       };
     skipped_rules =
       res.skipped_rules


### PR DESCRIPTION
Scan the same set of files for both the first and second runs of the differential scan to remove duplicated findings.

Closes SAF-971

test plan: https://github.com/semgrep/semgrep-proprietary/pull/1407
