### PR TITLE
fix(secrets): move `--historical-secrets` to pro options

### DIFF
--- a/changelog.d/scrt-570.fixed
+++ b/changelog.d/scrt-570.fixed
@@ -1,0 +1,2 @@
+Moved `--historical-secrets` to the "Pro Engine" option group, instead of
+"Output formats", where it was previously (in error).

--- a/cli/src/semgrep/commands/scan.py
+++ b/cli/src/semgrep/commands/scan.py
@@ -277,11 +277,6 @@ _scan_options: List[Callable] = [
         flag_value=OutputFormat.GITLAB_SECRETS,
     ),
     optgroup.option(
-        "--historical-secrets",
-        "historical_secrets",
-        is_flag=True,
-    ),
-    optgroup.option(
         "--junit-xml",
         "output_format",
         type=OutputFormat,
@@ -359,6 +354,11 @@ _scan_options: List[Callable] = [
         "disable_secrets_validation_flag",
         is_flag=True,
         hidden=True,
+    ),
+    optgroup.option(
+        "--historical-secrets",
+        "historical_secrets",
+        is_flag=True,
     ),
     optgroup.option(
         "--allow-untrusted-validators",


### PR DESCRIPTION
The `--historical-secrets` flag was in the "Output format" option group in error, which led to issues as pysemgrep treated it as mutually exclusive with output options like `--json`. This moves it to the correct group.

Test plan: existing tests for regression. Will add a test in pro to ensure that usage with `--json` works as expected.

