### PR TITLE
fix(osemgrep): initialize parsing and handle dataflow flag

### DIFF
--- a/changelog.d/saf-1020.fixed
+++ b/changelog.d/saf-1020.fixed
@@ -1,0 +1,5 @@
+Osemgrep only:
+
+When rules have metavariable-type, they don't show up in the SARIF output. This change fixes that.
+
+Also right now dataflow traces are always shown in SARIF even when --dataflow-traces is not passed. This change also fixes that.

--- a/cli/src/semgrep/formatter/osemgrep_sarif.py
+++ b/cli/src/semgrep/formatter/osemgrep_sarif.py
@@ -78,6 +78,8 @@ class OsemgrepSarifFormatter(BaseFormatter):
 
             engine_label = "PRO" if is_pro else "OSS"
 
+            show_dataflow_traces = extra["dataflow_traces"]
+
             # Sort according to RuleMatch.get_ordering_key
             sorted_findings = sorted(rule_matches)
             cli_matches = [
@@ -91,6 +93,7 @@ class OsemgrepSarifFormatter(BaseFormatter):
                 rules_path,
                 cli_matches,
                 cli_errors,
+                show_dataflow_traces,
             )
             formatted_output = ocaml.sarif_format(rpc_params)
             if formatted_output:

--- a/cli/tests/default/e2e/rules/metavariable_type.yaml
+++ b/cli/tests/default/e2e/rules/metavariable_type.yaml
@@ -1,0 +1,11 @@
+rules:
+  - id: metavar-type
+    patterns:
+      - pattern: $X
+      - metavariable-type:
+          metavariable: $X
+          type: string
+    message: rules with metavariable type
+    languages:
+      - python
+    severity: ERROR

--- a/cli/tests/default/e2e/test_osemgrep_output.py
+++ b/cli/tests/default/e2e/test_osemgrep_output.py
@@ -1,3 +1,8 @@
+from pathlib import Path
+from typing import List
+from typing import Optional
+from typing import Union
+
 import pytest
 from tests.fixtures import RunSemgrep
 
@@ -8,14 +13,33 @@ from semgrep.constants import OutputFormat
 @pytest.mark.parametrize("output_format", [OutputFormat.SARIF])
 @pytest.mark.parametrize(
     "rule_and_target",
-    [("rules/eqeq.yaml", "basic/stupid.py"), ("rules/cwe_tag.yaml", "basic/stupid.py")],
+    [
+        # Simple case that should pass.
+        ("rules/eqeq.yaml", "basic/stupid.py"),
+        # Whenever there's a CWE tag, there should be a security tag.
+        ("rules/cwe_tag.yaml", "basic/stupid.py"),
+        # Rules with metavariable-type need parser initialization to parse correctly.
+        ("rules/metavariable_type.yaml", "basic/stupid.py"),
+        # Dataflow traces in SARIF should abide by --dataflow-traces.
+        ("rules/taint_trace.yaml", "taint/taint_trace.cpp"),
+    ],
 )
-def test_sarif_output(run_semgrep_in_tmp: RunSemgrep, output_format, rule_and_target):
+@pytest.mark.parametrize("dataflow_traces", [True, False])
+def test_sarif_output(
+    run_semgrep_in_tmp: RunSemgrep, output_format, rule_and_target, dataflow_traces
+):
     rule, target = rule_and_target
+    # The type annotation is there to make the type checker happy
+    options: Optional[List[Union[str, Path]]]
+    if dataflow_traces:
+        options = ["--verbose", "--use-osemgrep-sarif", "--dataflow-traces"]
+    else:
+        options = ["--verbose", "--use-osemgrep-sarif"]
+
     _out, err = run_semgrep_in_tmp(
         rule,
         target_name=target,
-        options=["--verbose", "--use-osemgrep-sarif"],
+        options=options,
         output_format=output_format,
         assert_exit_code=0,
     )

--- a/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -1065,6 +1065,7 @@ let cmdline_term caps ~allow_empty_config : conf Term.t =
         dryrun;
         strict;
         force_color;
+        show_dataflow_traces = dataflow_traces;
         output_format;
         max_chars_per_line;
         max_lines_per_finding;

--- a/src/osemgrep/reporting/Output.ml
+++ b/src/osemgrep/reporting/Output.ml
@@ -25,6 +25,8 @@ type conf = {
    * Output_format.Text *)
   force_color : bool;
   logging_level : Logs.level option;
+  (* For text and SARIF *)
+  show_dataflow_traces : bool;
   (* Display options *)
   (* mix of --json, --emacs, --vim, etc. *)
   output_format : Output_format.t;
@@ -42,6 +44,7 @@ let default : conf =
     dryrun = false;
     strict = false;
     logging_level = Some Logs.Warning;
+    show_dataflow_traces = false;
     output_format = Output_format.Text;
     force_color = false;
     max_chars_per_line = 160;
@@ -151,7 +154,8 @@ let dispatch_output_format (output_format : Output_format.t) (conf : conf)
         || not runtime_params.is_using_registry
       in
       let sarif_json =
-        Sarif_output.sarif_output hide_nudge engine_label hrules cli_output
+        Sarif_output.sarif_output hide_nudge engine_label
+          conf.show_dataflow_traces hrules cli_output
       in
       UConsole.print
         (Sarif.Sarif_v_2_1_0_j.string_of_sarif_json_schema sarif_json)

--- a/src/osemgrep/reporting/Output.mli
+++ b/src/osemgrep/reporting/Output.mli
@@ -9,6 +9,8 @@ type conf = {
    * Output_format.Text *)
   force_color : bool;
   logging_level : Logs.level option;
+  (* For text and SARIF *)
+  show_dataflow_traces : bool;
   (* Display options *)
   (* mix of --json, --emacs, --vim, etc. *)
   output_format : Output_format.t;

--- a/src/osemgrep/reporting/Sarif_output.ml
+++ b/src/osemgrep/reporting/Sarif_output.ml
@@ -332,7 +332,7 @@ let sarif_codeflow (cli_match : OutT.cli_match) =
             ~thread_flows ();
         ]
 
-let results (cli_output : OutT.cli_output) =
+let results show_dataflow_traces (cli_output : OutT.cli_output) =
   let result (cli_match : OutT.cli_match) =
     let location =
       let physical_location =
@@ -356,7 +356,9 @@ let results (cli_output : OutT.cli_output) =
       | Some true -> Some [ Sarif_v.create_suppression ~kind:`InSource () ]
     in
     let fixes = sarif_fixes cli_match in
-    let code_flows = sarif_codeflow cli_match in
+    let code_flows =
+      if show_dataflow_traces then sarif_codeflow cli_match else None
+    in
     Sarif_v.create_result
       ~rule_id:(Rule_ID.to_string cli_match.check_id)
       ~message:(message cli_match.extra.message)
@@ -388,8 +390,8 @@ let error_to_sarif_notification (e : OutT.cli_error) =
 (* Entry point *)
 (*****************************************************************************)
 
-let sarif_output ~hide_nudge ~engine_label hrules (cli_output : OutT.cli_output)
-    =
+let sarif_output ~hide_nudge ~engine_label ~show_dataflow_traces hrules
+    (cli_output : OutT.cli_output) =
   let sarif_schema =
     "https://docs.oasis-open.org/sarif/sarif/v2.1.0/os/schemas/sarif-schema-2.1.0.json"
   in
@@ -403,7 +405,7 @@ let sarif_output ~hide_nudge ~engine_label hrules (cli_output : OutT.cli_output)
       in
       Sarif_v.create_tool ~driver ()
     in
-    let results = results cli_output in
+    let results = results show_dataflow_traces cli_output in
     let invocation =
       (* TODO no test case(s) for executionNotifications being non-empty *)
       let tool_execution_notifications =

--- a/src/osemgrep/reporting/Sarif_output.mli
+++ b/src/osemgrep/reporting/Sarif_output.mli
@@ -2,6 +2,7 @@
 val sarif_output :
   hide_nudge:bool ->
   engine_label:string ->
+  show_dataflow_traces:bool ->
   Rule.hrules ->
   Semgrep_output_v1_t.cli_output ->
   Sarif.Sarif_v_2_1_0_t.sarif_json_schema


### PR DESCRIPTION
This PR fixes two issues.
1. When rules have metavariable-type, they don't show up in the SARIF output. Parsing should be initialized in the RPC handler. Otherwise semgrep thinks the rule is invalid when parsing it.
2. Dataflow traces are always shown in SARIF even when --dataflow-traces is not passed. 

Fixes SAF-1020.

Depends on https://github.com/semgrep/semgrep-interfaces/pull/249

Tested: `make e2e # new tests added`