### PR TITLE
ci: add platform dep installation to ocaml5

### DIFF
--- a/.github/workflows/build-test-core-x86-ocaml5.jsonnet
+++ b/.github/workflows/build-test-core-x86-ocaml5.jsonnet
@@ -28,7 +28,7 @@ local job = {
       key=opam_switch + '-_opam-' + "${{ hashFiles('semgrep.opam') }}",
       path="_opam",
     ),
-    // alt: no 'make install-deps-UBUNTU-for-semgrep-core'
+    // alt: no 'sudo make install-deps-UBUNTU-for-semgrep-core'
     // possibly looks like opam and setup-ocaml@ can automatically install
     // depext dependencies, but ran into issues for git-unix with libev. Best if
     // we have install-deps-for-semgrep-core have the platform version in the
@@ -37,7 +37,7 @@ local job = {
       name: 'Install semgrep dependencies',
       run: |||
         eval $(opam env)
-        make install-deps-UBUNTU-for-semgrep-core
+        sudo make install-deps-UBUNTU-for-semgrep-core
         make install-deps-for-semgrep-core
       |||,
     },

--- a/.github/workflows/build-test-core-x86-ocaml5.jsonnet
+++ b/.github/workflows/build-test-core-x86-ocaml5.jsonnet
@@ -28,13 +28,16 @@ local job = {
       key=opam_switch + '-_opam-' + "${{ hashFiles('semgrep.opam') }}",
       path="_opam",
     ),
-    // alt: call 'sudo make install-deps-UBUNTU-for-semgrep-core'
-    // but looks like opam and setup-ocaml@ can automatically install
-    // depext dependencies.
+    // alt: no 'make install-deps-UBUNTU-for-semgrep-core'
+    // possibly looks like opam and setup-ocaml@ can automatically install
+    // depext dependencies, but ran into issues for git-unix with libev. Best if
+    // we have install-deps-for-semgrep-core have the platform version in the
+    // rule or as a prereq?
     {
       name: 'Install semgrep dependencies',
       run: |||
         eval $(opam env)
+        make install-deps-UBUNTU-for-semgrep-core
         make install-deps-for-semgrep-core
       |||,
     },

--- a/.github/workflows/build-test-core-x86-ocaml5.yml
+++ b/.github/workflows/build-test-core-x86-ocaml5.yml
@@ -19,6 +19,7 @@ jobs:
       - name: Install semgrep dependencies
         run: |
           eval $(opam env)
+          make install-deps-UBUNTU-for-semgrep-core
           make install-deps-for-semgrep-core
       - name: Build semgrep
         run: |

--- a/.github/workflows/build-test-core-x86-ocaml5.yml
+++ b/.github/workflows/build-test-core-x86-ocaml5.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install semgrep dependencies
         run: |
           eval $(opam env)
-          make install-deps-UBUNTU-for-semgrep-core
+          sudo make install-deps-UBUNTU-for-semgrep-core
           make install-deps-for-semgrep-core
       - name: Build semgrep
         run: |


### PR DESCRIPTION
We think this may be necessary based off of some recent CI failures related to libev not being able to be linked when git-unix is being used. See <https://github.com/semgrep/semgrep/actions/runs/8474645693/job/23221419153>.

Not clear why this passes for some PRs and not for others, but we think it may be related to a dirty state on the container. It may be better to have the `install-deps-for-semgrep-core` to have a prereq on or otherwise run `install-deps-$PLATFORM-for-semgrep-core`, but we haven't evaluated this deeply.

Test plan: CI passes (:pray:).
