### PR TITLE
Fix slowest rules report from --time flag

### DIFF
--- a/cli/src/semgrep/formatter/text.py
+++ b/cli/src/semgrep/formatter/text.py
@@ -586,9 +586,9 @@ def print_time_summary(
         )
 
     console.print(f"Slowest {items_to_show} rules to match")
-    slowest_rule_times = sorted(rule_match_timings.items(), reverse=True)[
-        :items_to_show
-    ]
+    slowest_rule_times = sorted(
+        rule_match_timings.items(), reverse=True, key=lambda x: x[1]
+    )[:items_to_show]
     for rule_id, match_time in slowest_rule_times:
         rule_id = truncate(rule_id, col_lim) + ":"
         console.print(


### PR DESCRIPTION
The "slowest rules" report which is printed when `--time` is passed to `semgrep scan` was not printing the slowest rules. Instead, it was printing the last five rules, when the list is sorted alphabetically.

This change ensures that the rules are sorted by run-time instead of rule name.

Fixes https://github.com/semgrep/semgrep/issues/11065

(cc @samueljsb)