### PR TITLE
Fix misleading --help text about default subcommand behavior

### DIFF
--- a/cli/tests/default/e2e/snapshots/test_help/test_help_text/--help/help.txt
+++ b/cli/tests/default/e2e/snapshots/test_help/test_help_text/--help/help.txt
@@ -4,7 +4,7 @@
 
   Run [36m`semgrep SUBCOMMAND --help`[39m for more information on each subcommand
 
-  If no subcommand is passed, will run [36m`scan`[39m subcommand by default
+  If no subcommand is passed, will show a welcome message with usage info
 
 [4mOptions[24m:
   -h, --help  Show this message and exit.

--- a/cli/tests/default/e2e/snapshots/test_help/test_help_text/-h/help.txt
+++ b/cli/tests/default/e2e/snapshots/test_help/test_help_text/-h/help.txt
@@ -4,7 +4,7 @@
 
   Run [36m`semgrep SUBCOMMAND --help`[39m for more information on each subcommand
 
-  If no subcommand is passed, will run [36m`scan`[39m subcommand by default
+  If no subcommand is passed, will show a welcome message with usage info
 
 [4mOptions[24m:
   -h, --help  Show this message and exit.

--- a/src/osemgrep/cli/Help.ml
+++ b/src/osemgrep/cli/Help.ml
@@ -73,7 +73,7 @@ let print_semgrep_dashdash_help () =
 
   Run @{<cyan>`semgrep SUBCOMMAND --help`@} for more information on each subcommand
 
-  If no subcommand is passed, will run @{<cyan>`scan`@} subcommand by default
+  If no subcommand is passed, will show a welcome message with usage info
 
 @{<ul>Options@}:
   -h, --help  Show this message and exit.


### PR DESCRIPTION
## Summary
- `semgrep --help` incorrectly states that running `semgrep` without a subcommand runs the `scan` subcommand
- Running `semgrep` with no arguments actually shows a welcome/usage screen via `Help.print_help()` in `CLI.ml`
- Updated the help text in `Help.ml` and the corresponding test snapshots to accurately describe this behavior

Fixes #10063

## Test plan
- [x] Verified `dispatch_subcommand` in `CLI.ml` calls `Help.print_help()` for bare invocation
- [x] Updated both `--help` and `-h` snapshot test fixtures
- [x] Grep confirms no remaining references to old text