### PR TITLE
fix(cli): correct help text to accurately describe default behavior

### DIFF
--- a/src/osemgrep/cli/Help.ml
+++ b/src/osemgrep/cli/Help.ml
@@ -73,7 +73,7 @@ let print_semgrep_dashdash_help () =
 
   Run @{<cyan>`semgrep SUBCOMMAND --help`@} for more information on each subcommand
 
-  If no subcommand is passed, will run @{<cyan>`scan`@} subcommand by default
+  If no subcommand is passed, will show the general help message
 
 @{<ul>Options@}:
   -h, --help  Show this message and exit.


### PR DESCRIPTION
## Summary

This PR fixes issue #10063 by correcting the help text in `semgrep --help` to accurately describe the actual CLI behavior.

## Problem

The current help text states:
> "If no subcommand is passed, will run `scan` subcommand by default"

However, when users run `semgrep` without any subcommand, the actual behavior is to display the general help message (from the `print_help` function), not to run the scan subcommand.

## Fix

Updated the help text in `src/osemgrep/cli/Help.ml` to correctly describe the behavior:

**Before:**
```
If no subcommand is passed, will run `scan` subcommand by default
```

**After:**
```
If no subcommand is passed, will show the general help message
```

## Verification

- [x] The help text now accurately reflects the actual CLI behavior
- [x] No functional changes to the code

Fixes #10063