### PR TITLE
fix: truncate SARIF rule identifiers exceeding 255-char limit

### DIFF
--- a/changelog.d/gh-10941.fixed
+++ b/changelog.d/gh-10941.fixed
@@ -1,0 +1,1 @@
+Truncate SARIF rule identifiers to 255 characters so that output can be uploaded to GitHub code scanning without errors

--- a/src/osemgrep/reporting/Sarif_output.ml
+++ b/src/osemgrep/reporting/Sarif_output.ml
@@ -37,6 +37,21 @@ module Sarif = Sarif.Sarif_v_2_1_0_v
 (* Helpers *)
 (*****************************************************************************)
 
+(* GitHub's SARIF upload enforces a maximum identifier length of 255.
+   See https://github.com/semgrep/semgrep/issues/10941 *)
+let max_sarif_id_length = 255
+
+(* Truncate a SARIF identifier to [max_sarif_id_length] characters. When
+   truncation is needed we keep a prefix and append a short hash so that
+   distinct long IDs are unlikely to collide. *)
+let truncate_sarif_id (id : string) : string =
+  if String.length id <= max_sarif_id_length then id
+  else
+    let hash = Digest.string id |> Digest.to_hex in
+    let hash_suffix = Str.first_chars hash 8 in
+    let prefix_len = max_sarif_id_length - 1 - String.length hash_suffix in
+    Str.first_chars id prefix_len ^ "-" ^ hash_suffix
+
 (* SARIF v2.1.0-compliant severity string.
  * See the "level" property in the spec
  * See https://github.com/oasis-tcs/sarif-spec/blob/a6473580/Schemata/sarif-schema-2.1.0.json#L1566
@@ -136,7 +151,9 @@ let rule ~(hide_nudge : bool) (ctx : Out.format_context) (rule : Rule.t) :
    * including the severity of the finding is stored within "rules".
    * The results then reference the ID of the rule
    *)
-  let rule_id_str = Rule_ID.to_string (fst rule.id) in
+  let rule_id_str =
+    Rule_ID.to_string (fst rule.id) |> truncate_sarif_id
+  in
   let default_configuration =
     Sarif.create_reporting_configuration
       ~level:(severity_of_severity rule.severity)
@@ -411,7 +428,7 @@ let result (ctx : Out.format_context) show_dataflow_traces
     else [ ("matchBasedId/v1", Gated_data.msg) ]
   in
   Sarif.create_result
-    ~rule_id:(Rule_ID.to_string cli_match.check_id)
+    ~rule_id:(Rule_ID.to_string cli_match.check_id |> truncate_sarif_id)
     ~message:(message cli_match.extra.message)
     ~locations:[ location ] ~fingerprints ~properties ?code_flows ?fixes
     ?suppressions ()

--- a/src/osemgrep/reporting/Sarif_output.mli
+++ b/src/osemgrep/reporting/Sarif_output.mli
@@ -11,6 +11,10 @@
    LICENSE for more details.
 *)
 (* Formats the CLI output to the SARIF format. *)
+
+val max_sarif_id_length : int
+val truncate_sarif_id : string -> string
+
 val sarif_output :
   Rule.hrules ->
   Semgrep_output_v1_t.format_context ->

--- a/src/osemgrep/reporting/Unit_reporting.ml
+++ b/src/osemgrep/reporting/Unit_reporting.ml
@@ -155,9 +155,48 @@ let test_string_of_formulas () =
                          (spf "could not parse or more than one rule for %s"
                             title)))))
 
+let test_truncate_sarif_id () =
+  Testo.categorize "truncate_sarif_id"
+    [
+      t "short id unchanged" (fun () ->
+          let id = "rules.my-rule" in
+          Alcotest.(check string)
+            __LOC__ id
+            (Sarif_output.truncate_sarif_id id));
+      t "exactly 255 chars unchanged" (fun () ->
+          let id = String.make 255 'a' in
+          Alcotest.(check string)
+            __LOC__ id
+            (Sarif_output.truncate_sarif_id id));
+      t "256 chars truncated to 255" (fun () ->
+          let id = String.make 256 'a' in
+          let result = Sarif_output.truncate_sarif_id id in
+          Alcotest.(check int)
+            __LOC__ 255
+            (String.length result));
+      t "very long id truncated to 255" (fun () ->
+          let id = String.make 400 'x' in
+          let result = Sarif_output.truncate_sarif_id id in
+          Alcotest.(check int)
+            __LOC__ Sarif_output.max_sarif_id_length
+            (String.length result));
+      t "distinct long ids produce distinct results" (fun () ->
+          let id_a = String.make 300 'a' in
+          let id_b = String.make 300 'b' in
+          let result_a = Sarif_output.truncate_sarif_id id_a in
+          let result_b = Sarif_output.truncate_sarif_id id_b in
+          Alcotest.(check bool) __LOC__ false (String.equal result_a result_b));
+      t "deterministic" (fun () ->
+          let id = String.make 300 'z' in
+          let r1 = Sarif_output.truncate_sarif_id id in
+          let r2 = Sarif_output.truncate_sarif_id id in
+          Alcotest.(check string) __LOC__ r1 r2);
+    ]
+
 (*****************************************************************************)
 (* Entry point *)
 (*****************************************************************************)
 
 let tests =
-  Testo.categorize_suites "Osemgrep reporting" [ test_string_of_formulas () ]
+  Testo.categorize_suites "Osemgrep reporting"
+    [ test_string_of_formulas (); test_truncate_sarif_id () ]


### PR DESCRIPTION
Closes #10941

GitHub's `upload-sarif` action rejects SARIF files with identifiers longer than 255 characters. Some community rules (e.g. `gitlab.flawfinder.drand48`) have IDs of 327+ characters, causing:

> could not convert rules: sarif identifier exceeds maximum length of 255 characters

This PR truncates SARIF rule identifiers to 255 characters in `Sarif_output.ml`. When truncation is needed, a prefix + MD5 hash suffix scheme preserves uniqueness across distinct long IDs. The truncation is applied consistently to both `rules[].id` and `results[].ruleId`.

### Test plan
- Added 6 unit tests for `truncate_sarif_id` covering: short IDs unchanged, boundary (255 chars), truncation to 255, very long IDs, distinct long IDs produce distinct results, and determinism.
- Existing SARIF e2e tests should remain unaffected since they use short rule IDs.