### PR TITLE
fix: Delete extraneous log

### DIFF
--- a/libs/networking/http_mock_client/Http_mock_client.ml
+++ b/libs/networking/http_mock_client/Http_mock_client.ml
@@ -336,7 +336,6 @@ let client_from_file req_resp_file =
         with
         | Some ((expected_req, request_body), (response, response_body), used)
           ->
-            Logs.debug (fun m -> m "FOUND ONE RESPONSE");
             check_method expected_req.meth req.meth;
             check_headers req.headers expected_req.headers;
             Lwt.async (fun () -> check_body body request_body);


### PR DESCRIPTION
I added this while testing https://github.com/semgrep/semgrep/pull/10216 because log sources weren't working for me, but it shouldn't be needed.