### PR TITLE
fix(ci): handle empty repo URL when git remote is not set

### DIFF
--- a/cli/src/semgrep/external/git_url_parser.py
+++ b/cli/src/semgrep/external/git_url_parser.py
@@ -96,7 +96,7 @@ class Parser(str):
     def __init__(self, url: str):
         # to fix an open bug with trailing slashes: https://github.com/coala/git-url-parse/issues/46
         self._url: str = url
-        if url[-1] == "/":
+        if url and url[-1] == "/":
           self._url = url[:-1]
 
     def parse(self) -> Parsed:

--- a/cli/src/semgrep/meta.py
+++ b/cli/src/semgrep/meta.py
@@ -62,7 +62,7 @@ def get_url_from_sstp_url(sstp_url: Optional[str]) -> Optional[str]:
     parser and rebuilding it into an HTTP/S url
     """
 
-    if sstp_url is None:
+    if not sstp_url:
         return None
     p = Parser(sstp_url)
     result = p.parse()
@@ -165,7 +165,8 @@ class GitMeta:
             )
             if git_parse.returncode != 0:
                 logger.warning(
-                    f"Unable to infer repo_url. Set SEMGREP_REPO_URL environment variable or run in a valid git project with remote origin defined"
+                    "Unable to infer repo_url. `semgrep ci` must be run from within a git repository with a remote origin defined. "
+                    "Set SEMGREP_REPO_URL to override, or use `semgrep scan` instead."
                 )
             repo_url = git_parse.stdout.strip()
 

--- a/cli/tests/default/unit/test_meta.py
+++ b/cli/tests/default/unit/test_meta.py
@@ -342,3 +342,23 @@ def test_get_url_from_sstp_url():
 
     for url, expected in tests:
         assert get_url_from_sstp_url(url) == expected
+
+
+@pytest.mark.quick
+def test_get_url_from_sstp_url_empty_string():
+    # Regression test for https://github.com/semgrep/semgrep/issues/11342
+    # When git has no remote set, repo_url is an empty string — should not crash.
+    assert get_url_from_sstp_url("") is None
+
+
+@pytest.mark.quick
+def test_get_url_from_sstp_url_none():
+    assert get_url_from_sstp_url(None) is None
+
+
+@pytest.mark.quick
+def test_parser_empty_string():
+    # Regression test for https://github.com/semgrep/semgrep/issues/11342
+    # Parser.__init__ should not crash on empty string input.
+    p = Parser("")
+    assert p._url == ""


### PR DESCRIPTION
## Summary

- Fixes an `IndexError` crash in `semgrep ci` when run in a git repo with no remote origin set
- The empty string returned by `git remote get-url origin` was being passed to `Parser.__init__`, which accessed `url[-1]` without guarding against empty input
- Improves the warning message to suggest `semgrep scan` as an alternative

## Changes

- `meta.py`: `get_url_from_sstp_url` now returns `None` for empty strings (primary fix)
- `git_url_parser.py`: `Parser.__init__` guards against empty string before indexing (defensive hardening)
- `meta.py`: warning message now reads: `` `semgrep ci` must be run from within a git repository with a remote origin defined. Set SEMGREP_REPO_URL to override, or use `semgrep scan` instead. ``
- Adds regression tests for all three cases

## Test plan

- [x] `test_get_url_from_sstp_url_empty_string` — verifies no crash and returns `None`
- [x] `test_get_url_from_sstp_url_none` — documents existing `None` behavior
- [x] `test_parser_empty_string` — verifies `Parser("")` no longer crashes
- [x] All existing `test_meta.py` tests still pass

Fixes #11342

🤖 Generated with [Claude Code](https://claude.com/claude-code)