### PR TITLE
refactor: tainting: Prepare for list/tuple unpacking

### DIFF
--- a/src/analyzing/AST_to_IL.ml
+++ b/src/analyzing/AST_to_IL.ml
@@ -241,13 +241,13 @@ let name_of_entity ent =
       Some name
   | _____else_____ -> None
 
-let composite_of_container ~e_gen : G.container_operator -> IL.composite_kind =
+let composite_of_container ~g_expr : G.container_operator -> IL.composite_kind =
   function
   | Array -> CArray
   | List -> CList
   | Tuple -> CTuple
   | Set -> CSet
-  | Dict -> impossible (E e_gen)
+  | Dict -> impossible (E g_expr)
 
 let mk_unnamed_args (exps : IL.exp list) = List_.map (fun x -> Unnamed x) exps
 
@@ -429,8 +429,8 @@ and try_catch_else_finally env ~try_st ~catches ~opt_else ~opt_finally =
 (*****************************************************************************)
 (* Assign *)
 (*****************************************************************************)
-and assign env lhs tok rhs_exp e_gen =
-  let eorig = SameAs e_gen in
+and assign env ~g_expr lhs tok rhs_exp =
+  let eorig = SameAs g_expr in
   match lhs.G.e with
   | G.N _
   | G.DotAccess _
@@ -445,7 +445,7 @@ and assign env lhs tok rhs_exp e_gen =
           (* lval translation failed, we use a fresh lval instead *)
           let fixme_lval = fresh_lval ~str:"_FIXME" env tok in
           add_instr env (mk_i (Assign (fixme_lval, rhs_exp)) eorig);
-          fixme_exp kind any_generic (related_exp e_gen))
+          fixme_exp kind any_generic (related_exp g_expr))
   | G.Container (((G.Tuple | G.Array) as ckind), (tok1, lhss, tok2)) ->
       (* TODO: handle cases like [a, b, ...rest] = e *)
       (* E1, ..., En = RHS *)
@@ -465,19 +465,19 @@ and assign env lhs tok rhs_exp e_gen =
                  }
                in
                let lval_i = { base = Var tmp; rev_offset = [ offset_i ] } in
-               assign env lhs_i tok1
-                 { e = Fetch lval_i; eorig = related_exp lhs_i }
-                 e_gen)
+               assign env ~g_expr lhs_i tok1
+                 { e = Fetch lval_i; eorig = related_exp lhs_i })
       in
       (* (E1, ..., En) *)
       mk_e
-        (Composite (composite_of_container ~e_gen ckind, (tok1, tup_elems, tok2)))
+        (Composite
+           (composite_of_container ~g_expr ckind, (tok1, tup_elems, tok2)))
         (related_exp lhs)
   | G.Record (tok1, fields, tok2) ->
       assign_to_record env (tok1, fields, tok2) rhs_exp (related_exp lhs)
   | _ ->
-      add_instr env (fixme_instr ToDo (G.E e_gen) (related_exp e_gen));
-      fixme_exp ToDo (G.E e_gen) (related_exp lhs)
+      add_instr env (fixme_instr ToDo (G.E g_expr) (related_exp g_expr));
+      fixme_exp ToDo (G.E g_expr) (related_exp lhs)
 
 and assign_to_record env (tok1, fields, tok2) rhs_exp lhs_orig =
   (* Assignments of the form
@@ -559,9 +559,9 @@ and assign_to_record env (tok1, fields, tok2) rhs_exp lhs_orig =
 (* We set `void` to `true` when the value of the expression is being discarded, in
  * which case, for certain expressions and in certain languages, we assume that the
  * expression has side-effects. See translation of operators below. *)
-and expr_aux env ?(void = false) e_gen =
-  let eorig = SameAs e_gen in
-  match e_gen.G.e with
+and expr_aux env ?(void = false) g_expr =
+  let eorig = SameAs g_expr in
+  match g_expr.G.e with
   | G.Call
       ( { e = G.IdSpecial (G.Op ((G.And | G.Or) as op), tok); _ },
         (_, arg0 :: args, _) )
@@ -577,7 +577,7 @@ and expr_aux env ?(void = false) e_gen =
          * Ruby `s << "hello"` is syntax sugar for `s.<<("hello")` and it mutates
          * the string `s` appending "hello" to it. *)
         match args with
-        | [] -> impossible (G.E e_gen)
+        | [] -> impossible (G.E g_expr)
         | obj :: args' ->
             let obj_var, _obj_lval =
               mk_aux_var env tok (IL_helpers.exp_of_arg obj)
@@ -625,7 +625,7 @@ and expr_aux env ?(void = false) e_gen =
           in
           add_instr env (mk_i (Assign (lval, opexp)) eorig);
           lvalexp
-      | _ -> impossible (G.E e_gen))
+      | _ -> impossible (G.E g_expr))
   | G.Call
       ( {
           e =
@@ -695,7 +695,7 @@ and expr_aux env ?(void = false) e_gen =
             CallSpecial (res, special, args))
       with
       | Fixme (kind, any_generic) ->
-          let fixme = fixme_exp kind any_generic (related_exp e_gen) in
+          let fixme = fixme_exp kind any_generic (related_exp g_expr) in
           add_call env tok eorig ~void (fun res -> Call (res, fixme, args)))
   | G.Call (e, args) ->
       let tok = G.fake "call" in
@@ -712,7 +712,7 @@ and expr_aux env ?(void = false) e_gen =
   | G.DotAccess (_, _, _)
   | G.ArrayAccess (_, _)
   | G.DeRef (_, _) ->
-      let lval = lval env e_gen in
+      let lval = lval env g_expr in
       let exp = mk_e (Fetch lval) eorig in
       let ident_function_call_hack exp =
         (* Taking into account Ruby's ability to allow function calls without
@@ -765,13 +765,13 @@ and expr_aux env ?(void = false) e_gen =
       mk_e (Fetch lval) (SameAs obj_e)
   | G.Assign (e1, tok, e2) ->
       let exp = expr env e2 in
-      assign env e1 tok exp e_gen
+      assign env ~g_expr e1 tok exp
   | G.AssignOp (e1, (G.Eq, tok), e2) ->
       (* AsssignOp(Eq) is used to represent plain assignment in some languages,
        * e.g. Go's `:=` is represented as `AssignOp(Eq)`, and C#'s assignments
        * are all represented this way too. *)
       let exp = expr env e2 in
-      assign env e1 tok exp e_gen
+      assign env ~g_expr e1 tok exp
   | G.AssignOp (e1, op, e2) ->
       let exp = expr env e2 in
       let lval = lval env e1 in
@@ -789,7 +789,7 @@ and expr_aux env ?(void = false) e_gen =
       mk_unit (G.fake "()") NoOrig
   | G.Seq xs -> (
       match List.rev xs with
-      | [] -> impossible (G.E e_gen)
+      | [] -> impossible (G.E g_expr)
       | last :: xs ->
           let xs = List.rev xs in
           xs
@@ -798,12 +798,12 @@ and expr_aux env ?(void = false) e_gen =
                  ());
           expr env last)
   | G.Record fields -> record env fields
-  | G.Container (G.Dict, xs) -> dict env xs e_gen
+  | G.Container (G.Dict, xs) -> dict env xs g_expr
   | G.Container (kind, xs) ->
       let xs = bracket_keep (List_.map (expr env)) xs in
-      let kind = composite_kind ~e_gen kind in
+      let kind = composite_kind ~g_expr kind in
       mk_e (Composite (kind, xs)) eorig
-  | G.Comprehension _ -> todo (G.E e_gen)
+  | G.Comprehension _ -> todo (G.E g_expr)
   | G.Lambda fdef ->
       (* TODO: we should have a use def.f_tok *)
       let tok = G.fake "lambda" in
@@ -839,8 +839,8 @@ and expr_aux env ?(void = false) e_gen =
       | Some var_special ->
           let lval = lval_of_base (VarSpecial (var_special, tok)) in
           mk_e (Fetch lval) eorig
-      | None -> impossible (G.E e_gen))
-  | G.SliceAccess (_, _) -> todo (G.E e_gen)
+      | None -> impossible (G.E g_expr))
+  | G.SliceAccess (_, _) -> todo (G.E g_expr)
   (* e1 ? e2 : e3 ==>
    *  pre: lval = e1;
    *       if(lval) { lval = e2 } else { lval = e3 }
@@ -909,8 +909,8 @@ and expr_aux env ?(void = false) e_gen =
   | G.DisjExpr (_, _)
   | G.DeepEllipsis _
   | G.DotAccessEllipsis _ ->
-      sgrep_construct (G.E e_gen)
-  | G.StmtExpr st -> stmt_expr env ~e_gen st
+      sgrep_construct (G.E g_expr)
+  | G.StmtExpr st -> stmt_expr env ~g_expr st
   | G.OtherExpr ((str, tok), xs) ->
       let es =
         xs
@@ -922,8 +922,8 @@ and expr_aux env ?(void = false) e_gen =
       let other_expr = mk_e (Composite (CTuple, (tok, es, tok))) eorig in
       let _, tmp = mk_aux_var ~str env tok other_expr in
       let partial = mk_e (Fetch tmp) (related_tok tok) in
-      fixme_exp ToDo (G.E e_gen) (related_tok tok) ~partial
-  | G.RawExpr _ -> todo (G.E e_gen)
+      fixme_exp ToDo (G.E g_expr) (related_tok tok) ~partial
+  | G.RawExpr _ -> todo (G.E g_expr)
 
 and expr env ?void e_gen =
   try expr_aux env ?void e_gen with
@@ -994,10 +994,10 @@ and call_special _env (x, tok) =
         todo (G.E (G.IdSpecial (x, tok) |> G.e))),
     tok )
 
-and composite_kind ~e_gen = function
+and composite_kind ~g_expr = function
   | G.Array -> CArray
   | G.List -> CList
-  | G.Dict -> impossible (E e_gen)
+  | G.Dict -> impossible (E g_expr)
   | G.Set -> CSet
   | G.Tuple -> CTuple
 
@@ -1143,9 +1143,9 @@ and xml_expr env xml =
     (Composite (CTuple, (tok, List.rev_append attrs body, tok)))
     (Related (G.Xmls xml.G.xml_body))
 
-and stmt_expr env ?e_gen st =
+and stmt_expr env ?g_expr st =
   let todo () =
-    match e_gen with
+    match g_expr with
     | None -> todo (G.E (G.e (G.StmtExpr st)))
     | Some e_gen -> todo (G.E e_gen)
   in
@@ -1198,7 +1198,7 @@ and stmt_expr env ?e_gen st =
       add_stmts env
         (ss @ [ mk_s (If (tok, e', pre_a1 @ [ a1 ], pre_a2 @ [ a2 ])) ]);
       let eorig =
-        match e_gen with
+        match g_expr with
         | None -> related_exp (G.e (G.StmtExpr st))
         | Some e_gen -> SameAs e_gen
       in

--- a/src/analyzing/Eval_il_partial.ml
+++ b/src/analyzing/Eval_il_partial.ml
@@ -248,7 +248,7 @@ let rec eval (env : env) (exp : IL.exp) : G.svalue =
       | __else__ -> eval_op env op args)
   | Operator (op, args) -> eval_op env op args
   | Composite _
-  | Record _
+  | RecordOrDict _
   | Cast _
   | FixmeExp _ ->
       G.NotCst

--- a/src/core/Lang.ml
+++ b/src/core/Lang.ml
@@ -122,6 +122,7 @@ let keys = Common2.hkeys lang_map
 let supported_langs : string = String.concat ", " keys
 
 (* TODO: move file identification to lang.json *)
+(* TODO: Solidity *)
 let langs_of_filename filename =
   let typ = File_type.file_type_of_file filename in
   match typ with

--- a/src/engine/Match_tainting_mode.ml
+++ b/src/engine/Match_tainting_mode.ml
@@ -23,6 +23,7 @@ module PM = Pattern_match
 module RM = Range_with_metavars
 module RP = Core_result
 module T = Taint
+module Sig = Taint_sig
 module Lval_env = Taint_lval_env
 module MV = Metavariable
 module ME = Matching_explanation
@@ -481,7 +482,7 @@ let lazy_force x = Lazy.force x [@@profiling]
 
 (* If the 'requires' has the shape 'A and ...' then we assume that 'A' is the
  * preferred label for reporting the taint trace. *)
-let preferred_label_of_sink ({ rule_sink; _ } : T.sink) =
+let preferred_label_of_sink ({ rule_sink; _ } : Sig.sink) =
   match rule_sink.sink_requires with
   | Some { precondition = PAnd (PLabel label :: _); _ } -> Some label
   | Some _
@@ -513,7 +514,7 @@ let sources_of_taints ?preferred_label taints =
    * they need to specify the parameters as taint sources. *)
   let taint_sources =
     taints
-    |> List_.map_filter (fun { T.taint = { orig; tokens }; sink_trace } ->
+    |> List_.map_filter (fun { Sig.taint = { orig; tokens }; sink_trace } ->
            match orig with
            | Src src -> Some (src, tokens, sink_trace)
            (* even if there is any taint "variable", it's irrelevant for the
@@ -565,10 +566,10 @@ let trace_of_source source =
 
 let pms_of_finding ~match_on finding =
   match finding with
-  | T.ToLval _
-  | T.ToReturn _ ->
+  | Sig.ToLval _
+  | Sig.ToReturn _ ->
       []
-  | ToSink
+  | Sig.ToSink
       {
         taints_with_precondition = taints, requires;
         sink = { pm = sink_pm; _ } as sink;
@@ -577,7 +578,7 @@ let pms_of_finding ~match_on finding =
       if
         not
           (T.taints_satisfy_requires
-             (List_.map (fun t -> t.T.taint) taints)
+             (List_.map (fun t -> t.Sig.taint) taints)
              requires)
       then []
       else

--- a/src/engine/Match_tainting_mode.mli
+++ b/src/engine/Match_tainting_mode.mli
@@ -53,7 +53,7 @@ val taint_config_of_rule :
   AST_generic.program * Tok.location list ->
   Rule.taint_rule ->
   (Dataflow_tainting.var option ->
-  Taint.result list ->
+  Taint_sig.result list ->
   Taint_lval_env.t ->
   unit) ->
   Dataflow_tainting.config * debug_taint * Matching_explanation.t list

--- a/src/il/Display_IL.ml
+++ b/src/il/Display_IL.ml
@@ -1,4 +1,5 @@
 open IL
+module G = AST_generic
 
 let string_of_type (ty : G.type_) =
   match ty.t with
@@ -14,6 +15,12 @@ let string_of_base base =
 let string_of_offset offset =
   match offset.o with
   | Dot a -> ident_str_of_name a
+  | Index { e = Literal (G.Int parsed_int); _ } -> (
+      match Parsed_int.to_int_opt parsed_int with
+      | Some i -> Common.spf "[%d]" i
+      | None -> "[...]")
+  | Index { e = Literal (G.String (_, (str, _), _)); _ } ->
+      Common.spf "[\"%s\"]" str
   | Index _ -> "[...]"
 
 let string_of_offset_list offset =
@@ -56,10 +63,9 @@ let rec string_of_exp_kind e =
         (string_of_exp e2)
   | Operator ((op, _), _) -> Common.spf "<OP %s ...>" (G.show_operator op)
   | FixmeExp _ -> "<FIXME-EXP>"
-  | Composite (_, _)
-  | Record _
-  | Cast (_, _) ->
-      "<EXP>"
+  | Composite (_, _) -> "<COMPOSITE>"
+  | RecordOrDict _ -> "<RECORD-OR-DICT>"
+  | Cast (_, _) -> "<CAST>"
 
 and string_of_exp e = string_of_exp_kind e.e
 

--- a/src/il/Display_IL.mli
+++ b/src/il/Display_IL.mli
@@ -2,3 +2,4 @@ val display_cfg : IL.cfg -> unit
 val short_string_of_node_kind : IL.node_kind -> string
 val string_of_offset_list : IL.offset list -> string
 val string_of_lval : IL.lval -> string
+val string_of_exp : IL.exp -> string

--- a/src/il/IL_helpers.ml
+++ b/src/il/IL_helpers.ml
@@ -44,13 +44,14 @@ let rec lvals_of_exp e =
   | Cast (_, e) -> lvals_of_exp e
   | Composite (_, (_, xs, _)) -> lvals_of_exps xs
   | Operator (_, xs) -> lvals_of_exps (List_.map exp_of_arg xs)
-  | Record ys ->
+  | RecordOrDict ys ->
       lvals_of_exps
         (ys
-        |> List_.map @@ function
+        |> List.concat_map @@ function
            | Field (_, e)
            | Spread e ->
-               e)
+               [ e ]
+           | Entry (ke, ve) -> [ ke; ve ])
   | FixmeExp (_, _, Some e) -> lvals_of_exp e
   | FixmeExp (_, _, None) -> []
 

--- a/src/tainting/Dataflow_tainting.mli
+++ b/src/tainting/Dataflow_tainting.mli
@@ -54,7 +54,7 @@ type config = {
   unify_mvars : bool;  (** Unify metavariables in sources and sinks? *)
   handle_results :
     var option (** function name ('None' if anonymous) *) ->
-    Taint.result list ->
+    Taint_sig.result list ->
     Taint_lval_env.t ->
     unit;
       (** Callback to report results. *)
@@ -82,7 +82,7 @@ val mk_empty_java_props_cache : unit -> java_props_cache
 val hook_function_taint_signature :
   (config ->
   AST_generic.expr ->
-  (AST_generic.parameters (* params of function *) * Taint.signature) option)
+  (AST_generic.parameters (* params of function *) * Taint_sig.signature) option)
   option
   ref
 (** Pro inter-file (aka deep) *)
@@ -95,7 +95,7 @@ val hook_check_tainted_at_exit_sinks :
   (config ->
   Taint_lval_env.t ->
   IL.node ->
-  (Taint.taints * Taint.sink list) option)
+  (Taint.taints * Taint_sig.sink list) option)
   option
   ref
 (** Pro: support for `at-exit: true` sinks *)

--- a/src/tainting/Taint.ml
+++ b/src/tainting/Taint.ml
@@ -19,6 +19,9 @@ module R = Rule
 module LabelSet = Set.Make (String)
 open Common
 
+(* TODO: Consider renaming the `show_xyz` functions to `pretty_xyz` and
+ * generate `show_xyz` ones via `deriving show`. *)
+
 let base_tag_strings = [ __MODULE__; "taint" ]
 let _tags = Logs_.create_tags base_tag_strings
 let error = Logs_.create_tags (base_tag_strings @ [ "error" ])

--- a/src/tainting/Taint.mli
+++ b/src/tainting/Taint.mli
@@ -196,7 +196,9 @@ val taints_of_pms :
 
 val show_taints : taints -> string
 
-(*  *)
+(*****************************************************************************)
+(* Taint-oriented comparison functions for non-taint types *)
+(*****************************************************************************)
 
 val compare_matches : Pattern_match.t -> Pattern_match.t -> int
 val compare_metavar_env : Metavariable.bindings -> Metavariable.bindings -> int

--- a/src/tainting/Taint.mli
+++ b/src/tainting/Taint.mli
@@ -26,6 +26,8 @@ type 'spec call_trace =
   | Call of AST_generic.expr * tainted_tokens * 'spec call_trace
       (** An indirect match through a function call. *)
 
+val show_call_trace : ('spec -> string) -> 'spec call_trace -> string
+
 type arg = { name : string; index : int }
 (** A formal argument of a function given by its name and it's index/position. *)
 
@@ -152,6 +154,8 @@ val pm_of_trace : 'a call_trace -> Pattern_match.t * 'a
 val map_preconditions : (taint list -> taint list) -> taint -> taint option
 val show_lval : lval -> string
 val show_taint : taint -> string
+val compare_lval : lval -> lval -> int
+val compare_taint : taint -> taint -> int
 
 (*****************************************************************************)
 (* Taint sets *)
@@ -167,6 +171,7 @@ module Taint_set : sig
   val is_empty : t -> bool
   val cardinal : t -> int
   val equal : t -> t -> bool
+  val compare : t -> t -> int
   val singleton : taint -> t
   val add : taint -> t -> t
   val union : t -> t -> t
@@ -191,89 +196,7 @@ val taints_of_pms :
 
 val show_taints : taints -> string
 
-(*****************************************************************************)
-(* Taint results & signatures *)
-(*****************************************************************************)
+(*  *)
 
-type sink = { pm : Pattern_match.t; rule_sink : Rule.taint_sink }
-[@@deriving show]
-(** A sink match with its corresponding sink specification (one of the `pattern-sinks`). *)
-
-type taint_to_sink_item = {
-  taint : taint;
-  sink_trace : unit call_trace;
-      (** This trace is from the current calling context of the taint finding,
-        to the sink.
-        It's a `unit` call_trace because we don't actually need the item at the
-        end, and we need to be able to dispatch on the particular variant of taint
-        (source or arg).
-        *)
-}
-[@@deriving show]
-
-type taints_to_sink = {
-  taints_with_precondition : taint_to_sink_item list * Rule.precondition;
-      (** Taints reaching the sink and the precondition for the sink to apply. *)
-  sink : sink;
-  merged_env : Metavariable.bindings;
-      (** The metavariable environment that results of merging the environment from
-   * matching the source and the one from matching the sink. *)
-}
-[@@deriving show]
-
-(** Function-level result.
-  *
-  * 'ToSink' results where a taint source reaches a sink are candidates for
-  * actual Semgrep findings, although some may be dropped by deduplication.
-  *
-  * Results are computed for each function/method definition, and formulated
-  * using 'lval' taints to act as placeholders of the taint that may be passed
-  * by an arbitrary caller via the function arguments. Thus the results are
-  * polymorphic/context-sensitive, as the 'lval' taints can be instantiated
-  * accordingly at each call site.
-  *)
-type result =
-  | ToSink of taints_to_sink  (** Taints reach a sink. *)
-  | ToReturn of taint list * AST_generic.tok
-      (** Taints reach a `return` statement. *)
-  | ToLval of taint list * lval
-      (** Taints reach an l-value in the scope of the function/method. *)
-
-val compare_result : result -> result -> int
-
-module Results : Set.S with type elt = result
-module Results_tbl : Hashtbl.S with type key = result
-
-type signature = Results.t
-(** A (polymorphic) taint signature: simply a set of results for a function.
- *
- * Note that this signature is polymorphic/context-sensitive given that the
- * potential taints coming into the function via its arguments are represented
- * by 'lval' taints, that can be instantiated as needed.
- *
- * For example given:
- *
- *     def foo(x):
- *         sink(x.a)
- *
- * We infer the signature (simplified):
- *
- *     {ToSink {taints_with_precondition = [(x#0).a]; sink = ... ; ...}}
- *
- * where '(x#0).a' is taint variable that denotes the taint of the offset `.a`
- * of the parameter `x` (where '#0' means it is the first argument) of `foo`.
- * The signature tells us that '(x#0).a' will reach a sink.
- *
- * Given a concrete call `foo(obj)`, Semgrep will instantiate this signature with
- * taint assigned to `obj.a` in that calling context. If it is tainted, then
- * Semgrep will report a finding.
- *
- * Also note that, within each function, if there are multiple paths through
- * which a taint source may reach a sink, we do not keep all of them but only
- * the shortest one.
- *
- * THINK: Could we have a "taint shape" for functions/methods ?
- *)
-
-val show_result : result -> string
-val show_signature : signature -> string
+val compare_matches : Pattern_match.t -> Pattern_match.t -> int
+val compare_metavar_env : Metavariable.bindings -> Metavariable.bindings -> int

--- a/src/tainting/Taint_shape.mli
+++ b/src/tainting/Taint_shape.mli
@@ -61,7 +61,11 @@ and obj = ref Fields.t
  *)
 
 val equal_ref : ref -> ref -> bool
+val equal_shape : shape -> shape -> bool
+val compare_ref : ref -> ref -> int
+val compare_shape : shape -> shape -> int
 val show_ref : ref -> string
+val show_shape : shape -> string
 
 val union_ref : ref -> ref -> ref
 (** Merge refs at JOIN nodes of the CFG. *)

--- a/src/tainting/Taint_sig.ml
+++ b/src/tainting/Taint_sig.ml
@@ -1,0 +1,104 @@
+open Common
+module G = AST_generic
+module R = Rule
+module T = Taint
+module S = Taint_shape
+
+type sink = { pm : Pattern_match.t; rule_sink : R.taint_sink }
+
+let compare_sink { pm = pm1; rule_sink = sink1 } { pm = pm2; rule_sink = sink2 }
+    =
+  match String.compare sink1.Rule.sink_id sink2.Rule.sink_id with
+  | 0 -> T.compare_matches pm1 pm2
+  | other -> other
+
+let show_sink { rule_sink; _ } = rule_sink.R.sink_id
+
+type taint_to_sink_item = { taint : T.taint; sink_trace : unit T.call_trace }
+
+let show_taint_to_sink_item { taint; sink_trace } =
+  Printf.sprintf "%s@{%s}" (T.show_taint taint)
+    (Taint.show_call_trace [%show: unit] sink_trace)
+
+let show_taints_and_traces taints =
+  Common2.string_of_list show_taint_to_sink_item taints
+
+let compare_taint_to_sink_item { taint = taint1; sink_trace = _ }
+    { taint = taint2; sink_trace = _ } =
+  T.compare_taint taint1 taint2
+
+type taints_to_sink = {
+  (* These taints were incoming to the sink, under a certain
+     REQUIRES expression.
+     When we discharge the taint signature, we will produce
+     a certain number of findings suitable to how the sink was
+     reached.
+  *)
+  taints_with_precondition : taint_to_sink_item list * R.precondition;
+  sink : sink;
+  merged_env : Metavariable.bindings;
+}
+
+let compare_taints_to_sink
+    { taints_with_precondition = ttsis1, pre1; sink = sink1; merged_env = env1 }
+    { taints_with_precondition = ttsis2, pre2; sink = sink2; merged_env = env2 }
+    =
+  match compare_sink sink1 sink2 with
+  | 0 -> (
+      match List.compare compare_taint_to_sink_item ttsis1 ttsis2 with
+      | 0 -> (
+          match R.compare_precondition pre1 pre2 with
+          | 0 -> T.compare_metavar_env env1 env2
+          | other -> other)
+      | other -> other)
+  | other -> other
+
+type result =
+  | ToSink of taints_to_sink
+  | ToReturn of T.taint list * G.tok
+  | ToLval of T.taint list * T.lval (* TODO: CleanArg ? *)
+
+let show_taints_to_sink { taints_with_precondition = taints, _; sink; _ } =
+  Common.spf "%s ~~~> %s" (show_taints_and_traces taints) (show_sink sink)
+
+let show_result = function
+  | ToSink x -> show_taints_to_sink x
+  | ToReturn (taints, _) ->
+      Printf.sprintf "return (%s)" (Common2.string_of_list T.show_taint taints)
+  | ToLval (taints, lval) ->
+      Printf.sprintf "%s ----> %s"
+        (Common2.string_of_list T.show_taint taints)
+        (T.show_lval lval)
+
+let compare_result r1 r2 =
+  match (r1, r2) with
+  | ToSink tts1, ToSink tts2 -> compare_taints_to_sink tts1 tts2
+  | ToReturn (ts1, _tok1), ToReturn (ts2, _tok2) ->
+      List.compare T.compare_taint ts1 ts2
+  | ToLval (ts1, lv1), ToLval (ts2, lv2) -> (
+      match List.compare T.compare_taint ts1 ts2 with
+      | 0 -> T.compare_lval lv1 lv2
+      | other -> other)
+  | ToSink _, (ToReturn _ | ToLval _) -> -1
+  | ToReturn _, ToLval _ -> -1
+  | ToReturn _, ToSink _ -> 1
+  | ToLval _, (ToSink _ | ToReturn _) -> 1
+
+module Results = Set.Make (struct
+  type t = result
+
+  let compare = compare_result
+end)
+
+module Results_tbl = Hashtbl.Make (struct
+  type t = result
+
+  let equal r1 r2 = compare_result r1 r2 =|= 0
+  let hash = Hashtbl.hash
+end)
+
+type signature = Results.t
+
+let show_signature s =
+  s |> Results.to_seq |> List.of_seq |> List_.map show_result
+  |> String.concat " + "

--- a/src/tainting/Taint_sig.mli
+++ b/src/tainting/Taint_sig.mli
@@ -1,0 +1,83 @@
+(*****************************************************************************)
+(* Taint results & signatures *)
+(*****************************************************************************)
+
+type sink = { pm : Pattern_match.t; rule_sink : Rule.taint_sink }
+(** A sink match with its corresponding sink specification (one of the `pattern-sinks`). *)
+
+type taint_to_sink_item = {
+  taint : Taint.taint;
+  sink_trace : unit Taint.call_trace;
+      (** This trace is from the current calling context of the taint finding,
+        to the sink.
+        It's a `unit` call_trace because we don't actually need the item at the
+        end, and we need to be able to dispatch on the particular variant of taint
+        (source or arg).
+        *)
+}
+
+type taints_to_sink = {
+  taints_with_precondition : taint_to_sink_item list * Rule.precondition;
+      (** Taints reaching the sink and the precondition for the sink to apply. *)
+  sink : sink;
+  merged_env : Metavariable.bindings;
+      (** The metavariable environment that results of merging the environment from
+   * matching the source and the one from matching the sink. *)
+}
+
+(** Function-level result.
+  *
+  * 'ToSink' results where a taint source reaches a sink are candidates for
+  * actual Semgrep findings, although some may be dropped by deduplication.
+  *
+  * Results are computed for each function/method definition, and formulated
+  * using 'lval' taints to act as placeholders of the taint that may be passed
+  * by an arbitrary caller via the function arguments. Thus the results are
+  * polymorphic/context-sensitive, as the 'lval' taints can be instantiated
+  * accordingly at each call site.
+  *)
+type result =
+  | ToSink of taints_to_sink  (** Taints reach a sink. *)
+  | ToReturn of Taint.taint list * AST_generic.tok
+      (** Taints reach a `return` statement. *)
+  | ToLval of Taint.taint list * Taint.lval
+      (** Taints reach an l-value in the scope of the function/method. *)
+
+val compare_result : result -> result -> int
+
+module Results : Set.S with type elt = result
+module Results_tbl : Hashtbl.S with type key = result
+
+type signature = Results.t
+(** A (polymorphic) taint signature: simply a set of results for a function.
+ *
+ * Note that this signature is polymorphic/context-sensitive given that the
+ * potential taints coming into the function via its arguments are represented
+ * by 'lval' taints, that can be instantiated as needed.
+ *
+ * For example given:
+ *
+ *     def foo(x):
+ *         sink(x.a)
+ *
+ * We infer the signature (simplified):
+ *
+ *     {ToSink {taints_with_precondition = [(x#0).a]; sink = ... ; ...}}
+ *
+ * where '(x#0).a' is taint variable that denotes the taint of the offset `.a`
+ * of the parameter `x` (where '#0' means it is the first argument) of `foo`.
+ * The signature tells us that '(x#0).a' will reach a sink.
+ *
+ * Given a concrete call `foo(obj)`, Semgrep will instantiate this signature with
+ * taint assigned to `obj.a` in that calling context. If it is tainted, then
+ * Semgrep will report a finding.
+ *
+ * Also note that, within each function, if there are multiple paths through
+ * which a taint source may reach a sink, we do not keep all of them but only
+ * the shortest one.
+ *
+ * THINK: Could we have a "taint shape" for functions/methods ?
+ *)
+
+val show_result : result -> string
+val show_signature : signature -> string

--- a/src/tainting/Taint_smatch.ml
+++ b/src/tainting/Taint_smatch.ml
@@ -26,7 +26,7 @@ type 'spec t = {
 }
 
 let is_exact x = x.overlap > 0.99
-let sink_of_match x = { Taint.pm = x.spec_pm; rule_sink = x.spec }
+let sink_of_match x = { Taint_sig.pm = x.spec_pm; rule_sink = x.spec }
 
 let _show x =
   Range.content_at_range x.spec_pm.path.internal_path_to_content x.range

--- a/src/tainting/Taint_smatch.mli
+++ b/src/tainting/Taint_smatch.mli
@@ -31,7 +31,7 @@ type 'spec t = {
 val is_exact : 'spec t -> bool
 (** An exact match, i.e. overlap 0.99. Typically useful for l-values. *)
 
-val sink_of_match : Rule.taint_sink t -> Taint.sink
+val sink_of_match : Rule.taint_sink t -> Taint_sig.sink
 val _show : 'spec t -> string
 
 (** Any kind of spec-match (existential type). *)

--- a/src/tainting/Xtaint.ml
+++ b/src/tainting/Xtaint.ml
@@ -29,6 +29,16 @@ let equal xt1 xt2 =
   | `Clean, _ ->
       false
 
+let compare xt1 xt2 =
+  match (xt1, xt2) with
+  | `Tainted taints1, `Tainted taints2 -> Taints.compare taints1 taints2
+  | `None, `None
+  | `Clean, `Clean ->
+      0
+  | `Tainted _, _ -> -1
+  | `None, _ -> -1
+  | `Clean, _ -> 1
+
 let show = function
   | `Tainted taints -> Taint.show_taints taints
   | `None -> "0"

--- a/src/tainting/Xtaint.mli
+++ b/src/tainting/Xtaint.mli
@@ -13,6 +13,7 @@ type t_or_sanitized = [ t | `Sanitized ]
  * matching a sanitizer. See NOTE [lval/sanitized] in 'Dataflow_tainting'. *)
 
 val equal : t -> t -> bool
+val compare : t -> t -> int
 val show : t -> string
 
 val union : t -> t -> t


### PR DESCRIPTION
- IL: Separate dictionaries from "composites" (lists, tuples, and alike) and merge them with records.
- Separate taint signature's related types into a new `Taint_sig` module, this allows to later add shapes into signatures (otherwise there would be a cyclic module dependency between `Taint` and `Taint_shape`).
- Add comparisons functions for taint shapes.
 
test plan:
make test

