### PR TITLE
Fix List_.map in libs/python-str-rep and adjust precommit exclude

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -202,16 +202,16 @@ repos:
         # the very latest docker image, which is nice, but is far slower.
         language: python
 
-        # Both the .semgrepignore file and the --exclude option
+        # Note that both the .semgrepignore file and the --exclude option
         # do nothing because the target files are passed
-        # explicitly on the command line by pre-commit!
+        # explicitly on the command line by pre-commit!!!
         # TODO: remove once file targeting is revamped and supports
         # filtering for explicit targets (a command-line flag should do)
-        # exclude: "xxx.ml"
+        exclude: "tests"
         # TODO: we could also set 'pass_filenames: false', see
         # https://stackoverflow.com/questions/57199833/run-pre-commit-com-hook-once-not-for-every-file-if-a-matched-file-is-detected
 
-        #coupling: 'make check' and the SEMGREP_ARGS variable
+        #coupling: 'make check' and the SEMGREP_ARGS variable.
         args: [
             # use osemgrep!
             "--experimental",
@@ -239,6 +239,9 @@ repos:
             # this can save 3sec sometimes (a bit sad, would be good to dodgood
             # also our metrics, but the slowdown is annoying)
             "--metrics=off",
+            # commented on purpose: "--exclude tests"
+            # This is implemented via the exclude: above (see the comment
+            # further above to understand why)
           ]
   # Dogfooding .pre-commit-hooks.yml and setup.py
   # Use a fixed version of p/python and p/bandit to not get new findings

--- a/libs/python-str-repr/lib/dune
+++ b/libs/python-str-repr/lib/dune
@@ -1,4 +1,7 @@
 (library
  (name python_str_repr)
  (public_name python-str-repr)
- (libraries uutf uucp))
+ (libraries
+   commons ; just for List_.map
+   uutf uucp
+ ))

--- a/libs/python-str-repr/test/test_py_python_str_repr.ml
+++ b/libs/python-str-repr/test/test_py_python_str_repr.ml
@@ -16,7 +16,7 @@ let repr = Python_str_repr.repr ~unicode_version:py_unicode_version
 
 let test_repr =
   let inputs = [ ""; "a"; "'"; "\""; "tab\tthis" ] in
-  List.map
+  List_.map
     (fun input ->
       ( Printf.sprintf "%S" input,
         `Quick,

--- a/libs/python-str-repr/test/test_python_str_repr.ml
+++ b/libs/python-str-repr/test/test_python_str_repr.ml
@@ -7,7 +7,7 @@ let make_test ?unicode_version (message, input, expected) =
       Alcotest.(check string) message expected (repr ?unicode_version input) )
 
 let test_repr =
-  List.map make_test
+  List_.map make_test
     [
       ("empty", "", "''");
       ("simple", "a", "'a'");
@@ -27,7 +27,7 @@ let test_repr =
     ]
 
 let test_repr_unicode =
-  List.map make_test
+  List_.map make_test
     [ ("unicode 'æ'", "æ", "'æ'"); ("unicode '\u{80}'", "\u{80}", "'\\x80'") ]
 
 let test_repr_unicode_version =


### PR DESCRIPTION
Not sure this was not done by martin's recent PR.

One of the reason we needed this PR is because martin recently removed the paths: exclude: for many rules
and relied on the --exclude tests instead of semgrep, but this does not work with precommit.


test plan:
make
make check
pre-commit run -a