### PR TITLE
osemgrep: warn when metrics server returns an error

### DIFF
--- a/src/osemgrep/networking/Semgrep_App.ml
+++ b/src/osemgrep/networking/Semgrep_App.ml
@@ -109,8 +109,8 @@ let extract_scan_id (data : string) : (scan_id, string) result =
         )
     | _else -> Error ("Bad json in body when asking for scan id: " ^ data)
   with
-  | e ->
-      Error ("Couldn't parse json, error: " ^ Printexc.to_string e ^ ": " ^ data)
+  | Yojson.Json_error msg ->
+      Error (spf "Couldn't parse json, err = %s, data was %s" msg data)
 
 (* the server reply when POST to "/api/agent/scans/<scan_id>/results"  *)
 let extract_errors (data : string) : string list =


### PR DESCRIPTION
test plan:
```
$ ./bin/osemgrep --experimental --config semgrep.jsonnet --error
--strict --exclude tests src/typing/
...
Ran 59 rules on 2 files: 0 findings.
[02.33][WARNING]: Metrics server error: {"errorType":"TypeError","errorMessage":"Cannot read property 'map' of undefined","trace":["TypeError: Cannot read property 'map' of undefined","    at createPerRuleObjects (/var/task/index.js:287:24)","    at Runtime.exports.handler (/var/task/index.js:363:20)","    at Runtime.handleOnceNonStreaming (/var/runtime/Runtime.js:74:25)"]}
```