### PR TITLE
Change aliengrep metavariable kind to align with spacegrep

### DIFF
--- a/changelog.d/gh-10222.fixed
+++ b/changelog.d/gh-10222.fixed
@@ -1,0 +1,2 @@
+Fixed bug that was preventing the use of `metavariable-pattern` with
+the aliengrep engine of the generic mode.

--- a/cli/tests/default/e2e/rules/aliengrep/metavariable-pattern.yaml
+++ b/cli/tests/default/e2e/rules/aliengrep/metavariable-pattern.yaml
@@ -1,0 +1,19 @@
+rules:
+  # used to fail with error message in --strict --verbose mode:
+  # "metavariable-pattern failed because $X does not bind to a
+  # sub-program. please check your rule"
+  - id: test-aliengrep-mv
+    severity: ERROR
+    languages:
+      - generic
+    options:
+      generic_engine: aliengrep
+    message: |
+      found '$X'
+    patterns:
+      - pattern: |
+          key = $X
+      - focus-metavariable: $X
+      - metavariable-pattern:
+          metavariable: $X
+          pattern: value

--- a/cli/tests/default/e2e/snapshots/test_aliengrep/test_aliengrep/rulesaliengrepmetavariable-pattern.yaml-aliengrepmetavariable-pattern.conf/results.json
+++ b/cli/tests/default/e2e/snapshots/test_aliengrep/test_aliengrep/rulesaliengrepmetavariable-pattern.yaml-aliengrepmetavariable-pattern.conf/results.json
@@ -1,0 +1,52 @@
+{
+  "errors": [],
+  "interfile_languages_used": [],
+  "paths": {
+    "scanned": [
+      "targets/aliengrep/metavariable-pattern.conf"
+    ]
+  },
+  "results": [
+    {
+      "check_id": "rules.aliengrep.test-aliengrep-mv",
+      "end": {
+        "col": 12,
+        "line": 1,
+        "offset": 11
+      },
+      "extra": {
+        "engine_kind": "OSS",
+        "fingerprint": "0x42",
+        "is_ignored": false,
+        "lines": "key = value",
+        "message": "found 'value'\n",
+        "metadata": {},
+        "metavars": {
+          "$X": {
+            "abstract_content": "value",
+            "end": {
+              "col": 12,
+              "line": 1,
+              "offset": 11
+            },
+            "start": {
+              "col": 7,
+              "line": 1,
+              "offset": 6
+            }
+          }
+        },
+        "severity": "ERROR",
+        "validation_state": "NO_VALIDATOR"
+      },
+      "path": "targets/aliengrep/metavariable-pattern.conf",
+      "start": {
+        "col": 7,
+        "line": 1,
+        "offset": 6
+      }
+    }
+  ],
+  "skipped_rules": [],
+  "version": "0.42"
+}

--- a/cli/tests/default/e2e/targets/aliengrep/metavariable-pattern.conf
+++ b/cli/tests/default/e2e/targets/aliengrep/metavariable-pattern.conf
@@ -1,0 +1,1 @@
+key = value

--- a/cli/tests/default/e2e/test_aliengrep.py
+++ b/cli/tests/default/e2e/test_aliengrep.py
@@ -17,6 +17,10 @@ from tests.fixtures import RunSemgrep
         # Aliengrep-specific tests
         ("rules/aliengrep/begin-end.yaml", "aliengrep/begin-end.log"),
         ("rules/aliengrep/long-match.yaml", "aliengrep/long-match.txt"),
+        (
+            "rules/aliengrep/metavariable-pattern.yaml",
+            "aliengrep/metavariable-pattern.conf",
+        ),
     ],
 )
 def test_aliengrep(run_semgrep_in_tmp: RunSemgrep, snapshot, rule, target):

--- a/libs/aliengrep/Match.ml
+++ b/libs/aliengrep/Match.ml
@@ -46,6 +46,10 @@ let convert_match (pat : Pat_compile.t) target_str
     List_.map
       (fun (capture_id, mv) ->
         let loc = loc_of_substring target_str substrings capture_id in
+        Log.debug (fun m ->
+            m "captured metavariable %s = %S"
+              (Pat_compile.show_metavariable mv)
+              loc.substring);
         (mv, loc))
       pat.metavariable_groups
   in

--- a/libs/aliengrep/Pat_compile.mli
+++ b/libs/aliengrep/Pat_compile.mli
@@ -8,8 +8,11 @@ type metavariable_kind =
   | Metavariable_ellipsis (* regular or long *)
 [@@deriving show, eq]
 
-(* metavariable kind, bare name *)
-type metavariable = metavariable_kind * string [@@deriving show, eq]
+type metavariable = {
+  kind : metavariable_kind;
+  bare_name : string; (* 'X', not '$X', not '$...X' *)
+}
+[@@deriving show, eq]
 
 type t = private {
   pcre : Pcre_.t;
@@ -17,11 +20,8 @@ type t = private {
 }
 [@@deriving show, eq]
 
-(*
-   Convert a pattern AST into a PCRE pattern and the array of metavariables
-   corresponding to the PCRE matching groups.
-*)
-val compile : Conf.t -> Pat_AST.t -> t
-
 (* Shortcut for all parsing + compilation *)
 val from_string : Conf.t -> string -> t
+
+(* Convert a metavariable to concrete semgrep syntax e.g. '$X' or '$...X' *)
+val string_of_metavariable : metavariable -> string

--- a/libs/aliengrep/Unit_Match.ml
+++ b/libs/aliengrep/Unit_Match.ml
@@ -21,6 +21,7 @@ type expectation =
   | Not of expectation
 [@@deriving show]
 
+let mv kind bare_name : Pat_compile.metavariable = { kind; bare_name }
 let match_subs (x : Match.match_) = x.match_loc.substring
 let check_num_matches n matches = List.length matches = n
 
@@ -116,22 +117,22 @@ let test_metavariables () =
     [
       Num_matches 1;
       Match_value "a xy b";
-      Capture (Metavariable, "X");
-      Capture_value ((Metavariable, "X"), "xy");
+      Capture (mv Metavariable "X");
+      Capture_value (mv Metavariable "X", "xy");
     ];
   check slconf {|a $AB_4! b|} {|a xy! b|}
     [
       Num_matches 1;
       Match_value "a xy! b";
-      Capture_value ((Metavariable, "AB_4"), "xy");
+      Capture_value (mv Metavariable "AB_4", "xy");
     ];
   check slconf {|$ X|} {|$ X|}
     [
       Num_matches 1;
       Match_value "$ X";
-      Not (Capture (Metavariable, "X"));
-      Not (Capture (Metavariable, ""));
-      Not (Capture (Metavariable, "$"));
+      Not (Capture (mv Metavariable "X"));
+      Not (Capture (mv Metavariable ""));
+      Not (Capture (mv Metavariable "$"));
     ];
   check slconf {|$A $B|} {|1 2 3 4|}
     [
@@ -139,12 +140,12 @@ let test_metavariables () =
       Num_matches 2;
       (* first match *)
       Match_value "1 2";
-      Capture_value ((Metavariable, "A"), "1");
-      Capture_value ((Metavariable, "B"), "2");
+      Capture_value (mv Metavariable "A", "1");
+      Capture_value (mv Metavariable "B", "2");
       (* other match *)
       Match_value "3 4";
-      Capture_value ((Metavariable, "A"), "3");
-      Capture_value ((Metavariable, "B"), "4");
+      Capture_value (mv Metavariable "A", "3");
+      Capture_value (mv Metavariable "B", "4");
     ]
 
 let test_ellipsis_brackets () =
@@ -197,7 +198,7 @@ let test_backreferences () =
     [
       Num_matches 1;
       Match_value {|a, b, c, a|};
-      Capture_value ((Metavariable, "A"), "a");
+      Capture_value (mv Metavariable "A", "a");
     ];
   (* no overlaps -> only 2 matches *)
   check slconf {|$A ... $A ... $A|} {|a x x x a x x x a x x x x a|}
@@ -205,8 +206,8 @@ let test_backreferences () =
       Num_matches 2;
       Match_value {|a x x x a x x x a|};
       Match_value {|x x x|};
-      Capture_value ((Metavariable, "A"), "a");
-      Capture_value ((Metavariable, "A"), "x");
+      Capture_value (mv Metavariable "A", "a");
+      Capture_value (mv Metavariable "A", "x");
     ];
   (* back-references should not end in the middle of a word *)
   check slconf {|$A ... $A|} {|ab abc|} [ Num_matches 0 ];
@@ -214,33 +215,33 @@ let test_backreferences () =
   check slconf {|$A ... $A|} {|abc bc|} [ Num_matches 0 ];
   (* ellipsis extremities that are not words may touch words *)
   check slconf {|... $...A : $...A ...|} {|x+ : +x|}
-    [ Num_matches 1; Capture_value ((Metavariable_ellipsis, "A"), "+") ];
+    [ Num_matches 1; Capture_value (mv Metavariable_ellipsis "A", "+") ];
   (* ellipsis extremities that are not words may touch [specific] words *)
   check slconf {|x $...A : $...A x|} {|x+ : +x|}
     [ Num_matches 1; Match_value {|x+ : +x|} ];
   (* ellipsis extremities that are words may not touch words *)
   check slconf {|... $...A : $...A ...|} {|xy : yx|}
-    [ Num_matches 1; Capture_value ((Metavariable_ellipsis, "A"), "") ];
+    [ Num_matches 1; Capture_value (mv Metavariable_ellipsis "A", "") ];
   (* ellipsis extremities that are words may not touch [specific] words *)
   check slconf {|x $...A : $...A x|} {|x+ : +x|}
     [
       Num_matches 1;
       Match_value {|x+ : +x|};
-      Capture_value ((Metavariable_ellipsis, "A"), "+");
+      Capture_value (mv Metavariable_ellipsis "A", "+");
     ];
   (* word extremities of ellipsis back-references may not touch words *)
   check slconf {|... $...A : $...A ...|} {|x : xx|}
-    [ Num_matches 1; Capture_value ((Metavariable_ellipsis, "A"), "") ];
+    [ Num_matches 1; Capture_value (mv Metavariable_ellipsis "A", "") ];
   (* nonword extremities of ellipsis back-references may touch words *)
   check slconf {|... $...A : $...A ...|} {|+ : ++|}
-    [ Num_matches 1; Capture_value ((Metavariable_ellipsis, "A"), "+") ]
+    [ Num_matches 1; Capture_value (mv Metavariable_ellipsis "A", "+") ]
 
 let test_ellipsis_metavariable () =
   check slconf {|[$...ITEMS]|} {|a, [ b, c ], d|}
     [
       Num_matches 1;
       Match_value {|[ b, c ]|};
-      Capture_value ((Metavariable_ellipsis, "ITEMS"), {|b, c|});
+      Capture_value (mv Metavariable_ellipsis "ITEMS", {|b, c|});
     ];
   (* regular vs. long ellipsis in single-line mode *)
   check slconf {|[$...ITEMS]|} "a, [ b,\nc ], d" [ Num_matches 0 ];
@@ -248,14 +249,14 @@ let test_ellipsis_metavariable () =
     [
       Num_matches 1;
       Match_value "[ b,\nc ]";
-      Capture_value ((Metavariable_ellipsis, "ITEMS"), "b,\nc");
+      Capture_value (mv Metavariable_ellipsis "ITEMS", "b,\nc");
     ];
   (* backtracking and back-references *)
   check slconf {|[$...A $...A]|} "[a b a b]"
     [
       Num_matches 1;
       Match_value "[a b a b]";
-      Capture_value ((Metavariable_ellipsis, "A"), "a b");
+      Capture_value (mv Metavariable_ellipsis "A", "a b");
     ];
   (* back-references require exact whitespace match, unfortunately *)
   check slconf {|[$...A $...A]|} "[a b a  b]" [ Num_matches 0 ]
@@ -282,8 +283,8 @@ var e = "xx";
   check slconf pat target
     [
       Num_matches 1;
-      Capture_value ((Metavariable, "ORIG"), "b");
-      Capture_value ((Metavariable, "COPY"), "d");
+      Capture_value (mv Metavariable "ORIG", "b");
+      Capture_value (mv Metavariable "COPY", "d");
     ]
 
 let test_left_anchored_ellipses () =

--- a/src/engine/Metavariable_pattern.ml
+++ b/src/engine/Metavariable_pattern.ml
@@ -180,11 +180,7 @@ let get_nested_metavar_pattern_bindings get_nested_formula_matches env r mvar
           in
           match opt_xlang with
           | None -> (
-              (* We match wrt the same language as the rule.
-               * NOTE: A generic pattern nested inside a generic won't work because
-               *   generic mode binds metavariables to `MV.Text`, and
-               *   `MV.program_of_mvalue` does not handle `MV.Text`. So one must
-               *   specify `language: generic` (case `Some xlang` below). *)
+              (* We match wrt the same language as the rule. *)
               match MV.program_of_mvalue mval with
               | None ->
                   error env

--- a/src/engine/Metavariable_pattern.mli
+++ b/src/engine/Metavariable_pattern.mli
@@ -15,6 +15,7 @@ val get_nested_metavar_pattern_bindings :
   Range_with_metavars.t ->
   (* The arguments in CondNestedFormula *)
   Metavariable.mvar ->
+  (* Why is this xlang optional? *)
   Xlang.t option ->
   Rule.formula ->
   Metavariable.bindings list

--- a/src/engine/Xpattern_match_aliengrep.ml
+++ b/src/engine/Xpattern_match_aliengrep.ml
@@ -28,12 +28,8 @@ let convert_capture ~file
   let str = loc.substring in
   let pos = convert_pos ~file loc in
   let tok = Tok.tok_of_loc pos in
-  let name_with_dollar =
-    match mv with
-    | Metavariable, name -> "$" ^ name
-    | Metavariable_ellipsis, name -> "$..." ^ name
-  in
-  (name_with_dollar, Metavariable.Text (str, tok, tok))
+  let name_with_dollar = Aliengrep.Pat_compile.string_of_metavariable mv in
+  (name_with_dollar, Xpattern_matcher.mval_of_string str tok)
 
 (* Convert locations to the file/line/column format etc. *)
 let convert_match ~file (match_ : Aliengrep.Match.match_) =


### PR DESCRIPTION
Aliengrep now uses the same function as Spacegrep to extract a metavariable value (`Xpattern_matcher.mval_of_string`), resulting in an int or string literal instead of a `Text` node.

This avoids a problem that was apparently known for the "generic mode" - presumably just Spacegrep at the time - since there was a comment about it. I removed the comment because it no longer applies. I don't fully understand what's going on with this `opt_xlang` value in `Metavariable_pattern.ml`: why it is `None` for both Spacegrep and Aliengrep?

Anyway, now both generic modes do the same thing so it's a little simpler. The relevant change is just one line. In the course of the investigation, I changed the metavariable type used by Aliengrep from a tuple to a record to minimize future confusion.

Fixes https://github.com/semgrep/semgrep/issues/10222

