### PR TITLE
Use Logs src for ojsonnet and networking library and restore use of Logs.info instead of Logs.debug in Scan_subcommand.ml

### DIFF
--- a/cli/tests/default/e2e/snapshots/test_output/test_debug_experimental_rule/results.txt
+++ b/cli/tests/default/e2e/snapshots/test_output/test_debug_experimental_rule/results.txt
@@ -46,6 +46,7 @@ Running Semgrep engine with command:
 <MASKED> -json -rules <MASKED> -j <MASKED> -strict -targets <MASKED> -timeout 5 -timeout_threshold 3 -max_memory 0 -fast --debug
 --- semgrep-core stderr ---
 [<MASKED>][DEBUG](default): setup_logging: highlight_setting=Std_msg.On, highlight=true
+[<MASKED>][DEBUG](default): Skipping logs for networking.http
 [<MASKED>][DEBUG](default): Skipping logs for cohttp.lwt.client
 [<MASKED>][DEBUG](default): Skipping logs for cohttp.lwt.io
 [<MASKED>][DEBUG](default): Skipping logs for conduit_lwt_server
@@ -56,6 +57,7 @@ Running Semgrep engine with command:
 [<MASKED>][DEBUG](default): Skipping logs for tls.config
 [<MASKED>][DEBUG](default): Skipping logs for tls.tracing
 [<MASKED>][DEBUG](default): Skipping logs for x509
+[<MASKED>][DEBUG](default): Skipping logs for ojsonnet.eval
 [<MASKED>][DEBUG](default): Skipping logs for git.value
 [<MASKED>][DEBUG](default): Skipping logs for git.tree
 [<MASKED>][DEBUG](default): Skipping logs for git.stream
@@ -155,6 +157,7 @@ Running Semgrep engine with command:
 <MASKED> -json -rules <MASKED> -j <MASKED> -strict -targets <MASKED> -timeout 5 -timeout_threshold 3 -max_memory 0 -fast --debug
 --- semgrep-core stderr ---
 [<MASKED>][[32mDEBUG[0m](default): setup_logging: highlight_setting=Std_msg.On, highlight=true
+[<MASKED>][[32mDEBUG[0m](default): Skipping logs for networking.http
 [<MASKED>][[32mDEBUG[0m](default): Skipping logs for cohttp.lwt.client
 [<MASKED>][[32mDEBUG[0m](default): Skipping logs for cohttp.lwt.io
 [<MASKED>][[32mDEBUG[0m](default): Skipping logs for conduit_lwt_server
@@ -165,6 +168,7 @@ Running Semgrep engine with command:
 [<MASKED>][[32mDEBUG[0m](default): Skipping logs for tls.config
 [<MASKED>][[32mDEBUG[0m](default): Skipping logs for tls.tracing
 [<MASKED>][[32mDEBUG[0m](default): Skipping logs for x509
+[<MASKED>][[32mDEBUG[0m](default): Skipping logs for ojsonnet.eval
 [<MASKED>][[32mDEBUG[0m](default): Skipping logs for git.value
 [<MASKED>][[32mDEBUG[0m](default): Skipping logs for git.tree
 [<MASKED>][[32mDEBUG[0m](default): Skipping logs for git.stream

--- a/libs/ojsonnet/Eval_jsonnet_common.ml
+++ b/libs/ojsonnet/Eval_jsonnet_common.ml
@@ -17,6 +17,10 @@ open Core_jsonnet
 module A = AST_jsonnet
 module V = Value_jsonnet
 
+let src = Logs.Src.create "ojsonnet.eval"
+
+module Log = (val Logs.src_log src : Logs.LOG)
+
 (*****************************************************************************)
 (* Prelude *)
 (*****************************************************************************)
@@ -104,7 +108,7 @@ let short_string_of_value (v : V.t) : string =
 
 let debug_call (env : V.env) (e0 : expr) (l, args, _r) : unit =
   if not env.in_debug_call then
-    Logs.debug (fun m ->
+    Log.debug (fun m ->
         let env = { env with in_debug_call = true } in
         let fstr = str_of_caller e0 in
         m "%s> %s(%s) at %s"
@@ -132,7 +136,7 @@ let debug_call (env : V.env) (e0 : expr) (l, args, _r) : unit =
 
 let debug_ret (env : V.env) (e0 : expr) (_l, _args, _r) (retv : V.t) : unit =
   if not env.in_debug_call then
-    Logs.debug (fun m ->
+    Log.debug (fun m ->
         let fstr = str_of_caller e0 in
         m "%s< %s(...) = %s"
           (Common2.repeat "-" env.depth |> String.concat "")

--- a/src/osemgrep/cli/CLI.ml
+++ b/src/osemgrep/cli/CLI.ml
@@ -102,7 +102,7 @@ let log_cli_feature (flag : string) : unit =
 *)
 let send_metrics (caps : < Cap.network ; .. >) : unit =
   if Metrics_.is_enabled () then Semgrep_Metrics.send caps
-  else Logs.debug (fun m -> m "Metrics not enabled, skipping sending")
+  else Logs.info (fun m -> m "Metrics not enabled, skip sending metrics")
 
 (*****************************************************************************)
 (* Subcommands dispatch *)

--- a/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -29,8 +29,6 @@ module SS = Set.Make (String)
    from semgrep_main.py and core_runner.py.
 *)
 
-let tags = Logs_.create_tags [ __MODULE__ ]
-
 (*****************************************************************************)
 (* Types *)
 (*****************************************************************************)
@@ -50,11 +48,14 @@ type caps =
 (* Logging/Profiling/Debugging *)
 (*****************************************************************************)
 
+(* Note that basic logging (Logs_.setup_basic()) was done in CLI.ml before, but
+ * in CLI_common.setup_logging() we do the full setup (Logs_.setup()) now
+ * that we have a conf object.
+ *)
 let setup_logging (conf : Scan_CLI.conf) =
-  Logs_.sdebug ~tags "CLI_common.setup_logging";
   CLI_common.setup_logging ~force_color:conf.output_conf.force_color
     ~level:conf.common.logging_level;
-  Logs.debug (fun m -> m ~tags "Semgrep version: %s" Version.version);
+  Logs.info (fun m -> m "Semgrep version: %s" Version.version);
   ()
 
 (* ugly: also partially done in CLI.ml *)
@@ -66,8 +67,7 @@ let setup_profiling (conf : Scan_CLI.conf) =
   *)
   if conf.common.profile then (
     (* ugly: no need to set Common.profile, this was done in CLI.ml *)
-    Logs.debug (fun m -> m ~tags "Profile mode On");
-    Logs.debug (fun m -> m ~tags "disabling -j when in profiling mode");
+    Logs.info (fun m -> m "Profile mode On (running one job, ignoring -j)");
     { conf with core_runner_conf = { conf.core_runner_conf with num_jobs = 1 } })
   else conf
 
@@ -192,7 +192,7 @@ let print_logo () : unit =
 └─────────────┘
 |}
   in
-  Logs.app (fun m -> m ~tags "%s" logo);
+  Logs.app (fun m -> m "%s" logo);
   ()
 
 let feature_status_str ~(enabled : bool) : string =
@@ -233,11 +233,11 @@ let print_feature_section ~(includes_token : bool) ~(engine : Engine_type.t) :
   List.iter
     (fun (feature_name, desc, is_enabled) ->
       Logs.app (fun m ->
-          m ~tags "%s %s"
+          m "%s %s"
             (feature_status_str ~enabled:is_enabled)
             (Ocolor_format.asprintf {|@{<bold>%s@}|} feature_name));
       Logs.app (fun m ->
-          m ~tags "  %s %s\n" (feature_status_str ~enabled:is_enabled) desc))
+          m "  %s %s\n" (feature_status_str ~enabled:is_enabled) desc))
     features;
   ()
 
@@ -262,7 +262,7 @@ let display_rule_source ~(rule_source : Rules_source.t) : unit =
           "Loading rules from local config..."
     | Pattern _ -> Ocolor_format.asprintf {|@{  %s@}|} "Using custom pattern."
   in
-  Logs.app (fun m -> m ~tags "%s" msg);
+  Logs.app (fun m -> m "%s" msg);
   ()
 
 (*************************************************************************)
@@ -424,7 +424,7 @@ let remove_matches_in_baseline caps (commit : string) (baseline : Core_result.t)
              else x_end_range.pos.bytepos - y_end_range.pos.bytepos))
   in
   Logs.app (fun m ->
-      m ~tags "Removed %s that were in baseline scan"
+      m "Removed %s that were in baseline scan"
         (String_.unit_str !removed "finding"));
   { head with processed_matches }
 
@@ -571,18 +571,19 @@ let run_scan_files (caps : < Cap.stdout ; Cap.chdir ; Cap.tmp >)
     let filtered_rules =
       Rule_filtering.filter_rules conf.rule_filtering_conf rules
     in
-    Logs.debug (fun m ->
-        m ~tags "%a" Rules_report.pp_rules (conf.rules_source, filtered_rules));
+    Logs.info (fun m ->
+        m "%a" Rules_report.pp_rules (conf.rules_source, filtered_rules));
 
     (* step 2: printing the skipped targets *)
     let targets, skipped = targets_and_skipped in
     Logs.debug (fun m ->
-        m ~tags "%a" Targets_report.pp_targets_debug
+        m "%a" Targets_report.pp_targets_debug
           (conf.target_roots, skipped, targets));
+    (* alt: use Logs.info but this is quite long so better Logs.debug *)
     Logs.debug (fun m ->
         skipped
         |> List.iter (fun (x : Semgrep_output_v1_t.skipped_target) ->
-               m ~tags "Ignoring %s due to %s (%s)"
+               m "Ignoring %s due to %s (%s)"
                  !!(x.Semgrep_output_v1_t.path)
                  (Semgrep_output_v1_t.show_skip_reason
                     x.Semgrep_output_v1_t.reason)
@@ -741,7 +742,7 @@ let run_scan_files (caps : < Cap.stdout ; Cap.chdir ; Cap.tmp >)
 
     let skipped_groups = Skipped_report.group_skipped skipped in
     Logs.debug (fun m ->
-        m ~tags "%a" Skipped_report.pp_skipped
+        m "%a" Skipped_report.pp_skipped
           ( conf.targeting_conf.respect_gitignore,
             conf.common.maturity,
             conf.targeting_conf.max_target_bytes,
@@ -750,7 +751,7 @@ let run_scan_files (caps : < Cap.stdout ; Cap.chdir ; Cap.tmp >)
      * prefix), and is filtered when using --quiet.
      *)
     Logs.app (fun m ->
-        m ~tags "%a"
+        m "%a"
           (Summary_report.pp_summary
              ~respect_gitignore:conf.targeting_conf.respect_gitignore
              ~maturity:conf.common.maturity
@@ -758,7 +759,7 @@ let run_scan_files (caps : < Cap.stdout ; Cap.chdir ; Cap.tmp >)
              ~skipped_groups)
           ());
     Logs.app (fun m ->
-        m ~tags "Ran %s on %s: %s."
+        m "Ran %s on %s: %s."
           (String_.unit_str (List.length rules_with_targets) "rule")
           (String_.unit_str (List.length cli_output.paths.scanned) "file")
           (String_.unit_str (List.length cli_output.results) "finding"));
@@ -817,7 +818,7 @@ let run_scan_conf (caps : caps) (conf : Scan_CLI.conf) : Exit_code.t =
      match conf.rules_source with
      | Pattern _ ->
          Logs.app (fun m ->
-             m ~tags "%s"
+             m "%s"
                (Ocolor_format.asprintf {|@{<bold>  %s@}|}
                   "Code scanning at ludicrous speed.\n"))
      | _ ->
@@ -855,7 +856,7 @@ let run_scan_conf (caps : caps) (conf : Scan_CLI.conf) : Exit_code.t =
            configs only from local files (like --config=xyz.yml) does not \
            enable metrics.@.@.More information: \
            https://semgrep.dev/docs/metrics");
-    Logs.app (fun m -> m ~tags "%s" pysemgrep_hack2);
+    Logs.app (fun m -> m "%s" pysemgrep_hack2);
     let settings =
       {
         settings with
@@ -934,7 +935,7 @@ let run_conf (caps : caps) (conf : Scan_CLI.conf) : Exit_code.t =
   setup_logging conf;
   (* return a new conf because can adjust conf.num_jobs (-j) *)
   let conf = setup_profiling conf in
-  Logs.debug (fun m -> m ~tags "conf = %s" (Scan_CLI.show_conf conf));
+  Logs.debug (fun m -> m "conf = %s" (Scan_CLI.show_conf conf));
 
   match () with
   (* "alternate modes" where no search is performed.

--- a/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -741,7 +741,7 @@ let run_scan_files (caps : < Cap.stdout ; Cap.chdir ; Cap.tmp >)
       Metrics_.add_profiling profiler);
 
     let skipped_groups = Skipped_report.group_skipped skipped in
-    Logs.debug (fun m ->
+    Logs.info (fun m ->
         m "%a" Skipped_report.pp_skipped
           ( conf.targeting_conf.respect_gitignore,
             conf.common.maturity,

--- a/src/osemgrep/configuring/Semgrep_settings.ml
+++ b/src/osemgrep/configuring/Semgrep_settings.ml
@@ -82,7 +82,7 @@ let to_yaml { has_shown_metrics_notification; api_token; anonymous_user_id } =
 
 let load ?(maturity = Maturity.Default) ?(include_env = true) () =
   let settings = !Semgrep_envvars.v.user_settings_file in
-  Logs.debug (fun m -> m "Loading settings from %a" Fpath.pp settings);
+  Logs.info (fun m -> m "Loading settings from %a" Fpath.pp settings);
   try
     if
       Sys.file_exists (Fpath.to_string settings)

--- a/src/osemgrep/networking/Rule_fetching.ml
+++ b/src/osemgrep/networking/Rule_fetching.ml
@@ -115,7 +115,7 @@ let partition_rules_and_errors (xs : rules_and_origin list) :
 let fetch_content_from_url_async ?(token_opt = None) caps (url : Uri.t) :
     string Lwt.t =
   (* TOPORT? _nice_semgrep_url() *)
-  Logs.debug (fun m -> m "trying to download from %s" (Uri.to_string url));
+  Logs.info (fun m -> m "trying to download from %s" (Uri.to_string url));
   let content =
     let headers =
       match token_opt with
@@ -130,7 +130,7 @@ let fetch_content_from_url_async ?(token_opt = None) caps (url : Uri.t) :
         Error.abort
           (spf "Failed to download config from %s: %s" (Uri.to_string url) msg)
   in
-  Logs.debug (fun m -> m "finished downloading from %s" (Uri.to_string url));
+  Logs.info (fun m -> m "finished downloading from %s" (Uri.to_string url));
   content
 
 let fetch_content_from_registry_url_async ~token_opt caps url =
@@ -146,7 +146,7 @@ let fetch_content_from_registry_url ~token_opt caps url =
 (*****************************************************************************)
 
 let parse_yaml_for_jsonnet (file : Fpath.t) : AST_jsonnet.program =
-  Logs.debug (fun m -> m "loading yaml file %s, converting to jsonnet" !!file);
+  Logs.info (fun m -> m "loading yaml file %s, converting to jsonnet" !!file);
   (* TODO? or use Yaml_to_generic.parse_yaml_file which seems
    * to be used to parse semgrep rules?
    *)
@@ -308,11 +308,11 @@ let parse_rule ~rewrite_rule_ids ~origin caps (file : Fpath.t) :
  *)
 let load_rules_from_file ~rewrite_rule_ids ~origin caps (file : Fpath.t) :
     (rules_and_origin, Rule.error) Result.t =
-  Logs.debug (fun m -> m "loading local config from %s" !!file);
+  Logs.info (fun m -> m "loading local config from %s" !!file);
   if Sys.file_exists !!file then
     match parse_rule ~rewrite_rule_ids ~origin caps file with
     | Ok (rules, errors) ->
-        Logs.debug (fun m -> m "Done loading local config from %s" !!file);
+        Logs.info (fun m -> m "Done loading local config from %s" !!file);
         Ok { rules; errors; origin = Local_file file }
     | Error err -> Error err
   else


### PR DESCRIPTION
test plan:
```
$ SEMGREP_LOG_SRCS=networking ./bin/osemgrep --experimental --config
semgrep.jsonnet --error --strict --exclude tests --verbose
```
and see networking info logs about GET and POST requests.