### PR TITLE
Mask also temporary folder obtained after resolving the symlinks

### DIFF
--- a/libs/commons/Testutil.ml
+++ b/libs/commons/Testutil.ml
@@ -7,6 +7,8 @@ let run what f =
   UPrintf.printf "running %s...\n%!" what;
   Common.protect ~finally:(fun () -> UPrintf.printf "done with %s.\n%!" what) f
 
+(* TODO: move this to Testo once it's ok with requiring ocaml >= 4.13
+   (needed for Unix.realpath) *)
 let mask_temp_paths ?depth ?replace () =
   let mask_original_path = Testo.mask_temp_paths ?depth ?replace () in
   let mask_physical_path =

--- a/libs/commons/Testutil.ml
+++ b/libs/commons/Testutil.ml
@@ -6,3 +6,12 @@
 let run what f =
   UPrintf.printf "running %s...\n%!" what;
   Common.protect ~finally:(fun () -> UPrintf.printf "done with %s.\n%!" what) f
+
+let mask_temp_paths ?depth ?replace () =
+  let mask_original_path = Testo.mask_temp_paths ?depth ?replace () in
+  let mask_physical_path =
+    Testo.mask_temp_paths ?depth ?replace
+      ~tmpdir:(UFilename.get_temp_dir_name () |> UUnix.realpath)
+      ()
+  in
+  fun text -> text |> mask_original_path |> mask_physical_path

--- a/libs/commons/Testutil.mli
+++ b/libs/commons/Testutil.mli
@@ -12,3 +12,14 @@
    parsed.
 *)
 val run : string -> (unit -> 'a) -> 'a
+
+(*
+   Extension of Testo.mask_temp_paths that also masks the physical path
+   to the temporary folder in case the original is a symlink.
+
+   This is not done in Testo becauseit uses Unix.realpath which
+   requires ocaml >= 4.13 and for now, Testo is meant to work starting with
+   ocaml 4.08.
+*)
+val mask_temp_paths :
+  ?depth:int option -> ?replace:(string -> string) -> unit -> string -> string

--- a/libs/git_wrapper/Unit_git_wrapper.ml
+++ b/libs/git_wrapper/Unit_git_wrapper.ml
@@ -19,7 +19,7 @@ let mask_test_dirname =
   Testo.mask_pcre_pattern ~replace:(fun _ -> "<HEX>") "test-([a-f0-9]{1,8})"
 
 let normalize =
-  [ mask_temp_git_hash; Testo.mask_temp_paths (); mask_test_dirname ]
+  [ mask_temp_git_hash; Testutil.mask_temp_paths (); mask_test_dirname ]
 
 let t = Testo.create
 let capture = Testo.create ~checked_output:Stdout ~normalize

--- a/libs/gitignore/Unit_gitignore.ml
+++ b/libs/gitignore/Unit_gitignore.ml
@@ -54,7 +54,7 @@ let test_filter (files : F.t list) () =
 (*****************************************************************************)
 
 let t =
-  Testo.create ~checked_output:Stdout ~normalize:[ Testo.mask_temp_paths () ]
+  Testo.create ~checked_output:Stdout ~normalize:[ Testutil.mask_temp_paths () ]
 
 let tests =
   let open F in


### PR DESCRIPTION
This is a workaround to the issue of temporary folders being symlinks as described in 
https://github.com/semgrep/testo/pull/42.

This is not done in Testo because I find it too restrictive for Testo to require OCaml >= 4.13 at this time.

The other bug addressed by https://github.com/semgrep/testo/pull/42 (trailing slashes in temp folder path) will be fixed in Testo.

Test plan: CI checks must pass but symlinked temp folders still fail for other reasons:
```
$ ln -s /tmp link-to-tmp
$ TMPDIR=$(pwd)/link-to-tmp make test
```
1. If the temp folder is relative, the tests fail because of a chdir. It's understandable.
2. With an absolute path such as `/home/martin/link-to-tmp`, 12 tests fail. Here's the error we get for test 1d84c9d09005 (`Language Server (unit) > Session Targets > Test multiple workspaces with some dirty (only_git_dirty: false)`):
```
 FAIL: The test raised an exception: Failure: cannot make path "/home/martin/semgrep2/link-to-tmp/test_workspace_9c93dc2d-def6-48f2-84cc-65eeade3e0d2" relative to project root "/tmp/test_workspace_9c93dc2d-def6-48f2-84cc-65eeade3e0d2".
 cwd: /home/martin/semgrep2
 realpath for .: { Rfpath.fpath = .; rpath = (Rpath.Rpath /home/martin/semgrep2);
   cwd = (Rpath.Rpath /home/martin/semgrep2) }
 Sys.argv: ./test
```
It is a known bug that is not simple to fix. See https://github.com/semgrep/semgrep/pull/10003

Some other language server tests fail with 30-second timeouts. This should be fixed such that exceptions cause an immediate failure.