### PR TITLE
fix: typo in --json-val help text

### DIFF
--- a/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -588,7 +588,7 @@ let make_o_format_outputs : ?fancy:string -> string -> string list Term.t =
       [ format ^ "-output" ]
       ~doc:
         ("Write a copy of the " ^ fancy_format
-       ^ " output to a file or post to or post to URL.")
+       ^ " output to a file or post to URL.")
   in
   Arg.value (Arg.opt_all Arg.string [] info)
 


### PR DESCRIPTION
Fixed a typo in the help text of the `--json-output` part, outputted from the command `semgrep scan --help`.