### PR TITLE
pro: Let interproc const-prop infer concrete constants

### DIFF
--- a/changelog.d/flow-61.added
+++ b/changelog.d/flow-61.added
@@ -1,0 +1,12 @@
+Pro: const-prop: Previously inter-procedural const-prop could only infer whether
+a function returned an arbitrary string constant. Now it is now able to infer
+whether a function returns a concrete constant value, e.g.:
+
+```python
+def bar():
+  return "bar"
+
+def test():
+  x = bar()
+  foo(x) # now also matches pattern `foo("bar")`, previously only `foo("...")`
+```

--- a/changelog.d/flow-61.added
+++ b/changelog.d/flow-61.added
@@ -1,5 +1,5 @@
 Pro: const-prop: Previously inter-procedural const-prop could only infer whether
-a function returned an arbitrary string constant. Now it is now able to infer
+a function returned an arbitrary string constant. Now it will be able to infer
 whether a function returns a concrete constant value, e.g.:
 
 ```python

--- a/src/analyzing/Dataflow_svalue.mli
+++ b/src/analyzing/Dataflow_svalue.mli
@@ -2,14 +2,8 @@
 
 type mapping = AST_generic.svalue Dataflow_var_env.mapping
 
-(* Indicates guarantees on the return value of a function *)
-(* TODO: This should be AST_generic.svalue, if we need something more complex,
- * then we build it on top of the svalue type. *)
-type constness = Constant of AST_generic.const_type | NotConstant
-[@@deriving show]
-
 val hook_constness_of_function :
-  (AST_generic.expr -> constness option) option ref
+  (AST_generic.expr -> AST_generic.svalue option) option ref
 
 val hook_transfer_of_assume :
   (bool ->


### PR DESCRIPTION
Previously inter-procedural const-prop could only infer whether a function returned an arbitrary string constant. Now it is able to infer whether a function returns a concrete constant value.

test plan:
See Pro PR semgrep/semgrep-proprietary#1457

