### PR TITLE
Update Testo, fixing temporary path masking bug

### DIFF
--- a/libs/commons/Testutil.ml
+++ b/libs/commons/Testutil.ml
@@ -7,8 +7,15 @@ let run what f =
   UPrintf.printf "running %s...\n%!" what;
   Common.protect ~finally:(fun () -> UPrintf.printf "done with %s.\n%!" what) f
 
-(* TODO: move this to Testo once it's ok with requiring ocaml >= 4.13
-   (needed for Unix.realpath) *)
+(*
+   Semgrep applies 'Unix.realpath' to some paths resulting in
+   the temporary folder being rewritten to its physical path if it
+   was a symlink (MacOS). Here, we mask all known temporary folder paths
+   in Semgrep test output.
+
+   TODO: move this to Testo once it's ok with requiring ocaml >= 4.13
+   (needed for Unix.realpath)
+*)
 let mask_temp_paths ?depth ?replace () =
   let mask_original_path =
     (* nosemgrep: mask-all-temp-paths *)
@@ -20,6 +27,4 @@ let mask_temp_paths ?depth ?replace () =
       ~tmpdir:(UFilename.get_temp_dir_name () |> UUnix.realpath)
       ()
   in
-  (* NOTE: Haven't investigated why yet, but order is important here,
-   *       we must mask the physical path before the original path. *)
   fun text -> text |> mask_physical_path |> mask_original_path

--- a/libs/commons/Testutil.ml
+++ b/libs/commons/Testutil.ml
@@ -27,4 +27,4 @@ let mask_temp_paths ?depth ?replace () =
       ~tmpdir:(UFilename.get_temp_dir_name () |> UUnix.realpath)
       ()
   in
-  fun text -> text |> mask_physical_path |> mask_original_path
+  fun text -> text |> mask_original_path |> mask_physical_path


### PR DESCRIPTION
The bug was causing e.g. `/var/tmp` to be replaced by `/var<TMP>` if `/tmp` was the temporary folder path. See https://github.com/semgrep/testo/pull/56

This is why we had to mask the longer path first (`/a/b/c`) and only then the shorter path (`/b/c`) that happened to be a substring of the former.
