### PR TITLE
Update returntocorp refs, mainly for docs automations

### DIFF
--- a/cli/src/semgrep/constants.py
+++ b/cli/src/semgrep/constants.py
@@ -8,7 +8,7 @@ RULES_KEY = "rules"
 MISSED_KEY = "missed"  # The number of Pro rules missed out on
 ID_KEY = "id"
 CLI_RULE_ID = "-"
-PLEASE_FILE_ISSUE_TEXT = "An error occurred while invoking the Semgrep engine. Please help us fix this by creating an issue at https://github.com/returntocorp/semgrep"
+PLEASE_FILE_ISSUE_TEXT = "An error occurred while invoking the Semgrep engine. Please help us fix this by creating an issue at https://github.com/semgrep/semgrep"
 
 DEFAULT_SEMGREP_APP_CONFIG_URL = "api/agent/deployments/scans/config"
 

--- a/semgrep.opam
+++ b/semgrep.opam
@@ -12,7 +12,7 @@ maintainer: ["Yoann Padioleau <pad@semgrep.com>"]
 authors: ["Yoann Padioleau <pad@semgrep.com>"]
 license: "LGPL-2.1"
 homepage: "https://semgrep.dev"
-bug-reports: "https://github.com/returntocorp/semgrep/issues"
+bug-reports: "https://github.com/semgrep/semgrep/issues"
 depends: [
   "ocaml" {>= "4.13.0"}
   "dune" {>= "3.7" & >= "2.7.0"}
@@ -96,4 +96,4 @@ build: [
     "@doc" {with-doc}
   ]
 ]
-dev-repo: "git+https://github.com/returntocorp/semgrep.git"
+dev-repo: "git+https://github.com/semgrep/semgrep.git"

--- a/src/osemgrep/core/CLI_common.ml
+++ b/src/osemgrep/core/CLI_common.ml
@@ -130,7 +130,7 @@ let help_page_bottom =
     `S Manpage.s_bugs;
     `P
       "If you encounter an issue, please report it at\n\
-      \      https://github.com/returntocorp/semgrep/issues";
+      \      https://github.com/semgrep/semgrep/issues";
   ]
 
 (* Small wrapper around Cmdliner.Cmd.eval_value.

--- a/src/osemgrep/core/Constants.ml
+++ b/src/osemgrep/core/Constants.ml
@@ -8,7 +8,7 @@ let rule_id_for_dash_e = Rule_ID.of_string "-"
 
 let _please_file_issue_text =
   "An error occurred while invoking the Semgrep engine. Please help us fix \
-   this by creating an issue at https://github.com/returntocorp/semgrep"
+   this by creating an issue at https://github.com/semgrep/semgrep"
 
 let _default_semgrep_config_name = "semgrep"
 


### PR DESCRIPTION
We still have a bunch of returntocorp references in `semgrep/semgrep`, which is generally OK due to the GitHub redirect, but there are a few of these that appear in help outputs and such which are used in places that are already updated (like the docs site), and end up looking funny.

This PR updates a few of the more problematic cases to use semgrep/semgrep. It was going to be rather of a Project to do all of them so I focused on ones that seemed the most useful to fix.