### PR TITLE
fix(cli): remove misleading subcommand info from --help text

### DIFF
--- a/src/osemgrep/cli/Help.ml
+++ b/src/osemgrep/cli/Help.ml
@@ -73,8 +73,6 @@ let print_semgrep_dashdash_help () =
 
   Run @{<cyan>`semgrep SUBCOMMAND --help`@} for more information on each subcommand
 
-  If no subcommand is passed, will run @{<cyan>`scan`@} subcommand by default
-
 @{<ul>Options@}:
   -h, --help  Show this message and exit.
 


### PR DESCRIPTION
fix(cli): remove misleading subcommand info from --help text

Hi Semgrep team! 👋

I noticed this issue (#10063) and wanted to help fix it.

**The Problem:**
When running `semgrep --help`, the help text states:
> "If no subcommand is passed, will run `scan` subcommand by default"

However, when you actually run `semgrep` without any subcommand, it displays a welcome message instead of running the scan subcommand:

```
┌──── ○○○ ────┐
│ Semgrep CLI │
└─────────────┘
Semgrep CLI scans your code for bugs, security and dependency vulnerabilities...
```

**The Fix:**
This PR removes the misleading line from the `--help` output. The scan subcommand is still used as a default when arguments are provided without an explicit subcommand (e.g., `semgrep --config auto`), but not when no arguments are given at all.

**Changes:**
- Removed the line "If no subcommand is passed, will run `scan` subcommand by default" from `src/osemgrep/cli/Help.ml`

Thanks for maintaining such a great tool! 🙏 Let me know if you'd like any adjustments.

Fixes #10063