### PR TITLE
chore: pin tls-mirage version

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -496,6 +496,7 @@ For more information see https://semgrep.dev
     tls-lwt ; needed for TLS support in the cohttp HTTP client (only TLS 1.3 seems to work)
     emile
     (digestif (>= 1.0.0))
+    (tls-mirage (= 0.17.3)) ; force older version of conf-libcurl to make windows work
     ; concurrency
     lwt
     lwt_ppx
@@ -507,7 +508,6 @@ For more information see https://semgrep.dev
     (js_of_ocaml-lwt (= 5.5.2))
     ctypes_stubs_js
     integers_stubs_js
-    (tls-mirage (= 0.17.3))
   )
 )
 

--- a/dune-project
+++ b/dune-project
@@ -496,7 +496,7 @@ For more information see https://semgrep.dev
     tls-lwt ; needed for TLS support in the cohttp HTTP client (only TLS 1.3 seems to work)
     emile
     (digestif (>= 1.0.0))
-    (tls-mirage (= 0.17.3)) ; force older version of conf-libcurl to make windows work
+    (tls-mirage (= 0.17.3)) ; force older version of tls-mirage to make windows work
     ; concurrency
     lwt
     lwt_ppx

--- a/dune-project
+++ b/dune-project
@@ -507,6 +507,7 @@ For more information see https://semgrep.dev
     (js_of_ocaml-lwt (= 5.5.2))
     ctypes_stubs_js
     integers_stubs_js
+    (tls-mirage (= 0.17.3))
   )
 )
 

--- a/semgrep.opam
+++ b/semgrep.opam
@@ -69,6 +69,7 @@ depends: [
   "tls-lwt"
   "emile"
   "digestif" {>= "1.0.0"}
+  "tls-mirage" {= "0.17.3"}
   "lwt"
   "lwt_ppx"
   "conf-libev" {os != "win32"}
@@ -78,7 +79,6 @@ depends: [
   "js_of_ocaml-lwt" {= "5.5.2"}
   "ctypes_stubs_js"
   "integers_stubs_js"
-  "tls-mirage" {= "0.17.3"}
   "odoc" {with-doc}
 ]
 build: [

--- a/semgrep.opam
+++ b/semgrep.opam
@@ -78,6 +78,7 @@ depends: [
   "js_of_ocaml-lwt" {= "5.5.2"}
   "ctypes_stubs_js"
   "integers_stubs_js"
+  "tls-mirage" {= "0.17.3"}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
Windows doesn't seem to like Tls_mirage 0.17.4. Example failing workflow from last week: https://github.com/semgrep/semgrep/actions/runs/8573190639/job/23499854171?pr=10064#step:8:906

So we need to pin the tls-mirage version to 0.17.3 for now.

I think the dependency is git-unix -> git-mirage -> git-paf -> paf -> tls-mirage. It seems like we use the most recent version of git-unix. I don't really know why paf 0.3 is being picked up, when 0.5 is the latest version.

There's a more recent commit in paf: https://github.com/dinosaure/paf-le-chien/commit/1751aec7161c5c449c887910c48fcaf526bddfb9#diff-69ea6088051956fa16649edb6c1460d9e6ccdb49778943abff2a5e127ec2b412R16, and it seems like it may work with tls-mirage 0.17.4, so we should probably re-visit later.

That said, this is blocking our current release, and I think pinning the version of tls-mirage so it can build in Windows is a good short term solution for now.