### PR TITLE
chore: bump lsp version

### DIFF
--- a/dev/optional.opam
+++ b/dev/optional.opam
@@ -13,7 +13,6 @@ depends: [
   # - https://github.com/returntocorp/ocaml-layer/blob/master/common-config.sh
   # - scripts/lint-ocaml
   # - .github/workflows/lint.yml and its pre-commit-ocaml job
-  "feather" # used by hello_script.ml
   "ocaml-lsp-server" {= "1.22.0"} # used by the VSCode extension
   "earlybird" {= "1.3.3"} # used by the VSCode extension
   "utop" # used by the various text editors with ocaml support

--- a/dune-project
+++ b/dune-project
@@ -124,7 +124,7 @@ For more information see https://semgrep.dev
     parmap
     semver
     (timedesc (>= 2.0.0)) ; used via git-wrapper
-    (lsp (= 1.20.1))
+    (lsp (= 1.22.0))
     git
     ; tracing
     trace

--- a/semgrep.opam
+++ b/semgrep.opam
@@ -60,7 +60,7 @@ depends: [
   "parmap"
   "semver"
   "timedesc" {>= "2.0.0"}
-  "lsp" {= "1.20.1"}
+  "lsp" {= "1.22.0"}
   "git"
   "trace"
   "memtrace"


### PR DESCRIPTION
A user in the community slack reported a package conflict version related to our pinned version of `lsp`.  This patch bumps that dependency to [the latest](https://opam.ocaml.org/packages/lsp/), and removes a vestigial one that was causing a subsequent package conflict.

test plan: Verify that `make dev-setup` now succeeds normally. 