### PR TITLE
Updating MCP Docs to add an additional step to the Claude Setup Instructions

### DIFF
--- a/cli/src/semgrep/mcp/README.md
+++ b/cli/src/semgrep/mcp/README.md
@@ -96,6 +96,20 @@ A Model Context Protocol (MCP) server for using [Semgrep](https://semgrep.dev) t
     ```bash
     /setup-semgrep-plugin
     ```
+5. Add the following to ~/.claude.json
+   ```bash
+   "mcpServers": {
+    "semgrep": {
+      "command": "semgrep",
+      "args": [
+        "mcp"
+      ],
+      "env": {
+        "SEMGREP_APP_TOKEN": "<TOKEN>"
+      }
+    }
+  }
+  ```
 
 ### Cursor
 

--- a/cli/src/semgrep/mcp/README.md
+++ b/cli/src/semgrep/mcp/README.md
@@ -106,10 +106,10 @@ A Model Context Protocol (MCP) server for using [Semgrep](https://semgrep.dev) t
       ],
       "env": {
         "SEMGREP_APP_TOKEN": "<TOKEN>"
-      }
-    }
-  }
-  ```
+       }
+     }
+   }
+   ```
 
 ### Cursor
 


### PR DESCRIPTION
Customer mentioned:

"Turns out I did not fully configure the semgrep MCP integration so it was running scans but wasn't connected with AppSec Platform :sweat_smile: . Gonna play around with this today. Would be helpful to include in the Claude Code setup instructions to add this to ~/.claude.json
```
  "mcpServers": {
    "semgrep": {
      "command": "semgrep",
      "args": [
        "mcp"
      ],
      "env": {
        "SEMGREP_APP_TOKEN": "<TOKEN>"
      }
    }
  }
```