### PR TITLE
fix: send notification when rules have refreshed

### DIFF
--- a/src/osemgrep/language_server/Test_LS_e2e.ml
+++ b/src/osemgrep/language_server/Test_LS_e2e.ml
@@ -662,7 +662,8 @@ let check_startup info folders (files : Fpath.t list) =
   in
   send_initialized info;
   let%lwt () = assert_progress info "Refreshing Rules" in
-
+  let%lwt rulesRefreshedNotif = receive_notification info in
+  let%lwt () = assert_notif rulesRefreshedNotif "semgrep/rulesRefreshed" in
   let%lwt () = assert_progress info "Scanning Open Documents" in
 
   let%lwt scan_notifications =

--- a/src/osemgrep/language_server/scan_helpers/Scan_helpers.ml
+++ b/src/osemgrep/language_server/scan_helpers/Scan_helpers.ml
@@ -263,17 +263,7 @@ let refresh_rules server =
   Lwt.async (fun () ->
       let%lwt () = Session.cache_session server.session in
       end_progress token;
-      let refresh_rules_notif =
-        Jsonrpc.Notification.create ~method_:"semgrep/rulesRefreshed" ()
-      in
-
-      let%lwt () =
-        match Lsp.Server_notification.of_jsonrpc refresh_rules_notif with
-        | Ok notif -> RPC_server.notify notif
-        | Error e ->
-            Logs.err (fun m -> m "Failed to send semgrep/rulesRefreshed: %s" e);
-            Lwt.return_unit
-      in
+      RPC_server.notify_custom "semgrep/rulesRefreshed";
 
       (* We used to scan ALL files in the workspace *)
       (* Now we just scan open documents so we aren't killing *)

--- a/src/osemgrep/language_server/scan_helpers/dune
+++ b/src/osemgrep/language_server/scan_helpers/dune
@@ -3,6 +3,8 @@
  (name osemgrep_language_server_scan_helpers)
  (wrapped false)
  (libraries
+   lsp
+
    semgrep.language_server.server
    semgrep.language_server.util
    semgrep.osemgrep_reporting

--- a/src/osemgrep/language_server/server/RPC_server.ml
+++ b/src/osemgrep/language_server/server/RPC_server.ml
@@ -155,6 +155,14 @@ let notify notification =
   let%lwt () = Io.write packet in
   Io.flush ()
 
+let notify_custom ?params method_ =
+  let jsonrpc_notif = Jsonrpc.Notification.create ~method_ ?params () in
+  let server_notif = SN.of_jsonrpc jsonrpc_notif in
+  match server_notif with
+  | Ok notif -> Lwt.async (fun () -> notify notif)
+  | Error e ->
+      Logs.err (fun m -> m "Error creating notification %s: %s" method_ e)
+
 (** Send a bunch of notifications to the client *)
 let batch_notify notifications =
   Logs.debug (fun m -> m "Sending notifications");

--- a/src/osemgrep/language_server/server/RPC_server.mli
+++ b/src/osemgrep/language_server/server/RPC_server.mli
@@ -52,6 +52,9 @@ end
 
 type t = { session : Session.t; state : State.t }
 
+val notify : Lsp.Server_notification.t -> unit Lwt.t
+(** [notify t notif] sends a notification to the client. *)
+
 val batch_notify : Lsp.Server_notification.t list -> unit
 (** [batch_notify t notifs] sends a batch of notifications to the client. *)
 

--- a/src/osemgrep/language_server/server/RPC_server.mli
+++ b/src/osemgrep/language_server/server/RPC_server.mli
@@ -52,8 +52,8 @@ end
 
 type t = { session : Session.t; state : State.t }
 
-val notify : Lsp.Server_notification.t -> unit Lwt.t
-(** [notify t notif] sends a notification to the client. *)
+val notify_custom : ?params:Jsonrpc.Structured.t -> string -> unit
+(** [notify_custom ?params ~method_] sends a custom notification to the client. *)
 
 val batch_notify : Lsp.Server_notification.t list -> unit
 (** [batch_notify t notifs] sends a batch of notifications to the client. *)

--- a/src/osemgrep/language_server/server/User_settings.ml
+++ b/src/osemgrep/language_server/server/User_settings.ml
@@ -28,7 +28,7 @@ type t = {
   configuration : string list; [@default []]
   exclude : string list; [@default []]
   include_ : string list; [@key "include"] [@default []]
-  jobs : int; [@default 2]
+  jobs : int; [@default Parmap.get_ncores ()]
   max_memory : int; [@key "maxMemory"] [@default 0]
   max_target_bytes : int; [@key "maxTargetBytes"] [@default 1000000]
   timeout : int; [@default 30]


### PR DESCRIPTION
We now send a notification when rules have refreshed so we can do things like start tests on the IDE side. And so we can restart settings and then run a full workspace scan.

Also we now use parmap to get the # of cores for the default number of jobs which should speed things up for people by default

## Test plan
make core
scan full workspace using 
https://github.com/semgrep/semgrep-vscode/pull/127
