### PR TITLE
Pass timeout, jobs, and max_memory through to semgrep-core in test mode

### DIFF
--- a/cli/src/semgrep/commands/scan.py
+++ b/cli/src/semgrep/commands/scan.py
@@ -962,6 +962,10 @@ def scan(
                 json=output_format == OutputFormat.JSON,
                 optimizations=optimizations,
                 engine_type=engine_type,
+                timeout=timeout,
+                timeout_threshold=timeout_threshold,
+                max_memory=max_memory,
+                jobs=jobs,
             )
 
         filtered_matches_by_rule: FilteredMatches = FilteredMatches(kept={}, removed={})

--- a/cli/src/semgrep/test.py
+++ b/cli/src/semgrep/test.py
@@ -473,6 +473,10 @@ def generate_test_results(
     json_output: bool,
     engine_type: EngineType,
     optimizations: str = "none",
+    timeout: int = 0,
+    timeout_threshold: int = 0,
+    max_memory: int = 0,
+    jobs: Optional[int] = None,
 ) -> None:
     config_filenames = get_config_filenames(config)
     config_test_filenames = get_config_test_filenames(config, config_filenames, target)
@@ -506,8 +510,12 @@ def generate_test_results(
         no_rewrite_rule_ids=no_rewrite_rule_ids,
         strict=strict,
         optimizations=optimizations,
+        timeout=timeout,
+        timeout_threshold=timeout_threshold,
+        max_memory=max_memory,
     )
-    with multiprocessing.Pool(multiprocessing.cpu_count()) as pool:
+    pool_size = jobs if jobs and jobs > 0 else multiprocessing.cpu_count()
+    with multiprocessing.Pool(pool_size) as pool:
         results = pool.starmap(invoke_semgrep_fn, config_with_tests)
 
     config_with_errors, config_without_errors = partition(results, lambda r: bool(r[1]))
@@ -600,11 +608,14 @@ def generate_test_results(
         no_rewrite_rule_ids=no_rewrite_rule_ids,
         strict=strict,
         optimizations=optimizations,
+        timeout=timeout,
+        timeout_threshold=timeout_threshold,
+        max_memory=max_memory,
         # only option that differs from the earlier call to semgrep-core:
         autofix=AutofixBehavior.APPLY,
     )
 
-    with multiprocessing.Pool(multiprocessing.cpu_count()) as pool:
+    with multiprocessing.Pool(pool_size) as pool:
         results = pool.starmap(invoke_semgrep_with_autofix_fn, config_with_tempfiles)
 
     fixtest_comparisons = {
@@ -723,6 +734,10 @@ def test_main(
     json: bool,
     optimizations: str,
     engine_type: EngineType,
+    timeout: int = 0,
+    timeout_threshold: int = 0,
+    max_memory: int = 0,
+    jobs: Optional[int] = None,
 ) -> None:
     if len(scanning_roots) != 1:
         raise Exception("only one target directory allowed for tests")
@@ -744,4 +759,8 @@ def test_main(
         json_output=json,
         engine_type=engine_type,
         optimizations=optimizations,
+        timeout=timeout,
+        timeout_threshold=timeout_threshold,
+        max_memory=max_memory,
+        jobs=jobs,
     )

--- a/cli/tests/default/e2e/test_test.py
+++ b/cli/tests/default/e2e/test_test.py
@@ -73,7 +73,8 @@ def test_cli_test_directory(run_semgrep_in_tmp: RunSemgrep, posix_snapshot):
 
 # It should output an "error" field with the right error message (timeout)
 # in the JSON output.
-# TODO: adding "--timeout", "1", does not seem to speedup things
+# Now that --timeout is forwarded to semgrep-core in test mode, we pass
+# timeout=1 so the deliberately slow rule actually triggers a timeout.
 @pytest.mark.slow
 @pytest.mark.osemfail
 @skip_on_windows  # better backslash replacement logic
@@ -83,6 +84,7 @@ def test_timeout(run_semgrep_in_tmp: RunSemgrep, posix_snapshot):
         options=["--test"],
         target_name="test_test/long.py",
         output_format=OutputFormat.JSON,
+        timeout=1,
         assert_exit_code=1,
     )
     posix_snapshot.assert_match(


### PR DESCRIPTION
## Summary
- When running `semgrep scan --test`, the `--timeout`, `--timeout-threshold`, `--max-memory`, and `-j` (jobs) flags were silently ignored
- The test code path in `scan.py` called `test_main()` without forwarding these parameters to semgrep-core
- This fix threads all four flags through the full call chain: `scan()` -> `test_main()` -> `generate_test_results()` -> `invoke_semgrep_multi` partials
- The `-j` flag also controls the Python `multiprocessing.Pool` size in test mode (previously hardcoded to `cpu_count()`)

Fixes #11373

## Changes
- `cli/src/semgrep/commands/scan.py`: Forward `timeout`, `timeout_threshold`, `max_memory`, `jobs` to `test_main()`
- `cli/src/semgrep/test.py`: Accept and propagate all four parameters through `test_main()` and `generate_test_results()` into both `invoke_semgrep_multi` partial functions

## Test plan
- [ ] Run `semgrep scan --test --debug --timeout 10 -j 2 --max-memory 500` and verify debug output shows correct flags passed to semgrep-core
- [ ] Verify default behavior unchanged when flags are not specified
- [ ] Run existing test suite to confirm no regressions