### PR TITLE
Update PATH from entrypoint parent directory to scripts directory

### DIFF
--- a/.github/workflows/build-test-manylinux-x86.yml
+++ b/.github/workflows/build-test-manylinux-x86.yml
@@ -58,7 +58,7 @@ jobs:
           name: manylinux-x86-wheel
       - run: unzip dist.zip
       - name: create venv
-        run: python -m venv env
+        run: /opt/python/cp38-cp38/bin/python3 -m venv env
       - name: install package
         run: env/bin/pip install dist/*.whl
       - name: test package

--- a/.github/workflows/build-test-manylinux-x86.yml
+++ b/.github/workflows/build-test-manylinux-x86.yml
@@ -47,6 +47,26 @@ jobs:
         run: |
           export PATH=/opt/python/cp38-cp38/bin:$PATH
           echo '1 == 1' | semgrep -l python -e '$X == $X' -
+  test-wheels-venv:
+    container: quay.io/pypa/manylinux2014_x86_64
+    needs:
+      - build-wheels
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: manylinux-x86-wheel
+      - run: unzip dist.zip
+      - name: create venv
+        run: python -m venv env
+      - name: install package
+        run: env/bin/pip install dist/*.whl
+      - name: test package
+        run: |
+          env/bin/semgrep --version
+      - name: e2e semgrep-core test
+        run: |
+          echo '1 == 1' | env/bin/semgrep -l python -e '$X == $X' -
 name: build-test-manylinux-x86
 on:
   workflow_call: null

--- a/cli/src/semgrep/console_scripts/entrypoint.py
+++ b/cli/src/semgrep/console_scripts/entrypoint.py
@@ -32,6 +32,7 @@ import os
 import platform
 import shutil
 import sys
+import sysconfig
 import warnings
 
 # alt: you can also add '-W ignore::DeprecationWarning' after the python3 above,
@@ -50,7 +51,7 @@ warnings.filterwarnings("ignore", category=DeprecationWarning)
 # nosem: no-env-vars-on-top-level
 PATH = os.environ.get("PATH", "")
 # nosem: no-env-vars-on-top-level
-os.environ["PATH"] = PATH + os.pathsep + os.path.dirname(os.path.abspath(__file__))
+os.environ["PATH"] = PATH + os.pathsep + sysconfig.get_path("scripts")
 
 IS_WINDOWS = platform.system() == "Windows"
 


### PR DESCRIPTION
Fixes #10652

Repro steps with Docker:
```
chris@chriss-mbp /tmp % docker run --rm -it python:3.12 /bin/bash
root@cf1c44df9491:/# python3 -m venv /semgrep
root@cf1c44df9491:/# /semgrep/bin/pip install semgrep==1.94.0
<snip>
root@cf1c44df9491:/# /semgrep/bin/semgrep --version
[00.05][ERROR]: Error: exception Unix_error: No such file or directory execvp pysemgrep
Raised by primitive operation at CLI.safe_run in file "src/osemgrep/cli/CLI.ml", line 272, characters 8-12
```

Verification steps:
Apply patch to `/semgrep/lib/python3.12/site-packages/semgrep/console_scripts/entrypoint.py`

```
root@cf1c44df9491:/# /semgrep/bin/semgrep --version
1.94.0
```
