### PR TITLE
feat(matching): unify constraint-introduced metavariables

### DIFF
--- a/src/engine/Match_search_mode.ml
+++ b/src/engine/Match_search_mode.ml
@@ -606,7 +606,7 @@ let rec filter_ranges (env : env) (init_ranges : RM.t list)
         We reuse the same original range because that will guarantee that the intersection works,
         we only care about the metavariables unifying.
     *)
-    List.fold_right
+    List_.fold_right
       (fun cond_bindingss ranges ->
         RM.intersect_ranges env.xconf.config ~debug_matches:!debug_matches
           ranges

--- a/src/engine/Range_with_metavars.mli
+++ b/src/engine/Range_with_metavars.mli
@@ -21,6 +21,9 @@ type ranges = t list [@@deriving show]
 val match_result_to_range : Pattern_match.t -> t
 val range_to_pattern_match_adjusted : Rule.rule -> t -> Pattern_match.t
 
+val bindings_compatible :
+  Rule_options.t -> Metavariable.bindings -> Metavariable.bindings -> bool
+
 (* Set functions *)
 
 val intersect_ranges :

--- a/tests/rules/defer-persistent-binding.py
+++ b/tests/rules/defer-persistent-binding.py
@@ -1,10 +1,14 @@
 
+# OLD BEHAVIOR:
 # We should produce this finding, because the binding from the first `metavariable-pattern`
 # should not express a constraint on the second `metavariable-pattern`.
-
 # Because the binding is deferred, both `$B`s are understood to be separate.
 
-# ruleid: defer-persistent-binding 
+# NEW BEHAVIOR:
+# We no longer "defer" the introduced metavariables. When our conditions introduce $B, we
+# unify them before introducing them into the match, meaning that we should not get a
+# finding here.
+
 foo(
   inside(
     bar(1),

--- a/tests/rules/unify_condition_introduced_mvars.py
+++ b/tests/rules/unify_condition_introduced_mvars.py
@@ -1,0 +1,22 @@
+
+
+# ruleid: unify-condition-introduced-mvars
+foo((
+    one(1, 2),
+    two(2, 3)
+))
+
+# ruleid: unify-condition-introduced-mvars
+foo((
+    two(2, 3),
+    one(1, 2)
+))
+
+foo((
+    one(1, 3),
+    two(2, 3)
+))
+
+foo((
+    one(1, 3)
+))

--- a/tests/rules/unify_condition_introduced_mvars.yaml
+++ b/tests/rules/unify_condition_introduced_mvars.yaml
@@ -1,0 +1,20 @@
+rules:
+  - id: unify-condition-introduced-mvars
+    message: |
+      The only matches should be where "one" and "two"
+      are called such that their second and first arguments
+      are the same!
+    patterns:
+      - pattern: |
+          foo($A)
+      - metavariable-pattern:
+          metavariable: $A
+          pattern: |
+            one($B, $C)
+      - metavariable-pattern:
+          metavariable: $A
+          pattern: |
+            two($C, $D)
+    languages:
+      - python
+    severity: WARNING


### PR DESCRIPTION
## What:
This PR makes it such that simultaneous conditions which introduce metavariables will unify their metavariables in the resulting match.

## Why:
Previously, we had logic which was such that for every succeeding instance of a condition (for instance, each succeeding match in a `metavariable-pattern`), we would produce a brand new match which only had the new metavariables from that instance.

This means, for instance, if we had a `metavariable-regex` and `metavariable-pattern`, both of which introduce metavariables, we would produce two matches with the metavariables from either, instead of one match which unifies their metavariables. This is not intuitive, and undesirable.

## How:
We make it such that we handle all constraints and ranges simultaneously (so that we can still generate the per-condition matching explanations). We save all the introduced metavariables per succeeding constraint, and then find all the ways to combine them pairwise to unify their metavariables.

## Test plan:
Automated tests.