### PR TITLE
fix: bug in url of azure git repo

### DIFF
--- a/cli/src/semgrep/external/git_url_parser.py
+++ b/cli/src/semgrep/external/git_url_parser.py
@@ -43,7 +43,7 @@ Parsed = collections.namedtuple('Parsed', [
     'port',
     'name',
     'owner',
-    'azure_url'
+    'azure_git_dir'
 ])
 
 POSSIBLE_REGEXES = (
@@ -111,7 +111,7 @@ class Parser(str):
             'port': None,
             'name': None,
             'owner': None,
-            'azure_url': False
+            'azure_git_dir': ''
         }
         # Parsing is super slow even after fixing obvious problems in regexps.
         # This mitigates the damage of quadratic behavior.
@@ -128,7 +128,7 @@ class Parser(str):
             raise ParserError(msg)
 
         if d['owner'] is not None and cast(str, d['owner']).endswith('/_git'):  # Azure DevOps Git URLs
-            d['azure_url'] = True
+            d['azure_git_dir'] = '/_git'
             d['owner'] = d['owner'][:-len('/_git')]
 
         return Parsed(**d)

--- a/cli/src/semgrep/external/git_url_parser.py
+++ b/cli/src/semgrep/external/git_url_parser.py
@@ -43,6 +43,7 @@ Parsed = collections.namedtuple('Parsed', [
     'port',
     'name',
     'owner',
+    'azure_url'
 ])
 
 POSSIBLE_REGEXES = (
@@ -110,6 +111,7 @@ class Parser(str):
             'port': None,
             'name': None,
             'owner': None,
+            'azure_url': False
         }
         # Parsing is super slow even after fixing obvious problems in regexps.
         # This mitigates the damage of quadratic behavior.
@@ -126,6 +128,7 @@ class Parser(str):
             raise ParserError(msg)
 
         if d['owner'] is not None and cast(str, d['owner']).endswith('/_git'):  # Azure DevOps Git URLs
+            d['azure_url'] = True
             d['owner'] = d['owner'][:-len('/_git')]
 
         return Parsed(**d)

--- a/cli/src/semgrep/meta.py
+++ b/cli/src/semgrep/meta.py
@@ -65,8 +65,7 @@ def get_url_from_sstp_url(sstp_url: Optional[str]) -> Optional[str]:
     if None in [protocol, result.resource, result.owner, result.name]:
         return sstp_url
 
-    extra_git = './_git' if result.azure_url else ''
-    return f"{protocol}://{result.resource}/{result.owner}{extra_git}/{result.name}"
+    return f"{protocol}://{result.resource}/{result.owner}{result.azure_git_dir}/{result.name}"
 
 
 def get_repo_name_from_repo_url(repo_url: Optional[str]) -> Optional[str]:

--- a/cli/src/semgrep/meta.py
+++ b/cli/src/semgrep/meta.py
@@ -65,7 +65,8 @@ def get_url_from_sstp_url(sstp_url: Optional[str]) -> Optional[str]:
     if None in [protocol, result.resource, result.owner, result.name]:
         return sstp_url
 
-    return f"{protocol}://{result.resource}/{result.owner}/{result.name}"
+    extra_git = './_git' if result.azure_url else ''
+    return f"{protocol}://{result.resource}/{result.owner}{extra_git}/{result.name}"
 
 
 def get_repo_name_from_repo_url(repo_url: Optional[str]) -> Optional[str]:

--- a/cli/tests/default/e2e-pro/test_meta.py
+++ b/cli/tests/default/e2e-pro/test_meta.py
@@ -11,11 +11,11 @@ def test_git_url_parser():
         # This used to cause the URL parser to crash.
         (
             "https://test@dev.azure.com/test/TestName/_git/Core.Thing",
-            "https://dev.azure.com/test/TestName/Core.Thing",
+            "https://dev.azure.com/test/TestName/_git/Core.Thing",
         ),
         (
             "https://foobar.visualstudio.com/Data%20Classification/_git/Data%20Classification",
-            "https://foobar.visualstudio.com/Data%20Classification/Data%20Classification",
+            "https://foobar.visualstudio.com/Data%20Classification/_git/Data%20Classification",
         ),
         # This one has a "subgroup" structure, which we should be able to parse.
         (


### PR DESCRIPTION
Remove stripping "/_git" from url that are created from azure git repos while preserving stripping it from repo names. This closes [SAF-950](https://linear.app/semgrep/issue/SAF-950/-git-gets-removed-from-repo-url-when-using-docker-run-works-fine).

## test plan
* Modified test results. CI should continue to pass.
* Manually check that this resolves the reported issue.
  * `SEMGREP_REPO_URL=https://akuhlens@dev.azure.com/akuhlens/demo/_git/demo semgrep ci`
  * In a repo, correctly links to the web view of the finding, when clicking the finding location in the web app.