### PR TITLE
fix(cli): correct help text for default behavior when no subcommand passed

### DIFF
--- a/src/osemgrep/cli/Help.ml
+++ b/src/osemgrep/cli/Help.ml
@@ -73,7 +73,7 @@ let print_semgrep_dashdash_help () =
 
   Run @{<cyan>`semgrep SUBCOMMAND --help`@} for more information on each subcommand
 
-  If no subcommand is passed, will run @{<cyan>`scan`@} subcommand by default
+  If no subcommand is passed, help information will be displayed
 
 @{<ul>Options@}:
   -h, --help  Show this message and exit.


### PR DESCRIPTION
Hi team! 👋 

This PR fixes a small inconsistency in the CLI help text reported in #10063.

## Problem

The help message stated that running `semgrep` without a subcommand would default to the `scan` subcommand. However, the actual behavior is to display the help information from `print_help`.

This inconsistency could confuse users who expect `semgrep` to start scanning when run without arguments.

## Solution

Updated the help text in `src/osemgrep/cli/Help.ml` to accurately describe the actual behavior.

**Before:**
```
If no subcommand is passed, will run `scan` subcommand by default
```

**After:**
```
If no subcommand is passed, help information will be displayed
```

## Testing

- Verified the change by checking the file content
- Confirmed the help text now matches the actual behavior

This is my first contribution to Semgrep - please let me know if I need to adjust anything! 😊

Fixes #10063