### PR TITLE
chore: use Logs src in Pcre2_.ml too

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -417,13 +417,16 @@ For more information see https://semgrep.dev
 ; Development-only dependencies are in 'dev/dev.opam'.
 
 ;coupling: for semgrep CI to be fast, we try to pre-install these packages as
-; part of of the base docker image. When you add a new package or change a version
-; here, please also update the list of packages there:
+; part of of the base docker image. When you add a new package or change a
+; version here, please also update the list of packages there:
 ;
 ;   https://github.com/returntocorp/ocaml-layer/blob/master/common-config.sh
 ;
 ; or ask Martin to do so.
 ; You may also need to update the ocaml:alpine-xxx image used in ../Dockerfile.
+;coupling: because of the way we need to statically link on macOS, if
+; you add a library here, you'll probably need to update src/main/flags.sh
+; if this library has some C stubs.
 ;TODO: restore  "bisect_ppx" {>= "2.5.0"} once can use ppxlib 0.22.0
   (depends
     ; core deps

--- a/libs/commons/Pcre2_.ml
+++ b/libs/commons/Pcre2_.ml
@@ -1,6 +1,6 @@
-(* Yoann Padioleau, Cooper Pierce, Martin Jambon
+(* Cooper Pierce, Martin Jambon
 
-   (c) 2019 Semgrep, Inc.
+   (c) 2024 Semgrep, Inc.
 
    This library is free software; you can redistribute it and/or modify it
    under the terms of the GNU Lesser General Public License version 2.1 as
@@ -10,18 +10,21 @@
    This library is distributed in the hope that it will be useful, but WITHOUT
    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
    FITNESS FOR A PARTICULAR PURPOSE. See the file LICENSE for more details.
+*)
+
+(*
+   Shared settings for using the Pcre2 module (pcre-ocaml library).
 
    This file is mostly a port of Pcre_.ml (and the previous Regexp_engine.ml)
    for PCRE2.
 *)
 
-(*
-   Shared settings for using the Pcre2 module (pcre-ocaml library).
-*)
-
 open Printf
 
-let tags = Logs_.create_tags [ __MODULE__ ]
+(* we reuse the one in Pcre_.ml, no need to differentiate *)
+let src = Pcre_.src [@@alert "-deprecated"]
+
+module Log = (val Logs.src_log src : Logs.LOG)
 
 (* Keep the regexp source around for better error reporting and
    troubleshooting. *)
@@ -119,8 +122,8 @@ let log_error rex subj err =
     if len < 200 then subj
     else sprintf "%s ... (%i bytes)" (Str.first_chars subj 200) len
   in
-  Logs.warn (fun m ->
-      m ~tags "PCRE error: %a on input %S. Source regexp: %S" pp_error err
+  Log.warn (fun m ->
+      m "PCRE error: %a on input %S. Source regexp: %S" pp_error err
         string_fragment rex.pattern)
 
 let pmatch_noerr ?iflags ?flags ~rex ?pos ?callout ?(on_error = false) subj =

--- a/libs/commons/Pcre_.ml
+++ b/libs/commons/Pcre_.ml
@@ -1,3 +1,17 @@
+(* Martin Jambon
+
+   (c) 2019 Semgrep, Inc.
+
+   This library is free software; you can redistribute it and/or modify it
+   under the terms of the GNU Lesser General Public License version 2.1 as
+   published by the Free Software Foundation, with the special exception on
+   linking described in file LICENSE.
+
+   This library is distributed in the hope that it will be useful, but WITHOUT
+   ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE. See the file LICENSE for more details.
+*)
+
 (*
    Shared settings for using the Pcre module (pcre-ocaml library).
 *)

--- a/libs/commons/Pcre_.mli
+++ b/libs/commons/Pcre_.mli
@@ -233,3 +233,6 @@ val get_named_substring_and_ofs :
   ((string * (int * int)) option, string) Result.t
 
 val quote : string -> string
+
+(* internals, reused in Pcre2_.ml *)
+val src : Logs.src


### PR DESCRIPTION
Like in Pcre_.ml

test plan:
```
make check
```

does not print any more warnings about
Pcre2 error in Elf binaries