### PR TITLE
chore: fix logging for js tests

### DIFF
--- a/js/tests/Test_jsoo.ml
+++ b/js/tests/Test_jsoo.ml
@@ -144,6 +144,7 @@ let () =
                  (Testo.to_alcotest lwt_tests)
                  ~and_exit:false ~argv
              in
+             Logs_.setup_logging ~level:(Some Logs.Info) ();
              (* Some gymnastics are needed here because we need to
                 produce a top level promise, in order to properly transform the
                 lwt promise into a Javascript promise, and run it on the Node.js


### PR DESCRIPTION
This sets `INFO` logging for JS tests, which are currently ginormous and can't even be inspected in the browser. It seems all `DEBUG` logs are being printed by `build-test-javascript`.

## Test plan:
See if the logs can be inspected here