### PR TITLE
Start using Logs.src instead of tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,19 +20,10 @@
 ### Changed
 
 
-- Passing --debug to Semgrep will not print much, unless a set of tags is specified
-  via `LOG_TAGS`. You can get all debug logs with `LOG_TAGS=everything`. We do
+- Passing --debug to Semgrep should now print less logs. We do
   not want --debug's output to be enormous, as it tends not to be useful and yet
   cause some problems. Note that --debug is mainly intended for Semgrep developers,
   please ask for help if needed. (gh-10044)
-- The environment variables used to select the debug-level log messages
-  are now prefixed with `SEMGREP_` (or `PYTEST_SEMGREP_`) to avoid namespace
-  pollution and undesired cross-application side effects.
-  The supported environment variables are now `SEMGREP_LOG_TAGS`
-  and `PYTEST_SEMGREP_LOG_TAGS`. (gh-10087)
-- The implicit tag to show all debug-level log messages changes from
-  `everything` to `all`. All debug-level messages shown by default are
-  now tagged and selectable with a `default` tag. (gh-10089)
 
 
 ### Fixed

--- a/cli/tests/default/e2e/snapshots/test_output/test_debug_experimental_rule/results.txt
+++ b/cli/tests/default/e2e/snapshots/test_output/test_debug_experimental_rule/results.txt
@@ -11,7 +11,6 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
 === end of stdout - plain
 
 === stderr - plain
-[<MASKED>][DEBUG](default): setup_logging: highlight_setting=Std_msg.Auto, highlight=false
 semgrep version <MASKED>
 Failed to get project url from 'git ls-remote': Command failed with exit code: 128
 -----
@@ -47,6 +46,23 @@ Running Semgrep engine with command:
 <MASKED> -json -rules <MASKED> -j <MASKED> -strict -targets <MASKED> -timeout 5 -timeout_threshold 3 -max_memory 0 -fast --debug
 --- semgrep-core stderr ---
 [<MASKED>][DEBUG](default): setup_logging: highlight_setting=Std_msg.On, highlight=true
+[<MASKED>][DEBUG](default): Skipping logs for cohttp.lwt.client
+[<MASKED>][DEBUG](default): Skipping logs for cohttp.lwt.io
+[<MASKED>][DEBUG](default): Skipping logs for conduit_lwt_server
+[<MASKED>][DEBUG](default): Skipping logs for ca-certs
+[<MASKED>][DEBUG](default): Skipping logs for mirage-crypto-rng-lwt
+[<MASKED>][DEBUG](default): Skipping logs for mirage-crypto-rng.unix
+[<MASKED>][DEBUG](default): Skipping logs for handshake
+[<MASKED>][DEBUG](default): Skipping logs for tls.config
+[<MASKED>][DEBUG](default): Skipping logs for tls.tracing
+[<MASKED>][DEBUG](default): Skipping logs for x509
+[<MASKED>][DEBUG](default): Skipping logs for git.value
+[<MASKED>][DEBUG](default): Skipping logs for git.tree
+[<MASKED>][DEBUG](default): Skipping logs for git.stream
+[<MASKED>][DEBUG](default): Skipping logs for git.blob
+[<MASKED>][DEBUG](default): Skipping logs for commons.pcre
+[<MASKED>][DEBUG](default): Skipping logs for bos
+[<MASKED>][DEBUG](default): Showing logs for application
 [<MASKED>][INFO]: Executed as: <MASKED> -json -rules <MASKED> -j <MASKED> -strict -targets <MASKED> -timeout 5 -timeout_threshold 3 -max_memory 0 -fast --debug
 [<MASKED>][INFO]: Version: semgrep-core version: <MASKED>
 --- end semgrep-core stderr ---
@@ -104,7 +120,6 @@ Not sending pseudonymous metrics since metrics are configured to OFF and registr
 === end of stdout - color
 
 === stderr - color
-[<MASKED>][DEBUG](default): setup_logging: highlight_setting=Std_msg.Auto, highlight=false
 semgrep version <MASKED>
 Failed to get project url from 'git ls-remote': Command failed with exit code: 128
 -----
@@ -140,6 +155,23 @@ Running Semgrep engine with command:
 <MASKED> -json -rules <MASKED> -j <MASKED> -strict -targets <MASKED> -timeout 5 -timeout_threshold 3 -max_memory 0 -fast --debug
 --- semgrep-core stderr ---
 [<MASKED>][[32mDEBUG[0m](default): setup_logging: highlight_setting=Std_msg.On, highlight=true
+[<MASKED>][[32mDEBUG[0m](default): Skipping logs for cohttp.lwt.client
+[<MASKED>][[32mDEBUG[0m](default): Skipping logs for cohttp.lwt.io
+[<MASKED>][[32mDEBUG[0m](default): Skipping logs for conduit_lwt_server
+[<MASKED>][[32mDEBUG[0m](default): Skipping logs for ca-certs
+[<MASKED>][[32mDEBUG[0m](default): Skipping logs for mirage-crypto-rng-lwt
+[<MASKED>][[32mDEBUG[0m](default): Skipping logs for mirage-crypto-rng.unix
+[<MASKED>][[32mDEBUG[0m](default): Skipping logs for handshake
+[<MASKED>][[32mDEBUG[0m](default): Skipping logs for tls.config
+[<MASKED>][[32mDEBUG[0m](default): Skipping logs for tls.tracing
+[<MASKED>][[32mDEBUG[0m](default): Skipping logs for x509
+[<MASKED>][[32mDEBUG[0m](default): Skipping logs for git.value
+[<MASKED>][[32mDEBUG[0m](default): Skipping logs for git.tree
+[<MASKED>][[32mDEBUG[0m](default): Skipping logs for git.stream
+[<MASKED>][[32mDEBUG[0m](default): Skipping logs for git.blob
+[<MASKED>][[32mDEBUG[0m](default): Skipping logs for commons.pcre
+[<MASKED>][[32mDEBUG[0m](default): Skipping logs for bos
+[<MASKED>][[32mDEBUG[0m](default): Showing logs for application
 [<MASKED>][[34mINFO[0m]: Executed as: <MASKED> -json -rules <MASKED> -j <MASKED> -strict -targets <MASKED> -timeout 5 -timeout_threshold 3 -max_memory 0 -fast --debug
 [<MASKED>][[34mINFO[0m]: Version: semgrep-core version: <MASKED>
 --- end semgrep-core stderr ---

--- a/js/tests/Test_jsoo.ml
+++ b/js/tests/Test_jsoo.ml
@@ -144,7 +144,7 @@ let () =
                  (Testo.to_alcotest lwt_tests)
                  ~and_exit:false ~argv
              in
-             Logs_.setup_logging ~level:(Some Logs.Info) ();
+             Logs_.setup ~level:(Some Logs.Info) ();
              (* Some gymnastics are needed here because we need to
                 produce a top level promise, in order to properly transform the
                 lwt promise into a Javascript promise, and run it on the Node.js

--- a/libs/commons/Logs_.ml
+++ b/libs/commons/Logs_.ml
@@ -170,7 +170,7 @@ let reporter ~dst ~require_one_of_these_tags
   let select_all_debug_messages = List.mem "all" require_one_of_these_tags in
   let report src level ~over k msgf =
     let src_name = Logs.Src.name src in
-    let is_app = src_name = "application" in
+    let is_default_src = src_name = "application" in
     let pp_style, _style, style_off =
       match color level with
       | None -> ((fun _ppf _style -> ()), "", "")
@@ -189,7 +189,7 @@ let reporter ~dst ~require_one_of_these_tags
               ("@[[%05.2f]%a%a%s: " ^^ fmt ^^ "@]@.")
               (current -. time_program_start)
               Logs_fmt.pp_header (level, header) pp_tags tags
-              (if is_app then "" else "(" ^ src_name ^ ")")
+              (if is_default_src then "" else "(" ^ src_name ^ ")")
           in
           match level with
           | App ->
@@ -320,9 +320,11 @@ let setup_logging ?(highlight_setting = Std_msg.get_highlight_setting ())
            | "application" -> false
            | x -> skip_libs |> List.exists (fun re -> Re.execp re x)
          in
-         if skip_log then (
-           Logs.Src.set_level src None;
-           Logs.debug (fun m -> m "Skipping log for %s src" src_name)))
+         if skip_log then Logs.Src.set_level src None;
+         Logs.debug (fun m ->
+             m "%s logs for %s"
+               (if skip_log then "Skipping" else "Showing")
+               src_name))
 
 (*****************************************************************************)
 (* Missing basic functions *)

--- a/libs/commons/Logs_.ml
+++ b/libs/commons/Logs_.ml
@@ -24,39 +24,18 @@ open Common
 (* Globals *)
 (*****************************************************************************)
 
+(* unix time in seconds *)
+let now () : float = UUnix.gettimeofday ()
+
 (* This global is used by the reporter to print the difference between
    the time the log call was done and the time the program was started.
 
    TODO? Actually, the implementation is a bit dumb and probably show weird
    metrics when we use [lwt]. For such case, it's better to add a _counter_
    and use the tag mechanism to really show right metrics.
-
-   This variable is set when we configure loggers.
-
    alt: use Mtime_clock.now ()
 *)
-let now () : float = UUnix.gettimeofday ()
-
-(* unix time in seconds *)
 let time_program_start = now ()
-
-(* Some libraries have multiple log sources (i.e. lib.m1 and lib.m2)
- * so we use regexps below to catch them all.
- *)
-let default_skip_src : Re.re list =
-  [
-    "^bos$";
-    "^ca-certs$";
-    "^cohttp.lwt.*$";
-    "^conduit_lwt_server";
-    "^dns";
-    "^git.*$";
-    "^handshake$";
-    "^mirage-crypto-rng.*$";
-    "^tls.*$";
-    "^x509$";
-  ]
-  |> List_.map Re.Pcre.regexp
 
 (*****************************************************************************)
 (* String tags *)
@@ -114,6 +93,10 @@ let string_of_tags tags =
    being potentially extremely slow. -- Martin
 *)
 let pp_tags fmt tags = Format.pp_print_string fmt (string_of_tags tags)
+let default_tag_str = "default"
+let default_tags = [ default_tag_str ]
+let default_tag = create_tag default_tag_str
+let default_tag_set = create_tag_set [ default_tag ]
 
 (*****************************************************************************)
 (* Helpers *)
@@ -140,34 +123,52 @@ let has_nonempty_intersection tag_str_list tag_set =
       ok || List.mem (Logs.Tag.name def) tag_str_list)
     tag_set false
 
-let default_tag_str = "default"
-let default_tags = [ default_tag_str ]
-let default_tag = create_tag default_tag_str
-let default_tag_set = create_tag_set [ default_tag ]
-
 (* Consult environment variables from left-to-right in order of precedence. *)
-let read_from_environment_variables vars =
+let read_from_env_vars (vars : string list) : string option =
   List.find_map (fun var -> USys.getenv_opt var) vars
 
-let read_tags_from_env_vars vars =
-  vars |> read_from_environment_variables
-  |> Option.map (String.split_on_char ',')
+let read_csv_from_env_vars (vars : string list) : string list option =
+  vars |> read_from_env_vars |> Option.map (String.split_on_char ',')
 
-(* log reporter
+(* Note that writing to a freshly-opened file path can still write to
+   a terminal. Such an example is '/dev/stderr'. *)
+let isatty chan =
+  let fd = UUnix.descr_of_out_channel chan in
+  !ANSITerminal.isatty fd
 
-   This code was copy-pasted and derived from the example in the Logs library.
+let create_formatter opt_file =
+  let chan, fmt =
+    match opt_file with
+    | None -> (UStdlib.stderr, UFormat.err_formatter)
+    | Some out_file ->
+        let oc =
+          (* This truncates the log file, which is usually what we want for
+             Semgrep. *)
+          UStdlib.open_out (Fpath.to_string out_file)
+        in
+        (oc, UFormat.formatter_of_out_channel oc)
+  in
+  (isatty chan, fmt)
+
+(*****************************************************************************)
+(* The "reporter" *)
+(*****************************************************************************)
+
+(* This code was copy-pasted and derived from the example in the Logs library.
    The Logs library interface makes us write this code that is frankly
    incomprehensible and excessively complicated given how little it provides.
 *)
-let reporter ~dst ~require_one_of_these_tags
+let mk_reporter ~dst ~require_one_of_these_tags
     ~read_tags_from_env_vars:(env_vars : string list) () =
   let require_one_of_these_tags =
-    match read_tags_from_env_vars env_vars with
+    match read_csv_from_env_vars env_vars with
     | Some tags -> tags
     | None -> require_one_of_these_tags
   in
   (* Each debug message is implicitly tagged with "all". *)
   let select_all_debug_messages = List.mem "all" require_one_of_these_tags in
+
+  (* here we go ... this is quite complicated *)
   let report src level ~over k msgf =
     let src_name = Logs.Src.name src in
     let is_default_src = src_name = "application" in
@@ -215,31 +216,11 @@ let reporter ~dst ~require_one_of_these_tags
   in
   { Logs.report }
 
-(* Note that writing to a freshly-opened file path can still write to
-   a terminal. Such an example is '/dev/stderr'. *)
-let isatty chan =
-  let fd = UUnix.descr_of_out_channel chan in
-  !ANSITerminal.isatty fd
-
-let create_formatter opt_file =
-  let chan, fmt =
-    match opt_file with
-    | None -> (UStdlib.stderr, UFormat.err_formatter)
-    | Some out_file ->
-        let oc =
-          (* This truncates the log file, which is usually what we want for
-             Semgrep. *)
-          UStdlib.open_out (Fpath.to_string out_file)
-        in
-        (oc, UFormat.formatter_of_out_channel oc)
-  in
-  (isatty chan, fmt)
-
 (*****************************************************************************)
 (* Specifying the log level with an environment variable *)
 (*****************************************************************************)
 
-let log_level_of_string_opt str : Logs.level option option =
+let log_level_of_string_opt (str : string) : Logs.level option option =
   match str with
   | "app" -> Some (Some App)
   | "error" -> Some (Some Error)
@@ -249,15 +230,9 @@ let log_level_of_string_opt str : Logs.level option option =
   | "none" -> Some None
   | _ -> None
 
-(* TODO: document this and handle the interpretation at the time
-   of parsing the command line.
-
-   The PYTEST_ prefix is needed when using pytest because it will unset
-   all other environment variables.
-*)
-let read_level_from_env vars =
+let read_level_from_env (vars : string list) : Logs.level option option =
   (* from more specific to least specific *)
-  match read_from_environment_variables vars with
+  match read_from_env_vars vars with
   | None -> None
   | Some str -> log_level_of_string_opt str
 
@@ -268,26 +243,28 @@ let read_level_from_env vars =
 (* Enable basic logging (level = Logs.Warning) so that you can use Logging
  * calls even before a precise call to setup_logging.
  *)
-let enable_logging () =
+let setup_basic () =
   Logs.set_level ~all:true (Some Logs.Warning);
   Logs.set_reporter
-    (reporter ~dst:UFormat.err_formatter ~require_one_of_these_tags:[]
+    (mk_reporter ~dst:UFormat.err_formatter ~require_one_of_these_tags:[]
        ~read_tags_from_env_vars:[] ());
   ()
 
-let setup_logging ?(highlight_setting = Std_msg.get_highlight_setting ())
-    ?log_to_file:opt_file ?(skip_libs = default_skip_src)
-    ?(require_one_of_these_tags = default_tags)
-    ?(read_level_from_env_vars =
-      [ "PYTEST_SEMGREP_LOG_LEVEL"; "SEMGREP_LOG_LEVEL" ])
-    ?(read_tags_from_env_vars =
-      [ "PYTEST_SEMGREP_LOG_TAGS"; "SEMGREP_LOG_TAGS" ]) ~level () =
+let setup ?(highlight_setting = Std_msg.get_highlight_setting ())
+    ?log_to_file:opt_file ?(require_one_of_these_tags = default_tags)
+    ?(read_level_from_env_vars = [ "LOG_LEVEL" ])
+    ?(read_srcs_from_env_vars = [ "LOG_SRCS" ])
+    ?(read_tags_from_env_vars = [ "LOG_TAGS" ]) ~level () =
   (* Override the log level if it's provided by an environment variable!
      This is for debugging a command that gets called by some wrapper. *)
-  let level =
+  let level : Logs.level option =
     match read_level_from_env read_level_from_env_vars with
     | Some level_from_env -> level_from_env
     | None -> level
+  in
+  let show_srcs : Re.re list =
+    read_csv_from_env_vars read_srcs_from_env_vars
+    |> List_.optlist_to_list |> List_.map Re.Pcre.regexp
   in
   let isatty, dst = create_formatter opt_file in
   let highlight =
@@ -304,26 +281,28 @@ let setup_logging ?(highlight_setting = Std_msg.get_highlight_setting ())
   Fmt_tty.setup_std_outputs ?style_renderer ();
   Logs.set_level ~all:true level;
   Logs.set_reporter
-    (reporter ~dst ~require_one_of_these_tags ~read_tags_from_env_vars ());
+    (mk_reporter ~dst ~require_one_of_these_tags ~read_tags_from_env_vars ());
   Logs.debug (fun m ->
       m "setup_logging: highlight_setting=%s, highlight=%B"
         (Std_msg.show_highlight_setting highlight_setting)
         highlight);
-  (* from https://github.com/mirage/ocaml-cohttp#debugging *)
-  (* Disable all third-party libs logs *)
+  (* From https://github.com/mirage/ocaml-cohttp#debugging.
+   * Disable all (third-party) libs logs unless specified in show_srcs
+   * (which itself is derived from LOG_SRCS or similar environment variable).
+   *)
   Logs.Src.list ()
   |> List.iter (fun src ->
          let src_name = Logs.Src.name src in
-         let skip_log =
+         let show_log =
            match src_name with
            (* those are the one we are really interested in *)
-           | "application" -> false
-           | x -> skip_libs |> List.exists (fun re -> Re.execp re x)
+           | "application" -> true
+           | x -> show_srcs |> List.exists (fun re -> Re.execp re x)
          in
-         if skip_log then Logs.Src.set_level src None;
+         if not show_log then Logs.Src.set_level src None;
          Logs.debug (fun m ->
              m "%s logs for %s"
-               (if skip_log then "Skipping" else "Showing")
+               (if show_log then "Showing" else "Skipping")
                src_name))
 
 (*****************************************************************************)

--- a/libs/commons/Logs_.ml
+++ b/libs/commons/Logs_.ml
@@ -1,4 +1,4 @@
-(* Yoann Padioleau, Martin Jambon
+(* Yoann Padioleau
  *
  * Copyright (C) 2022-2024 Semgrep Inc.
  *

--- a/libs/commons/Logs_.ml
+++ b/libs/commons/Logs_.ml
@@ -168,7 +168,6 @@ let mk_reporter ~dst ~require_one_of_these_tags
   (* Each debug message is implicitly tagged with "all". *)
   let select_all_debug_messages = List.mem "all" require_one_of_these_tags in
 
-  (* here we go ... this is quite complicated *)
   let report src level ~over k msgf =
     let src_name = Logs.Src.name src in
     let is_default_src = src_name = "application" in

--- a/libs/commons/Logs_.mli
+++ b/libs/commons/Logs_.mli
@@ -34,14 +34,10 @@
      Semgrep: activated with --debug
 *)
 
-(* Enable basic logging (level = Logs.Warning) so that
-   you can use Logging calls even before a precise call
-   to setup_logging.
-*)
-val enable_logging : unit -> unit
-
-(* List of Logs.src we don't want to enable logging for (third-party libs) *)
-val default_skip_src : Re.re list
+(* Enable basic logging (level = Logs.Warning) so you can use Logging calls
+ * even before a precise call to setup_logging().
+ *)
+val setup_basic : unit -> unit
 
 (* Setup the Logs library. This call is necessary before any logging
    calls, otherwise your log will not go anywhere (not even on stderr).
@@ -55,8 +51,15 @@ val default_skip_src : Re.re list
    of these tags must be set for a log instruction to be printed.
 
    'read_level_from_env_var': environment variables that override the
-   'level' argument. The default is ["PYTEST_SEMGREP_LOG_LEVEL";
-   "SEMGREP_LOG_LEVEL"]. See also 'read_tags_from_env_vars'.
+   'level' argument. The default is ["LOG_LEVEL"].
+    See also 'read_tags_from_env_vars'.
+
+   'read_srcs_from_env_vars': specifies environment variables
+   from which a list of comma-separated (PCRE compliant) regexps will be
+   read if the variable is set, in which case the list of regexps will be
+   used to enable logging for third-party libraries whose src is matching
+   one of the regexp.
+   This variable is "LOG_SRCS" by default.
 
    'read_tags_from_env_vars': specifies environment variables
    from which a list of comma-separated tags will be read if the variable
@@ -86,12 +89,12 @@ val default_skip_src : Re.re list
      [00.45][DEBUG](Match_rules): checking tests/parsing/ocaml/basic.mli with 1 rules
      ...
 *)
-val setup_logging :
+val setup :
   ?highlight_setting:Std_msg.highlight_setting ->
   ?log_to_file:Fpath.t ->
-  ?skip_libs:Re.re list ->
   ?require_one_of_these_tags:string list ->
   ?read_level_from_env_vars:string list ->
+  ?read_srcs_from_env_vars:string list ->
   ?read_tags_from_env_vars:string list ->
   level:Logs.level option ->
   unit ->

--- a/libs/commons/Logs_.mli
+++ b/libs/commons/Logs_.mli
@@ -64,15 +64,13 @@ val setup_basic : unit -> unit
    'read_tags_from_env_vars': specifies environment variables
    from which a list of comma-separated tags will be read if the variable
    is set, in which case the list of tags will override any value set
-   via 'require_one_of_these_tags'. This variable is "SEMGREP_LOG_TAGS"
-   by default. "PYTEST_SEMGREP_LOG_TAGS" is also supported and allows
-   modifying the logging behavior of pytest tests since pytest clears
-   the environment except for variables starting with "PYTEST_".
+   via 'require_one_of_these_tags'. This variable is "LOG_TAGS"
+   by default.
    To disable it, set it to None. The following shell command shows how
    to make semgrep run at the debug level but only show lines tagged with
    'Match_rules' or 'Core_scan'.
 
-     $ SEMGREP_LOG_TAGS=Match_rules,Core_scan semgrep -e 'Obj.magic' -l ocaml --debug
+     $ LOG_TAGS=Match_rules,Core_scan semgrep -e 'Obj.magic' -l ocaml --debug
      ...
      [00.45][INFO](Core_scan): Analyzing TCB/CapStdlib.ml
      [00.45][INFO](Core_scan): Analyzing tests/parsing/ocaml/attribute_type.ml

--- a/libs/commons/Logs_.mli
+++ b/libs/commons/Logs_.mli
@@ -1,4 +1,4 @@
-(* Small helpers around the Logs library.
+(* Small wrapper around the Logs library.
 
    Here are the usage conventions for the Logs library level,
    augmented from https://erratique.ch/software/logs/doc/Logs/index.html#usage
@@ -40,8 +40,8 @@
 *)
 val enable_logging : unit -> unit
 
-(* list of Logs.src we don't want to enable logging for (third-party libs) *)
-val default_skip_libs : Re.re list
+(* List of Logs.src we don't want to enable logging for (third-party libs) *)
+val default_skip_src : Re.re list
 
 (* Setup the Logs library. This call is necessary before any logging
    calls, otherwise your log will not go anywhere (not even on stderr).

--- a/libs/commons/Logs_.mli
+++ b/libs/commons/Logs_.mli
@@ -1,10 +1,11 @@
-(* Small wrapper around the Logs library.
+(* A few helpers for the Logs library.
 
-   Here are the usage conventions for the Logs library level,
-   augmented from https://erratique.ch/software/logs/doc/Logs/index.html#usage
+   Here are the usage conventions for the Logs library "level"
+   from https://erratique.ch/software/logs/doc/Logs/index.html#usage
+   (slightly augmented).
 
    Attention: Any log message that can't be understood without context
-   will be moved to the Debug level!
+   should be moved to the Debug level!
 
    - App: unlike the other levels, this prints ordinary messages without any
      special formatting.
@@ -20,27 +21,28 @@
      program from running normally but may eventually lead to an error
      condition.
 
-   - Info: condition that allows the program user to get a better
+   - Info: condition that allows the program *user* to get a better
      understanding of what the program is doing.
      Log messages at this level and above may not clutter up the log
      output not should they reduce performance significantly. If that's
      the case, log at the Debug level.
-     Semgrep: activated with --verbose
+     This is usually activated with a --verbose flag.
 
-   - Debug: condition that allows the program developer to get a
+   - Debug: condition that allows the program *developer* to get a
      better understanding of what the program is doing.
      It may reduce the performance of the application or result in
      unreadable logs unless they're filtered. Use tags for filtering.
-     Semgrep: activated with --debug
+     This is usually activated with a --debug flag.
 *)
 
 (* Enable basic logging (level = Logs.Warning) so you can use Logging calls
- * even before a precise call to setup_logging().
+ * even before a precise call to setup().
  *)
 val setup_basic : unit -> unit
 
 (* Setup the Logs library. This call is necessary before any logging
-   calls, otherwise your log will not go anywhere (not even on stderr).
+   calls, otherwise your log will not go anywhere (not even on stderr,
+   unless you used setup_basic() below).
 
    'highlight_setting': whether the output should be formatted with color
    and font effects. It defaults to the current setting we have for stderr
@@ -66,7 +68,8 @@ val setup_basic : unit -> unit
    is set, in which case the list of tags will override any value set
    via 'require_one_of_these_tags'. This variable is "LOG_TAGS"
    by default.
-   To disable it, set it to None. The following shell command shows how
+
+   The following shell command shows how
    to make semgrep run at the debug level but only show lines tagged with
    'Match_rules' or 'Core_scan'.
 

--- a/libs/commons/Pcre_.ml
+++ b/libs/commons/Pcre_.ml
@@ -12,7 +12,9 @@ type t = {
 }
 [@@deriving show, eq]
 
-let tags = Logs_.create_tags [ __MODULE__ ]
+let src = Logs.Src.create "commons.pcre"
+
+module Log = (val Logs.src_log src : Logs.LOG)
 
 (*
    Provide missing error->string conversion
@@ -110,9 +112,9 @@ let log_error rex subj err =
     if len < 200 then subj
     else sprintf "%s ... (%i bytes)" (Str.first_chars subj 200) len
   in
-  Logs.warn (fun m ->
-      m ~tags "PCRE error: %s on input %S. Source regexp: %S"
-        (string_of_error err) string_fragment rex.pattern)
+  Log.err (fun m ->
+      m "PCRE error: %s on input %S. Source regexp: %S" (string_of_error err)
+        string_fragment rex.pattern)
 
 let pmatch_noerr ?iflags ?flags ~rex ?pos ?callout ?(on_error = false) subj =
   match pmatch ?iflags ?flags ~rex ?pos ?callout subj with

--- a/libs/commons/dune
+++ b/libs/commons/dune
@@ -3,11 +3,12 @@
  (wrapped false)
  (flags (:standard -open TCB))
  (libraries
-   str
    TCB
+   ; stdlib
+   str
    unix
+   ; popular libs
    fpath
-   uri
    yojson
    atdgen-runtime
    fmt
@@ -24,7 +25,7 @@
    digestif.ocaml
    sexplib
    ; web stuff
-   uuidm
+   uri uuidm
    ; async stuff
    lwt
    alcotest-lwt

--- a/src/core_cli/Core_CLI.ml
+++ b/src/core_cli/Core_CLI.ml
@@ -715,13 +715,15 @@ let main_no_exn_handler (caps : Cap.all_caps) (sys_argv : string array) : unit =
   let config = mk_config () in
 
   Core_profiling.profiling := config.debug || config.report_time;
+
+  (* coupling: CLI_common.setup_logging *)
   Std_msg.setup ~highlight_setting:On ();
-  Logs_.setup_logging ?log_to_file:config.log_to_file
-    ?require_one_of_these_tags:None
+  Logs_.setup ?log_to_file:config.log_to_file ?require_one_of_these_tags:None
     ~level:
       (* TODO: command-line option or env variable to choose the log level *)
       (if config.debug then Some Debug else Some Info)
     ();
+
   Logs.info (fun m -> m ~tags "Executed as: %s" (argv |> String.concat " "));
   Logs.info (fun m -> m ~tags "Version: %s" version);
   let config =

--- a/src/core_cli/Core_CLI.ml
+++ b/src/core_cli/Core_CLI.ml
@@ -729,6 +729,8 @@ let main_no_exn_handler (caps : Cap.all_caps) (sys_argv : string array) : unit =
    * The PYTEST_XXX env vars allows modifying the logging behavior of pytest
    * tests since pytest clears the environment except for variables starting
    * with "PYTEST_".
+   * LATER: once we remove pysemgrep and switch from pytest to Testo, we
+   * can get rid of those PYTEST_xxx env vars.
    *)
   Logs_.setup ?log_to_file:config.log_to_file ?require_one_of_these_tags:None
     ~read_level_from_env_vars:

--- a/src/core_cli/Core_CLI.ml
+++ b/src/core_cli/Core_CLI.ml
@@ -718,7 +718,23 @@ let main_no_exn_handler (caps : Cap.all_caps) (sys_argv : string array) : unit =
 
   (* coupling: CLI_common.setup_logging *)
   Std_msg.setup ~highlight_setting:On ();
+  (* We override the default use of LOG_XXX env var in Logs_.setup() with
+   * SEMGREP_LOG_XXX env vars because Gitlab was reporting perf problems due
+   * to all the logging produced by Semgrep. Indeed, Gitlab CI itself is running
+   * jobs with LOG_LEVEL=debug, so better to use a different name for now.
+   * LATER: once we migrate most of our logs to use Logs.src, we should have
+   * far less logging by default, even in debug level, so we can restore
+   * LOG_LEVEL.
+   *
+   * The PYTEST_XXX env vars allows modifying the logging behavior of pytest
+   * tests since pytest clears the environment except for variables starting
+   * with "PYTEST_".
+   *)
   Logs_.setup ?log_to_file:config.log_to_file ?require_one_of_these_tags:None
+    ~read_level_from_env_vars:
+      [ "PYTEST_SEMGREP_LOG_LEVEL"; "SEMGREP_LOG_LEVEL" ]
+    ~read_srcs_from_env_vars:[ "PYTEST_SEMGREP_LOG_SRCS"; "SEMGREP_LOG_SRCS" ]
+    ~read_tags_from_env_vars:[ "PYTEST_SEMGREP_LOG_TAGS"; "SEMGREP_LOG_TAGS" ]
     ~level:
       (* TODO: command-line option or env variable to choose the log level *)
       (if config.debug then Some Debug else Some Info)

--- a/src/osemgrep/cli/CLI.ml
+++ b/src/osemgrep/cli/CLI.ml
@@ -323,9 +323,10 @@ let main (caps : caps) (argv : string array) : Exit_code.t =
      *)
   *)
 
-  (* The precise Logs_.setup() is done in Scan_subcommand.ml,
+  (* The precise Logs_.setup() is done in CLI_Common.setup_logging()
+   * called from the different Xxx_subcommand.ml
    * because that's when we have a conf object which contains
-   * the --quiet/--verbose/--debug options. In the mean time we still
+   * the --quiet/--verbose/--debug options. In the mean time, we still
    * enable some basic logging so you can call logging functions
    * even before we fully parse the command-line arguments.
    * alt: we could analyze [argv] and do it sooner for all subcommands here.

--- a/src/osemgrep/cli/CLI.ml
+++ b/src/osemgrep/cli/CLI.ml
@@ -323,14 +323,14 @@ let main (caps : caps) (argv : string array) : Exit_code.t =
      *)
   *)
 
-  (* The precise Logs_helpers.setup_logging() is done in Scan_subcommand.ml,
+  (* The precise Logs_.setup() is done in Scan_subcommand.ml,
    * because that's when we have a conf object which contains
    * the --quiet/--verbose/--debug options. In the mean time we still
-   * enable some default basic logging so you can call logging functions
+   * enable some basic logging so you can call logging functions
    * even before we fully parse the command-line arguments.
    * alt: we could analyze [argv] and do it sooner for all subcommands here.
    *)
-  Logs_.enable_logging ();
+  Logs_.setup_basic ();
   (* TOADAPT: profile_start := Unix.gettimeofday (); *)
   (* pad poor's man profiler *)
   if profile then Profiling.profile := Profiling.ProfAll;

--- a/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -930,13 +930,9 @@ let cmdline_term caps ~allow_empty_config : conf Term.t =
       test_ignore_todo text time_flag timeout _timeout_interfileTODO
       timeout_threshold trace trace_endpoint validate version version_check vim
       =
-    (* ugly: call setup_logging ASAP so the Logs.xxx below are displayed
-     * correctly *)
-    Std_msg.setup ?highlight_setting:(if force_color then Some On else None) ();
-    Logs_.setup_logging ~level:common.CLI_common.logging_level ();
     let target_roots, imply_always_select_explicit_targets =
       replace_target_roots_by_regular_files_where_needed caps
-        ~experimental:(common.maturity =*= Maturity.Experimental)
+        ~experimental:(common.CLI_common.maturity =*= Maturity.Experimental)
         target_roots
     in
     let project_root =

--- a/src/osemgrep/core/CLI_common.ml
+++ b/src/osemgrep/core/CLI_common.ml
@@ -69,14 +69,22 @@ let o_logging : Logs.level option Term.t =
   in
   Term.(const combine $ o_debug $ o_quiet $ o_verbose)
 
-(* ugly: also partially done in CLI.ml *)
 let setup_logging ~force_color ~level =
   Logs.debug (fun m ->
       m ~tags "Logging setup for osemgrep: force_color=%B level=%s" force_color
         (Logs.level_to_string level));
   Std_msg.setup ~highlight_setting:(if force_color then On else Auto) ();
-  (* coupling: See also calls to Logs_.setup() in Core_CLI.ml *)
-  Logs_.setup ~level ();
+  (* coupling: See also the call to Logs_.setup() in Core_CLI.ml and the
+   * comments in it about the environment variables.
+   * TODO: add --semgrep-log-xxx flags for those so this can be set
+   * also with CLI flags and will be part of the man page.
+   *)
+  Logs_.setup
+    ~read_level_from_env_vars:
+      [ "PYTEST_SEMGREP_LOG_LEVEL"; "SEMGREP_LOG_LEVEL" ]
+    ~read_srcs_from_env_vars:[ "PYTEST_SEMGREP_LOG_SRCS"; "SEMGREP_LOG_SRCS" ]
+    ~read_tags_from_env_vars:[ "PYTEST_SEMGREP_LOG_TAGS"; "SEMGREP_LOG_TAGS" ]
+    ~level ();
   (* TOPORT
         # Setup file logging
         # env.user_log_file dir must exist

--- a/src/osemgrep/core/CLI_common.ml
+++ b/src/osemgrep/core/CLI_common.ml
@@ -75,7 +75,8 @@ let setup_logging ~force_color ~level =
       m ~tags "Logging setup for osemgrep: force_color=%B level=%s" force_color
         (Logs.level_to_string level));
   Std_msg.setup ~highlight_setting:(if force_color then On else Auto) ();
-  Logs_.setup_logging ~level ();
+  (* coupling: See also calls to Logs_.setup() in Core_CLI.ml *)
+  Logs_.setup ~level ();
   (* TOPORT
         # Setup file logging
         # env.user_log_file dir must exist

--- a/src/tests/Test.ml
+++ b/src/tests/Test.ml
@@ -142,13 +142,13 @@ let main (caps : Cap.all_caps) : unit =
       Core_CLI.register_exception_printers ();
       (* Show log messages produced when building the list of tests *)
       Std_msg.setup ~highlight_setting:On ();
-      Logs_.setup_logging ~level:(Some Logs.Info) ();
+      Logs_.setup ~level:(Some Logs.Info) ();
       let reset () =
         (* Some tests change this configuration so we have to reset
            it before each test. In particular, tests that check the semgrep
            output can or should change these settings. *)
         Std_msg.setup ~highlight_setting:On ();
-        Logs_.setup_logging ~highlight_setting:On ~level:(Some Logs.Debug) ()
+        Logs_.setup ~highlight_setting:On ~level:(Some Logs.Debug) ()
       in
       Testo.interpret_argv ~project_name:"semgrep-core" (fun () ->
           tests_with_delayed_error caps |> cleanup_before_each_test reset))


### PR DESCRIPTION
We're currently abusing tags for something it was not designed for.
The standard convention in the OCaml libraries world
is to use the Logs "src" to separate the logging
done by different libraries, so let's do the same
in the semgrep codebase.
See https://erratique.ch/software/logs/doc/Logs/index.html#srcs

test plan:
```
$ make check
...
[00.04][WARNING]: Support for Jsonnet rules is experimental and currently meant for internal use only. The syntax may change or be removed at any point.
[00.92][ERROR](commons.pcre): PCRE error: BadUTF8 on input "\127ELF\002\001\001\003\000\000\000\000\000\000\000\000\003\000>\000\001\000\000\0000\021\200\001\000\000\000\00
...
```