### PR TITLE
chore: add changelog entry for PCRE2 update

### DIFF
--- a/changelog.d/scrt-467.changed
+++ b/changelog.d/scrt-467.changed
@@ -1,0 +1,5 @@
+The main regex engine is now PCRE2 (was PCRE). While the syntax is mostly
+compatible, there are some minor instances where updates to rules may be
+needed, since PCRE2 is slightly more strict in some cases. For example, while
+we previously accepted `[\w-.]`, such a pattern would now need to be written
+`[\w_.]` or `[\w\-.]` since PCRE2 rejects the first as having an invalid range.


### PR DESCRIPTION
For https://github.com/semgrep/semgrep/pull/9919/, which was merged without a changelog.