### PR TITLE
Fix: update error message to be more accurate

### DIFF
--- a/cli/tests/default/e2e/snapshots/test_rule_validation/test_validation_of_invalid_rules/rulesinvalid-rulesmissing-pattern.yaml/results.txt
+++ b/cli/tests/default/e2e/snapshots/test_rule_validation/test_validation_of_invalid_rules/rulesinvalid-rulesmissing-pattern.yaml/results.txt
@@ -10,4 +10,4 @@ semgrep error: Invalid rule schema
 One of these properties is missing: 'match', 'pattern', 'pattern-either', 'pattern-regex', 'patterns', 'r2c-internal-project-depends-on'
 
 [ERROR] Rule parse error in rule eqeq:
- Expected one of `pattern`, `pattern-either`, `patterns`, `pattern-regex` to be present
+ Expected one of `pattern`, `pattern-either`, `patterns`, `pattern-regex`, or `r2c-internal-project-depends-on` to be present.

--- a/src/parsing/Parse_rule_formula.ml
+++ b/src/parsing/Parse_rule_formula.ml
@@ -271,8 +271,10 @@ let find_formula_old env (rule_dict : dict) : key * G.expr =
   with
   | None, None, None, None ->
       error env.id rule_dict.first_tok
+        (* Note, we shouldn't reach this code if
+           r2c-internal-project-depends-on is present. *)
         "Expected one of `pattern`, `pattern-either`, `patterns`, \
-         `pattern-regex` to be present"
+         `pattern-regex`, or `r2c-internal-project-depends-on` to be present."
   | Some (key, value), None, None, None
   | None, Some (key, value), None, None
   | None, None, Some (key, value), None


### PR DESCRIPTION
This just modifies a parsing error message to be more accurate whenever it is printed out during a failure.

## test plan
Update snapshot for affected test. CI should continue to pass.