### PR TITLE
Use `temp_` consistently instead of a mix of `tmp_` and `temp_`

### DIFF
--- a/languages/go/menhir/parse_go.ml
+++ b/languages/go/menhir/parse_go.ml
@@ -97,7 +97,7 @@ let parse_program file =
 (*****************************************************************************)
 
 let program_of_string (caps : < Cap.tmp >) (s : string) : Ast_go.program =
-  CapTmp.with_tmp_file caps#tmp ~str:s ~ext:"go" parse_program
+  CapTmp.with_temp_file caps#tmp ~str:s ~ext:"go" parse_program
 
 (* for sgrep/spatch *)
 let any_of_string s =

--- a/languages/java/menhir/parse_java.ml
+++ b/languages/java/menhir/parse_java.ml
@@ -102,7 +102,7 @@ let parse_program file =
 
 let parse_string (caps : < Cap.tmp >) (w : string) :
     (Ast_java.program, Parser_java.token) Parsing_result.t =
-  CapTmp.with_tmp_file caps#tmp ~str:w ~ext:"java" parse
+  CapTmp.with_temp_file caps#tmp ~str:w ~ext:"java" parse
 
 (*****************************************************************************)
 (* Sub parsers *)

--- a/languages/javascript/menhir/parse_js.ml
+++ b/languages/javascript/menhir/parse_js.ml
@@ -308,7 +308,7 @@ let parse_program file =
   res.Parsing_result.ast
 
 let program_of_string (caps : < Cap.tmp >) (w : string) : Ast.a_program =
-  CapTmp.with_tmp_file caps#tmp ~str:w ~ext:"js" parse_program
+  CapTmp.with_temp_file caps#tmp ~str:w ~ext:"js" parse_program
 
 (*****************************************************************************)
 (* Sub parsers *)

--- a/languages/ocaml/menhir/unit_parsing_ml.ml
+++ b/languages/ocaml/menhir/unit_parsing_ml.ml
@@ -28,7 +28,7 @@ let tests (caps : < Cap.tmp >) =
        * sub-sub expressions inside parenthesis).
        *)
       t "visitor" (fun () ->
-          CapTmp.with_tmp_file caps#tmp ~ext:".ml"
+          CapTmp.with_temp_file caps#tmp ~ext:".ml"
             ~str:"open Foo1\nmodule A = Foo2\n" (fun file ->
               let _ast = Parse_ml.parse_program file in
               let _cnt = ref 0 in

--- a/languages/python/menhir/Parse_python.ml
+++ b/languages/python/menhir/Parse_python.ml
@@ -170,7 +170,7 @@ let parse_program ?parsing_mode file =
 (*****************************************************************************)
 
 let program_of_string (caps : < Cap.tmp >) (s : string) : AST_python.program =
-  CapTmp.with_tmp_file caps#tmp ~str:s ~ext:"py" parse_program
+  CapTmp.with_temp_file caps#tmp ~str:s ~ext:"py" parse_program
 
 let type_of_string ?(parsing_mode = Python) s =
   let lexbuf = Lexing.from_string s in

--- a/languages/tree-sitter-to-generic/Parse_vue_tree_sitter.ml
+++ b/languages/tree-sitter-to-generic/Parse_vue_tree_sitter.ml
@@ -393,7 +393,7 @@ let map_component (env : env) (xs : CST.component) : stmt list =
 (* TODO: move in Parse_tree_sitter_helpers.ml and avoid using tmp file *)
 let parse_string_and_adjust_wrt_base content tbase fparse =
   (* nosemgrep: forbid-tmp *)
-  UTmp.with_tmp_file ~str:content ~ext:"js" (fun file ->
+  UTmp.with_temp_file ~str:content ~ext:"js" (fun file ->
       let x = fparse file in
 
       let visitor =

--- a/libs/commons/CapTmp.ml
+++ b/libs/commons/CapTmp.ml
@@ -1,4 +1,4 @@
-let with_tmp_file _caps = UTmp.with_tmp_file
+let with_temp_file _caps = UTmp.with_temp_file
 let get_temp_dir_name _caps = UTmp.get_temp_dir_name ()
 let erase_temp_files _caps = UTmp.erase_temp_files ()
 let new_temp_file ?temp_dir _caps = UTmp.new_temp_file ?temp_dir

--- a/libs/commons/CapTmp.mli
+++ b/libs/commons/CapTmp.mli
@@ -1,6 +1,6 @@
 (* Capability aware wrappers to UTmp.ml *)
 
-val with_tmp_file :
+val with_temp_file :
   Cap.FS.tmp -> str:string -> ext:string -> (Fpath.t -> 'a) -> 'a
 
 val get_temp_dir_name : Cap.FS.tmp -> Fpath.t

--- a/libs/commons/UTmp.ml
+++ b/libs/commons/UTmp.ml
@@ -32,35 +32,35 @@ let _temp_files_created = Hashtbl.create 101
 
 (* old: was in Common2.cmdline_flags_devel()
     ( "-keep_tmp_files",
-      Arg.Set UTmp.save_tmp_files,
+      Arg.Set UTmp.save_temp_files,
       " keep temporary generated files" );
 *)
 
-let save_tmp_files = ref false
+let save_temp_files = ref false
 
 let erase_temp_files () =
-  if not !save_tmp_files then (
+  if not !save_temp_files then (
     _temp_files_created
     |> Hashtbl.iter (fun s () ->
            Logs.debug (fun m -> m ~tags "erasing: %s" s);
            USys.remove s);
     Hashtbl.clear _temp_files_created)
 
-(* hooks for with_tmp_file() *)
-let tmp_file_cleanup_hooks = ref []
+(* hooks for with_temp_file() *)
+let temp_file_cleanup_hooks = ref []
 
 (* See the .mli for a long explanation.
  *
- * alt: define your own with_tmp_file wrapper, for example:
+ * alt: define your own with_temp_file wrapper, for example:
  * let hmemo = Hashtbl.create 101
  * ...
- * let with_tmp_file ~str ~ext f =
- *  UTmp.with_tmp_file ~str ~ext (fun file ->
+ * let with_temp_file ~str ~ext f =
+ *  UTmp.with_temp_file ~str ~ext (fun file ->
  *     Common.protect
  *       ~finally:(fun () -> Hashtbl.remove hmemo file)
  *       (fun () -> f file))
  *)
-let register_tmp_file_cleanup_hook f = Stack_.push f tmp_file_cleanup_hooks
+let register_temp_file_cleanup_hook f = Stack_.push f temp_file_cleanup_hooks
 
 (*****************************************************************************)
 (* Legacy API using 'string' for filenames *)
@@ -71,25 +71,25 @@ module Legacy = struct
   let new_temp_file ?temp_dir prefix suffix =
     let pid = if !Common.jsoo then 42 else UUnix.getpid () in
     let processid = i_to_s pid in
-    let tmp_file =
+    let temp_file =
       UFilename.temp_file ?temp_dir (prefix ^ "-" ^ processid ^ "-") suffix
     in
-    Hashtbl.add _temp_files_created tmp_file ();
-    tmp_file
+    Hashtbl.add _temp_files_created temp_file ();
+    temp_file
 
   let erase_this_temp_file f =
-    if not !save_tmp_files then (
+    if not !save_temp_files then (
       Hashtbl.remove _temp_files_created f;
       Logs.debug (fun m -> m ~tags "erasing: %s" f);
       USys.remove f)
 
-  let with_tmp_file ~(str : string) ~(ext : string) (f : string -> 'a) : 'a =
+  let with_temp_file ~(str : string) ~(ext : string) (f : string -> 'a) : 'a =
     let tmpfile = new_temp_file "tmp" ("." ^ ext) in
     UFile.Legacy.write_file ~file:tmpfile str;
     Common.finalize
       (fun () -> f tmpfile)
       (fun () ->
-        !tmp_file_cleanup_hooks
+        !temp_file_cleanup_hooks
         |> List.iter (fun cleanup -> cleanup (Fpath.v tmpfile));
         erase_this_temp_file tmpfile)
 end
@@ -106,8 +106,8 @@ let new_temp_file ?(temp_dir = get_temp_dir_name ()) prefix suffix =
 
 let erase_this_temp_file path = Legacy.erase_this_temp_file !!path
 
-let with_tmp_file ~str ~ext f =
-  Legacy.with_tmp_file ~str ~ext (fun file -> f (Fpath.v file))
+let with_temp_file ~str ~ext f =
+  Legacy.with_temp_file ~str ~ext (fun file -> f (Fpath.v file))
 
 let write_temp_file_with_autodelete ~prefix ~suffix ~data : Fpath.t =
   let tmp_path, oc =

--- a/libs/commons/UTmp.mli
+++ b/libs/commons/UTmp.mli
@@ -6,7 +6,7 @@
  * you can call erase_temp_files() before exiting your program to
  * clean things up.
  *
- * Note: You should use with_tmp_file() instead in most cases.
+ * Note: You should use with_temp_file() instead in most cases.
  *)
 val new_temp_file :
   ?temp_dir:Fpath.t -> string (* prefix *) -> string (* suffix *) -> Fpath.t
@@ -18,7 +18,7 @@ val erase_temp_files : unit -> unit
 
 (* To not erase tmp files after they have been used (can be useful to
  * help debug failures). Usually set via a -keep_tmp_files CLI flag. *)
-val save_tmp_files : bool ref
+val save_temp_files : bool ref
 
 (* Erase the tmp file created by new_temp_file() and remove it from
  * the global, so erase_temp_files() will not try to delete an already
@@ -31,9 +31,9 @@ val erase_this_temp_file : Fpath.t -> unit
  * file once done (using erase_this_temp_file()).
  * You can also setup cleanup hooks, see below.
  *)
-val with_tmp_file : str:string -> ext:string -> (Fpath.t -> 'a) -> 'a
+val with_temp_file : str:string -> ext:string -> (Fpath.t -> 'a) -> 'a
 
-(* The hooks below are run just before a tmp file created by with_tmp_file()
+(* The hooks below are run just before a tmp file created by with_temp_file()
  * is deleted. Multiple hooks can be added, but the order in which they are
  * called is unspecified.
  *
@@ -50,7 +50,7 @@ val with_tmp_file : str:string -> ext:string -> (Fpath.t -> 'a) -> 'a
  *
  * See https://github.com/returntocorp/semgrep/issues/5277 for more info.
  *)
-val register_tmp_file_cleanup_hook : (Fpath.t -> unit) -> unit
+val register_temp_file_cleanup_hook : (Fpath.t -> unit) -> unit
 
 (* If the file is a named pipe (e.g., created with <(echo 'foo')), copy it
    into a temporary regular file (with prefix [prefix]) and return the path

--- a/libs/commons2/common2.ml
+++ b/libs/commons2/common2.ml
@@ -4913,7 +4913,7 @@ module Infix = struct
 end
 
 let with_pr2_to_string caps f =
-  CapTmp.with_tmp_file caps ~str:"" ~ext:"out" (fun path ->
+  CapTmp.with_temp_file caps ~str:"" ~ext:"out" (fun path ->
       let file = Fpath.to_string path in
       redirect_stdout_stderr file f;
       cat file)

--- a/libs/ojsonnet/Std_jsonnet.ml
+++ b/libs/ojsonnet/Std_jsonnet.ml
@@ -1684,5 +1684,5 @@ let get_std_jsonnet () =
    * no need to use tmp file
    *)
   (* nosemgrep: forbid-tmp *)
-  UTmp.with_tmp_file ~str:std ~ext:"jsonnet" (fun file ->
+  UTmp.with_temp_file ~str:std ~ext:"jsonnet" (fun file ->
       Parse_jsonnet.parse_program file)

--- a/src/core/Range.ml
+++ b/src/core/Range.ml
@@ -139,7 +139,7 @@ let hmemo : (Fpath.t, string) Hashtbl.t = Hashtbl.create 101
 
 let () =
   (* nosemgrep: forbid-tmp *)
-  UTmp.register_tmp_file_cleanup_hook (fun file -> Hashtbl.remove hmemo file)
+  UTmp.register_temp_file_cleanup_hook (fun file -> Hashtbl.remove hmemo file)
 
 let content_at_range file r =
   let str = Common.memoized hmemo file (fun () -> UFile.read_file file) in

--- a/src/core_cli/Core_CLI.ml
+++ b/src/core_cli/Core_CLI.ml
@@ -604,7 +604,7 @@ let options caps actions =
         " output profiling information" );
       ( "-keep_tmp_files",
         (* nosemgrep: forbid-tmp *)
-        Arg.Set UTmp.save_tmp_files,
+        Arg.Set UTmp.save_temp_files,
         " keep temporary generated files" );
     ]
   @ Meta_AST.cmdline_flags_precision () (* -full_token_info *)

--- a/src/engine/Metavariable_pattern.ml
+++ b/src/engine/Metavariable_pattern.ml
@@ -204,7 +204,7 @@ let get_nested_metavar_pattern_bindings get_nested_formula_matches env r mvar
                   in
                   (* TODO: find a way to not use tmp files! parse strings *)
                   (* nosemgrep: forbid-tmp *)
-                  UTmp.with_tmp_file ~str:content ~ext:"mvar-pattern"
+                  UTmp.with_temp_file ~str:content ~ext:"mvar-pattern"
                     (fun (file : Fpath.t) ->
                       let mast' =
                         AST_generic_helpers.fix_token_locations_program
@@ -275,7 +275,7 @@ let get_nested_metavar_pattern_bindings get_nested_formula_matches env r mvar
                   (* We re-parse the matched text as `xlang`. *)
                   (* TODO: find a way to not use tmp files! parse strings *)
                   (* nosemgrep: forbid-tmp *)
-                  UTmp.with_tmp_file ~str:content ~ext:"mvar-pattern"
+                  UTmp.with_temp_file ~str:content ~ext:"mvar-pattern"
                     (fun file ->
                       let ast_and_errors_res =
                         match xlang with

--- a/src/engine/Xpattern_matcher.ml
+++ b/src/engine/Xpattern_matcher.ml
@@ -108,7 +108,7 @@ let hmemo : (Fpath.t, Pos.bytepos_linecol_converters) Hashtbl.t =
 
 let () =
   (* nosemgrep: forbid-tmp *)
-  UTmp.register_tmp_file_cleanup_hook (fun file -> Hashtbl.remove hmemo file)
+  UTmp.register_temp_file_cleanup_hook (fun file -> Hashtbl.remove hmemo file)
 
 let line_col_of_charpos (file : Fpath.t) (charpos : int) : int * int =
   let conv =

--- a/src/fixing/Autofix.ml
+++ b/src/fixing/Autofix.ml
@@ -99,7 +99,7 @@ let parse_pattern lang pattern =
 let parse_target lang text =
   (* ext shouldn't matter, but could use Lang.ext_of_lang if needed *)
   (* nosemgrep: forbid-tmp *)
-  UTmp.with_tmp_file ~str:text ~ext:"check" (fun file ->
+  UTmp.with_temp_file ~str:text ~ext:"check" (fun file ->
       try Ok (Parse_target.just_parse_with_lang lang file) with
       | Time_limit.Timeout _ as e -> Exception.catch_and_reraise e
       | e ->

--- a/src/fixing/tests/Unit_autofix_printer.ml
+++ b/src/fixing/tests/Unit_autofix_printer.ml
@@ -35,7 +35,7 @@ let t = Testo.create
  *)
 let check lang { target; pattern; fix_pattern; expected } =
   let ext = List_.hd_exn "unexpected empty list" (Lang.ext_of_lang lang) in
-  UTmp.with_tmp_file ~str:target ~ext (fun target_file ->
+  UTmp.with_temp_file ~str:target ~ext (fun target_file ->
       let matches =
         Unit_engine.match_pattern ~lang
           ~hook:(fun _ -> ())

--- a/src/osemgrep/cli_ci/Ci_subcommand.ml
+++ b/src/osemgrep/cli_ci/Ci_subcommand.ml
@@ -168,7 +168,7 @@ let at_url_maybe ppf () : unit =
  * TODO: factorize with Session.decode_rules()
  *)
 let decode_json_rules caps (data : string) : Rule_fetching.rules_and_origin =
-  CapTmp.with_tmp_file caps#tmp ~str:data ~ext:"json" (fun file ->
+  CapTmp.with_temp_file caps#tmp ~str:data ~ext:"json" (fun file ->
       match
         Rule_fetching.load_rules_from_file ~rewrite_rule_ids:false ~origin:App
           caps file

--- a/src/osemgrep/language_server/server/Session.ml
+++ b/src/osemgrep/language_server/server/Session.ml
@@ -78,7 +78,7 @@ let dirty_files_of_folder folder =
 
 (* TODO: registry caching is not anymore in semgrep-OSS! *)
 let decode_rules caps data =
-  CapTmp.with_tmp_file caps#tmp ~str:data ~ext:"json" (fun file ->
+  CapTmp.with_temp_file caps#tmp ~str:data ~ext:"json" (fun file ->
       match
         Rule_fetching.load_rules_from_file ~rewrite_rule_ids:false ~origin:App
           caps file

--- a/src/osemgrep/networking/Rule_fetching.ml
+++ b/src/osemgrep/networking/Rule_fetching.ml
@@ -206,7 +206,8 @@ let mk_import_callback (caps : < Cap.network ; Cap.tmp ; .. >) base str =
               * header mimetype when downloading the URL to decide how to
               * convert it further?
               *)
-             CapTmp.with_tmp_file caps#tmp ~str:content ~ext:"yaml" (fun file ->
+             CapTmp.with_temp_file caps#tmp ~str:content ~ext:"yaml"
+               (fun file ->
                  (* LATER: adjust locations so refer to registry URL *)
                  parse_yaml_for_jsonnet file))
 [@@profiling]
@@ -337,7 +338,7 @@ let load_rules_from_url_async ~origin ?token_opt ?(ext = "yaml") caps url :
       | _failure -> (ext, content)
     else (ext, content)
   in
-  CapTmp.with_tmp_file caps#tmp ~str:content ~ext (fun file ->
+  CapTmp.with_temp_file caps#tmp ~str:content ~ext (fun file ->
       load_rules_from_file ~rewrite_rule_ids:false ~origin caps file)
   |> Lwt.return
 
@@ -386,7 +387,7 @@ let rules_from_dashdash_config_async ~rewrite_rule_ids ~token_opt caps kind :
       let%lwt content =
         fetch_content_from_registry_url_async ~token_opt caps url
       in
-      CapTmp.with_tmp_file caps#tmp ~str:content ~ext:"yaml" (fun file ->
+      CapTmp.with_temp_file caps#tmp ~str:content ~ext:"yaml" (fun file ->
           [ load_rules_from_file ~rewrite_rule_ids ~origin:Registry caps file ])
       |> Result_.partition_result Fun.id
       |> Lwt.return

--- a/src/osemgrep/networking/Unit_Login.ml
+++ b/src/osemgrep/networking/Unit_Login.ml
@@ -72,7 +72,7 @@ let with_mock_four_o_four_responses =
   Http_mock_client.with_testing_client make_fn
 
 let with_mock_envvars f () =
-  UTmp.with_tmp_file ~str:fake_settings ~ext:"yml" (fun tmp_settings_file ->
+  UTmp.with_temp_file ~str:fake_settings ~ext:"yml" (fun tmp_settings_file ->
       let new_settings =
         { !Semgrep_envvars.v with user_settings_file = tmp_settings_file }
       in

--- a/src/parsing/tests/Test_parsing.ml
+++ b/src/parsing/tests/Test_parsing.ml
@@ -552,8 +552,8 @@ let diff_pfff_tree_sitter xs =
          in
          let s1 = AST_generic.show_program ast1 in
          let s2 = AST_generic.show_program ast2 in
-         UTmp.with_tmp_file ~str:s1 ~ext:"x" (fun file1 ->
-             UTmp.with_tmp_file ~str:s2 ~ext:"x" (fun file2 ->
+         UTmp.with_temp_file ~str:s1 ~ext:"x" (fun file1 ->
+             UTmp.with_temp_file ~str:s2 ~ext:"x" (fun file2 ->
                  let xs = Common2.unix_diff !!file1 !!file2 in
                  xs |> List.iter UCommon.pr2)))
 


### PR DESCRIPTION
Motivation: what happened is I was searching for a function named `with_temp_file` and I didn't find one, then wrote my own, only to later realize it was named `with_tmp_file`.