### PR TITLE
feat: add argument to specify the number of jobs being used for interfile

### DIFF
--- a/cli/src/semgrep/commands/scan.py
+++ b/cli/src/semgrep/commands/scan.py
@@ -145,6 +145,10 @@ _scan_options: List[Callable] = [
         type=int,
     ),
     optgroup.option(
+        "--interfile-jobs",
+        type=int,
+    ),
+    optgroup.option(
         "--max-memory",
         type=int,
     ),
@@ -511,6 +515,7 @@ def scan(
     exclude_rule: Optional[Tuple[str, ...]],
     force_color: bool,
     include: Optional[Tuple[str, ...]],
+    interfile_jobs: Optional[int],
     jobs: Optional[int],
     lang: Optional[str],
     matching_explanations: bool,
@@ -719,6 +724,7 @@ def scan(
                     try:
                         metacheck_errors = CoreRunner(
                             jobs=jobs,
+                            interfile_jobs=interfile_jobs,
                             engine_type=engine_type,
                             timeout=timeout,
                             max_memory=max_memory,
@@ -775,6 +781,7 @@ def scan(
                     lang=lang,
                     configs=(config or ["auto"]),
                     no_rewrite_rule_ids=(not rewrite_rule_ids),
+                    interfile_jobs=interfile_jobs,
                     jobs=jobs,
                     include=include,
                     exclude={product: (exclude or ()) for product in ALL_PRODUCTS},

--- a/cli/src/semgrep/core_runner.py
+++ b/cli/src/semgrep/core_runner.py
@@ -476,6 +476,7 @@ class CoreRunner:
     def __init__(
         self,
         jobs: Optional[int],
+        interfile_jobs: Optional[int],
         engine_type: EngineType,
         timeout: int,
         max_memory: int,
@@ -489,6 +490,7 @@ class CoreRunner:
     ):
         self._binary_path = engine_type.get_binary_path()
         self._jobs = jobs or engine_type.default_jobs
+        self._interfile_jobs = jobs or engine_type.default_interfile_jobs
         self._engine_type = engine_type
         self._timeout = timeout
         self._max_memory = max_memory
@@ -899,6 +901,7 @@ Could not find the semgrep-core executable. Your Semgrep install is likely corru
                         "-timeout_for_interfile_analysis",
                         str(self._interfile_timeout),
                     ]
+                    cmd += ["-interfile_jobs", str(self._interfile_jobs)]
                     cmd += [root]
                 elif engine is EngineType.PRO_INTRAFILE:
                     cmd += ["-deep_intra_file"]

--- a/cli/src/semgrep/engine.py
+++ b/cli/src/semgrep/engine.py
@@ -130,10 +130,12 @@ class EngineType(Enum):
 
     @property
     def default_jobs(self) -> int:
-        if self == EngineType.PRO_INTERFILE:
-            return 1
         # Maxing out number of cores used to 16 if more not requested to not overload on large machines
         return min(16, self.get_cpu_count())
+
+    @property
+    def default_interfile_jobs(self) -> int:
+        return 1
 
     @property
     def default_max_memory(self) -> int:

--- a/cli/src/semgrep/run_scan.py
+++ b/cli/src/semgrep/run_scan.py
@@ -352,6 +352,7 @@ def run_scan(
         str
     ],  # NOTE: Since the `ci` command reuses this function, we intentionally do not set a default at this level.
     no_rewrite_rule_ids: bool = False,
+    interfile_jobs: Optional[int] = None,
     jobs: Optional[int] = None,
     include: Optional[Sequence[str]] = None,
     exclude: Optional[Mapping[Product, Sequence[str]]] = None,
@@ -552,6 +553,7 @@ def run_scan(
     core_start_time = time.time()
     core_runner = CoreRunner(
         jobs=jobs,
+        interfile_jobs=interfile_jobs,
         engine_type=engine_type,
         timeout=timeout,
         max_memory=max_memory,


### PR DESCRIPTION
In combination with changes to semgrep-proprietary, this produces a speedup for interfile runs that use both intrafile and interfile rules. Instead of running both the intrafile and interfile rules with `-j 1`, it runs first the intrafile rules with the default number of jobs, and then the interfile rules with a single job. This conserves memory for the interfile rules while allowing the intrafile rules to benefit from multiprocessing.

TODO: we can remove the supply chain hack that disables interfile when possible to get multiprocessing

Test plan: see corresponding semgrep-proprietary PR

