### PR TITLE
osemgrep: Add more Logs.info for osemgrep scan

### DIFF
--- a/cli/tests/default/e2e/snapshots/test_output/test_debug_experimental_rule/results.txt
+++ b/cli/tests/default/e2e/snapshots/test_output/test_debug_experimental_rule/results.txt
@@ -57,11 +57,13 @@ Running Semgrep engine with command:
 [<MASKED>][DEBUG](default): Skipping logs for tls.config
 [<MASKED>][DEBUG](default): Skipping logs for tls.tracing
 [<MASKED>][DEBUG](default): Skipping logs for x509
+[<MASKED>][DEBUG](default): Skipping logs for semgrep.targeting
 [<MASKED>][DEBUG](default): Skipping logs for ojsonnet.eval
 [<MASKED>][DEBUG](default): Skipping logs for git.value
 [<MASKED>][DEBUG](default): Skipping logs for git.tree
 [<MASKED>][DEBUG](default): Skipping logs for git.stream
 [<MASKED>][DEBUG](default): Skipping logs for git.blob
+[<MASKED>][DEBUG](default): Skipping logs for paths
 [<MASKED>][DEBUG](default): Skipping logs for commons.pcre
 [<MASKED>][DEBUG](default): Skipping logs for bos
 [<MASKED>][DEBUG](default): Showing logs for application
@@ -168,11 +170,13 @@ Running Semgrep engine with command:
 [<MASKED>][[32mDEBUG[0m](default): Skipping logs for tls.config
 [<MASKED>][[32mDEBUG[0m](default): Skipping logs for tls.tracing
 [<MASKED>][[32mDEBUG[0m](default): Skipping logs for x509
+[<MASKED>][[32mDEBUG[0m](default): Skipping logs for semgrep.targeting
 [<MASKED>][[32mDEBUG[0m](default): Skipping logs for ojsonnet.eval
 [<MASKED>][[32mDEBUG[0m](default): Skipping logs for git.value
 [<MASKED>][[32mDEBUG[0m](default): Skipping logs for git.tree
 [<MASKED>][[32mDEBUG[0m](default): Skipping logs for git.stream
 [<MASKED>][[32mDEBUG[0m](default): Skipping logs for git.blob
+[<MASKED>][[32mDEBUG[0m](default): Skipping logs for paths
 [<MASKED>][[32mDEBUG[0m](default): Skipping logs for commons.pcre
 [<MASKED>][[32mDEBUG[0m](default): Skipping logs for bos
 [<MASKED>][[32mDEBUG[0m](default): Showing logs for application

--- a/src/fixing/Autofix.ml
+++ b/src/fixing/Autofix.ml
@@ -15,7 +15,6 @@
 open Common
 module OutJ = Semgrep_output_v1_t
 
-let tags = Logs_.create_tags [ __MODULE__; "autofix" ]
 let ( let/ ) = Result.bind
 
 (*****************************************************************************)
@@ -151,7 +150,7 @@ let transform_fix lang ast =
 
 (* Check whether the proposed fix results in syntactically valid code *)
 let validate_fix lang target_contents edit =
-  Logs.debug (fun m -> m ~tags "validate fix %s" (Textedit.show edit));
+  Logs.debug (fun m -> m "validate fix %s" (Textedit.show edit));
   let fail err =
     Error
       (spf "Rendered autofix does not parse. Aborting: `%s`:\n%s"
@@ -272,7 +271,7 @@ let ast_based_fix ~fix (start, end_) (pm : Pattern_match.t) : Textedit.t option
       (* Print line-by-line so that each line is preceded by the logging header.
          Looks nicer and makes it easier to mask in e2e test output.
          TODO: make the Logs_ library do this by default. *)
-      String.split_on_char '\n' msg |> List.iter (Logs_.swarn ~tags);
+      String.split_on_char '\n' msg |> List.iter Logs_.swarn;
       None
 
 let basic_fix ~(fix : string) (start, end_) (pm : Pattern_match.t) : Textedit.t
@@ -386,7 +385,7 @@ let apply_fixes ?(dryrun = false) (edits : Textedit.t list) =
   (match modified_files with
   | _ :: _ ->
       Logs.info (fun m ->
-          m ~tags "%smodified %s."
+          m "%smodified %s."
             (match failed_fixes with
             | [] -> "successfully "
             | _ -> "")
@@ -396,7 +395,7 @@ let apply_fixes ?(dryrun = false) (edits : Textedit.t list) =
   | [] -> ()
   | _ ->
       Logs.warn (fun m ->
-          m ~tags "failed to apply %i fix(es)." (List.length failed_fixes))
+          m "failed to apply %i fix(es)." (List.length failed_fixes))
 
 let apply_fixes_of_core_matches ?dryrun (matches : OutJ.core_match list) =
   matches


### PR DESCRIPTION
test plan:
```
$ ./bin/osemgrep scan --experimental --config semgrep.yml --exclude tests --verbose
...
[00.04][INFO]: Getting the rules
...
[00.04][INFO]: Computing the targets
...
[00.05][INFO]: running the semgrep engine
...
[00.11][INFO]: reporting matches if any
...
```

I should probably add a Testo e2e test to make sure we don't have
regression on this.
For example some recent change made disappear completely the list of
skipped
files even with --verbose because of the switch to Logs.debug and tags

Time for e2e test of osemgrep too