### PR TITLE
fix: do not run historical scans on diff scans

### DIFF
--- a/changelog.d/scrt-545.fixed
+++ b/changelog.d/scrt-545.fixed
@@ -1,0 +1,1 @@
+Secrets historical scans: fixed a bug where historical scans could run on differential scans.

--- a/cli/src/semgrep/commands/ci.py
+++ b/cli/src/semgrep/commands/ci.py
@@ -513,7 +513,11 @@ def ci(
         run_secrets and scan_handler and scan_handler.historical_config.enabled
     ) or historical_secrets
 
-    if run_historical_secrets_scan:
+    if run_historical_secrets_scan and metadata.merge_base_ref:
+        logger.info(
+            f"Historical scanning was enabled, but is not yet supported on diff scans."
+        )
+    elif run_historical_secrets_scan:
         try:
             console.print(Title("Secrets Historical Scan"))
 


### PR DESCRIPTION
In some instances, the App could send that historical scanning was enabled to a diff scan. This ensures that in that event, we don't run the historical scan (for time reasons) and print a diagnostic.

In the future, when we have a historical diff scan, that logic can be inserted here instead.

