### PR TITLE
Associate Containerfiles with dockerfile language

### DIFF
--- a/changelog.d/gh-11091.added
+++ b/changelog.d/gh-11091.added
@@ -1,0 +1,1 @@
+Associate Containerfiles with the `dockerfile` language

--- a/libs/commons/File_type.ml
+++ b/libs/commons/File_type.ml
@@ -84,7 +84,7 @@ and pl_type =
 
 and config_type =
   | Makefile
-  | Dockerfile
+  | Dockerfile (* Dockerfile, Containerfile *)
   (* note: XML is in webpl_type below *)
   | Json
   | Jsonnet
@@ -274,7 +274,9 @@ let file_type_of_file file =
   | "tf" -> Config Terraform
   | "toml" -> Config Toml
   (* sometimes people use foo.Dockerfile *)
-  | "Dockerfile" -> Config Dockerfile
+  | "Dockerfile"
+  | "Containerfile" ->
+      Config Dockerfile
   | "sql" -> PL (Web Sql)
   | "sqlite" -> PL (Web Sql)
   (* apple stuff ? *)
@@ -402,7 +404,7 @@ let file_type_of_file file =
   | "ex" -> PL Elixir
   | _ when UFile.is_executable file -> Binary e
   | _ when b = "Makefile" || b = "mkfile" || b = "Imakefile" -> Config Makefile
-  | _ when b = "Dockerfile" -> Config Dockerfile
+  | _ when b = "Dockerfile" || b = "Containerfile" -> Config Dockerfile
   | _ when b = "dune" -> Config Sexp
   | _ when b = "README" -> Text "txt"
   | _ when b = "CODEOWNERS" -> Text "txt"


### PR DESCRIPTION
Containerfile and Dockerfile are syntactically equivalent file formats - associate file names matching `Containerfile` and `*.Containerfile` with the `dockerfile` language, similarly to how file names matching `Dockerfile` and `*.Dockerfile` currently are.

Closes #11091.

