### PR TITLE
ci: Preserve authorship of imported OSS PRs

### DIFF
--- a/.github/workflows/sync-with-PRO.jsonnet
+++ b/.github/workflows/sync-with-PRO.jsonnet
@@ -54,19 +54,30 @@ local job = {
         # Get PR information and store it for later
         gh pr view $PR_NUMBER --json title --jq .title > /tmp/pr_title
         gh pr view $PR_NUMBER --json body --jq .body > /tmp/pr_body
-        AUTHOR=$(gh pr view $PR_NUMBER --json author --jq .author.login)
-        # Add original attribution
-        echo "" >> /tmp/pr_body
-        echo "Synced from OSS PR https://github.com/semgrep/semgrep/pull/$PR_NUMBER" >> /tmp/pr_body
-        echo "Closes https://github.com/semgrep/semgrep/pull/$PR_NUMBER" >> /tmp/pr_body
-        echo "Author: @$AUTHOR" >> /tmp/pr_body
-        echo "Imported by: @${{ github.actor }}" >> /tmp/pr_body
 
         BASE_BRANCH=$(gh pr view $PR_NUMBER --json baseRefName --jq .baseRefName)
 
         # Get the merge base and current HEAD
         git fetch origin $BASE_BRANCH
         MERGE_BASE=$(git merge-base origin/$BASE_BRANCH HEAD)
+
+        # Author's GitHub username
+        AUTHOR=$(gh pr view $PR_NUMBER --json author --jq .author.login)
+        # Add original attribution
+        echo "" >> /tmp/pr_body
+        echo "Synced from OSS PR https://github.com/semgrep/semgrep/pull/$PR_NUMBER" >> /tmp/pr_body
+        echo "Author: @$AUTHOR" >> /tmp/pr_body
+        echo "Imported by: @${{ github.actor }}" >> /tmp/pr_body
+        echo "" >> /tmp/pr_body
+        echo "Closes https://github.com/semgrep/semgrep/pull/$PR_NUMBER" >> /tmp/pr_body
+
+        # Indicates to our sync tool that this commit should be attributed to
+        # the original author when it is synced back to OSS. This is the
+        # author's name and email, not their GitHub username.
+        #
+        # coupling: "OSS-sync-author" also appears in our sync script.
+        FIRST_COMMIT_AUTHOR=$(git log "$MERGE_BASE..HEAD" --format='format:%aN <%aE>' | tail -n 1)
+        echo "OSS-sync-author: $FIRST_COMMIT_AUTHOR" >> /tmp/pr_body
 
         # Check if any commits are already synced from Pro
         if git log $MERGE_BASE..HEAD --oneline | grep -q "synced from Pro"; then

--- a/.github/workflows/sync-with-PRO.yml
+++ b/.github/workflows/sync-with-PRO.yml
@@ -47,19 +47,30 @@ jobs:
           # Get PR information and store it for later
           gh pr view $PR_NUMBER --json title --jq .title > /tmp/pr_title
           gh pr view $PR_NUMBER --json body --jq .body > /tmp/pr_body
-          AUTHOR=$(gh pr view $PR_NUMBER --json author --jq .author.login)
-          # Add original attribution
-          echo "" >> /tmp/pr_body
-          echo "Synced from OSS PR https://github.com/semgrep/semgrep/pull/$PR_NUMBER" >> /tmp/pr_body
-          echo "Closes https://github.com/semgrep/semgrep/pull/$PR_NUMBER" >> /tmp/pr_body
-          echo "Author: @$AUTHOR" >> /tmp/pr_body
-          echo "Imported by: @${{ github.actor }}" >> /tmp/pr_body
 
           BASE_BRANCH=$(gh pr view $PR_NUMBER --json baseRefName --jq .baseRefName)
 
           # Get the merge base and current HEAD
           git fetch origin $BASE_BRANCH
           MERGE_BASE=$(git merge-base origin/$BASE_BRANCH HEAD)
+
+          # Author's GitHub username
+          AUTHOR=$(gh pr view $PR_NUMBER --json author --jq .author.login)
+          # Add original attribution
+          echo "" >> /tmp/pr_body
+          echo "Synced from OSS PR https://github.com/semgrep/semgrep/pull/$PR_NUMBER" >> /tmp/pr_body
+          echo "Author: @$AUTHOR" >> /tmp/pr_body
+          echo "Imported by: @${{ github.actor }}" >> /tmp/pr_body
+          echo "" >> /tmp/pr_body
+          echo "Closes https://github.com/semgrep/semgrep/pull/$PR_NUMBER" >> /tmp/pr_body
+
+          # Indicates to our sync tool that this commit should be attributed to
+          # the original author when it is synced back to OSS. This is the
+          # author's name and email, not their GitHub username.
+          #
+          # coupling: "OSS-sync-author" also appears in our sync script.
+          FIRST_COMMIT_AUTHOR=$(git log "$MERGE_BASE..HEAD" --format='format:%aN <%aE>' | tail -n 1)
+          echo "OSS-sync-author: $FIRST_COMMIT_AUTHOR" >> /tmp/pr_body
 
           # Check if any commits are already synced from Pro
           if git log $MERGE_BASE..HEAD --oneline | grep -q "synced from Pro"; then


### PR DESCRIPTION
This adds a magic line to the body of imported PRs indicating original authorship, which ultimately makes its way into the commit message of the squashed commit when the PR is merged. We can use this line to set the author of the resulting commit when we sync the commit back out to OSS.

Together with https://github.com/semgrep/semgrep-proprietary/pull/5346, this should ensure that imported OSS PRs get attributed properly when they are synced back out. Currently, the author of such commits appears as semgrep-ci[bot], e.g. https://github.com/semgrep/semgrep/commit/2b08b3b1a1d385952b86fe7d9ad923b8c1131a4d (note that I appear as a committer, but that is because I merged the sync PR that synced those commits out and not because I authored the original commit).

I also [tried ensuring](https://github.com/semgrep/semgrep/pull/11424) that the Co-authored-by line appears correctly in the synced-out commits, but that proved to be more trouble than I expected and I prefer this approach.

I also looked into whether we could merge the imported PR with a custom author. It does not appear that GitHub allows that.

Test plan:
* Imported this PR with these changes to the sync workflow. The author line got inserted as expected: https://github.com/semgrep/semgrep-proprietary/pull/5351