### PR TITLE
Add options to 'with_temp_file'

### DIFF
--- a/languages/go/menhir/parse_go.ml
+++ b/languages/go/menhir/parse_go.ml
@@ -97,7 +97,7 @@ let parse_program file =
 (*****************************************************************************)
 
 let program_of_string (caps : < Cap.tmp >) (s : string) : Ast_go.program =
-  CapTmp.with_temp_file caps#tmp ~str:s ~ext:"go" parse_program
+  CapTmp.with_temp_file caps#tmp ~contents:s ~suffix:".go" parse_program
 
 (* for sgrep/spatch *)
 let any_of_string s =

--- a/languages/java/menhir/parse_java.ml
+++ b/languages/java/menhir/parse_java.ml
@@ -102,7 +102,7 @@ let parse_program file =
 
 let parse_string (caps : < Cap.tmp >) (w : string) :
     (Ast_java.program, Parser_java.token) Parsing_result.t =
-  CapTmp.with_temp_file caps#tmp ~str:w ~ext:"java" parse
+  CapTmp.with_temp_file caps#tmp ~contents:w ~suffix:".java" parse
 
 (*****************************************************************************)
 (* Sub parsers *)

--- a/languages/javascript/menhir/parse_js.ml
+++ b/languages/javascript/menhir/parse_js.ml
@@ -308,7 +308,7 @@ let parse_program file =
   res.Parsing_result.ast
 
 let program_of_string (caps : < Cap.tmp >) (w : string) : Ast.a_program =
-  CapTmp.with_temp_file caps#tmp ~str:w ~ext:"js" parse_program
+  CapTmp.with_temp_file caps#tmp ~contents:w ~suffix:".js" parse_program
 
 (*****************************************************************************)
 (* Sub parsers *)

--- a/languages/ocaml/menhir/unit_parsing_ml.ml
+++ b/languages/ocaml/menhir/unit_parsing_ml.ml
@@ -28,8 +28,8 @@ let tests (caps : < Cap.tmp >) =
        * sub-sub expressions inside parenthesis).
        *)
       t "visitor" (fun () ->
-          CapTmp.with_temp_file caps#tmp ~ext:".ml"
-            ~str:"open Foo1\nmodule A = Foo2\n" (fun file ->
+          CapTmp.with_temp_file caps#tmp ~suffix:".ml"
+            ~contents:"open Foo1\nmodule A = Foo2\n" (fun file ->
               let _ast = Parse_ml.parse_program file in
               let _cnt = ref 0 in
               (* TODO use Visitor_AST of ml_to_generic

--- a/languages/python/menhir/Parse_python.ml
+++ b/languages/python/menhir/Parse_python.ml
@@ -170,7 +170,7 @@ let parse_program ?parsing_mode file =
 (*****************************************************************************)
 
 let program_of_string (caps : < Cap.tmp >) (s : string) : AST_python.program =
-  CapTmp.with_temp_file caps#tmp ~str:s ~ext:"py" parse_program
+  CapTmp.with_temp_file caps#tmp ~contents:s ~suffix:".py" parse_program
 
 let type_of_string ?(parsing_mode = Python) s =
   let lexbuf = Lexing.from_string s in

--- a/languages/tree-sitter-to-generic/Parse_vue_tree_sitter.ml
+++ b/languages/tree-sitter-to-generic/Parse_vue_tree_sitter.ml
@@ -391,9 +391,9 @@ let map_component (env : env) (xs : CST.component) : stmt list =
 (*****************************************************************************)
 
 (* TODO: move in Parse_tree_sitter_helpers.ml and avoid using tmp file *)
-let parse_string_and_adjust_wrt_base content tbase fparse =
+let parse_string_and_adjust_wrt_base contents tbase fparse =
   (* nosemgrep: forbid-tmp *)
-  UTmp.with_temp_file ~str:content ~ext:"js" (fun file ->
+  UTmp.with_temp_file ~contents ~suffix:".js" (fun file ->
       let x = fparse file in
 
       let visitor =

--- a/libs/commons/CapTmp.ml
+++ b/libs/commons/CapTmp.ml
@@ -1,7 +1,11 @@
-let with_temp_file _caps = UTmp.with_temp_file
+let with_temp_file ?contents ?persist ?prefix ?suffix ?temp_dir _caps f =
+  UTmp.with_temp_file ?contents ?persist ?prefix ?suffix ?temp_dir f
+
 let get_temp_dir_name _caps = UTmp.get_temp_dir_name ()
 let erase_temp_files _caps = UTmp.erase_temp_files ()
-let new_temp_file ?temp_dir _caps = UTmp.new_temp_file ?temp_dir
+
+let new_temp_file ?prefix ?suffix ?temp_dir _caps =
+  UTmp.new_temp_file ?prefix ?suffix ?temp_dir ()
 
 let replace_named_pipe_by_regular_file_if_needed _caps =
   UTmp.replace_named_pipe_by_regular_file_if_needed

--- a/libs/commons/CapTmp.mli
+++ b/libs/commons/CapTmp.mli
@@ -1,12 +1,19 @@
 (* Capability aware wrappers to UTmp.ml *)
 
 val with_temp_file :
-  Cap.FS.tmp -> str:string -> ext:string -> (Fpath.t -> 'a) -> 'a
+  ?contents:string ->
+  ?persist:bool ->
+  ?prefix:string ->
+  ?suffix:string ->
+  ?temp_dir:Fpath.t ->
+  Cap.FS.tmp ->
+  (Fpath.t -> 'a) ->
+  'a
 
 val get_temp_dir_name : Cap.FS.tmp -> Fpath.t
 
 val new_temp_file :
-  ?temp_dir:Fpath.t -> Cap.FS.tmp -> string -> string -> Fpath.t
+  ?prefix:string -> ?suffix:string -> ?temp_dir:Fpath.t -> Cap.FS.tmp -> Fpath.t
 
 val replace_named_pipe_by_regular_file_if_needed :
   Cap.FS.tmp -> ?prefix:string -> Fpath.t -> Fpath.t option

--- a/libs/commons/UTmp.mli
+++ b/libs/commons/UTmp.mli
@@ -1,15 +1,17 @@
 (* Creation of /tmp files, a la gcc
- * ex: new_temp_file "cocci" ".c" will create a new tmp file and return
- * its name (e.g., "/tmp/cocci-3252-434465.c").
- *
- * Note: the set of tmp files created are saved in a global and
- * you can call erase_temp_files() before exiting your program to
- * clean things up.
- *
- * Note: You should use with_temp_file() instead in most cases.
- *)
+   ex: new_temp_file "cocci" ".c" will create a new tmp file and return
+   its name (e.g., "/tmp/cocci-3252-434465.c").
+
+   Note: the set of tmp files created are saved in a global and
+   you can call erase_temp_files() before exiting your program to
+   clean things up.
+
+   Note: You should use with_temp_file() instead in most cases.
+
+   Options: see 'with_temp_file'.
+*)
 val new_temp_file :
-  ?temp_dir:Fpath.t -> string (* prefix *) -> string (* suffix *) -> Fpath.t
+  ?prefix:string -> ?suffix:string -> ?temp_dir:Fpath.t -> unit -> Fpath.t
 
 (* Erase all the temporary files created by new_temp_file().
  * Usually called before exiting the program to clean things up.
@@ -27,11 +29,27 @@ val save_temp_files : bool ref
 val erase_this_temp_file : Fpath.t -> unit
 
 (* Create a new temporary file (using new_temp_file() above), invoke
- * the passed function on the temporary file, and erase the temporary
- * file once done (using erase_this_temp_file()).
- * You can also setup cleanup hooks, see below.
- *)
-val with_temp_file : str:string -> ext:string -> (Fpath.t -> 'a) -> 'a
+   the passed function on the temporary file, and erase the temporary
+   file once done (using erase_this_temp_file()).
+   You can also setup cleanup hooks, see below.
+
+   Options:
+   - contents: optional data to write into the file. Default: none.
+   - persist: keep the file instead of deleting it when done. This can
+              be useful for debugging.
+   - prefix: a prefix for the file name. Default: derived from argv[0].
+   - suffix: an optional suffix for the file name e.g. '.py'. Default: empty.
+   - temp_dir: folder containing the temporary file. Defaults to the
+               system-defined temporary folder e.g. '/tmp'.
+*)
+val with_temp_file :
+  ?contents:string ->
+  ?persist:bool ->
+  ?prefix:string ->
+  ?suffix:string ->
+  ?temp_dir:Fpath.t ->
+  (Fpath.t -> 'a) ->
+  'a
 
 (* The hooks below are run just before a tmp file created by with_temp_file()
  * is deleted. Multiple hooks can be added, but the order in which they are

--- a/libs/commons2/common2.ml
+++ b/libs/commons2/common2.ml
@@ -4913,7 +4913,7 @@ module Infix = struct
 end
 
 let with_pr2_to_string caps f =
-  CapTmp.with_temp_file caps ~str:"" ~ext:"out" (fun path ->
+  CapTmp.with_temp_file caps ~suffix:".out" (fun path ->
       let file = Fpath.to_string path in
       redirect_stdout_stderr file f;
       cat file)

--- a/libs/ojsonnet/Std_jsonnet.ml
+++ b/libs/ojsonnet/Std_jsonnet.ml
@@ -1684,5 +1684,5 @@ let get_std_jsonnet () =
    * no need to use tmp file
    *)
   (* nosemgrep: forbid-tmp *)
-  UTmp.with_temp_file ~str:std ~ext:"jsonnet" (fun file ->
+  UTmp.with_temp_file ~contents:std ~suffix:".jsonnet" (fun file ->
       Parse_jsonnet.parse_program file)

--- a/src/core/Target.ml
+++ b/src/core/Target.ml
@@ -41,9 +41,14 @@ type t = Regular of regular | Lockfile of lockfile [@@deriving show]
     which contains the contents of the git blob object identified by [sha] *)
 let tempfile_of_git_blob sha =
   let contents = sha |> Git_wrapper.cat_file_blob |> Result.get_ok in
+  (* TODO: delete this file when done! For this, use 'with_temp_file'. *)
   (* TODO: use CapTmp, but that requires to change lots of callers *)
-  (* nosemgrep: forbid-tmp *)
-  let file = UTmp.new_temp_file "git-blob" (Git_wrapper.hex_of_hash sha) in
+  let file =
+    (* nosemgrep: forbid-tmp *)
+    UTmp.new_temp_file ~prefix:"git-blob-"
+      ~suffix:(Git_wrapper.hex_of_hash sha)
+      ()
+  in
   UFile.write_file file contents;
   file
 

--- a/src/engine/Metavariable_pattern.ml
+++ b/src/engine/Metavariable_pattern.ml
@@ -199,12 +199,12 @@ let get_nested_metavar_pattern_bindings get_nested_formula_matches env r mvar
                   (* Note that due to symbolic propagation, `mast` may be
                    * outside of the current file/AST, so we must get
                    * `mval_range` from `mval_file` and not from `env.file`! *)
-                  let content =
+                  let contents =
                     Range.content_at_range (Fpath.v mval_file) mval_range
                   in
                   (* TODO: find a way to not use tmp files! parse strings *)
                   (* nosemgrep: forbid-tmp *)
-                  UTmp.with_temp_file ~str:content ~ext:"mvar-pattern"
+                  UTmp.with_temp_file ~contents ~suffix:".mvar-pattern"
                     (fun (file : Fpath.t) ->
                       let mast' =
                         AST_generic_helpers.fix_token_locations_program
@@ -219,7 +219,7 @@ let get_nested_metavar_pattern_bindings get_nested_formula_matches env r mvar
                               internal_path_to_content = file;
                             };
                           lazy_ast_and_errors = lazy (mast', []);
-                          lazy_content = lazy content;
+                          lazy_content = lazy contents;
                         }
                       in
                       (* Persist the bindings from inside the `metavariable-pattern`
@@ -267,15 +267,15 @@ let get_nested_metavar_pattern_bindings get_nested_formula_matches env r mvar
                          is not text: %s"
                         mvar (MV.show_mvalue mval));
                   []
-              | Some content ->
-                  let content = adjust_content_for_language xlang content in
+              | Some contents ->
+                  let contents = adjust_content_for_language xlang contents in
                   Logs.debug (fun m ->
                       m ~tags "nested analysis of |||%s||| with lang '%s'"
-                        content (Xlang.to_string xlang));
+                        contents (Xlang.to_string xlang));
                   (* We re-parse the matched text as `xlang`. *)
                   (* TODO: find a way to not use tmp files! parse strings *)
                   (* nosemgrep: forbid-tmp *)
-                  UTmp.with_temp_file ~str:content ~ext:"mvar-pattern"
+                  UTmp.with_temp_file ~contents ~suffix:".mvar-pattern"
                     (fun file ->
                       let ast_and_errors_res =
                         match xlang with
@@ -331,7 +331,7 @@ let get_nested_metavar_pattern_bindings get_nested_formula_matches env r mvar
                                 };
                               xlang;
                               lazy_ast_and_errors;
-                              lazy_content = lazy content;
+                              lazy_content = lazy contents;
                             }
                           in
                           (* Persist the bindings from inside the `metavariable-pattern`

--- a/src/fixing/Autofix.ml
+++ b/src/fixing/Autofix.ml
@@ -98,7 +98,7 @@ let parse_pattern lang pattern =
 let parse_target lang text =
   (* ext shouldn't matter, but could use Lang.ext_of_lang if needed *)
   (* nosemgrep: forbid-tmp *)
-  UTmp.with_temp_file ~str:text ~ext:"check" (fun file ->
+  UTmp.with_temp_file ~contents:text ~suffix:".check" (fun file ->
       try Ok (Parse_target.just_parse_with_lang lang file) with
       | Time_limit.Timeout _ as e -> Exception.catch_and_reraise e
       | e ->

--- a/src/fixing/tests/Unit_autofix_printer.ml
+++ b/src/fixing/tests/Unit_autofix_printer.ml
@@ -35,7 +35,7 @@ let t = Testo.create
  *)
 let check lang { target; pattern; fix_pattern; expected } =
   let ext = List_.hd_exn "unexpected empty list" (Lang.ext_of_lang lang) in
-  UTmp.with_temp_file ~str:target ~ext (fun target_file ->
+  UTmp.with_temp_file ~contents:target ~suffix:("." ^ ext) (fun target_file ->
       let matches =
         Unit_engine.match_pattern ~lang
           ~hook:(fun _ -> ())

--- a/src/osemgrep/cli_ci/Ci_subcommand.ml
+++ b/src/osemgrep/cli_ci/Ci_subcommand.ml
@@ -168,7 +168,7 @@ let at_url_maybe ppf () : unit =
  * TODO: factorize with Session.decode_rules()
  *)
 let decode_json_rules caps (data : string) : Rule_fetching.rules_and_origin =
-  CapTmp.with_temp_file caps#tmp ~str:data ~ext:"json" (fun file ->
+  CapTmp.with_temp_file caps#tmp ~contents:data ~suffix:".json" (fun file ->
       match
         Rule_fetching.load_rules_from_file ~rewrite_rule_ids:false ~origin:App
           caps file

--- a/src/osemgrep/language_server/server/Session.ml
+++ b/src/osemgrep/language_server/server/Session.ml
@@ -78,7 +78,7 @@ let dirty_paths_of_folder folder =
 
 (* TODO: registry caching is not anymore in semgrep-OSS! *)
 let decode_rules caps data =
-  CapTmp.with_temp_file caps#tmp ~str:data ~ext:"json" (fun file ->
+  CapTmp.with_temp_file caps#tmp ~contents:data ~suffix:".json" (fun file ->
       match
         Rule_fetching.load_rules_from_file ~rewrite_rule_ids:false ~origin:App
           caps file

--- a/src/osemgrep/networking/Unit_Login.ml
+++ b/src/osemgrep/networking/Unit_Login.ml
@@ -72,7 +72,8 @@ let with_mock_four_o_four_responses =
   Http_mock_client.with_testing_client make_fn
 
 let with_mock_envvars f () =
-  UTmp.with_temp_file ~str:fake_settings ~ext:"yml" (fun tmp_settings_file ->
+  UTmp.with_temp_file ~contents:fake_settings ~suffix:".yml"
+    (fun tmp_settings_file ->
       let new_settings =
         { !Semgrep_envvars.v with user_settings_file = tmp_settings_file }
       in

--- a/src/parsing/tests/Test_parsing.ml
+++ b/src/parsing/tests/Test_parsing.ml
@@ -552,8 +552,8 @@ let diff_pfff_tree_sitter xs =
          in
          let s1 = AST_generic.show_program ast1 in
          let s2 = AST_generic.show_program ast2 in
-         UTmp.with_temp_file ~str:s1 ~ext:"x" (fun file1 ->
-             UTmp.with_temp_file ~str:s2 ~ext:"x" (fun file2 ->
+         UTmp.with_temp_file ~contents:s1 ~suffix:".x" (fun file1 ->
+             UTmp.with_temp_file ~contents:s2 ~suffix:".x" (fun file2 ->
                  let xs = Common2.unix_diff !!file1 !!file2 in
                  xs |> List.iter UCommon.pr2)))
 


### PR DESCRIPTION
This is for https://github.com/semgrep/semgrep/pull/10131

* `~str` is now `~contents` for clarity.
* `~ext` was replaced by `~suffix` so that we don't have to worry about whether the period is included (in fact we had a bug like this where it was `~ext:".ml"` instead of `~ext:"ml"`).
* temporary file names are now prefixed by the name of the current program.
* I migrated `UTmp.Legacy` to `Fpath`.
* `new_temp_file` now takes the same arguments as `with_temp_file`.

semgrep-pro PR: https://github.com/semgrep/semgrep-proprietary/pull/1447