### PR TITLE
Remove some @osemfail for tests that are now passing!

### DIFF
--- a/cli/tests/default/e2e/snapshots/test_max_target_bytes/test_max_target_bytes/1.3R/error.txt
+++ b/cli/tests/default/e2e/snapshots/test_max_target_bytes/test_max_target_bytes/1.3R/error.txt
@@ -2,5 +2,3 @@ semgrep scan: option '--max-target-bytes': Invalid representation for a
               number of bytes: 1.3R
 Usage: semgrep scan [OPTION]… [TARGETS]…
 Try 'semgrep scan --help' for more information.
-Error: fatal error
-Exiting with error status 2: osemgrep --max-target-bytes 1.3R --strict --config rules/eqeq.yaml --json targets/basic

--- a/cli/tests/default/e2e/snapshots/test_max_target_bytes/test_max_target_bytes_osemfail/1.3R/error.txt
+++ b/cli/tests/default/e2e/snapshots/test_max_target_bytes/test_max_target_bytes_osemfail/1.3R/error.txt
@@ -1,4 +1,0 @@
-semgrep scan: option '--max-target-bytes': Invalid representation for a
-              number of bytes: 1.3R
-Usage: semgrep scan [OPTION]… [TARGETS]…
-Try 'semgrep scan --help' for more information.

--- a/cli/tests/default/e2e/test_exclude_include.py
+++ b/cli/tests/default/e2e/test_exclude_include.py
@@ -44,7 +44,6 @@ LS = ["--x-ls"]
     ],
     ids=idfn,
 )
-@pytest.mark.osemfail
 def test_exclude_include(run_semgrep_in_tmp: RunSemgrep, snapshot, options):
     stdout, stderr = run_semgrep_in_tmp(
         "rules/eqeq.yaml",  # unused

--- a/cli/tests/default/e2e/test_fixtest.py
+++ b/cli/tests/default/e2e/test_fixtest.py
@@ -18,7 +18,6 @@ from semgrep.constants import OutputFormat
 # It should report passing fixtests in the text output.
 # TODO: rename test_passed_text_output
 @pytest.mark.kinda_slow
-@pytest.mark.osemfail
 def test_fixtest_test1_no_json(run_semgrep_in_tmp: RunSemgrep, snapshot):
     results, _ = run_semgrep_in_tmp(
         "rules/fixtest/basic_fix.yaml",
@@ -36,7 +35,6 @@ def test_fixtest_test1_no_json(run_semgrep_in_tmp: RunSemgrep, snapshot):
 # It should report passing fixtests in the JSON output.
 # TODO: rename test_passed_json_output
 @pytest.mark.kinda_slow
-@pytest.mark.osemfail
 def test_fixtest_test1_json(run_semgrep_in_tmp: RunSemgrep, snapshot):
     stdout, _ = run_semgrep_in_tmp(
         "rules/fixtest/basic_fix.yaml",
@@ -67,7 +65,6 @@ def test_fixtest_test2_no_json(run_semgrep_in_tmp: RunSemgrep, snapshot):
 # It should report config_missing_fixtests in the JSON output.
 # TODO: rename test_missing_fixtest_json_output aka test_config_missing_fixtests
 @pytest.mark.kinda_slow
-@pytest.mark.osemfail
 def test_fixtest_test2_json(run_semgrep_in_tmp: RunSemgrep, snapshot):
     stdout, _ = run_semgrep_in_tmp(
         "rules/fixtest/basic_fix.yaml",
@@ -100,7 +97,6 @@ def test_fixtest_test3_no_json(run_semgrep_in_tmp: RunSemgrep, snapshot):
 # It should report '"passed": false' for a bad fixtest in the JSON output.
 # TODO: rename test_fixtest_not_passed_json_output
 @pytest.mark.kinda_slow
-@pytest.mark.osemfail
 def test_fixtest_test3_json(run_semgrep_in_tmp: RunSemgrep, snapshot):
     stdout, _ = run_semgrep_in_tmp(
         "rules/fixtest/other_fix.yaml",

--- a/cli/tests/default/e2e/test_max_target_bytes.py
+++ b/cli/tests/default/e2e/test_max_target_bytes.py
@@ -3,7 +3,7 @@ from tests.fixtures import RunSemgrep
 
 
 @pytest.mark.kinda_slow
-@pytest.mark.parametrize("max_bytes", ["1MB"])
+@pytest.mark.parametrize("max_bytes", ["1MB", "1.3R"])
 def test_max_target_bytes(run_semgrep_in_tmp: RunSemgrep, snapshot, max_bytes):
     stdout, stderr = run_semgrep_in_tmp(
         "rules/eqeq.yaml",
@@ -16,7 +16,12 @@ def test_max_target_bytes(run_semgrep_in_tmp: RunSemgrep, snapshot, max_bytes):
 
 
 @pytest.mark.kinda_slow
-@pytest.mark.parametrize("max_bytes", ["1B", "1.3R"])
+@pytest.mark.parametrize(
+    "max_bytes",
+    [
+        "1B",
+    ],
+)
 @pytest.mark.osemfail
 def test_max_target_bytes_osemfail(run_semgrep_in_tmp: RunSemgrep, snapshot, max_bytes):
     test_max_target_bytes(run_semgrep_in_tmp, snapshot, max_bytes)

--- a/cli/tests/default/e2e/test_output.py
+++ b/cli/tests/default/e2e/test_output.py
@@ -301,7 +301,6 @@ def test_omit_inventory(run_semgrep_in_tmp: RunSemgrep, snapshot):
 
 # it should not report findings from rules using the "EXPERIMENT" severity
 @pytest.mark.kinda_slow
-@pytest.mark.osemfail
 def test_omit_experiment(run_semgrep_in_tmp: RunSemgrep, snapshot):
     stdout, _ = run_semgrep_in_tmp(
         "rules/severity_experiment.yaml",


### PR DESCRIPTION
The fix of those tests were actually in previous PRs, where
we didn't realize those tests were now passing.

Test_fixtest.py (thx to my work on osemgrep test)
test_output.py, test_max_target_bytes (thx to Logs.info in Main.ml
 instead of eprintf)
test_include_exclude.py (thx to Martin)

198 -> 218 osempass :)

test plan:
make osempass
make osempass-check-if-new-osempass is empty now