### PR TITLE
feat: allow TargetManager to exclude per product

### DIFF
--- a/cli/src/semgrep/commands/scan.py
+++ b/cli/src/semgrep/commands/scan.py
@@ -45,6 +45,7 @@ from semgrep.rule import Rule
 from semgrep.rule_match import RuleMatchMap
 from semgrep.semgrep_core import SemgrepCore
 from semgrep.state import get_state
+from semgrep.target_manager import ALL_PRODUCTS
 from semgrep.target_manager import write_pipes_to_disk
 from semgrep.util import abort
 from semgrep.util import with_color
@@ -777,7 +778,7 @@ def scan(
                     no_rewrite_rule_ids=(not rewrite_rule_ids),
                     jobs=jobs,
                     include=include,
-                    exclude=exclude,
+                    exclude={product: (exclude or ()) for product in ALL_PRODUCTS},
                     exclude_rule=exclude_rule,
                     max_target_bytes=max_target_bytes,
                     replacement=replacement,

--- a/cli/src/semgrep/run_scan.py
+++ b/cli/src/semgrep/run_scan.py
@@ -74,6 +74,9 @@ from semgrep.semgrep_types import JOIN_MODE
 from semgrep.state import get_state
 from semgrep.target_manager import ECOSYSTEM_TO_LOCKFILES
 from semgrep.target_manager import FileTargetingLog
+from semgrep.target_manager import SAST_PRODUCT
+from semgrep.target_manager import SCA_PRODUCT
+from semgrep.target_manager import SECRETS_PRODUCT
 from semgrep.target_manager import TargetManager
 from semgrep.target_mode import TargetModeConfig
 from semgrep.util import unit_str
@@ -122,13 +125,15 @@ def get_file_ignore() -> FileIgnore:
     return file_ignore
 
 
-def file_ignore_to_ignore_profiles(file_ignore: FileIgnore) -> Dict[str, FileIgnore]:
+def file_ignore_to_ignore_profiles(
+    file_ignore: FileIgnore,
+) -> Dict[Product, FileIgnore]:
     # TODO: This pattern encodes the default Targeting Profiles
     # of .semgrepignore. Don't hardcode this like it is.
     return {
-        out.SAST().kind: file_ignore,
-        out.SCA().kind: file_ignore,
-        out.Secrets().kind: FileIgnore(file_ignore.base_path, frozenset()),
+        SAST_PRODUCT: file_ignore,
+        SCA_PRODUCT: file_ignore,
+        SECRETS_PRODUCT: FileIgnore(file_ignore.base_path, frozenset()),
     }
 
 

--- a/cli/src/semgrep/run_scan.py
+++ b/cli/src/semgrep/run_scan.py
@@ -21,6 +21,7 @@ from typing import Any
 from typing import Collection
 from typing import Dict
 from typing import List
+from typing import Mapping
 from typing import Optional
 from typing import Sequence
 from typing import Set
@@ -68,6 +69,7 @@ from semgrep.semgrep_interfaces.semgrep_metrics import SecretsOrigin
 from semgrep.semgrep_interfaces.semgrep_metrics import Semgrep as SemgrepSecretsOrigin
 from semgrep.semgrep_interfaces.semgrep_metrics import SupplyChainConfig
 from semgrep.semgrep_interfaces.semgrep_output_v1 import FoundDependency
+from semgrep.semgrep_interfaces.semgrep_output_v1 import Product
 from semgrep.semgrep_types import JOIN_MODE
 from semgrep.state import get_state
 from semgrep.target_manager import ECOSYSTEM_TO_LOCKFILES
@@ -347,7 +349,7 @@ def run_scan(
     no_rewrite_rule_ids: bool = False,
     jobs: Optional[int] = None,
     include: Optional[Sequence[str]] = None,
-    exclude: Optional[Sequence[str]] = None,
+    exclude: Optional[Mapping[Product, Sequence[str]]] = None,
     exclude_rule: Optional[Sequence[str]] = None,
     strict: bool = False,
     autofix: bool = False,
@@ -404,7 +406,7 @@ def run_scan(
         include = []
 
     if exclude is None:
-        exclude = []
+        exclude = {}
 
     if exclude_rule is None:
         exclude_rule = []

--- a/cli/src/semgrep/target_manager.py
+++ b/cli/src/semgrep/target_manager.py
@@ -54,7 +54,7 @@ from semgrep.util import path_has_permissions, sub_check_output
 from semgrep.util import with_color
 from semgrep.verbose_logging import getLogger
 
-from semgrep.semgrep_interfaces.semgrep_output_v1 import Cargo, Product
+from semgrep.semgrep_interfaces.semgrep_output_v1 import Cargo
 from semgrep.semgrep_interfaces.semgrep_output_v1 import Ecosystem
 from semgrep.semgrep_interfaces.semgrep_output_v1 import Gem
 from semgrep.semgrep_interfaces.semgrep_output_v1 import Gomod
@@ -555,7 +555,7 @@ class TargetManager:
 
     target_strings: FrozenSet[Path]
     includes: Sequence[str] = Factory(list)
-    excludes: Mapping[Product, Sequence[str]] = Factory(dict)
+    excludes: Mapping[out.Product, Sequence[str]] = Factory(dict)
     max_target_bytes: int = -1
     respect_git_ignore: bool = False
     respect_rule_paths: bool = True

--- a/cli/src/semgrep/target_manager.py
+++ b/cli/src/semgrep/target_manager.py
@@ -561,8 +561,7 @@ class TargetManager:
     respect_rule_paths: bool = True
     baseline_handler: Optional[BaselineHandler] = None
     allow_unknown_extensions: bool = False
-    # ignore_profiles range is str of product.kind
-    ignore_profiles: Dict[str, FileIgnore] = Factory(dict)
+    ignore_profiles: Mapping[out.Product, FileIgnore] = Factory(dict)
     ignore_log: FileTargetingLog = Factory(FileTargetingLog, takes_self=True)
     targets: Sequence[Target] = field(init=False)
 
@@ -773,8 +772,8 @@ class TargetManager:
             files = self.filter_by_size(self.max_target_bytes, candidates=files.kept)
             self.ignore_log.size_limit.update(files.removed)
 
-        if product.kind in self.ignore_profiles:
-            file_ignore = self.ignore_profiles[product.kind]
+        if product in self.ignore_profiles:
+            file_ignore = self.ignore_profiles[product]
             files = file_ignore.filter_paths(candidates=files.kept)
             # TODO: Fix ignore_log to log which profile filtered which files.
             self.ignore_log.semgrepignored.update(files.removed)

--- a/cli/tests/default/e2e-pro/snapshots/test_ci/test_app_ignore/_foo.py/results.txt
+++ b/cli/tests/default/e2e-pro/snapshots/test_ci/test_app_ignore/_foo.py/results.txt
@@ -1,0 +1,141 @@
+=== command
+SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERSION_CACHE_PATH="<MASKED>" SEMGREP_ENABLE_VERSION_CHECK="0" SEMGREP_SEND_METRICS="off" semgrep ci --no-suppress-errors
+=== end of command
+
+=== exit code
+1
+=== end of exit code
+
+=== stdout - plain
+
+
+┌──────────────────────────┐
+│ 6 Blocking Code Findings │
+└──────────────────────────┘
+
+    foo.py
+   ❯❯❱ eqeq-bad
+          useless comparison
+
+            4┆ a == a
+            ⋮┆----------------------------------------
+            5┆ a == a
+            ⋮┆----------------------------------------
+            7┆ a == a
+            ⋮┆----------------------------------------
+           11┆ y == y
+
+   ❯❯❱ eqeq-four
+          useless comparison to 4
+
+           19┆ baz == 4
+
+    ❯❱ taint-test
+          unsafe use of danger
+
+           27┆ sink(d2)
+
+
+          Taint comes from:
+
+           26┆ d2 = danger
+
+
+          Taint flows through these intermediate variables:
+
+           26┆ d2 = danger
+
+
+                This is how taint reaches the sink:
+
+           27┆ sink(d2)
+
+
+
+┌──────────────────────────────────┐
+│ 1 Reachable Supply Chain Finding │
+└──────────────────────────────────┘
+
+    poetry.lock
+   ❯❯❱ supply-chain1
+          found a dependency
+
+            2┆ name = "badlib"
+
+
+┌─────────────────────────────┐
+│ 1 Non-blocking Code Finding │
+└─────────────────────────────┘
+
+    foo.py
+   ❯❯❱ eqeq-five
+          useless comparison to 5
+
+           ▶▶┆ Autofix ▶ (x == 2)
+           15┆ x == 5
+
+  BLOCKING CODE RULES FIRED:
+    eqeq-bad
+    eqeq-four
+    taint-test
+
+
+=== end of stdout - plain
+
+=== stderr - plain
+
+
+┌────────────────┐
+│ Debugging Info │
+└────────────────┘
+
+  SCAN ENVIRONMENT
+  versions    - semgrep <MASKED> on python <MASKED>
+  environment - running in environment git, triggering event is unknown
+
+  CONNECTION
+  Initializing scan (deployment=org_name, scan_id=12345)
+  Enabled products: Code, Supply Chain
+
+  ENGINE
+  Using Semgrep Pro Version: <MASKED>
+  Installed at <MASKED>
+
+
+┌─────────────┐
+│ Scan Status │
+└─────────────┘
+  Scanning 4 files tracked by git with 4 Code rules, 3 Supply Chain rules:
+
+
+  CODE RULES
+  Scanning 1 file with 4 python rules.
+
+  SUPPLY CHAIN RULES
+  Scanning 1 file.
+
+
+┌──────────────┐
+│ Scan Summary │
+└──────────────┘
+Some files were skipped or only partially analyzed.
+  Scan was limited to files tracked by git.
+
+CI scan completed successfully.
+  Found 8 findings (6 blocking) from 7 rules.
+  Uploading scan results
+  Finalizing scan           View results in Semgrep Cloud Platform:
+    https://semgrep.dev/orgs/org_name/findings?repo=local_scan/checkout_project_name&ref=some/branch-name
+    https://semgrep.dev/orgs/org_name/supply-chain
+  Has findings for blocking rules so exiting with code 1
+  semgrep.dev is suggesting a non-zero exit code (Test Reason)
+
+=== end of stderr - plain
+
+=== stdout - color
+<same as above: stdout - plain>
+=== end of stdout - color
+
+=== stderr - color
+<same as above: stderr - plain>
+=== end of stderr - color

--- a/cli/tests/default/e2e-pro/snapshots/test_ci/test_app_ignore/empty/results.txt
+++ b/cli/tests/default/e2e-pro/snapshots/test_ci/test_app_ignore/empty/results.txt
@@ -1,0 +1,141 @@
+=== command
+SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERSION_CACHE_PATH="<MASKED>" SEMGREP_ENABLE_VERSION_CHECK="0" SEMGREP_SEND_METRICS="off" semgrep ci --no-suppress-errors
+=== end of command
+
+=== exit code
+1
+=== end of exit code
+
+=== stdout - plain
+
+
+┌──────────────────────────┐
+│ 6 Blocking Code Findings │
+└──────────────────────────┘
+
+    foo.py
+   ❯❯❱ eqeq-bad
+          useless comparison
+
+            4┆ a == a
+            ⋮┆----------------------------------------
+            5┆ a == a
+            ⋮┆----------------------------------------
+            7┆ a == a
+            ⋮┆----------------------------------------
+           11┆ y == y
+
+   ❯❯❱ eqeq-four
+          useless comparison to 4
+
+           19┆ baz == 4
+
+    ❯❱ taint-test
+          unsafe use of danger
+
+           27┆ sink(d2)
+
+
+          Taint comes from:
+
+           26┆ d2 = danger
+
+
+          Taint flows through these intermediate variables:
+
+           26┆ d2 = danger
+
+
+                This is how taint reaches the sink:
+
+           27┆ sink(d2)
+
+
+
+┌──────────────────────────────────┐
+│ 1 Reachable Supply Chain Finding │
+└──────────────────────────────────┘
+
+    poetry.lock
+   ❯❯❱ supply-chain1
+          found a dependency
+
+            2┆ name = "badlib"
+
+
+┌─────────────────────────────┐
+│ 1 Non-blocking Code Finding │
+└─────────────────────────────┘
+
+    foo.py
+   ❯❯❱ eqeq-five
+          useless comparison to 5
+
+           ▶▶┆ Autofix ▶ (x == 2)
+           15┆ x == 5
+
+  BLOCKING CODE RULES FIRED:
+    eqeq-bad
+    eqeq-four
+    taint-test
+
+
+=== end of stdout - plain
+
+=== stderr - plain
+
+
+┌────────────────┐
+│ Debugging Info │
+└────────────────┘
+
+  SCAN ENVIRONMENT
+  versions    - semgrep <MASKED> on python <MASKED>
+  environment - running in environment git, triggering event is unknown
+
+  CONNECTION
+  Initializing scan (deployment=org_name, scan_id=12345)
+  Enabled products: Code, Supply Chain
+
+  ENGINE
+  Using Semgrep Pro Version: <MASKED>
+  Installed at <MASKED>
+
+
+┌─────────────┐
+│ Scan Status │
+└─────────────┘
+  Scanning 4 files tracked by git with 4 Code rules, 3 Supply Chain rules:
+
+
+  CODE RULES
+  Scanning 1 file with 4 python rules.
+
+  SUPPLY CHAIN RULES
+  Scanning 1 file.
+
+
+┌──────────────┐
+│ Scan Summary │
+└──────────────┘
+Some files were skipped or only partially analyzed.
+  Scan was limited to files tracked by git.
+
+CI scan completed successfully.
+  Found 8 findings (6 blocking) from 7 rules.
+  Uploading scan results
+  Finalizing scan           View results in Semgrep Cloud Platform:
+    https://semgrep.dev/orgs/org_name/findings?repo=local_scan/checkout_project_name&ref=some/branch-name
+    https://semgrep.dev/orgs/org_name/supply-chain
+  Has findings for blocking rules so exiting with code 1
+  semgrep.dev is suggesting a non-zero exit code (Test Reason)
+
+=== end of stderr - plain
+
+=== stdout - color
+<same as above: stdout - plain>
+=== end of stdout - color
+
+=== stderr - color
+<same as above: stderr - plain>
+=== end of stderr - color

--- a/cli/tests/default/e2e-pro/snapshots/test_ci/test_app_ignore/foo.py/results.txt
+++ b/cli/tests/default/e2e-pro/snapshots/test_ci/test_app_ignore/foo.py/results.txt
@@ -1,0 +1,83 @@
+=== command
+SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERSION_CACHE_PATH="<MASKED>" SEMGREP_ENABLE_VERSION_CHECK="0" SEMGREP_SEND_METRICS="off" semgrep ci --no-suppress-errors
+=== end of command
+
+=== exit code
+1
+=== end of exit code
+
+=== stdout - plain
+
+
+┌──────────────────────────────────┐
+│ 1 Reachable Supply Chain Finding │
+└──────────────────────────────────┘
+
+    poetry.lock
+   ❯❯❱ supply-chain1
+          found a dependency
+
+            2┆ name = "badlib"
+
+
+=== end of stdout - plain
+
+=== stderr - plain
+
+
+┌────────────────┐
+│ Debugging Info │
+└────────────────┘
+
+  SCAN ENVIRONMENT
+  versions    - semgrep <MASKED> on python <MASKED>
+  environment - running in environment git, triggering event is unknown
+
+  CONNECTION
+  Initializing scan (deployment=org_name, scan_id=12345)
+  Enabled products: Code, Supply Chain
+
+  ENGINE
+  Using Semgrep Pro Version: <MASKED>
+  Installed at <MASKED>
+
+
+┌─────────────┐
+│ Scan Status │
+└─────────────┘
+  Scanning 4 files tracked by git with 4 Code rules, 3 Supply Chain rules:
+
+
+  CODE RULES
+  Nothing to scan.
+
+  SUPPLY CHAIN RULES
+  Nothing to scan.
+
+
+┌──────────────┐
+│ Scan Summary │
+└──────────────┘
+Some files were skipped or only partially analyzed.
+  Scan was limited to files tracked by git.
+  Scan skipped: 1 files matching --exclude patterns
+  For a full list of skipped files, run semgrep with the --verbose flag.
+
+CI scan completed successfully.
+  Found 1 finding (0 blocking) from 7 rules.
+  Uploading scan results
+  Finalizing scan           View results in Semgrep Cloud Platform:
+    https://semgrep.dev/orgs/org_name/findings?repo=local_scan/checkout_project_name&ref=some/branch-name
+    https://semgrep.dev/orgs/org_name/supply-chain
+  No blocking findings so exiting with code 0
+  semgrep.dev is suggesting a non-zero exit code (Test Reason)
+
+=== end of stderr - plain
+
+=== stdout - color
+<same as above: stdout - plain>
+=== end of stdout - color
+
+=== stderr - color
+<same as above: stderr - plain>
+=== end of stderr - color

--- a/cli/tests/default/unit/targeting/test_target_manager.py
+++ b/cli/tests/default/unit/targeting/test_target_manager.py
@@ -252,11 +252,11 @@ def test_explicit_path(tmp_path, monkeypatch):
     )
 
     # Should include explicitly passed python file even if is in excludes
-    assert foo_a not in TargetManager(["."], [], ["foo/a.py"]).get_files_for_rule(
-        python_language, [], [], "dummy_rule_id", SAST_PRODUCT
-    )
+    assert foo_a not in TargetManager(
+        ["."], [], {SAST_PRODUCT: ["foo/a.py"]}
+    ).get_files_for_rule(python_language, [], [], "dummy_rule_id", SAST_PRODUCT)
     assert foo_a in TargetManager(
-        [".", "foo/a.py"], [], ["foo/a.py"]
+        [".", "foo/a.py"], [], {SAST_PRODUCT: ["foo/a.py"]}
     ).get_files_for_rule(python_language, [], [], "dummy_rule_id", SAST_PRODUCT)
 
     # Should ignore expliclty passed .go file when requesting python


### PR DESCRIPTION
Updates pysemgrep's `TargetManager` to track exclude information on a per-product basis. The main application of this is to allow us to send per-product information from the App, instead of setting it for all products, or providing command-line flags which allow specifying `--exclude` for certain products only.

Test plan: addition pytest coverage; `make test`.