### PR TITLE
Sync with Pro

### DIFF
--- a/changelog.d/jsx-taint.fixed
+++ b/changelog.d/jsx-taint.fixed
@@ -1,0 +1,1 @@
+[Pro Engine Only] Tainted values are now tracked through instantiation of React functional components via JSX.

--- a/src/analyzing/AST_to_IL.ml
+++ b/src/analyzing/AST_to_IL.ml
@@ -899,7 +899,7 @@ and expr_aux env ?(void = false) g_expr =
       mk_e (Composite (Constructor cname, (tok1, es, tok2))) eorig
   | G.RegexpTemplate ((l, e, r), _opt) ->
       mk_e (Composite (Regexp, (l, [ expr env e ], r))) NoOrig
-  | G.Xml xml -> xml_expr env xml
+  | G.Xml xml -> xml_expr env ~void eorig xml
   | G.Cast (typ, _, e) ->
       let e = expr env e in
       mk_e (Cast (typ, e)) eorig
@@ -1121,16 +1121,13 @@ and dict env (_, orig_entries, _) orig =
   in
   mk_e (RecordOrDict entries) (SameAs orig)
 
-and xml_expr env xml =
-  let attrs =
-    xml.G.xml_attrs
-    |> List_.map_filter (function
-         | G.XmlAttr (_, tok, eorig)
-         | G.XmlAttrExpr (tok, eorig, _) ->
-             let exp = expr env eorig in
-             let _, lval = mk_aux_var env tok exp in
-             Some (mk_e (Fetch lval) (SameAs eorig))
-         | _ -> None)
+and xml_expr env ~void eorig xml =
+  let tok, jsx_name =
+    match xml.G.xml_kind with
+    | G.XmlClassic (tok, name, _, _)
+    | G.XmlSingleton (tok, name, _) ->
+        (tok, Some name)
+    | G.XmlFragment (tok, _) -> (tok, None)
   in
   let body =
     xml.G.xml_body
@@ -1139,19 +1136,72 @@ and xml_expr env xml =
              let exp = expr env eorig in
              let _, lval = mk_aux_var env tok exp in
              Some (mk_e (Fetch lval) (SameAs eorig))
-         | G.XmlXml xml' -> Some (xml_expr env xml')
-         | _ -> None)
+         | G.XmlXml xml' ->
+             let eorig' = SameAs (G.Xml xml' |> G.e) in
+             Some (xml_expr env ~void:false eorig' xml')
+         | G.XmlExpr (_, None, _)
+         | G.XmlText _ ->
+             None)
   in
-  let tok =
-    match xml.G.xml_kind with
-    | G.XmlClassic (tok, _, _, _)
-    | G.XmlSingleton (tok, _, _)
-    | G.XmlFragment (tok, _) ->
-        tok
-  in
-  mk_e
-    (Composite (CTuple, (tok, List.rev_append attrs body, tok)))
-    (Related (G.Xmls xml.G.xml_body))
+  match jsx_name with
+  | Some jsx_name when Lang.is_js env.lang ->
+      (* Model `<Foo x={y}>{bar}</Foo>` as `Foo({x: y, children: [bar])`
+       *
+       * Technically, this should be modeled as `React.createElement(Foo, {x:
+       * y}, bar)`, and we should then correctly track taint through the call to
+       * `React.createElement`. But realistically we can shortcut that and just
+       * model it as a direct call.
+       *
+       * This works for functional components, which are standard practice these
+       * days. In order to correctly model older kinds of React components,
+       * we'll need to do more work. *)
+      let name_eorig = SameAs (G.N jsx_name |> G.e) in
+      let name_lval = name env jsx_name in
+      let e = mk_e (Fetch name_lval) name_eorig in
+      let fields =
+        xml.G.xml_attrs
+        |> List_.map_filter (function
+             | G.XmlAttr (id, tok, eorig) ->
+                 let e = expr env eorig in
+                 let _, lval = mk_aux_var env tok e in
+                 let e = mk_e (Fetch lval) (SameAs eorig) in
+                 Some (Field (id, e))
+             | G.XmlAttrExpr _ ->
+                 (* TODO, handle <Foo {...bar} /> (spread) *)
+                 None
+             | G.XmlEllipsis _ ->
+                 (* Should never encounter this in a target *)
+                 None)
+      in
+      let body_exp =
+        mk_e
+          (Composite (CArray, Tok.unsafe_fake_bracket body))
+          (Related (G.Xmls xml.G.xml_body))
+      in
+      let fields = Field (("children", G.fake ""), body_exp) :: fields in
+      let fields_orig =
+        let attrs = xml.G.xml_attrs |> List_.map (fun attr -> G.XmlAt attr) in
+        let body = G.Xmls xml.G.xml_body in
+        Related (G.Anys (body :: attrs))
+      in
+      let record = mk_e (RecordOrDict fields) fields_orig in
+      let args = [ Unnamed record ] in
+      add_call env tok eorig ~void (fun res -> Call (res, e, args))
+  | Some _
+  | None ->
+      let attrs =
+        xml.G.xml_attrs
+        |> List_.map_filter (function
+             | G.XmlAttr (_, tok, eorig)
+             | G.XmlAttrExpr (tok, eorig, _) ->
+                 let exp = expr env eorig in
+                 let _, lval = mk_aux_var env tok exp in
+                 Some (mk_e (Fetch lval) (SameAs eorig))
+             | _ -> None)
+      in
+      mk_e
+        (Composite (CTuple, (tok, List.rev_append attrs body, tok)))
+        (Related (G.Xmls xml.G.xml_body))
 
 and stmt_expr env ?g_expr st =
   let todo () =


### PR DESCRIPTION
    OSS repo was last synced with Pro commit 53265fde316d01109b1c0f026b5ba58940b7f9dd.
    There are 4 commit(s) to sync.
    Syncing...
    * Skipping (empty) dbbb209e910 annotations: Initial support for source annotations (#1493)
    * 413902d50aa fix: Model JSX component instantiation as a call (#1510)
    * Skipping (empty) 84ea534860e Add PR template (#1522)
    * Skipping (empty) 82525da21a6 annotations: Improve error handling (#1499)
    Success!