### PR TITLE
fix: Properly close Python logging handlers

### DIFF
--- a/cli/src/semgrep/terminal.py
+++ b/cli/src/semgrep/terminal.py
@@ -54,7 +54,10 @@ class Terminal:
 
         # Assumes only one of verbose, debug, quiet is True
         logger = logging.getLogger("semgrep")
-        logger.handlers = []  # Reset to no handlers
+        # Reset to no handlers
+        for handler in list(logger.handlers):
+            logger.removeHandler(handler)
+            handler.close()
 
         stdout_level = logging.INFO
         if verbose:


### PR DESCRIPTION
This fixes `ResourceWarning: unclosed file <_io.TextIOWrapper name='/home/vagrant/.semgrep/semgrep.log' mode='w' encoding='UTF-8'>` when Python warnings are enabled (e.g. with `PYTHONDEVMODE=1` or `PYTHONWARNINGS=error`).