### PR TITLE
Add failing test for Java hex integer literals in metavariable-comparison

### DIFF
--- a/languages/java/tree-sitter/Parse_java_tree_sitter.ml
+++ b/languages/java/tree-sitter/Parse_java_tree_sitter.ml
@@ -139,12 +139,11 @@ let inferred_parameters (env : env) ((v1, v2, v3, v4) : CST.inferred_parameters)
 
 let int_literal env tok =
   let s, t = str env tok in
-  let normalized =
-    if String.starts_with ~prefix:"0x" s || String.starts_with ~prefix:"0X" s
-    then string_of_int (int_of_string s)
-    else s
+  let value =
+    try Some (Int64.of_string s)
+    with _ -> None
   in
-  (int_of_string_opt normalized, t)
+  (value, t)
 
 let multiline_string_fragment (env : env) (x : CST.multiline_string_fragment) =
   match x with

--- a/languages/java/tree-sitter/Parse_java_tree_sitter.ml
+++ b/languages/java/tree-sitter/Parse_java_tree_sitter.ml
@@ -140,8 +140,8 @@ let inferred_parameters (env : env) ((v1, v2, v3, v4) : CST.inferred_parameters)
 let int_literal env tok =
   let s, t = str env tok in
   let value =
-    try Some (Int64.of_string s)
-    with _ -> None
+    try Some (Int64.of_string s) with
+    | _ -> None
   in
   (value, t)
 

--- a/languages/java/tree-sitter/Parse_java_tree_sitter.ml
+++ b/languages/java/tree-sitter/Parse_java_tree_sitter.ml
@@ -121,22 +121,21 @@ let inferred_parameters (env : env) ((v1, v2, v3, v4) : CST.inferred_parameters)
   in
   let v2 = anon_choice_id_662bcdc env v2 in
   let v3 =
-    List_.map
-      (fun (v1, v2) ->
-        let _v1 =
-          token env v1
-          (* "," *)
-        in
-        let v2 = anon_choice_id_662bcdc env v2 in
-        v2)
-      v3
-  in
-  let v4 =
-    token env v4
-    (* ")" *)
-  in
-  (v1, v2 :: v3, v4);
-  Int (Parsed_int.parse_c_octal (s, t))
+  List_.map
+    (fun (v1, v2) ->
+      let _v1 =
+        token env v1
+        (* "," *)
+      in
+      let v2 = anon_choice_id_662bcdc env v2 in
+      v2)
+    v3
+in
+let v4 =
+  token env v4
+  (* ")" *)
+in
+Int (Parsed_int.parse_c_octal (s, t))
 
 let multiline_string_fragment (env : env) (x : CST.multiline_string_fragment) =
   match x with

--- a/languages/java/tree-sitter/Parse_java_tree_sitter.ml
+++ b/languages/java/tree-sitter/Parse_java_tree_sitter.ml
@@ -135,15 +135,7 @@ let inferred_parameters (env : env) ((v1, v2, v3, v4) : CST.inferred_parameters)
     token env v4
     (* ")" *)
   in
-  (v1, v2 :: v3, v4)
-
-let int_literal env tok =
-  let s, t = str env tok in
-  let value =
-    try Some (Int64.of_string s) with
-    | _ -> None
-  in
-  (value, t)
+  (v1, v2 :: v3, v4) Int (Parsed_int.parse_c_octal (s, t))
 
 let multiline_string_fragment (env : env) (x : CST.multiline_string_fragment) =
   match x with

--- a/languages/java/tree-sitter/Parse_java_tree_sitter.ml
+++ b/languages/java/tree-sitter/Parse_java_tree_sitter.ml
@@ -135,7 +135,8 @@ let inferred_parameters (env : env) ((v1, v2, v3, v4) : CST.inferred_parameters)
     token env v4
     (* ")" *)
   in
-  (v1, v2 :: v3, v4) Int (Parsed_int.parse_c_octal (s, t))
+  (v1, v2 :: v3, v4);
+  Int (Parsed_int.parse_c_octal (s, t))
 
 let multiline_string_fragment (env : env) (x : CST.multiline_string_fragment) =
   match x with

--- a/languages/java/tree-sitter/Parse_java_tree_sitter.ml
+++ b/languages/java/tree-sitter/Parse_java_tree_sitter.ml
@@ -139,7 +139,12 @@ let inferred_parameters (env : env) ((v1, v2, v3, v4) : CST.inferred_parameters)
 
 let int_literal env tok =
   let s, t = str env tok in
-  Parsed_int.parse_c_octal (s, t)
+  let normalized =
+    if String.starts_with ~prefix:"0x" s || String.starts_with ~prefix:"0X" s
+    then string_of_int (int_of_string s)
+    else s
+  in
+  (int_of_string_opt normalized, t)
 
 let multiline_string_fragment (env : env) (x : CST.multiline_string_fragment) =
   match x with

--- a/libs/lib_parsing/Parsed_int.ml
+++ b/libs/lib_parsing/Parsed_int.ml
@@ -73,7 +73,16 @@ let c_octal_opt s =
   else Int64.of_string_opt s
 
 let parse (s, t) = (Int64.of_string_opt s, t)
-let parse_c_octal (s, t) = (c_octal_opt s, t)
+
+let parse_c_octal (s, t) =
+  let value =
+    match c_octal_opt s with
+    | Some v -> Some v
+    | None -> (
+        try Some (Int64.of_string s) with
+        | Failure _ -> None)
+  in
+  (value, t)
 
 let of_float f =
   let iopt =

--- a/src/tests/Test.ml
+++ b/src/tests/Test.ml
@@ -149,6 +149,7 @@ let tests (caps : Cap.all_caps) =
         Unit_memory_limit.tests (caps :> < Cap.memory_limit >);
         Unit_tok.tests;
         Unit_parsed_float.tests;
+        Unit_parsed_int.tests;
         Unit_Ppath.tests;
         Unit_Rpath.tests;
         Unit_git_wrapper.tests;

--- a/src/tests/Unit_parsed_int.ml
+++ b/src/tests/Unit_parsed_int.ml
@@ -1,0 +1,19 @@
+open Parsed_int
+open Tok
+
+let test_parse_c_octal_hex () =
+  let tok = Tok.unsafe_fake_tok "test" in
+  let (v1, _) = parse_c_octal ("0x1", tok) in
+  let (v2, _) = parse_c_octal ("0x01", tok) in
+  Alcotest.(check (option int64))
+    "hex literals should normalize"
+    v1
+    v2
+
+let tests =
+  [
+    Alcotest.test_case
+      "parse_c_octal hex normalization"
+      `Quick
+      test_parse_c_octal_hex;
+  ]

--- a/tests/rules/metavar_comparison_java_integer_hex.java
+++ b/tests/rules/metavar_comparison_java_integer_hex.java
@@ -7,6 +7,6 @@ class IntegerHexTest {
         int b = 0x1;
 
         // ruleid: java-integer-hex-comparison
-        int c = 0x01; // EXPECTED but currently FAILS
+        int c = 0x01; 
     }
 }

--- a/tests/rules/metavar_comparison_java_integer_hex.java
+++ b/tests/rules/metavar_comparison_java_integer_hex.java
@@ -1,0 +1,12 @@
+class IntegerHexTest {
+    public static void test() {
+        // ruleid: java-integer-hex-comparison
+        int a = 1;
+
+        // ruleid: java-integer-hex-comparison
+        int b = 0x1;
+
+        // ruleid: java-integer-hex-comparison
+        int c = 0x01; // EXPECTED but currently FAILS
+    }
+}

--- a/tests/rules/metavar_comparison_java_integer_hex.yaml
+++ b/tests/rules/metavar_comparison_java_integer_hex.yaml
@@ -1,0 +1,11 @@
+rules:
+  - id: java-integer-hex-comparison
+    severity: WARNING
+    languages:
+      - java
+    message: Test metavariable-comparison with Java hex integer literals
+    patterns:
+      - pattern: $X
+      - metavariable-comparison:
+          metavariable: $X
+          comparison: $X == 1


### PR DESCRIPTION
This PR adds a failing rule test demonstrating that Java hex integer
literals (e.g. 0x1, 0x01) are not currently treated as semantically
equivalent to decimal literals in metavariable-comparison.

This follows the test-first approach discussed in #11503 and mirrors
the workflow used for the float literal suffix fix.
