### PR TITLE
For Semgrep Pro install, mention SEMGREP_APP_TOKEN for non-interactive env

### DIFF
--- a/changelog.d/gh-10303.added
+++ b/changelog.d/gh-10303.added
@@ -1,0 +1,1 @@
+Added guidance for resolving token issues for `install-semgrep-pro` in non-interactive environments.

--- a/cli/src/semgrep/commands/install.py
+++ b/cli/src/semgrep/commands/install.py
@@ -113,8 +113,7 @@ def run_install_semgrep_pro(custom_binary: Optional[str] = None) -> None:
     if state.app_session.token is None and custom_binary is None:
         logger.info(
             "Run `semgrep login` before running `semgrep install-semgrep-pro`."
-            "Or in non-interactive environments, ensure your SEMGREP_APP_TOKEN \
-            variable is set correctly."
+            "Or in non-interactive environments, ensure your SEMGREP_APP_TOKEN variable is set correctly."
         )
         sys.exit(INVALID_API_KEY_EXIT_CODE)
 

--- a/cli/src/semgrep/commands/install.py
+++ b/cli/src/semgrep/commands/install.py
@@ -111,7 +111,11 @@ def run_install_semgrep_pro(custom_binary: Optional[str] = None) -> None:
 
     state = get_state()
     if state.app_session.token is None and custom_binary is None:
-        logger.info("run `semgrep login` before running `semgrep install-semgrep-pro`")
+        logger.info(
+            "Run `semgrep login` before running `semgrep install-semgrep-pro`."
+            "Or in non-interactive environments, ensure your SEMGREP_APP_TOKEN \
+            variable is set correctly."
+        )
         sys.exit(INVALID_API_KEY_EXIT_CODE)
 
     logger.debug(f"platform is {sys.platform}")

--- a/cli/src/semgrep/commands/install.py
+++ b/cli/src/semgrep/commands/install.py
@@ -112,7 +112,7 @@ def run_install_semgrep_pro(custom_binary: Optional[str] = None) -> None:
     state = get_state()
     if state.app_session.token is None and custom_binary is None:
         logger.info(
-            "Run `semgrep login` before running `semgrep install-semgrep-pro`."
+            "Run `semgrep login` before running `semgrep install-semgrep-pro`. "
             "Or in non-interactive environments, ensure your SEMGREP_APP_TOKEN variable is set correctly."
         )
         sys.exit(INVALID_API_KEY_EXIT_CODE)

--- a/src/osemgrep/cli_install_semgrep_pro/Install_semgrep_pro_subcommand.ml
+++ b/src/osemgrep/cli_install_semgrep_pro/Install_semgrep_pro_subcommand.ml
@@ -137,7 +137,10 @@ let run_conf (caps : caps) (conf : Install_semgrep_pro_CLI.conf) : Exit_code.t =
   match ((Semgrep_settings.load ()).api_token, conf.custom_binary) with
   | None, None ->
       Logs.err (fun m ->
-          m "run `semgrep login` before running `semgrep install-semgrep-pro`");
+          m
+            "Run `semgrep login` before running `semgrep install-semgrep-pro`. \
+             Or in non-interactive environments, ensure your SEMGREP_APP_TOKEN \
+             variable is set correctly.");
       Exit_code.fatal ~__LOC__
   | _ ->
       let platform_kind =


### PR DESCRIPTION
This change is similar to https://github.com/semgrep/semgrep/pull/10133, but for the `install-semgrep-pro` command rather than the `ci` command. The current message can confuse folks if they are seeing the error in a CI build system or other environment where they need to already have a correct token rather than running interactive login. I've added a second sentence giving that alternative for non-interactive environments.

To test: locally, run semgrep ci with pipenv (or equivalent), while having no/invalid token in the environment or in your current settings.yml.

```
$ pipenv run semgrep install-semgrep-pro
Semgrep Pro Engine will be installed in /Users/alexis/code/semgrep/cli/src/semgrep/bin/semgrep-core-proprietary
Overwriting Semgrep Pro Engine already installed!
Run `semgrep login` before running `semgrep install-semgrep-pro`. Or in non-interactive environments, ensure your SEMGREP_APP_TOKEN variable is set correctly.
```