### PR TITLE
feat(search): filter irrelevant rules and core search

### DIFF
--- a/src/osemgrep/language_server/scan_helpers/Scan_helpers.ml
+++ b/src/osemgrep/language_server/scan_helpers/Scan_helpers.ml
@@ -157,7 +157,7 @@ let run_semgrep ?(targets : Fpath.t list option) ?rules ?git_ref
    on django) before the notifications are received by the extension.
    In the interim, we will just continue to hook into core.
 *)
-let run_core_search rule (file : Fpath.t) =
+let run_core_search xconf rule (file : Fpath.t) =
   let hook _file _pm = () in
   let xlang = rule.Rule.target_analyzer in
   (* We have to look at all the initial files again when we do this.
@@ -170,11 +170,18 @@ let run_core_search rule (file : Fpath.t) =
         (Target.mk_regular xlang Product.all (File file))
     in
     try
-      (* !!calling the engine!! *)
-      let ({ Core_result.matches; _ } : _ Core_result.match_result) =
-        Match_search_mode.check_rule rule hook Match_env.default_xconfig xtarget
+      let is_relevant_rule =
+        Match_rules.is_relevant_rule_for_xtarget
+          (rule :> Rule.rule)
+          xconf xtarget
       in
-      Some matches
+      if is_relevant_rule then
+        (* !!calling the engine!! *)
+        let ({ Core_result.matches; _ } : _ Core_result.match_result) =
+          Match_search_mode.check_rule rule hook xconf xtarget
+        in
+        Some matches
+      else None
     with
     | Parsing_error.Syntax_error _ -> None
   else None

--- a/src/osemgrep/language_server/scan_helpers/Scan_helpers.mli
+++ b/src/osemgrep/language_server/scan_helpers/Scan_helpers.mli
@@ -11,7 +11,11 @@ val run_semgrep :
   * used as the git ref for what matches are filtered out based on git diff.
   *)
 
-val run_core_search : Rule.search_rule -> Fpath.t -> Pattern_match.t list option
+val run_core_search :
+  Match_env.xconfig ->
+  Rule.search_rule ->
+  Fpath.t ->
+  Pattern_match.t list option
 (** [run_core_search] runs a search intended for the /semgrep/search IDE
     search command, by hooking lower into the Match_search_mode matching
     process, bypassing the CLI.

--- a/src/osemgrep/language_server/server/Search_config.ml
+++ b/src/osemgrep/language_server/server/Search_config.ml
@@ -28,5 +28,9 @@ module OutJ = Semgrep_output_v1_t
 (* Types *)
 (*****************************************************************************)
 
-type t = { rules : Rule.search_rule list; files : Fpath.t list }
+type t = {
+  rules : Rule.search_rule list;
+  files : Fpath.t list;
+  xconf : Match_env.xconfig; [@opaque]
+}
 [@@deriving show]


### PR DESCRIPTION
## What:
This PR makes it so that instead of using `run_semgrep`, IDE search instead hooks directly into the Core engine with `Match_search_mode`.

## Why:
This shows an immense performance improvement over running `run_semgrep` many times (for streaming searches). We go from scanning `django` incrementally over the course of two minutes to six seconds.

## How:
Just used the `run_core_search` function which already exists, and re-added back the filtering of irrelevant rules. 

## Test plan:
Tested the perf boost locally