### PR TITLE
WiP run plan debug output fix

### DIFF
--- a/cli/src/semgrep/core_runner.py
+++ b/cli/src/semgrep/core_runner.py
@@ -648,7 +648,7 @@ class CoreRunner:
             Tuple[Path, Language], Tuple[List[int], Set[str]]
         ] = collections.defaultdict(lambda: (list(), set()))
 
-        lockfiles = target_manager.get_all_lockfiles()
+        lockfiles = target_manager.get_all_lockfiles(ignore_baseline_handler=True)
         unused_rules = []
 
         for rule_num, rule in enumerate(rules):

--- a/cli/src/semgrep/run_scan.py
+++ b/cli/src/semgrep/run_scan.py
@@ -36,6 +36,7 @@ from semdep.parsers.util import DependencyParserError
 from semgrep import __VERSION__
 from semgrep.autofix import apply_fixes
 from semgrep.config_resolver import get_config
+from semgrep.console import console
 from semgrep.constants import DEFAULT_DIFF_DEPTH
 from semgrep.constants import DEFAULT_TIMEOUT
 from semgrep.constants import OutputFormat
@@ -663,6 +664,13 @@ def run_scan(
                             get_file_ignore()
                         ),
                     )
+
+                    filterd_rules = [
+                        rule
+                        for rule, matches in rule_matches_by_rule.items()
+                        if matches
+                    ]
+                    console.print(filterd_rules)
 
                     (
                         baseline_rule_matches_by_rule,

--- a/cli/src/semgrep/target_manager.py
+++ b/cli/src/semgrep/target_manager.py
@@ -822,7 +822,9 @@ class TargetManager:
 
         return paths.kept
 
-    def get_all_lockfiles(self) -> Dict[Ecosystem, FrozenSet[Path]]:
+    def get_all_lockfiles(
+        self, ignore_baseline_handler: bool = False
+    ) -> Dict[Ecosystem, FrozenSet[Path]]:
         """
         Return a dict mapping each ecosystem to the set of lockfiles for that ecosystem
         """
@@ -841,7 +843,10 @@ class TargetManager:
         }
 
         return {
-            ecosystem: self.get_lockfiles(ecosystem) for ecosystem in ALL_ECOSYSTEMS
+            ecosystem: self.get_lockfiles(
+                ecosystem, ignore_baseline_handler=ignore_baseline_handler
+            )
+            for ecosystem in ALL_ECOSYSTEMS
         }
 
     @lru_cache(maxsize=None)


### PR DESCRIPTION
Unedited lockfiles are now scanned in diff-aware scans, but not are not reflected in the debug output stats prior to starting the scan.

Need to verify that this change accurately displays the list of lockfiles that will be scanned, and the number of rules in each category.

Also, from my single, shallow test, the baseline scan run still showed no supply chain rules - was the correct, or is something missing in these changes?