### PR TITLE
fix: Fix ./scripts/release/bump

### DIFF
--- a/scripts/release/bump
+++ b/scripts/release/bump
@@ -114,7 +114,7 @@ fi
 
 bump
 
-if git status -s | grep -vq 'cli/src/semgrep/__init__.py\|cli/setup.py\|setup.py\|src/core/Version.ml'; then
+if git status -s | grep -vq 'cli/src/semgrep/__init__.py\|cli/setup.py\|setup.py\|src/core/Version.ml\|dune-project'; then
   error <<EOF
 The release branch contains unexpected changes, cancelling release.
 EOF


### PR DESCRIPTION
Broken in #10080.

Test plan: `SEMGREP_RELEASE_NEXT_VERSION=1.69.0 ./scripts/release/bump`. Before it errored out. Now it runs fine.

