### PR TITLE
Initialize user name and email in temporary git repos to avoid warning

### DIFF
--- a/libs/commons/Testutil_files.mli
+++ b/libs/commons/Testutil_files.mli
@@ -107,15 +107,16 @@ val with_tempdir : ?persist:bool -> ?chdir:bool -> (Fpath.t -> 'a) -> 'a
 (*
    Create files under a temporary root and execute a function in this
    context. See 'with_tempdir' for the meaning of the options.
+
+   'verbose' prints the list of files.
 *)
 val with_tempfiles :
-  ?persist:bool -> ?chdir:bool -> t list -> (Fpath.t -> 'a) -> 'a
+  ?chdir:bool ->
+  ?persist:bool ->
+  ?verbose:bool ->
+  t list ->
+  (Fpath.t -> 'a) ->
+  'a
 
 (* Debugging function which can be used inside an alcotest *)
 val print_files : t list -> unit
-
-(* Similar to with_tempfiles but internally use print_files
-   and show the output of the 'tree' command for a more
-   output
-*)
-val with_tempfiles_verbose : t list -> (Fpath.t -> 'a) -> 'a

--- a/libs/git_wrapper/Git_wrapper.ml
+++ b/libs/git_wrapper/Git_wrapper.ml
@@ -668,6 +668,19 @@ let init ?cwd ?(branch = "main") () =
   | Ok (`Exited 0) -> ()
   | _ -> raise (Error "Error running git init")
 
+let config_set ?cwd key value =
+  let cmd = (git, cd cwd @ [ "config"; key; value ]) in
+  match UCmd.status_of_run cmd with
+  | Ok (`Exited 0) -> ()
+  | _ -> raise (Error "Error setting git config entry")
+
+let config_get ?cwd key =
+  let cmd = (git, cd cwd @ [ "config"; key ]) in
+  match UCmd.string_of_run ~trim:true cmd with
+  | Ok (data, (_, `Exited 0)) -> Some data
+  | Ok (_empty, (_, `Exited 1)) -> None
+  | _ -> raise (Error "Error getting git config entry")
+
 let add ?cwd ?(force = false) files =
   let files = List_.map Fpath.to_string files in
   let cmd = (git, cd cwd @ [ "add" ] @ flag "--force" force @ files) in
@@ -749,10 +762,29 @@ let cat_file_blob ?cwd (hash : hash) =
   | Error (`Msg s) ->
       Error s
 
-let with_git_repo (files : Testutil_files.t list) func =
-  Testutil_files.with_tempfiles_verbose files (fun path ->
-      Testutil_files.with_chdir path (fun () ->
-          init ();
-          add ~force:true [ Fpath.v "." ];
-          commit "Add all the files";
-          func ()))
+(*****************************************************************************)
+(* Combination of git commands (for testing etc.) *)
+(*****************************************************************************)
+
+let create_git_repo ?(honor_gitignore = true)
+    ?(user_email = "tester@example.com") ?(user_name = "Tester") () =
+  flush stdout;
+  flush stderr;
+  init ();
+  (* We set user name and email to avoid warnings in some git
+     versions. *)
+  config_set "user.name" user_name;
+  config_set "user.email" user_email;
+  add ~force:(not honor_gitignore) [ Fpath.v "." ];
+  let msg =
+    if honor_gitignore then "Add files"
+    else "Add all the files (including gitignored files)"
+  in
+  commit msg
+
+let with_git_repo ?honor_gitignore ?(really_create_git_repo = true) ?user_email
+    ?user_name (files : Testutil_files.t list) func =
+  Testutil_files.with_tempfiles ~verbose:true ~chdir:true files (fun cwd ->
+      if really_create_git_repo then
+        create_git_repo ?honor_gitignore ?user_email ?user_name ();
+      func cwd)

--- a/libs/git_wrapper/Git_wrapper.mli
+++ b/libs/git_wrapper/Git_wrapper.mli
@@ -156,6 +156,12 @@ val init : ?cwd:Fpath.t -> ?branch:string -> unit -> unit
     on the git version.
 *)
 
+(* Set or replace an entry in the user's config tied to the repo. *)
+val config_set : ?cwd:Fpath.t -> string -> string -> unit
+
+(* Get the value of an entry in the user's config. *)
+val config_get : ?cwd:Fpath.t -> string -> string option
+
 val add : ?cwd:Fpath.t -> ?force:bool -> Fpath.t list -> unit
 (** [add files] adds the [files] to the git index. *)
 
@@ -221,12 +227,39 @@ val remote_repo_name : string -> string option
 (** [remote_repo_name "https://github.com/semgrep/semgrep.git"] will return [Some "semgrep"] *)
 
 (*****************************************************************************)
-(* For testing *)
+(* Combination of git commands (for testing etc.) *)
 (*****************************************************************************)
 
 (*
    Create a temporary git repo for testing purposes, cd into it,
    call a function, tear down the repo, and restore the original cwd.
    This is an extension of Testutil_files.
+
+   At least one regular file must be specified for the operation to succeed
+   e.g. [File ("empty", "")].
+
+   User name and email are set locally for the repo using default values
+   which can be overridden.
+
+   'really_create_git_repo:false' allows for tests to not create a git repo but
+   create temporary files and remove them when done. Default is true.
+
+   'honor_gitignore:false' will cause gitignored files to be added anyway.
+   Default is true.
 *)
-val with_git_repo : Testutil_files.t list -> (unit -> 'a) -> 'a
+val with_git_repo :
+  ?honor_gitignore:bool ->
+  ?really_create_git_repo:bool ->
+  ?user_email:string ->
+  ?user_name:string ->
+  Testutil_files.t list ->
+  (Fpath.t -> 'a) ->
+  'a
+
+(* Initialize a git repo similarly to 'with_git_repo'. *)
+val create_git_repo :
+  ?honor_gitignore:bool ->
+  ?user_email:string ->
+  ?user_name:string ->
+  unit ->
+  unit

--- a/libs/git_wrapper/Unit_git_wrapper.ml
+++ b/libs/git_wrapper/Unit_git_wrapper.ml
@@ -38,7 +38,7 @@ let test_ls_files_relative ~mk_cwd ~mk_scanning_root () =
         dir "a" [ dir "b" [ file "target" ] ]; dir "x" [ dir "y" [ file "z" ] ];
       ]
   in
-  Git_wrapper.with_git_repo repo_files (fun () ->
+  Git_wrapper.with_git_repo repo_files (fun _cwd ->
       let project_root = Rpath.getcwd () in
       let cwd = mk_cwd ~project_root in
       Testutil_files.with_chdir (Rpath.to_fpath cwd) (fun () ->
@@ -54,8 +54,25 @@ let test_ls_files_relative ~mk_cwd ~mk_scanning_root () =
           file_list
           |> List.iter (fun path -> printf "  %s\n" (Fpath.to_string path))))
 
+let test_user_identity () =
+  Git_wrapper.with_git_repo
+    [ File ("empty", "") ]
+    (fun _cwd ->
+      let not_found = Git_wrapper.config_get "xxxxxxxxxxxxxxxxxxxxxxxxxxx" in
+      Alcotest.(check (option string)) "missing entry" None not_found;
+      let user_name = Git_wrapper.config_get "user.name" in
+      Alcotest.(check (option string))
+        "default user name" (Some "Tester") user_name;
+      let user_email = Git_wrapper.config_get "user.email" in
+      Alcotest.(check (option string))
+        "default user email" (Some "tester@example.com") user_email;
+      Git_wrapper.config_set "user.name" "nobody";
+      let nobody = Git_wrapper.config_get "user.name" in
+      Alcotest.(check (option string)) "new user name" (Some "nobody") nobody)
+
 let tests =
   [
+    t "user identity" test_user_identity;
     capture "ls-files from project root"
       (test_ls_files_relative
          ~mk_cwd:(fun ~project_root -> project_root)

--- a/libs/gitignore/Unit_gitignore.ml
+++ b/libs/gitignore/Unit_gitignore.ml
@@ -14,7 +14,7 @@ let gitignore lines : Testutil_files.t = File (".gitignore", concat_lines lines)
 
 (* Test that Testutil_files works as it should *)
 let test_list (files : F.t list) () =
-  F.with_tempfiles_verbose files (fun root ->
+  F.with_tempfiles ~verbose:true files (fun root ->
       let files2 = F.read root |> F.sort in
       printf "Output files:\n";
       F.print_files files2;

--- a/src/osemgrep/tests/Test_target_selection.ml
+++ b/src/osemgrep/tests/Test_target_selection.ml
@@ -121,6 +121,6 @@ let tests caps : Testo.test list =
                   ~category:[ "target selection on real git repos"; repo_name ]
                   ~checked_output:(Testo.stdout ()) ~normalize test_name
                   (fun () ->
-                    Git_wrapper.with_git_repo repo_files (fun () ->
-                        test_func caps))))
+                    Git_wrapper.with_git_repo ~honor_gitignore:false repo_files
+                      (fun _cwd -> test_func caps))))
   |> List_.flatten

--- a/src/targeting/Unit_find_targets.ml
+++ b/src/targeting/Unit_find_targets.ml
@@ -25,19 +25,6 @@ module Out = Semgrep_output_v1_t
 *)
 
 (*
-   git init + add all the files that we put in,
-   honoring .gitignore if present.
-
-   TODO: move this functionality to Testutil_files?
-*)
-let create_git_repo () =
-  flush stdout;
-  flush stderr;
-  Git_wrapper.init ();
-  Git_wrapper.add [ Fpath.v "." ];
-  Git_wrapper.commit "Add files"
-
-(*
    Generic function that puts files into a temporary workspace and lists them.
 
    with_git: make this a git repository
@@ -49,24 +36,23 @@ let test_find_targets ?includes ?(excludes = [])
   let category = if with_git then "with git" else "without git" in
   let test_func () =
     printf "Test name: %s > %s\n" category name;
-    F.with_tempdir ~chdir:true (fun root ->
-        let git_files, non_git_files =
-          if with_git then (F.sort files, F.sort non_git_files)
-          else ([], F.sort (files @ non_git_files))
-        in
-        (match git_files with
-        | [] -> ()
-        | _ ->
-            printf "--- Files added before 'git add' ---\n";
-            print_files git_files);
-        (match non_git_files with
-        | [] -> ()
-        | _ ->
-            printf "--- Files not added to git ---\n";
-            print_files non_git_files);
+    let git_files, non_git_files =
+      if with_git then (F.sort files, F.sort non_git_files)
+      else ([], F.sort (files @ non_git_files))
+    in
+    (match git_files with
+    | [] -> ()
+    | _ ->
+        printf "--- Files added before 'git add' ---\n";
+        print_files git_files);
+    (match non_git_files with
+    | [] -> ()
+    | _ ->
+        printf "--- Files not added to git ---\n";
+        print_files non_git_files);
 
-        F.write root git_files;
-        if with_git then create_git_repo ();
+    Git_wrapper.with_git_repo ~honor_gitignore:true
+      ~really_create_git_repo:with_git git_files (fun root ->
         F.write root non_git_files;
 
         let conf =

--- a/tests/snapshots/semgrep-core/02b60a2d07a2/stdout
+++ b/tests/snapshots/semgrep-core/02b60a2d07a2/stdout
@@ -1,11 +1,12 @@
+--- begin input files ---
+.gitignore
+a
+--- end input files ---
 Initialized empty Git repository in<MASKED>
-[main (root-commit) <MASKED>] Add all the files
+[main (root-commit) <MASKED>] Add all the files (including gitignored files)
  2 files changed, 1 insertion(+)
  create mode 100644 .gitignore
  create mode 100644 a
-Input files:
-.gitignore
-a
 RUN semgrep scan --experimental --x-ls .
 selected .gitignore
 ignored a [semgrepignore_patterns_match]

--- a/tests/snapshots/semgrep-core/0307ab87fd4c/stdout
+++ b/tests/snapshots/semgrep-core/0307ab87fd4c/stdout
@@ -1,9 +1,10 @@
+--- begin input files ---
+a/b/target
+--- end input files ---
 Initialized empty Git repository in<MASKED>
-[main (root-commit) <MASKED>] Add all the files
+[main (root-commit) <MASKED>] Add all the files (including gitignored files)
  1 file changed, 0 insertions(+), 0 deletions(-)
  create mode 100644 a/b/target
-Input files:
-a/b/target
 cwd: /tmp<MASKED>/a
 Target files:
   b/target

--- a/tests/snapshots/semgrep-core/17c29a0136d9/stdout
+++ b/tests/snapshots/semgrep-core/17c29a0136d9/stdout
@@ -1,11 +1,12 @@
+--- begin input files ---
+a/b/target
+x/y/z
+--- end input files ---
 Initialized empty Git repository in <TMP>/<MASKED>/.git/
-[main (root-commit) <MASKED>] Add all the files
+[main (root-commit) <MASKED>] Add files
  2 files changed, 0 insertions(+), 0 deletions(-)
  create mode 100644 a/b/target
  create mode 100644 x/y/z
-Input files:
-a/b/target
-x/y/z
 project root: <TMP>/<MASKED>
 cwd: <TMP>
 scanning root: <TMP>/<MASKED>

--- a/tests/snapshots/semgrep-core/2162b499e124/stdout
+++ b/tests/snapshots/semgrep-core/2162b499e124/stdout
@@ -1,17 +1,18 @@
+--- begin input files ---
+.gitignore
+.semgrepignore
+a
+b
+c
+--- end input files ---
 Initialized empty Git repository in<MASKED>
-[main (root-commit) <MASKED>] Add all the files
+[main (root-commit) <MASKED>] Add all the files (including gitignored files)
  5 files changed, 2 insertions(+)
  create mode 100644 .gitignore
  create mode 100644 .semgrepignore
  create mode 100644 a
  create mode 100644 b
  create mode 100644 c
-Input files:
-.gitignore
-.semgrepignore
-a
-b
-c
 RUN semgrep scan --experimental --x-ls .
 selected .gitignore
 selected .semgrepignore

--- a/tests/snapshots/semgrep-core/2d9d84ce2ca9/stdout
+++ b/tests/snapshots/semgrep-core/2d9d84ce2ca9/stdout
@@ -1,8 +1,9 @@
+--- begin input files ---
+a/b/target
+--- end input files ---
 Initialized empty Git repository in<MASKED>
-[main (root-commit) <MASKED>] Add all the files
+[main (root-commit) <MASKED>] Add all the files (including gitignored files)
  1 file changed, 0 insertions(+), 0 deletions(-)
  create mode 100644 a/b/target
-Input files:
-a/b/target
 Target files:
   a/b/target

--- a/tests/snapshots/semgrep-core/343da82ffbcb/stdout
+++ b/tests/snapshots/semgrep-core/343da82ffbcb/stdout
@@ -1,11 +1,12 @@
+--- begin input files ---
+a/b/target
+x/y/z
+--- end input files ---
 Initialized empty Git repository in <TMP>/<MASKED>/.git/
-[main (root-commit) <MASKED>] Add all the files
+[main (root-commit) <MASKED>] Add files
  2 files changed, 0 insertions(+), 0 deletions(-)
  create mode 100644 a/b/target
  create mode 100644 x/y/z
-Input files:
-a/b/target
-x/y/z
 project root: <TMP>/<MASKED>
 cwd: <TMP>/<MASKED>
 scanning root: .

--- a/tests/snapshots/semgrep-core/36408fbb6ab3/stdout
+++ b/tests/snapshots/semgrep-core/36408fbb6ab3/stdout
@@ -1,11 +1,12 @@
+--- begin input files ---
+a/b/target
+x/y/z
+--- end input files ---
 Initialized empty Git repository in <TMP>/<MASKED>/.git/
-[main (root-commit) <MASKED>] Add all the files
+[main (root-commit) <MASKED>] Add files
  2 files changed, 0 insertions(+), 0 deletions(-)
  create mode 100644 a/b/target
  create mode 100644 x/y/z
-Input files:
-a/b/target
-x/y/z
 project root: <TMP>/<MASKED>
 cwd: <TMP>/<MASKED>/a
 scanning root: .

--- a/tests/snapshots/semgrep-core/36becc511b8a/stdout
+++ b/tests/snapshots/semgrep-core/36becc511b8a/stdout
@@ -2,6 +2,10 @@ Test name: with git > deep include
 --- Files added before 'git add' ---
 dir/a
 dir/b
+--- begin input files ---
+dir/a
+dir/b
+--- end input files ---
 Initialized empty Git repository in <TMP>/<MASKED>/.git/
 [main (root-commit) <MASKED>] Add files
  2 files changed, 0 insertions(+), 0 deletions(-)

--- a/tests/snapshots/semgrep-core/3e63db713cdd/stdout
+++ b/tests/snapshots/semgrep-core/3e63db713cdd/stdout
@@ -4,6 +4,12 @@ Test name: with git > gitignore file takes precedence over --include
 c
 dir/a
 dir/b
+--- begin input files ---
+.gitignore
+c
+dir/a
+dir/b
+--- end input files ---
 Initialized empty Git repository in <TMP>/<MASKED>/.git/
 [main (root-commit) <MASKED>] Add files
  2 files changed, 1 insertion(+)

--- a/tests/snapshots/semgrep-core/4148713a0e06/stdout
+++ b/tests/snapshots/semgrep-core/4148713a0e06/stdout
@@ -1,9 +1,10 @@
-Input files:
+--- begin input files ---
 a
 b
 c
 dir/d
 dir/e
+--- end input files ---
 Output files:
 a
 b

--- a/tests/snapshots/semgrep-core/4b1e1d216d04/stdout
+++ b/tests/snapshots/semgrep-core/4b1e1d216d04/stdout
@@ -3,6 +3,11 @@ Test name: with git > basic semgrepignore
 .semgrepignore
 a
 b
+--- begin input files ---
+.semgrepignore
+a
+b
+--- end input files ---
 Initialized empty Git repository in <TMP>/<MASKED>/.git/
 [main (root-commit) <MASKED>] Add files
  3 files changed, 1 insertion(+)

--- a/tests/snapshots/semgrep-core/58a845e402fc/stdout
+++ b/tests/snapshots/semgrep-core/58a845e402fc/stdout
@@ -2,6 +2,8 @@ Test name: without git > deep include
 --- Files not added to git ---
 dir/a
 dir/b
+--- begin input files ---
+--- end input files ---
 --- '--include' patterns ---
 a
 --- Selected targets ---

--- a/tests/snapshots/semgrep-core/7c0c5fe922a0/stdout
+++ b/tests/snapshots/semgrep-core/7c0c5fe922a0/stdout
@@ -1,9 +1,10 @@
+--- begin input files ---
+a/b/target
+--- end input files ---
 Initialized empty Git repository in<MASKED>
-[main (root-commit) <MASKED>] Add all the files
+[main (root-commit) <MASKED>] Add all the files (including gitignored files)
  1 file changed, 0 insertions(+), 0 deletions(-)
  create mode 100644 a/b/target
-Input files:
-a/b/target
 cwd: /tmp<MASKED>/a/b
 Target files:
   target

--- a/tests/snapshots/semgrep-core/7c91655c3e4b/stdout
+++ b/tests/snapshots/semgrep-core/7c91655c3e4b/stdout
@@ -3,6 +3,11 @@ Test name: with git > basic gitignore
 .gitignore
 a
 b
+--- begin input files ---
+.gitignore
+a
+b
+--- end input files ---
 Initialized empty Git repository in <TMP>/<MASKED>/.git/
 [main (root-commit) <MASKED>] Add files
  2 files changed, 1 insertion(+)

--- a/tests/snapshots/semgrep-core/84402e376e39/stdout
+++ b/tests/snapshots/semgrep-core/84402e376e39/stdout
@@ -1,17 +1,18 @@
+--- begin input files ---
+.gitignore
+.semgrepignore
+a
+b
+c
+--- end input files ---
 Initialized empty Git repository in<MASKED>
-[main (root-commit) <MASKED>] Add all the files
+[main (root-commit) <MASKED>] Add all the files (including gitignored files)
  5 files changed, 2 insertions(+)
  create mode 100644 .gitignore
  create mode 100644 .semgrepignore
  create mode 100644 a
  create mode 100644 b
  create mode 100644 c
-Input files:
-.gitignore
-.semgrepignore
-a
-b
-c
 Target files:
   .gitignore
   .semgrepignore

--- a/tests/snapshots/semgrep-core/8bdf63abd0d3/stdout
+++ b/tests/snapshots/semgrep-core/8bdf63abd0d3/stdout
@@ -3,6 +3,8 @@ Test name: without git > basic semgrepignore
 .semgrepignore
 a
 b
+--- begin input files ---
+--- end input files ---
 --- Selected targets ---
 selected .semgrepignore
 selected a

--- a/tests/snapshots/semgrep-core/8fc63b2e9272/stdout
+++ b/tests/snapshots/semgrep-core/8fc63b2e9272/stdout
@@ -1,13 +1,14 @@
+--- begin input files ---
+.gitignore
+bin/ignore-me
+bin/ignore-me-not
+--- end input files ---
 Initialized empty Git repository in<MASKED>
-[main (root-commit) <MASKED>] Add all the files
+[main (root-commit) <MASKED>] Add all the files (including gitignored files)
  3 files changed, 2 insertions(+)
  create mode 100644 .gitignore
  create mode 100644 bin/ignore-me
  create mode 100644 bin/ignore-me-not
-Input files:
-.gitignore
-bin/ignore-me
-bin/ignore-me-not
 RUN semgrep scan --experimental --x-ls .
 selected .gitignore
 selected bin/ignore-me-not

--- a/tests/snapshots/semgrep-core/946b937b8376/stdout
+++ b/tests/snapshots/semgrep-core/946b937b8376/stdout
@@ -1,11 +1,12 @@
+--- begin input files ---
+a/b/target
+x/y/z
+--- end input files ---
 Initialized empty Git repository in <TMP>/<MASKED>/.git/
-[main (root-commit) <MASKED>] Add all the files
+[main (root-commit) <MASKED>] Add files
  2 files changed, 0 insertions(+), 0 deletions(-)
  create mode 100644 a/b/target
  create mode 100644 x/y/z
-Input files:
-a/b/target
-x/y/z
 project root: <TMP>/<MASKED>
 cwd: <TMP>
 scanning root: test-<HEX>

--- a/tests/snapshots/semgrep-core/9becc34e8fd7/stdout
+++ b/tests/snapshots/semgrep-core/9becc34e8fd7/stdout
@@ -1,13 +1,14 @@
+--- begin input files ---
+.gitignore
+bin/ignore-me
+bin/ignore-me-not
+--- end input files ---
 Initialized empty Git repository in<MASKED>
-[main (root-commit) <MASKED>] Add all the files
+[main (root-commit) <MASKED>] Add all the files (including gitignored files)
  3 files changed, 2 insertions(+)
  create mode 100644 .gitignore
  create mode 100644 bin/ignore-me
  create mode 100644 bin/ignore-me-not
-Input files:
-.gitignore
-bin/ignore-me
-bin/ignore-me-not
 Target files:
   .gitignore
   bin/ignore-me-not

--- a/tests/snapshots/semgrep-core/a0283f7165eb/stdout
+++ b/tests/snapshots/semgrep-core/a0283f7165eb/stdout
@@ -4,6 +4,12 @@ Test name: with git > semgrepignore file takes precedence over --include
 c.c
 dir/a.c
 dir/b.c
+--- begin input files ---
+.semgrepignore
+c.c
+dir/a.c
+dir/b.c
+--- end input files ---
 Initialized empty Git repository in <TMP>/<MASKED>/.git/
 [main (root-commit) <MASKED>] Add files
  4 files changed, 1 insertion(+)

--- a/tests/snapshots/semgrep-core/a7a68e5155cd/stdout
+++ b/tests/snapshots/semgrep-core/a7a68e5155cd/stdout
@@ -3,6 +3,8 @@ Test name: without git > basic gitignore
 .gitignore
 a
 b
+--- begin input files ---
+--- end input files ---
 --- Selected targets ---
 selected .gitignore
 selected a

--- a/tests/snapshots/semgrep-core/bbb375beed7d/stdout
+++ b/tests/snapshots/semgrep-core/bbb375beed7d/stdout
@@ -1,11 +1,12 @@
+--- begin input files ---
+a/b/target
+x/y/z
+--- end input files ---
 Initialized empty Git repository in <TMP>/<MASKED>/.git/
-[main (root-commit) <MASKED>] Add all the files
+[main (root-commit) <MASKED>] Add files
  2 files changed, 0 insertions(+), 0 deletions(-)
  create mode 100644 a/b/target
  create mode 100644 x/y/z
-Input files:
-a/b/target
-x/y/z
 project root: <TMP>/<MASKED>
 cwd: <TMP>/<MASKED>/x
 scanning root: ../a

--- a/tests/snapshots/semgrep-core/bc375a75a0d3/stdout
+++ b/tests/snapshots/semgrep-core/bc375a75a0d3/stdout
@@ -1,6 +1,8 @@
 Test name: without git > basic test
 --- Files not added to git ---
 .gitignore
+--- begin input files ---
+--- end input files ---
 --- Selected targets ---
 selected .gitignore
 --- Skipped targets ---

--- a/tests/snapshots/semgrep-core/c293d4dbc560/stdout
+++ b/tests/snapshots/semgrep-core/c293d4dbc560/stdout
@@ -2,6 +2,8 @@ Test name: without git > basic include
 --- Files not added to git ---
 a
 b
+--- begin input files ---
+--- end input files ---
 --- '--include' patterns ---
 a
 --- Selected targets ---

--- a/tests/snapshots/semgrep-core/c298e1785db2/stdout
+++ b/tests/snapshots/semgrep-core/c298e1785db2/stdout
@@ -2,6 +2,8 @@ Test name: without git > basic exclude
 --- Files not added to git ---
 a
 b
+--- begin input files ---
+--- end input files ---
 --- '--exclude' patterns ---
 b
 --- Selected targets ---

--- a/tests/snapshots/semgrep-core/d5c73b8c6b15/stdout
+++ b/tests/snapshots/semgrep-core/d5c73b8c6b15/stdout
@@ -1,4 +1,5 @@
-Input files:
+--- begin input files ---
 a
+--- end input files ---
 Output files:
 a

--- a/tests/snapshots/semgrep-core/d7d1151b7841/stdout
+++ b/tests/snapshots/semgrep-core/d7d1151b7841/stdout
@@ -5,6 +5,10 @@ c
 --- Files not added to git ---
 a
 b
+--- begin input files ---
+.gitignore
+c
+--- end input files ---
 Initialized empty Git repository in <TMP>/<MASKED>/.git/
 [main (root-commit) <MASKED>] Add files
  2 files changed, 1 insertion(+)

--- a/tests/snapshots/semgrep-core/d86c57ae3b9c/stdout
+++ b/tests/snapshots/semgrep-core/d86c57ae3b9c/stdout
@@ -1,10 +1,11 @@
+--- begin input files ---
+.gitignore
+a
+--- end input files ---
 Initialized empty Git repository in<MASKED>
-[main (root-commit) <MASKED>] Add all the files
+[main (root-commit) <MASKED>] Add all the files (including gitignored files)
  2 files changed, 1 insertion(+)
  create mode 100644 .gitignore
  create mode 100644 a
-Input files:
-.gitignore
-a
 Target files:
   .gitignore

--- a/tests/snapshots/semgrep-core/e3c19e7fa9c7/stdout
+++ b/tests/snapshots/semgrep-core/e3c19e7fa9c7/stdout
@@ -1,6 +1,9 @@
 Test name: with git > basic test
 --- Files added before 'git add' ---
 .gitignore
+--- begin input files ---
+.gitignore
+--- end input files ---
 Initialized empty Git repository in <TMP>/<MASKED>/.git/
 [main (root-commit) <MASKED>] Add files
  1 file changed, 0 insertions(+), 0 deletions(-)

--- a/tests/snapshots/semgrep-core/e4610a95c51e/stdout
+++ b/tests/snapshots/semgrep-core/e4610a95c51e/stdout
@@ -4,6 +4,8 @@ Test name: without git > semgrepignore file takes precedence over --include
 c.c
 dir/a.c
 dir/b.c
+--- begin input files ---
+--- end input files ---
 --- '--include' patterns ---
 *.c
 --- Selected targets ---

--- a/tests/snapshots/semgrep-core/f0c91a5124a2/stdout
+++ b/tests/snapshots/semgrep-core/f0c91a5124a2/stdout
@@ -2,6 +2,10 @@ Test name: with git > basic exclude
 --- Files added before 'git add' ---
 a
 b
+--- begin input files ---
+a
+b
+--- end input files ---
 Initialized empty Git repository in <TMP>/<MASKED>/.git/
 [main (root-commit) <MASKED>] Add files
  2 files changed, 0 insertions(+), 0 deletions(-)

--- a/tests/snapshots/semgrep-core/f4ba77a8739a/stdout
+++ b/tests/snapshots/semgrep-core/f4ba77a8739a/stdout
@@ -1,11 +1,12 @@
+--- begin input files ---
+a/b/target
+x/y/z
+--- end input files ---
 Initialized empty Git repository in <TMP>/<MASKED>/.git/
-[main (root-commit) <MASKED>] Add all the files
+[main (root-commit) <MASKED>] Add files
  2 files changed, 0 insertions(+), 0 deletions(-)
  create mode 100644 a/b/target
  create mode 100644 x/y/z
-Input files:
-a/b/target
-x/y/z
 project root: <TMP>/<MASKED>
 cwd: <TMP>/<MASKED>/x
 scanning root: <TMP>/<MASKED>/a

--- a/tests/snapshots/semgrep-core/f76e4684cf69/stdout
+++ b/tests/snapshots/semgrep-core/f76e4684cf69/stdout
@@ -2,6 +2,10 @@ Test name: with git > basic include
 --- Files added before 'git add' ---
 a
 b
+--- begin input files ---
+a
+b
+--- end input files ---
 Initialized empty Git repository in <TMP>/<MASKED>/.git/
 [main (root-commit) <MASKED>] Add files
  2 files changed, 0 insertions(+), 0 deletions(-)


### PR DESCRIPTION
Some versions of git produce a warning if `user.name` or `user.email` were not set. This PR adds functions to set config entries to a git repo and consolidates the code we use to create and tear down temporary git repos in tests.

test plan:
```
+ Committer: admin <admin@admins-Virtual-Machine.local>
+Your name and email address were configured automatically based
+on your username and hostname. Please check that they are accurate.
+You can suppress this message by setting them explicitly. Run the
+following command and follow the instructions in your editor to edit
+your configuration file:
+
+    git config --global --edit
+
+After doing this, you may fix the identity used for this commit with:
+
+    git commit --amend --reset-author
+
```
should no longer occur in https://github.com/semgrep/semgrep/pull/10096 (regular CI checks involving a macos/arm host that happens to run a version of git that prints this warning)
