### PR TITLE
fix(kotlin): preserve full range for ::class.java in autofix

### DIFF
--- a/languages/kotlin/generic/Parse_kotlin_tree_sitter.ml
+++ b/languages/kotlin/generic/Parse_kotlin_tree_sitter.ml
@@ -1925,30 +1925,51 @@ and modifiers_opt env x =
 and navigation_suffix (env : env) (x : CST.navigation_suffix) =
   match x with
   | `Member_access_op_choice_simple_id (v1, v2) -> (
-      let op = member_access_operator env v1 in
-      let fld =
-        match v2 with
-        | `Simple_id x ->
-            let id = simple_identifier env x in
-            FN (Id (id, empty_id_info ()))
-        | `Paren_exp x ->
-            let e = parenthesized_expression env x in
-            FDynamic e
-        | `Class tok ->
-            let id = str env tok in
-            (* "class" *)
-            FN (Id (id, empty_id_info ()))
-      in
-      fun e ->
-        match op with
-        | Either.Left tdot -> DotAccess (e, tdot, fld) |> G.e
-        | Either.Right otherop ->
-            let any_fld =
-              match fld with
-              | FN n -> E (N n |> G.e)
-              | FDynamic e -> E e
-            in
-            OtherExpr (otherop, [ any_fld; E e ]) |> G.e)
+      match (v1, v2) with
+      | `COLONCOLON tok, `Class class_tok ->
+          (* Kotlin's Klass::class - use DotAccess to preserve source range for autofix *)
+          let coloncolon = token env tok in
+          let class_id = str env class_tok in
+          fun e ->
+            G.DotAccess (e, coloncolon, FN (Id (class_id, G.empty_id_info ())))
+            |> G.e
+      | `COLONCOLON tok, `Simple_id x ->
+          (* Kotlin's Klass::method - use DotAccess to preserve source range *)
+          let coloncolon = token env tok in
+          let method_id = simple_identifier env x in
+          fun e ->
+            G.DotAccess (e, coloncolon, FN (Id (method_id, G.empty_id_info ())))
+            |> G.e
+      | `COLONCOLON tok, `Paren_exp x ->
+          (* Klass::(expr) - dynamic method reference *)
+          let coloncolon = token env tok in
+          let paren_e = parenthesized_expression env x in
+          fun e -> G.DotAccess (e, coloncolon, FDynamic paren_e) |> G.e
+      | _ -> (
+          let op = member_access_operator env v1 in
+          let fld =
+            match v2 with
+            | `Simple_id x ->
+                let id = simple_identifier env x in
+                FN (Id (id, empty_id_info ()))
+            | `Paren_exp x ->
+                let e = parenthesized_expression env x in
+                FDynamic e
+            | `Class tok ->
+                let id = str env tok in
+                (* "class" *)
+                FN (Id (id, empty_id_info ()))
+          in
+          fun e ->
+            match op with
+            | Either.Left tdot -> DotAccess (e, tdot, fld) |> G.e
+            | Either.Right otherop ->
+                let any_fld =
+                  match fld with
+                  | FN n -> E (N n |> G.e)
+                  | FDynamic e -> E e
+                in
+                OtherExpr (otherop, [ any_fld; E e ]) |> G.e))
   | `Member_access_op_ellips (v1, v2) -> (
       let op = member_access_operator env v1 in
       let tellipsis = token env v2 in
@@ -2077,37 +2098,58 @@ and primary_expression (env : env) (x : CST.primary_expression) : expr =
       G.N (H2.name_of_id id) |> G.e
   | `Lit_cst x -> L (literal_constant env x) |> G.e
   | `Str_lit x -> string_literal env x
-  | `Call_ref (v1, v2, v3) ->
+  | `Call_ref (v1, v2, v3) -> (
       let v1 =
         match v1 with
-        | Some x ->
-            let id = simple_identifier env x in
-            Some id
+        | Some x -> Some (simple_identifier env x)
         | None -> None
       in
       let v2 =
         token env v2
         (* "::" *)
       in
-      let v3 =
-        match v3 with
-        | `Simple_id x -> simple_identifier env x
-        (* TODO? use G.OE_ClassLiteral like for Java? *)
-        | `Class tok -> str env tok
-        (* "class" *)
-      in
-      let name_info =
-        match (v1, v2, v3) with
-        | _ ->
-            {
-              name_last = (v3, None);
-              name_middle = None (* TODO*);
-              name_top = None;
-              name_info = empty_id_info ();
-            }
-        (* TODO use qualifiers, with v1TODO above *)
-      in
-      G.N (IdQualified name_info) |> G.e
+      match v3 with
+      | `Class tok ->
+          (* Kotlin's Klass::class corresponds to Java's Klass.class
+             Use DotAccess to preserve source range for autofix *)
+          let class_tok = str env tok in
+          let lhs =
+            match v1 with
+            | Some id -> G.N (H2.name_of_id id) |> G.e
+            | None -> G.N (H2.name_of_id class_tok) |> G.e
+          in
+          let expr =
+            G.DotAccess (lhs, v2, FN (Id (class_tok, G.empty_id_info ())))
+            |> G.e
+          in
+          (* Set e_range explicitly so metavariable binding captures the full range *)
+          let first_tok =
+            match v1 with
+            | Some id -> snd id
+            | None -> snd class_tok
+          in
+          H2.set_e_range first_tok (snd class_tok) expr;
+          expr
+      | `Simple_id x ->
+          (* Kotlin's Klass::method - use DotAccess to preserve source range *)
+          let method_id = simple_identifier env x in
+          let lhs =
+            match v1 with
+            | Some id -> G.N (H2.name_of_id id) |> G.e
+            | None -> G.N (H2.name_of_id method_id) |> G.e
+          in
+          let expr =
+            G.DotAccess (lhs, v2, FN (Id (method_id, G.empty_id_info ())))
+            |> G.e
+          in
+          (* Set e_range explicitly so metavariable binding captures the full range *)
+          let first_tok =
+            match v1 with
+            | Some id -> snd id
+            | None -> snd method_id
+          in
+          H2.set_e_range first_tok (snd method_id) expr;
+          expr)
   | `Func_lit x -> function_literal env x
   | `Obj_lit (v1, v2, v3) ->
       let v1 =

--- a/languages/kotlin/generic/Parse_kotlin_tree_sitter.ml
+++ b/languages/kotlin/generic/Parse_kotlin_tree_sitter.ml
@@ -1925,51 +1925,30 @@ and modifiers_opt env x =
 and navigation_suffix (env : env) (x : CST.navigation_suffix) =
   match x with
   | `Member_access_op_choice_simple_id (v1, v2) -> (
-      match (v1, v2) with
-      | `COLONCOLON tok, `Class class_tok ->
-          (* Kotlin's Klass::class - use DotAccess to preserve source range for autofix *)
-          let coloncolon = token env tok in
-          let class_id = str env class_tok in
-          fun e ->
-            G.DotAccess (e, coloncolon, FN (Id (class_id, G.empty_id_info ())))
-            |> G.e
-      | `COLONCOLON tok, `Simple_id x ->
-          (* Kotlin's Klass::method - use DotAccess to preserve source range *)
-          let coloncolon = token env tok in
-          let method_id = simple_identifier env x in
-          fun e ->
-            G.DotAccess (e, coloncolon, FN (Id (method_id, G.empty_id_info ())))
-            |> G.e
-      | `COLONCOLON tok, `Paren_exp x ->
-          (* Klass::(expr) - dynamic method reference *)
-          let coloncolon = token env tok in
-          let paren_e = parenthesized_expression env x in
-          fun e -> G.DotAccess (e, coloncolon, FDynamic paren_e) |> G.e
-      | _ -> (
-          let op = member_access_operator env v1 in
-          let fld =
-            match v2 with
-            | `Simple_id x ->
-                let id = simple_identifier env x in
-                FN (Id (id, empty_id_info ()))
-            | `Paren_exp x ->
-                let e = parenthesized_expression env x in
-                FDynamic e
-            | `Class tok ->
-                let id = str env tok in
-                (* "class" *)
-                FN (Id (id, empty_id_info ()))
-          in
-          fun e ->
-            match op with
-            | Either.Left tdot -> DotAccess (e, tdot, fld) |> G.e
-            | Either.Right otherop ->
-                let any_fld =
-                  match fld with
-                  | FN n -> E (N n |> G.e)
-                  | FDynamic e -> E e
-                in
-                OtherExpr (otherop, [ any_fld; E e ]) |> G.e))
+      let op = member_access_operator env v1 in
+      let fld =
+        match v2 with
+        | `Simple_id x ->
+            let id = simple_identifier env x in
+            FN (Id (id, empty_id_info ()))
+        | `Paren_exp x ->
+            let e = parenthesized_expression env x in
+            FDynamic e
+        | `Class tok ->
+            let id = str env tok in
+            (* "class" *)
+            FN (Id (id, empty_id_info ()))
+      in
+      fun e ->
+        match op with
+        | Either.Left tdot -> DotAccess (e, tdot, fld) |> G.e
+        | Either.Right otherop ->
+            let any_fld =
+              match fld with
+              | FN n -> E (N n |> G.e)
+              | FDynamic e -> E e
+            in
+            OtherExpr (otherop, [ any_fld; E e ]) |> G.e)
   | `Member_access_op_ellips (v1, v2) -> (
       let op = member_access_operator env v1 in
       let tellipsis = token env v2 in
@@ -2098,58 +2077,41 @@ and primary_expression (env : env) (x : CST.primary_expression) : expr =
       G.N (H2.name_of_id id) |> G.e
   | `Lit_cst x -> L (literal_constant env x) |> G.e
   | `Str_lit x -> string_literal env x
-  | `Call_ref (v1, v2, v3) -> (
+  | `Call_ref (v1, v2, v3) ->
       let v1 =
         match v1 with
-        | Some x -> Some (simple_identifier env x)
+        | Some x ->
+            let id = simple_identifier env x in
+            Some id
         | None -> None
       in
       let v2 =
         token env v2
         (* "::" *)
       in
-      match v3 with
-      | `Class tok ->
-          (* Kotlin's Klass::class corresponds to Java's Klass.class
-             Use DotAccess to preserve source range for autofix *)
-          let class_tok = str env tok in
-          let lhs =
-            match v1 with
-            | Some id -> G.N (H2.name_of_id id) |> G.e
-            | None -> G.N (H2.name_of_id class_tok) |> G.e
-          in
-          let expr =
-            G.DotAccess (lhs, v2, FN (Id (class_tok, G.empty_id_info ())))
-            |> G.e
-          in
-          (* Set e_range explicitly so metavariable binding captures the full range *)
-          let first_tok =
-            match v1 with
-            | Some id -> snd id
-            | None -> snd class_tok
-          in
-          H2.set_e_range first_tok (snd class_tok) expr;
-          expr
-      | `Simple_id x ->
-          (* Kotlin's Klass::method - use DotAccess to preserve source range *)
-          let method_id = simple_identifier env x in
-          let lhs =
-            match v1 with
-            | Some id -> G.N (H2.name_of_id id) |> G.e
-            | None -> G.N (H2.name_of_id method_id) |> G.e
-          in
-          let expr =
-            G.DotAccess (lhs, v2, FN (Id (method_id, G.empty_id_info ())))
-            |> G.e
-          in
-          (* Set e_range explicitly so metavariable binding captures the full range *)
-          let first_tok =
-            match v1 with
-            | Some id -> snd id
-            | None -> snd method_id
-          in
-          H2.set_e_range first_tok (snd method_id) expr;
-          expr)
+      let v3 =
+        match v3 with
+        | `Simple_id x -> simple_identifier env x
+        (* TODO? use G.OE_ClassLiteral like for Java? *)
+        | `Class tok -> str env tok
+        (* "class" *)
+      in
+      (* Use DotAccess to preserve full source range for autofix *)
+      let lhs =
+        match v1 with
+        | Some id -> G.N (H2.name_of_id id) |> G.e
+        | None -> G.N (H2.name_of_id v3) |> G.e
+      in
+      let expr =
+        G.DotAccess (lhs, v2, FN (Id (v3, G.empty_id_info ()))) |> G.e
+      in
+      let first_tok =
+        match v1 with
+        | Some id -> snd id
+        | None -> snd v3
+      in
+      H2.set_e_range first_tok (snd v3) expr;
+      expr
   | `Func_lit x -> function_literal env x
   | `Obj_lit (v1, v2, v3) ->
       let v1 =

--- a/libs/lwt_platform/unix/Lwt_platform.ml
+++ b/libs/lwt_platform/unix/Lwt_platform.ml
@@ -28,7 +28,9 @@ let detach = Lwt_preemptive.detach
 let init_preemptive = Lwt_preemptive.init
 
 let set_engine () =
-  if Sys.unix then Lwt_engine.set (new Lwt_engine.libev ())
+  if Sys.unix then
+    try Lwt_engine.set (new Lwt_engine.libev ()) with
+    | Lwt_sys.Not_available _ -> Lwt_engine.set (new Lwt_engine.select)
   else Lwt_engine.set (new Lwt_engine.select)
 
 let sleep = Lwt_unix.sleep

--- a/libs/lwt_platform/unix/Lwt_platform.ml
+++ b/libs/lwt_platform/unix/Lwt_platform.ml
@@ -28,9 +28,7 @@ let detach = Lwt_preemptive.detach
 let init_preemptive = Lwt_preemptive.init
 
 let set_engine () =
-  if Sys.unix then
-    try Lwt_engine.set (new Lwt_engine.libev ()) with
-    | Lwt_sys.Not_available _ -> Lwt_engine.set (new Lwt_engine.select)
+  if Sys.unix then Lwt_engine.set (new Lwt_engine.libev ())
   else Lwt_engine.set (new Lwt_engine.select)
 
 let sleep = Lwt_unix.sleep

--- a/tests/autofix/kotlin/class_reference.fix
+++ b/tests/autofix/kotlin/class_reference.fix
@@ -1,0 +1,1 @@
+assertThat($ACTUAL).isInstanceOf($EXPECTED)

--- a/tests/autofix/kotlin/class_reference.fixed
+++ b/tests/autofix/kotlin/class_reference.fixed
@@ -1,0 +1,2 @@
+assertThat(cell).isInstanceOf(BigDecimal::class.java)
+assertThat(name).isInstanceOf(String::class.java)

--- a/tests/autofix/kotlin/class_reference.kt
+++ b/tests/autofix/kotlin/class_reference.kt
@@ -1,0 +1,2 @@
+assertInstanceOf(BigDecimal::class.java, cell)
+assertInstanceOf(String::class.java, name)

--- a/tests/autofix/kotlin/class_reference.sgrep
+++ b/tests/autofix/kotlin/class_reference.sgrep
@@ -1,0 +1,1 @@
+assertInstanceOf($EXPECTED, $ACTUAL)

--- a/tests/parsing/kotlin/call_ref.kt
+++ b/tests/parsing/kotlin/call_ref.kt
@@ -1,0 +1,12 @@
+// Test for ::class and ::method patterns (Issue #11252)
+fun main() {
+    // Class reference with ::class.java
+    val clazz1 = BigDecimal::class.java
+    val clazz2 = String::class
+
+    // Method reference
+    val func = MyClass::myMethod
+
+    // Used in function call
+    assertInstanceOf(BigDecimal::class.java, cell)
+}

--- a/tests/patterns/kotlin/class_reference.kt
+++ b/tests/patterns/kotlin/class_reference.kt
@@ -1,0 +1,10 @@
+fun test() {
+    //ERROR:
+    assertInstanceOf(BigDecimal::class.java, cell)
+
+    //ERROR:
+    assertInstanceOf(String::class.java, name)
+
+    // Not a match (different function)
+    checkType(BigDecimal::class.java, cell)
+}

--- a/tests/patterns/kotlin/class_reference.sgrep
+++ b/tests/patterns/kotlin/class_reference.sgrep
@@ -1,0 +1,1 @@
+assertInstanceOf($EXPECTED, $ACTUAL)

--- a/tests/snapshots/semgrep-core/52daeef8c7d8/name
+++ b/tests/snapshots/semgrep-core/52daeef8c7d8/name
@@ -1,0 +1,1 @@
+lang parsing > Kotlin > call_ref.kt

--- a/tests/snapshots/semgrep-core/52daeef8c7d8/stdout
+++ b/tests/snapshots/semgrep-core/52daeef8c7d8/stdout
@@ -1,0 +1,290 @@
+[{ s =
+   (DefStmt
+      ({ name =
+         (EN
+            (Id (("main", _),
+               { id_resolved = ref (None);
+                 id_resolved_alternatives = ref ([]); id_type = ref (None);
+                 id_svalue = ref (None); id_flags = ref (0); id_info_id = _ }
+               )));
+         attrs = []; tparams = None },
+       (FuncDef
+          { fkind = (Function, _); fparams = (_, [], _); frettype = None;
+            fbody =
+            (FBStmt
+               { s =
+                 (Block
+                    (_,
+                     [{ s =
+                        (DefStmt
+                           ({ name =
+                              (EN
+                                 (Id (("clazz1", _),
+                                    { id_resolved =
+                                      ref ((Some (LocalVar, _)));
+                                      id_resolved_alternatives = ref ([]);
+                                      id_type = ref (None);
+                                      id_svalue = ref (None);
+                                      id_flags = ref (4); id_info_id = _ }
+                                    )));
+                              attrs = [(KeywordAttr (Const, _))];
+                              tparams = None },
+                            (VarDef
+                               { vinit =
+                                 (Some { e =
+                                         (DotAccess (
+                                            { e =
+                                              (DotAccess (
+                                                 { e =
+                                                   (N
+                                                      (Id (("BigDecimal", _),
+                                                         { id_resolved =
+                                                           ref (None);
+                                                           id_resolved_alternatives =
+                                                           ref ([]);
+                                                           id_type =
+                                                           ref (None);
+                                                           id_svalue =
+                                                           ref (None);
+                                                           id_flags = ref (0);
+                                                           id_info_id = _ }
+                                                         )));
+                                                   e_id = 0; e_range = None;
+                                                   is_implicit_return = false;
+                                                   facts = <opaque> },
+                                                 _,
+                                                 (FN
+                                                    (Id (("class", _),
+                                                       { id_resolved =
+                                                         ref (None);
+                                                         id_resolved_alternatives =
+                                                         ref ([]);
+                                                         id_type = ref (None);
+                                                         id_svalue =
+                                                         ref (None);
+                                                         id_flags = ref (0);
+                                                         id_info_id = _ }
+                                                       )))
+                                                 ));
+                                              e_id = 0;
+                                              e_range = (Some (_, _));
+                                              is_implicit_return = false;
+                                              facts = <opaque> },
+                                            _,
+                                            (FN
+                                               (Id (("java", _),
+                                                  { id_resolved = ref (None);
+                                                    id_resolved_alternatives =
+                                                    ref ([]);
+                                                    id_type = ref (None);
+                                                    id_svalue = ref (None);
+                                                    id_flags = ref (0);
+                                                    id_info_id = _ }
+                                                  )))
+                                            ));
+                                         e_id = 0; e_range = None;
+                                         is_implicit_return = false;
+                                         facts = <opaque> });
+                                 vtype = None; vtok = None })));
+                        s_range = None };
+                       { s =
+                         (DefStmt
+                            ({ name =
+                               (EN
+                                  (Id (("clazz2", _),
+                                     { id_resolved =
+                                       ref ((Some (LocalVar, _)));
+                                       id_resolved_alternatives = ref ([]);
+                                       id_type = ref (None);
+                                       id_svalue = ref (None);
+                                       id_flags = ref (4); id_info_id = _ }
+                                     )));
+                               attrs = [(KeywordAttr (Const, _))];
+                               tparams = None },
+                             (VarDef
+                                { vinit =
+                                  (Some { e =
+                                          (DotAccess (
+                                             { e =
+                                               (N
+                                                  (Id (("String", _),
+                                                     { id_resolved =
+                                                       ref (None);
+                                                       id_resolved_alternatives =
+                                                       ref ([]);
+                                                       id_type = ref (None);
+                                                       id_svalue = ref (None);
+                                                       id_flags = ref (0);
+                                                       id_info_id = _ }
+                                                     )));
+                                               e_id = 0; e_range = None;
+                                               is_implicit_return = false;
+                                               facts = <opaque> },
+                                             _,
+                                             (FN
+                                                (Id (("class", _),
+                                                   { id_resolved = ref (None);
+                                                     id_resolved_alternatives =
+                                                     ref ([]);
+                                                     id_type = ref (None);
+                                                     id_svalue = ref (None);
+                                                     id_flags = ref (0);
+                                                     id_info_id = _ }
+                                                   )))
+                                             ));
+                                          e_id = 0; e_range = (Some (_, _));
+                                          is_implicit_return = false;
+                                          facts = <opaque> });
+                                  vtype = None; vtok = None })));
+                         s_range = None };
+                       { s =
+                         (DefStmt
+                            ({ name =
+                               (EN
+                                  (Id (("func", _),
+                                     { id_resolved =
+                                       ref ((Some (LocalVar, _)));
+                                       id_resolved_alternatives = ref ([]);
+                                       id_type = ref (None);
+                                       id_svalue = ref (None);
+                                       id_flags = ref (4); id_info_id = _ }
+                                     )));
+                               attrs = [(KeywordAttr (Const, _))];
+                               tparams = None },
+                             (VarDef
+                                { vinit =
+                                  (Some { e =
+                                          (DotAccess (
+                                             { e =
+                                               (N
+                                                  (Id (("MyClass", _),
+                                                     { id_resolved =
+                                                       ref (None);
+                                                       id_resolved_alternatives =
+                                                       ref ([]);
+                                                       id_type = ref (None);
+                                                       id_svalue = ref (None);
+                                                       id_flags = ref (0);
+                                                       id_info_id = _ }
+                                                     )));
+                                               e_id = 0; e_range = None;
+                                               is_implicit_return = false;
+                                               facts = <opaque> },
+                                             _,
+                                             (FN
+                                                (Id (("myMethod", _),
+                                                   { id_resolved = ref (None);
+                                                     id_resolved_alternatives =
+                                                     ref ([]);
+                                                     id_type = ref (None);
+                                                     id_svalue = ref (None);
+                                                     id_flags = ref (0);
+                                                     id_info_id = _ }
+                                                   )))
+                                             ));
+                                          e_id = 0; e_range = (Some (_, _));
+                                          is_implicit_return = false;
+                                          facts = <opaque> });
+                                  vtype = None; vtok = None })));
+                         s_range = None };
+                       { s =
+                         (ExprStmt (
+                            { e =
+                              (Call (
+                                 { e =
+                                   (N
+                                      (Id (("assertInstanceOf", _),
+                                         { id_resolved = ref (None);
+                                           id_resolved_alternatives =
+                                           ref ([]); id_type = ref (None);
+                                           id_svalue = ref (None);
+                                           id_flags = ref (0); id_info_id = _
+                                           }
+                                         )));
+                                   e_id = 0; e_range = None;
+                                   is_implicit_return = false;
+                                   facts = <opaque> },
+                                 (_,
+                                  [(Arg
+                                      { e =
+                                        (DotAccess (
+                                           { e =
+                                             (DotAccess (
+                                                { e =
+                                                  (N
+                                                     (Id (("BigDecimal", _),
+                                                        { id_resolved =
+                                                          ref (None);
+                                                          id_resolved_alternatives =
+                                                          ref ([]);
+                                                          id_type =
+                                                          ref (None);
+                                                          id_svalue =
+                                                          ref (None);
+                                                          id_flags = ref (0);
+                                                          id_info_id = _ }
+                                                        )));
+                                                  e_id = 0; e_range = None;
+                                                  is_implicit_return = false;
+                                                  facts = <opaque> },
+                                                _,
+                                                (FN
+                                                   (Id (("class", _),
+                                                      { id_resolved =
+                                                        ref (None);
+                                                        id_resolved_alternatives =
+                                                        ref ([]);
+                                                        id_type = ref (None);
+                                                        id_svalue =
+                                                        ref (None);
+                                                        id_flags = ref (0);
+                                                        id_info_id = _ }
+                                                      )))
+                                                ));
+                                             e_id = 0;
+                                             e_range = (Some (_, _));
+                                             is_implicit_return = false;
+                                             facts = <opaque> },
+                                           _,
+                                           (FN
+                                              (Id (("java", _),
+                                                 { id_resolved = ref (None);
+                                                   id_resolved_alternatives =
+                                                   ref ([]);
+                                                   id_type = ref (None);
+                                                   id_svalue = ref (None);
+                                                   id_flags = ref (0);
+                                                   id_info_id = _ }
+                                                 )))
+                                           ));
+                                        e_id = 0; e_range = None;
+                                        is_implicit_return = false;
+                                        facts = <opaque> });
+                                    (Arg
+                                       { e =
+                                         (N
+                                            (Id (("cell", _),
+                                               { id_resolved = ref (None);
+                                                 id_resolved_alternatives =
+                                                 ref ([]);
+                                                 id_type = ref (None);
+                                                 id_svalue = ref (None);
+                                                 id_flags = ref (0);
+                                                 id_info_id = _ }
+                                               )));
+                                         e_id = 0; e_range = None;
+                                         is_implicit_return = false;
+                                         facts = <opaque> })
+                                    ],
+                                  _)
+                                 ));
+                              e_id = 0; e_range = None;
+                              is_implicit_return = false; facts = <opaque> },
+                            _));
+                         s_range = None }
+                       ],
+                     _));
+                 s_range = None })
+            })));
+   s_range = None }
+  ]


### PR DESCRIPTION
Closes https://github.com/semgrep/semgrep/issues/11252

Fix Kotlin's `Klass::class.java` pattern to correctly preserve the full source range for metavariable binding. Previously, `BigDecimal::class.java` would lose the `BigDecimal::` part during autofix, resulting in just `class.java`.

Changes:
- Use DotAccess instead of IdQualified for Call_ref handling
- Explicitly set e_range to capture the full expression range
- Handle both ::class and ::method patterns consistently

