### PR TITLE
fix: declare build requirements

### DIFF
--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
 [tool.pytest.ini_options]
 # coupling: if you add a dep here it would be great if you added it to the top
 # level flake.nix in devPipInputs


### PR DESCRIPTION
This should fix the build with modern versions of pip by explicitly declaring `setup.py` needs `wheel`
