### PR TITLE
test(osemgrep): make osemgrep sarif format test pass

### DIFF
--- a/cli/tests/default/e2e/test_osemgrep_output.py
+++ b/cli/tests/default/e2e/test_osemgrep_output.py
@@ -4,7 +4,6 @@ from tests.fixtures import RunSemgrep
 from semgrep.constants import OutputFormat
 
 
-@pytest.mark.skip(reason="TODO: make osemgrep output match pysemgrep")
 @pytest.mark.kinda_slow
 @pytest.mark.parametrize(
     "output_format",
@@ -14,7 +13,7 @@ def test_sarif_output(run_semgrep_in_tmp: RunSemgrep, output_format):
     _out, err = run_semgrep_in_tmp(
         "rules/eqeq.yaml",
         target_name="basic/stupid.py",
-        options=["--verbose", "--use-osemgrep-format-output"],
+        options=["--verbose", "--use-osemgrep-sarif"],
         output_format=output_format,
         assert_exit_code=0,
     )


### PR DESCRIPTION
For the current e2e we have, the only mismatch between pysemgrep vs osemgrep is the ordering of rules

The ordering of rules in the sarif output format shouldn't matter to the users, so there's no code update here. Only tests that compare the json objects.

Tested with `make e2e`.