### PR TITLE
tracing: include a ppx option to open a trace inside a function

### DIFF
--- a/libs/tracing/ppx_tests/nested_let.ml
+++ b/libs/tracing/ppx_tests/nested_let.ml
@@ -1,0 +1,8 @@
+let top a b =
+  let add_one a = a + 1 [@@trace] in
+  add_one a + b
+
+let top2 a b =
+  let%trace sp = "example" in
+  a + 1;
+  Tracing.add_data_to_span sp [ ("a", `Int 1) ]


### PR DESCRIPTION
The trace ppx allows the syntax:

```
let f =
  ...
[@@trace]
```

to trace functions, in keeping with previous convention in our codebase. However, for tracing, this syntax is limited because is does not allow you to trace just a function, and it doesn't allow you to save the span name to add to the span later.

To improve that, we also support the syntax

```
let f =
   let%trace sp = "<trace_name>" in
   g(42);
   Trace.add_data_to_span _sp ["x", `Int 42]
```

This syntax is the same as the syntax for the maintainer's ppx and the implementation is mostly taken from there.

### Why not just use the maintainer's ppx?

The maintainer's ppx uses `enter_span` and `exit_span` instead of `with_span` (to avoid the extra frame). We prefer `with_span`, which creates a child span.

We could have contributed the change to the maintainer's ppx. However, there were several other considerations. We currently use `[@@profiling]` already in our codebase, and while I want to migrate away from that, it's easier for now to just modify our own. Additionally, it's nice to have the flexibility to add new features when we need them, since there are some more changes we're interested in (e.g. ppx with different modes).

Ultimately, adding this feature to our ppx wasn't that hard, and if we later find that we're missing out by not getting improvements, we can pretty easily contribute the changes we've made so far with (hopefully) less back and forth.

### Test plan

```
➜  ppx_tests git:(9af4bad8f) ✗ pwd
/Users/emma/workspace/semgrep-proprietary/semgrep/libs/tracing/ppx_tests ➜  ppx_tests git:(emma/support-creating-trace-spans) ✗ dune describe pp semgrep/libs/tracing/ppx_tests/nested_let.ml Entering directory '/Users/emma/workspace/semgrep-proprietary' ...
let top a b =
  let add_one a =
    (Tracing.with_span ~__FILE__ ~__LINE__ "Nested_let.add_one") @@
      (fun _sp -> a + 1)[@@trace ] in
  (add_one a) + b
let top2 a b =
  (Tracing.with_span ~__FILE__ ~__LINE__ "example") @@
    (fun sp -> a + 1; Tracing.add_data_to_span sp [("a", (`Int 1))])
```
