### PR TITLE
ci: Add GitHub Container Registry (GHCR) publishing support

### DIFF
--- a/.github/workflows/libs/actions.libsonnet
+++ b/.github/workflows/libs/actions.libsonnet
@@ -159,8 +159,8 @@ local merge_base_output = '${{ steps.get-merge-base.outputs.commit }}';
         uses: 'actions/checkout@v4',
         with: {
           submodules: true,
-        },
-      } + (if ref == '' then {} else { ref: ref }),
+        } + (if ref == '' then {} else { ref: ref }),
+      },
     ],
 
   // ---------------------------------------------------------
@@ -206,6 +206,16 @@ local merge_base_output = '${{ steps.get-merge-base.outputs.commit }}';
     with: {
       username: '${{ secrets.DOCKER_USERNAME }}',
       password: '${{ secrets.DOCKER_PASSWORD }}',
+    },
+  },
+
+  // Login to GitHub Container Registry (ghcr.io)
+  ghcr_login_step: {
+    uses: 'docker/login-action@v3',
+    with: {
+      registry: 'ghcr.io',
+      username: '${{ github.actor }}',
+      password: '${{ secrets.GITHUB_TOKEN }}',
     },
   },
 

--- a/.github/workflows/libs/docker.libsonnet
+++ b/.github/workflows/libs/docker.libsonnet
@@ -229,6 +229,7 @@ local build_steps(
         images: (if push then |||
                    returntocorp/%(name)s
                    semgrep/%(name)s
+                   ghcr.io/semgrep/%(name)s
                  ||| % { name: name } else '') + (if push || push_ecr then |||
                                                     %(ecr_repo)s
                                                   ||| % { ecr_repo: ecr_repo } else ''),
@@ -406,6 +407,8 @@ local job(
              if push then [
                // This is needed so we can push images to docker hub successfully.
                actions.docker_login_step,
+               // Login to GitHub Container Registry (ghcr.io)
+               actions.ghcr_login_step,
              ] else []
            ) + (if push_ecr || push then [
                   // The configure-aws-credentials and login-ecr steps are needed so


### PR DESCRIPTION
## Summary

Adds GitHub Container Registry (GHCR) publishing alongside existing Docker Hub and Amazon ECR publishing.

## Benefits

- **No rate limits** for authenticated users (vs Docker Hub's 100 pulls/6h for free tier)
- **No new secrets needed** - uses existing `GITHUB_TOKEN`
- **Faster pulls** in GitHub Actions
- **Better discoverability** - images appear on repository's packages page

## Changes

- Added `ghcr_login_step` to `.github/workflows/libs/actions.libsonnet`
- Added `ghcr.io/semgrep/semgrep` to images list in `.github/workflows/libs/docker.libsonnet`
- Fixed `checkout_with_submodules()` ref parameter placement bug

## Testing

Tested in fork: https://github.com/ugiordan/semgrep/actions/runs/20261365615

Published to: https://github.com/ugiordan/semgrep/pkgs/container/semgrep

## Backward Compatibility

Non-breaking - existing Docker Hub and ECR publishing unchanged.