### PR TITLE
fix: Handle `Cast` in expr_to_pattern

### DIFF
--- a/libs/ast_generic/AST_generic_helpers.ml
+++ b/libs/ast_generic/AST_generic_helpers.ml
@@ -199,6 +199,7 @@ let rec expr_to_pattern e =
   | Container (List, (t1, xs, t2)) ->
       PatList (t1, xs |> List_.map expr_to_pattern, t2)
   | Ellipsis t -> PatEllipsis t
+  | Cast (ty, _tok, expr) -> PatTyped (expr_to_pattern expr, ty)
   (* TODO:  PatKeyVal and more *)
   | _ -> OtherPat (("ExprToPattern", fake ""), [ E e ])
 


### PR DESCRIPTION
This handles things like the below in TypeScript:

`function foo({x}: Y) { ... }`

This prevents the parameter pattern from being turned into `OtherPat`, which hinders semantic analysis which we do in the pro engine.

I don't think this changes any OSS behavior, but if it does it's likely only some strange edge cases in matching.

Test plan: Automated tests, plus upcoming PR in semgrep-proprietary.

