### PR TITLE
Fix Python parsing of non-f-strings when match statements are used

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,7 @@ clean:
 install:
 	$(MAKE) copy-core-for-cli
 # Install semgrep and semgrep-core in a place known to pip.
-	python3 -m pip --ignore-installed  install ./cli
+	python3 -m pip install --ignore-installed ./cli
 
 .PHONY: uninstall
 uninstall:

--- a/changelog.d/gh-11287.fixed
+++ b/changelog.d/gh-11287.fixed
@@ -1,0 +1,1 @@
+Fix Python parsing for files that contains empty strings (or quotes in docstrings) along with match statements.

--- a/languages/python/tree-sitter/Parse_python_tree_sitter.ml
+++ b/languages/python/tree-sitter/Parse_python_tree_sitter.ml
@@ -1115,8 +1115,18 @@ and map_primary_expression (env : env) (x : CST.primary_expression) : expr =
       if String.starts_with "f" l then InterpolatedString (t1, s, t2)
       else
         match s with
+        | [] -> Literal (Str ("", t1))
         | [ x ] -> x
-        | _ -> raise Common.Impossible)
+        | xs ->
+            let concatenated =
+              xs
+              |> List_.map (fun x ->
+                     match x with
+                     | Literal (Str (s, _)) -> s
+                     | _ -> "")
+              |> String.concat ""
+            in
+            Literal (Str (concatenated, t1)))
   | `Conc_str (v1, v2) ->
       let _, v1, _ = map_string_ env v1 in
       let v2 = List_.map (map_string_ env) v2 in

--- a/languages/python/tree-sitter/Parse_python_tree_sitter.ml
+++ b/languages/python/tree-sitter/Parse_python_tree_sitter.ml
@@ -1123,7 +1123,7 @@ and map_primary_expression (env : env) (x : CST.primary_expression) : expr =
               |> List_.map (fun x ->
                      match x with
                      | Literal (Str (s, _)) -> s
-                     | _ -> "")
+                     | _ -> raise Common.Impossible)
               |> String.concat ""
             in
             Literal (Str (concatenated, t1)))

--- a/tests/parsing/python/docstrings.py
+++ b/tests/parsing/python/docstrings.py
@@ -1,0 +1,7 @@
+def f1():
+    """
+    "Regression test to ensure quotes can be parsed inside docstrings
+    "
+    "
+    """
+    pass

--- a/tests/patterns/python/dots_fstring_with_match_stmt.py
+++ b/tests/patterns/python/dots_fstring_with_match_stmt.py
@@ -5,9 +5,14 @@ def foo():
   # ERROR: match
   print(f"this should {match}")
 
+  # ERROR: match
+  print(f"")
+
   print("hello")
 
   print("hello" "world")
+
+  print("")
 
 match status:
     case 400:

--- a/tests/snapshots/semgrep-core/8e740180b65e/name
+++ b/tests/snapshots/semgrep-core/8e740180b65e/name
@@ -1,0 +1,1 @@
+lang parsing > Python > docstrings.py

--- a/tests/snapshots/semgrep-core/8e740180b65e/stdout
+++ b/tests/snapshots/semgrep-core/8e740180b65e/stdout
@@ -1,0 +1,38 @@
+[{ s =
+   (DefStmt
+      ({ name =
+         (EN
+            (Id (("f1", _),
+               { id_resolved = ref (None);
+                 id_resolved_alternatives = ref ([]); id_type = ref (None);
+                 id_svalue = ref (None); id_flags = ref (0); id_info_id = _ }
+               )));
+         attrs = []; tparams = None },
+       (FuncDef
+          { fkind = (Function, _); fparams = (_, [], _); frettype = None;
+            fbody =
+            (FBStmt
+               { s =
+                 (Block
+                    (_,
+                     [{ s =
+                        (ExprStmt (
+                           { e =
+                             (L
+                                (String
+                                   (_,
+                                    ("\n    \"Regression test to ensure quotes can be parsed inside docstrings\n    \"\n    \"\n    ",
+                                     _),
+                                    _)));
+                             e_id = 0; e_range = None;
+                             is_implicit_return = false; facts = <opaque> },
+                           _));
+                        s_range = None };
+                       { s = (OtherStmt (OS_Pass, [(Tk _)])); s_range = None
+                         }
+                       ],
+                     _));
+                 s_range = None })
+            })));
+   s_range = None }
+  ]


### PR DESCRIPTION
This PR fixes two bugs that manifest when a Python file has a `match` statement. If a file has a match statement and either: 1. an empty string, or
2. double quotes present in a docstring.

Then the file fails to be parsed with a syntax error.

The fix extends the parser to also match empty strings, and docstrings with quotes.

It fixes https://github.com/semgrep/semgrep/issues/11287

Test plan:
- Added empty strings to the f-strings tests
- Added a parser test for quotes in a docstring
- `$ make test` passes without error

It also fixes a tiny error in the Makefile, so the `install` target works correctly, which is useful for development.

