### PR TITLE
fix: explain nonzero exit status when --error is set and findings exist

### DIFF
--- a/changelog.d/gh-7661.fixed
+++ b/changelog.d/gh-7661.fixed
@@ -1,0 +1,1 @@
+Explain why semgrep exits with a nonzero status when --error is set and findings are found

--- a/cli/src/semgrep/output.py
+++ b/cli/src/semgrep/output.py
@@ -587,6 +587,16 @@ class OutputHandler:
             console.print(Title("Scan Summary"))
             logger.info(output_text)
 
+        if (
+            any_findings_not_ignored
+            and self.settings.error_on_findings
+            and not self.final_error
+        ):
+            logger.info(
+                "Exiting with error status because --error is set and there are findings."
+                ' Look for the "Code Finding" section of the output for details.'
+            )
+
         self._final_raise(final_error)
 
     def _save_output(self, destination: str, output: str) -> None:

--- a/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -678,8 +678,13 @@ let run_scan_conf (conf : Scan_CLI.conf) : Exit_code.t =
       | Error exit_code -> exit_code
       | Ok (_rules, res, cli_output) ->
           (* final result for the shell *)
-          if conf.error_on_findings && not (List_.null cli_output.results) then
-            Exit_code.findings ~__LOC__
+          if conf.error_on_findings && not (List_.null cli_output.results) then (
+            Logs.app (fun m ->
+                m
+                  "Exiting with error status because --error is set and there \
+                   are findings. Look for the \"Code Finding\" section of the \
+                   output for details.");
+            Exit_code.findings ~__LOC__)
           else
             exit_code_of_errors ~strict:conf.core_runner_conf.strict
               res.core.errors)


### PR DESCRIPTION
Closes #7661

When using `semgrep scan --error` in CI, a nonzero exit status is returned if there are findings, but the output doesn't explain why. This makes it hard to find the cause in long CI logs.

This PR adds a clear message after the scan summary:

> Exiting with error status because --error is set and there are findings. Look for the "Code Finding" section of the output for details.

The message is added to both the Python CLI (`output.py`) and the OCaml scan subcommand (`Scan_subcommand.ml`).

### Test plan
- The message only appears when `--error` is active AND there are non-ignored findings AND no prior fatal error
- Existing SARIF `--error` test is unaffected (message goes to stderr, SARIF test checks stdout)
- Manual test: run `semgrep scan --error --config auto .` on a project with findings and verify the message appears at the end