### PR TITLE
Handle TypeError in join_rule

### DIFF
--- a/cli/src/semgrep/join_rule.py
+++ b/cli/src/semgrep/join_rule.py
@@ -518,7 +518,7 @@ def run_join_rule(
             parsed_errors.append(
                 ERROR_MAP[error_dict.get(errortype)].from_dict(error_dict)
             )
-        except KeyError:
+        except (KeyError, TypeError):
             logger.warning(
                 f"Could not reconstitute Semgrep error: {error_dict}.\nSkipping processing of error"
             )


### PR DESCRIPTION
For https://github.com/semgrep/semgrep/issues/10281

Quick fix to handle `TypeError` in the above issue.