### PR TITLE
fix(c/cpp): parse h files as only cpp

### DIFF
--- a/src/core/Lang.ml
+++ b/src/core/Lang.ml
@@ -131,7 +131,7 @@ let langs_of_filename filename =
   | FT.PL FT.Python -> [ Python; Python2; Python3 ]
   (* .h could also be Cpp at some point *)
   | FT.PL (FT.C "c") -> [ C ]
-  | FT.PL (FT.C "h") -> [ C; Cpp ]
+  | FT.PL (FT.C "h") -> [ Cpp ]
   | FT.PL (FT.Cplusplus _) -> [ Cpp ]
   | FT.PL (FT.OCaml ("ml" | "mli")) -> [ Ocaml ]
   | FT.PL FT.Java -> [ Java ]


### PR DESCRIPTION
# What:
This PR makes it so that we now parse `.h` files using only the C++ parser.

## Why:
Before, we were parsing with both, as it was ambiguous for which language it would correspond to. This meant that, for `.h` files using C++ specific features, we would fail to parse the `.h` file with the C parser, emitting a warning. This usually didn't actually matter analysis-wise, though, as we would succeed with the C++ parser.

## How:
Removed `.h` as an extension for the C language, and made it only correspond to C++.

## Test plan:
After this change, on using a C++ rule to parse a `.h` file with C++ features, we now get:
```
  Partially analyzed due to parsing or internal Semgrep errors

   • <none>
```

Before, this was
```
  Partially analyzed due to parsing or internal Semgrep errors

   • test.h (9 lines skipped)
```