### PR TITLE
fix(mcp): Reduce post-tool hook output verbosity

### DIFF
--- a/cli/src/semgrep/mcp/hooks/post_tool.py
+++ b/cli/src/semgrep/mcp/hooks/post_tool.py
@@ -73,7 +73,15 @@ async def run_cli_scan(top_level_span: trace.Span | None) -> PostToolHookRespons
     if len(scan_result.results) > 0:
         hook_response = PostToolHookResponse(
             decision="block",
-            reason=str(scan_result.results),
+            reason=str([
+                {
+                    "display_name": r["extra"]["metadata"].get("display-name"),
+                    "message": r["extra"]["message"],
+                    "severity": r["extra"]["severity"],
+                    "cwe": r["extra"]["metadata"].get("cwe"),
+                }
+                for r in scan_result.results
+            ]),
         )
     else:
         hook_response = PostToolHookResponse(decision=None, reason=None)

--- a/cli/src/semgrep/mcp/hooks/post_tool.py
+++ b/cli/src/semgrep/mcp/hooks/post_tool.py
@@ -71,20 +71,18 @@ async def run_cli_scan(top_level_span: trace.Span | None) -> PostToolHookRespons
     scan_result: SemgrepScanResult = SemgrepScanResult.model_validate_json(output)
     hook_response = PostToolHookResponse(decision=None, reason=None)
     if len(scan_result.results) > 0:
-        hook_response = PostToolHookResponse(
-            decision="block",
-            reason=str(
-                [
-                    {
-                        "display_name": r["extra"]["metadata"].get("display-name"),
-                        "message": r["extra"]["message"],
-                        "severity": r["extra"]["severity"],
-                        "cwe": r["extra"]["metadata"].get("cwe"),
-                    }
-                    for r in scan_result.results
-                ]
-            ),
+        reason = str(
+            [
+                {
+                    "display_name": r["extra"]["metadata"].get("display-name"),
+                    "message": r["extra"]["message"],
+                    "severity": r["extra"]["severity"],
+                    "cwe": r["extra"]["metadata"].get("cwe"),
+                }
+                for r in scan_result.results
+            ]
         )
+        hook_response = PostToolHookResponse(decision="block", reason=reason)
     else:
         hook_response = PostToolHookResponse(decision=None, reason=None)
     attach_scan_metrics(

--- a/cli/src/semgrep/mcp/hooks/post_tool.py
+++ b/cli/src/semgrep/mcp/hooks/post_tool.py
@@ -73,15 +73,17 @@ async def run_cli_scan(top_level_span: trace.Span | None) -> PostToolHookRespons
     if len(scan_result.results) > 0:
         hook_response = PostToolHookResponse(
             decision="block",
-            reason=str([
-                {
-                    "display_name": r["extra"]["metadata"].get("display-name"),
-                    "message": r["extra"]["message"],
-                    "severity": r["extra"]["severity"],
-                    "cwe": r["extra"]["metadata"].get("cwe"),
-                }
-                for r in scan_result.results
-            ]),
+            reason=str(
+                [
+                    {
+                        "display_name": r["extra"]["metadata"].get("display-name"),
+                        "message": r["extra"]["message"],
+                        "severity": r["extra"]["severity"],
+                        "cwe": r["extra"]["metadata"].get("cwe"),
+                    }
+                    for r in scan_result.results
+                ]
+            ),
         )
     else:
         hook_response = PostToolHookResponse(decision=None, reason=None)

--- a/cli/src/semgrep/mcp/hooks/stop.py
+++ b/cli/src/semgrep/mcp/hooks/stop.py
@@ -141,18 +141,18 @@ async def run_cli_scan(top_level_span: trace.Span | None) -> StopHookResponse:
         scan_result: SemgrepScanResult = SemgrepScanResult.model_validate_json(output)
 
         if len(scan_result.results) > 0:
-            details = [
-                {
-                    "display_name": r["extra"]["metadata"].get("display-name"),
-                    "message": r["extra"]["message"],
-                    "severity": r["extra"]["severity"],
-                    "cwe": r["extra"]["metadata"].get("cwe"),
-                }
-                for r in scan_result.results
-            ]
-            hook_response = StopHookResponse(
-                followup_message=f"Found {len(details)} security findings in {dir}. Details: {details}"
+            reason = str(
+                [
+                    {
+                        "display_name": r["extra"]["metadata"].get("display-name"),
+                        "message": r["extra"]["message"],
+                        "severity": r["extra"]["severity"],
+                        "cwe": r["extra"]["metadata"].get("cwe"),
+                    }
+                    for r in scan_result.results
+                ]
             )
+            hook_response = StopHookResponse(followup_message=reason)
         else:
             hook_response = StopHookResponse(followup_message=None)
 

--- a/cli/src/semgrep/mcp/hooks/stop.py
+++ b/cli/src/semgrep/mcp/hooks/stop.py
@@ -141,8 +141,17 @@ async def run_cli_scan(top_level_span: trace.Span | None) -> StopHookResponse:
         scan_result: SemgrepScanResult = SemgrepScanResult.model_validate_json(output)
 
         if len(scan_result.results) > 0:
+            details = [
+                {
+                    "display_name": r["extra"]["metadata"].get("display-name"),
+                    "message": r["extra"]["message"],
+                    "severity": r["extra"]["severity"],
+                    "cwe": r["extra"]["metadata"].get("cwe"),
+                }
+                for r in scan_result.results
+            ]
             hook_response = StopHookResponse(
-                followup_message=f"Found {len(scan_result.results)} security findings in {dir}. Details: {scan_result.results}"
+                followup_message=f"Found {len(details)} security findings in {dir}. Details: {details}"
             )
         else:
             hook_response = StopHookResponse(followup_message=None)


### PR DESCRIPTION
## Summary
- The Claude Code post-tool hook put the entire raw semgrep scan result into the `reason` field — including metadata, fingerprints, license text, semgrep.dev URLs, rule version IDs, etc.
- Now extracts only the 4 fields the LLM needs to fix the issue: `display_name`, `message`, `severity`, and `cwe`
- I'll monitor to see if this meaningfully changes the quality of the Claude Hook output, but this seemed like the minimal fields required. 

🤖 Generated with [Claude Code](https://claude.com/claude-code)