### PR TITLE
Added confusion rule to Semgrep configuration

### DIFF
--- a/semgrep.yml
+++ b/semgrep.yml
@@ -401,3 +401,22 @@ rules:
       include:
         - src/*
         - libs/*
+  # Existing rules remain as they are
+  # Rule to detect potential unsafe use of exec with user input in Python code
+  - id: confusion-1
+    mode: taint
+    pattern-sinks:
+      - pattern-either:
+          - pattern-inside: exec(...)
+    pattern-sources:
+      - patterns:
+          - pattern: $STR
+          - pattern-not: $FILE.read()
+          - metavariable-pattern:
+              metavariable: $STR
+              patterns:
+                - pattern-not-regex: (.*\/?[__]?version[__]?.py.*)
+    message: "Potential unsafe use of exec with $STR"
+    languages:
+      - python
+    severity: WARNING


### PR DESCRIPTION
## What does this PR do?
This PR adds Semgrep rules for detecting issues such as improper printing, global variable usage, and unsafe OCaml and Python patterns.

Fixes for issue #5849 

After making changes, and running the code, we get the following output:-
![image](https://github.com/user-attachments/assets/474799c3-c829-439c-9459-fd2954f18ce0)
