### PR TITLE
Implements a `--list-rules` flag that allows users to inspect which rules would be run for a given config without executing a scan.

### DIFF
--- a/cli/src/semgrep/commands/scan.py
+++ b/cli/src/semgrep/commands/scan.py
@@ -671,6 +671,13 @@ class ScanResult:
     is_flag=True,
     default=False,
 )
+@optgroup.option(
+    "--list-rules",
+    "list_rules",
+    is_flag=True,
+    default=False,
+    help="List the rules that would be run and exit without scanning.",
+)
 @optgroup.group("Test and debug options")
 @optgroup.option("--test", is_flag=True, default=False)
 @optgroup.option(
@@ -774,6 +781,7 @@ def scan(
     x_ignore_semgrepignore_files: bool,
     x_ls: bool,
     x_ls_long: bool,
+    list_rules: bool,
     enable_transitive_reachability: Optional[bool],
     x_eio: bool,
     x_parmap: bool,
@@ -1128,6 +1136,7 @@ def scan(
                         baseline_commit=baseline_commit,
                         x_ls=x_ls,
                         x_ls_long=x_ls_long,
+                        list_rules=list_rules,
                         enable_transitive_reachability=enable_transitive_reachability,
                         x_parmap=x_parmap,
                         x_pro_naming=x_pro_naming,

--- a/cli/src/semgrep/run_scan.py
+++ b/cli/src/semgrep/run_scan.py
@@ -1186,6 +1186,7 @@ def run_scan(
     baseline_commit_is_mergebase: bool = False,
     x_ls: bool = False,
     x_ls_long: bool = False,
+    list_rules: bool = False,
     enable_transitive_reachability: Optional[bool] = None,
     x_parmap: bool = False,
     x_pro_naming: bool = False,
@@ -1307,6 +1308,30 @@ def run_scan(
             rule for rule in all_rules if rule.severity in shown_severities
         ]
     filtered_rules = filter_exclude_rule(filtered_rules, exclude_rule)
+
+    if list_rules:
+        output_format = output_handler.settings.output_format
+        if output_format == OutputFormat.JSON:
+            print(
+                json.dumps(
+                    [
+                        {
+                            "id": rule.id,
+                            "severity": rule.severity.to_json(),
+                            "languages": [str(l) for l in rule.languages],
+                            "message": rule.message,
+                        }
+                        for rule in sorted(filtered_rules, key=lambda r: r.id)
+                    ],
+                    indent=2,
+                )
+            )
+        else:
+            for rule in sorted(filtered_rules, key=lambda r: r.id):
+                langs = ", ".join(str(l) for l in rule.languages)
+                print(f"{rule.id}  ({rule.severity.to_json()}, [{langs}])")
+            print(f"\n{len(filtered_rules)} rules")
+        exit(0)
 
     if dump_rule_partitions_params:
         dump_partitions_and_exit(filtered_rules, dump_rule_partitions_params)


### PR DESCRIPTION
## Summary
Implements a --list-rules flag that allows users to inspect which rules would be run for a given config without executing a scan.

## Changes
- Added --list-rules flag to semgrep scan command
- Exits early after rule resolution and filtering, before target computation
- Respects --severity and --exclude-rule filters
- Supports both text and JSON output formats

## Usage

List rules from a ruleset:
semgrep --config p/r2c --list-rules .

With JSON output:
semgrep --config p/r2c --list-rules --json .

With severity filter:
semgrep --config p/r2c --list-rules --severity ERROR .

## Output Examples

Text format:
python.flask.security.injection.tainted-sql-string  (ERROR, [python])
python.lang.security.audit.exec-detected  (WARNING, [python])

JSON format:
[
  {
    "id": "python.flask.security.injection.tainted-sql-string",
    "severity": "ERROR",
    "languages": ["python"],
    "message": "..."
  }
]

Fixes #5614