### PR TITLE
Fix date format of start time and end time in gl-sast report

### DIFF
--- a/src/osemgrep/reporting/Gitlab_output.ml
+++ b/src/osemgrep/reporting/Gitlab_output.ml
@@ -224,12 +224,13 @@ let output f (matches : Out.cli_match list) : JSON.yojson =
       ]
   in
   let start_time = Metrics_.g.payload.started_at
-  and end_time = Timedesc.Timestamp.now () in
+  and end_time = Timedesc.Timestamp.now ()
+  and date_format = "{year}-{mon:cX}-{day:cX}T{hour:cX}:{min:cX}:{sec:cX}" in
   let scan =
     `Assoc
       [
-        ("start_time", `String (Timedesc.Timestamp.to_rfc3339 start_time));
-        ("end_time", `String (Timedesc.Timestamp.to_rfc3339 end_time));
+        ("start_time", `String (Timedesc.Timestamp.to_string ~format:date_format start_time));
+        ("end_time", `String (Timedesc.Timestamp.to_string ~format:date_format end_time));
         ("analyzer", tool);
         ("scanner", tool);
         ("version", `String Version.version);


### PR DESCRIPTION
The date format of `start_time` and `end_time` in GitLab SAST reports currently does not match the expected pattern which is defined in [GitLab's report schema](https://gitlab.com/gitlab-org/security-products/security-report-schemas/-/blob/941f497a3824d4393eb8a7efced497f738895ab4/dist/sast-report-format.json#L710). This PR aims to fix the date format according to the required pattern by replacing the RFC 3339 format with a special `YYYY-MM-DD HH:MM:SS` format.

Without this PR, GitLab SAST reports currently cannot be displayed in GitLab because of aforementioned issue:

<img width="1158" alt="image" src="https://github.com/user-attachments/assets/5e2d8c53-70db-40df-b14b-58965ef21468">

_Note: I am not familiar with OCaml. Please bear with me if anything is wrong or conceptually bad :)_