### PR TITLE
New logging tags `default` and `all`.

### DIFF
--- a/changelog.d/gh-10089.changed
+++ b/changelog.d/gh-10089.changed
@@ -1,0 +1,3 @@
+The implicit tag to show all debug-level log messages changes from
+`everything` to `all`. All debug-level messages shown by default are
+now tagged and selectable with a `default` tag.

--- a/cli/tests/default/e2e/snapshots/test_output/test_debug_experimental_rule/results.txt
+++ b/cli/tests/default/e2e/snapshots/test_output/test_debug_experimental_rule/results.txt
@@ -11,6 +11,7 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
 === end of stdout - plain
 
 === stderr - plain
+[<MASKED>][DEBUG](default): setup_logging: highlight_setting=Std_msg.Auto, highlight=false
 semgrep version <MASKED>
 Failed to get project url from 'git ls-remote': Command failed with exit code: 128
 -----
@@ -45,6 +46,7 @@ Passing whole rules directly to semgrep_core
 Running Semgrep engine with command:
 <MASKED> -json -rules <MASKED> -j <MASKED> -strict -targets <MASKED> -timeout 5 -timeout_threshold 3 -max_memory 0 -fast --debug
 --- semgrep-core stderr ---
+[<MASKED>][DEBUG](default): setup_logging: highlight_setting=Std_msg.On, highlight=true
 [<MASKED>][INFO](cli, Core_CLI): Executed as: <MASKED> -json -rules <MASKED> -j <MASKED> -strict -targets <MASKED> -timeout 5 -timeout_threshold 3 -max_memory 0 -fast --debug
 [<MASKED>][INFO](cli, Core_CLI): Version: semgrep-core version: <MASKED>
 --- end semgrep-core stderr ---
@@ -102,6 +104,7 @@ Not sending pseudonymous metrics since metrics are configured to OFF and registr
 === end of stdout - color
 
 === stderr - color
+[<MASKED>][DEBUG](default): setup_logging: highlight_setting=Std_msg.Auto, highlight=false
 semgrep version <MASKED>
 Failed to get project url from 'git ls-remote': Command failed with exit code: 128
 -----
@@ -136,6 +139,7 @@ Passing whole rules directly to semgrep_core
 Running Semgrep engine with command:
 <MASKED> -json -rules <MASKED> -j <MASKED> -strict -targets <MASKED> -timeout 5 -timeout_threshold 3 -max_memory 0 -fast --debug
 --- semgrep-core stderr ---
+[<MASKED>][[32mDEBUG[0m](default): setup_logging: highlight_setting=Std_msg.On, highlight=true
 [<MASKED>][[34mINFO[0m](cli, Core_CLI): Executed as: <MASKED> -json -rules <MASKED> -j <MASKED> -strict -targets <MASKED> -timeout 5 -timeout_threshold 3 -max_memory 0 -fast --debug
 [<MASKED>][[34mINFO[0m](cli, Core_CLI): Version: semgrep-core version: <MASKED>
 --- end semgrep-core stderr ---

--- a/libs/commons/Logs_.ml
+++ b/libs/commons/Logs_.ml
@@ -144,20 +144,8 @@ let has_nonempty_intersection tag_str_list tag_set =
 
 let has_tag opt_str_list tag_set =
   match opt_str_list with
-  | None (* = no filter *) ->
-      (* If there is no filter, we filter out every tagged message. We don't want
-       * --debug's output to be enourmous, that tends not to be useful. You should
-       * instead first consider what exact debug info you need (i.e. what "tags").
-       * This is also a perf problem for the Python CLI that captures all this
-       * output in-memory (despite it shouldn't do that in the first place...). *)
-      Logs.Tag.is_empty tag_set
-  | Some [ "everything" ] ->
-      (* Special tag "everything" prints every debug message. *)
-      true
-  | Some tag_str_list ->
-      (* Untagged messages are always printed. *)
-      Logs.Tag.is_empty tag_set
-      || has_nonempty_intersection tag_str_list tag_set
+  | None (* = no filter *) -> true
+  | Some tag_str_list -> has_nonempty_intersection tag_str_list tag_set
 
 let read_tags_from_env_var opt_var =
   match opt_var with


### PR DESCRIPTION
* The implicit tag `all` replaces `everything` because it makes the semgrep command-line shorter.
* The tag set `{default}` is now assigned by default to any debug-level log message that doesn't specify tags.
* If no tags are specified at runtime (e.g. via the `SEMGREP_LOG_TAGS` environment variable), the tag selector is set to `{default}` which will select all debug-level messages tagged with `default`.

What changed is the following:
* A log message can be tagged with `default` and some other tags. The `default` tag is no longer mutually exclusive with other tags.
* It is now possible to print all the default messages and some extra ones e.g. by setting `SEMGREP_LOG_TAGS=default,Core_scan`.

Note that the parallel PR #10087 changes the environment variable `LOG_TAGS` to `SEMGREP_LOG_TAGS`.

Test plan:

The following commands should behave nicely:

`[DEBUG]` occurs only followed by `(default)`:
```
semgrep -l python -e hello <(echo hello) --debug
```

`[DEBUG]` occurs followed by `(default)` and various other tags e.g. `[DEBUG](svalue, Constant_propagation)`:
```
SEMGREP_LOG_TAGS=all semgrep -l python -e hello <(echo hello) --debug
```

`[DEBUG]` occurs only followed by `(default)` or `(Core_scan)`:
```
SEMGREP_LOG_TAGS=Core_scan,default semgrep -l python -e hello <(echo hello) --debug
```

No line contains `[DEBUG]`:
```
SEMGREP_LOG_TAGS= semgrep -l python -e hello <(echo hello) --debug
```
