### PR TITLE
feat(sms): add SCM run id to ScanHandler

### DIFF
--- a/cli/src/semgrep/app/scans.py
+++ b/cli/src/semgrep/app/scans.py
@@ -63,6 +63,7 @@ class ScanHandler:
         """
         state = get_state()
         self.local_id = str(state.local_scan_id)
+        self.scm_run_id = str(state.env.scm_run_id)
         self.scan_metadata = out.ScanMetadata(
             cli_version=out.Version(__VERSION__),
             unique_id=out.Uuid(self.local_id),
@@ -242,7 +243,7 @@ class ScanHandler:
         returns ignored list
         """
         state = get_state()
-
+        logger.debug(f"SCM run id: {self.scm_run_id}")
         request = out.ScanRequest(
             meta=out.RawJson(
                 {

--- a/cli/src/semgrep/env.py
+++ b/cli/src/semgrep/env.py
@@ -67,6 +67,7 @@ class Env:
         converter=url,
     )
     app_token: Optional[str] = field(default=EnvFactory("SEMGREP_APP_TOKEN"))
+    scm_run_id: Optional[str] = field(default=EnvFactory("SCM_RUN_ID"))
 
     version_check_url: str = field(
         default=EnvFactory(


### PR DESCRIPTION
We need to know the SCM run ID in the CLI in order to connect the scan with the SCM run id reliably over time.

The first step is to accept this ID as an environment variable. That is what is being done in this PR.

The next step is to extend semgrep-interfaces to send this parameter from the CLI to the semgrep-app backend as part of the api/cli/scans body (extend ScanRequest). That is being done in [this semgrep-interfaces PR](https://github.com/semgrep/semgrep-interfaces/pull/306).

The final piece here will be to bump the version of semgrep-interfaces in `semgrep` so that it recognizes this new field and to update the body of what is being sent to api/cli/scans to include this scm_run_id field. 