### PR TITLE
chore: refactor cli output engine for multiple outputs.

### DIFF
--- a/cli/src/semgrep/commands/ci.py
+++ b/cli/src/semgrep/commands/ci.py
@@ -605,7 +605,7 @@ def ci(
 
     # Since we keep nosemgrep disabled for the actual scan, we have to apply
     # that flag here
-    keep_ignored = not enable_nosem or output_handler.formatter.keep_ignores()
+    keep_ignored = not enable_nosem or output_handler.keep_ignores()
     for rule, matches in removed_prev_scan_matches.items():
         # Filter out any matches that are triaged as ignored on the app
         if scan_handler:

--- a/cli/src/semgrep/commands/ci.py
+++ b/cli/src/semgrep/commands/ci.py
@@ -603,8 +603,11 @@ def ci(
         if (not rule.from_transient_scan)
     }
 
-    # Since we keep nosemgrep disabled for the actual scan, we have to apply
-    # that flag here
+    # Since we keep nosemgrep disabled for the actual scan, we have to
+    # apply that flag here.
+    # If there are multiple outputs and any request to keep_ignores
+    # then all outputs keep the ignores. The only output format that
+    # keep ignored matches currently is sarif.
     keep_ignored = not enable_nosem or output_handler.keep_ignores()
     for rule, matches in removed_prev_scan_matches.items():
         # Filter out any matches that are triaged as ignored on the app

--- a/cli/src/semgrep/output.py
+++ b/cli/src/semgrep/output.py
@@ -122,7 +122,9 @@ def _build_time_json(
 # as an argument to our official API: 'semgrep_main.invoke_semgrep'. Try to minimize
 # changes to this API, and make them backwards compatible, if possible.
 class OutputSettings(NamedTuple):
-    output_format: OutputFormat
+    # List of OutputFormat x OutputDestination
+    outputs: Optional[Tuple[Tuple[OutputFormat, Optional[str]], ...]] = None
+    output_format: Optional[OutputFormat] = None
     output_destination: Optional[str] = None
     output_per_finding_max_lines_limit: Optional[int] = None
     output_per_line_max_chars_limit: Optional[int] = None
@@ -134,6 +136,21 @@ class OutputSettings(NamedTuple):
     dataflow_traces: bool = False
     use_osemgrep_to_format: Optional[Set[OutputFormat]] = None
 
+    def normalize(self) -> OutputSettings:
+
+        # Move output_format and output_destination to outputs 
+        if self.output_format is None:
+            if self.outputs is None:
+                # error here
+            return self
+        current_outputs = ()
+        if self.outputs is not None:
+            current_outputs = self.outputs
+
+        current_outputs += ((self.output_format, self.output_destination),)
+        
+        
+        
 
 class OutputHandler:
     """

--- a/cli/src/semgrep/output.py
+++ b/cli/src/semgrep/output.py
@@ -583,7 +583,7 @@ class OutputHandler:
                     ],
                 )
                 extra["verbose_errors"] = True
-            if self.settings.has_text_output():
+            if output_format == OutputFormat.TEXT:
                 extra["color_output"] = (
                     (output_destination is None and sys.stdout.isatty())
                     or os.environ.get("SEMGREP_FORCE_COLOR")
@@ -595,7 +595,7 @@ class OutputHandler:
                     "per_line_max_chars_limit"
                 ] = self.settings.output_per_line_max_chars_limit
                 extra["dataflow_traces"] = self.settings.dataflow_traces
-            if self.settings.has_output_format(OutputFormat.SARIF):
+            if output_format == OutputFormat.SARIF:
                 extra["dataflow_traces"] = self.settings.dataflow_traces
 
             state = get_state()

--- a/cli/src/semgrep/output.py
+++ b/cli/src/semgrep/output.py
@@ -120,8 +120,8 @@ def _build_time_json(
 
 
 # This class is the internal representation of OutputSettings below.
-# Since it is internal it can change as much as necisarry to make
-# typchecking more accurate and enforce invariants.
+# Since it is internal it can change as much as necesarry to make
+# typechecking more accurate and enforce invariants.
 class NormalizedOutputSettings(NamedTuple):
     # Immutable List of OutputDestination x OutputFormat
     outputs: Tuple[Tuple[Optional[str], OutputFormat], ...]

--- a/cli/src/semgrep/run_scan.py
+++ b/cli/src/semgrep/run_scan.py
@@ -711,7 +711,7 @@ def run_scan(
                 raise SemgrepError(e)
 
     ignores_start_time = time.time()
-    keep_ignored = disable_nosem or output_handler.formatter.keep_ignores()
+    keep_ignored = disable_nosem or output_handler.keep_ignores()
     filtered_matches_by_rule = filter_ignored(
         rule_matches_by_rule, keep_ignored=keep_ignored
     )
@@ -810,4 +810,8 @@ def run_scan_and_return_json(
     output_handler.explanations = output_extra.core.explanations
     output_handler.extra = output_extra
 
-    return json.loads(output_handler._build_output())  # type: ignore
+    outputs = tuple(output_handler._build_output())
+    if len(outputs) != 1:
+        raise RuntimeError("run_scan_and_return_json: expects a single output")
+
+    return json.loads(outputs[0][1])  # type: ignore

--- a/cli/src/semgrep/run_scan.py
+++ b/cli/src/semgrep/run_scan.py
@@ -710,6 +710,9 @@ def run_scan(
             except Exception as e:
                 raise SemgrepError(e)
 
+    # If there are multiple outputs and any request to keep_ignores
+    # then all outputs keep the ignores. The only output format that
+    # keep ignored matches currently is sarif.
     ignores_start_time = time.time()
     keep_ignored = disable_nosem or output_handler.keep_ignores()
     filtered_matches_by_rule = filter_ignored(
@@ -810,7 +813,7 @@ def run_scan_and_return_json(
     output_handler.explanations = output_extra.core.explanations
     output_handler.extra = output_extra
 
-    outputs = tuple(output_handler._build_output())
+    outputs = tuple(output_handler._build_outputs())
     if len(outputs) != 1:
         raise RuntimeError("run_scan_and_return_json: expects a single output")
 


### PR DESCRIPTION
This PR refactors/multiplexes the `OutputHandler` in `output.py` so that it should be trivial to add multiple output destinations.

towards [SAF-341](https://linear.app/semgrep/issue/SAF-341/multiple-output-options-simultaneously)

# test plan

CI should continue to pass.