### PR TITLE
correct misspelling of 'default' in src/osemgrep/cli_scan/Scan_CLI.ml

### DIFF
--- a/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -786,7 +786,7 @@ let o_exclude_minified_files : bool Term.t =
     ~default:default.targeting_conf.exclude_minified_files
     ~doc:
       {|Skip minified files. These are files that are > 7% whitespace, or who
-        have a large number of bytes per line. By defualt minified files are
+        have a large number of bytes per line. By default minified files are
    scanned |}
 
 (* ------------------------------------------------------------------ *)


### PR DESCRIPTION
corrects misspelling of `default`