### PR TITLE
SARIF output shows incorrect file paths in dataflow trace locations

### DIFF
--- a/src/osemgrep/reporting/Sarif_output.ml
+++ b/src/osemgrep/reporting/Sarif_output.ml
@@ -239,7 +239,7 @@ let sarif_fixes (cli_match : Out.cli_match) : Sarif.fix list option =
   in
   Some [ fix ]
 
-let thread_flow_location (cli_match : Out.cli_match) message
+let thread_flow_location (_cli_match : Out.cli_match) message
     (location : Out.location) content nesting_level =
   let location =
     Sarif.create_location ~message
@@ -249,7 +249,7 @@ let thread_flow_location (cli_match : Out.cli_match) message
              (region ~message ~snippet:content location.start location.end_)
            ~artifact_location:
              (Sarif.create_artifact_location
-                ~uri:(Fpath.to_string cli_match.path)
+                ~uri:(Fpath.to_string location.path)
                 ())
            ())
       ()

--- a/src/osemgrep/reporting/Sarif_output.ml
+++ b/src/osemgrep/reporting/Sarif_output.ml
@@ -239,8 +239,7 @@ let sarif_fixes (cli_match : Out.cli_match) : Sarif.fix list option =
   in
   Some [ fix ]
 
-let thread_flow_location (_cli_match : Out.cli_match) message
-    (location : Out.location) content nesting_level =
+let thread_flow_location message (location : Out.location) content nesting_level =
   let location =
     Sarif.create_location ~message
       ~physical_location:
@@ -258,7 +257,7 @@ let thread_flow_location (_cli_match : Out.cli_match) message
     ~nesting_level:(Int64.of_int nesting_level)
     ~location ()
 
-let intermediate_var_locations cli_match intermediate_vars =
+let intermediate_var_locations intermediate_vars =
   intermediate_vars
   |> List_.map (fun ({ location; content } : Out.match_intermediate_var) ->
          let propagation_message_text =
@@ -267,8 +266,7 @@ let intermediate_var_locations cli_match intermediate_vars =
              location.start.line
            |> message
          in
-         thread_flow_location cli_match propagation_message_text location
-           content 0)
+         thread_flow_location propagation_message_text location content 0)
 
 let thread_flows (cli_match : Out.cli_match)
     (dataflow_trace : Out.match_dataflow_trace) (location : Out.location)
@@ -282,23 +280,23 @@ let thread_flows (cli_match : Out.cli_match)
         location.start.line
       |> message
     in
-    thread_flow_location cli_match source_message_text location content 0
+    thread_flow_location source_message_text location content 0
   in
   let intermediate_var_locations =
     match intermediate_vars with
     | None -> []
     | Some intermediate_vars ->
-        intermediate_var_locations cli_match intermediate_vars
+        intermediate_var_locations intermediate_vars
   in
   let sink_flow_location =
     let sink_message_text =
       spf "Sink: '%s' @ '%s:%d'"
-        (String.trim cli_match.extra.lines) (* rule_match.get_lines() ?! *)
+        (String.trim cli_match.extra.lines)
         (Fpath.to_string cli_match.path)
         cli_match.start.line
       |> message
     in
-    thread_flow_location cli_match sink_message_text
+    thread_flow_location sink_message_text
       {
         Out.start = cli_match.start;
         end_ = cli_match.end_;


### PR DESCRIPTION
## Description
When generating SARIF output with dataflow traces, the file paths in artifactLocation.uri are incorrect for intermediate trace locations. The path shown in the message.text is correct, but the artifactLocation.uri shows a different path.

For example:
```json
{
    "location": {
        "message": {
            "text": "Propagator : 'curBase' @ 'src/example/handler/trace.cpp:15'"
        },
        "physicalLocation": {
            "artifactLocation": {
                "uri": "src/example/utils/helper.cpp" // INCORRECT PATH
            },
            "region": {
                "endColumn": 12,
                "endLine": 15,
                "message": {
                    "text": "Propagator : 'curBase' @ 'src/example/handler/trace.cpp:15'"
                },
                "snippet": {
                    "text": "curBase"
                },
                "startColumn": 5,
                "startLine": 15
            }
        }
    },
    "nestingLevel": 0
}
```
The artifactLocation.uri should be src/example/handler/trace.cpp to match the path shown in the message.

The bug was in Sarif_output.ml where cli_match.path was incorrectly used instead of location.path when creating thread flow locations.
## Changes
* Modified `thread_flow_location` function to use `location.path` for `artifactLocation.uri`
* Added `_` prefix to unused `cli_match` parameter to fix compilation warning

The fix ensures that the file paths in artifactLocation.uri match the paths shown in the trace messages.


