### PR TITLE
Make sure to use 'Testutil.mask_temp_paths'

### DIFF
--- a/libs/commons/Testutil.ml
+++ b/libs/commons/Testutil.ml
@@ -10,8 +10,12 @@ let run what f =
 (* TODO: move this to Testo once it's ok with requiring ocaml >= 4.13
    (needed for Unix.realpath) *)
 let mask_temp_paths ?depth ?replace () =
-  let mask_original_path = Testo.mask_temp_paths ?depth ?replace () in
+  let mask_original_path =
+    (* nosemgrep: mask-all-temp-paths *)
+    Testo.mask_temp_paths ?depth ?replace ()
+  in
   let mask_physical_path =
+    (* nosemgrep: mask-all-temp-paths *)
     Testo.mask_temp_paths ?depth ?replace
       ~tmpdir:(UFilename.get_temp_dir_name () |> UUnix.realpath)
       ()

--- a/semgrep.jsonnet
+++ b/semgrep.jsonnet
@@ -84,6 +84,19 @@ local semgrep_rules = [
       `Hashtbl.find_all`.
     |||,
   },
+  {
+    id: 'mask-all-temp-paths',
+    pattern: 'Testo.mask_temp_paths',
+    fix: 'Testutil.mask_temp_paths',
+    message: |||
+      Semgrep applies `Unix.realpath` to some paths resulting in
+      the temporary folder being rewritten to its physical path if it
+      was a symlink (MacOS). Use `Testutil.mask_temp_paths` to mask all known
+      temporary folder paths in Semgrep test output.
+    |||,
+    languages: ['ocaml'],
+    severity: 'ERROR',
+  },
 ];
 
 // ----------------------------------------------------------------------------

--- a/src/targeting/Unit_find_targets.ml
+++ b/src/targeting/Unit_find_targets.ml
@@ -102,7 +102,7 @@ let test_find_targets ?includes ?(excludes = [])
     ~checked_output:(Testo.stdout ())
     ~normalize:
       [
-        Testo.mask_temp_paths ();
+        Testutil.mask_temp_paths ();
         Testo.mask_line ~after:"(root-commit) " ~before:"]" ();
       ]
 


### PR DESCRIPTION
This will fix some failing tests on some MacOS platforms revealed by https://github.com/semgrep/semgrep/actions/runs/8692006380/job/23835582043?pr=10096