### PR TITLE
Push to semgrep/semgrep instead of returntocorp/semgrep

### DIFF
--- a/.github/workflows/tests.jsonnet
+++ b/.github/workflows/tests.jsonnet
@@ -555,7 +555,7 @@ local ignore_md = {
     // Docker stuff
     'build-test-docker': build_test_docker_job,
     'push-docker-returntocorp':
-       push_docker_job(docker_artifact_name, 'returntocorp/semgrep') +
+       push_docker_job(docker_artifact_name, docker_repository_name) +
        { needs: [ 'build-test-docker' ] },
     'build-test-docker-nonroot':
       build_test_docker_other_target_job("-nonroot", "nonroot"),

--- a/.github/workflows/tests.jsonnet
+++ b/.github/workflows/tests.jsonnet
@@ -16,8 +16,7 @@ local core_x86 = import 'build-test-core-x86.jsonnet';
 // intermediate image produced by build-push-action
 local docker_artifact_name = 'semgrep-docker-image-artifact';
 
-// TODO: change to 'semgrep/semgrep' at some point as the default
-local docker_repository_name = 'returntocorp/semgrep';
+local docker_repository_name = 'semgrep/semgrep';
 
 // ----------------------------------------------------------------------------
 // Helpers

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -112,7 +112,7 @@ jobs:
     with:
       artifact-name: semgrep-docker-image-artifact
       dry-run: false
-      repository-name: returntocorp/semgrep
+      repository-name: semgrep/semgrep
   test-cli:
     name: test semgrep-cli
     needs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,7 @@ jobs:
         type=sha,event=branch
       enable-tests: true
       file: Dockerfile
-      repository-name: returntocorp/semgrep
+      repository-name: semgrep/semgrep
       target: semgrep-cli
   build-test-docker-nonroot:
     needs:
@@ -63,7 +63,7 @@ jobs:
         type=ref,event=pr
       enable-tests: false
       file: Dockerfile
-      repository-name: returntocorp/semgrep
+      repository-name: semgrep/semgrep
       target: nonroot
   build-test-docker-performance-tests:
     needs:
@@ -80,7 +80,7 @@ jobs:
         type=ref,event=pr
       enable-tests: false
       file: Dockerfile
-      repository-name: returntocorp/semgrep
+      repository-name: semgrep/semgrep
       target: performance-tests
   build-test-javascript:
     secrets: inherit
@@ -330,7 +330,7 @@ jobs:
     uses: ./.github/workflows/test-semgrep-pro.yml
     with:
       artifact-name: semgrep-docker-image-artifact
-      repository-name: returntocorp/semgrep
+      repository-name: semgrep/semgrep
   trigger-semgrep-comparison-argo:
     if: ${{ github.event_name == 'pull_request' && !startsWith(github.event.pull_request.base.ref, 'release') && !startsWith(github.head_ref, 'release') }}
     needs:


### PR DESCRIPTION
test plan:
wait for green CI checks, check
https://hub.docker.com/r/semgrep/semgrep
whether we can see new docker images