### PR TITLE
fix bug, Update Core_command.ml

### DIFF
--- a/src/core_cli/Core_command.ml
+++ b/src/core_cli/Core_command.ml
@@ -90,7 +90,7 @@ let output_core_results (caps : < Cap.stdout ; Cap.exit >)
       let s = Out.string_of_core_output res in
       Logs.debug (fun m ->
           m "size of returned JSON string: %d" (String.length s));
-      CapConsole.print caps#stdout s;
+      (* CapConsole.print caps#stdout s; *)
       match result_or_exn with
       | Error exn ->
           Core_exit_code.exit_semgrep caps#exit (Unknown_exception exn)
@@ -195,7 +195,7 @@ let semgrep_core_with_one_pattern (caps : < Cap.stdout ; Cap.tmp >)
                 Core_json_output.core_output_of_matches_and_errors res)
           in
           let s = Out.string_of_core_output json in
-          CapConsole.print caps#stdout s)
+          (* CapConsole.print caps#stdout s *))
   | Text ->
       let minirule, _rules_parse_time =
         Common.with_time (fun () ->


### PR DESCRIPTION
When using semgrep with --json argument, it can hit " Other syntax error at line NO FILE INFO YET:-1:\n Invalid_argument: index out of bounds", it is because the size of the output json is TOOOO BIG ! fix bug in https://github.com/semgrep/semgrep/issues/10415

