### PR TITLE
feat(tracing): support tracing levels

### DIFF
--- a/libs/tracing/Tracing.mli
+++ b/libs/tracing/Tracing.mli
@@ -31,6 +31,8 @@ type level =
   | Debug  (** Enable commonly used debug tracing *)
   | Trace  (** Enable everything *)
 
+val show_level : level -> string
+
 (*****************************************************************************)
 (* Functions to instrument the code *)
 (*****************************************************************************)

--- a/libs/tracing/Tracing.mli
+++ b/libs/tracing/Tracing.mli
@@ -23,11 +23,20 @@ type span = Trace_core.span [@@deriving show]
 type user_data = Trace_core.user_data
 
 (*****************************************************************************)
+(* Levels *)
+(*****************************************************************************)
+
+type level =
+  | Info  (** Enable standard tracing (default level) *)
+  | Debug  (** Enable commonly used debug tracing *)
+  | Trace  (** Enable everything *)
+
+(*****************************************************************************)
 (* Functions to instrument the code *)
 (*****************************************************************************)
 
 val with_span :
-  ?level:Trace_core__.Level.t ->
+  ?level:level ->
   ?__FUNCTION__:string ->
   __FILE__:string ->
   __LINE__:int ->

--- a/libs/tracing/js/Tracing.ml
+++ b/libs/tracing/js/Tracing.ml
@@ -45,12 +45,8 @@ let level_to_trace_level level =
 (*****************************************************************************)
 (* Code *)
 (*****************************************************************************)
-let with_span ?level =
-  let level =
-    level
-    |> Option.fold ~none:Trace_core.Level.Info ~some:(fun l ->
-           level_to_trace_level l)
-  in
+let with_span ?(level = Info) =
+  let level = level_to_trace_level level in
   Trace_core.with_span ~level
 
 let add_data_to_span (_i : span) (_data : (string * Trace_core.user_data) list)

--- a/libs/tracing/js/Tracing.ml
+++ b/libs/tracing/js/Tracing.ml
@@ -28,9 +28,30 @@ type span = int64 [@@deriving show]
 type user_data = Trace_core.user_data
 
 (*****************************************************************************)
+(* Levels *)
+(*****************************************************************************)
+
+type level =
+  | Info  (** Enable standard tracing (default level) *)
+  | Debug  (** Enable commonly used debug tracing *)
+  | Trace  (** Enable everything *)
+
+let level_to_trace_level level =
+  match level with
+  | Info -> Trace_core.Level.Info
+  | Debug -> Trace_core.Level.Debug1
+  | Trace -> Trace_core.Level.Trace
+
+(*****************************************************************************)
 (* Code *)
 (*****************************************************************************)
-let with_span = Trace_core.with_span
+let with_span ?level =
+  let level =
+    level
+    |> Option.fold ~none:Trace_core.Level.Info ~some:(fun l ->
+           level_to_trace_level l)
+  in
+  Trace_core.with_span ~level
 
 let add_data_to_span (_i : span) (_data : (string * Trace_core.user_data) list)
     =

--- a/libs/tracing/js/Tracing.ml
+++ b/libs/tracing/js/Tracing.ml
@@ -36,6 +36,11 @@ type level =
   | Debug  (** Enable commonly used debug tracing *)
   | Trace  (** Enable everything *)
 
+let show_level = function
+  | Info -> "Info"
+  | Debug -> "Debug"
+  | Trace -> "Trace"
+
 let level_to_trace_level level =
   match level with
   | Info -> Trace_core.Level.Info

--- a/libs/tracing/ppx/dune
+++ b/libs/tracing/ppx/dune
@@ -5,5 +5,6 @@
  (libraries
    commons
    ppxlib
+   tracing
  )
 )

--- a/libs/tracing/ppx/ppx_tracing.ml
+++ b/libs/tracing/ppx/ppx_tracing.ml
@@ -43,6 +43,13 @@ open Ast_helper
 (* Helpers *)
 (*****************************************************************************)
 
+type level = Info | Debug
+
+let level_to_str level =
+  match level with
+  | Info -> "Info"
+  | Debug -> "Debug"
+
 let location_errorf ~loc fmt =
   Format.kasprintf
     (fun err ->
@@ -54,8 +61,8 @@ let name_of_func_pat (pat : Parsetree.pattern) =
   | Ppat_var { txt; _ } -> txt
   | _ -> "<no func name>"
 
-let tracing_attr (attr : Parsetree.attribute) =
-  if attr.attr_name.txt = "trace" then
+let trace_attr (attr : Parsetree.attribute) =
+  if attr.attr_name.txt = "trace" || attr.attr_name.txt = "trace_debug" then
     let payload =
       match attr.attr_payload with
       | PStr
@@ -71,7 +78,8 @@ let tracing_attr (attr : Parsetree.attribute) =
           Some str
       | _ -> None
     in
-    Some payload
+    let level = if attr.attr_name.txt = "trace_debug" then Debug else Info in
+    Some (payload, level)
   else None
 
 (* borrowed from module_ml.ml *)
@@ -83,15 +91,9 @@ let module_name_of_loc loc =
 
 (* To produce arguments like `~__FILE__`*)
 let make_label loc l =
-  ( Labelled l,
-    {
-      pexp_desc = Pexp_ident { txt = Lident l; loc };
-      pexp_loc_stack = [];
-      pexp_loc = loc;
-      pexp_attributes = [];
-    } )
+  (Labelled l, Exp.mk (Pexp_ident { txt = Lident l; loc }) ~loc)
 
-let make_traced_expr loc action_name var_pat e =
+let make_traced_expr ~level loc action_name var_pat e =
   Exp.apply
     (Exp.ident { txt = Lident "@@"; loc })
     [
@@ -99,6 +101,11 @@ let make_traced_expr loc action_name var_pat e =
         Exp.apply
           (Exp.ident { txt = Ldot (Lident "Tracing", "with_span"); loc })
           [
+            ( Labelled "level",
+              Exp.mk ~loc
+                (Pexp_construct
+                   ( { txt = Ldot (Lident "Tracing", level_to_str level); loc },
+                     None )) );
             make_label loc "__FILE__";
             make_label loc "__LINE__";
             (Nolabel, Exp.constant (Pconst_string (action_name, loc, None)));
@@ -113,7 +120,7 @@ let make_traced_expr loc action_name var_pat e =
 (* Turn `let f args = body` into
    `let f args = Trace_core.with_span ~__FILE__ ~__LINE__ "<action_name>" @@
                  fun _sp -> body`*)
-let map_expr_add_tracing attr_payload pat e =
+let map_expr_add_tracing ~level attr_payload pat e =
   match e.pexp_desc with
   | Pexp_fun (arg_label, exp_opt, pattern, e) ->
       let loc = e.pexp_loc in
@@ -125,7 +132,9 @@ let map_expr_add_tracing attr_payload pat e =
             module_name_of_loc loc ^ "." ^ name_of_func_pat pat
       in
       let var_pat = Ast_builder.Default.ppat_var ~loc { txt = "_sp"; loc } in
-      let body_with_tracing = make_traced_expr loc action_name var_pat e in
+      let body_with_tracing =
+        make_traced_expr ~level loc action_name var_pat e
+      in
       {
         e with
         pexp_desc = Pexp_fun (arg_label, exp_opt, pattern, body_with_tracing);
@@ -141,7 +150,7 @@ let map_expr_add_tracing attr_payload pat e =
  * I only copied `rule_let` because for top level annotations we're still
  * using [@@trace] as discussed later *)
 
-let expand_let ~ctxt var (action_name : string) e =
+let expand_let ~level ~ctxt var (action_name : string) e =
   let loc = Expansion_context.Extension.extension_point_loc ctxt in
   Ast_builder.Default.(
     let var_pat =
@@ -149,27 +158,34 @@ let expand_let ~ctxt var (action_name : string) e =
       | `Var v -> ppat_var ~loc:v.loc v
       | `Unit -> ppat_var ~loc { loc; txt = "_sp" }
     in
-    make_traced_expr loc action_name var_pat e)
+    make_traced_expr ~level loc action_name var_pat e)
+
+let let_payload =
+  let open! Ast_pattern in
+  single_expr_payload
+    (pexp_let nonrecursive
+       (value_binding
+          ~pat:
+            (let pat_var = ppat_var __' |> map ~f:(fun f v -> f (`Var v)) in
+             let pat_unit =
+               as__ @@ ppat_construct (lident (string "()")) none
+               |> map ~f:(fun f _ -> f `Unit)
+             in
+             alt pat_var pat_unit)
+          ~expr:(estring __)
+       ^:: nil)
+       __)
 
 let extension_let =
-  Extension.V3.declare "trace" Extension.Context.expression
-    (let open! Ast_pattern in
-     single_expr_payload
-       (pexp_let nonrecursive
-          (value_binding
-             ~pat:
-               (let pat_var = ppat_var __' |> map ~f:(fun f v -> f (`Var v)) in
-                let pat_unit =
-                  as__ @@ ppat_construct (lident (string "()")) none
-                  |> map ~f:(fun f _ -> f `Unit)
-                in
-                alt pat_var pat_unit)
-             ~expr:(estring __)
-          ^:: nil)
-          __))
-    expand_let
+  Extension.V3.declare "trace" Extension.Context.expression let_payload
+    (expand_let ~level:Info)
+
+let extension_let_debug =
+  Extension.V3.declare "trace_debug" Extension.Context.expression let_payload
+    (expand_let ~level:Debug)
 
 let rule_let = Ppxlib.Context_free.Rule.extension extension_let
+let rule_let_debug = Ppxlib.Context_free.Rule.extension extension_let_debug
 
 (*****************************************************************************)
 (* Main driver *)
@@ -189,9 +205,11 @@ let impl (xs : structure) : structure =
       method! value_binding vb =
         let vb = super#value_binding vb in
         let { pvb_expr; pvb_attributes; pvb_pat; _ } = vb in
-        match List.find_map tracing_attr pvb_attributes with
-        | Some attr_payload ->
-            let e' = map_expr_add_tracing attr_payload pvb_pat pvb_expr in
+        match List.find_map trace_attr pvb_attributes with
+        | Some (attr_payload, level) ->
+            let e' =
+              map_expr_add_tracing ~level attr_payload pvb_pat pvb_expr
+            in
             { vb with pvb_expr = e' }
         | None -> vb
     end
@@ -203,6 +221,7 @@ let impl (xs : structure) : structure =
 (* Entry point *)
 (*****************************************************************************)
 
-(* TODO: add ~extensions so that `let%trace = ` is a possible transformation.
-   Copy https://github.com/c-cube/ocaml-trace/blob/main/src/ppx/ppx_trace.ml *)
-let () = Driver.register_transformation ~rules:[ rule_let ] ~impl "ppx_tracing"
+let () =
+  Driver.register_transformation
+    ~rules:[ rule_let; rule_let_debug ]
+    ~impl "ppx_tracing"

--- a/libs/tracing/ppx/ppx_tracing.ml
+++ b/libs/tracing/ppx/ppx_tracing.ml
@@ -81,7 +81,7 @@ let trace_attr (attr : Parsetree.attribute) =
       | _ -> None
     in
     let level =
-      if attr.attr_name.txt = "trace_debug" then "Debug" else "Info"
+      if attr.attr_name.txt = "trace_debug" then Tracing.Debug else Tracing.Info
     in
     Some (payload, level)
   else None
@@ -108,7 +108,11 @@ let make_traced_expr ~level loc action_name var_pat e =
             ( Labelled "level",
               Exp.mk ~loc
                 (Pexp_construct
-                   ({ txt = Ldot (Lident "Tracing", level); loc }, None)) );
+                   ( {
+                       txt = Ldot (Lident "Tracing", Tracing.show_level level);
+                       loc;
+                     },
+                     None )) );
             make_label loc "__FILE__";
             make_label loc "__LINE__";
             (Nolabel, Exp.constant (Pconst_string (action_name, loc, None)));
@@ -181,11 +185,11 @@ let let_payload =
 
 let extension_let =
   Extension.V3.declare "trace" Extension.Context.expression let_payload
-    (expand_let ~level:"Info")
+    (expand_let ~level:Tracing.Info)
 
 let extension_let_debug =
   Extension.V3.declare "trace_debug" Extension.Context.expression let_payload
-    (expand_let ~level:"Debug")
+    (expand_let ~level:Tracing.Debug)
 
 let rule_let = Ppxlib.Context_free.Rule.extension extension_let
 let rule_let_debug = Ppxlib.Context_free.Rule.extension extension_let_debug

--- a/libs/tracing/ppx_tests/trace_debug.ml
+++ b/libs/tracing/ppx_tests/trace_debug.ml
@@ -1,0 +1,17 @@
+let top a b =
+  let add_one a = a + 1 [@@trace] in
+  add_one a + b
+
+let top a b =
+  let add_one a = a + 1 [@@trace_debug] in
+  add_one a + b
+
+let top2 a b =
+  let%trace sp = "example" in
+  a + 1;
+  Tracing.add_data_to_span sp [ ("a", `Int 1) ]
+
+let top2 a b =
+  let%trace_debug sp = "example" in
+  a + 1;
+  Tracing.add_data_to_span sp [ ("a", `Int 1) ]

--- a/libs/tracing/unix/Tracing.ml
+++ b/libs/tracing/unix/Tracing.ml
@@ -69,7 +69,7 @@ type user_data = Trace_core.user_data
 let default_endpoint = "https://telemetry.semgrep.dev"
 let default_dev_endpoint = "https://telemetry.dev2.semgrep.dev"
 let default_local_endpoint = "http://localhost:4318"
-let trace_level_var = "TRACE_LEVEL"
+let trace_level_var = "SEMGREP_TRACE_LEVEL"
 
 (*****************************************************************************)
 (* Levels *)

--- a/libs/tracing/unix/Tracing.ml
+++ b/libs/tracing/unix/Tracing.ml
@@ -80,6 +80,11 @@ type level =
   | Debug  (** Traces to help profile a specific run *)
   | Trace  (** All traces *)
 
+let show_level = function
+  | Info -> "Info"
+  | Debug -> "Debug"
+  | Trace -> "Trace"
+
 let level_to_trace_level level =
   match level with
   | Info -> Trace_core.Level.Info
@@ -89,12 +94,8 @@ let level_to_trace_level level =
 (*****************************************************************************)
 (* Wrapping functions Trace gives us to instrument the code *)
 (*****************************************************************************)
-let with_span ?level =
-  let level =
-    level
-    |> Option.fold ~none:Trace_core.Level.Info ~some:(fun l ->
-           level_to_trace_level l)
-  in
+let with_span ?(level = Info) =
+  let level = level_to_trace_level level in
   Trace_core.with_span ~level
 
 let add_data_to_span = Trace_core.add_data_to_span

--- a/src/engine/Match_rules.ml
+++ b/src/engine/Match_rules.ml
@@ -172,9 +172,9 @@ let check ~match_hook ~timeout ~timeout_threshold
           m ~tags "forcing parsing of AST outside of rules, for better profile");
       Lazy.force lazy_ast_and_errors |> ignore
   | _else_ -> ());
-  let per_rule_boilerplate_fn =
+  let per_rule_boilerplate_fn rule =
     per_rule_boilerplate_fn ~timeout ~timeout_threshold
-      !!internal_path_to_content
+      !!internal_path_to_content rule
   in
 
   (* We separate out the taint rules specifically, because we may want to

--- a/src/engine/Match_rules.ml
+++ b/src/engine/Match_rules.ml
@@ -172,9 +172,9 @@ let check ~match_hook ~timeout ~timeout_threshold
           m ~tags "forcing parsing of AST outside of rules, for better profile");
       Lazy.force lazy_ast_and_errors |> ignore
   | _else_ -> ());
-  let per_rule_boilerplate_fn rule =
+  let per_rule_boilerplate_fn =
     per_rule_boilerplate_fn ~timeout ~timeout_threshold
-      !!internal_path_to_content rule
+      !!internal_path_to_content
   in
 
   (* We separate out the taint rules specifically, because we may want to

--- a/src/engine/Match_search_mode.ml
+++ b/src/engine/Match_search_mode.ml
@@ -966,6 +966,13 @@ and matches_of_formula xconf rule xtarget formula opt_context :
 let check_rule ?dependency_matches ({ R.mode = `Search formula; _ } as r) hook
     xconf xtarget =
   let rule_id = fst r.id in
+
+  let%trace_debug sp = "Match_search_mode.check_rule" in
+  Tracing.add_data_to_span sp
+    [
+      ("rule_id", `String (rule_id |> Rule_ID.to_string)); ("taint", `Bool false);
+    ];
+
   let res, final_ranges = matches_of_formula xconf r xtarget formula None in
   let errors = res.errors |> E.ErrorSet.map (error_with_rule_id rule_id) in
   {

--- a/src/engine/Match_tainting_mode.ml
+++ b/src/engine/Match_tainting_mode.ml
@@ -1066,6 +1066,13 @@ let check_rules ?get_dep_matches ~match_hook
 
   rules
   |> List_.map (fun rule ->
+         let%trace_debug sp = "Match_tainting_mode.check_rules.rule" in
+         Tracing.add_data_to_span sp
+           [
+             ("rule_id", `String (fst rule.R.id |> Rule_ID.to_string));
+             ("taint", `Bool true);
+           ];
+
          let dep_matches =
            Option.bind get_dep_matches (fun f -> f (fst rule.R.id))
          in

--- a/src/engine/dune
+++ b/src/engine/dune
@@ -8,6 +8,7 @@
    calendar
 
    commons
+   tracing
    pfff-lang_GENERIC-analyze
 
    parser_regexp
@@ -28,5 +29,5 @@
    semgrep_reporting; for Test_engine.ml, we should split in tests/ separate dir
  )
  (inline_tests)
- (preprocess (pps ppx_deriving.show ppx_profiling ppx_inline_test))
+ (preprocess (pps ppx_deriving.show ppx_profiling ppx_inline_test tracing.ppx))
 )


### PR DESCRIPTION
We have two primary use cases for tracing:
1. Monitoring our performance over time to detect errors and regressions
2. Profiling a particular run to figure out why it's slow

Sending a large number of traces does have some perf overhead, and it would also take a lot of storage, which is expensive. Therefore, we don't want to do this by default. However, when profiling, it's helpful to have all the significant functions traced.

Fortunately, ocaml-trace supports different trace levels, so that we can support both use cases.

This PR adds support for three trace levels:
- Info
- Debug
- Trace

which can be configured via the env var `TRACE_LEVEL` and adds ppx support for Info vs Debug.

It additionally adds per-rule logging in debug mode.

I chose to add only three trace levels, though ocaml-trace supports more, because we currently have no need for finer grained levels and this simplifies the options. We may wish to change them in the future.

Test plan:

Start the local endpoint. Then run:
```
➜  injection git:(4b0ac74d) ✗ pwd
/Users/emma/workspace/semgrep/tests/semgrep-rules/go/lang/security/injection
➜  injection git:(4b0ac74d) ✗ TRACE_LEVEL=debug sc -rules tainted-sql-string.yaml . -l go -trace -trace_endpoint semgrep-local
```

The trace that shows up should have 10 spans.

To see it work with multiple rules, you can run:

```
TRACE_LEVEL=debug semgrep --config p/default . --trace --trace-endpoint semgrep-local -j 1
```

