### PR TITLE
Update Testo

### DIFF
--- a/libs/commons/Logs_.mli
+++ b/libs/commons/Logs_.mli
@@ -118,7 +118,7 @@ val serr : ?src:Logs.src -> ?tags:Logs.Tag.set -> string -> unit
    A function that masks the timestamps in log output so that we can compare
    logs from one run to another. To be used as:
 
-     Testo.create ~checked_output:Stderr ~mask_output:[Logs_.mask_time] ...
+     Testo.create ~checked_output:(Testo.stderr ()) ~mask_output:[Logs_.mask_time] ...
 
    This is crude. Beware false positives.
 *)
@@ -129,7 +129,7 @@ val mask_time : string -> string
    logs:
 
      Testo.create
-        ~checked_output:Stderr
+        ~checked_output:(Testo.stderr ())
         ~mask_output:[Logs_.mask_log_lines]
         ...
 

--- a/libs/commons/tests/Unit_List_.ml
+++ b/libs/commons/tests/Unit_List_.ml
@@ -15,7 +15,7 @@ let string_of_int_option = function
 
 let test_iter_with_view_into_neighbor_elements name list =
   Testo.create ~category:[ "List_.iter_with_view_into_neighbor_elements" ]
-    ~checked_output:Stdout name (fun () ->
+    ~checked_output:(Testo.stdout ()) name (fun () ->
       printf "input list: %s\n" (string_of_int_list list);
       list
       |> List_.iter_with_view_into_neighbor_elements (fun ~prev ~cur ~next ->

--- a/libs/commons/tests/Unit_String_.ml
+++ b/libs/commons/tests/Unit_String_.ml
@@ -104,7 +104,7 @@ let tests =
   Testo.categorize "String_"
     [
       t "safe_sub" test_safe_sub;
-      t ~checked_output:Stdout "show" test_show;
+      t ~checked_output:(Testo.stdout ()) "show" test_show;
       t "trim_cr" test_trim_cr;
       t "lines_of_range" test_lines_of_range;
     ]

--- a/libs/git_wrapper/Unit_git_wrapper.ml
+++ b/libs/git_wrapper/Unit_git_wrapper.ml
@@ -22,7 +22,7 @@ let normalize =
   [ mask_temp_git_hash; Testutil.mask_temp_paths (); mask_test_dirname ]
 
 let t = Testo.create
-let capture = Testo.create ~checked_output:Stdout ~normalize
+let capture = Testo.create ~checked_output:(Testo.stdout ()) ~normalize
 
 (*
    List repo files relative to 'cwd' which can be the root of the git repo,

--- a/libs/gitignore/Unit_gitignore.ml
+++ b/libs/gitignore/Unit_gitignore.ml
@@ -58,7 +58,8 @@ let test_filter (files : F.t list) () =
 (*****************************************************************************)
 
 let t =
-  Testo.create ~checked_output:Stdout ~normalize:[ Testutil.mask_temp_paths () ]
+  Testo.create ~checked_output:(Testo.stdout ())
+    ~normalize:[ Testutil.mask_temp_paths () ]
 
 let tests =
   let open F in

--- a/src/osemgrep/cli_login/Test_login_subcommand.ml
+++ b/src/osemgrep/cli_login/Test_login_subcommand.ml
@@ -58,7 +58,7 @@ let with_fake_deployment_response return_value f =
  * to move this file out of cli_login/ because of mutual dependencies.
  *)
 let test_logout_not_logged_in caps : Testo.test =
-  t ~checked_output:Stderr
+  t ~checked_output:(Testo.stderr ())
     ~normalize:[ Testo.mask_not_substring "You are not logged in" ]
     __FUNCTION__
     (with_login_test_env (fun () ->
@@ -66,7 +66,7 @@ let test_logout_not_logged_in caps : Testo.test =
          Exit_code.Check.ok exit_code))
 
 let test_login_no_tty caps : Testo.test =
-  t ~checked_output:Stderr
+  t ~checked_output:(Testo.stderr ())
     ~normalize:
       [ Testo.mask_not_substring "meant to be run in an interactive terminal" ]
     __FUNCTION__
@@ -100,7 +100,7 @@ let fake_deployment =
 |}
 
 let test_login_with_env_token caps : Testo.test =
-  t ~checked_output:Stderr
+  t ~checked_output:(Testo.stderr ())
     ~normalize:
       [
         Testo.mask_not_substrings ~mask:"[...]\n"

--- a/src/osemgrep/cli_publish/Test_publish_subcommand.ml
+++ b/src/osemgrep/cli_publish/Test_publish_subcommand.ml
@@ -172,7 +172,7 @@ let tests (caps : < Cap.network ; Cap.stdout ; Cap.tmp >) =
           (Should_fail
              "TODO: something calls 'Error.exit 2' which raises an exception \
               that makes the test fail where it shouldn't.")
-        ~checked_output:Stderr
+        ~checked_output:(Testo.stderr ())
         ~normalize:
           [
             (* We expect all these substrings, in this order *)

--- a/src/osemgrep/tests/Test_osemgrep.ml
+++ b/src/osemgrep/tests/Test_osemgrep.ml
@@ -50,7 +50,7 @@ let test_scan_config_registry_no_token (caps : CLI.caps) =
 
 (* Remaining part of test_login.py (see also Test_login_subcommand.ml) *)
 let test_scan_config_registry_with_invalid_token caps : Testo.test =
-  Testo.create ~checked_output:Stderr __FUNCTION__
+  Testo.create ~checked_output:(Testo.stderr ()) __FUNCTION__
     ~normalize:[ Testo.mask_not_substrings [ "Saved access token" ] ]
     (TL.with_login_test_env (fun () ->
          Semgrep_envvars.with_envvar "SEMGREP_APP_TOKEN" TL.fake_token

--- a/src/osemgrep/tests/Test_target_selection.ml
+++ b/src/osemgrep/tests/Test_target_selection.ml
@@ -119,7 +119,8 @@ let tests caps : Testo.test list =
          |> List_.map (fun (test_name, test_func) ->
                 Testo.create
                   ~category:[ "target selection on real git repos"; repo_name ]
-                  ~checked_output:Stdout ~normalize test_name (fun () ->
+                  ~checked_output:(Testo.stdout ()) ~normalize test_name
+                  (fun () ->
                     Git_wrapper.with_git_repo repo_files (fun () ->
                         test_func caps))))
   |> List_.flatten

--- a/src/targeting/Unit_find_targets.ml
+++ b/src/targeting/Unit_find_targets.ml
@@ -98,7 +98,8 @@ let test_find_targets ?includes ?(excludes = [])
                printf "ignored %s [%s]\n" !!(x.path)
                  (Out.show_skip_reason x.reason)))
   in
-  Testo.create name test_func ~category:[ category ] ~checked_output:Stdout
+  Testo.create name test_func ~category:[ category ]
+    ~checked_output:(Testo.stdout ())
     ~normalize:
       [
         Testo.mask_temp_paths ();


### PR DESCRIPTION
Now allows keeping expected test snapshots wherever it's specified by the user. Note that the path must be relative to the project root where the test program runs.

See https://semgrep.github.io/testo/reference/testo/Testo/#type-checked_output_kind