### PR TITLE
Make sure that the temp-dir path is a real path

### DIFF
--- a/libs/commons/Filename_.ml
+++ b/libs/commons/Filename_.ml
@@ -18,6 +18,9 @@ open Common
 (* Filenames *)
 (*****************************************************************************)
 
+(* nosemgrep: forbid-tmp *)
+let get_temp_dir_name () = UFilename.get_temp_dir_name () |> UUnix.realpath
+
 let chop_dirsymbol = function
   | s when s =~ "\\(.*\\)/$" -> Common.matched1 s
   | s -> s

--- a/libs/commons/Filename_.mli
+++ b/libs/commons/Filename_.mli
@@ -1,3 +1,6 @@
+val get_temp_dir_name : unit -> string
+(** Same as 'Filename.get_temp_dir_name' but resolves symlinks (returns a "real path"). *)
+
 (* Deprecated: use the Ppath module instead! *)
 val filename_without_leading_path :
   string -> string (* filename *) -> string (* filename *)

--- a/libs/commons/UTmp.ml
+++ b/libs/commons/UTmp.ml
@@ -98,7 +98,8 @@ end
 (* API using Fpath.t for filenames *)
 (*****************************************************************************)
 
-let get_temp_dir_name () = Fpath.v (UFilename.get_temp_dir_name ())
+let get_temp_dir_name () =
+  Fpath.v (UFilename.get_temp_dir_name () |> UUnix.realpath)
 
 let new_temp_file ?(temp_dir = get_temp_dir_name ()) prefix suffix =
   let temp_dir = !!temp_dir in

--- a/libs/git_wrapper/Unit_git_wrapper.ml
+++ b/libs/git_wrapper/Unit_git_wrapper.ml
@@ -96,7 +96,7 @@ let tests =
                  (Sys.getcwd ())));
     t "fail to get git project root" (fun () ->
         (* A standard folder that we know is not in a git repo *)
-        let cwd = Filename.get_temp_dir_name () |> Fpath.v in
+        let cwd = Filename_.get_temp_dir_name () |> Fpath.v in
         match Git_wrapper.get_project_root ~cwd () with
         | Some root ->
             Alcotest.fail

--- a/semgrep.yml
+++ b/semgrep.yml
@@ -349,6 +349,25 @@ rules:
     languages: [ocaml]
     severity: WARNING
 
+  - id: no-filename-get-temp-dir-name
+    pattern: List.map
+    message: >-
+      `Filename.get_temp_dir_name` may return a path that is not "real", that is,
+      contains symlinks, that may cause problems specially in test suites.
+      Use `Filename_.get_temp_dir_name` instead.
+    fix: Filename_.get_temp_dir_anme
+    languages: [ocaml]
+    severity: ERROR
+    paths:
+      include:
+        - src/*
+      exclude:
+        - profiling/*
+        - ppx_profiling/*
+        - commons/*
+        - graph_code/*
+        - lib_parsing/*
+
   - id: no-metavariable-equal-xyz
     patterns:
       - pattern: Metavariable.$F

--- a/src/osemgrep/language_server/Unit_LS.ml
+++ b/src/osemgrep/language_server/Unit_LS.ml
@@ -103,7 +103,7 @@ let mock_workspace ?(git = false) () : Fpath.t =
   let rand_dir () =
     let uuid = Uuidm.v `V4 in
     let dir_name = "test_workspace_" ^ Uuidm.to_string uuid in
-    let dir = Filename.concat (Filename.get_temp_dir_name ()) dir_name in
+    let dir = Filename.concat (Filename_.get_temp_dir_name ()) dir_name in
     Unix.mkdir dir 0o777;
     dir
   in

--- a/src/osemgrep/tests/Test_target_selection.ml
+++ b/src/osemgrep/tests/Test_target_selection.ml
@@ -107,6 +107,7 @@ let normalize =
     Testo.mask_line ~after:"Initialized empty Git repository in" ();
     Testo.mask_line ~after:"[main (root-commit) " ~before:"]" ();
     Testo.mask_pcre_pattern "/test-[a-f0-9]+";
+    Testutil.mask_temp_paths ();
   ]
 
 (*

--- a/tests/snapshots/semgrep-core/0307ab87fd4c/stdout
+++ b/tests/snapshots/semgrep-core/0307ab87fd4c/stdout
@@ -4,6 +4,6 @@ Initialized empty Git repository in<MASKED>
  create mode 100644 a/b/target
 Input files:
 a/b/target
-cwd: /tmp<MASKED>/a
+cwd: <TMP><MASKED>/a
 Target files:
   b/target

--- a/tests/snapshots/semgrep-core/7c0c5fe922a0/stdout
+++ b/tests/snapshots/semgrep-core/7c0c5fe922a0/stdout
@@ -4,6 +4,6 @@ Initialized empty Git repository in<MASKED>
  create mode 100644 a/b/target
 Input files:
 a/b/target
-cwd: /tmp<MASKED>/a/b
+cwd: <TMP><MASKED>/a/b
 Target files:
   target


### PR DESCRIPTION
In many places, especially in test suites, we assume that the temp-dir path is a real path, but in macOS it is not.

test plan:
TMPDIR=/path/containing/symlinks make test
  #^ previously dozens of failing tests

