### PR TITLE
chore: Print error logs from the RPC subprocess

### DIFF
--- a/cli/src/semgrep/ocaml.py
+++ b/cli/src/semgrep/ocaml.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 from typing import IO
 from typing import Optional
 from typing import Type
@@ -97,6 +98,8 @@ def _call(call: out.FunctionCall, cls: Type[T]) -> Optional[T]:
         [semgrep_core_path, "-rpc"],
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
+        # Print error logs, if any
+        stderr=sys.stderr,
         text=True,
         encoding=ENCODING,
     ) as proc:


### PR DESCRIPTION
Test plan:

* Automated tests
* Add `prerr_endline "HELLO WORLD";` to the beginning of the `RPC.main` function. Run an autofix rule with `--autofix` and observe the autofix get correctly applied and observe "HELLO WORLD" in the output of pysemgrep.

