### PR TITLE
fix: toggle only git dirty if scan all files ran

### DIFF
--- a/changelog.d/gh-10139.fixed
+++ b/changelog.d/gh-10139.fixed
@@ -1,0 +1,1 @@
+The Semgrep Language Server now will toggle "Only Git Dirty" to disabled when "Scan all files in workspace" is ran, and toggle it to enabled if "Scan all changed files in workspace" is ran


### PR DESCRIPTION
Previously users would run "scan all files" and this would scan files regardless of git status, but sometimes these would disappear. Now "scan all files" makes it so that semgrep will always scan files regardless of git status until "Scan all changed files" is ran, or until the editor restarts. There is also heavy notification around it to inform users.

## Test plan
make core
run "Scan all files" in editor, click around files

