### PR TITLE
Fix metavar not found error in metavariable-type

### DIFF
--- a/changelog.d/code-7042.fixed
+++ b/changelog.d/code-7042.fixed
@@ -1,0 +1,3 @@
+Fix `couldn't find metavar $MT in the match results` error, which may occur
+when we capture FQN with the metavariable and use metavariable-type filter on
+it.

--- a/src/engine/Match_search_mode.ml
+++ b/src/engine/Match_search_mode.ml
@@ -576,6 +576,10 @@ let rec filter_ranges (env : env) (xs : (RM.t * MV.bindings list) list)
              let mvalue_to_expr m =
                match Metavariable.mvalue_to_any m with
                | G.E e -> Some e
+               (* When we capture `IdQualified` with `Id`
+                  metavariable, `Metavariable.N` is generated in
+                  `Generic_vs_generic.m_name_inner` *)
+               | G.Name n -> Some (N n |> G.e)
                | _ -> None
              in
              match

--- a/tests/rules/metavar_type_decorator_python.py
+++ b/tests/rules/metavar_type_decorator_python.py
@@ -1,0 +1,3 @@
+@x.bar()
+def test():
+    pass

--- a/tests/rules/metavar_type_decorator_python.yaml
+++ b/tests/rules/metavar_type_decorator_python.yaml
@@ -1,0 +1,13 @@
+rules:
+  - id: test
+    message: Test
+    languages:
+      - python
+    severity: WARNING
+    patterns:
+      - pattern: |
+          @$X
+      - metavariable-type:
+          metavariable: $X
+          type: foo
+


### PR DESCRIPTION
test plan:
make test
semgrep/semgrep-proprietary#1450