### PR TITLE
Introducing Semgrep Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@
   <a href="https://twitter.com/intent/follow?screen_name=semgrep">
     <img src="https://img.shields.io/twitter/follow/semgrep?label=Follow%20semgrep&style=social&color=blue" alt="Follow @semgrep on Twitter" />
   </a>
+  <a href="https://gurubase.io/g/semgrep">
+    <img src="https://img.shields.io/badge/Gurubase-Ask%20Semgrep%20Guru-006BFF?style=flat-square" alt="Ask Semgrep Guru" />
+  </a>
 </p>
 </br>
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Semgrep Guru](https://gurubase.io/g/semgrep) to Gurubase. Semgrep Guru uses the data from this repo and data from the [docs](https://semgrep.dev/docs/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Semgrep Guru", which highlights that Semgrep now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Semgrep Guru in Gurubase, just let me know that's totally fine.
