### PR TITLE
chore(tracing): Use latest trace and opentelemetry

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -481,7 +481,7 @@ For more information see https://semgrep.dev
     ; tracing
     trace
     ppx_trace
-    (opentelemetry (>= 0.8))
+    (opentelemetry (>= 0.9))
     opentelemetry-client-ocurl
     ambient-context-lwt
     (conf-libcurl (= 1)) ; force older version of conf-libcurl to make windows work

--- a/libs/tracing/Tracing.mli
+++ b/libs/tracing/Tracing.mli
@@ -27,6 +27,7 @@ type user_data = Trace_core.user_data
 (*****************************************************************************)
 
 val with_span :
+  ?level:Trace_core__.Level.t ->
   ?__FUNCTION__:string ->
   __FILE__:string ->
   __LINE__:int ->

--- a/semgrep.opam
+++ b/semgrep.opam
@@ -59,7 +59,7 @@ depends: [
   "git-unix"
   "trace"
   "ppx_trace"
-  "opentelemetry" {>= "0.8"}
+  "opentelemetry" {>= "0.9"}
   "opentelemetry-client-ocurl"
   "ambient-context-lwt"
   "conf-libcurl" {= "1"}


### PR DESCRIPTION
Now that opentelemetry supports the lateset trace, upgrade both. This also gets us trace levels!

Test plan: make

