### PR TITLE
fix(cli): correct help text about default subcommand behavior

### DIFF
--- a/src/osemgrep/cli/Help.ml
+++ b/src/osemgrep/cli/Help.ml
@@ -73,7 +73,7 @@ let print_semgrep_dashdash_help () =
 
   Run @{<cyan>`semgrep SUBCOMMAND --help`@} for more information on each subcommand
 
-  If no subcommand is passed, will run @{<cyan>`scan`@} subcommand by default
+  If no subcommand is passed, help information will be displayed
 
 @{<ul>Options@}:
   -h, --help  Show this message and exit.


### PR DESCRIPTION
## Summary

This PR fixes the incorrect help text reported in #10063.

## Problem

The help text incorrectly stated that semgrep would run the `scan` subcommand by default when no subcommand is provided:

> If no subcommand is passed, will run `scan` subcommand by default

However, the actual behavior when running `semgrep` without arguments is to display the main help information, not to run the scan subcommand.

## Solution

Updated the help text to accurately reflect the behavior:

> If no subcommand is passed, help information will be displayed

## Testing

- Verified the help text now correctly describes the behavior
- Confirmed this matches the actual CLI behavior described in #10063

## Related Issues

Fixes #10063

---

Thanks for maintaining Semgrep! This is my first contribution to the project - happy to make any adjustments if needed. 😊