### PR TITLE
refactor: Include `name` in XML kind

### DIFF
--- a/languages/html/generic/Parse_html_tree_sitter.ml
+++ b/languages/html/generic/Parse_html_tree_sitter.ml
@@ -106,14 +106,14 @@ let map_attribute (env : env) ((v1, v2) : CST.attribute) : xml_attribute =
 
 let map_script_start_tag (env : env) ((v1, v2, v3, v4) : CST.script_start_tag) =
   let v1 = token env v1 (* "<" *) in
-  let v2 = (str env v2 (* script_start_tag_name *), G.empty_id_info ()) in
+  let v2 = Id (str env v2 (* script_start_tag_name *), G.empty_id_info ()) in
   let v3 = List_.map (map_attribute env) v3 in
   let v4 = token env v4 (* ">" *) in
   (v1, v2, v3, v4)
 
 let map_style_start_tag (env : env) ((v1, v2, v3, v4) : CST.style_start_tag) =
   let v1 = token env v1 (* "<" *) in
-  let v2 = (str env v2 (* style_start_tag_name *), G.empty_id_info ()) in
+  let v2 = Id (str env v2 (* style_start_tag_name *), G.empty_id_info ()) in
   let v3 = List_.map (map_attribute env) v3 in
   let v4 = token env v4 (* ">" *) in
   (v1, v2, v3, v4)
@@ -123,7 +123,7 @@ let map_start_tag (env : env) (x : CST.start_tag) =
   | `Semg_start_tag (v1, v2, v3, v4)
   | `LT_start_tag_name_rep_attr_GT (v1, v2, v3, v4) ->
       let v1 = token env v1 (* "<" *) in
-      let v2 = (str env v2 (* start_tag_name *), G.empty_id_info ()) in
+      let v2 = Id (str env v2 (* start_tag_name *), G.empty_id_info ()) in
       let v3 = List_.map (map_attribute env) v3 in
       let v4 = token env v4 (* ">" *) in
       (v1, v2, v3, v4)
@@ -142,7 +142,7 @@ let rec map_element (env : env) (x : CST.element) : xml =
       { xml_kind = XmlClassic (l, id, r, v3); xml_attrs = attrs; xml_body = v2 }
   | `Self_clos_tag (v1, v2, v3, v4) ->
       let l = token env v1 (* "<" *) in
-      let id = (str env v2 (* start_tag_name *), G.empty_id_info ()) in
+      let id = Id (str env v2 (* start_tag_name *), G.empty_id_info ()) in
       let attrs = List_.map (map_attribute env) v3 in
       let r = token env v4 (* "/>" *) in
       { xml_kind = XmlSingleton (l, id, r); xml_attrs = attrs; xml_body = [] }
@@ -152,8 +152,9 @@ and map_node (env : env) (x : CST.node) : xml_body =
   | `Doct_ (v1, v2, v3, v4) ->
       let l = token env v1 (* "<!" *) in
       let id =
-        ( str env v2 (* pattern [Dd][Oo][Cc][Tt][Yy][Pp][Ee] *),
-          G.empty_id_info () )
+        Id
+          ( str env v2 (* pattern [Dd][Oo][Cc][Tt][Yy][Pp][Ee] *),
+            G.empty_id_info () )
       in
       let _misc = token env v3 (* pattern [^>]+ *) in
       let r = token env v4 (* ">" *) in
@@ -206,7 +207,9 @@ and map_node (env : env) (x : CST.node) : xml_body =
       XmlXml xml
   | `Errons_end_tag (v1, v2, v3) ->
       let l = token env v1 (* "</" *) in
-      let id = (str env v2 (* erroneous_end_tag_name *), G.empty_id_info ()) in
+      let id =
+        Id (str env v2 (* erroneous_end_tag_name *), G.empty_id_info ())
+      in
       let r = token env v3 (* ">" *) in
       (* todo? raise an exception instead? *)
       let xml =
@@ -222,7 +225,7 @@ let map_toplevel_node (env : env) (x : CST.toplevel_node) : xml_body =
       let r = (* "?>" *) token env v3 in
       let xml =
         {
-          xml_kind = XmlSingleton (l, (("xml", l), G.empty_id_info ()), r);
+          xml_kind = XmlSingleton (l, Id (("xml", l), G.empty_id_info ()), r);
           xml_attrs;
           xml_body = [];
         }

--- a/languages/javascript/generic/js_to_generic.ml
+++ b/languages/javascript/generic/js_to_generic.ml
@@ -197,10 +197,12 @@ and xml { xml_kind = xml_tag; xml_attrs; xml_body } =
 
 and xml_kind = function
   | XmlClassic (v0, v1, v2, v3) ->
-      let v1 = (ident v1, G.empty_id_info ()) in
+      (* TODO Correctly parse Foo.Bar into IdQualified *)
+      let v1 = G.Id (ident v1, G.empty_id_info ()) in
       G.XmlClassic (v0, v1, v2, v3)
   | XmlSingleton (v0, v1, v2) ->
-      let v1 = (ident v1, G.empty_id_info ()) in
+      (* TODO Correctly parse Foo.Bar into IdQualified *)
+      let v1 = G.Id (ident v1, G.empty_id_info ()) in
       XmlSingleton (v0, v1, v2)
   | XmlFragment (v1, v2) -> XmlFragment (v1, v2)
 

--- a/languages/tree-sitter-to-generic/Parse_hack_tree_sitter.ml
+++ b/languages/tree-sitter-to-generic/Parse_hack_tree_sitter.ml
@@ -2876,7 +2876,7 @@ and xhp_expression (env : env) (x : CST.xhp_expression) : G.xml =
   match x with
   | `Xhp_open_close (v1, v2, v3, v4) ->
       let v1 = (* "<" *) token env v1 in
-      let v2 = (xhp_identifier_ env v2, G.empty_id_info ()) in
+      let v2 = G.Id (xhp_identifier_ env v2, G.empty_id_info ()) in
       let v3 = List_.map (xhp_attribute env) v3 in
       let v4 = (* "/>" *) token env v4 in
       { xml_kind = G.XmlSingleton (v1, v2, v4); xml_attrs = v3; xml_body = [] }
@@ -2909,7 +2909,7 @@ and xhp_expression (env : env) (x : CST.xhp_expression) : G.xml =
 
 and xhp_open (env : env) ((v1, v2, v3, v4) : CST.xhp_open) =
   let v1 = (* "<" *) token env v1 in
-  let v2 = (xhp_identifier_ env v2, G.empty_id_info ()) in
+  let v2 = G.Id (xhp_identifier_ env v2, G.empty_id_info ()) in
   let v3 = List_.map (xhp_attribute env) v3 in
   let v4 = (* ">" *) token env v4 in
   (v1, v2, v3, v4)

--- a/languages/tree-sitter-to-generic/Parse_vue_tree_sitter.ml
+++ b/languages/tree-sitter-to-generic/Parse_vue_tree_sitter.ml
@@ -224,7 +224,7 @@ let map_anon_choice_attr_a1991da (env : env) (x : CST.anon_choice_attr_a1991da)
 
 let map_start_tag (env : env) ((v1, v2, v3, v4) : CST.start_tag) =
   let v1 = token env v1 (* "<" *) in
-  let v2 = (str env v2 (* start_tag_name *), G.empty_id_info ()) in
+  let v2 = Id (str env v2 (* start_tag_name *), G.empty_id_info ()) in
   let v3 = List_.map (map_anon_choice_attr_a1991da env) v3 in
   let v4 = token env v4 (* ">" *) in
   (v1, v2, v3, v4)
@@ -232,21 +232,21 @@ let map_start_tag (env : env) ((v1, v2, v3, v4) : CST.start_tag) =
 let map_template_start_tag (env : env)
     ((v1, v2, v3, v4) : CST.template_start_tag) =
   let v1 = token env v1 (* "<" *) in
-  let v2 = (str env v2 (* template_start_tag_name *), G.empty_id_info ()) in
+  let v2 = Id (str env v2 (* template_start_tag_name *), G.empty_id_info ()) in
   let v3 = List_.map (map_anon_choice_attr_a1991da env) v3 in
   let v4 = token env v4 (* ">" *) in
   (v1, v2, v3, v4)
 
 let map_style_start_tag (env : env) ((v1, v2, v3, v4) : CST.style_start_tag) =
   let v1 = token env v1 (* "<" *) in
-  let v2 = (str env v2 (* style_start_tag_name *), G.empty_id_info ()) in
+  let v2 = Id (str env v2 (* style_start_tag_name *), G.empty_id_info ()) in
   let v3 = List_.map (map_anon_choice_attr_a1991da env) v3 in
   let v4 = token env v4 (* ">" *) in
   (v1, v2, v3, v4)
 
 let map_script_start_tag (env : env) ((v1, v2, v3, v4) : CST.script_start_tag) =
   let v1 = token env v1 (* "<" *) in
-  let v2 = (str env v2 (* script_start_tag_name *), G.empty_id_info ()) in
+  let v2 = Id (str env v2 (* script_start_tag_name *), G.empty_id_info ()) in
   let v3 = List_.map (map_anon_choice_attr_a1991da env) v3 in
   let v4 = token env v4 (* ">" *) in
   (v1, v2, v3, v4)
@@ -289,7 +289,7 @@ let rec map_element (env : env) (x : CST.element) : xml =
       { xml_kind = XmlClassic (l, id, r, v3); xml_attrs = attrs; xml_body = v2 }
   | `Self_clos_tag (v1, v2, v3, v4) ->
       let l = token env v1 (* "<" *) in
-      let id = (str env v2 (* start_tag_name *), G.empty_id_info ()) in
+      let id = Id (str env v2 (* start_tag_name *), G.empty_id_info ()) in
       let attrs = List_.map (map_anon_choice_attr_a1991da env) v3 in
       let r = token env v4 (* "/>" *) in
       { xml_kind = XmlSingleton (l, id, r); xml_attrs = attrs; xml_body = [] }
@@ -338,7 +338,9 @@ and map_node (env : env) (x : CST.node) : xml_body list =
       [ XmlXml xml ]
   | `Errons_end_tag (v1, v2, v3) ->
       let l = token env v1 (* "</" *) in
-      let id = (str env v2 (* erroneous_end_tag_name *), G.empty_id_info ()) in
+      let id =
+        Id (str env v2 (* erroneous_end_tag_name *), G.empty_id_info ())
+      in
       let r = token env v3 (* ">" *) in
       (* todo? raise an exn instead? *)
       let xml =

--- a/libs/ast_generic/AST_generic.ml
+++ b/libs/ast_generic/AST_generic.ml
@@ -1100,13 +1100,11 @@ and xml = {
 }
 
 and xml_kind =
-  (* <foo>...</foo> *)
-  (* TODO use `name`? JS/TS allows `<Foo.Bar>...` *)
-  | XmlClassic of
-      tok (*'<'*) * (ident * id_info) * tok (*'>'*) * tok (*'</foo>'*)
+  (* <foo>...</foo>
+   * Name instead of id + info because Foo.Bar is valid in JS, maybe others. *)
+  | XmlClassic of tok (*'<'*) * name * tok (*'>'*) * tok (*'</foo>'*)
   (* <foo/> *)
-  | XmlSingleton of
-      tok (*'<'*) * (ident * id_info) * tok (* '/>', with xml_body = [] *)
+  | XmlSingleton of tok (*'<'*) * name * tok (* '/>', with xml_body = [] *)
   (* React/JS specific *)
   | XmlFragment of tok (* '<>' *) * (* '</>', with xml_attrs = [] *) tok
 

--- a/libs/ast_generic/AST_generic_to_v1.ml
+++ b/libs/ast_generic/AST_generic_to_v1.ml
@@ -55,6 +55,17 @@ let error any =
   failwith (spf "TODO: %s" s)
 
 (*****************************************************************************)
+(* Helpers *)
+(*****************************************************************************)
+
+(* Inaccurate. Used so that we can keep backwards compatibility as we add more
+ * information to the generic AST. *)
+let ident_of_name = function
+  | Id (id, _)
+  | IdQualified { name_last = id, _; _ } ->
+      id
+
+(*****************************************************************************)
 (* Mapper *)
 (*****************************************************************************)
 
@@ -141,15 +152,17 @@ and map_xml
   { B.xml_kind = v_xml_tag; xml_attrs = v_xml_attrs; xml_body = v_xml_body }
 
 and map_xml_kind = function
-  | XmlClassic (v0, (v1, _info), v2, v3) ->
+  | XmlClassic (v0, v1, v2, v3) ->
       let v0 = map_tok v0 in
-      let v1 = map_ident v1 in
+      (* TODO Update the AST JSON output to include a name here. *)
+      let v1 = ident_of_name v1 |> map_ident in
       let v2 = map_tok v2 in
       let v3 = map_tok v3 in
       `XmlClassic (v0, v1, v2, v3)
-  | XmlSingleton (v0, (v1, _info), v2) ->
+  | XmlSingleton (v0, v1, v2) ->
       let v0 = map_tok v0 in
-      let v1 = map_ident v1 in
+      (* TODO Update the AST JSON output to include a name here. *)
+      let v1 = ident_of_name v1 |> map_ident in
       let v2 = map_tok v2 in
       `XmlSingleton (v0, v1, v2)
   | XmlFragment (v1, v2) ->

--- a/libs/ast_generic/Meta_AST.ml
+++ b/libs/ast_generic/Meta_AST.ml
@@ -241,19 +241,17 @@ and vof_xml
   OCaml.VDict bnds
 
 and vof_xmlkind = function
-  | XmlClassic (v0, (id, info), v2, v3) ->
+  | XmlClassic (v0, name, v2, v3) ->
       let v0 = vof_tok v0 in
-      let id = vof_ident id in
-      let info = vof_id_info info in
+      let name = vof_name name in
       let v2 = vof_tok v2 in
       let v3 = vof_tok v3 in
-      OCaml.VSum ("XmlClassic", [ v0; id; info; v2; v3 ])
-  | XmlSingleton (v0, (id, info), v2) ->
+      OCaml.VSum ("XmlClassic", [ v0; name; v2; v3 ])
+  | XmlSingleton (v0, name, v2) ->
       let v0 = vof_tok v0 in
-      let id = vof_ident id in
-      let info = vof_id_info info in
+      let name = vof_name name in
       let v2 = vof_tok v2 in
-      OCaml.VSum ("XmlSingleton", [ v0; id; info; v2 ])
+      OCaml.VSum ("XmlSingleton", [ v0; name; v2 ])
   | XmlFragment (v1, v2) ->
       let v1 = vof_tok v1 in
       let v2 = vof_tok v2 in

--- a/src/matching/Generic_vs_generic.ml
+++ b/src/matching/Generic_vs_generic.ml
@@ -1544,19 +1544,19 @@ and m_xml_kind a b =
         (fun x -> x.Options.xml_singleton_loose_matching)
         ~then_:
           (let* () = m_tok a0 b0 in
-           let* () = m_ident_and_id_info a1 b1 in
+           let* () = m_name a1 b1 in
            let* () = m_tok a2 b2 in
            return ())
         ~else_:(fail ())
   | G.XmlClassic (a0, a1, a2, a3), B.XmlClassic (b0, b1, b2, b3) ->
       let* () = m_tok a0 b0 in
-      let* () = m_ident_and_id_info a1 b1 in
+      let* () = m_name a1 b1 in
       let* () = m_tok a2 b2 in
       let* () = m_tok a3 b3 in
       return ()
   | G.XmlSingleton (a0, a1, a2), B.XmlSingleton (b0, b1, b2) ->
       let* () = m_tok a0 b0 in
-      let* () = m_ident_and_id_info a1 b1 in
+      let* () = m_name a1 b1 in
       let* () = m_tok a2 b2 in
       return ()
   | G.XmlFragment (a1, a2), B.XmlFragment (b1, b2) ->


### PR DESCRIPTION
This is a followup to #10182, where I added `id_info` to the XML kind.

I added a TODO to consider changing this to `name`, since in JS/TS, `<Foo.Bar />` is legal, so we should be able to use `IdQualified` in such cases.

I figured we could just change it when we need it. However, I failed to understand that the Pro Engine traverses the AST looking for `name`s in order to compute taint signatures in dependency order. This led to strange problems with my work in progress. Instead of updating that traversal to special-case XML kind, I'm just putting a `name` here like I eventually intended to do anyway.

Test plan: Automated tests

