### PR TITLE
refactor(osemgrep): move logic outside of sarif formatting code

### DIFF
--- a/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -974,6 +974,7 @@ let cmdline_term caps ~allow_empty_config : conf Term.t =
         max_chars_per_line;
         max_lines_per_finding;
         logging_level = common.logging_level;
+        dataflow_traces;
       }
     in
 
@@ -1022,6 +1023,7 @@ let cmdline_term caps ~allow_empty_config : conf Term.t =
                 supply_chain_config;
               }
     in
+
     let explicit_analyzer = Option.map Xlang.of_string lang in
     let rules_source =
       match (config, (pattern, explicit_analyzer, replacement)) with

--- a/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -974,7 +974,6 @@ let cmdline_term caps ~allow_empty_config : conf Term.t =
         max_chars_per_line;
         max_lines_per_finding;
         logging_level = common.logging_level;
-        dataflow_traces;
       }
     in
 
@@ -1023,7 +1022,6 @@ let cmdline_term caps ~allow_empty_config : conf Term.t =
                 supply_chain_config;
               }
     in
-
     let explicit_analyzer = Option.map Xlang.of_string lang in
     let rules_source =
       match (config, (pattern, explicit_analyzer, replacement)) with

--- a/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -708,10 +708,18 @@ let run_scan_files (caps : < Cap.stdout ; Cap.chdir ; Cap.tmp >)
     (* step 5: report the matches *)
     (* outputting the result on stdout! in JSON/Text/... depending on conf *)
     let cli_output =
-      let is_logged_in = Semgrep_login.is_logged_in () in
+      let runtime_params =
+        Output.
+          {
+            is_logged_in = Semgrep_login.is_logged_in ();
+            is_using_registry =
+              Metrics_.g.is_using_registry
+              || !Semgrep_envvars.v.mock_using_registry;
+          }
+      in
       Output.output_result
         { conf.output_conf with output_format }
-        profiler ~is_logged_in res
+        profiler runtime_params res
     in
     Profiler.stop_ign profiler ~name:"total_time";
 

--- a/src/osemgrep/reporting/Output.ml
+++ b/src/osemgrep/reporting/Output.ml
@@ -30,7 +30,6 @@ type conf = {
   output_format : Output_format.t;
   max_chars_per_line : int;
   max_lines_per_finding : int;
-  dataflow_traces : bool;
 }
 [@@deriving show]
 
@@ -47,7 +46,6 @@ let default : conf =
     force_color = false;
     max_chars_per_line = 160;
     max_lines_per_finding = 10;
-    dataflow_traces = false;
   }
 
 (*****************************************************************************)
@@ -153,8 +151,7 @@ let dispatch_output_format (output_format : Output_format.t) (conf : conf)
         || not runtime_params.is_using_registry
       in
       let sarif_json =
-        Sarif_output.sarif_output hide_nudge conf.dataflow_traces engine_label
-          hrules cli_output
+        Sarif_output.sarif_output hide_nudge engine_label hrules cli_output
       in
       Out.put (Sarif.Sarif_v_2_1_0_j.string_of_sarif_json_schema sarif_json)
   | Junit_xml ->

--- a/src/osemgrep/reporting/Output.mli
+++ b/src/osemgrep/reporting/Output.mli
@@ -14,7 +14,6 @@ type conf = {
   output_format : Output_format.t;
   max_chars_per_line : int;
   max_lines_per_finding : int;
-  dataflow_traces : bool;
 }
 [@@deriving show]
 

--- a/src/osemgrep/reporting/Output.mli
+++ b/src/osemgrep/reporting/Output.mli
@@ -14,8 +14,16 @@ type conf = {
   output_format : Output_format.t;
   max_chars_per_line : int;
   max_lines_per_finding : int;
+  dataflow_traces : bool;
 }
 [@@deriving show]
+
+(* Some parameters that are determined at runtime can also affect
+ * the output. For example, if a user is not logged in, then in
+ * the SARIF output format, we include a message to nudge the user
+ * to log in and try Pro.
+ *)
+type runtime_params = { is_logged_in : bool; is_using_registry : bool }
 
 val default : conf
 
@@ -37,8 +45,4 @@ val preprocess_result : conf -> Core_runner.result -> OutJ.cli_output
  * ugly: this also apply autofixes depending on the configuration.
  *)
 val output_result :
-  conf ->
-  Profiler.t ->
-  is_logged_in:bool ->
-  Core_runner.result ->
-  OutJ.cli_output
+  conf -> Profiler.t -> runtime_params -> Core_runner.result -> OutJ.cli_output

--- a/src/osemgrep/reporting/Sarif_output.ml
+++ b/src/osemgrep/reporting/Sarif_output.ml
@@ -360,8 +360,7 @@ let error_to_sarif_notification (e : OutT.cli_error) =
   in
   Sarif_v.create_notification ~message ~descriptor ~level ()
 
-let sarif_output hide_nudge _dataflow_traces engine_label hrules
-    (cli_output : OutT.cli_output) =
+let sarif_output hide_nudge engine_label hrules (cli_output : OutT.cli_output) =
   let sarif_schema =
     "https://docs.oasis-open.org/sarif/sarif/v2.1.0/os/schemas/sarif-schema-2.1.0.json"
   in

--- a/src/osemgrep/reporting/Sarif_output.ml
+++ b/src/osemgrep/reporting/Sarif_output.ml
@@ -360,7 +360,8 @@ let error_to_sarif_notification (e : OutT.cli_error) =
   in
   Sarif_v.create_notification ~message ~descriptor ~level ()
 
-let sarif_output hide_nudge engine_label hrules (cli_output : OutT.cli_output) =
+let sarif_output ~hide_nudge ~engine_label hrules (cli_output : OutT.cli_output)
+    =
   let sarif_schema =
     "https://docs.oasis-open.org/sarif/sarif/v2.1.0/os/schemas/sarif-schema-2.1.0.json"
   in

--- a/src/osemgrep/reporting/Sarif_output.ml
+++ b/src/osemgrep/reporting/Sarif_output.ml
@@ -360,24 +360,12 @@ let error_to_sarif_notification (e : OutT.cli_error) =
   in
   Sarif_v.create_notification ~message ~descriptor ~level ()
 
-let sarif_output is_logged_in hrules (cli_output : OutT.cli_output) =
+let sarif_output hide_nudge _dataflow_traces engine_label hrules
+    (cli_output : OutT.cli_output) =
   let sarif_schema =
     "https://docs.oasis-open.org/sarif/sarif/v2.1.0/os/schemas/sarif-schema-2.1.0.json"
   in
-  let engine_label, is_pro =
-    match cli_output.OutT.engine_requested with
-    | Some `OSS
-    | None ->
-        ("OSS", false)
-    | Some `PRO -> ("PRO", true)
-  in
   let run =
-    let hide_nudge =
-      let is_using_registry =
-        Metrics_.g.is_using_registry || !Semgrep_envvars.v.mock_using_registry
-      in
-      is_logged_in || is_pro || not is_using_registry
-    in
     let rules = rules hide_nudge hrules in
     let tool =
       let driver =

--- a/src/osemgrep/reporting/Sarif_output.mli
+++ b/src/osemgrep/reporting/Sarif_output.mli
@@ -1,6 +1,7 @@
+(* Formats the CLI output to the SARIF format. *)
 val sarif_output :
-  bool ->
-  string ->
+  hide_nudge:bool ->
+  engine_label:string ->
   Rule.hrules ->
   Semgrep_output_v1_t.cli_output ->
   Sarif.Sarif_v_2_1_0_t.sarif_json_schema

--- a/src/osemgrep/reporting/Sarif_output.mli
+++ b/src/osemgrep/reporting/Sarif_output.mli
@@ -1,6 +1,5 @@
 val sarif_output :
   bool ->
-  bool ->
   string ->
   Rule.hrules ->
   Semgrep_output_v1_t.cli_output ->

--- a/src/osemgrep/reporting/Sarif_output.mli
+++ b/src/osemgrep/reporting/Sarif_output.mli
@@ -1,5 +1,7 @@
 val sarif_output :
   bool ->
+  bool ->
+  string ->
   Rule.hrules ->
   Semgrep_output_v1_t.cli_output ->
   Sarif.Sarif_v_2_1_0_t.sarif_json_schema


### PR DESCRIPTION
There is logic in sarif formatting code that checks if
1. a user is logged in and
2. the scan is using a registry

Having these states be determined in the formatting code makes it difficult to isolate this function on its own. Isolation helps here because we'd like to call formatting code through an RPC for osemgrep work, where the ocaml function's behavior depends solely on its parameters.

This PR moves some of this logic outside of sarif formatting code.

This is osemgrep code only, which is not executed by default. It is guarded by the `--experimental` flag.

Test plan: ran `make osempass` which ensures previously passing osemgrep tests are still passing.