### PR TITLE
correct `semgrep whoami` to `semgrep show identity`

### DIFF
--- a/src/osemgrep/cli_show/Whoami.ml
+++ b/src/osemgrep/cli_show/Whoami.ml
@@ -35,6 +35,6 @@ let print (caps : < Cap.network ; Cap.stdout >) (kind : identity_kind) :
       Logs.err (fun m ->
           m
             "%s You are not logged in! Run `semgrep login` before using \
-             `semgrep whoami`"
+             `semgrep show identity`"
             (Console.warning_tag ()));
       Exit_code.fatal ~__LOC__


### PR DESCRIPTION
The `whoami` command doesnt exist- the error message shown should direct users to the `show identity` command.