### PR TITLE
devops: Run make core-test in OSX arm64 runs

### DIFF
--- a/.github/workflows/build-test-osx-arm64.jsonnet
+++ b/.github/workflows/build-test-osx-arm64.jsonnet
@@ -72,6 +72,10 @@ local build_core_job = {
     },
     actions.make_artifact_step("./bin/semgrep-core"),
     actions.upload_artifact_step(artifact_name),
+    {
+      name: 'Test semgrep-core',
+      run: 'opam exec -- make core-test',
+    }
   ],
 };
 

--- a/.github/workflows/build-test-osx-arm64.yml
+++ b/.github/workflows/build-test-osx-arm64.yml
@@ -41,6 +41,8 @@ jobs:
         with:
           name: semgrep-osx-arm64-${{ github.sha }}
           path: artifacts.tgz
+      - name: Test semgrep-core
+        run: opam exec -- make core-test
   build-wheels:
     needs:
       - build-core

--- a/libs/commons/Testutil.ml
+++ b/libs/commons/Testutil.ml
@@ -20,4 +20,6 @@ let mask_temp_paths ?depth ?replace () =
       ~tmpdir:(UFilename.get_temp_dir_name () |> UUnix.realpath)
       ()
   in
+  (* NOTE: Haven't investigated why yet, but order is important here,
+   *       we must mask the physical path before the original path. *)
   fun text -> text |> mask_physical_path |> mask_original_path

--- a/libs/commons/Testutil.ml
+++ b/libs/commons/Testutil.ml
@@ -20,4 +20,4 @@ let mask_temp_paths ?depth ?replace () =
       ~tmpdir:(UFilename.get_temp_dir_name () |> UUnix.realpath)
       ()
   in
-  fun text -> text |> mask_original_path |> mask_physical_path
+  fun text -> text |> mask_physical_path |> mask_original_path

--- a/src/osemgrep/tests/Test_target_selection.ml
+++ b/src/osemgrep/tests/Test_target_selection.ml
@@ -107,6 +107,7 @@ let normalize =
     Testo.mask_line ~after:"Initialized empty Git repository in" ();
     Testo.mask_line ~after:"[main (root-commit) " ~before:"]" ();
     Testo.mask_pcre_pattern "/test-[a-f0-9]+";
+    Testutil.mask_temp_paths ();
   ]
 
 (*

--- a/tests/snapshots/semgrep-core/0307ab87fd4c/stdout
+++ b/tests/snapshots/semgrep-core/0307ab87fd4c/stdout
@@ -5,6 +5,6 @@ Initialized empty Git repository in<MASKED>
 [main (root-commit) <MASKED>] Add all the files (including gitignored files)
  1 file changed, 0 insertions(+), 0 deletions(-)
  create mode 100644 a/b/target
-cwd: /tmp<MASKED>/a
+cwd: <TMP><MASKED>/a
 Target files:
   b/target

--- a/tests/snapshots/semgrep-core/7c0c5fe922a0/stdout
+++ b/tests/snapshots/semgrep-core/7c0c5fe922a0/stdout
@@ -5,6 +5,6 @@ Initialized empty Git repository in<MASKED>
 [main (root-commit) <MASKED>] Add all the files (including gitignored files)
  1 file changed, 0 insertions(+), 0 deletions(-)
  create mode 100644 a/b/target
-cwd: /tmp<MASKED>/a/b
+cwd: <TMP><MASKED>/a/b
 Target files:
   target


### PR DESCRIPTION
Many of us running macOS have a baseline of dozens of failing tests after changes in the test suite. This was possible because our CI did not run the tests on macOS.

test plan:
CI

