### PR TITLE
Add help message when using --debug on how to use SEMGREP_LOG_SRCS

### DIFF
--- a/cli/tests/default/e2e/snapshots/test_output/test_debug_experimental_rule/results.txt
+++ b/cli/tests/default/e2e/snapshots/test_output/test_debug_experimental_rule/results.txt
@@ -59,6 +59,7 @@ Running Semgrep engine with command:
 [<MASKED>][DEBUG](default): Skipping logs for x509
 [<MASKED>][DEBUG](default): Skipping logs for semgrep.targeting
 [<MASKED>][DEBUG](default): Skipping logs for ojsonnet.eval
+[<MASKED>][DEBUG](default): Skipping logs for semgrep
 [<MASKED>][DEBUG](default): Skipping logs for git.value
 [<MASKED>][DEBUG](default): Skipping logs for git.tree
 [<MASKED>][DEBUG](default): Skipping logs for git.stream
@@ -67,6 +68,28 @@ Running Semgrep engine with command:
 [<MASKED>][DEBUG](default): Skipping logs for commons.pcre
 [<MASKED>][DEBUG](default): Skipping logs for bos
 [<MASKED>][DEBUG](default): Showing logs for application
+[<MASKED>][DEBUG](default): !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+[<MASKED>][DEBUG](default):
+If you want to show the logs of a particular library
+(e.g., the semgrep targeting library), you'll need to adjust the
+SEMGREP_LOG_SRCS environment variable as in
+
+  export SEMGREP_LOG_SRCS="semgrep.targeting" semgrep ... --debug
+
+or for osemgrep you can use it with any log level as in
+
+   export SEMGREP_LOG_SRCS="semgrep.targeting" <MASKED> ... --verbose
+
+You can see the list of possible libraries above in this log as in
+...
+[<MASKED>][DEBUG](default): Skipping logs for semgrep.targeting
+...
+[<MASKED>][DEBUG](default): Skipping logs for commons.pcre
+...
+For more information, See
+https:/<MASKED>
+
+[<MASKED>][DEBUG](default): !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 [<MASKED>][INFO]: Executed as: <MASKED> -json -rules <MASKED> -j <MASKED> -strict -targets <MASKED> -timeout 5 -timeout_threshold 3 -max_memory 0 -fast --debug
 [<MASKED>][INFO]: Version: semgrep-core version: <MASKED>
 [<MASKED>][DEBUG](default): size of returned JSON string: <MASKED>
@@ -173,6 +196,7 @@ Running Semgrep engine with command:
 [<MASKED>][[32mDEBUG[0m](default): Skipping logs for x509
 [<MASKED>][[32mDEBUG[0m](default): Skipping logs for semgrep.targeting
 [<MASKED>][[32mDEBUG[0m](default): Skipping logs for ojsonnet.eval
+[<MASKED>][[32mDEBUG[0m](default): Skipping logs for semgrep
 [<MASKED>][[32mDEBUG[0m](default): Skipping logs for git.value
 [<MASKED>][[32mDEBUG[0m](default): Skipping logs for git.tree
 [<MASKED>][[32mDEBUG[0m](default): Skipping logs for git.stream
@@ -181,6 +205,28 @@ Running Semgrep engine with command:
 [<MASKED>][[32mDEBUG[0m](default): Skipping logs for commons.pcre
 [<MASKED>][[32mDEBUG[0m](default): Skipping logs for bos
 [<MASKED>][[32mDEBUG[0m](default): Showing logs for application
+[<MASKED>][[32mDEBUG[0m](default): !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+[<MASKED>][[32mDEBUG[0m](default):
+If you want to show the logs of a particular library
+(e.g., the semgrep targeting library), you'll need to adjust the
+SEMGREP_LOG_SRCS environment variable as in
+
+  export SEMGREP_LOG_SRCS="semgrep.targeting" semgrep ... --debug
+
+or for osemgrep you can use it with any log level as in
+
+   export SEMGREP_LOG_SRCS="semgrep.targeting" <MASKED> ... --verbose
+
+You can see the list of possible libraries above in this log as in
+...
+[<MASKED>][DEBUG](default): Skipping logs for semgrep.targeting
+...
+[<MASKED>][DEBUG](default): Skipping logs for commons.pcre
+...
+For more information, See
+https:/<MASKED>
+
+[<MASKED>][[32mDEBUG[0m](default): !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 [<MASKED>][[34mINFO[0m]: Executed as: <MASKED> -json -rules <MASKED> -j <MASKED> -strict -targets <MASKED> -timeout 5 -timeout_threshold 3 -max_memory 0 -fast --debug
 [<MASKED>][[34mINFO[0m]: Version: semgrep-core version: <MASKED>
 [<MASKED>][[32mDEBUG[0m](default): size of returned JSON string: <MASKED>

--- a/src/core/Log_semgrep.ml
+++ b/src/core/Log_semgrep.ml
@@ -5,16 +5,18 @@ module Log = (val Logs.src_log src : Logs.LOG)
 let help_msg =
   {|
 If you want to show the logs of a particular library
-(e.g., the semgrep secrets library), you'll need to adjust the
+(e.g., the semgrep targeting library), you'll need to adjust the
 SEMGREP_LOG_SRCS environment variable as in
 
-  export SEMGREP_LOG_SRCS="semgrep.secrets" semgrep ... --debug
+  export SEMGREP_LOG_SRCS="semgrep.targeting" semgrep ... --debug
 
 or for osemgrep you can use it with any log level as in
 
-   export SEMGREP_LOG_SRCS="semgrep.secrets" ./bin/osemgrep ... --verbose
+   export SEMGREP_LOG_SRCS="semgrep.targeting" ./bin/osemgrep ... --verbose
 
 You can see the list of possible libraries above in this log as in
+...
+[00.04][DEBUG](default): Skipping logs for semgrep.targeting
 ...
 [00.04][DEBUG](default): Skipping logs for commons.pcre
 ...

--- a/src/core/Log_semgrep.ml
+++ b/src/core/Log_semgrep.ml
@@ -1,0 +1,54 @@
+let src = Logs.Src.create "semgrep"
+
+module Log = (val Logs.src_log src : Logs.LOG)
+
+let help_msg =
+  {|
+If you want to show the logs of a particular library
+(e.g., the semgrep secrets library), you'll need to adjust the
+SEMGREP_LOG_SRCS environment variable as in
+
+  export SEMGREP_LOG_SRCS="semgrep.secrets" semgrep ... --debug
+
+or for osemgrep you can use it with any log level as in
+
+   export SEMGREP_LOG_SRCS="semgrep.secrets" ./bin/osemgrep ... --verbose
+
+You can see the list of possible libraries above in this log as in
+...
+[00.04][DEBUG](default): Skipping logs for commons.pcre
+...
+For more information, See
+https://www.notion.so/semgrep/Logging-in-semgrep-semgrep-core-osemgrep-67c9046fa53744728d9d725a5a244f64
+|}
+
+(* Small wrapper around Logs_.setup() (itself a wrapper around Logs.set_xxx)
+ * TODO: add some --semgrep-log-xxx flags in osemgrep CLI for the envvars so
+ * they can be set also with CLI flags and will be part of the man page.
+ *)
+let setup ?log_to_file ?require_one_of_these_tags ~force_color ~level () =
+  UConsole.setup ~highlight_setting:(if force_color then On else Auto) ();
+  (* We override the default use of LOG_XXX env var in Logs_.setup() with
+   * SEMGREP_LOG_XXX env vars because Gitlab was reporting perf problems due
+   * to all the logging produced by Semgrep. Indeed, Gitlab CI itself is running
+   * jobs with LOG_LEVEL=debug, so better to use a different name for now.
+   * LATER: once we migrate most of our logs to use Logs.src, we should have
+   * far less logging by default, even in debug level, so we can maybe restore
+   * the use of the standard LOG_LEVEL envvar.
+   *
+   * The PYTEST_XXX env vars allows modifying the logging behavior of pytest
+   * tests since pytest clears the environment except for variables starting
+   * with "PYTEST_".
+   * LATER: once we remove pysemgrep and switch from pytest to Testo, we
+   * can get rid of those PYTEST_xxx env vars.
+   *)
+  Logs_.setup ?log_to_file ?require_one_of_these_tags
+    ~read_level_from_env_vars:
+      [ "PYTEST_SEMGREP_LOG_LEVEL"; "SEMGREP_LOG_LEVEL" ]
+    ~read_srcs_from_env_vars:[ "PYTEST_SEMGREP_LOG_SRCS"; "SEMGREP_LOG_SRCS" ]
+    ~read_tags_from_env_vars:[ "PYTEST_SEMGREP_LOG_TAGS"; "SEMGREP_LOG_TAGS" ]
+    ~level ();
+  Logs.debug (fun m -> m "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
+  Logs.debug (fun m -> m "%s" help_msg);
+  Logs.debug (fun m -> m "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
+  ()

--- a/src/core_cli/Core_CLI.ml
+++ b/src/core_cli/Core_CLI.ml
@@ -718,27 +718,8 @@ let main_no_exn_handler (caps : Cap.all_caps) (sys_argv : string array) : unit =
 
   Core_profiling.profiling := config.debug || config.report_time;
 
-  (* coupling: CLI_common.setup_logging *)
-  UConsole.setup ~highlight_setting:On ();
-  (* We override the default use of LOG_XXX env var in Logs_.setup() with
-   * SEMGREP_LOG_XXX env vars because Gitlab was reporting perf problems due
-   * to all the logging produced by Semgrep. Indeed, Gitlab CI itself is running
-   * jobs with LOG_LEVEL=debug, so better to use a different name for now.
-   * LATER: once we migrate most of our logs to use Logs.src, we should have
-   * far less logging by default, even in debug level, so we can restore
-   * LOG_LEVEL.
-   *
-   * The PYTEST_XXX env vars allows modifying the logging behavior of pytest
-   * tests since pytest clears the environment except for variables starting
-   * with "PYTEST_".
-   * LATER: once we remove pysemgrep and switch from pytest to Testo, we
-   * can get rid of those PYTEST_xxx env vars.
-   *)
-  Logs_.setup ?log_to_file:config.log_to_file ?require_one_of_these_tags:None
-    ~read_level_from_env_vars:
-      [ "PYTEST_SEMGREP_LOG_LEVEL"; "SEMGREP_LOG_LEVEL" ]
-    ~read_srcs_from_env_vars:[ "PYTEST_SEMGREP_LOG_SRCS"; "SEMGREP_LOG_SRCS" ]
-    ~read_tags_from_env_vars:[ "PYTEST_SEMGREP_LOG_TAGS"; "SEMGREP_LOG_TAGS" ]
+  Log_semgrep.setup ?log_to_file:config.log_to_file
+    ?require_one_of_these_tags:None ~force_color:true
     ~level:
       (* TODO: command-line option or env variable to choose the log level *)
       (if config.debug then Some Debug else Some Info)

--- a/src/osemgrep/core/CLI_common.ml
+++ b/src/osemgrep/core/CLI_common.ml
@@ -8,8 +8,6 @@ open Cmdliner
    semgrep CLI.
 *)
 
-let tags = Logs_.create_tags [ __MODULE__ ]
-
 (*************************************************************************)
 (* Types *)
 (*************************************************************************)
@@ -70,21 +68,10 @@ let o_logging : Logs.level option Term.t =
   Term.(const combine $ o_debug $ o_quiet $ o_verbose)
 
 let setup_logging ~force_color ~level =
+  Log_semgrep.setup ~force_color ~level ();
   Logs.debug (fun m ->
-      m ~tags "Logging setup for osemgrep: force_color=%B level=%s" force_color
+      m "Logging setup for osemgrep: force_color=%B level=%s" force_color
         (Logs.level_to_string level));
-  UConsole.setup ~highlight_setting:(if force_color then On else Auto) ();
-  (* coupling: See also the call to Logs_.setup() in Core_CLI.ml and the
-   * comments in it about the environment variables.
-   * TODO: add --semgrep-log-xxx flags for those so this can be set
-   * also with CLI flags and will be part of the man page.
-   *)
-  Logs_.setup
-    ~read_level_from_env_vars:
-      [ "PYTEST_SEMGREP_LOG_LEVEL"; "SEMGREP_LOG_LEVEL" ]
-    ~read_srcs_from_env_vars:[ "PYTEST_SEMGREP_LOG_SRCS"; "SEMGREP_LOG_SRCS" ]
-    ~read_tags_from_env_vars:[ "PYTEST_SEMGREP_LOG_TAGS"; "SEMGREP_LOG_TAGS" ]
-    ~level ();
   (* TOPORT
         # Setup file logging
         # env.user_log_file dir must exist
@@ -98,7 +85,7 @@ let setup_logging ~force_color ~level =
         logger.addHandler(file_handler)
   *)
   Logs.debug (fun m ->
-      m ~tags "Executed as: %s" (Sys.argv |> Array.to_list |> String.concat " "))
+      m "Executed as: %s" (Sys.argv |> Array.to_list |> String.concat " "))
 
 (*************************************************************************)
 (* Profiling options *)

--- a/src/tests/Test.ml
+++ b/src/tests/Test.ml
@@ -153,6 +153,7 @@ let main (caps : Cap.all_caps) : unit =
            it before each test. In particular, tests that check the semgrep
            output can or should change these settings. *)
         UConsole.setup ~highlight_setting:On ();
+        (* TODO? use Log_semgrep.setup? *)
         Logs_.setup_basic ~level:(Some Logs.Debug) ()
       in
       (* Show log messages produced when building the list of tests *)

--- a/tools/hello_script.ml
+++ b/tools/hello_script.ml
@@ -123,9 +123,7 @@ let simple_shell_programming_demo () =
 (*****************************************************************************)
 
 let run (caps : Cap.all_caps) (conf : conf) =
-  Logs_.setup_logging
-    ~level:(if conf.debug then Some Logs.Debug else Some Logs.Info)
-    ();
+  Logs_.setup ~level:(if conf.debug then Some Logs.Debug else Some Logs.Info) ();
   Logs.debug (fun m -> m "params = %s" (show_conf conf));
   Logs.info (fun m -> m "Hello %s from %s" conf.command conf.username);
   simple_shell_programming_demo ();


### PR DESCRIPTION
test plan:
```
$ ./bin/osemgrep --experimental --debug
00.04][DEBUG](default): setup_logging: highlight_setting=Console.Auto, highlight=true
[00.04][DEBUG](default): Skipping logs for networking.http
[00.04][DEBUG](default): Skipping logs for cohttp.lwt.client
[00.04][DEBUG](default): Skipping logs for cohttp.lwt.io
[00.04][DEBUG](default): Skipping logs for conduit_lwt_server
[00.04][DEBUG](default): Skipping logs for ca-certs
[00.04][DEBUG](default): Skipping logs for mirage-crypto-rng-lwt
[00.04][DEBUG](default): Skipping logs for mirage-crypto-rng.unix
[00.04][DEBUG](default): Skipping logs for handshake
[00.04][DEBUG](default): Skipping logs for tls.config
[00.04][DEBUG](default): Skipping logs for tls.tracing
[00.04][DEBUG](default): Skipping logs for x509
[00.04][DEBUG](default): Skipping logs for semgrep.targeting
[00.04][DEBUG](default): Skipping logs for ojsonnet.eval
[00.04][DEBUG](default): Skipping logs for semgrep
[00.04][DEBUG](default): Skipping logs for git.value
[00.04][DEBUG](default): Skipping logs for git.tree
[00.04][DEBUG](default): Skipping logs for git.stream
[00.04][DEBUG](default): Skipping logs for git.blob
[00.04][DEBUG](default): Skipping logs for paths
[00.04][DEBUG](default): Skipping logs for commons.pcre
[00.04][DEBUG](default): Skipping logs for bos
[00.04][DEBUG](default): Showing logs for application
[00.04][DEBUG](default): !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
[00.04][DEBUG](default):
If you want to show the logs of a particular library
(e.g., the semgrep secrets library), you'll need to adjust the
SEMGREP_LOG_SRCS environment variable as in

  export SEMGREP_LOG_SRCS="semgrep.secrets" semgrep ... --debug

or for osemgrep you can use it with any log level as in

   export SEMGREP_LOG_SRCS="semgrep.secrets" ./bin/osemgrep ... --verbose

You can see the list of possible libraries above in this log as in
...
[00.04][DEBUG](default): Skipping logs for commons.pcre
...
For more information, See
https://www.notion.so/semgrep/Logging-in-semgrep-semgrep-core-osemgrep-67c9046fa53744728d9d725a5a244f64

[00.04][DEBUG](default): !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
[00.04][DEBUG](default): Logging setup for osemgrep: force_color=false level=debug
[00.04][DEBUG](default): Executed as: ./bin/osemgrep --experimental --debug
[00.04][INFO]: Semgrep version: 1.70.0
[00.04][DEBUG](default): conf = { Scan_CLI.rules_source = (Rules_source.Configs ["auto"]);
  target_roots = [.];
...
```

and for pysemgrep:
```
$ semgrep --config rules/fixtest/test4.yaml --test targets/fixtest/test4.py --debug
semgrep version 1.70.0
Loading local config from rules/fixtest/test4.yaml
Done loading local config from rules/fixtest/test4.yaml
loaded 1 configs in 0.12055730819702148
Error in add_engine_config: name 'EngineType' is not defined
...
Passing whole rules directly to semgrep_core
Running Semgrep engine with command:
/home/pad/github/R2C-main-repos/semgrep/cli/src/semgrep/bin/semgrep-core -json -rules /tmp/tmp4i3vg39j.json -j 16 -targets /tmp/tmp01eau8nh -timeout 5 -timeout_threshold 0 -max_memory 0 -disable_rule_paths -fast --debug
--- semgrep-core stderr ---
[00.04][DEBUG](default): setup_logging: highlight_setting=Console.On, highlight=true
[00.04][DEBUG](default): Skipping logs for networking.http
[00.04][DEBUG](default): Skipping logs for cohttp.lwt.client
[00.04][DEBUG](default): Skipping logs for cohttp.lwt.io
[00.04][DEBUG](default): Skipping logs for conduit_lwt_server
[00.04][DEBUG](default): Skipping logs for ca-certs
[00.04][DEBUG](default): Skipping logs for mirage-crypto-rng-lwt
[00.04][DEBUG](default): Skipping logs for mirage-crypto-rng.unix
[00.04][DEBUG](default): Skipping logs for handshake
[00.04][DEBUG](default): Skipping logs for tls.config
[00.04][DEBUG](default): Skipping logs for tls.tracing
[00.04][DEBUG](default): Skipping logs for x509
[00.04][DEBUG](default): Skipping logs for semgrep.targeting
[00.04][DEBUG](default): Skipping logs for ojsonnet.eval
[00.04][DEBUG](default): Skipping logs for semgrep
[00.04][DEBUG](default): Skipping logs for git.value
[00.04][DEBUG](default): Skipping logs for git.tree
[00.04][DEBUG](default): Skipping logs for git.stream
[00.04][DEBUG](default): Skipping logs for git.blob
[00.04][DEBUG](default): Skipping logs for paths
[00.04][DEBUG](default): Skipping logs for commons.pcre
[00.04][DEBUG](default): Skipping logs for bos
[00.04][DEBUG](default): Showing logs for application
[00.04][DEBUG](default): !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
[00.04][DEBUG](default):
If you want to show the logs of a particular library
(e.g., the semgrep secrets library), you'll need to adjust the
SEMGREP_LOG_SRCS environment variable as in

  export SEMGREP_LOG_SRCS="semgrep.secrets" semgrep ... --debug

or for osemgrep you can use it with any log level as in

   export SEMGREP_LOG_SRCS="semgrep.secrets" ./bin/osemgrep ... --verbose

You can see the list of possible libraries above in this log as in
...
[00.04][DEBUG](default): Skipping logs for commons.pcre
...
For more information, See
https://www.notion.so/semgrep/Logging-in-semgrep-semgrep-core-osemgrep-67c9046fa53744728d9d725a5a244f64

[00.04][DEBUG](default): !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
[00.04][INFO]: Executed as: /home/pad/github/R2C-main-repos/semgrep/cli/src/semgrep/bin/semgrep-core -json -rules /tmp/tmp4i3vg39j.json -j 16 -targets /tmp/tmp01eau8nh -timeout 5 -timeout_threshold 0 -max_memory 0 -disable_rule_paths -fast --debug
[00.04][INFO]: Version: semgrep-core version: 1.70.0
[00.06][DEBUG](default): size of returned JSON string: 473
--- end semgrep-core stderr ---
semgrep ran in 0:00:00.091383 on 1 files
findings summary: 0 warning
semgrep version 1.70.0
...
```