### PR TITLE
Rename environment variable `LOG_TAGS` to `SEMGREP_LOG_TAGS`

### DIFF
--- a/changelog.d/gh-10087.changed
+++ b/changelog.d/gh-10087.changed
@@ -1,0 +1,5 @@
+* The environment variables used to select the debug-level log messages
+  are now prefixed with `SEMGREP_` (or `PYTEST_SEMGREP_`) to avoid namespace
+  pollution and undesired cross-application side effects.
+  The supported environment variables are now `SEMGREP_LOG_TAGS`
+  and `PYTEST_SEMGREP_LOG_TAGS`.

--- a/cli/tests/default/e2e/snapshots/test_output/test_debug_experimental_rule/results.txt
+++ b/cli/tests/default/e2e/snapshots/test_output/test_debug_experimental_rule/results.txt
@@ -11,6 +11,7 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
 === end of stdout - plain
 
 === stderr - plain
+[<MASKED>][DEBUG]: setup_logging: highlight_setting=Std_msg.Auto, highlight=false
 semgrep version <MASKED>
 Failed to get project url from 'git ls-remote': Command failed with exit code: 128
 -----
@@ -45,8 +46,9 @@ Passing whole rules directly to semgrep_core
 Running Semgrep engine with command:
 <MASKED> -json -rules <MASKED> -j <MASKED> -strict -targets <MASKED> -timeout 5 -timeout_threshold 3 -max_memory 0 -fast --debug
 --- semgrep-core stderr ---
-[<MASKED>][INFO](cli, Core_CLI): Executed as: <MASKED> -json -rules <MASKED> -j <MASKED> -strict -targets <MASKED> -timeout 5 -timeout_threshold 3 -max_memory 0 -fast --debug
-[<MASKED>][INFO](cli, Core_CLI): Version: semgrep-core version: <MASKED>
+[<MASKED>][DEBUG]: setup_logging: highlight_setting=Std_msg.On, highlight=true
+[<MASKED>][INFO]: Executed as: <MASKED> -json -rules <MASKED> -j <MASKED> -strict -targets <MASKED> -timeout 5 -timeout_threshold 3 -max_memory 0 -fast --debug
+[<MASKED>][INFO]: Version: semgrep-core version: <MASKED>
 --- end semgrep-core stderr ---
 semgrep ran in <MASKED> on 1 files
 findings summary: 2 experiment
@@ -102,6 +104,7 @@ Not sending pseudonymous metrics since metrics are configured to OFF and registr
 === end of stdout - color
 
 === stderr - color
+[<MASKED>][DEBUG]: setup_logging: highlight_setting=Std_msg.Auto, highlight=false
 semgrep version <MASKED>
 Failed to get project url from 'git ls-remote': Command failed with exit code: 128
 -----
@@ -136,8 +139,9 @@ Passing whole rules directly to semgrep_core
 Running Semgrep engine with command:
 <MASKED> -json -rules <MASKED> -j <MASKED> -strict -targets <MASKED> -timeout 5 -timeout_threshold 3 -max_memory 0 -fast --debug
 --- semgrep-core stderr ---
-[<MASKED>][[34mINFO[0m](cli, Core_CLI): Executed as: <MASKED> -json -rules <MASKED> -j <MASKED> -strict -targets <MASKED> -timeout 5 -timeout_threshold 3 -max_memory 0 -fast --debug
-[<MASKED>][[34mINFO[0m](cli, Core_CLI): Version: semgrep-core version: <MASKED>
+[<MASKED>][[32mDEBUG[0m]: setup_logging: highlight_setting=Std_msg.On, highlight=true
+[<MASKED>][[34mINFO[0m]: Executed as: <MASKED> -json -rules <MASKED> -j <MASKED> -strict -targets <MASKED> -timeout 5 -timeout_threshold 3 -max_memory 0 -fast --debug
+[<MASKED>][[34mINFO[0m]: Version: semgrep-core version: <MASKED>
 --- end semgrep-core stderr ---
 semgrep ran in <MASKED> on 1 files
 findings summary: 2 experiment

--- a/libs/commons/Logs_.ml
+++ b/libs/commons/Logs_.ml
@@ -192,7 +192,7 @@ let reporter ~dst ~require_one_of_these_tags
     in
     let r =
       msgf (fun ?header ?(tags = Logs.Tag.empty) fmt ->
-          let pp_w_time () =
+          let pp_w_time ~tags =
             let current = now () in
             (* Add a header *)
             Format.kfprintf k dst
@@ -207,10 +207,12 @@ let reporter ~dst ~require_one_of_these_tags
           | Error
           | Warning
           | Info ->
-              pp_w_time ()
+              (* Print no tags for levels other than Debug since we can't
+                 filter these messages by tag. *)
+              pp_w_time ~tags:Logs.Tag.empty
           | Debug ->
               (* Tag-based filtering *)
-              if has_tag require_one_of_these_tags tags then pp_w_time ()
+              if has_tag require_one_of_these_tags tags then pp_w_time ~tags
               else (* print nothing *)
                 Format.ikfprintf k dst fmt)
     in

--- a/libs/commons/Logs_.ml
+++ b/libs/commons/Logs_.ml
@@ -285,8 +285,8 @@ let enable_logging () =
 
 let setup_logging ?(highlight_setting = Std_msg.get_highlight_setting ())
     ?log_to_file:opt_file ?(skip_libs = default_skip_libs)
-    ?require_one_of_these_tags ?(read_tags_from_env_var = Some "LOG_TAGS")
-    ~level () =
+    ?require_one_of_these_tags
+    ?(read_tags_from_env_var = Some "SEMGREP_LOG_TAGS") ~level () =
   (* Override the log level if it's provided by an environment variable!
      This is for debugging a command that gets called by some wrapper. *)
   let level =

--- a/libs/commons/Logs_.mli
+++ b/libs/commons/Logs_.mli
@@ -57,12 +57,13 @@ val default_skip_libs : Re.re list
    'read_tags_from_env_var': specifies an environment variable
    from which a list of comma-separated tags will be read if the variable
    is set, in which case the list of tags will override any value set
-   via 'require_one_of_these_tags'. This variable is "LOG_TAGS" by default.
+   via 'require_one_of_these_tags'. This variable is "SEMGREP_LOG_TAGS"
+   by default.
    To disable it, set it to None. The following shell command shows how
    to make semgrep run at the debug level but only show lines tagged with
    'Match_rules' or 'Core_scan'.
 
-     $ LOG_TAGS=Match_rules,Core_scan semgrep -e 'Obj.magic' -l ocaml --debug
+     $ SEMGREP_LOG_TAGS=Match_rules,Core_scan semgrep -e 'Obj.magic' -l ocaml --debug
      ...
      [00.45][INFO](Core_scan): Analyzing TCB/CapStdlib.ml
      [00.45][INFO](Core_scan): Analyzing tests/parsing/ocaml/attribute_type.ml

--- a/libs/commons/Logs_.mli
+++ b/libs/commons/Logs_.mli
@@ -54,11 +54,17 @@ val default_skip_libs : Re.re list
    'require_one_of_these_tags': if a list of tags is provided, at least one
    of these tags must be set for a log instruction to be printed.
 
-   'read_tags_from_env_var': specifies an environment variable
+   'read_level_from_env_var': environment variables that override the
+   'level' argument. The default is ["PYTEST_SEMGREP_LOG_LEVEL";
+   "SEMGREP_LOG_LEVEL"]. See also 'read_tags_from_env_vars'.
+
+   'read_tags_from_env_vars': specifies environment variables
    from which a list of comma-separated tags will be read if the variable
    is set, in which case the list of tags will override any value set
    via 'require_one_of_these_tags'. This variable is "SEMGREP_LOG_TAGS"
-   by default.
+   by default. "PYTEST_SEMGREP_LOG_TAGS" is also supported and allows
+   modifying the logging behavior of pytest tests since pytest clears
+   the environment except for variables starting with "PYTEST_".
    To disable it, set it to None. The following shell command shows how
    to make semgrep run at the debug level but only show lines tagged with
    'Match_rules' or 'Core_scan'.
@@ -85,7 +91,8 @@ val setup_logging :
   ?log_to_file:Fpath.t ->
   ?skip_libs:Re.re list ->
   ?require_one_of_these_tags:string list ->
-  ?read_tags_from_env_var:string option ->
+  ?read_level_from_env_vars:string list ->
+  ?read_tags_from_env_vars:string list ->
   level:Logs.level option ->
   unit ->
   unit


### PR DESCRIPTION
To minimize namespace pollution, all environment variables that are specific to Semgrep should have the `SEMGREP_` prefix.

We also support the `PYTEST_SEMGREP_` prefix, the `PYTEST_` prefix instructing pytest to not unset these environment variables. This allows us to log more when debugging a test run with `pytest`.

Bonus fix: some Info-level messages produced by the test command below used to show tags. Since tags are irrelevant at levels other than Debug, I made sure they are no longer displayed.

test plan:
```
$ SEMGREP_LOG_TAGS=Core_scan semgrep2 -l python -e hello <(echo hello) --debug
[00.08][DEBUG]: setup_logging: highlight_setting=Std_msg.Auto, highlight=true
stdin or piped targets, adding --scan-unknown-extensions
semgrep version 1.68.0
using path ignore rules from user provided .semgrepignore
Rules:
- -
Passing whole rules directly to semgrep_core
Running Semgrep engine with command:
/home/martin/semgrep2/cli/src/semgrep/bin/semgrep-core -json -rules /tmp/tmpa47ntjb0.json -j 4 -targets /tmp/tmp2bjdgb55 -timeout 5 -timeout_threshold 3 -max_memory 0 -fast --debug
--- semgrep-core stderr ---
[00.08][DEBUG]: setup_logging: highlight_setting=Std_msg.On, highlight=true
[00.08][INFO]: Executed as: /home/martin/semgrep2/cli/src/semgrep/bin/semgrep-core -json -rules /tmp/tmpa47ntjb0.json -j 4 -targets /tmp/tmp2bjdgb55 -timeout 5 -timeout_threshold 3 -max_memory 0 -fast --debug
[00.08][INFO]: Version: semgrep-core version: 1.68.0
[00.08][DEBUG](Core_scan): Parsing /tmp/tmpa47ntjb0.json:
{
  "rules": [
    {
      "id": "-",
      "languages": [
        "python"
      ],
      "message": "hello",
      "pattern": "hello",
      "severity": "ERROR"
    }
  ]
}
[00.08][DEBUG](Core_scan): processing 1 files, skipping 0 files
[00.10][DEBUG](Core_scan): Analyzing /tmp/tmp8x_g0mad/dev_fd_63 (contents in /tmp/tmp8x_g0mad/dev_fd_63)
[00.14][DEBUG](Core_scan): done with /tmp/tmp8x_g0mad/dev_fd_63 (contents in /tmp/tmp8x_g0mad/dev_fd_63)
[00.27][DEBUG](Core_scan): found 1 matches, 0 errors
[00.27][DEBUG](Core_scan): there were 0 skipped targets
--- end semgrep-core stderr ---
semgrep ran in 0:00:00.333536 on 1 files
findings summary: 1 error
                  
                  
┌────────────────┐
│ 1 Code Finding │
└────────────────┘
                                             
    /tmp/tmp8x_g0mad/dev_fd_63
            1┆ hello


========================================
Files skipped:
========================================

  Always skipped by Semgrep:

   • <none>

  Skipped by .gitignore:
  (Disable by passing --no-git-ignore)

   • <all files not listed by `git ls-files` were skipped>

  Skipped by .semgrepignore:
  - https://semgrep.dev/docs/ignoring-files-folders-
  code/#understanding-semgrep-defaults

   • <none>

  Skipped by --include patterns:

   • <none>

  Skipped by --exclude patterns:

   • <none>

  Skipped by limiting to files smaller than 1000000 bytes:
  (Adjust with the --max-target-bytes flag)

   • <none>

  Partially analyzed due to parsing or internal Semgrep errors

   • <none>

                
                
┌──────────────┐
│ Scan Summary │
└──────────────┘

Ran 1 rule on 1 file: 1 finding.
Not sending pseudonymous metrics since metrics are configured to AUTO and registry usage is False
```

The output above should show debug logs that all contain `[DEBUG](Core_scan)`.
