### PR TITLE
Remove CODEOWNERS for .github

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,2 @@
-
-# Matches all files in the .github/ dir, recursively.
-.github/ @aryx
 src/analyzing @IagoAbal
 src/tainting @IagoAbal


### PR DESCRIPTION
Recently emma and cooper had issues releasing semgrep
because I was OOO and they could not modify
some GHA workflows. Simpler to not have any codeowners
for this critical part of the semgrep repo.

test plan:
see if I'm assigned on this PR since it modifies a file
in .github/