### PR TITLE
fix(cli): remove outdated default_command='scan' from CLI entry

### DIFF
--- a/cli/src/semgrep/cli.py
+++ b/cli/src/semgrep/cli.py
@@ -55,7 +55,7 @@ def maybe_set_git_safe_directories() -> None:
 ##############################################################################
 
 
-@click.group(cls=DefaultGroup, default_command="scan", name="semgrep")
+@click.group(cls=DefaultGroup, name="semgrep")
 @click.help_option("--help", "-h")
 @click.pass_context
 def cli(ctx: click.Context) -> None:


### PR DESCRIPTION
### What This PR Does
Removes the `default_command="scan"` logic from the CLI entry point to align with current Semgrep behavior.

The help output currently says:
> If no subcommand is passed, will run `scan` subcommand by default

However, as of Semgrep 1.67.0, running `semgrep` with no subcommand no longer triggers `scan`; it instead shows a help message.

This PR removes the outdated logic and prevents the CLI from showing incorrect guidance.

### Linked Issue
Closes #10063
