### PR TITLE
Don't honor the `LOG_LEVEL` environment variable

### DIFF
--- a/changelog.d/gh-10044.fixed
+++ b/changelog.d/gh-10044.fixed
@@ -1,0 +1,6 @@
+The environment variable `LOG_LEVEL` (as well as `PYTEST_LOG_LEVEL`) is
+no longer consulted by Semgrep to determine the log level. Only
+`SEMGREP_LOG_LEVEL` is consulted. `PYTEST_SEMGREP_LOG_LEVEL` is also
+consulted in the current implementation but should not be used outside of
+Semgrep's Pytest tests. This is to avoid accidentally affecting Semgrep
+when inheriting the `LOG_LEVEL` destined to another application.

--- a/libs/commons/Logs_.ml
+++ b/libs/commons/Logs_.ml
@@ -250,14 +250,7 @@ let log_level_of_string_opt str : Logs.level option option =
 let read_level_from_env () =
   (* left-to-right in order of precedence = from more specific to least
      specific *)
-  let vars =
-    [
-      "PYTEST_SEMGREP_LOG_LEVEL";
-      "SEMGREP_LOG_LEVEL";
-      "PYTEST_LOG_LEVEL";
-      "LOG_LEVEL";
-    ]
-  in
+  let vars = [ "PYTEST_SEMGREP_LOG_LEVEL"; "SEMGREP_LOG_LEVEL" ] in
   vars
   |> List.find_map (fun var ->
          match USys.getenv_opt var with


### PR DESCRIPTION
No longer consult the environment variables `LOG_LEVEL` and `PYTEST_LOG_LEVEL` to avoid unexpected logging when another app uses these variables. `SEMGREP_LOG_LEVEL` should be used instead. `PYTEST_SEMGREP_LOG_LEVEL` should only be used when working with semgrep's pytest tests.

Fixes https://github.com/semgrep/semgrep/issues/10044

Test plan:

```
$ SEMGREP_LOG_LEVEL=debug semgrep -l python -e hello <(echo hello)
[00.07][DEBUG]: setup_logging: highlight_setting=Std_msg.Auto, highlight=true
[00.07][DEBUG](Pysemgrep): execute pysemgrep: "osemgrep" "-l" "python" "-e" "hello" "/dev/fd/63"
                  
                  
┌────────────────┐
│ 1 Code Finding │
└────────────────┘
                                             
    /tmp/tmpacpgm_z4/dev_fd_63
            1┆ hello

                
                
┌──────────────┐
│ Scan Summary │
└──────────────┘

Ran 1 rule on 1 file: 1 finding.
```
The same command with `LOG_LEVEL` instead of `SEMGREP_LOG_LEVEL` should not show the `DEBUG` lines:
```
$ LOG_LEVEL=debug semgrep -l python -e hello <(echo hello)
                  
                  
┌────────────────┐
│ 1 Code Finding │
└────────────────┘
                                             
    /tmp/tmpb9lj2xhx/dev_fd_63
            1┆ hello

                
                
┌──────────────┐
│ Scan Summary │
└──────────────┘

Ran 1 rule on 1 file: 1 finding.
```
