### PR TITLE
ci: Sync PRs to pro before merging

### DIFF
--- a/.github/workflows/sync-with-PRO.jsonnet
+++ b/.github/workflows/sync-with-PRO.jsonnet
@@ -51,15 +51,21 @@ local job = {
       // the git config are needed otherwise GHA complains about
       // unknown identity
       run: |||
-        # Get PR information
-        PR_TITLE=$(gh pr view $PR_NUMBER --json title --jq .title)
-        PR_BODY=$(gh pr view $PR_NUMBER --json body --jq .body)
+        # Get PR information and store it for later
+        gh pr view $PR_NUMBER --json title --jq .title > /tmp/pr_title
+        gh pr view $PR_NUMBER --json body --jq .body > /tmp/pr_body
+        AUTHOR=$(gh pr view $PR_NUMBER --json author --jq .author.login)
+        # Add original attribution
+        echo "" >> /tmp/pr_body
+        echo "Closes $PR_NUMBER" >> /tmp/pr_body
+        echo "Author: $AUTHOR" >> /tmp/pr_body
+        # TODO add who imported the PR
+
         BASE_BRANCH=$(gh pr view $PR_NUMBER --json baseRefName --jq .baseRefName)
 
         # Get the merge base and current HEAD
         git fetch origin $BASE_BRANCH
         MERGE_BASE=$(git merge-base origin/$BASE_BRANCH HEAD)
-        OSSREF=$(git rev-parse HEAD)
 
         # Check if any commits are already synced from Pro
         if git log $MERGE_BASE..HEAD --oneline | grep -q "synced from Pro"; then
@@ -68,11 +74,7 @@ local job = {
         fi
 
         # Generate patches for all commits in the PR
-        git format-patch $MERGE_BASE..HEAD
-
-        # Store PR info for later
-        echo "$PR_TITLE" > /tmp/pr_title
-        echo "$PR_BODY" > /tmp/pr_body
+        PATCHES=$(git format-patch $MERGE_BASE..HEAD)
 
         cd PRO
         git config --global user.name "GitHub Actions Bot"
@@ -80,16 +82,14 @@ local job = {
         git checkout -b $BRANCHNAME
 
         # Apply all patches
-        for patch in ../*.patch; do
-          if [ -f "$patch" ]; then
-            git am --directory=OSS "$patch"
-          fi
+        for patch in $PATCHES; do
+          git am --directory=OSS "../$patch"
         done
 
         # Amend the last commit to add sync reference
         git log -1 --pretty=%B >message
         echo "" >>message
-        echo "synced from OSS https://github.com/semgrep/semgrep/pull/$PR_NUMBER ($OSSREF)" >>message
+        echo "synced from OSS https://github.com/semgrep/semgrep/pull/$PR_NUMBER" >>message
         git commit --amend -F message
         git push origin $BRANCHNAME
       |||,

--- a/.github/workflows/sync-with-PRO.jsonnet
+++ b/.github/workflows/sync-with-PRO.jsonnet
@@ -127,7 +127,7 @@ local job = {
     workflow_dispatch: {
       inputs: {
         pr_number: {
-          description: 'PR number to sync to PRO',
+          description: 'PR number to sync to PRO (e.g. "11420")',
           required: true,
           type: 'number',
         },

--- a/.github/workflows/sync-with-PRO.jsonnet
+++ b/.github/workflows/sync-with-PRO.jsonnet
@@ -86,11 +86,6 @@ local job = {
           git am --directory=OSS "../$patch"
         done
 
-        # Amend the last commit to add sync reference
-        git log -1 --pretty=%B >message
-        echo "" >>message
-        echo "synced from OSS https://github.com/semgrep/semgrep/pull/$PR_NUMBER" >>message
-        git commit --amend -F message
         git push origin $BRANCHNAME
       |||,
     },

--- a/.github/workflows/sync-with-PRO.jsonnet
+++ b/.github/workflows/sync-with-PRO.jsonnet
@@ -25,8 +25,8 @@ local job = {
       name: 'Checkout OSS',
       uses: uses.actions.checkout,
       with: {
-        ref: 'develop',
-        // fetch all history, seems needed to reference develop^ below
+        ref: 'refs/pull/${{ inputs.pr_number }}/head',
+        // fetch all history to get base branch and all PR commits
         'fetch-depth': 0,
         // Use the token provided by the JWT token getter above
         token: semgrep.github_bot.token_ref,
@@ -46,25 +46,50 @@ local job = {
       env: {
         BRANCHNAME: 'sync-with-PRO-${{ github.run_id }}-${{ github.run_attempt }}',
         GITHUB_TOKEN: semgrep.github_bot.token_ref,
+        PR_NUMBER: '${{ inputs.pr_number }}',
       },
       // the git config are needed otherwise GHA complains about
       // unknown identity
       run: |||
-        if git show --stat develop | grep -q "synced from Pro"; then
-           echo "error: HEAD commit already comes from Pro and cannot be synced"
+        # Get PR information
+        PR_TITLE=$(gh pr view $PR_NUMBER --json title --jq .title)
+        PR_BODY=$(gh pr view $PR_NUMBER --json body --jq .body)
+        BASE_BRANCH=$(gh pr view $PR_NUMBER --json baseRefName --jq .baseRefName)
+
+        # Get the merge base and current HEAD
+        git fetch origin $BASE_BRANCH
+        MERGE_BASE=$(git merge-base origin/$BASE_BRANCH HEAD)
+        OSSREF=$(git rev-parse HEAD)
+
+        # Check if any commits are already synced from Pro
+        if git log $MERGE_BASE..HEAD --oneline | grep -q "synced from Pro"; then
+           echo "error: PR contains commits that already come from Pro and cannot be synced"
            exit 1
         fi
-        # will generate a 0001-xxx patch
-        git format-patch develop^
-        OSSREF=`git rev-parse develop`
+
+        # Generate patches for all commits in the PR
+        git format-patch $MERGE_BASE..HEAD
+
+        # Store PR info for later
+        echo "$PR_TITLE" > /tmp/pr_title
+        echo "$PR_BODY" > /tmp/pr_body
+
         cd PRO
         git config --global user.name "GitHub Actions Bot"
         git config --global user.email "<>"
         git checkout -b $BRANCHNAME
-        git am --directory=OSS ../0001-*
+
+        # Apply all patches
+        for patch in ../*.patch; do
+          if [ -f "$patch" ]; then
+            git am --directory=OSS "$patch"
+          fi
+        done
+
+        # Amend the last commit to add sync reference
         git log -1 --pretty=%B >message
         echo "" >>message
-        echo "synced from OSS $OSSREF" >>message
+        echo "synced from OSS https://github.com/semgrep/semgrep/pull/$PR_NUMBER ($OSSREF)" >>message
         git commit --amend -F message
         git push origin $BRANCHNAME
       |||,
@@ -76,7 +101,9 @@ local job = {
       },
       run: |||
         cd PRO
-        gh pr create --fill --base develop
+        PR_TITLE=$(cat /tmp/pr_title)
+        PR_BODY=$(cat /tmp/pr_body)
+        gh pr create --title "$PR_TITLE" --body "$PR_BODY" --base develop
       |||,
     },
 
@@ -90,8 +117,15 @@ local job = {
 {
   name: 'sync-with-PRO',
   on: {
-    // TODO: call this workflow from the release workflow
-    workflow_dispatch: null,
+    workflow_dispatch: {
+      inputs: {
+        pr_number: {
+          description: 'PR number to sync to PRO',
+          required: true,
+          type: 'number',
+        },
+      },
+    },
   },
   jobs: {
     job: job,

--- a/.github/workflows/sync-with-PRO.jsonnet
+++ b/.github/workflows/sync-with-PRO.jsonnet
@@ -57,6 +57,7 @@ local job = {
         AUTHOR=$(gh pr view $PR_NUMBER --json author --jq .author.login)
         # Add original attribution
         echo "" >> /tmp/pr_body
+        echo "Synced from OSS PR https://github.com/semgrep/semgrep/pull/$PR_NUMBER" >> /tmp/pr_body
         echo "Closes https://github.com/semgrep/semgrep/pull/$PR_NUMBER" >> /tmp/pr_body
         echo "Author: @$AUTHOR" >> /tmp/pr_body
         echo "Imported by: @${{ github.actor }}" >> /tmp/pr_body

--- a/.github/workflows/sync-with-PRO.jsonnet
+++ b/.github/workflows/sync-with-PRO.jsonnet
@@ -103,6 +103,13 @@ local job = {
         cd PRO
         PR_TITLE=$(cat /tmp/pr_title)
         PR_BODY=$(cat /tmp/pr_body)
+
+        # Append PR template if it exists
+        if [ -f .github/pull_request_template.md ]; then
+          TEMPLATE_CONTENT=$(cat .github/pull_request_template.md)
+          PR_BODY="$PR_BODY$TEMPLATE_CONTENT"
+        fi
+
         gh pr create --title "$PR_TITLE" --body "$PR_BODY" --base develop
       |||,
     },

--- a/.github/workflows/sync-with-PRO.jsonnet
+++ b/.github/workflows/sync-with-PRO.jsonnet
@@ -59,7 +59,7 @@ local job = {
         echo "" >> /tmp/pr_body
         echo "Closes https://github.com/semgrep/semgrep/pull/$PR_NUMBER" >> /tmp/pr_body
         echo "Author: @$AUTHOR" >> /tmp/pr_body
-        # TODO add who imported the PR
+        echo "Imported by: @${{ github.actor }}" >> /tmp/pr_body
 
         BASE_BRANCH=$(gh pr view $PR_NUMBER --json baseRefName --jq .baseRefName)
 

--- a/.github/workflows/sync-with-PRO.jsonnet
+++ b/.github/workflows/sync-with-PRO.jsonnet
@@ -57,8 +57,8 @@ local job = {
         AUTHOR=$(gh pr view $PR_NUMBER --json author --jq .author.login)
         # Add original attribution
         echo "" >> /tmp/pr_body
-        echo "Closes $PR_NUMBER" >> /tmp/pr_body
-        echo "Author: $AUTHOR" >> /tmp/pr_body
+        echo "Closes https://github.com/semgrep/semgrep/pull/$PR_NUMBER" >> /tmp/pr_body
+        echo "Author: @$AUTHOR" >> /tmp/pr_body
         # TODO add who imported the PR
 
         BASE_BRANCH=$(gh pr view $PR_NUMBER --json baseRefName --jq .baseRefName)

--- a/.github/workflows/sync-with-PRO.yml
+++ b/.github/workflows/sync-with-PRO.yml
@@ -44,15 +44,21 @@ jobs:
           PR_NUMBER: ${{ inputs.pr_number }}
         name: Creating the branch and commiting to it
         run: |
-          # Get PR information
-          PR_TITLE=$(gh pr view $PR_NUMBER --json title --jq .title)
-          PR_BODY=$(gh pr view $PR_NUMBER --json body --jq .body)
+          # Get PR information and store it for later
+          gh pr view $PR_NUMBER --json title --jq .title > /tmp/pr_title
+          gh pr view $PR_NUMBER --json body --jq .body > /tmp/pr_body
+          AUTHOR=$(gh pr view $PR_NUMBER --json author --jq .author.login)
+          # Add original attribution
+          echo "" >> /tmp/pr_body
+          echo "Closes $PR_NUMBER" >> /tmp/pr_body
+          echo "Author: $AUTHOR" >> /tmp/pr_body
+          # TODO add who imported the PR
+
           BASE_BRANCH=$(gh pr view $PR_NUMBER --json baseRefName --jq .baseRefName)
 
           # Get the merge base and current HEAD
           git fetch origin $BASE_BRANCH
           MERGE_BASE=$(git merge-base origin/$BASE_BRANCH HEAD)
-          OSSREF=$(git rev-parse HEAD)
 
           # Check if any commits are already synced from Pro
           if git log $MERGE_BASE..HEAD --oneline | grep -q "synced from Pro"; then
@@ -61,11 +67,7 @@ jobs:
           fi
 
           # Generate patches for all commits in the PR
-          git format-patch $MERGE_BASE..HEAD
-
-          # Store PR info for later
-          echo "$PR_TITLE" > /tmp/pr_title
-          echo "$PR_BODY" > /tmp/pr_body
+          PATCHES=$(git format-patch $MERGE_BASE..HEAD)
 
           cd PRO
           git config --global user.name "GitHub Actions Bot"
@@ -73,16 +75,14 @@ jobs:
           git checkout -b $BRANCHNAME
 
           # Apply all patches
-          for patch in ../*.patch; do
-            if [ -f "$patch" ]; then
-              git am --directory=OSS "$patch"
-            fi
+          for patch in $PATCHES; do
+            git am --directory=OSS "../$patch"
           done
 
           # Amend the last commit to add sync reference
           git log -1 --pretty=%B >message
           echo "" >>message
-          echo "synced from OSS https://github.com/semgrep/semgrep/pull/$PR_NUMBER ($OSSREF)" >>message
+          echo "synced from OSS https://github.com/semgrep/semgrep/pull/$PR_NUMBER" >>message
           git commit --amend -F message
           git push origin $BRANCHNAME
       - env:

--- a/.github/workflows/sync-with-PRO.yml
+++ b/.github/workflows/sync-with-PRO.yml
@@ -50,9 +50,9 @@ jobs:
           AUTHOR=$(gh pr view $PR_NUMBER --json author --jq .author.login)
           # Add original attribution
           echo "" >> /tmp/pr_body
-          echo "Closes $PR_NUMBER" >> /tmp/pr_body
-          echo "Author: $AUTHOR" >> /tmp/pr_body
-          # TODO add who imported the PR
+          echo "Closes https://github.com/semgrep/semgrep/pull/$PR_NUMBER" >> /tmp/pr_body
+          echo "Author: @$AUTHOR" >> /tmp/pr_body
+          echo "Imported by: @${{ github.actor }}" >> /tmp/pr_body
 
           BASE_BRANCH=$(gh pr view $PR_NUMBER --json baseRefName --jq .baseRefName)
 

--- a/.github/workflows/sync-with-PRO.yml
+++ b/.github/workflows/sync-with-PRO.yml
@@ -92,6 +92,13 @@ jobs:
           cd PRO
           PR_TITLE=$(cat /tmp/pr_title)
           PR_BODY=$(cat /tmp/pr_body)
+
+          # Append PR template if it exists
+          if [ -f .github/pull_request_template.md ]; then
+            TEMPLATE_CONTENT=$(cat .github/pull_request_template.md)
+            PR_BODY="$PR_BODY$TEMPLATE_CONTENT"
+          fi
+
           gh pr create --title "$PR_TITLE" --body "$PR_BODY" --base develop
 name: sync-with-PRO
 on:

--- a/.github/workflows/sync-with-PRO.yml
+++ b/.github/workflows/sync-with-PRO.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
-          ref: develop
+          ref: refs/pull/${{ inputs.pr_number }}/head
           token: ${{ steps.token.outputs.token }}
       - name: Checkout PRO
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -41,23 +41,48 @@ jobs:
       - env:
           BRANCHNAME: sync-with-PRO-${{ github.run_id }}-${{ github.run_attempt }}
           GITHUB_TOKEN: ${{ steps.token.outputs.token }}
+          PR_NUMBER: ${{ inputs.pr_number }}
         name: Creating the branch and commiting to it
         run: |
-          if git show --stat develop | grep -q "synced from Pro"; then
-             echo "error: HEAD commit already comes from Pro and cannot be synced"
+          # Get PR information
+          PR_TITLE=$(gh pr view $PR_NUMBER --json title --jq .title)
+          PR_BODY=$(gh pr view $PR_NUMBER --json body --jq .body)
+          BASE_BRANCH=$(gh pr view $PR_NUMBER --json baseRefName --jq .baseRefName)
+
+          # Get the merge base and current HEAD
+          git fetch origin $BASE_BRANCH
+          MERGE_BASE=$(git merge-base origin/$BASE_BRANCH HEAD)
+          OSSREF=$(git rev-parse HEAD)
+
+          # Check if any commits are already synced from Pro
+          if git log $MERGE_BASE..HEAD --oneline | grep -q "synced from Pro"; then
+             echo "error: PR contains commits that already come from Pro and cannot be synced"
              exit 1
           fi
-          # will generate a 0001-xxx patch
-          git format-patch develop^
-          OSSREF=`git rev-parse develop`
+
+          # Generate patches for all commits in the PR
+          git format-patch $MERGE_BASE..HEAD
+
+          # Store PR info for later
+          echo "$PR_TITLE" > /tmp/pr_title
+          echo "$PR_BODY" > /tmp/pr_body
+
           cd PRO
           git config --global user.name "GitHub Actions Bot"
           git config --global user.email "<>"
           git checkout -b $BRANCHNAME
-          git am --directory=OSS ../0001-*
+
+          # Apply all patches
+          for patch in ../*.patch; do
+            if [ -f "$patch" ]; then
+              git am --directory=OSS "$patch"
+            fi
+          done
+
+          # Amend the last commit to add sync reference
           git log -1 --pretty=%B >message
           echo "" >>message
-          echo "synced from OSS $OSSREF" >>message
+          echo "synced from OSS https://github.com/semgrep/semgrep/pull/$PR_NUMBER ($OSSREF)" >>message
           git commit --amend -F message
           git push origin $BRANCHNAME
       - env:
@@ -65,7 +90,14 @@ jobs:
         name: Create the Pull request with gh
         run: |
           cd PRO
-          gh pr create --fill --base develop
+          PR_TITLE=$(cat /tmp/pr_title)
+          PR_BODY=$(cat /tmp/pr_body)
+          gh pr create --title "$PR_TITLE" --body "$PR_BODY" --base develop
 name: sync-with-PRO
 on:
-  workflow_dispatch: null
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number to sync to PRO
+        required: true
+        type: number

--- a/.github/workflows/sync-with-PRO.yml
+++ b/.github/workflows/sync-with-PRO.yml
@@ -79,11 +79,6 @@ jobs:
             git am --directory=OSS "../$patch"
           done
 
-          # Amend the last commit to add sync reference
-          git log -1 --pretty=%B >message
-          echo "" >>message
-          echo "synced from OSS https://github.com/semgrep/semgrep/pull/$PR_NUMBER" >>message
-          git commit --amend -F message
           git push origin $BRANCHNAME
       - env:
           GITHUB_TOKEN: ${{ steps.token.outputs.token }}

--- a/.github/workflows/sync-with-PRO.yml
+++ b/.github/workflows/sync-with-PRO.yml
@@ -105,6 +105,6 @@ on:
   workflow_dispatch:
     inputs:
       pr_number:
-        description: PR number to sync to PRO
+        description: PR number to sync to PRO (e.g. "11420")
         required: true
         type: number

--- a/.github/workflows/sync-with-PRO.yml
+++ b/.github/workflows/sync-with-PRO.yml
@@ -50,6 +50,7 @@ jobs:
           AUTHOR=$(gh pr view $PR_NUMBER --json author --jq .author.login)
           # Add original attribution
           echo "" >> /tmp/pr_body
+          echo "Synced from OSS PR https://github.com/semgrep/semgrep/pull/$PR_NUMBER" >> /tmp/pr_body
           echo "Closes https://github.com/semgrep/semgrep/pull/$PR_NUMBER" >> /tmp/pr_body
           echo "Author: @$AUTHOR" >> /tmp/pr_body
           echo "Imported by: @${{ github.actor }}" >> /tmp/pr_body


### PR DESCRIPTION
Our current process of syncing open source contributions is problematic. We first merge them in the open source repository, then sync them back to semgrep-proprietary. This has several downsides:
* We don't learn about build or test failures that appear only on semgrep-proprietary until the PR has already been merged.
*  The commit history in semgrep-proprietary can be in a different order than the commit history in OSS. This is, at best, unsettling.
* Our sync script does not handle a differing commit history gracefully. In fact, it will end up reverting the newly-merged commit in the OSS repository as part of the first synced commit and then reapply it later. This is, at best, confusing.

Instead, we should treat semgrep-proprietary as the source of truth. When it's time to merge an OSS PR, we should sync it back to semgrep-proprietary FIRST by running the `sync-with-PRO` workflow on the OSS repo, merge the resulting PR to semgrep-proprietary, and then let the synced out commit close the PR.

Caveats:
* This currently can only create a new PR on semgrep-proprietary and cannot update an existing one. If we import a PR once, then updates occur, we will have to import it again, creating a separate PR.
* I don't know how this handles merge commits. It may be necessary to rebase and/or squash prior to syncing.
* The original PR on the OSS repository will be marked as closed rather than merged.
* The patches may not apply cleanly if the OSS PR is based on an older revision. If that occurs, the OSS PR needs to be rebased onto a recent revision. We could improve this in the future by applying the patches onto the pro commit upon which the PR is based.

Test plan:
* Sync this PR
* Sync a PR from a fork:
  * https://github.com/semgrep/semgrep/pull/11421
  * Produced https://github.com/semgrep/semgrep-proprietary/pull/5337