### PR TITLE
feat: `--historical-secrets` flag

### DIFF
--- a/changelog.d/scrt-531.added
+++ b/changelog.d/scrt-531.added
@@ -1,0 +1,3 @@
+`--historical-secrets` flag for running Semgrep Secrets regex rules on git
+history (requires Semgrep Secrets). This flag is not yet implemented for
+`--experimental`.

--- a/cli/src/semgrep/commands/ci.py
+++ b/cli/src/semgrep/commands/ci.py
@@ -142,7 +142,6 @@ def fix_head_if_github_action(metadata: GitMeta) -> None:
 )
 @click.option("--code", is_flag=True, hidden=True)
 @click.option("--beta-testing-secrets", is_flag=True, hidden=True)
-@click.option("--historical-secrets", is_flag=True, hidden=True)
 @click.option(
     "--secrets",
     "run_secrets_flag",

--- a/cli/src/semgrep/commands/scan.py
+++ b/cli/src/semgrep/commands/scan.py
@@ -269,6 +269,11 @@ _scan_options: List[Callable] = [
         flag_value=OutputFormat.GITLAB_SECRETS,
     ),
     optgroup.option(
+        "--historical-secrets",
+        "historical_secrets",
+        is_flag=True,
+    ),
+    optgroup.option(
         "--junit-xml",
         "output_format",
         type=OutputFormat,
@@ -407,11 +412,6 @@ def scan_options(func: Callable) -> Callable:
     is_flag=True,
     hidden=True,
     help="Contact support@semgrep.com for more informationon this.",
-)
-@click.option(
-    "--historical-secrets",
-    "historical_secrets",
-    is_flag=True,
 )
 @scan_options
 @handle_command_errors

--- a/src/osemgrep/cli_ci/Ci_CLI.ml
+++ b/src/osemgrep/cli_ci/Ci_CLI.ml
@@ -100,10 +100,6 @@ let o_secrets : bool Term.t =
   in
   Arg.value (Arg.flag info)
 
-let o_historical_secrets : bool Term.t =
-  let info = Arg.info [ "historical-secrets" ] in
-  Arg.value (Arg.flag info)
-
 let o_suppress_errors : bool Term.t =
   H.negatable_flag_with_env [ "suppress-errors" ]
     ~neg_options:[ "no-suppress-errors" ]
@@ -127,7 +123,7 @@ let cmdline_term caps : conf Term.t =
    *)
   let combine scan_conf audit_on beta_testing_secrets code dry_run
       _internal_ci_scan_results secrets supply_chain suppress_errors _git_meta
-      _github_meta _historical_secrets =
+      _github_meta =
     let products =
       (if beta_testing_secrets || secrets then [ `Secrets ] else [])
       @ (if code then [ `SAST ] else [])
@@ -140,8 +136,7 @@ let cmdline_term caps : conf Term.t =
     $ Scan_CLI.cmdline_term caps ~allow_empty_config:true
     $ o_audit_on $ o_beta_testing_secrets $ o_code $ o_dry_run
     $ o_internal_ci_scan_results $ o_secrets $ o_supply_chain
-    $ o_suppress_errors $ Git_metadata.env $ Github_metadata.env
-    $ o_historical_secrets)
+    $ o_suppress_errors $ Git_metadata.env $ Github_metadata.env)
 
 let doc = "the recommended way to run semgrep in CI"
 

--- a/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -540,6 +540,13 @@ let o_allow_untrusted_validators : bool Term.t =
   in
   Arg.value (Arg.flag info)
 
+let o_historical_secrets : bool Term.t =
+  let info =
+    Arg.info [ "historical-secrets" ]
+      ~doc:{|Scans git history using Secrets rules.|}
+  in
+  Arg.value (Arg.flag info)
+
 (* ------------------------------------------------------------------ *)
 (* Engine type (mutually exclusive) *)
 (* ------------------------------------------------------------------ *)
@@ -882,15 +889,15 @@ let cmdline_term caps ~allow_empty_config : conf Term.t =
   let combine allow_untrusted_validators autofix baseline_commit common config
       dataflow_traces diff_depth dryrun dump_ast dump_command_for_core
       dump_engine_path emacs error exclude_ exclude_rule_ids files_with_matches
-      force_color gitlab_sast gitlab_secrets include_ incremental_output json
-      junit_xml lang ls matching_explanations max_chars_per_line
-      max_lines_per_finding max_memory_mb max_target_bytes metrics num_jobs
-      no_secrets_validation nosem optimizations oss output pattern pro
-      project_root pro_intrafile pro_lang remote replacement respect_gitignore
-      rewrite_rule_ids sarif scan_unknown_extensions secrets severity
-      show_supported_languages strict target_roots test test_ignore_todo text
-      time_flag timeout _timeout_interfileTODO timeout_threshold trace validate
-      version version_check vim =
+      force_color gitlab_sast gitlab_secrets _historical_secrets include_
+      incremental_output json junit_xml lang ls matching_explanations
+      max_chars_per_line max_lines_per_finding max_memory_mb max_target_bytes
+      metrics num_jobs no_secrets_validation nosem optimizations oss output
+      pattern pro project_root pro_intrafile pro_lang remote replacement
+      respect_gitignore rewrite_rule_ids sarif scan_unknown_extensions secrets
+      severity show_supported_languages strict target_roots test
+      test_ignore_todo text time_flag timeout _timeout_interfileTODO
+      timeout_threshold trace validate version version_check vim =
     (* ugly: call setup_logging ASAP so the Logs.xxx below are displayed
      * correctly *)
     Std_msg.setup ?highlight_setting:(if force_color then Some On else None) ();
@@ -1236,8 +1243,8 @@ let cmdline_term caps ~allow_empty_config : conf Term.t =
     $ CLI_common.o_common $ o_config $ o_dataflow_traces $ o_diff_depth
     $ o_dryrun $ o_dump_ast $ o_dump_command_for_core $ o_dump_engine_path
     $ o_emacs $ o_error $ o_exclude $ o_exclude_rule_ids $ o_files_with_matches
-    $ o_force_color $ o_gitlab_sast $ o_gitlab_secrets $ o_include
-    $ o_incremental_output $ o_json $ o_junit_xml $ o_lang $ o_ls
+    $ o_force_color $ o_gitlab_sast $ o_gitlab_secrets $ o_historical_secrets
+    $ o_include $ o_incremental_output $ o_json $ o_junit_xml $ o_lang $ o_ls
     $ o_matching_explanations $ o_max_chars_per_line $ o_max_lines_per_finding
     $ o_max_memory_mb $ o_max_target_bytes $ o_metrics $ o_num_jobs
     $ o_no_secrets_validation $ o_nosem $ o_optimizations $ o_oss $ o_output


### PR DESCRIPTION
Ensure that `--historical-secrets` is visible for both osemgrep and pysemgrep for both the scan and ci subcommands. Adds a docstring for the osemgrep man page.