### PR TITLE
Do not print telemetry info when metrics are off

### DIFF
--- a/cli/src/semgrep/notifications.py
+++ b/cli/src/semgrep/notifications.py
@@ -12,7 +12,8 @@ logger = getLogger(__name__)
 def possibly_notify_user() -> None:
     from semgrep.state import get_state
 
-    settings = get_state().settings
+    state = get_state()
+    settings, metrics = state.settings, state.metrics
 
     has_shown = False
     try:
@@ -20,7 +21,7 @@ def possibly_notify_user() -> None:
     except PermissionError:
         logger.debug("Semgrep does not have access to user settings file")
 
-    if not has_shown:
+    if metrics.is_enabled and not has_shown:
         logger.warning(
             with_color(
                 Colors.yellow,

--- a/cli/tests/default/e2e-other/snapshots/test_download_config/test_new_feature_registry_config/output.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_download_config/test_new_feature_registry_config/output.txt
@@ -1,9 +1,3 @@
-METRICS: Using configs from the Registry (like --config=p/ci) reports pseudonymous rule metrics to semgrep.dev.
-To disable Registry rule metrics, use "--metrics=off".
-When using configs only from local files (like --config=xyz.yml) metrics are sent only when the user is logged in.
-
-More information: https://semgrep.dev/docs/metrics
-
 
 Rules downloaded from https://semgrep.dev/p/ci failed to parse.
 This is likely because rules have been added that use functionality introduced in later versions of semgrep.

--- a/cli/tests/default/e2e/snapshots/test_misc/test_terminal_output/results.txt
+++ b/cli/tests/default/e2e/snapshots/test_misc/test_terminal_output/results.txt
@@ -26,12 +26,6 @@
 === end of stdout - plain
 
 === stderr - plain
-METRICS: Using configs from the Registry (like --config=p/ci) reports pseudonymous rule metrics to semgrep.dev.
-To disable Registry rule metrics, use "--metrics=off".
-When using configs only from local files (like --config=xyz.yml) metrics are sent only when the user is logged in.
-
-More information: https://semgrep.dev/docs/metrics
-
 
 
 ┌─────────────┐
@@ -84,12 +78,6 @@ Ran 4 rules on 14 files: 2 findings.
 === end of stdout - color
 
 === stderr - color
-[33m[22m[24mMETRICS: Using configs from the Registry (like --config=p/ci) reports pseudonymous rule metrics to semgrep.dev.
-To disable Registry rule metrics, use "--metrics=off".
-When using configs only from local files (like --config=xyz.yml) metrics are sent only when the user is logged in.
-
-More information: https://semgrep.dev/docs/metrics
-[0m
 
 
 ┌─────────────┐

--- a/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -66,7 +66,10 @@ let add_project_and_config_metrics (conf : Scan_CLI.conf) : unit =
   | Pattern _ -> ()
 
 let notify_user_about_metrics_once (settings : Semgrep_settings.t) : unit =
-  if not (settings.has_shown_metrics_notification =*= Some true) then (
+  if
+    Metrics_.is_enabled ()
+    && not (settings.has_shown_metrics_notification =*= Some true)
+  then (
     (* python compatibility: the 22m and 24m are "normal color or intensity",
        and "underline off". It doesn't change how the text is rendered
        but allows us to produce the same exact output as pysemgrep.

--- a/src/osemgrep/cli_scan/Test_scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Test_scan_subcommand.ml
@@ -121,7 +121,12 @@ let test_basic_output (caps : Scan_subcommand.caps) () =
             without_settings (fun () ->
                 Scan_subcommand.main caps
                   [|
-                    "semgrep-scan"; "--experimental"; "--config"; "rules.yml";
+                    "semgrep-scan";
+                    "--experimental";
+                    (* explicitly turn metrics on to ensure debug text prints to console *)
+                    "--metrics=on";
+                    "--config";
+                    "rules.yml";
                   |])
           in
           Exit_code.Check.ok exit_code))
@@ -160,6 +165,54 @@ let test_basic_verbose_output (caps : Scan_subcommand.caps) () =
           in
           Exit_code.Check.ok exit_code))
 
+let test_basic_output_with_metrics_off (caps : Scan_subcommand.caps) () =
+  with_env_app_token (fun () ->
+      let repo_files =
+        [
+          F.File ("rules.yml", eqeq_basic_content);
+          F.File ("stupid.py", stupid_py_content);
+        ]
+      in
+      Testutil_git.with_git_repo ~verbose:true repo_files (fun _cwd ->
+          let exit_code =
+            without_settings (fun () ->
+                Scan_subcommand.main caps
+                  [|
+                    "semgrep-scan";
+                    "--experimental";
+                    "--metrics=off";
+                    "--config";
+                    "rules.yml";
+                  |])
+          in
+          Exit_code.Check.ok exit_code))
+
+let test_metrics_output_supressed_on_subsequent_runs
+    (caps : Scan_subcommand.caps) () =
+  with_env_app_token (fun () ->
+      let repo_files =
+        [
+          F.File ("rules.yml", eqeq_basic_content);
+          F.File ("stupid.py", stupid_py_content);
+        ]
+      in
+      Testutil_git.with_git_repo ~verbose:true repo_files (fun _cwd ->
+          let run_scan () =
+            without_settings (fun () ->
+                Scan_subcommand.main caps
+                  [|
+                    "semgrep-scan";
+                    "--experimental";
+                    "--metrics=on";
+                    "--config";
+                    "rules.yml";
+                  |])
+          in
+          let exit_code1 = run_scan () in
+          let exit_code2 = run_scan () in
+          Exit_code.Check.ok exit_code1;
+          Exit_code.Check.ok exit_code2))
+
 (*****************************************************************************)
 (* Entry point *)
 (*****************************************************************************)
@@ -189,4 +242,11 @@ let tests (caps : < Scan_subcommand.caps >) =
         ~skipped:"captured output depends on which tests run before it"
         ~checked_output:(Testo.stdxxx ()) ~normalize
         (test_basic_verbose_output caps);
+      t "basic output with metrics off" ?skipped:Testutil.skip_on_windows
+        ~checked_output:(Testo.stdxxx ()) ~normalize
+        (test_basic_output_with_metrics_off caps);
+      t "basic output with metrics on only prints debug text once"
+        ?skipped:Testutil.skip_on_windows ~checked_output:(Testo.stdxxx ())
+        ~normalize
+        (test_metrics_output_supressed_on_subsequent_runs caps);
     ]

--- a/tests/snapshots/semgrep-core/67608f448702/name
+++ b/tests/snapshots/semgrep-core/67608f448702/name
@@ -1,0 +1,1 @@
+Osemgrep Scan (e2e) > basic output with metrics off

--- a/tests/snapshots/semgrep-core/67608f448702/stdxxx
+++ b/tests/snapshots/semgrep-core/67608f448702/stdxxx
@@ -1,0 +1,59 @@
+--- begin input files ---
+rules.yml
+stupid.py
+--- end input files ---
+[<MASKED TIMESTAMP>][INFO]: Running external command: 'git' 'init' '-b' 'main'
+Initialized empty Git repository in <TMP>/<MASKED>/.git/
+[<MASKED TIMESTAMP>][INFO]: Running external command: 'git' 'config' 'user.name' 'Tester'
+[<MASKED TIMESTAMP>][INFO]: Running external command: 'git' 'config' 'user.email' 'tester@example.com'
+[<MASKED TIMESTAMP>][INFO]: Running external command: 'git' 'add' '.'
+[<MASKED TIMESTAMP>][INFO]: Running external command: 'git' 'commit' '-m' 'Add files'
+[main (root-commit) <MASKED>] Add files
+ 2 files changed, 11 insertions(+)
+ create mode 100644 rules.yml
+ create mode 100644 stupid.py
+
+┌──── [32m○○○[39m ────┐
+│ Semgrep CLI │
+└─────────────┘
+
+✔ Semgrep OSS
+  ✔ Basic security coverage for first-party code vulnerabilities.
+
+✔ Semgrep Code (SAST)
+  ✔ Find and fix vulnerabilities in the code you write with advanced scanning and expert security rules.
+
+✘ Semgrep Secrets
+  ✘ Detect and validate potential secrets in your code.
+
+
+  Loading rules from local config...
+
+
+┌─────────────┐
+│ Scan Status │
+└─────────────┘
+  Scanning 3 files tracked by git with 1 Code rule:
+  Scanning 3 files.
+
+
+┌────────────────┐
+│ 1 Code Finding │
+└────────────────┘
+
+    stupid.py
+   ❯❯❱ eqeq-bad
+          useless comparison
+
+            3┆ return a + b == a + b
+
+
+
+┌──────────────┐
+│ Scan Summary │
+└──────────────┘
+Some files were skipped or only partially analyzed.
+  Scan was limited to files tracked by git.
+
+Ran 1 rule on 1 file: 1 finding.
+ASSERT exit code

--- a/tests/snapshots/semgrep-core/67608f448702/stdxxx
+++ b/tests/snapshots/semgrep-core/67608f448702/stdxxx
@@ -33,8 +33,8 @@ Initialized empty Git repository in <TMP>/<MASKED>/.git/
 ┌─────────────┐
 │ Scan Status │
 └─────────────┘
-  Scanning 3 files tracked by git with 1 Code rule:
-  Scanning 3 files.
+  Scanning 2 files tracked by git with 1 Code rule:
+  Scanning 2 files.
 
 
 ┌────────────────┐

--- a/tests/snapshots/semgrep-core/c6333bc90e8c/name
+++ b/tests/snapshots/semgrep-core/c6333bc90e8c/name
@@ -1,0 +1,1 @@
+Osemgrep Scan (e2e) > basic output with metrics on only prints debug text once

--- a/tests/snapshots/semgrep-core/c6333bc90e8c/stdxxx
+++ b/tests/snapshots/semgrep-core/c6333bc90e8c/stdxxx
@@ -1,0 +1,110 @@
+--- begin input files ---
+rules.yml
+stupid.py
+--- end input files ---
+[<MASKED TIMESTAMP>][INFO]: Running external command: 'git' 'init' '-b' 'main'
+Initialized empty Git repository in <TMP>/<MASKED>/.git/
+[<MASKED TIMESTAMP>][INFO]: Running external command: 'git' 'config' 'user.name' 'Tester'
+[<MASKED TIMESTAMP>][INFO]: Running external command: 'git' 'config' 'user.email' 'tester@example.com'
+[<MASKED TIMESTAMP>][INFO]: Running external command: 'git' 'add' '.'
+[<MASKED TIMESTAMP>][INFO]: Running external command: 'git' 'commit' '-m' 'Add files'
+[main (root-commit) <MASKED>] Add files
+ 2 files changed, 11 insertions(+)
+ create mode 100644 rules.yml
+ create mode 100644 stupid.py
+
+┌──── [32m○○○[39m ────┐
+│ Semgrep CLI │
+└─────────────┘
+
+✔ Semgrep OSS
+  ✔ Basic security coverage for first-party code vulnerabilities.
+
+✔ Semgrep Code (SAST)
+  ✔ Find and fix vulnerabilities in the code you write with advanced scanning and expert security rules.
+
+✘ Semgrep Secrets
+  ✘ Detect and validate potential secrets in your code.
+
+
+METRICS: Using configs from the Registry (like --config=p/ci) reports pseudonymous rule metrics to semgrep.dev.
+To disable Registry rule metrics, use "--metrics=off".
+When using configs only from local files (like --config=xyz.yml) metrics are sent only when the user is logged in.
+
+More information: https://semgrep.dev/docs/metrics
+
+  Loading rules from local config...
+
+
+┌─────────────┐
+│ Scan Status │
+└─────────────┘
+  Scanning 3 files tracked by git with 1 Code rule:
+  Scanning 3 files.
+
+
+┌────────────────┐
+│ 1 Code Finding │
+└────────────────┘
+
+    stupid.py
+   ❯❯❱ eqeq-bad
+          useless comparison
+
+            3┆ return a + b == a + b
+
+
+
+┌──────────────┐
+│ Scan Summary │
+└──────────────┘
+Some files were skipped or only partially analyzed.
+  Scan was limited to files tracked by git.
+
+Ran 1 rule on 1 file: 1 finding.
+
+┌──── [32m○○○[39m ────┐
+│ Semgrep CLI │
+└─────────────┘
+
+✔ Semgrep OSS
+  ✔ Basic security coverage for first-party code vulnerabilities.
+
+✔ Semgrep Code (SAST)
+  ✔ Find and fix vulnerabilities in the code you write with advanced scanning and expert security rules.
+
+✘ Semgrep Secrets
+  ✘ Detect and validate potential secrets in your code.
+
+
+  Loading rules from local config...
+
+
+┌─────────────┐
+│ Scan Status │
+└─────────────┘
+  Scanning 3 files tracked by git with 1 Code rule:
+  Scanning 3 files.
+
+
+┌────────────────┐
+│ 1 Code Finding │
+└────────────────┘
+
+    stupid.py
+   ❯❯❱ eqeq-bad
+          useless comparison
+
+            3┆ return a + b == a + b
+
+
+
+┌──────────────┐
+│ Scan Summary │
+└──────────────┘
+Some files were skipped or only partially analyzed.
+  Scan was limited to files tracked by git.
+
+Ran 1 rule on 1 file: 1 finding.
+ASSERT exit code
+ASSERT exit code


### PR DESCRIPTION
Currently, the debug message about how to turn off metrics prints at least once, even if the metrics have already been disabled. Now, the metrics will print once only when metrics are being sent. Resolves #5333.

