### PR TITLE
osemgrep: finish porting the --test and fixtest

### DIFF
--- a/cli/tests/default/e2e/rules/fixtest/fix_trailing_newline.yaml
+++ b/cli/tests/default/e2e/rules/fixtest/fix_trailing_newline.yaml
@@ -1,0 +1,9 @@
+rules:
+- id: basic-fix
+  pattern: "42"
+  fix: |
+    666
+  message: |
+      Do not use 42
+  languages: [go]
+  severity: WARNING

--- a/cli/tests/default/e2e/snapshots/test_fixtest/test_fix_trailing_newline/test-results.json
+++ b/cli/tests/default/e2e/snapshots/test_fixtest/test_fix_trailing_newline/test-results.json
@@ -1,0 +1,21 @@
+{
+  "config_missing_fixtests": [],
+  "config_missing_tests": [],
+  "config_with_errors": [],
+  "fixtest_results": {
+    "targets/fixtest/basic.go": {
+      "passed": true
+    }
+  },
+  "results": {
+    "rules/fixtest/fix_trailing_newline.yaml": {
+      "checks": {
+        "basic-fix": {
+          "errors": [],
+          "matches": "<masked in tests>",
+          "passed": true
+        }
+      }
+    }
+  }
+}

--- a/cli/tests/default/e2e/snapshots/test_output/test_debug_experimental_rule/results.txt
+++ b/cli/tests/default/e2e/snapshots/test_output/test_debug_experimental_rule/results.txt
@@ -57,6 +57,7 @@ Running Semgrep engine with command:
 [<MASKED>][DEBUG](default): Skipping logs for tls.config
 [<MASKED>][DEBUG](default): Skipping logs for tls.tracing
 [<MASKED>][DEBUG](default): Skipping logs for x509
+[<MASKED>][DEBUG](default): Skipping logs for semgrep.core_scan
 [<MASKED>][DEBUG](default): Skipping logs for semgrep.engine
 [<MASKED>][DEBUG](default): Skipping logs for semgrep.fixing
 [<MASKED>][DEBUG](default): Skipping logs for semgrep.parsing
@@ -199,6 +200,7 @@ Running Semgrep engine with command:
 [<MASKED>][[32mDEBUG[0m](default): Skipping logs for tls.config
 [<MASKED>][[32mDEBUG[0m](default): Skipping logs for tls.tracing
 [<MASKED>][[32mDEBUG[0m](default): Skipping logs for x509
+[<MASKED>][[32mDEBUG[0m](default): Skipping logs for semgrep.core_scan
 [<MASKED>][[32mDEBUG[0m](default): Skipping logs for semgrep.engine
 [<MASKED>][[32mDEBUG[0m](default): Skipping logs for semgrep.fixing
 [<MASKED>][[32mDEBUG[0m](default): Skipping logs for semgrep.parsing

--- a/cli/tests/default/e2e/targets/fixtest/basic.fixed.go
+++ b/cli/tests/default/e2e/targets/fixtest/basic.fixed.go
@@ -1,0 +1,8 @@
+func test1() {
+	// ruleid: basic-fix
+	return 666
+}
+
+func test2() {
+	return 52
+}

--- a/cli/tests/default/e2e/targets/fixtest/basic.go
+++ b/cli/tests/default/e2e/targets/fixtest/basic.go
@@ -1,0 +1,8 @@
+func test1() {
+	// ruleid: basic-fix
+	return 42
+}
+
+func test2() {
+	return 52
+}

--- a/cli/tests/default/e2e/test_fixtest.py
+++ b/cli/tests/default/e2e/test_fixtest.py
@@ -201,3 +201,16 @@ def test_missing_fixtest_fix_regex(run_semgrep_in_tmp: RunSemgrep, snapshot):
         output_format=OutputFormat.JSON,
     )
     snapshot.assert_match(stdout, "test-results.json")
+
+
+# It should not add the trailing newlines in a fix: replacement string
+# in the fixed file
+@pytest.mark.kinda_slow
+def test_fix_trailing_newline(run_semgrep_in_tmp: RunSemgrep, snapshot):
+    stdout, _ = run_semgrep_in_tmp(
+        "rules/fixtest/fix_trailing_newline.yaml",
+        target_name="fixtest/basic.go",
+        options=["--test"],
+        output_format=OutputFormat.JSON,
+    )
+    snapshot.assert_match(stdout, "test-results.json")

--- a/cli/tests/default/e2e/test_fixtest.py
+++ b/cli/tests/default/e2e/test_fixtest.py
@@ -203,8 +203,12 @@ def test_missing_fixtest_fix_regex(run_semgrep_in_tmp: RunSemgrep, snapshot):
     snapshot.assert_match(stdout, "test-results.json")
 
 
-# It should not add the trailing newlines in a fix: replacement string
-# in the fixed file
+# It should not add the trailing newlines from a fix: replacement string
+# in the fixed file.
+# Note that this matters only for languages where the AST-based autofix
+# is not supported (e.g., Go); Indeed, with AST-based autofix semgrep-core
+# is parsing the fix pattern and then pretty print back the transformed
+# pattern, so newlines do not matter.
 @pytest.mark.kinda_slow
 def test_fix_trailing_newline(run_semgrep_in_tmp: RunSemgrep, snapshot):
     stdout, _ = run_semgrep_in_tmp(

--- a/src/core/Rule.ml
+++ b/src/core/Rule.ml
@@ -621,7 +621,22 @@ type 'mode rule_info = {
    * TODO: if we resurrect the feature, we should parse the string
    *)
   equivalences : string list option;
-  (* a.k.a autofix *)
+  (* Optional replacement pattern, a.k.a autofix.
+   *
+   * Note that the pattern string is passed through String.trim() during rule
+   * parsing. This is to handle rules like
+   *
+   *        pattern: foobar($X)
+   *        fix: |
+   *            bar($X)
+   * which are parsed by the yaml parser as 'fix: "bar($X)\n"', but we don't
+   * want the extra newline added by the autofix.
+   * history: this used to be done only on the pysemgrep side in rule_match.py
+   * but better to do it here so osemgrep behaves like pysemgrep.
+   * Note that this trimming is useful only for languages where the AST-based
+   * autofix is not supported, in which case we don't parse the fix pattern
+   * but perform a basic textual replacement on the fix pattern string.
+   *)
   fix : string option;
   fix_regexp : fix_regexp option;
   (* TODO: we should get rid of this and instead provide a more general

--- a/src/core_scan/Core_scan.ml
+++ b/src/core_scan/Core_scan.ml
@@ -575,8 +575,6 @@ let rules_from_rule_source (caps : < Cap.tmp >) (config : Core_scan_config.t) :
         (* TODO: ensure that this doesn't happen *)
         failwith "missing rules"
   in
-  Log.debug (fun m -> m "core scan rules = ");
-  rules |> List.iter (fun r -> Log.debug (fun m -> m "%s" (Rule.show r)));
   (rules, rule_errors)
 [@@trace]
 

--- a/src/core_scan/Core_scan.ml
+++ b/src/core_scan/Core_scan.ml
@@ -565,14 +565,19 @@ let rules_from_rule_source (caps : < Cap.tmp >) (config : Core_scan_config.t) :
              (replace_named_pipe_by_regular_file caps file))
     | other -> other
   in
-  match rule_source with
-  | Some (Core_scan_config.Rule_file file) ->
-      Log.debug (fun m -> m "Parsing %s:\n%s" !!file (UFile.read_file file));
-      Parse_rule.parse_and_filter_invalid_rules ~rewrite_rule_ids:None file
-  | Some (Core_scan_config.Rules rules) -> (rules, [])
-  | None ->
-      (* TODO: ensure that this doesn't happen *)
-      failwith "missing rules"
+  let rules, rule_errors =
+    match rule_source with
+    | Some (Core_scan_config.Rule_file file) ->
+        Log.debug (fun m -> m "Parsing %s:\n%s" !!file (UFile.read_file file));
+        Parse_rule.parse_and_filter_invalid_rules ~rewrite_rule_ids:None file
+    | Some (Core_scan_config.Rules rules) -> (rules, [])
+    | None ->
+        (* TODO: ensure that this doesn't happen *)
+        failwith "missing rules"
+  in
+  Log.debug (fun m -> m "core scan rules = ");
+  rules |> List.iter (fun r -> Log.debug (fun m -> m "%s" (Rule.show r)));
+  (rules, rule_errors)
 [@@trace]
 
 (* TODO? this is currently deprecated, but pad still has hope the

--- a/src/core_scan/Core_scan.ml
+++ b/src/core_scan/Core_scan.ml
@@ -22,7 +22,9 @@ module RP = Core_result
 module In = Input_to_core_j
 module OutJ = Semgrep_output_v1_j
 
-let tags = Logs_.create_tags [ __MODULE__ ]
+let src = Logs.Src.create "semgrep.core_scan"
+
+module Log = (val Logs.src_log src : Logs.LOG)
 
 (*****************************************************************************)
 (* Purpose *)
@@ -457,8 +459,8 @@ let filter_files_with_too_many_matches_and_transform_as_timeout
     offending_file_list
     |> List_.map (fun file ->
            (* logging useful info for rule writers *)
-           Logs.debug (fun m ->
-               m ~tags "too many matches on %s, generating exn for it" file);
+           Log.warn (fun m ->
+               m "too many matches on %s, generating exn for it" file);
            let sorted_offending_rules =
              let matches = List.assoc file per_files in
              matches
@@ -479,9 +481,8 @@ let filter_files_with_too_many_matches_and_transform_as_timeout
              | _ -> assert false
            in
            let (id, pat), cnt = biggest_offending_rule in
-           Logs.debug (fun m ->
-               m ~tags
-                 "most offending rule: id = %s, matches = %d, pattern = %s"
+           Log.warn (fun m ->
+               m "most offending rule: id = %s, matches = %d, pattern = %s"
                  (Rule_ID.to_string id) cnt pat);
 
            (* todo: we should maybe use a new error: TooManyMatches of int * string*)
@@ -566,8 +567,7 @@ let rules_from_rule_source (caps : < Cap.tmp >) (config : Core_scan_config.t) :
   in
   match rule_source with
   | Some (Core_scan_config.Rule_file file) ->
-      Logs.debug (fun m ->
-          m ~tags "%s" (spf "Parsing %s:\n%s" !!file (UFile.read_file file)));
+      Log.debug (fun m -> m "Parsing %s:\n%s" !!file (UFile.read_file file));
       Parse_rule.parse_and_filter_invalid_rules ~rewrite_rule_ids:None file
   | Some (Core_scan_config.Rules rules) -> (rules, [])
   | None ->
@@ -608,8 +608,8 @@ let iter_targets_and_get_matches_and_exn_to_errors (config : Core_scan_config.t)
     |> map_targets config.ncores (fun (target : Target.t) ->
            let internal_path = Target.internal_path target in
            let origin = Target.origin target in
-           Logs.debug (fun m ->
-               m ~tags "Analyzing %s (contents in %s)" (Origin.to_string origin)
+           Log.info (fun m ->
+               m "Analyzing %s (contents in %s)" (Origin.to_string origin)
                  !!internal_path);
            let (res, was_scanned), run_time =
              Common.with_time (fun () ->
@@ -648,8 +648,8 @@ let iter_targets_and_get_matches_and_exn_to_errors (config : Core_scan_config.t)
                         * not testing -max_memory.
                         *)
                        if config.test then Gc.full_major ();
-                       Logs.debug (fun m ->
-                           m ~tags "done with %s (contents in %s)"
+                       Log.info (fun m ->
+                           m "done with %s (contents in %s)"
                              (Origin.to_string origin) !!internal_path);
 
                        (res, was_scanned))
@@ -665,18 +665,17 @@ let iter_targets_and_get_matches_and_exn_to_errors (config : Core_scan_config.t)
                      (match !Match_patterns.last_matched_rule with
                      | None -> ()
                      | Some rule ->
-                         Logs.debug (fun m ->
-                             m ~tags "critical exn while matching ruleid %s"
+                         Log.warn (fun m ->
+                             m "critical exn while matching ruleid %s"
                                (Rule_ID.to_string rule.id);
-                             Logs.debug (fun m ->
-                                 m ~tags "full pattern is: %s"
-                                   rule.MR.pattern_string)));
+                             Log.debug (fun m ->
+                                 m "full pattern is: %s" rule.MR.pattern_string)));
                      let loc = Tok.first_loc_of_file !!internal_path in
                      let errors =
                        match exn with
                        | Match_rules.File_timeout rule_ids ->
-                           Logs.debug (fun m ->
-                               m ~tags "Timeout on %s (contents in %s)"
+                           Log.warn (fun m ->
+                               m "Timeout on %s (contents in %s)"
                                  (Origin.to_string origin) !!internal_path);
                            (* TODO what happened here is several rules
                               timed out while trying to scan a file.
@@ -693,8 +692,8 @@ let iter_targets_and_get_matches_and_exn_to_errors (config : Core_scan_config.t)
                                     OutJ.Timeout)
                            |> E.ErrorSet.of_list
                        | Out_of_memory ->
-                           Logs.warn (fun m ->
-                               m ~tags "OutOfMemory on %s (contents in %s)"
+                           Log.warn (fun m ->
+                               m "OutOfMemory on %s (contents in %s)"
                                  (Origin.to_string origin) !!internal_path);
                            E.ErrorSet.singleton
                              (E.mk_error !Rule.last_matched_rule loc ""
@@ -835,8 +834,7 @@ let targets_of_config (caps : < Cap.tmp >) (config : Core_scan_config.t) :
       (* sanity checking *)
       (* in deep mode we actually have a single root dir passed *)
       if roots <> [] then
-        Logs.err (fun m ->
-            m ~tags "if you use -targets, you should not specify files");
+        Log.err (fun m -> m "if you use -targets, you should not specify files");
       (* TODO: ugly, this is because the code path for -e/-f requires
        * a language, even with a -target, see test_target_file.py
        *)
@@ -1084,9 +1082,8 @@ let scan ?match_hook (caps : < Cap.tmp >) config
     ];
 
   (* Let's go! *)
-  Logs.debug (fun m ->
-      m ~tags "processing %d files, skipping %d files" num_targets
-        num_skipped_targets);
+  Log.info (fun m ->
+      m "processing %d files, skipping %d files" num_targets num_skipped_targets);
   let file_results, scanned_targets =
     all_targets
     |> iter_targets_and_get_matches_and_exn_to_errors config
@@ -1122,8 +1119,7 @@ let scan ?match_hook (caps : < Cap.tmp >) config
   let num_errors = List.length res.errors in
   Tracing.add_data_to_opt_span config.top_level_span
     [ ("num_matches", `Int num_matches); ("num_errors", `Int num_errors) ];
-  Logs.debug (fun m ->
-      m ~tags "found %d matches, %d errors" num_matches num_errors);
+  Log.info (fun m -> m "found %d matches, %d errors" num_matches num_errors);
 
   let processed_matches, new_errors, new_skipped =
     filter_files_with_too_many_matches_and_transform_as_timeout
@@ -1140,8 +1136,8 @@ let scan ?match_hook (caps : < Cap.tmp >) config
 
   (* Concatenate all the skipped targets *)
   let skipped_targets = skipped @ new_skipped @ res.skipped_targets in
-  Logs.debug (fun m ->
-      m ~tags "there were %d skipped targets" (List.length skipped_targets));
+  Log.info (fun m ->
+      m "there were %d skipped targets" (List.length skipped_targets));
   (* TODO: returning, or not skipped_targets does not seem to have any impact
    * on our testsuite, weird. We need to add more tests. Maybe because
    * both pysemgrep and osemgrep do their own skip targets management.
@@ -1170,6 +1166,5 @@ let scan_with_exn_handler (caps : < Cap.tmp >) (config : Core_scan_config.t) :
   with
   | exn when not !Flag_semgrep.fail_fast ->
       let e = Exception.catch exn in
-      Logs.debug (fun m ->
-          m ~tags "Uncaught exception: %s" (Exception.to_string e));
+      Log.err (fun m -> m "Uncaught exception: %s" (Exception.to_string e));
       Error (e, None)

--- a/src/osemgrep/cli_test/Test_subcommand.ml
+++ b/src/osemgrep/cli_test/Test_subcommand.ml
@@ -487,7 +487,9 @@ let run_conf (caps : caps) (conf : Test_CLI.conf) : Exit_code.t =
                (* TODO? sanity check? call metachecker Check_rule.check()?
                 * TODO: error managementm parsing errors?
                 *)
-               let rules = Parse_rule.parse rule_file in
+               let rules, _errorsTODO =
+                 Parse_rule.parse_and_filter_invalid_rules rule_file
+               in
                match Test_engine.find_target_of_yaml_file_opt rule_file with
                | None ->
                    (* stricter: (but reported via config_missing_tests in JSON)*)

--- a/src/parsing/Parse_rule.ml
+++ b/src/parsing/Parse_rule.ml
@@ -1069,8 +1069,12 @@ let parse_file ?error_recovery ?(rewrite_rule_ids = None) file =
 (* Main Entry point *)
 (*****************************************************************************)
 
-let parse_and_filter_invalid_rules ?rewrite_rule_ids file =
-  parse_file ~error_recovery:true ?rewrite_rule_ids file
+let parse_and_filter_invalid_rules ?rewrite_rule_ids (file : Fpath.t) =
+  let rules, errors = parse_file ~error_recovery:true ?rewrite_rule_ids file in
+  Log.debug (fun m ->
+      m "Parse_rule.parse_and_filter_invalid_rules(%s) = " !!file);
+  rules |> List.iter (fun r -> Log.debug (fun m -> m "%s" (Rule.show r)));
+  (rules, errors)
 [@@profiling]
 
 let parse_xpattern xlang (str, tok) =

--- a/src/parsing/Parse_rule.ml
+++ b/src/parsing/Parse_rule.ml
@@ -125,6 +125,7 @@ let parse_fix_regex (env : env) (key : key) fields =
   let (regex : string R.wrap) =
     take_key fix_regex_dict env parse_string_wrap "regex"
   in
+  (* TODO? should we String.trim for consistency with fix: ? *)
   let (replacement : string) =
     take_key fix_regex_dict env parse_string "replacement"
   in
@@ -932,7 +933,7 @@ let parse_one_rule ~rewrite_rule_ids (i : int) (rule : G.expr) : Rule.t =
     product;
     (* optional fields *)
     metadata = metadata_opt;
-    fix = fix_opt;
+    fix = fix_opt |> Option.map String.trim;
     fix_regexp = fix_regex_opt;
     paths = paths_opt;
     equivalences = equivs_opt;


### PR DESCRIPTION
test plan:
run pysemgrep --test on semgrep-rules/ and osemgrep --test
and compare the JSON output and try to reduce the difference
in output to 0

This is the script `compare.sh` I'm currently using:
```
#!/usr/bin/bash
# assumes semgrep (pysemgrep) is in the PATH
LANG=$1
#set -e
semgrep --test $LANG --json > /tmp/json1 2>/dev/null
~/yy/bin/osemgrep test $LANG --json > /tmp/json2
json-diff /tmp/json1 /tmp/json2
```
and when run for example on `compare.sh semgrep-rules/go` it does not report any difference (meaning osemgrep and pysemgrep JSON outputs are the same)