### PR TITLE
external: git_url_parser: strip trailing slashes; error if no remote

### DIFF
--- a/cli/src/semgrep/external/git_url_parser.py
+++ b/cli/src/semgrep/external/git_url_parser.py
@@ -94,10 +94,12 @@ class Parser(str):
     """
 
     def __init__(self, url: str):
-        # to fix an open bug with trailing slashes: https://github.com/coala/git-url-parse/issues/46
-        self._url: str = url
-        if url[-1] == "/":
-          self._url = url[:-1]
+        if not url:
+            raise ParserError(
+                "No Git remote configured. Please add a remote (e.g., 'origin') to run the scan."
+            )
+
+        self._url: str = url.rstrip("/")
 
     def parse(self) -> Parsed:
         """


### PR DESCRIPTION
Description
- Problem: running Semgrep in a repository initialized with `git init` without `SEMGREP_REPO_URL` set and with no configured remote (`origin`) resulted in an empty repo URL, which led to an IndexError when the parser accessed `url[-1]`.
- Reproduction context:
  docker run --rm \
    -e SEMGREP_APP_TOKEN=... \
    -v "$PWD":/src \
    semgrep/semgrep semgrep ci
  Output included:
  Unable to infer repo_url. Set SEMGREP_REPO_URL environment variable or run in a valid git project with remote origin defined
  IndexError: string index out of range
- Root cause: `Parser.__init__` assumed a non-empty string and indexed the last character. Also, empty strings could reach `get_url_from_sstp_url`, which attempted to parse them.

Fixes
- Add an explicit check for empty URL in `Parser.__init__` with a clear English message:
  "No Git remote configured. Please add a remote (e.g., 'origin') to run the scan."
- Guard `get_url_from_sstp_url` against `None` or empty/whitespace-only strings to avoid invoking the parser when no URL is available.
- Normalize trailing slashes using `rstrip("/")`, ensuring that URLs with and without a trailing slash are parsed consistently. This addresses the behavior reported in: https://github.com/coala/git-url-parse/issues/46

Impact
- Prevents a crash when `SEMGREP_REPO_URL` is unset and the repository has no remote configured.
- Ensures consistent parsing for `https://github.com/test/foo` and `https://github.com/test/foo/`.
- No behavior changes for already supported valid URLs.

How to validate
- No env var and no remote:
  In a repo with only `git init`, run Semgrep. It should show a clear message about the missing remote and not raise `IndexError`.
- Trailing slash:
  Verify that `Parser("https://github.com/test/foo/").parse()` and `Parser("https://github.com/test/foo").parse()` return the same `resource`, `owner`, `name`, and `protocols`.

Notes
- Messages and comments kept in English per project conventions.

Complete error
```python
Unable to infer repo_url. Set SEMGREP_REPO_URL environment variable or run in a valid git project with remote origin defined
string index out of range
Traceback (most recent call last):
  File "/usr/lib/python3.12/site-packages/semgrep/commands/wrapper.py", line 39, in wrapper
    func(*args, **kwargs)
  File "/usr/lib/python3.12/site-packages/semgrep/commands/ci.py", line 399, in ci
    ).to_project_metadata()
      ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/semgrep/meta.py", line 248, in to_project_metadata
    repo_url=uri_opt(self.repo_url),
                     ^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/semgrep/meta.py", line 158, in repo_url
    return get_url_from_sstp_url(repo_url)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/semgrep/meta.py", line 53, in get_url_from_sstp_url
    p = Parser(sstp_url)
        ^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/semgrep/external/git_url_parser.py", line 99, in __init__
    if url[-1] == "/":
       ~~~^^^^
IndexError: string index out of range
There were errors during analysis but Semgrep will succeed because there were no blocking findings, use --no-suppress-errors if you want Semgrep to fail when there are errors.
```
