### PR TITLE
refactor: Remove dependency on SSC from search and taint engines

### DIFF
--- a/src/core_scan/Core_scan.ml
+++ b/src/core_scan/Core_scan.ml
@@ -332,6 +332,11 @@ let print_match ?str (config : Core_scan_config.t) match_ ii_of_any =
   } =
     match_
   in
+  let str =
+    match str with
+    | None -> Common.spf "with rule %s" (Rule_ID.to_string match_.rule_id.id)
+    | Some str -> str
+  in
   let toks = tokens_matched_code |> List.filter Tok.is_origintok in
   let dep_toks_and_version =
     (* Only print the extra data if it was a reachable finding *)
@@ -344,7 +349,7 @@ let print_match ?str (config : Core_scan_config.t) match_ ii_of_any =
     | _ -> None
   in
   (if config.mvars =*= [] then
-     Core_text_output.print_match ?str ~format:config.match_format toks
+     Core_text_output.print_match ~str ~format:config.match_format toks
    else
      (* similar to the code of Lib_matcher.print_match, maybe could
       * factorize code a bit.
@@ -989,9 +994,9 @@ let mk_target_handler (config : Core_scan_config.t) (valid_rules : Rule.t list)
              Parse_lockfile.parse_lockfile)
           target.lockfile
       in
-      let default_match_hook str match_ =
+      let default_match_hook match_ =
         if config.output_format =*= Text then
-          print_match ~str config match_ Metavariable.ii_of_mval
+          print_match config match_ Metavariable.ii_of_mval
       in
       let match_hook = Option.value match_hook ~default:default_match_hook in
       let xconf =

--- a/src/core_scan/Core_scan.mli
+++ b/src/core_scan/Core_scan.mli
@@ -34,7 +34,7 @@ val scan_with_exn_handler :
  * print_match() below.
  *)
 val scan :
-  ?match_hook:(string -> Pattern_match.t -> unit) ->
+  ?match_hook:(Pattern_match.t -> unit) ->
   < Cap.tmp > ->
   Core_scan_config.t ->
   (Rule.t list * Rule.invalid_rule_error list) * float ->

--- a/src/engine/Match_rules.ml
+++ b/src/engine/Match_rules.ml
@@ -145,6 +145,22 @@ let per_rule_boilerplate_fn ~timeout ~timeout_threshold =
           (Core_error.ErrorSet.singleton error)
           (Core_profiling.empty_rule_profiling rule)
 
+let scc_match_hook match_hook get_dep_matches pms =
+  pms
+  |> List.concat_map (fun (pm : Pattern_match.t) ->
+         let rule_id = pm.rule_id.id in
+         let dependency_matches = get_dep_matches rule_id in
+         let pms' =
+           Match_dependency.annotate_pattern_match dependency_matches pm
+         in
+         pms'
+         |> List.iter (fun pm' ->
+                let str =
+                  Common.spf "with rule %s" (Rule_ID.to_string rule_id)
+                in
+                match_hook str pm');
+         pms')
+
 (*****************************************************************************)
 (* Entry point *)
 (*****************************************************************************)
@@ -158,6 +174,8 @@ let check ~match_hook ~timeout ~timeout_threshold
     | Some table -> Hashtbl.find_opt table
     | None -> fun _ -> None
   in
+  let match_hook = scc_match_hook match_hook get_dep_matches in
+
   let { path = { internal_path_to_content; _ }; lazy_ast_and_errors; xlang; _ }
       : Xtarget.t =
     xtarget
@@ -192,13 +210,12 @@ let check ~match_hook ~timeout ~timeout_threshold
   let res_taint_rules =
     relevant_taint_rules_groups
     |> List.concat_map (fun relevant_taint_rules ->
-           Match_tainting_mode.check_rules ~get_dep_matches ~match_hook
-             ~per_rule_boilerplate_fn relevant_taint_rules xconf xtarget)
+           Match_tainting_mode.check_rules ~match_hook ~per_rule_boilerplate_fn
+             relevant_taint_rules xconf xtarget)
   in
   let res_nontaint_rules =
     relevant_nontaint_rules
     |> List_.map (fun r ->
-           let dependency_matches = get_dep_matches (fst r.R.id) in
            let xconf =
              Match_env.adjust_xconfig_with_rule_options xconf r.R.options
            in
@@ -208,8 +225,8 @@ let check ~match_hook ~timeout ~timeout_threshold
                (* dispatching *)
                match r.R.mode with
                | `Search _ as mode ->
-                   Match_search_mode.check_rule ?dependency_matches
-                     { r with mode } match_hook xconf xtarget
+                   Match_search_mode.check_rule { r with mode } match_hook xconf
+                     xtarget
                | `Extract extract_spec ->
                    Match_search_mode.check_rule
                      { r with mode = `Search extract_spec.R.formula }

--- a/src/engine/Match_rules.ml
+++ b/src/engine/Match_rules.ml
@@ -148,17 +148,11 @@ let per_rule_boilerplate_fn ~timeout ~timeout_threshold =
 let scc_match_hook match_hook get_dep_matches pms =
   pms
   |> List.concat_map (fun (pm : Pattern_match.t) ->
-         let rule_id = pm.rule_id.id in
-         let dependency_matches = get_dep_matches rule_id in
+         let dependency_matches = get_dep_matches pm.rule_id.id in
          let pms' =
            Match_dependency.annotate_pattern_match dependency_matches pm
          in
-         pms'
-         |> List.iter (fun pm' ->
-                let str =
-                  Common.spf "with rule %s" (Rule_ID.to_string rule_id)
-                in
-                match_hook str pm');
+         pms' |> List.iter match_hook;
          pms')
 
 (*****************************************************************************)

--- a/src/engine/Match_rules.mli
+++ b/src/engine/Match_rules.mli
@@ -20,7 +20,7 @@ exception File_timeout of Rule_ID.t list
  * This can also raise File_timeout.
  *)
 val check :
-  match_hook:(string -> Pattern_match.t -> unit) ->
+  match_hook:(Pattern_match.t -> unit) ->
   timeout:float ->
   timeout_threshold:int ->
   ?dependency_match_table:Match_dependency.dependency_match_table ->

--- a/src/engine/Match_search_mode.ml
+++ b/src/engine/Match_search_mode.ml
@@ -963,8 +963,7 @@ and matches_of_formula xconf rule xtarget formula opt_context :
 (* Main entry point *)
 (*****************************************************************************)
 
-let check_rule ?dependency_matches ({ R.mode = `Search formula; _ } as r) hook
-    xconf xtarget =
+let check_rule ({ R.mode = `Search formula; _ } as r) hook xconf xtarget =
   let rule_id = fst r.id in
 
   let%trace_debug sp = "Match_search_mode.check_rule" in
@@ -984,12 +983,6 @@ let check_rule ?dependency_matches ({ R.mode = `Search formula; _ } as r) hook
        * but different mini-rules matches can now become the same match)
        *)
       |> PM.uniq
-      |> List.concat_map
-           (Match_dependency.annotate_pattern_match dependency_matches)
-      |> before_return (fun v ->
-             v
-             |> List.iter (fun (m : Pattern_match.t) ->
-                    let str = spf "with rule %s" (Rule_ID.to_string rule_id) in
-                    hook str m));
+      |> hook;
     errors;
   }

--- a/src/engine/Match_search_mode.mli
+++ b/src/engine/Match_search_mode.mli
@@ -1,8 +1,7 @@
 (* main entry point *)
 val check_rule :
-  ?dependency_matches:Pattern_match.dependency_match list ->
   Rule.search_rule ->
-  (string -> Pattern_match.t -> unit) ->
+  (Pattern_match.t list -> Pattern_match.t list) ->
   Match_env.xconfig ->
   Xtarget.t ->
   Core_profiling.rule_profiling Core_result.match_result

--- a/src/engine/Match_tainting_mode.mli
+++ b/src/engine/Match_tainting_mode.mli
@@ -88,8 +88,7 @@ val check_fundef :
   *)
 
 val check_rules :
-  ?get_dep_matches:(Rule_ID.t -> Pattern_match.dependency_match list option) ->
-  match_hook:(string -> Pattern_match.t -> unit) ->
+  match_hook:(Pattern_match.t list -> Pattern_match.t list) ->
   per_rule_boilerplate_fn:
     (Rule.rule ->
     (unit -> Core_profiling.rule_profiling Core_result.match_result) ->

--- a/src/engine/Test_engine.ml
+++ b/src/engine/Test_engine.ml
@@ -239,7 +239,7 @@ let make_test_rule_file ?(fail_callback = fun _i m -> Alcotest.fail m)
           try
             (* !!!!let's go!!!! *)
             Match_rules.check
-              ~match_hook:(fun _ _ -> ())
+              ~match_hook:(fun _pm -> ())
               ~timeout:0. ~timeout_threshold:0 xconf rules xtarget
           with
           | exn ->

--- a/src/engine/Unit_engine.ml
+++ b/src/engine/Unit_engine.ml
@@ -685,8 +685,7 @@ let tainting_test lang rules_file file =
              }
            in
            let results =
-             Match_tainting_mode.check_rules
-               ~match_hook:(fun _ _ -> ())
+             Match_tainting_mode.check_rules ~match_hook:Fun.id
                ~per_rule_boilerplate_fn:(fun _rule f -> f ())
                [ rule ] xconf xtarget
            in

--- a/src/osemgrep/cli_test/Test_subcommand.ml
+++ b/src/osemgrep/cli_test/Test_subcommand.ml
@@ -127,7 +127,7 @@ let run_rules_against_target (xlang : Xlang.t) (rules : Rule.t list)
   (* TODO? extract rules *)
   let (res : Core_result.matches_single_file) =
     Match_rules.check
-      ~match_hook:(fun _ _ -> ())
+      ~match_hook:(fun _pm -> ())
       ~timeout:0. ~timeout_threshold:0 xconf rules xtarget
   in
   let actual_errors =

--- a/src/osemgrep/language_server/scan_helpers/Scan_helpers.ml
+++ b/src/osemgrep/language_server/scan_helpers/Scan_helpers.ml
@@ -158,7 +158,7 @@ let run_semgrep ?(targets : Fpath.t list option) ?rules ?git_ref
    In the interim, we will just continue to hook into core.
 *)
 let run_core_search xconf rule (file : Fpath.t) =
-  let hook _file _pm = () in
+  let hook = Fun.id in
   let xlang = rule.Rule.target_analyzer in
   (* We have to look at all the initial files again when we do this.
      TODO: Maybe could be better to infer languages from each file,


### PR DESCRIPTION
The engines should know nothing about SSC.

test plan:
make test

