### PR TITLE
ci: Update repo URL for QA job

### DIFF
--- a/cli/tests/qa/public_repos.py
+++ b/cli/tests/qa/public_repos.py
@@ -122,7 +122,7 @@ REPOS = [
     Repo("https://github.com/preset-io/elasticsearch-dbapi"),
     Repo("https://github.com/apache/libcloud"),
     Repo("https://github.com/keybase/pykeybasebot"),
-    Repo("https://gitbox.apache.org/repos/asf/cassandra"),
+    Repo("https://github.com/apache/cassandra"),
     Repo("https://github.com/keybase/python-triplesec"),
     Repo("https://github.com/psycopg/psycopg2"),
     Repo("https://github.com/preset-io/flask-jwt-extended"),


### PR DESCRIPTION
The clone [is failing](https://github.com/semgrep/semgrep/actions/runs/20831970635/job/59849870343?pr=11422) for this repo, when I open it in my browser it now redirects to GitHub. Let's try this.

Test plan: The previously failing CI job succeeds.