### PR TITLE
fix(osemgrep): SARIF correctly handles CWE tags

### DIFF
--- a/changelog.d/saf-991.fixed
+++ b/changelog.d/saf-991.fixed
@@ -1,0 +1,5 @@
+The SARIF output format should have the tag "security" when the "cwe"
+section is present in the rule. Moreover, duplicate tags should be
+de-duped.
+
+Osemgrep wasn't doing this before, but with this fix, now it does.

--- a/cli/src/semgrep/formatter/osemgrep_sarif.py
+++ b/cli/src/semgrep/formatter/osemgrep_sarif.py
@@ -1,4 +1,5 @@
 import contextlib
+import difflib
 import json
 import tempfile
 import timeit
@@ -150,6 +151,11 @@ class OsemgrepSarifFormatter(BaseFormatter):
             o_json = normalize_sarif_findings(json.loads(o_output), "osemgrep")
             py_json = normalize_sarif_findings(json.loads(py_output), "pysemgrep")
             is_match = o_json == py_json
+            if not is_match and get_state().terminal.is_debug:
+                o_lines = json.dumps(o_json, sort_keys=True, indent=4).split("\n")
+                py_lines = json.dumps(py_json, sort_keys=True, indent=4).split("\n")
+                diffs = difflib.unified_diff(o_lines, py_lines, n=10)
+                logger.debug("diff osemgrep vs pysemgrep:\n" + "\n".join(diffs))
             validate_elapse = timeit.default_timer() - validate_start
 
         # Update metrics so we can keep track of how well the migration is going.

--- a/cli/tests/default/e2e/rules/cwe_tag.yaml
+++ b/cli/tests/default/e2e/rules/cwe_tag.yaml
@@ -1,0 +1,16 @@
+# This is mainly for testing osemgrep's sarif output vs
+# pysemgrep. Tags should be de-duplicated and if there's a cwe section
+# inside metadata, the security tag is automatically inserted.
+
+rules:
+  - id: rule-with-cwe-tag
+    pattern: $X + $Y
+    message: Fake message.
+    metadata:
+      cwe:
+        - "CWE-99999999: Fake CWE"
+        - "CWE-99999999: Fake CWE"
+        - "CWE-88888888: Another fake CWE"
+    languages:
+      - python
+    severity: ERROR

--- a/cli/tests/default/e2e/test_osemgrep_output.py
+++ b/cli/tests/default/e2e/test_osemgrep_output.py
@@ -5,14 +5,16 @@ from semgrep.constants import OutputFormat
 
 
 @pytest.mark.kinda_slow
+@pytest.mark.parametrize("output_format", [OutputFormat.SARIF])
 @pytest.mark.parametrize(
-    "output_format",
-    [OutputFormat.SARIF],
+    "rule_and_target",
+    [("rules/eqeq.yaml", "basic/stupid.py"), ("rules/cwe_tag.yaml", "basic/stupid.py")],
 )
-def test_sarif_output(run_semgrep_in_tmp: RunSemgrep, output_format):
+def test_sarif_output(run_semgrep_in_tmp: RunSemgrep, output_format, rule_and_target):
+    rule, target = rule_and_target
     _out, err = run_semgrep_in_tmp(
-        "rules/eqeq.yaml",
-        target_name="basic/stupid.py",
+        rule,
+        target_name=target,
         options=["--verbose", "--use-osemgrep-sarif"],
         output_format=output_format,
         assert_exit_code=0,

--- a/src/osemgrep/reporting/Sarif_output.ml
+++ b/src/osemgrep/reporting/Sarif_output.ml
@@ -33,10 +33,11 @@ let tags_of_metadata metadata =
     | JSON.String s -> s
     | non_string -> JSON.string_of_json non_string
   in
+  (* Also add the "security" tag when the rule has CWE tags. *)
   let cwe =
     match JSON.member "cwe" metadata with
-    | Some (JSON.Array cwe) -> List_.map best_effort_string cwe
-    | Some single_cwe -> [ best_effort_string single_cwe ]
+    | Some (JSON.Array cwe) -> List_.map best_effort_string cwe @ [ "security" ]
+    | Some single_cwe -> [ best_effort_string single_cwe; "security" ]
     | None -> []
   in
   let owasp =
@@ -68,7 +69,8 @@ let tags_of_metadata metadata =
     | None ->
         []
   in
-  cwe @ owasp @ confidence @ semgrep_policy_slug @ tags
+  let all_tags = cwe @ owasp @ confidence @ semgrep_policy_slug @ tags in
+  List.sort_uniq String.compare all_tags
 
 (* We want to produce a json object? with the following shape:
    { id; name;


### PR DESCRIPTION
When CWE metadata is present in the rule, the "security" tag should automatically be added to the SARIF output format. Moreover, tags should be unique. This PR updates osemgrep to do this.

Also added debug logging, guarded by `--debug`, which prints out the diff when osemgrep and pysemgrep don't match. This was useful for testing and finding out this bug.

Tested with `make e2e`.

Fixes SAF-991.