### PR TITLE
feat(secrets): update origin info for pro changes

### DIFF
--- a/cli/src/semgrep/commands/scan.py
+++ b/cli/src/semgrep/commands/scan.py
@@ -332,7 +332,6 @@ _scan_options: List[Callable] = [
         "--allow-untrusted-validators",
         "allow_untrusted_validators",
         is_flag=True,
-        hidden=True,
     ),
 ]
 

--- a/cli/src/semgrep/commands/scan.py
+++ b/cli/src/semgrep/commands/scan.py
@@ -329,7 +329,7 @@ _scan_options: List[Callable] = [
         hidden=True,
     ),
     optgroup.option(
-        "--allow-custom-validators",
+        "--allow-untrusted-validators",
         "allow_untrusted_validators",
         is_flag=True,
         hidden=True,

--- a/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -535,8 +535,9 @@ let o_no_secrets_validation : bool Term.t =
 let o_allow_untrusted_validators : bool Term.t =
   let info =
     Arg.info
-      [ "allow-custom-validators" ]
-      ~doc:{|Run postprocessors from custom rules.|}
+      [ "allow-untrusted-validators" ]
+      ~doc:
+        {|Allows running rules with validators from origins other than semgrep.dev. Avoid running rules from origins you don't trust.|}
   in
   Arg.value (Arg.flag info)
 

--- a/src/osemgrep/core/Metrics_.ml
+++ b/src/osemgrep/core/Metrics_.ml
@@ -303,7 +303,7 @@ let add_engine_type (engine_type : Engine_type.t) =
                    Semgrep_metrics_t.secrets_config ->
                 {
                   permitted_origins =
-                    (if conf.allow_all_origins then `Any else `Semgrep);
+                    (if conf.allow_all_origins then `Any else `NoCommunity);
                 })
               secrets_config;
           supply_chain_config =


### PR DESCRIPTION
The default behaviour for which secrets rules are run is being updated in Pro; this provides the corresponding update for the sent metrics.

Wait to merge until after https://github.com/semgrep/semgrep-proprietary/pull/1416.

