### PR TITLE
Add suggestion for token setting in CI/non-interactive environments

### DIFF
--- a/changelog.d/gh-10133.added
+++ b/changelog.d/gh-10133.added
@@ -1,0 +1,1 @@
+Added guidance for resolving API token issues in CI environments.

--- a/cli/src/semgrep/app/scans.py
+++ b/cli/src/semgrep/app/scans.py
@@ -214,8 +214,8 @@ class ScanHandler:
 
         if response.status_code == 401:
             logger.info(
-                "API token not valid. Try to run `semgrep logout` and `semgrep login` again. \
-                 Or in CI, ensure your SEMGREP_APP_TOKEN variable is set correctly.",
+                "API token not valid. Try to run `semgrep logout` and `semgrep login` again."
+                "Or in CI, ensure your SEMGREP_APP_TOKEN variable is set correctly.",
             )
             sys.exit(INVALID_API_KEY_EXIT_CODE)
 

--- a/cli/src/semgrep/app/scans.py
+++ b/cli/src/semgrep/app/scans.py
@@ -214,7 +214,7 @@ class ScanHandler:
 
         if response.status_code == 401:
             logger.info(
-                "API token not valid. Try to run `semgrep logout` and `semgrep login` again."
+                "API token not valid. Try to run `semgrep logout` and `semgrep login` again. "
                 "Or in CI, ensure your SEMGREP_APP_TOKEN variable is set correctly.",
             )
             sys.exit(INVALID_API_KEY_EXIT_CODE)

--- a/cli/src/semgrep/app/scans.py
+++ b/cli/src/semgrep/app/scans.py
@@ -214,7 +214,8 @@ class ScanHandler:
 
         if response.status_code == 401:
             logger.info(
-                "API token not valid. Try to run `semgrep logout` and `semgrep login` again.",
+                "API token not valid. Try to run `semgrep logout` and `semgrep login` again. \
+                 Or in CI, ensure your SEMGREP_APP_TOKEN variable is set correctly.",
             )
             sys.exit(INVALID_API_KEY_EXIT_CODE)
 

--- a/cli/src/semgrep/commands/install.py
+++ b/cli/src/semgrep/commands/install.py
@@ -64,8 +64,8 @@ def download_semgrep_pro(
     with state.app_session.get(url, timeout=180, stream=True) as r:
         if r.status_code == 401:
             logger.info(
-                "API token not valid. Try to run `semgrep logout` and `semgrep login` again. \
-                 Or in CI, ensure your SEMGREP_APP_TOKEN variable is set correctly."
+                "API token not valid. Try to run `semgrep logout` and `semgrep login` again."
+                "Or in CI, ensure your SEMGREP_APP_TOKEN variable is set correctly."
             )
             sys.exit(INVALID_API_KEY_EXIT_CODE)
         if r.status_code == 403:

--- a/cli/src/semgrep/commands/install.py
+++ b/cli/src/semgrep/commands/install.py
@@ -64,7 +64,7 @@ def download_semgrep_pro(
     with state.app_session.get(url, timeout=180, stream=True) as r:
         if r.status_code == 401:
             logger.info(
-                "API token not valid. Try to run `semgrep logout` and `semgrep login` again."
+                "API token not valid. Try to run `semgrep logout` and `semgrep login` again. "
                 "Or in CI, ensure your SEMGREP_APP_TOKEN variable is set correctly."
             )
             sys.exit(INVALID_API_KEY_EXIT_CODE)

--- a/cli/src/semgrep/commands/install.py
+++ b/cli/src/semgrep/commands/install.py
@@ -64,7 +64,8 @@ def download_semgrep_pro(
     with state.app_session.get(url, timeout=180, stream=True) as r:
         if r.status_code == 401:
             logger.info(
-                "API token not valid. Try to run `semgrep logout` and `semgrep login` again."
+                "API token not valid. Try to run `semgrep logout` and `semgrep login` again. \
+                 Or in CI, ensure your SEMGREP_APP_TOKEN variable is set correctly."
             )
             sys.exit(INVALID_API_KEY_EXIT_CODE)
         if r.status_code == 403:

--- a/src/osemgrep/cli_ci/Ci_subcommand.ml
+++ b/src/osemgrep/cli_ci/Ci_subcommand.ml
@@ -144,7 +144,8 @@ let deployment_config (caps : < Cap.network ; Auth.cap_token ; .. >) :
       Logs.app (fun m ->
           m
             "API token not valid. Try to run `semgrep logout` and `semgrep \
-             login` again.");
+             login` again. Or in CI, ensure your SEMGREP_APP_TOKEN variable is \
+             set correctly.");
       Error.exit_code_exn (Exit_code.invalid_api_key ~__LOC__)
   | Some deployment_config ->
       Logs.debug (fun m ->

--- a/src/osemgrep/cli_install_semgrep_pro/Install_semgrep_pro_subcommand.ml
+++ b/src/osemgrep/cli_install_semgrep_pro/Install_semgrep_pro_subcommand.ml
@@ -63,7 +63,8 @@ let download_semgrep_pro (caps : < Cap.network ; .. >) platform_kind dest =
           Logs.err (fun m ->
               m
                 "API token not valid. Try to run `semgrep logout` and `semgrep \
-                 login` again.");
+                 login` again. Or in CI, ensure your SEMGREP_APP_TOKEN \
+                 variable is set correctly.");
           false
       | Error (_, { code = 403; _ }) ->
           Logs.err (fun m ->


### PR DESCRIPTION
The instructions we have currently if the API token is invalid only work in interactive/CLI environments, and can confuse folks if they are seeing the error in a CI build system or other environment where they need to already have a correct token. I've added a second sentence giving that alternative for CI environments.

To test: locally, run `semgrep ci` with pipenv (or equivalent), while having an invalid token in the environment or in your current `settings.yml`.

```
[alexis@Alexiss-MBP cli (improve-token-error-ci *)]$ pipenv run semgrep ci

┌────────────────┐
│ Debugging Info │
└────────────────┘
                  
  SCAN ENVIRONMENT
  versions    - semgrep 1.69.0 on python 3.11.9                        
  environment - running in environment git, triggering event is unknown
            
  CONNECTION
  Initializing scan .. API token not valid. Try to run `semgrep logout` and `semgrep login` again. Or in CI, ensure your SEMGREP_APP_TOKEN variable is set correctly.
  Initializing scan ..                                                                                                            
There were errors during analysis but Semgrep will succeed because there were no blocking findings, use --no-suppress-errors if you want Semgrep to fail when there are errors.

```