### PR TITLE
Making QDots in IdQualified resolvable

### DIFF
--- a/languages/cairo/generic/Parse_cairo_tree_sitter.ml
+++ b/languages/cairo/generic/Parse_cairo_tree_sitter.ml
@@ -124,7 +124,7 @@ let rec map_qualified_name (env : env) (x : CST.qualified_name) :
 
   {
     name_last = (last_name, type_arguments);
-    name_middle = Some (G.QDots path);
+    name_middle = Some (G.QDots (path, G.empty_id_info ()));
     name_top = None;
     name_info = G.empty_id_info ();
   }

--- a/languages/cpp/generic/cpp_to_generic.ml
+++ b/languages/cpp/generic/cpp_to_generic.ml
@@ -187,7 +187,8 @@ let rec map_name env (v1, v2, v3) : G.name =
         {
           G.name_last = v3;
           name_top = v1;
-          name_middle = (if v2 =*= [] then None else Some (QDots v2));
+          name_middle =
+            (if v2 =*= [] then None else Some (QDots (v2, G.empty_id_info ())));
           name_info = G.empty_id_info ();
         }
 

--- a/languages/java/generic/java_to_generic.ml
+++ b/languages/java/generic/java_to_generic.ml
@@ -113,7 +113,7 @@ and class_type v =
            {
              G.name_last = (id, None);
              name_top = None;
-             name_middle = Some (G.QDots (List.rev xs));
+             name_middle = Some (G.QDots (List.rev xs, G.empty_id_info ()));
              name_info = G.empty_id_info ();
            })
       |> G.t

--- a/languages/ql/generic/QL_to_generic.ml
+++ b/languages/ql/generic/QL_to_generic.ml
@@ -59,7 +59,8 @@ and qualified_info { name_last = v1, v2; name_middle } =
   let name_middle =
     Some
       (G.QDots
-         (list (fun (x, y) -> (ident x, option type_arguments y)) name_middle))
+         ( list (fun (x, y) -> (ident x, option type_arguments y)) name_middle,
+           G.empty_id_info () ))
   in
   G.{ name_last; name_middle; name_top = None; name_info = G.empty_id_info () }
 

--- a/languages/ruby/generic/ruby_to_generic.ml
+++ b/languages/ruby/generic/ruby_to_generic.ml
@@ -320,20 +320,20 @@ and scope_resolution x : G.name =
       let e = expr e in
       let qualif =
         match e with
-        | { G.e = G.N (G.Id (id, _info)); _ } -> G.QDots [ (id, None) ]
+        | { G.e = G.N (G.Id (id, info)); _ } -> G.QDots ([ (id, None) ], info)
         | {
          G.e =
            G.N
              (G.IdQualified
                {
                  name_last;
-                 name_middle = Some (G.QDots middle);
+                 name_middle = Some (G.QDots (middle, _info));
                  name_top = None;
-                 _;
+                 name_info;
                });
          _;
         } ->
-            G.QDots (middle @ [ name_last ])
+            G.QDots (middle @ [ name_last ], name_info)
         | _ -> G.QExpr (e, t)
       in
       IdQualified
@@ -718,7 +718,7 @@ and pattern pat =
             G.IdQualified
               {
                 G.name_last = (last, None);
-                name_middle = Some (G.QDots qualifier);
+                name_middle = Some (G.QDots (qualifier, G.empty_id_info ()));
                 name_top = None;
                 name_info = G.empty_id_info ();
               }

--- a/libs/ast_generic/AST_generic.ml
+++ b/libs/ast_generic/AST_generic.ml
@@ -581,7 +581,7 @@ and qualified_info = {
 
 and qualifier =
   (* Java/C++/Rust *)
-  | QDots of (ident * type_arguments option) list
+  | QDots of (ident * type_arguments option) list * id_info
   (* Ruby/Lua *)
   | QExpr of expr * tok
 

--- a/libs/ast_generic/AST_generic_to_v1.ml
+++ b/libs/ast_generic/AST_generic_to_v1.ml
@@ -202,7 +202,7 @@ and map_qualified_info { name_last; name_middle; name_top; name_info } =
   { B.name_last; name_middle; name_top; name_info }
 
 and map_qualifier = function
-  | QDots v1 ->
+  | QDots (v1, v2) ->
       let v1 =
         map_of_list
           (fun (v1, v2) ->
@@ -211,6 +211,7 @@ and map_qualifier = function
             (v1, v2))
           v1
       in
+      let _v2 = map_id_info v2 in
       `QDots v1
   | QExpr (e, t) ->
       let e = map_expr e in

--- a/libs/ast_generic/Meta_AST.ml
+++ b/libs/ast_generic/Meta_AST.ml
@@ -161,9 +161,10 @@ and vof_resolved_name_kind = function
       OCaml.VSum ("GlobalName", [ v1; v2 ])
 
 let rec vof_qualifier = function
-  | QDots v1 ->
+  | QDots (v1, v2) ->
       let v1 = OCaml.vof_list vof_ident_and_targs_opt v1 in
-      OCaml.VSum ("QDots", [ v1 ])
+      let v2 = vof_id_info v2 in
+      OCaml.VSum ("QDots", [ v1; v2 ])
   | QExpr (v1, v2) ->
       let v1 = vof_expr v1 in
       let v2 = vof_tok v2 in

--- a/src/analyzing/Dataflow_svalue.ml
+++ b/src/analyzing/Dataflow_svalue.ml
@@ -77,9 +77,11 @@ let eval_builtin_func lang env func args =
               name_middle =
                 Some
                   (QDots
-                    ( [ (("String", _), _) ]
-                    | [ (("java", _), _); (("lang", _), _); (("String", _), _) ]
-                      ));
+                    ( ( [ (("String", _), _) ]
+                      | [
+                          (("java", _), _); (("lang", _), _); (("String", _), _);
+                        ] ),
+                      _ ));
               _;
             } ) ->
           Some (eval_format env args)

--- a/src/analyzing/Eval_generic_partial.ml
+++ b/src/analyzing/Eval_generic_partial.ml
@@ -259,8 +259,10 @@ and eval_call env name args =
           name_middle =
             Some
               (QDots
-                ( [ (("String", _), _) ]
-                | [ (("java", _), _); (("lang", _), _); (("String", _), _) ] ));
+                ( ( [ (("String", _), _) ]
+                  | [ (("java", _), _); (("lang", _), _); (("String", _), _) ]
+                    ),
+                  _ ));
           _;
         },
       _args ) ->

--- a/src/naming/Naming_AST.ml
+++ b/src/naming/Naming_AST.ml
@@ -854,7 +854,7 @@ let resolve lang prog =
               name_top = None;
             } ->
             (match name_middle with
-            | Some (QDots ((m, None) :: rest_of_middle)) -> (
+            | Some (QDots ((m, None) :: rest_of_middle, _)) -> (
                 match lookup_scope_opt m env with
                 (* Resolve modules for OCaml *)
                 | Some { entname = ImportedModule xs, _sidm; _ }

--- a/src/printing/Pretty_print_AST.ml
+++ b/src/printing/Pretty_print_AST.ml
@@ -611,7 +611,7 @@ and id_qualified env { name_last = id, _toptTODO; name_middle; name_top; _ } =
   | Some _t -> "::")
   ^
   match name_middle with
-  | Some (QDots dot_ids) ->
+  | Some (QDots (dot_ids, _)) ->
       (* TODO: do not do fst, look also at type qualification *)
       F.sprintf "%s.%s" (dotted_access env (List_.map fst dot_ids)) (ident id)
   | Some (QExpr (e, _t)) -> expr env e ^ "::"

--- a/src/typing/Typing.ml
+++ b/src/typing/Typing.ml
@@ -278,7 +278,8 @@ let name_and_targs_of_named_type lang = function
   | Type.UnresolvedName (str, targs) ->
       Some (str, targs)
   | Type.N
-      ( ( G.IdQualified { G.name_last; name_middle = Some (QDots middle); _ },
+      ( ( G.IdQualified
+            { G.name_last; name_middle = Some (QDots (middle, _)); _ },
           targs ),
         _ ) ->
       let (str_last, _), _ = name_last in


### PR DESCRIPTION
test plan: `make test`

`QDots` in `IdQualified` need to be resolvable if we want to use a `metavariable-type` filter with the method annotation in Python, as shown in the example below:

```python
from flask import Flask
 
app = Flask(__name__)

@app.get("/items/<item_id>")
def read_item(item_id: str):
    return {"item_id": item_id}
```

```yaml
rules:
  - id: test
    message: Test
    languages:
      - python
    severity: WARNING
    patterns:
      - pattern: |
          @$APP.get(...)
          def $FUNC(..., $PARAM, ...):
            ... 
      - metavariable-type:
          metavariable: $APP
          type: Flask
```

`@app.get("/items/<item_id>")` is translated in AST as:

```
attrs=[NamedAttr((),
                IdQualified(
                  {name_last=(("get", ()), None); name_top=None; 
                   name_middle=Some(QDots([(("app", ()), None)])); 
                   name_info={id_info_id=7; id_flags=Ref(0); 
                              id_resolved=Ref(Some((GlobalName(
                                                      ["/Users/heejong/Works/semgrep-proprietary/temp/p";
                                                       "app"; "get"],
                                                      [["app"; "get"]]),
                                                    12)));
                              id_type=Ref(None); id_svalue=Ref(None); };
                   }), [Arg(L(String(("/items/<item_id>", ()))))])];
```
`QDots` is a list of `ident` so we can't infer the type.