### PR TITLE
nix: cacert and git are nativeBuildInputs

### DIFF
--- a/semgrep.nix
+++ b/semgrep.nix
@@ -242,7 +242,7 @@ let
 
     buildPhase = lib.buildPhaseSubmoduleCheck "make core";
     # needed for networking tests
-    nativeCheckInputs = (
+    nativeBuildInputs = (
       with pkgs;
       [
         cacert


### PR DESCRIPTION
This fixes an error building the flake where git and the CA certificates were not available.

Specifically building semgrep with the command `nix build ".?submodules=1#packages.x86_64-linux.semgrep"` would give the error:
```
Running phase: buildPhase
@nix { "action": "setPhase", "phase": "buildPhase" }
sh: line 1: git: command not found
dune build _build/install/default/bin/semgrep-core
Warning: Cache directories could not be created: Permission denied; disabling
cache
Hint: Make sure the directory /homeless-shelter/.cache/dune/db/temp can be
created
Scanned 300 directories^M                       ^MDone: 0% (0/0, 0 left) (jobs: 0)^M                                ^MDone: 0% (0/0, 0 left) (jobs: 0)^M                                ^MDone: 0% (0/0, 0 left) (jobs: 0)^M                                ^MDone: 0% (0/0, 0 left) (jobs: 0)^M                             >
Done: 33% (2882/8549, 5667 left) (jobs: 1)^M                                          ^MDone: 33% (2894/8596, 5702 left) (jobs: 5)^M                                          ^MDone: 33% (2895/8597, 5702 left) (jobs: 4)^M                                          ^MDone: 33% (2925/8606, 5681 left) (jobs: 6)^M         >
pcre2_stubs.c:137:29: warning: initialization discards 'volatile' qualifier from pointer target type [-Wdiscarded-qualifiers]
  137 |     caml_int_ptr ovec_dst = &Field(Field(v_substrings, 1), 0) + subgroups2_1;
      |                             ^
pcre2_stubs.c: In function 'pcre2_match_stub0':
pcre2_stubs.c:601:53: warning: 'workspace_len' may be used uninitialized [-Wmaybe-uninitialized]
  601 |           const int *workspace_src_stop = workspace + workspace_len;
      |                                                     ^
pcre2_stubs.c:554:11: note: 'workspace_len' was declared here
  554 |       int workspace_len;
      |           ^~~~~~~~~~~~~
pcre2_stubs.c:601:22: warning: 'workspace' may be used uninitialized [-Wmaybe-uninitialized]
  601 |           const int *workspace_src_stop = workspace + workspace_len;
      |                      ^~~~~~~~~~~~~~~~~~
pcre2_stubs.c:555:12: note: 'workspace' was declared here
  555 |       int *workspace;
      |            ^~~~~~~~~
Done: 37% (3301/8862, 5561 left) (jobs: 32)^M                                           ^MDone: 37% (3304/8862, 5558 left) (jobs: 32)^M                                           ^MDone: 37% (3305/8862, 5557 left) (jobs: 32)^M                                           ^MDone: 37% (3306/8862, 5556 left) (jobs: 32)^M  >
18 |  (preprocess (pps
19 |       ppx_deriving.show
20 |       ppx_profiling
21 |       ppx_telemetry
22 |    ))
Fatal error: exception Failure("Failed to create system store X509 authenticator: ca-certs: no trust anchor file found, looked into /no-cert-file.crt.\nPlease report an issue at https://github.com/mirage/ca-certs, including:\n- the output of uname -s\n- the distribution you use\n- the location of default trust ancho>
Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
Called from Opentelemetry_client_cohttp_eio.Httpc.authenticator in file "src/client-cohttp-eio/opentelemetry_client_cohttp_eio.ml", line 119, characters 6-75
Done: 78% (6951/8862, 1911 left) (jobs: 32)^M                                           ^MDone: 78% (6965/8862, 1897 left, 1 failed) (jobs: 32)^M                                                     ^MFile "src/analyzing/dune", lines 17-21, characters 4-78:
17 |     (pps
18 |       ppx_profiling
19 |       ppx_deriving.show
20 |       telemetry.ppx
21 |     )
```