### PR TITLE
Use value of $XDG_CACHE_HOME before hardcoded ~/.cache for semgrep_version file

### DIFF
--- a/changelog.d/gh-4465.fixed
+++ b/changelog.d/gh-4465.fixed
@@ -1,0 +1,1 @@
+Use value of $XDG_CACHE_HOME before hardcoded ~/.cache for semgrep_version file

--- a/cli/src/semgrep/env.py
+++ b/cli/src/semgrep/env.py
@@ -106,10 +106,10 @@ class Env:
         if value:
             return Path(value)
         cache_home = os.getenv("XDG_CACHE_HOME")
-        if cache_home is None or not Path(cache_home).is_dir():
-            parent_dir = Path.home() / ".cache"
-        else:
+        if cache_home and Path(cache_home).is_dir():
             parent_dir = Path(cache_home)
+        else:
+            parent_dir = Path.home() / ".cache"
         return parent_dir / "semgrep_version"
 
     @git_command_timeout.default

--- a/cli/src/semgrep/env.py
+++ b/cli/src/semgrep/env.py
@@ -105,7 +105,12 @@ class Env:
         value = os.getenv("SEMGREP_VERSION_CACHE_PATH")
         if value:
             return Path(value)
-        return Path.home() / ".cache" / "semgrep_version"
+        cache_home = os.getenv("XDG_CACHE_HOME")
+        if cache_home is None or not Path(cache_home).is_dir():
+            parent_dir = Path.home() / ".cache"
+        else:
+            parent_dir = Path(cache_home)
+        return parent_dir / "semgrep_version"
 
     @git_command_timeout.default
     def git_command_timeout_default(self) -> int:


### PR DESCRIPTION
Related to #4465

Right now, path to cache directory is hardcoded to `~/.cache` and value of `$XDG_CACHE_HOME` variable is not checked. This patch fixes it.