### PR TITLE
Initial version of matching on doc-string comments

### DIFF
--- a/interfaces/Rule_options.atd
+++ b/interfaces/Rule_options.atd
@@ -179,6 +179,24 @@ type t = {
    * inline, static, etc, are not affected by this option
    *)
   ~decorators_order_matters <ocaml default="false"> : bool;
+
+  (* Enable matching on doc-string comments attached to function definitions.
+     An example pattern for PHP is
+
+     /** $X */
+     function f() { ... }
+
+     This pattern matches any function `f` with a doc-string comment attached.
+     The metavariable will be bound to the text that is between the initial /**
+     and trailing */
+
+     A doc-string pattern can only be of the shape
+
+     <doc-string-leading-symbol> <metavar> <doc-string-trailing-symbol>
+
+     For now, doc-string matching only works for PHP.
+   *)
+  ~match_on_doc_comments <ocaml default="false"> : bool;
 }
 
 type cpp_parsing_opt = [

--- a/languages/php/ast/ast_php.ml
+++ b/languages/php/ast/ast_php.ml
@@ -347,6 +347,7 @@ and func_def = {
   l_uses : (bool (* is_ref *) * var) list;
   f_attrs : attribute list;
   f_body : stmt;
+  f_doc_comment : string wrap option;
 }
 
 and function_kind =

--- a/languages/php/ast/cst_php.ml
+++ b/languages/php/ast/cst_php.ml
@@ -560,6 +560,7 @@ and func_def = {
   f_return_type : (tok (* : *) * hint_type) option;
   (* the opening/closing brace can be (fakeInfo(), ';') for abstract methods *)
   f_body : stmt_and_def list brace;
+  f_doc_comment : tok option; (* doc-string *)
 }
 
 and function_type =

--- a/languages/php/generic/php_to_generic.ml
+++ b/languages/php/generic/php_to_generic.ml
@@ -415,6 +415,7 @@ and expr e : G.expr =
        f_params = ps;
        f_return_type = rett;
        f_body = body;
+       f_doc_comment = _doc;
       } ->
           let _lusesTODO =
             list
@@ -526,6 +527,7 @@ and func_def
       l_uses;
       f_attrs;
       f_body;
+      f_doc_comment;
     } =
   let id = ident f_name in
   let fkind = function_kind f_kind in
@@ -545,8 +547,13 @@ and func_def
   in
   let attrs = list attribute f_attrs in
   let body = stmt f_body in
+  let doc_string_attr = match f_doc_comment with
+    | None -> []
+    | Some (s, t) -> [G.DocStringAttr (s, t)] in
   let ent =
-    G.basic_entity id ~attrs:(modifiers @ attrs) ~case_insensitive:true
+    G.basic_entity id
+      ~attrs:(modifiers @ attrs @ doc_string_attr)
+      ~case_insensitive:true
   in
   let def =
     { G.fparams = fb params; frettype = fret; fbody = G.FBStmt body; fkind }

--- a/languages/php/menhir/ast_php_build.ml
+++ b/languages/php/menhir/ast_php_build.ml
@@ -73,6 +73,9 @@ let brace (_, x, _) = x
 let bracket f (a, b, c) = (a, f b, c)
 let noop tok = A.Block (fb tok [])
 
+let doc_comment_wrap doc_comment_opt =
+  doc_comment_opt |> Option.map (fun tok -> (Tok.content_of_tok tok, tok))
+
 (*****************************************************************************)
 (* Main entry point *)
 (*****************************************************************************)
@@ -657,7 +660,8 @@ and func_def env f =
     A.f_kind = (A.Function, f.f_tok);
     A.m_modifiers = [];
     A.l_uses = [];
-  }
+    A.f_doc_comment = doc_comment_wrap f.f_doc_comment;
+    }
 
 and lambda_def env (l_use, ld) =
   let _, params, _ = ld.f_params in
@@ -680,6 +684,8 @@ and lambda_def env (l_use, ld) =
           comma_list xs
           |> List_.map (function LexicalVar (is_ref, name) ->
                  (is_ref <> None, dname name)));
+    A.f_doc_comment =
+      Option.map (fun tok -> Tok.content_of_tok tok, tok) ld.f_doc_comment;
   }
 
 and short_lambda_def env def =
@@ -706,6 +712,7 @@ and short_lambda_def env def =
     m_modifiers = [];
     f_attrs = [];
     l_uses = [];
+    f_doc_comment = None;
   }
 
 and type_def env def =
@@ -879,6 +886,7 @@ and method_def env m =
       A.f_body = (* implicit_assigns @ *) method_body env m.f_body;
       A.f_kind = (A.Method, m.f_tok);
       A.l_uses = [];
+      A.f_doc_comment = doc_comment_wrap m.f_doc_comment;
     },
     implicit_flds )
 

--- a/languages/php/menhir/parse_php.ml
+++ b/languages/php/menhir/parse_php.ml
@@ -85,12 +85,12 @@ let is_comment v =
 (* Main entry point *)
 (*****************************************************************************)
 
-let parse filename =
+let parse filename ~keep_func_doc =
   let stat = Parsing_stat.default_stat !!filename in
   let filelines = UFile.cat_array filename in
 
   let toks = tokens (Parsing_helpers.file !!filename) in
-  let toks = Parsing_hacks_php.fix_tokens toks in
+  let toks = Parsing_hacks_php.fix_tokens toks ~keep_func_doc in
 
   let tr, lexer, lexbuf_fake =
     Parsing_helpers.mk_lexer_for_yacc toks is_comment
@@ -147,26 +147,26 @@ let parse filename =
       }
 [@@profiling]
 
-let parse_program file =
-  let res = parse file in
+let parse_program file ~keep_func_doc =
+  let res = parse file ~keep_func_doc in
   res.Parsing_result.ast
 
 (*****************************************************************************)
 (* Sub parsers *)
 (*****************************************************************************)
 
-let any_of_string s =
+let any_of_string s ~keep_func_doc =
   Hook.with_hook_set Flag_parsing.sgrep_mode true (fun () ->
       let toks =
         tokens ~init_state:Lexer_php.ST_IN_SCRIPTING (Parsing_helpers.Str s)
       in
-      let toks = Parsing_hacks_php.fix_tokens toks in
+      let toks = Parsing_hacks_php.fix_tokens toks ~keep_func_doc in
       let _tr, lexer, lexbuf_fake =
         Parsing_helpers.mk_lexer_for_yacc toks is_comment
       in
       Parser_php.semgrep_pattern lexer lexbuf_fake)
 
-let program_of_string s =
-  match any_of_string s with
+let program_of_string s ~keep_func_doc =
+  match any_of_string s ~keep_func_doc with
   | Cst_php.Program x -> x
   | _else_ -> failwith ("not a program: " ^ s)

--- a/languages/php/menhir/parse_php.mli
+++ b/languages/php/menhir/parse_php.mli
@@ -11,11 +11,11 @@
    LICENSE for more details.
 *)
 (* This is the main function. raise Parse_error when not Flag.error_recovery.*)
-val parse : Fpath.t -> (Cst_php.program, Parser_php.token) Parsing_result.t
-val parse_program : Fpath.t -> Cst_php.program
+val parse : Fpath.t -> keep_func_doc:bool -> (Cst_php.program, Parser_php.token) Parsing_result.t
+val parse_program : Fpath.t -> keep_func_doc:bool -> Cst_php.program
 
 (* for sgrep/spatch patterns *)
-val any_of_string : string -> Cst_php.any
+val any_of_string : string -> keep_func_doc:bool -> Cst_php.any
 
 val tokens :
   ?init_state:Lexer_php.state_mode ->
@@ -23,4 +23,4 @@ val tokens :
   Parser_php.token list
 
 (* useful in tests *)
-val program_of_string : string -> Cst_php.program
+val program_of_string : string -> keep_func_doc:bool -> Cst_php.program

--- a/languages/php/menhir/parser_php.mly
+++ b/languages/php/menhir/parser_php.mly
@@ -126,6 +126,8 @@ let str_of_info x = Tok.content_of_tok x
 (* not mentionned in this grammar. filtered in parse_php.ml *)
 %token <Tok.t> T_COMMENT T_DOC_COMMENT
 
+%token <Tok.t> T_FUNC_DOC_COMMENT
+
 (* when use preprocessor and want to mark removed tokens as commented *)
 %token <Tok.t> TCommentPP
 
@@ -555,8 +557,8 @@ constant_declaration:
 (*************************************************************************)
 (* Function declaration *)
 (*************************************************************************)
-function_declaration: ioption(attributes) unticked_function_declaration
-   { { $2 with f_attrs = $1 } }
+function_declaration: ioption(T_FUNC_DOC_COMMENT) ioption(attributes) unticked_function_declaration
+   { { $3 with f_attrs = $2; f_doc_comment = $1 } }
 
 unticked_function_declaration:
  async_opt T_FUNCTION is_reference ident type_params_opt
@@ -568,6 +570,7 @@ unticked_function_declaration:
        f_return_type = $9; f_body = $10;
        f_attrs = None;
        f_type = FunctionRegular; f_modifiers = $1;
+       f_doc_comment = None;
     } }
 
 function_body:
@@ -753,7 +756,7 @@ member_declaration:
      { ClassVariables($1, $2, $3, $4)  }
 
 (* class methods *)
- | ioption(attributes) method_declaration { Method { $2 with f_attrs = $1 } }
+ | ioption(T_FUNC_DOC_COMMENT) ioption(attributes) method_declaration { Method { $3 with f_attrs = $2; f_doc_comment = $1 } }
 
 (* php 5.4 traits *)
  | T_USE class_name_list ";"
@@ -777,7 +780,7 @@ method_declaration:
        ({ f_tok = $2; f_ref = $3; f_name = Name $4; f_tparams = $5;
           f_params = ($6, $7, $8); f_return_type = $9;
           f_body = body; f_type = function_type; f_modifiers = $1;
-          f_attrs = None;
+          f_attrs = None; f_doc_comment = None;
         })
      }
 
@@ -1025,6 +1028,7 @@ expr:
                      f_return_type = $8; f_type = FunctionLambda;
                      f_modifiers = $1;
                      f_attrs = None;
+                     f_doc_comment = None; (* no doc-strings on anonymous functions *)
        })
    }
  (* php-facebook-ext: lambda (short closure)s *)

--- a/languages/php/menhir/parsing_hacks_php.ml
+++ b/languages/php/menhir/parsing_hacks_php.ml
@@ -114,6 +114,27 @@ let rec is_variable toks =
   | T_VARIABLE _ :: _ -> true
   | x :: xs -> if TH.is_comment x then is_variable xs else false
 
+
+let rec is_function_ahead toks =
+  match toks with
+  | [] -> false
+  | T_FUNCTION _ :: _ -> true
+  (* Skip whitespace and other comments *)
+  | (TSpaces _ | TNewline _ | T_COMMENT _) :: xs -> is_function_ahead xs
+  (* Skip attributes *)
+  | TOATTR _ :: xs -> skip_until_close_bracket xs
+  (* Skip modifiers that can precede function declarations *)
+  | ( T_PUBLIC _ | T_PROTECTED _ | T_PRIVATE _ | T_STATIC _ | T_ABSTRACT _
+    | T_FINAL _ | T_ASYNC _ ) :: xs -> is_function_ahead xs
+  | _ -> false
+
+(* Helper to skip tokens until we find the closing bracket of attributes *)
+and skip_until_close_bracket toks =
+  match toks with
+  | [] -> false
+  | TCBRA _ :: xs -> is_function_ahead xs
+  | _ :: xs -> skip_until_close_bracket xs
+
 (*
  * Find the next group of parenthesized tokens, being sure to balance parens.
  * Returns an empty list if the parens were imbalanced or the first non-comment
@@ -192,11 +213,24 @@ let find_typehint toks =
 (* Fix tokens *)
 (*****************************************************************************)
 
-let fix_tokens xs =
+let fix_tokens xs ~keep_func_doc =
   let rec aux env acc xs =
     match xs with
     (* need an acc, to be tail recursive, otherwise get some stack overflow *)
     | [] -> List.rev acc
+    (* If keep_func_doc is true and a T_DOC_COMMENT token is followed by a
+     * T_FUNCTION token (ignoring tokens as defined in is_function_ahead), we
+     * rewrite the T_DOC_COMMENT token into a T_FUNC_DOC_COMMENT token which
+     * the parser can pick up on to attach the doc-string to the function
+     * declaration
+     *)
+    | T_DOC_COMMENT ii :: xs' when keep_func_doc ->
+        let new_acc =
+          if is_function_ahead xs'
+          then  (T_FUNC_DOC_COMMENT ii :: acc)
+          else T_DOC_COMMENT ii :: acc
+        in
+        aux env new_acc xs'
     (* '>>', maybe should be split in two tokens '>' '>' when in generic
      * context
      *)

--- a/languages/php/menhir/parsing_hacks_php.mli
+++ b/languages/php/menhir/parsing_hacks_php.mli
@@ -10,4 +10,4 @@
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the file
    LICENSE for more details.
 *)
-val fix_tokens : Parser_php.token list -> Parser_php.token list
+val fix_tokens : Parser_php.token list -> keep_func_doc:bool -> Parser_php.token list

--- a/languages/php/menhir/token_helpers_php.ml
+++ b/languages/php/menhir/token_helpers_php.ml
@@ -144,6 +144,7 @@ let visitor_info_of_tok f = function
   | T_DIR ii -> T_DIR (f ii)
   | T_COMMENT ii -> T_COMMENT (f ii)
   | T_DOC_COMMENT ii -> T_DOC_COMMENT (f ii)
+  | T_FUNC_DOC_COMMENT ii -> T_FUNC_DOC_COMMENT (f ii)
   | T_OPEN_TAG ii -> T_OPEN_TAG (f ii)
   | T_OPEN_TAG_WITH_ECHO ii -> T_OPEN_TAG_WITH_ECHO (f ii)
   | T_CLOSE_TAG_OF_ECHO ii -> T_CLOSE_TAG_OF_ECHO (f ii)

--- a/languages/php/menhir/unit_parsing_php.ml
+++ b/languages/php/menhir/unit_parsing_php.ml
@@ -35,7 +35,7 @@ let tests =
   let assert_invalid p =
     Hook.with_hook_set Flag.show_parsing_error false (fun () ->
         Alcotest.match_raises __LOC__ is_syn_err (fun () ->
-            ignore (Parse_php.program_of_string p)))
+            ignore (Parse_php.program_of_string p ~keep_func_doc:false)))
   in
 
   Testo.categorize "parsing_php"
@@ -43,11 +43,11 @@ let tests =
       (* Parsing *)
       (*-----------------------------------------------------------------------*)
       t "parsing regular code" (fun () ->
-          let _ast = Parse_php.program_of_string "echo 1+2;" in
+          let _ast = Parse_php.program_of_string "echo 1+2;" ~keep_func_doc:false in
           ());
       (* had such a bug one day ... *)
       t "parsing empty comments" (fun () ->
-          let _ast = Parse_php.program_of_string "$a/**/ =1;" in
+          let _ast = Parse_php.program_of_string "$a/**/ =1;" ~keep_func_doc:false in
           ());
       t "rejecting bad code" (fun () -> assert_invalid "echo 1+");
       (* old:
@@ -75,7 +75,7 @@ let tests =
           files
           |> List.iter (fun file ->
                  try
-                   let _ = Parse_php.parse_program file in
+                   let _ = Parse_php.parse_program file ~keep_func_doc:false in
                    ()
                  with
                  | Parsing_error.Syntax_error _ ->
@@ -86,7 +86,7 @@ let tests =
       t "sphp" (fun () ->
           let t x =
             try
-              let _ = Parse_php.program_of_string x in
+              let _ = Parse_php.program_of_string x ~keep_func_doc:false in
               ()
             with
             | Parsing_error.Syntax_error _ ->

--- a/languages/php/tree-sitter/Parse_php_tree_sitter.ml
+++ b/languages/php/tree-sitter/Parse_php_tree_sitter.ml
@@ -1566,6 +1566,7 @@ and map_method_declaration (env : env)
       A.f_attrs = v1;
       A.l_uses = [];
       A.f_body = v4;
+      A.f_doc_comment = None;
     }
 
 and map_nullsafe_member_access_expression (env : env)
@@ -1684,6 +1685,7 @@ and map_primary_expression (env : env) (x : CST.primary_expression) : A.expr =
           A.f_attrs = [];
           A.l_uses = v5;
           A.f_body = v7;
+          A.f_doc_comment = None;
         }
   | `Arrow_func (v1, v2, v3, v4, v5, v6, v7) ->
       let v1 =
@@ -1713,6 +1715,7 @@ and map_primary_expression (env : env) (x : CST.primary_expression) : A.expr =
           A.f_attrs = [];
           A.l_uses = [];
           A.f_body = Expr (v7, Tok.unsafe_sc);
+          A.f_doc_comment = None;
         }
   | `Obj_crea_exp x -> map_object_creation_expression env x
   | `Update_exp x -> map_update_expression env x
@@ -2003,6 +2006,7 @@ and map_statement (env : env) (x : CST.statement) =
           A.f_attrs = v1;
           A.l_uses = [];
           A.f_body = v3;
+          A.f_doc_comment = None;
         }
   | `Class_decl (v1, v2, v3, v4, v5, v6, v7, v8) ->
       let v1 =

--- a/src/ast_generic/AST_generic.ml
+++ b/src/ast_generic/AST_generic.ml
@@ -1593,6 +1593,9 @@ and attribute =
   | KeywordAttr of keyword_attribute wrap
   (* a.k.a decorators, annotations *)
   | NamedAttr of tok (* '@' *) * name * arguments (* less: option *)
+  (* documentation comment; a pair of the comment string and the token from which
+     it originates. The first component is redundant, but convenient. *)
+  | DocStringAttr of string * tok
   (* e.g,, per-language specific keywords like 'transient', 'synchronized'
    * todo: Expr used for Python, but should transform in NamedAttr when can *)
   | OtherAttribute of todo_kind * any list

--- a/src/ast_generic/Meta_AST.ml
+++ b/src/ast_generic/Meta_AST.ml
@@ -803,6 +803,7 @@ and vof_attribute = function
   | OtherAttribute (v1, v2) ->
       let v1 = vof_todo_kind v1 and v2 = OCaml.vof_list vof_any v2 in
       OCaml.VSum ("OtherAttribute", [ v1; v2 ])
+  | DocStringAttr (docstr, _tok) -> OCaml.VSum("DocStringAttr", [VString docstr])
 
 and vof_stmt st =
   (* todo: dump also the s_id? *)

--- a/src/matching/Pattern_vs_code.ml
+++ b/src/matching/Pattern_vs_code.ml
@@ -57,7 +57,9 @@ let hook_r2c_pro_was_here = Hook.create false
  *  - the underlying AST uses some normalization (!= is transformed in !(..=))
  *    to support certain code equivalences (see equivalence: tag)
  *  - we do not care about differences in spaces/indentations/comments.
- *    we work at the AST-level.
+ *    we work at the AST-level -- however, doc-string comments can be matched
+ *    in case the option to do so is enabled (see "match_on_doc_comments" in
+ *    Rule_options)
  *  - other equivalences using global analysis (see deep: tag)
  *
  * alternatives:
@@ -72,6 +74,91 @@ let hook_r2c_pro_was_here = Hook.create false
 (*****************************************************************************)
 (* Extra Helpers *)
 (*****************************************************************************)
+
+
+(**
+ Removes leading /** and trailing */ from the input if present along with any
+ leading and trailing whitespace.
+ *)
+let remove_php_doc_string_delimiters raw =
+  let doc = String.trim raw in
+  if String.starts_with ~prefix:"/**" doc && String.ends_with ~suffix:"*/" doc
+  then String.sub doc 3 (String.length doc - 5) |> String.trim
+  else doc
+
+(**
+ Given a doc-string assumed to occur in a php context, remove
+ the doc-string delimiters and check what remains is a valid
+ meta-variable name.
+
+ For any string of the form "/** $X */", the string "$X" is
+ returned.
+
+ The following string would result in `None` being returned
+ because of the `*` preceding `$X`:
+
+  /**
+   * $X
+   */
+
+  *)
+let extract_metavariable_only s =
+    let trimmed = remove_php_doc_string_delimiters s in
+      if Mvar.is_metavar_name trimmed
+      then Some trimmed
+      else None
+
+(**
+  Remove php doc-string delimiters /** and */ if present
+  and adjust the token range accordingly.
+ *)
+let adjust_info_remove_doc_string_delimiters (s, tok) =
+  match Tok.loc_of_tok tok with
+  | Error _ -> (s, tok)
+  | Ok loc ->
+    let trimmed = remove_php_doc_string_delimiters s in
+    let re = Str.regexp_string trimmed in
+    try
+      let new_pos = Str.search_forward re loc.str 0 in
+      let new_loc = {
+        Loc.str = trimmed;
+        pos = {
+          loc.pos with
+            bytepos = loc.pos.bytepos + new_pos;
+            column = loc.pos.column + new_pos;
+        };
+      }
+      in
+      (trimmed, Tok.OriginTok new_loc)
+    with
+    | Not_found ->
+      Log.debug (fun m ->
+        m "could not find doc-string contents in %s" s);
+      (s, tok)
+
+(**
+  Returns a matcher for doc-string comments.
+
+  In this version, a doc-string pattern can be either interpreted as
+  completely concrete or entirely abstract and bind a given metvariable.
+
+  A doc-string pattern with a meta-variable is of the form "/** $X */".
+  That is, doc-string delimiters surrounding a valid metavariable name.
+  Anything else, is taken as a concrete string pattern.
+*)
+let m_doc_string_metavar_or_string (pat_str, pat_tok) (code_str, code_tok) =
+  with_lang (fun lang ->
+    if Lang.equal Lang.Php lang
+    then
+      let extracted_meta = extract_metavariable_only pat_str in
+      match extracted_meta with
+      | None -> m_string pat_str code_str
+      | Some mv ->
+        let (trimmed_str, trimmed_tok) =
+          adjust_info_remove_doc_string_delimiters (code_str, code_tok) in
+        envf (mv, pat_tok) (MV.Text (trimmed_str, trimmed_tok, code_tok))
+    else m_string pat_str code_str
+  )
 
 let env_add_matched_stmt rightmost_stmt (tin : tin) =
   [ extend_stmts_matched rightmost_stmt tin ]
@@ -2489,6 +2576,9 @@ and m_attribute a b =
   | ( G.NamedAttr (_, a1, a2),
       B.OtherAttribute (_, [ B.E { e = B.Call (b1, b2); _ } ]) ) ->
       m_expr (G.N a1 |> G.e) b1 >>= fun () -> m_bracket m_list__m_argument a2 b2
+  | G.DocStringAttr (pstr, pt), G.DocStringAttr (cstr, ct) ->
+      m_doc_string_metavar_or_string (pstr, pt) (cstr, ct)
+  | G.DocStringAttr _, _
   | G.KeywordAttr _, _
   | G.NamedAttr _, _
   | G.OtherAttribute _, _ ->

--- a/src/parsing/Parse_pattern.ml
+++ b/src/parsing/Parse_pattern.ml
@@ -89,7 +89,11 @@ let parse_pattern_by_lang options lang str =
       let any = Parse_go.any_of_string str in
       Go_to_generic.any any
   | Lang.Php ->
-      let any_cst = Parse_php.any_of_string str in
+      let keep_func_doc =
+        match options with
+        | None -> false
+        | Some opt -> opt.Rule_options_t.match_on_doc_comments in
+      let any_cst = Parse_php.any_of_string str ~keep_func_doc in
       let any = Ast_php_build.any any_cst in
       Php_to_generic.any any
   | Lang.Ocaml ->

--- a/src/parsing/Parse_target.ml
+++ b/src/parsing/Parse_target.ml
@@ -125,7 +125,7 @@ let just_parse_with_lang lang file : Parsing_result2.t =
               (* TODO: at some point parser_php.mly should go directly
                * to ast_php.ml and we should get rid of cst_php.ml
                *)
-              let cst, stat = throw_tokens Parse_php.parse file in
+              let cst, stat = throw_tokens (Parse_php.parse ~keep_func_doc:true) file in
               (Ast_php_build.program cst, stat));
           (* TODO: can't put TreeSitter first, because we still use Pfff
            * to parse the pattern, and there must be mismatch between the

--- a/tests/rules/doc-string-matching/doc-string-concrete-meta.php
+++ b/tests/rules/doc-string-matching/doc-string-concrete-meta.php
@@ -1,0 +1,19 @@
+<?php
+
+# ruleid:doc-string-concrete-meta
+/**
+ * $X
+ */
+function sayWelcomeMessage()
+{
+    echo "welcome world!";
+}
+
+/** $X */
+function sayWelcomeMessage2()
+{
+    echo "welcome world!";
+}
+
+
+?>

--- a/tests/rules/doc-string-matching/doc-string-concrete-meta.yaml
+++ b/tests/rules/doc-string-matching/doc-string-concrete-meta.yaml
@@ -1,0 +1,14 @@
+rules:
+  - id: doc-string-concrete-meta
+    options:
+      match_on_doc_comments: true
+    patterns:
+      - pattern: |
+          /**
+           * $X
+           */
+          function $FUNC(...) { ... }
+    message: >-
+      This is what is in the docstring: $X
+    languages: [php]
+    severity: INFO

--- a/tests/rules/doc-string-matching/doc-string-concrete.php
+++ b/tests/rules/doc-string-matching/doc-string-concrete.php
@@ -1,0 +1,12 @@
+<?php
+
+# ruleid:doc-string-concrete
+/**
+ * Something simple
+ */
+function sayWelcomeMessage()
+{
+    echo "welcome world!";
+}
+
+?>

--- a/tests/rules/doc-string-matching/doc-string-concrete.yaml
+++ b/tests/rules/doc-string-matching/doc-string-concrete.yaml
@@ -1,0 +1,14 @@
+rules:
+  - id: doc-string-concrete
+    options:
+      match_on_doc_comments: true
+    patterns:
+      - pattern: |
+          /**
+           * Something simple
+           */
+          function $FUNC(...) { ... }
+    message: >-
+      This is what is in the docstring: $X
+    languages: [php]
+    severity: INFO

--- a/tests/rules/doc-string-matching/doc-string-focus.php
+++ b/tests/rules/doc-string-matching/doc-string-focus.php
@@ -1,0 +1,12 @@
+<?php
+
+# ruleid:doc-string-focus
+/**
+ * Something simple
+ */
+function sayWelcomeMessage()
+{
+    echo "welcome world!";
+}
+
+?>

--- a/tests/rules/doc-string-matching/doc-string-focus.yaml
+++ b/tests/rules/doc-string-matching/doc-string-focus.yaml
@@ -1,0 +1,13 @@
+rules:
+  - id: doc-string-focus
+    options:
+      match_on_doc_comments: true
+    patterns:
+      - pattern: |
+          /** $X */
+          function $FUNC(...) { ... }
+      - focus-metavariable: $X
+    message: >-
+      This is what is in the docstring: $X
+    languages: [php]
+    severity: INFO

--- a/tests/rules/doc-string-matching/doc-string-ignored.php
+++ b/tests/rules/doc-string-matching/doc-string-ignored.php
@@ -1,0 +1,12 @@
+<?php
+
+# ruleid:doc-string-ignored
+/**
+ * Something simple
+ */
+function sayWelcomeMessage()
+{
+    echo "welcome world!";
+}
+
+?>

--- a/tests/rules/doc-string-matching/doc-string-ignored.yaml
+++ b/tests/rules/doc-string-matching/doc-string-ignored.yaml
@@ -1,0 +1,14 @@
+rules:
+  - id: doc-string-ignored
+    options:
+      match_on_doc_comments: false
+    patterns:
+      - pattern: |
+          /**
+           * This doc-string comment is ignored when matching.
+           */
+          function $FUNC(...) { ... }
+    message: >-
+      This is what is in the docstring: $X
+    languages: [php]
+    severity: INFO

--- a/tests/rules/doc-string-matching/multi-pattern.php
+++ b/tests/rules/doc-string-matching/multi-pattern.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * The first docstring
+ * And some more
+ */
+function sayWelcomeMessage() {
+    echo "welcome world!";
+}
+
+
+# ruleid:doc-string-multi-rule
+/**
+ * @special
+ */
+function withSpecial() {
+    echo "Test";
+}
+
+?>

--- a/tests/rules/doc-string-matching/multi-pattern.yaml
+++ b/tests/rules/doc-string-matching/multi-pattern.yaml
@@ -1,0 +1,17 @@
+rules:
+  - id: doc-string-multi-rule
+    options:
+      match_on_doc_comments: true
+    patterns:
+      - pattern: |
+          /** $X */
+          function $FUNC(...) { ... }
+      - metavariable-pattern:
+          language: generic
+          metavariable: $X
+          pattern: >-
+            @special
+    message: >-
+      This is what is in the docstring: $X
+    languages: [php]
+    severity: INFO

--- a/tests/rules/doc-string-matching/single-pattern.php
+++ b/tests/rules/doc-string-matching/single-pattern.php
@@ -1,0 +1,43 @@
+<?php
+
+# ruleid:doc-string-comment
+/**
+ * The first docstring
+ * And some more
+ */
+function sayWelcomeMessage() {
+    echo "welcome world!";
+}
+
+class A {
+    # ruleid:doc-string-comment
+    /**
+     * This considered part of the doc-comment.
+     */
+    function method1() {
+        echo "Go";
+    }
+
+    # ruleid:doc-string-comment
+    /**
+     * Another match
+     */
+    public function m2() {
+        echo "Test";
+    }
+}
+
+# ruleid:doc-string-comment
+/**
+ * With attributes
+ */
+#[ThisIsOk]
+function attrFunc() {
+    echo "Test";
+}
+
+function thisOneHasNoDocString() {
+    echo "Test";
+}
+
+?>

--- a/tests/rules/doc-string-matching/single-pattern.yaml
+++ b/tests/rules/doc-string-matching/single-pattern.yaml
@@ -1,0 +1,12 @@
+rules:
+  - id: doc-string-comment
+    options:
+      match_on_doc_comments: true
+    patterns:
+      - pattern: |
+          /** $X */
+          function $FUNC(...) { ... }
+    message: >-
+      This is what is in the docstring: $X
+    languages: [php]
+    severity: INFO


### PR DESCRIPTION
This PR adds a new feature of matching on doc-string comments.

For now, only the Pfff-parser for PHP has been changed to optionally include doc-string comments and for now it's also only supported on named function declarations and class methods.

The approach is to add a new case, `DocStringAttr` to the `attribute` type which is then added for constructing `entity` values for functions.

We could also have added the doc-string comment on `entity` directly, but then the impact would be that every single `x_to_generic` function would need to change just to provide no doc-string value.

A doc-string pattern can be of the form: (PHP)
```
/** $X */
```
When matching a doc-string pattern with a doc-string comment, the `$X` is extracted and bound to everything in the doc-string comment between `/**` and `*/`.