### PR TITLE
fix(cli): correct error message in semgrep publish command

### DIFF
--- a/cli/src/semgrep/commands/publish.py
+++ b/cli/src/semgrep/commands/publish.py
@@ -108,7 +108,7 @@ def publish(
     app_session = get_state().app_session
 
     if not app_session.token:
-        click.echo("run `semgrep login` before using upload", err=True)
+        click.echo("run `semgrep login` before using publish", err=True)
         sys.exit(FATAL_EXIT_CODE)
 
     fail_count = 0


### PR DESCRIPTION
## Summary

This PR fixes a minor but confusing error message in the `semgrep publish` command.

## Problem

When a user runs `semgrep publish` without being logged in, the error message says:
> run `semgrep login` before using **upload**

However, the command is actually called `publish`, not `upload`. This inconsistency could confuse users.

## Solution

Changed the error message to:
> run `semgrep login` before using **publish**

This aligns the error message with the actual command name.

## Related Issue

Fixes #10063

## Testing

- [x] Verified the fix locally
- [x] The change is minimal and only affects the error message

Thanks for maintaining Semgrep! 🙏