### PR TITLE
Update to pipenv 2024.0.1

### DIFF
--- a/.github/workflows/release.jsonnet
+++ b/.github/workflows/release.jsonnet
@@ -194,7 +194,7 @@ local park_pypi_packages_job = {
     },
     actions.setup_python_step('3.10'),
     {
-      run: 'sudo python3 -m pip install pipenv==2022.6.7',
+      run: 'sudo python3 -m pip install pipenv==2024.0.1',
     },
     {
       run: 'pipenv install --dev',

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,7 +126,7 @@ jobs:
         with:
           cache: pipenv
           python-version: "3.10"
-      - run: sudo python3 -m pip install pipenv==2022.6.7
+      - run: sudo python3 -m pip install pipenv==2024.0.1
       - run: pipenv install --dev
       - name: Build parked packages
         run: pipenv run python setup.py park

--- a/.github/workflows/start-release.jsonnet
+++ b/.github/workflows/start-release.jsonnet
@@ -26,7 +26,7 @@ local pr_number = '"${{ needs.release-setup.outputs.pr-number }}"';
 
 // For towncrier setup in scripts/release/
 local pipenv_setup = |||
-  pip3 install pipenv==2022.6.7
+  pip3 install pipenv==2024.0.1
   pipenv install --dev
 |||;
 

--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -381,7 +381,7 @@ jobs:
       - if: ${{ ! inputs.dry-run }}
         name: Create GitHub Release Body
         run: |
-          pip3 install pipenv==2022.6.7
+          pip3 install pipenv==2024.0.1
           pipenv install --dev
 
           pipenv run towncrier build --draft --version ${{ needs.get-version.outputs.version }} > release_body.txt
@@ -394,7 +394,7 @@ jobs:
           path: scripts/release/release_body.txt
       - name: Update Changelog
         run: |
-          pip3 install pipenv==2022.6.7
+          pip3 install pipenv==2024.0.1
           pipenv install --dev
 
           pipenv run towncrier build --yes --version ${{ needs.get-version.outputs.version }}

--- a/Makefile
+++ b/Makefile
@@ -428,7 +428,7 @@ install-deps-ALPINE-for-semgrep-core:
 # We pin to a specific version just to prevent things from breaking randomly.
 # We could update to a more recent version.
 # coupling: if you modify the version, please modify also .github/workflows/*
-PIPENV='pipenv==2022.6.7'
+PIPENV='pipenv==2024.0.1'
 
 # For '--ignore-installed distlib' below see
 # https://stackoverflow.com/questions/63515454/why-does-pip3-install-pipenv-give-error-error-cannot-uninstall-distlib


### PR DESCRIPTION
This is needed for the opentelemetry dependencies

test plan:
wait for green CI checks