### PR TITLE
feat(const-prop): propagate type casts

### DIFF
--- a/changelog.d/saf-987.fixed
+++ b/changelog.d/saf-987.fixed
@@ -1,0 +1,10 @@
+Constant propagation: Constants that are being type-casted will now
+propagate properly, e.g. in the following example:
+```
+const x = "source" as TypeName;
+sink(x);
+```
+will now match
+```
+sink("source")
+```

--- a/src/analyzing/Eval_il_partial.ml
+++ b/src/analyzing/Eval_il_partial.ml
@@ -230,6 +230,7 @@ let rec eval (env : G.svalue Dataflow_var_env.t) (exp : IL.exp) : G.svalue =
   match exp.e with
   | Fetch lval -> eval_lval env lval
   | Literal li -> G.Lit li
+  | Cast (_, e) -> eval env e
   (* Python: cond and <then-exp> or <else-exp> *)
   | Operator
       ( ((Or, _) as op),
@@ -247,7 +248,6 @@ let rec eval (env : G.svalue Dataflow_var_env.t) (exp : IL.exp) : G.svalue =
   | Operator (op, args) -> eval_op env op args
   | Composite _
   | Record _
-  | Cast _
   | FixmeExp _ ->
       G.NotCst
 

--- a/tests/patterns/ts/const_prop_cast.sgrep
+++ b/tests/patterns/ts/const_prop_cast.sgrep
@@ -1,0 +1,1 @@
+sink("source")

--- a/tests/patterns/ts/const_prop_cast.ts
+++ b/tests/patterns/ts/const_prop_cast.ts
@@ -1,0 +1,3 @@
+const x = "source" as TypeName;
+// ERROR:
+sink(x);


### PR DESCRIPTION
## What:
This PR makes it so that when we do constant propagation on a literal that is being casted, we propagate the literal.

## Why:
People asked for this.

## How:
I made it so evaluation of something being casted just evaluated the inner contents.

## Alternatives:
This behavior may be intentional -- in a C-like language, for instance, where you can do something like `(int) false`, which to my knowledge should actually be `0`, and not a literal `false`, this could be wrong. But, I think that this is probably a low-probability occurrence. If bothered by this, we can create a whitelist of languages in which it is safe to do this unwrapping of the cast.

## Test plan:
Automated tests.