### PR TITLE
chore(js): dont print raised ocaml exns in js

### DIFF
--- a/js/shared/Semgrep_js_shared.ml
+++ b/js/shared/Semgrep_js_shared.ml
@@ -36,8 +36,6 @@ let wrap_with_js_error ?(hook = None) f =
       (match hook with
       | Some hook -> hook ()
       | None -> ());
-      Firebug.console##error (Js.string (Printexc.to_string e));
-      Format.eprintf "\n%s\n%!" (Printexc.to_string e);
       (match e with
       | Js_error.Exn e ->
           let e = Js_error.to_error e in


### PR DESCRIPTION
## What:
This PR makes it so that we no longer log the name of OCaml exceptions raised in JSCaml code.

## Why:
This causes some degree of log spew. We already raise the exception, we don't need to unconditionally print the name of the exception.

## How:
Just removed the print.

## Test plan:
Tried it locally, and it no longer prints when a `parsePattern` raises a parsing error.