### PR TITLE
ci: ensure make exits with 2 when build fails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,7 @@
 # not exist but we still want 'make setup' to succeed
 -include libs/ocaml-tree-sitter-core/tree-sitter-config.mk
 
+SHELL := /bin/bash
 LINK_HELP_TEXT="Dune reported a linker error. If you ran into this after adding \
 	a new dependency, then this probably means that that dependency relies on \
 	a library that needs to be linked. See src/main/flags.sh on how to \

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,13 @@
 # not exist but we still want 'make setup' to succeed
 -include libs/ocaml-tree-sitter-core/tree-sitter-config.mk
 
+LINK_HELP_TEXT="Dune reported a linker error. If you ran into this after adding \
+	a new dependency, then this probably means that that dependency relies on \
+	a library that needs to be linked. See src/main/flags.sh on how to \
+	do that. If you didn't add a new dependency, you may not have every \
+	dependency needed for installation. Try running make dev-setup and \
+	building again"
+
 # First (and default) target.
 .PHONY: default
 default: core
@@ -120,18 +127,20 @@ minimal-build:
 	$(eval $@_TMP := $(shell mktemp -t dune-output.XXXXX))
 	@# Save the output of dune so we can provide more helpful error messages in
 	@# some cases
-	2>&1 dune build _build/install/default/bin/semgrep-core | tee $($@_TMP)
-	@grep -q "Error during linking" $($@_TMP) && ( \
-		tput bold; \
-		tput setaf 1; \
-		echo "Dune reported a linker error. If you ran into this after adding \
-	a new dependency, then this probably means that that dependency relies on \
-	a library that needs to be linked. See src/main/flags.sh on how to \
-	do that. If you didn't add a new dependency, you may not have every \
-	dependency needed for installation. Try running make dev-setup and \
-	building again" | fold -s; \
-		tput sgr 0) || echo "no error"
-	$(RM) $($@_TMP)
+	@#
+	@# Just display the dune command, instead of the whole unwieldy pipeline:
+	@echo 'dune build _build/install/default/bin/semgrep-core'
+	@( set -o pipefail; 													\
+		2>&1 dune build _build/install/default/bin/semgrep-core 			\
+			| tee $($@_TMP)) 												\
+		||  																\
+	 ( grep -q "Error during linking" $($@_TMP) 							\
+	 		&& (tput bold; 													\
+	 			tput setaf 1; 												\
+	 			echo $(LINK_HELP_TEXT) | fold -s; 							\
+	 			tput sgr 0) 												\
+			&& false)
+	@$(RM) $($@_TMP)
 
 
 .PHONY: minimal-build-bc

--- a/Makefile
+++ b/Makefile
@@ -130,16 +130,16 @@ minimal-build:
 	@#
 	@# Just display the dune command, instead of the whole unwieldy pipeline:
 	@echo 'dune build _build/install/default/bin/semgrep-core'
-	@( set -o pipefail; 													\
-		2>&1 dune build _build/install/default/bin/semgrep-core 			\
-			| tee $($@_TMP)) 												\
-		||  																\
-	 ( grep -q "Error during linking" $($@_TMP) 							\
-	 		&& (tput bold; 													\
-	 			tput setaf 1; 												\
-	 			echo $(LINK_HELP_TEXT) | fold -s; 							\
-	 			tput sgr 0) 												\
-			&& false)
+	@( set -o pipefail;                                                     \
+	   2>&1 dune build _build/install/default/bin/semgrep-core              \
+	      | tee $($@_TMP))                                                  \
+	   ||                                                                   \
+	 ( grep -q "Error during linking" $($@_TMP)                             \
+	   && (tput bold;                                                       \
+	       tput setaf 1;                                                    \
+	       echo $(LINK_HELP_TEXT) | fold -s;                                \
+	       tput sgr 0)                                                      \
+	   && false)
 	@$(RM) $($@_TMP)
 
 


### PR DESCRIPTION
As a result of the pipeline we introduced to save the output of dune so we could provide a more helpful message when a linking error occurs, make's exit status is now (incorrectly) always 0. This reworks the pipeline to run with `-o pipefail` so if dune fails, the exit status is correct (i.e., 2).

Test plan: tested manually:
<ul>
<li><details>
<summary>No Error</summary>

```
$ make
/Applications/Xcode.app/Contents/Developer/usr/bin/make minimal-build
dune build _build/install/default/bin/semgrep-core
ln -s semgrep-core bin/osemgrep
chmod +w bin/semgrep-core
strip bin/semgrep-core'
```

</details></li>
<li><details>
<summary>Compilation Error</summary>

```
$ make
/Applications/Xcode.app/Contents/Developer/usr/bin/make minimal-build
dune build _build/install/default/bin/semgrep-core
Generating flags for OS macosx
File "src/main/Main.ml", line 62, characters 53-55:
62 |           if not (Exit_code.Equal.ok exit_code) then aa
                                                          ^^
Error: Unbound value aa
make[1]: *** [minimal-build] Error 1
make: *** [core] Error 2
```

</details></li>
<li><details>
<summary>Linking Error</summary>

```
$ make
/Applications/Xcode.app/Contents/Developer/usr/bin/make minimal-build
dune build _build/install/default/bin/semgrep-core
Generating flags for OS macosx
File "src/main/dune", line 2, characters 8-12:
2 |  (names Main)
            ^^^^
Undefined symbols for architecture arm64:
  "_re_partial_match", referenced from:
      _camlStr__string_before_267 in str.a[2](str.o)
      _camlStr__data_begin in str.a[2](str.o)
  "_re_replacement_text", referenced from:
      _camlStr__string_before_267 in str.a[2](str.o)
      _camlStr__data_begin in str.a[2](str.o)
  "_re_search_backward", referenced from:
      _camlStr__string_before_267 in str.a[2](str.o)
      _camlStr__data_begin in str.a[2](str.o)
  "_re_search_forward", referenced from:
      _camlStr__string_before_267 in str.a[2](str.o)
      _camlStr__data_begin in str.a[2](str.o)
  "_re_string_match", referenced from:
      _camlStr__string_before_267 in str.a[2](str.o)
      _camlStr__data_begin in str.a[2](str.o)
ld: symbol(s) not found for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
File "caml_startup", line 1:
Error: Error during linking (exit code 1)
Dune reported a linker error. If you ran into this after adding a new
dependency, then this probably means that that dependency relies on a library
that needs to be linked. See src/main/flags.sh on how to do that. If you didn't
add a new dependency, you may not have every dependency needed for
installation. Try running make dev-setup and building again
make[1]: *** [minimal-build] Error 1
make: *** [core] Error 2
```

</details></ul>