### PR TITLE
Update to returntocorp/ocaml:alpine-2024-04-25 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -99,7 +99,7 @@ COPY cli/src/semgrep/semgrep_interfaces cli/src/semgrep/semgrep_interfaces
 # Visit https://hub.docker.com/r/returntocorp/ocaml/tags to see the latest
 # images available.
 #
-FROM returntocorp/ocaml:alpine-2023-10-17 as semgrep-core-container
+FROM returntocorp/ocaml:alpine-2024-04-25 as semgrep-core-container
 
 WORKDIR /src/semgrep
 COPY --from=semgrep-core-files /src/semgrep .


### PR DESCRIPTION
test plan:
make build-docker
wait for green CI check