### PR TITLE
ci: minor build updates

### DIFF
--- a/libs/spacegrep/src/bin/dune
+++ b/libs/spacegrep/src/bin/dune
@@ -9,7 +9,7 @@
   (flags (:include flags.sexp))
 )
 
-; use cli/flags.sh to generate the OS specific build flags
+; use src/main/flags.sh to generate the OS specific build flags
 (rule
  (targets flags.sexp)
- (action (run %{workspace_root}/src/main/flags.sh)))
+ (action (run %{project_root}/src/main/flags.sh)))

--- a/src/main/dune
+++ b/src/main/dune
@@ -23,7 +23,7 @@
  (enabled_if (<> %{os_type} Win32))
  (action
   (with-stdout-to flags.sexp
-   (run %{workspace_root}/src/main/flags.sh %{ocaml-config:system}))))
+   (run ./flags.sh %{ocaml-config:system}))))
 
 ; flags.sh won't run properly in Windows, so simply hardcode to ( :standard )
 ; todo: is there an easy way to do static compilation in Windows?


### PR DESCRIPTION
- Fast-forwards ocaml tree sitter core to include https://github.com/semgrep/ocaml-tree-sitter-core/pull/75
- Fixes some script paths. Currently, when building from semgrep-proprietary, `%{workspace_root}` expands to the repository root of semgrep-proprietary (instead of semgrep, as it would typically here). This means the incorrect script is used when attempting to build the targets from semgrep. Instead, we should use `%{project_root}`, which should consistently be the semgrep repository root.
