### PR TITLE
Add Go SQL injection rule for GORM Raw + query.Get + fmt.Sprintf

### DIFF
--- a/tests/tainting_rules/go/sql-injection-gorm-raw.yaml
+++ b/tests/tainting_rules/go/sql-injection-gorm-raw.yaml
@@ -1,0 +1,72 @@
+rules:
+  - id: go-sql-injection-gorm-raw
+    message: |
+      Possible SQL injection via GORM Raw with dynamically constructed query.
+      Query parameters from HTTP request (query.Get) flow into Raw() without sanitization.
+    languages:
+      - go
+    severity: ERROR
+    mode: taint
+    pattern-sources:
+      - patterns:
+          - pattern-either:
+              - pattern: |
+                  ($REQ : http.Request).$FUNC
+              - pattern: |
+                  ($REQ : *http.Request).$FUNC()
+              - pattern: |
+                  r.URL.Query()
+              - pattern: |
+                  r.FormValue($X)
+              - pattern: |
+                  r.PostFormValue($X)
+      - metavariable-regex:
+          metavariable: $FUNC
+          regex: ^(Get|GetQuery|PostForm|PostFormValue|FormValue|Form)$
+      - focus-metavariable:
+          - $REQ
+    pattern-sinks:
+      - patterns:
+          - pattern-either:
+              - pattern-inside: |
+                  ($DB : gorm.DB).Raw($SQL, ...)
+              - pattern-inside: |
+                  ($DB : gorm.DB).Exec($SQL, ...)
+              - pattern-inside: |
+                  ($DB : *gorm.DB).Raw($SQL, ...)
+              - pattern-inside: |
+                  ($DB : *gorm.DB).Exec($SQL, ...)
+              - pattern-inside: |
+                  db.Raw($SQL, ...)
+              - pattern-inside: |
+                  db.Exec($SQL, ...)
+              - pattern-inside: |
+                  ($DB : any).Raw($SQL, ...)
+              - pattern-inside: |
+                      GORM Lib Raw($SQL, ...)
+              - pattern-inside: |
+                      GORM Lib Exec($SQL, ...)
+          - focus-metavariable:
+              - $SQL
+    pattern-propagators:
+      - from: $SRC
+        to: $DST
+        patterns:
+          - pattern: |
+              fmt.Sprintf($FMT, $SRC, ...)
+          - metavariable-binding:
+              $DST: $SRC
+      - from: $SRC
+        to: $DST
+        patterns:
+          - pattern: |
+              string($SRC)
+          - metavariable-binding:
+              $DST: $SRC
+      - from: $SRC
+        to: $DST
+        patterns:
+          - pattern: |
+              $DST := fmt.Sprintf($FMT, ..., $SRC, ...)
+          - pattern: |
+              $DST = fmt.Sprintf($FMT, ..., $SRC, ...)


### PR DESCRIPTION
Addresses semgrep/semgrep-rules#3832 - detect SQL injection via query.Get(...) propagated through fmt.Sprintf into GORM Raw/Exec sinks.

The current Go SQL injection rules miss the common pattern where:
- query.Get(...) provides tainted input
- fmt.Sprintf(...) constructs SQL fragments
- GORM Raw/Exec executes the query

This new rule adds:
1. Sources: http.Request query.Get, FormValue, PostFormValue
2. Sinks: GORM DB.Raw/Exec with propagation via fmt.Sprintf and string() casting
3. Taint propagators to track data flow through string formatting