### PR TITLE
chore(matching-expls): report negations in reverse

### DIFF
--- a/src/engine/Match_search_mode.ml
+++ b/src/engine/Match_search_mode.ml
@@ -898,18 +898,17 @@ and evaluate_formula_kind env opt_context (kind : Rule.formula_kind) =
 
           (* let's remove the negative ranges *)
           let ranges, negs_expls =
-            neg
-            |> List.fold_left
-                 (fun (ranges, acc_expls) (tok, x) ->
-                   let ranges_neg, expl = evaluate_formula env opt_context x in
-                   let ranges =
-                     RM.difference_ranges env.xconf.config ranges ranges_neg
-                   in
-                   let expl =
-                     if_explanations env ranges [ expl ] (OutJ.Negation, tok)
-                   in
-                   (ranges, expl :: acc_expls))
-                 (ranges, [])
+            List.fold_right
+              (fun (tok, x) (ranges, acc_expls) ->
+                let ranges_neg, expl = evaluate_formula env opt_context x in
+                let ranges =
+                  RM.difference_ranges env.xconf.config ranges ranges_neg
+                in
+                let expl =
+                  if_explanations env ranges [ expl ] (OutJ.Negation, tok)
+                in
+                (ranges, expl :: acc_expls))
+              neg (ranges, [])
           in
 
           let expl =


### PR DESCRIPTION
## What:
This PR simply reverses our matching explanations, which are accumulated in reverse, so that our matching explanations are in the right order.

## Why:
Before, for a rule like:
```
rules:
  - id: dont-call-in-function
    languages:
      - python
    severity: ERROR
    message: ""
    patterns:
      - pattern: $FUNC(...)
      - pattern-not: foo(...)
      - pattern-not: bar(...)
```
we would get these explanations:
```
 Matching explanations:
   op = And (at 453), matches =
     op = (XPat "$FUNC(...)") (at 480), matches = 5-10 13-23 17-22 1-11
     op = Negation (at 529), matches =
       op = (XPat "bar(...)") (at 542), matches = 5-10 13-23
     op = Negation (at 499), matches = 5-10 13-23
       op = (XPat "foo(...)") (at 512), matches = 17-22 1-11
```
Note how the `bar` negation explanations come before the `foo` ones, even though `foo` appears before. We see from the matches associated to the node that this is also not representative of the way that the query is executed -- `foo` executes first and leaves two surviving matches, and `bar` executes next, and leaves no surviving matches.

This is a problem because matching explanations are assumed to be in the same structure as the original rule, meaning that this is misleading.

## How:
We just reverse the matches, which are produced in reverse order of when they are executed.

## Test plan:
```
 Matching explanations:
   op = And (at 453), matches =
     op = (XPat "$FUNC(...)") (at 480), matches = 5-10 13-23 17-22 1-11
     op = Negation (at 499), matches = 5-10 13-23
       op = (XPat "foo(...)") (at 512), matches = 17-22 1-11
     op = Negation (at 529), matches =
       op = (XPat "bar(...)") (at 542), matches = 5-10 13-23

```