### PR TITLE
fix: perform `nosemgrep` filtering in the legacy language server

### DIFF
--- a/src/lsp_legacy/scan_helpers/Legacy_processed_run.ml
+++ b/src/lsp_legacy/scan_helpers/Legacy_processed_run.ml
@@ -65,6 +65,15 @@ let filter_clean_lines git_ref matches =
 
 let of_matches ?(skipped_fingerprints = []) ?(only_git_dirty = true) ?git_ref
     (result : Core_runner.result) =
+  
+  let result =
+    let core =
+      { result.core with
+        results = Nosemgrep.filter_ignored ~keep_ignored:false result.core.results
+      }
+    in
+    { result with core }
+  in
   let result =
     Output.preprocess_result ~fips_mode:false ~fixed_lines:false result
   in


### PR DESCRIPTION
Likely closes [semgrep-vscode #159](https://github.com/semgrep/semgrep-vscode/issues/

The legacy language server was not respecting nosemgrep inline comments. 

Core_scan.scan() correctly marks matches as ignored via `Nosemgrep.produce_ignored`, but `Legacy_processed_run.of_matches` never calls `Nosemgrep.filter_ignored` to remove them before  converting results to diagnostics, unlike the CLI codepath which performs this in `Scan_subcommand.adjust_nosemgrep_and_autofix`.

This PR adds the missing filter step in Legacy_processed_run.of_matches, before Output.preprocess_result converts the result format.

Test plan: CI