### PR TITLE
feat(osemgrep): support SARIF formatting in osemgrep

### DIFF
--- a/changelog.d/saf-978.added
+++ b/changelog.d/saf-978.added
@@ -1,7 +1,7 @@
 Added an experimental feature for users to use osemgrep to format
 SARIF output.
 
-When the flag --sarif and --use-osemgrep-format-output is specified,
+When both the flags --sarif and --use-osemgrep-sarif are specified,
 semgrep will use the ocaml implementation to format SARIF.
 
 This flag is experimental and can be removed any time. Users must not

--- a/changelog.d/saf-978.added
+++ b/changelog.d/saf-978.added
@@ -1,0 +1,8 @@
+Added an experimental feature for users to use osemgrep to format
+SARIF output.
+
+When the flag --sarif and --use-osemgrep-format-output is specified,
+semgrep will use the ocaml implementation to format SARIF.
+
+This flag is experimental and can be removed any time. Users must not
+rely on it being available.

--- a/cli/src/semgrep/commands/scan.py
+++ b/cli/src/semgrep/commands/scan.py
@@ -421,8 +421,8 @@ def scan_options(func: Callable) -> Callable:
 )
 @optgroup.group("Osemgrep migration options")
 @optgroup.option(
-    "--use-osemgrep-format-output",
-    "use_osemgrep_format_output",
+    "--use-osemgrep-sarif",
+    "use_osemgrep_sarif",
     is_flag=True,
     default=False,
 )
@@ -479,7 +479,7 @@ def scan(
     trace: bool,
     trace_endpoint: Optional[str],
     use_git_ignore: bool,
-    use_osemgrep_format_output: bool,
+    use_osemgrep_sarif: bool,
     validate: bool,
     verbose: bool,
     version: bool,
@@ -568,6 +568,9 @@ def scan(
         semgrep.config_resolver.adjust_for_docker()
         targets = (os.curdir,)
 
+    use_osemgrep_to_format: Set[OutputFormat] = set()
+    if use_osemgrep_sarif:
+        use_osemgrep_to_format.add(OutputFormat.SARIF)
     output_settings = OutputSettings(
         output_format=output_format,
         output_destination=output,
@@ -579,7 +582,7 @@ def scan(
         output_per_finding_max_lines_limit=max_lines_per_finding,
         output_per_line_max_chars_limit=max_chars_per_line,
         dataflow_traces=dataflow_traces,
-        use_osemgrep_format_output=use_osemgrep_format_output,
+        use_osemgrep_to_format=use_osemgrep_to_format,
     )
 
     if test:

--- a/cli/src/semgrep/commands/scan.py
+++ b/cli/src/semgrep/commands/scan.py
@@ -419,6 +419,13 @@ def scan_options(func: Callable) -> Callable:
     hidden=True,
     help="Contact support@semgrep.com for more informationon this.",
 )
+@optgroup.group("Osemgrep migration options")
+@optgroup.option(
+    "--use-osemgrep-format-output",
+    "use_osemgrep_format_output",
+    is_flag=True,
+    default=False,
+)
 @scan_options
 @handle_command_errors
 def scan(
@@ -472,6 +479,7 @@ def scan(
     trace: bool,
     trace_endpoint: Optional[str],
     use_git_ignore: bool,
+    use_osemgrep_format_output: bool,
     validate: bool,
     verbose: bool,
     version: bool,
@@ -571,6 +579,7 @@ def scan(
         output_per_finding_max_lines_limit=max_lines_per_finding,
         output_per_line_max_chars_limit=max_chars_per_line,
         dataflow_traces=dataflow_traces,
+        use_osemgrep_format_output=use_osemgrep_format_output,
     )
 
     if test:

--- a/cli/src/semgrep/formatter/osemgrep_sarif.py
+++ b/cli/src/semgrep/formatter/osemgrep_sarif.py
@@ -14,10 +14,10 @@ from semgrep.error import SemgrepError
 from semgrep.formatter.base import BaseFormatter
 from semgrep.formatter.base import rule_match_to_CliMatch
 from semgrep.formatter.sarif import SarifFormatter
-from semgrep.metrics import Metrics
 from semgrep.rule import Rule
 from semgrep.rule_match import RuleMatch
 from semgrep.semgrep_interfaces.semgrep_metrics import OsemgrepFormatOutput
+from semgrep.state import get_state
 from semgrep.verbose_logging import getLogger
 
 
@@ -25,11 +25,6 @@ logger = getLogger(__name__)
 
 
 class OsemgrepSarifFormatter(BaseFormatter):
-    def __init__(self, metrics: Metrics) -> None:
-        # Metrics is temporarily needed so we can keep track of cases
-        # where we fail to format in osemgrep in production.
-        self.metrics = metrics
-
     def _osemgrep_format(
         self,
         rules: Iterable[Rule],
@@ -151,7 +146,7 @@ class OsemgrepSarifFormatter(BaseFormatter):
         format_metrics.osemgrep_format_time_seconds = o_elapse
         format_metrics.pysemgrep_format_time_seconds = py_elapse
         format_metrics.validation_time_seconds = validate_elapse
-        self.metrics.add_osemgrep_format_output_metrics(format_metrics)
+        get_state().metrics.add_osemgrep_format_output_metrics(format_metrics)
 
         if succeeded and is_match:
             return o_output

--- a/cli/src/semgrep/metrics.py
+++ b/cli/src/semgrep/metrics.py
@@ -46,6 +46,8 @@ from semgrep.semgrep_interfaces.semgrep_metrics import Interfile
 from semgrep.semgrep_interfaces.semgrep_metrics import Interprocedural
 from semgrep.semgrep_interfaces.semgrep_metrics import Intraprocedural
 from semgrep.semgrep_interfaces.semgrep_metrics import Misc
+from semgrep.semgrep_interfaces.semgrep_metrics import OsemgrepFormatOutput
+from semgrep.semgrep_interfaces.semgrep_metrics import OsemgrepMetrics
 from semgrep.semgrep_interfaces.semgrep_metrics import ParseStat
 from semgrep.semgrep_interfaces.semgrep_metrics import Payload
 from semgrep.semgrep_interfaces.semgrep_metrics import Performance
@@ -148,6 +150,7 @@ class Metrics:
             anonymous_user_id="",
             parse_rate=[],
             sent_at=Datetime(""),
+            osemgrep=None,
         )
     )
 
@@ -351,6 +354,12 @@ class Metrics:
         self.payload.errors.errors = [
             met.Error(error_type_string(e.type_())) for e in errors
         ]
+
+    @suppress_errors
+    def add_osemgrep_format_output_metrics(self, o: OsemgrepFormatOutput) -> None:
+        if self.payload.osemgrep is None:
+            self.payload.osemgrep = OsemgrepMetrics()
+        self.payload.osemgrep.format_output = o
 
     @suppress_errors
     def add_profiling(self, profiler: ProfileManager) -> None:

--- a/cli/src/semgrep/ocaml.py
+++ b/cli/src/semgrep/ocaml.py
@@ -151,3 +151,13 @@ def apply_fixes(args: out.ApplyFixesParams) -> Optional[out.ApplyFixesReturn]:
         # could cause this, and we log in the caller too.
         return None
     return ret.value
+
+
+def sarif_format(args: out.SarifFormatParams) -> Optional[out.RetSarifFormat]:
+    call = out.FunctionCall(out.CallSarifFormat(args))
+    ret: Optional[out.RetSarifFormat] = _call(call, out.RetSarifFormat)
+    if ret is None:
+        # No real point in logging here. We log for each of the conditions that
+        # could cause this, and we log in the caller too.
+        return None
+    return ret

--- a/cli/src/semgrep/output.py
+++ b/cli/src/semgrep/output.py
@@ -36,6 +36,7 @@ from semgrep.formatter.gitlab_sast import GitlabSastFormatter
 from semgrep.formatter.gitlab_secrets import GitlabSecretsFormatter
 from semgrep.formatter.json import JsonFormatter
 from semgrep.formatter.junit_xml import JunitXmlFormatter
+from semgrep.formatter.osemgrep_sarif import OsemgrepSarifFormatter
 from semgrep.formatter.sarif import SarifFormatter
 from semgrep.formatter.text import TextFormatter
 from semgrep.formatter.vim import VimFormatter
@@ -67,6 +68,7 @@ FORMATTERS: Mapping[OutputFormat, Type[BaseFormatter]] = {
     OutputFormat.TEXT: TextFormatter,
     OutputFormat.VIM: VimFormatter,
 }
+
 
 DEFAULT_SHOWN_SEVERITIES: Collection[out.MatchSeverity] = frozenset(
     {
@@ -125,6 +127,7 @@ class OutputSettings(NamedTuple):
     output_time: bool = False
     timeout_threshold: int = 0
     dataflow_traces: bool = False
+    use_osemgrep_format_output: bool = False
 
 
 class OutputHandler:
@@ -164,11 +167,28 @@ class OutputHandler:
         self.engine_type: EngineType = EngineType.OSS
 
         self.final_error: Optional[Exception] = None
-        formatter_type = FORMATTERS.get(self.settings.output_format)
-        if formatter_type is None:
-            raise RuntimeError(f"Invalid output format: {self.settings.output_format}")
 
-        self.formatter = formatter_type()
+        formatter: Optional[BaseFormatter] = None
+        # If configured to use osemgrep to format the output, use the osemgrep formatter.
+        if self.settings.use_osemgrep_format_output:
+            if self.settings.output_format == OutputFormat.SARIF:
+                metrics = get_state().metrics
+                formatter = OsemgrepSarifFormatter(metrics)
+            else:
+                logger.warning(
+                    f"Osemgrep formatter for {self.settings.output_format} is not supported yet. "
+                    "Falling back to pysemgrep formatter."
+                )
+
+        # If the formatter is not yet supported, fallback to the pysemgrep formatter
+        if formatter is None:
+            formatter_type = FORMATTERS.get(self.settings.output_format)
+            if formatter_type is not None:
+                formatter = formatter_type()
+
+        if formatter is None:
+            raise RuntimeError(f"Invalid output format: {self.settings.output_format}")
+        self.formatter = formatter
 
     def handle_semgrep_errors(self, errors: Sequence[SemgrepError]) -> None:
         timeout_errors = defaultdict(list)
@@ -311,6 +331,7 @@ class OutputHandler:
         is_ci_invocation: bool = False,
         executed_rule_count: int = 0,
         missed_rule_count: int = 0,
+        use_osemgrep_format_output: bool = False,
     ) -> None:
         state = get_state()
         self.has_output = True

--- a/cli/tests/default/e2e/test_osemgrep_output.py
+++ b/cli/tests/default/e2e/test_osemgrep_output.py
@@ -1,0 +1,28 @@
+import pytest
+from tests.fixtures import RunSemgrep
+
+from semgrep.constants import OutputFormat
+
+
+@pytest.mark.skip(reason="TODO: make osemgrep output match pysemgrep")
+@pytest.mark.kinda_slow
+@pytest.mark.parametrize(
+    "output_format",
+    [OutputFormat.SARIF],
+)
+def test_sarif_output(run_semgrep_in_tmp: RunSemgrep, output_format):
+    _out, err = run_semgrep_in_tmp(
+        "rules/eqeq.yaml",
+        target_name="basic/stupid.py",
+        options=["--verbose", "--use-osemgrep-format-output"],
+        output_format=output_format,
+        assert_exit_code=0,
+    )
+    # When --verbose is enabled, we log
+    #   "Osemgrep vs Pysemgrep SARIF output mismatch."
+    # when osemgrep and pysemgrep outputs don't match.
+    #
+    # See an example log in osemgrep_sarif.py. For other
+    # output formats, we should log this consistently
+    # for it to be tested here.
+    assert "output mismatch" not in err

--- a/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -541,6 +541,14 @@ let o_junit_xml : bool Term.t =
   in
   Arg.value (Arg.flag info)
 
+let o_use_osemgrep_format_output : bool Term.t =
+  let info =
+    Arg.info
+      [ "use-osemgrep-format-output" ]
+      ~doc:{|Output results using osemgrep.|}
+  in
+  Arg.value (Arg.flag info)
+
 (* ------------------------------------------------------------------ *)
 (* Run Secrets Post Processors                                  *)
 (* ------------------------------------------------------------------ *)
@@ -928,8 +936,8 @@ let cmdline_term caps ~allow_empty_config : conf Term.t =
       respect_gitignore rewrite_rule_ids sarif scan_unknown_extensions secrets
       severity show_supported_languages strict target_roots test
       test_ignore_todo text time_flag timeout _timeout_interfileTODO
-      timeout_threshold trace trace_endpoint validate version version_check vim
-      =
+      timeout_threshold trace trace_endpoint _use_osemgrep_format_output
+      validate version version_check vim =
     let target_roots, imply_always_select_explicit_targets =
       replace_target_roots_by_regular_files_where_needed caps
         ~experimental:(common.CLI_common.maturity =*= Maturity.Experimental)
@@ -1283,7 +1291,8 @@ let cmdline_term caps ~allow_empty_config : conf Term.t =
     $ o_show_supported_languages $ o_strict $ o_target_roots $ o_test
     $ Test_CLI.o_test_ignore_todo $ o_text $ o_time $ o_timeout
     $ o_timeout_interfile $ o_timeout_threshold $ o_trace $ o_trace_endpoint
-    $ o_validate $ o_version $ o_version_check $ o_vim)
+    $ o_use_osemgrep_format_output $ o_validate $ o_version $ o_version_check
+    $ o_vim)
 
 let doc = "run semgrep rules on files"
 

--- a/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -541,11 +541,9 @@ let o_junit_xml : bool Term.t =
   in
   Arg.value (Arg.flag info)
 
-let o_use_osemgrep_format_output : bool Term.t =
+let o_use_osemgrep_sarif : bool Term.t =
   let info =
-    Arg.info
-      [ "use-osemgrep-format-output" ]
-      ~doc:{|Output results using osemgrep.|}
+    Arg.info [ "use-osemgrep-sarif" ] ~doc:{|Output results using osemgrep.|}
   in
   Arg.value (Arg.flag info)
 
@@ -936,8 +934,8 @@ let cmdline_term caps ~allow_empty_config : conf Term.t =
       respect_gitignore rewrite_rule_ids sarif scan_unknown_extensions secrets
       severity show_supported_languages strict target_roots test
       test_ignore_todo text time_flag timeout _timeout_interfileTODO
-      timeout_threshold trace trace_endpoint _use_osemgrep_format_output
-      validate version version_check vim =
+      timeout_threshold trace trace_endpoint _use_osemgrep_sarif validate
+      version version_check vim =
     let target_roots, imply_always_select_explicit_targets =
       replace_target_roots_by_regular_files_where_needed caps
         ~experimental:(common.CLI_common.maturity =*= Maturity.Experimental)
@@ -1291,8 +1289,7 @@ let cmdline_term caps ~allow_empty_config : conf Term.t =
     $ o_show_supported_languages $ o_strict $ o_target_roots $ o_test
     $ Test_CLI.o_test_ignore_todo $ o_text $ o_time $ o_timeout
     $ o_timeout_interfile $ o_timeout_threshold $ o_trace $ o_trace_endpoint
-    $ o_use_osemgrep_format_output $ o_validate $ o_version $ o_version_check
-    $ o_vim)
+    $ o_use_osemgrep_sarif $ o_validate $ o_version $ o_version_check $ o_vim)
 
 let doc = "run semgrep rules on files"
 

--- a/src/rpc/RPC.ml
+++ b/src/rpc/RPC.ml
@@ -1,5 +1,5 @@
 open Common
-open Semgrep_output_v1_t
+open Semgrep_output_v1_j
 
 let ( let* ) = Result.bind
 
@@ -38,11 +38,57 @@ let handle_autofix dryrun edits =
     in
     (List.length modified_files, [])
 
-let handle_call : function_call -> (function_return, string) result = function
+let handle_sarif_format caps hide_nudge engine_label (rules : fpath)
+    (cli_matches : cli_match list) (cli_errors : cli_error list) =
+  let core_scan_conf =
+    {
+      Core_scan_config.default with
+      rule_source = Some (Core_scan_config.Rule_file rules);
+    }
+  in
+  let rules, _invalid_rules =
+    Core_scan.rules_from_rule_source caps core_scan_conf
+  in
+  let hrules = Rule.hrules_of_rules rules in
+  let cli_output =
+    {
+      results = cli_matches;
+      errors = cli_errors;
+      (* The only fields that matter for sarif are cli_output.results and cli_output.errors,
+       * so the rest of the fields are just populated with the minimal amount of info
+       *)
+      version = None;
+      paths = { scanned = []; skipped = None };
+      time = None;
+      explanations = None;
+      rules_by_engine = None;
+      engine_requested = None;
+      interfile_languages_used = None;
+      skipped_rules = [];
+    }
+  in
+  let output, format_time_seconds =
+    Common.with_time (fun () ->
+        let sarif_json =
+          Sarif_output.sarif_output hide_nudge engine_label hrules cli_output
+        in
+        Sarif.Sarif_v_2_1_0_j.string_of_sarif_json_schema sarif_json)
+  in
+  (output, format_time_seconds)
+
+let handle_call caps : function_call -> (function_return, string) result =
+  function
   | `CallApplyFixes { dryrun; edits } ->
       let modified_file_count, fixed_lines = handle_autofix dryrun edits in
       Ok (`RetApplyFixes { modified_file_count; fixed_lines })
-  | `CallSarifFormat _ -> Error "TODO: CallSarifFormat"
+  | `CallSarifFormat
+      { hide_nudge; engine_label; rules; cli_matches; cli_errors } ->
+      let output, format_time_seconds =
+        handle_sarif_format
+          (caps :> < Cap.tmp >)
+          hide_nudge engine_label rules cli_matches cli_errors
+      in
+      Ok (`RetSarifFormat { output; format_time_seconds })
 
 let read_packet chan =
   let* size_str =
@@ -71,7 +117,7 @@ let write_packet chan str =
 
 (* Blocks until a request comes in, then handles it and sends the result back.
  * *)
-let handle_single_request () =
+let handle_single_request caps () =
   let res =
     let* call_str = read_packet stdin in
     let* call =
@@ -83,7 +129,7 @@ let handle_single_request () =
           let e = Exception.catch e in
           Error (spf "Error parsing RPC request:\n%s" (Exception.to_string e))
     in
-    try handle_call call with
+    try handle_call caps call with
     (* Catch-all here. No matter what happens while handling this request, we
      * need to send a response back. *)
     | e ->
@@ -98,6 +144,6 @@ let handle_single_request () =
   let res_str = Semgrep_output_v1_j.string_of_function_return func_return in
   write_packet stdout res_str
 
-let main _caps =
+let main caps =
   (* For now, just handle one request and then exit. *)
-  handle_single_request ()
+  handle_single_request caps ()

--- a/src/rpc/dune
+++ b/src/rpc/dune
@@ -20,6 +20,7 @@
     semgrep.parsing.tests ; Test_parsing.parsing_stats
     semgrep.analyzing.tests ; Test_analyze_generic.actions
     semgrep.data
+    semgrep.osemgrep_reporting
 
     ; experiments
     semgrep.synthesizing


### PR DESCRIPTION
SARIF formatting in ocaml has already been implemented for a while. This PR hooks it up with RPC, so it can be called from python code and be incrementally rolled out to users sooner.

The user needs to specify `--sarif` along with `--use-osemgrep-format-output` to use ocaml's implementation of SARIF formatting.

Added a new formatter to the list of available formatters. The implementation is in osemgrep_sarif.py, which calls the RPC and compares its result to the python version. If the results are different, fallback to python output and log at verbose level.

In terms of correctness, users will never see a json whose content is different than pysemgrep. (The formatting may be different because ocaml doesn't indent or add new lines, but the json content is never different.)

The implementation for osemgrep_sarif.py and rpc.ml may look bulky, but it's mostly marshaling arguments to pass to an existing function. I think this is still a good step towards removing python code.

OutputSettings takes in a set of output formats that a user would like to output with osemgrep. Currently, we only support 1 output at a time so this might not look like it makes sense, but there's also another PR in flight that supports multiple outputs (https://github.com/semgrep/semgrep/pull/10112), and this osemgrep formatting will need to be eventually incorporated.

Performance numbers:
* for a large payload (~3000 rules and ~2000 findings)
  * I ran `semgrep scan --config r/all semgrep-repo`
  * ~92 seconds total time
  * ~2 seconds e2e RPC call
  * ~45ms ocaml formatting
  * ~144ms python formatting
  * ~280ms validating whether osemgrep == pysemgrep or not
* for a small payload (1 rule and 1 finding)
  * I ran `semgrep scan --config r/python.lang.security.audit.dangerous-os-exec-tainted-env-args.dangerous-os-exec-tainted-env-args `semgrep-repo/cli/bin/semgrep`
  * ~1 second total time
  * ~58ms e2e rpc call
  * <1ms ocaml formatting
  * <1ms python formatting
  * <1ms validating whether osemgrep == pysemgrep or not

I think this performance hit is acceptable, while it allows us to measure how safe the rollout is going.

Tested with make e2e to ensure no regressions. Added a test for osemgrep. It is skipped now, because there is a mismatch in the output. The mismatch in the test has to do with sorting the rules, but the rest of the payload, including the matched based id is the same. The fix will be in a separate PR. This PR focuses on having the first version of SARIF rpc.

Fixes SAF-978