### PR TITLE
refactor: Add id_info to XML names

### DIFF
--- a/languages/html/generic/Parse_html_tree_sitter.ml
+++ b/languages/html/generic/Parse_html_tree_sitter.ml
@@ -106,14 +106,14 @@ let map_attribute (env : env) ((v1, v2) : CST.attribute) : xml_attribute =
 
 let map_script_start_tag (env : env) ((v1, v2, v3, v4) : CST.script_start_tag) =
   let v1 = token env v1 (* "<" *) in
-  let v2 = str env v2 (* script_start_tag_name *) in
+  let v2 = (str env v2 (* script_start_tag_name *), G.empty_id_info ()) in
   let v3 = List_.map (map_attribute env) v3 in
   let v4 = token env v4 (* ">" *) in
   (v1, v2, v3, v4)
 
 let map_style_start_tag (env : env) ((v1, v2, v3, v4) : CST.style_start_tag) =
   let v1 = token env v1 (* "<" *) in
-  let v2 = str env v2 (* style_start_tag_name *) in
+  let v2 = (str env v2 (* style_start_tag_name *), G.empty_id_info ()) in
   let v3 = List_.map (map_attribute env) v3 in
   let v4 = token env v4 (* ">" *) in
   (v1, v2, v3, v4)
@@ -123,7 +123,7 @@ let map_start_tag (env : env) (x : CST.start_tag) =
   | `Semg_start_tag (v1, v2, v3, v4)
   | `LT_start_tag_name_rep_attr_GT (v1, v2, v3, v4) ->
       let v1 = token env v1 (* "<" *) in
-      let v2 = str env v2 (* start_tag_name *) in
+      let v2 = (str env v2 (* start_tag_name *), G.empty_id_info ()) in
       let v3 = List_.map (map_attribute env) v3 in
       let v4 = token env v4 (* ">" *) in
       (v1, v2, v3, v4)
@@ -142,7 +142,7 @@ let rec map_element (env : env) (x : CST.element) : xml =
       { xml_kind = XmlClassic (l, id, r, v3); xml_attrs = attrs; xml_body = v2 }
   | `Self_clos_tag (v1, v2, v3, v4) ->
       let l = token env v1 (* "<" *) in
-      let id = str env v2 (* start_tag_name *) in
+      let id = (str env v2 (* start_tag_name *), G.empty_id_info ()) in
       let attrs = List_.map (map_attribute env) v3 in
       let r = token env v4 (* "/>" *) in
       { xml_kind = XmlSingleton (l, id, r); xml_attrs = attrs; xml_body = [] }
@@ -151,7 +151,10 @@ and map_node (env : env) (x : CST.node) : xml_body =
   match x with
   | `Doct_ (v1, v2, v3, v4) ->
       let l = token env v1 (* "<!" *) in
-      let id = str env v2 (* pattern [Dd][Oo][Cc][Tt][Yy][Pp][Ee] *) in
+      let id =
+        ( str env v2 (* pattern [Dd][Oo][Cc][Tt][Yy][Pp][Ee] *),
+          G.empty_id_info () )
+      in
       let _misc = token env v3 (* pattern [^>]+ *) in
       let r = token env v4 (* ">" *) in
       let xml =
@@ -203,7 +206,7 @@ and map_node (env : env) (x : CST.node) : xml_body =
       XmlXml xml
   | `Errons_end_tag (v1, v2, v3) ->
       let l = token env v1 (* "</" *) in
-      let id = str env v2 (* erroneous_end_tag_name *) in
+      let id = (str env v2 (* erroneous_end_tag_name *), G.empty_id_info ()) in
       let r = token env v3 (* ">" *) in
       (* todo? raise an exception instead? *)
       let xml =
@@ -218,7 +221,11 @@ let map_toplevel_node (env : env) (x : CST.toplevel_node) : xml_body =
       let xml_attrs = List_.map (map_attribute env) v2 in
       let r = (* "?>" *) token env v3 in
       let xml =
-        { xml_kind = XmlSingleton (l, ("xml", l), r); xml_attrs; xml_body = [] }
+        {
+          xml_kind = XmlSingleton (l, (("xml", l), G.empty_id_info ()), r);
+          xml_attrs;
+          xml_body = [];
+        }
       in
       XmlXml xml
   | `Doct_ (v1, v2, v3, v4) -> map_node env (`Doct_ (v1, v2, v3, v4))

--- a/languages/javascript/generic/js_to_generic.ml
+++ b/languages/javascript/generic/js_to_generic.ml
@@ -198,10 +198,10 @@ and xml { xml_kind = xml_tag; xml_attrs; xml_body } =
 
 and xml_kind = function
   | XmlClassic (v0, v1, v2, v3) ->
-      let v1 = ident v1 in
+      let v1 = (ident v1, G.empty_id_info ()) in
       G.XmlClassic (v0, v1, v2, v3)
   | XmlSingleton (v0, v1, v2) ->
-      let v1 = ident v1 in
+      let v1 = (ident v1, G.empty_id_info ()) in
       XmlSingleton (v0, v1, v2)
   | XmlFragment (v1, v2) -> XmlFragment (v1, v2)
 

--- a/languages/tree-sitter-to-generic/Parse_hack_tree_sitter.ml
+++ b/languages/tree-sitter-to-generic/Parse_hack_tree_sitter.ml
@@ -2873,7 +2873,7 @@ and xhp_expression (env : env) (x : CST.xhp_expression) : G.xml =
   match x with
   | `Xhp_open_close (v1, v2, v3, v4) ->
       let v1 = (* "<" *) token env v1 in
-      let v2 = xhp_identifier_ env v2 in
+      let v2 = (xhp_identifier_ env v2, G.empty_id_info ()) in
       let v3 = List_.map (xhp_attribute env) v3 in
       let v4 = (* "/>" *) token env v4 in
       { xml_kind = G.XmlSingleton (v1, v2, v4); xml_attrs = v3; xml_body = [] }
@@ -2906,7 +2906,7 @@ and xhp_expression (env : env) (x : CST.xhp_expression) : G.xml =
 
 and xhp_open (env : env) ((v1, v2, v3, v4) : CST.xhp_open) =
   let v1 = (* "<" *) token env v1 in
-  let v2 = xhp_identifier_ env v2 in
+  let v2 = (xhp_identifier_ env v2, G.empty_id_info ()) in
   let v3 = List_.map (xhp_attribute env) v3 in
   let v4 = (* ">" *) token env v4 in
   (v1, v2, v3, v4)

--- a/languages/tree-sitter-to-generic/Parse_vue_tree_sitter.ml
+++ b/languages/tree-sitter-to-generic/Parse_vue_tree_sitter.ml
@@ -224,7 +224,7 @@ let map_anon_choice_attr_a1991da (env : env) (x : CST.anon_choice_attr_a1991da)
 
 let map_start_tag (env : env) ((v1, v2, v3, v4) : CST.start_tag) =
   let v1 = token env v1 (* "<" *) in
-  let v2 = str env v2 (* start_tag_name *) in
+  let v2 = (str env v2 (* start_tag_name *), G.empty_id_info ()) in
   let v3 = List_.map (map_anon_choice_attr_a1991da env) v3 in
   let v4 = token env v4 (* ">" *) in
   (v1, v2, v3, v4)
@@ -232,21 +232,21 @@ let map_start_tag (env : env) ((v1, v2, v3, v4) : CST.start_tag) =
 let map_template_start_tag (env : env)
     ((v1, v2, v3, v4) : CST.template_start_tag) =
   let v1 = token env v1 (* "<" *) in
-  let v2 = str env v2 (* template_start_tag_name *) in
+  let v2 = (str env v2 (* template_start_tag_name *), G.empty_id_info ()) in
   let v3 = List_.map (map_anon_choice_attr_a1991da env) v3 in
   let v4 = token env v4 (* ">" *) in
   (v1, v2, v3, v4)
 
 let map_style_start_tag (env : env) ((v1, v2, v3, v4) : CST.style_start_tag) =
   let v1 = token env v1 (* "<" *) in
-  let v2 = str env v2 (* style_start_tag_name *) in
+  let v2 = (str env v2 (* style_start_tag_name *), G.empty_id_info ()) in
   let v3 = List_.map (map_anon_choice_attr_a1991da env) v3 in
   let v4 = token env v4 (* ">" *) in
   (v1, v2, v3, v4)
 
 let map_script_start_tag (env : env) ((v1, v2, v3, v4) : CST.script_start_tag) =
   let v1 = token env v1 (* "<" *) in
-  let v2 = str env v2 (* script_start_tag_name *) in
+  let v2 = (str env v2 (* script_start_tag_name *), G.empty_id_info ()) in
   let v3 = List_.map (map_anon_choice_attr_a1991da env) v3 in
   let v4 = token env v4 (* ">" *) in
   (v1, v2, v3, v4)
@@ -289,7 +289,7 @@ let rec map_element (env : env) (x : CST.element) : xml =
       { xml_kind = XmlClassic (l, id, r, v3); xml_attrs = attrs; xml_body = v2 }
   | `Self_clos_tag (v1, v2, v3, v4) ->
       let l = token env v1 (* "<" *) in
-      let id = str env v2 (* start_tag_name *) in
+      let id = (str env v2 (* start_tag_name *), G.empty_id_info ()) in
       let attrs = List_.map (map_anon_choice_attr_a1991da env) v3 in
       let r = token env v4 (* "/>" *) in
       { xml_kind = XmlSingleton (l, id, r); xml_attrs = attrs; xml_body = [] }
@@ -338,7 +338,7 @@ and map_node (env : env) (x : CST.node) : xml_body list =
       [ XmlXml xml ]
   | `Errons_end_tag (v1, v2, v3) ->
       let l = token env v1 (* "</" *) in
-      let id = str env v2 (* erroneous_end_tag_name *) in
+      let id = (str env v2 (* erroneous_end_tag_name *), G.empty_id_info ()) in
       let r = token env v3 (* ">" *) in
       (* todo? raise an exn instead? *)
       let xml =

--- a/libs/ast_generic/AST_generic.ml
+++ b/libs/ast_generic/AST_generic.ml
@@ -1100,8 +1100,13 @@ and xml = {
 }
 
 and xml_kind =
-  | XmlClassic of tok (*'<'*) * ident * tok (*'>'*) * tok (*'</foo>'*)
-  | XmlSingleton of tok (*'<'*) * ident * tok (* '/>', with xml_body = [] *)
+  (* <foo>...</foo> *)
+  (* TODO use `name`? JS/TS allows `<Foo.Bar>...` *)
+  | XmlClassic of
+      tok (*'<'*) * (ident * id_info) * tok (*'>'*) * tok (*'</foo>'*)
+  (* <foo/> *)
+  | XmlSingleton of
+      tok (*'<'*) * (ident * id_info) * tok (* '/>', with xml_body = [] *)
   (* React/JS specific *)
   | XmlFragment of tok (* '<>' *) * (* '</>', with xml_attrs = [] *) tok
 

--- a/libs/ast_generic/AST_generic_to_v1.ml
+++ b/libs/ast_generic/AST_generic_to_v1.ml
@@ -141,13 +141,13 @@ and map_xml
   { B.xml_kind = v_xml_tag; xml_attrs = v_xml_attrs; xml_body = v_xml_body }
 
 and map_xml_kind = function
-  | XmlClassic (v0, v1, v2, v3) ->
+  | XmlClassic (v0, (v1, _info), v2, v3) ->
       let v0 = map_tok v0 in
       let v1 = map_ident v1 in
       let v2 = map_tok v2 in
       let v3 = map_tok v3 in
       `XmlClassic (v0, v1, v2, v3)
-  | XmlSingleton (v0, v1, v2) ->
+  | XmlSingleton (v0, (v1, _info), v2) ->
       let v0 = map_tok v0 in
       let v1 = map_ident v1 in
       let v2 = map_tok v2 in

--- a/libs/ast_generic/Meta_AST.ml
+++ b/libs/ast_generic/Meta_AST.ml
@@ -241,17 +241,19 @@ and vof_xml
   OCaml.VDict bnds
 
 and vof_xmlkind = function
-  | XmlClassic (v0, v1, v2, v3) ->
+  | XmlClassic (v0, (id, info), v2, v3) ->
       let v0 = vof_tok v0 in
-      let v1 = vof_ident v1 in
+      let id = vof_ident id in
+      let info = vof_id_info info in
       let v2 = vof_tok v2 in
       let v3 = vof_tok v3 in
-      OCaml.VSum ("XmlClassic", [ v0; v1; v2; v3 ])
-  | XmlSingleton (v0, v1, v2) ->
+      OCaml.VSum ("XmlClassic", [ v0; id; info; v2; v3 ])
+  | XmlSingleton (v0, (id, info), v2) ->
       let v0 = vof_tok v0 in
-      let v1 = vof_ident v1 in
+      let id = vof_ident id in
+      let info = vof_id_info info in
       let v2 = vof_tok v2 in
-      OCaml.VSum ("XmlSingleton", [ v0; v1; v2 ])
+      OCaml.VSum ("XmlSingleton", [ v0; id; info; v2 ])
   | XmlFragment (v1, v2) ->
       let v1 = vof_tok v1 in
       let v2 = vof_tok v2 in

--- a/src/matching/Generic_vs_generic.ml
+++ b/src/matching/Generic_vs_generic.ml
@@ -1544,19 +1544,19 @@ and m_xml_kind a b =
         (fun x -> x.Options.xml_singleton_loose_matching)
         ~then_:
           (let* () = m_tok a0 b0 in
-           let* () = m_ident a1 b1 in
+           let* () = m_ident_and_id_info a1 b1 in
            let* () = m_tok a2 b2 in
            return ())
         ~else_:(fail ())
   | G.XmlClassic (a0, a1, a2, a3), B.XmlClassic (b0, b1, b2, b3) ->
       let* () = m_tok a0 b0 in
-      let* () = m_ident a1 b1 in
+      let* () = m_ident_and_id_info a1 b1 in
       let* () = m_tok a2 b2 in
       let* () = m_tok a3 b3 in
       return ()
   | G.XmlSingleton (a0, a1, a2), B.XmlSingleton (b0, b1, b2) ->
       let* () = m_tok a0 b0 in
-      let* () = m_ident a1 b1 in
+      let* () = m_ident_and_id_info a1 b1 in
       let* () = m_tok a2 b2 in
       return ()
   | G.XmlFragment (a1, a2), B.XmlFragment (b1, b2) ->


### PR DESCRIPTION
We want to be able to resolve these names. For example, in JS/TS JSX syntax, `<Foo />` is a reference to the `Foo` React component. We would like to be able to track that.

Test plan: Automated tests

