### PR TITLE
chore(ci): use create-github-app-token + peter-evans/cpr for e2e [SEC-2052]

### DIFF
--- a/.github/workflows/libs/uses.json
+++ b/.github/workflows/libs/uses.json
@@ -10,6 +10,7 @@
     "actions": {
       "cache": "v4",
       "checkout": "v4",
+      "create-github-app-token": "v2",
       "download-artifact": "v4",
       "setup-go": "v5",
       "setup-python": "v5",
@@ -46,6 +47,9 @@
     },
     "marocchino": {
       "sticky-pull-request-comment": "v2"
+    },
+    "peter-evans": {
+      "create-pull-request": "v7"
     },
     "pre-commit": {
       "action": "v3.0.0"

--- a/.github/workflows/libs/useslockfile.json
+++ b/.github/workflows/libs/useslockfile.json
@@ -10,6 +10,7 @@
     "actions": {
       "cache": "0057852bfaa89a56745cba8c7296529d2fc39830",
       "checkout": "34e114876b0b11c390a56381ad16ebd13914f8d5",
+      "create-github-app-token": "fee1f7d63c2ff003460e3d139729b119787bc349",
       "download-artifact": "d3f86a106a0bac45b974a628896c90dbdf5c8093",
       "setup-go": "40f1582b2485089dde7abd97c1529aa768e1baff",
       "setup-python": "a26af69be951a213d495a4c3e4e4022e16d87065",
@@ -46,6 +47,9 @@
     },
     "marocchino": {
       "sticky-pull-request-comment": "773744901bac0e8cbb5a0dc842800d45e9b2b405"
+    },
+    "peter-evans": {
+      "create-pull-request": "22a9089034f40e5a961c8808d113e2c98fb63676"
     },
     "pre-commit": {
       "action": "646c83fcd040023954eafda54b4db0192ce70507"

--- a/.github/workflows/test-e2e-semgrep-ci.jsonnet
+++ b/.github/workflows/test-e2e-semgrep-ci.jsonnet
@@ -7,7 +7,6 @@
 // networking errors (or for other reasons such as a 'git' execution failure).
 
 local actions = import 'libs/actions.libsonnet';
-local gha = import 'libs/gha.libsonnet';
 local semgrep = import 'libs/semgrep.libsonnet';
 local uses = import 'libs/uses.libsonnet';
 
@@ -209,45 +208,49 @@ local semgrep_ci_on_pr_job = {
   'runs-on': 'ubuntu-22.04',
   needs: 'get-inputs',
   outputs: {
-    'pr-number': '${{ steps.open-pr.outputs.pr-number }}',
+    'pr-number': '${{ steps.cpr.outputs.pull-request-number }}',
   },
-  steps: semgrep.github_bot.get_token_steps + [
+  steps: [
+    {
+      name: 'Get token for semgrep-ci GitHub App',
+      id: 'token',
+      uses: uses.actions.create_github_app_token,
+      with: {
+        'app-id': '${{ secrets.SEMGREP_CI_APP_ID }}',
+        'private-key': '${{ secrets.SEMGREP_CI_APP_KEY }}',
+        owner: 'semgrep',
+        repositories: 'e2e',
+      },
+    },
     {
       uses: uses.actions.checkout,
       with: {
         repository: 'semgrep/e2e',
         ref: '${{ github.event.repository.default_branch }}',
-        token: semgrep.github_bot.token_ref,
+        token: '${{ steps.token.outputs.token }}',
       },
     },
     {
-      name: 'Prepare the PR',
+      name: 'Bump version',
       env: {
         DOCKER_TAG: docker_tag,
-        RUN_ID: '${{ github.run_id }}',
       },
-      run: |||
-        git checkout -b "e2e-test-pr-$RUN_ID"
-        scripts/change-version.sh "$DOCKER_TAG"
-        %s
-        git add --all
-        git commit -m "chore: Bump version to $DOCKER_TAG"
-        git push --set-upstream origin "e2e-test-pr-$RUN_ID"
-      ||| % gha.git_config_user,
+      run: 'scripts/change-version.sh "$DOCKER_TAG"',
     },
     {
-      name: 'Make the PR',
-      id: 'open-pr',
-      env: {
-        GITHUB_TOKEN: semgrep.github_bot.token_ref,
-        RUN_ID: '${{ github.run_id }}',
-        DOCKER_TAG: docker_tag,
+      id: 'cpr',
+      // sign-commits: commits are signed via the GitHub API as github-actions[bot],
+      // which satisfies the semgrep/e2e "Require Signed Commits" rule without a bypass.
+      uses: uses.peter_evans.create_pull_request,
+      with: {
+        token: '${{ steps.token.outputs.token }}',
+        branch: 'e2e-test-pr-${{ github.run_id }}',
+        'commit-message': 'chore: Bump version to ' + docker_tag,
+        title: 'chore: fake PR for ' + docker_tag,
+        body: 'Fake PR',
+        base: 'develop',
+        'sign-commits': true,
       },
-      run: |||
-        PR_URL=$(gh pr create --title "chore: fake PR for $DOCKER_TAG" --body "Fake PR" --base "develop" --head "e2e-test-pr-${RUN_ID}")
-        PR_NUMBER=$(echo $PR_URL | sed 's|.*pull/\(.*\)|\1|')
-        echo "pr-number=$PR_NUMBER" >> $GITHUB_OUTPUT
-      |||,
     },
   ],
 };
@@ -260,11 +263,22 @@ local len_checks = "$(gh pr -R semgrep/e2e view %s --json statusCheckRollup --jq
 local wait_for_checks_job = {
   'runs-on': 'ubuntu-22.04',
   needs: 'semgrep-ci-on-pr',
-  steps: semgrep.github_bot.get_token_steps + [
+  steps: [
+    {
+      name: 'Get token for semgrep-ci GitHub App',
+      id: 'token',
+      uses: uses.actions.create_github_app_token,
+      with: {
+        'app-id': '${{ secrets.SEMGREP_CI_APP_ID }}',
+        'private-key': '${{ secrets.SEMGREP_CI_APP_KEY }}',
+        owner: 'semgrep',
+        repositories: 'e2e',
+      },
+    },
     {
       name: 'Wait for checks to register',
       env: {
-        GITHUB_TOKEN: semgrep.github_bot.token_ref,
+        GITHUB_TOKEN: '${{ steps.token.outputs.token }}',
       },
       run: |||
         LEN_CHECKS=%s;
@@ -281,7 +295,7 @@ local wait_for_checks_job = {
     {
       name: 'Wait for checks to complete',
       env: {
-        GITHUB_TOKEN: semgrep.github_bot.token_ref,
+        GITHUB_TOKEN: '${{ steps.token.outputs.token }}',
       },
       run: 'gh pr -R semgrep/e2e checks %s --interval 30 --watch' % pr_number,
     },

--- a/.github/workflows/test-e2e-semgrep-ci.yml
+++ b/.github/workflows/test-e2e-semgrep-ci.yml
@@ -93,29 +93,17 @@ jobs:
   semgrep-ci-on-pr:
     needs: get-inputs
     outputs:
-      pr-number: ${{ steps.open-pr.outputs.pr-number }}
+      pr-number: ${{ steps.cpr.outputs.pull-request-number }}
     runs-on: ubuntu-22.04
     steps:
-      - env:
-          EXPIRATION: 600
-          ISSUER: ${{ secrets.SEMGREP_CI_APP_ID }}
-          PRIVATE_KEY: ${{ secrets.SEMGREP_CI_APP_KEY }}
-        id: jwt
-        name: Get JWT for semgrep-ci GitHub App
-        uses: docker://public.ecr.aws/y9k7q4m1/devops/cicd:latest
-      - env:
-          JWT: ${{ steps.jwt.outputs.jwt }}
-          SEMGREP_CI_APP_INSTALLATION_ID: ${{ secrets.SEMGREP_CI_APP_INSTALLATION_ID }}
-        id: token
+      - id: token
         name: Get token for semgrep-ci GitHub App
-        run: |
-          TOKEN="$(curl -X POST \
-          -H "Authorization: Bearer $JWT" \
-          -H "Accept: application/vnd.github.v3+json" \
-          "https://api.github.com/app/installations/${SEMGREP_CI_APP_INSTALLATION_ID}/access_tokens" | \
-          jq -r .token)"
-          echo "::add-mask::$TOKEN"
-          echo "token=$TOKEN" >> $GITHUB_OUTPUT
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349
+        with:
+          app-id: ${{ secrets.SEMGREP_CI_APP_ID }}
+          owner: semgrep
+          private-key: ${{ secrets.SEMGREP_CI_APP_KEY }}
+          repositories: e2e
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           ref: ${{ github.event.repository.default_branch }}
@@ -123,51 +111,30 @@ jobs:
           token: ${{ steps.token.outputs.token }}
       - env:
           DOCKER_TAG: ${{ needs.get-inputs.outputs.docker_tag }}
-          RUN_ID: ${{ github.run_id }}
-        name: Prepare the PR
-        run: |
-          git checkout -b "e2e-test-pr-$RUN_ID"
-          scripts/change-version.sh "$DOCKER_TAG"
-          git config user.name ${{ github.actor }}
-          git config user.email ${{ github.actor }}@users.noreply.github.com
-
-          git add --all
-          git commit -m "chore: Bump version to $DOCKER_TAG"
-          git push --set-upstream origin "e2e-test-pr-$RUN_ID"
-      - env:
-          DOCKER_TAG: ${{ needs.get-inputs.outputs.docker_tag }}
-          GITHUB_TOKEN: ${{ steps.token.outputs.token }}
-          RUN_ID: ${{ github.run_id }}
-        id: open-pr
-        name: Make the PR
-        run: |
-          PR_URL=$(gh pr create --title "chore: fake PR for $DOCKER_TAG" --body "Fake PR" --base "develop" --head "e2e-test-pr-${RUN_ID}")
-          PR_NUMBER=$(echo $PR_URL | sed 's|.*pull/\(.*\)|\1|')
-          echo "pr-number=$PR_NUMBER" >> $GITHUB_OUTPUT
+        name: Bump version
+        run: scripts/change-version.sh "$DOCKER_TAG"
+      - id: cpr
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676
+        with:
+          base: develop
+          body: Fake PR
+          branch: e2e-test-pr-${{ github.run_id }}
+          commit-message: 'chore: Bump version to ${{ needs.get-inputs.outputs.docker_tag }}'
+          sign-commits: true
+          title: 'chore: fake PR for ${{ needs.get-inputs.outputs.docker_tag }}'
+          token: ${{ steps.token.outputs.token }}
   wait-for-checks:
     needs: semgrep-ci-on-pr
     runs-on: ubuntu-22.04
     steps:
-      - env:
-          EXPIRATION: 600
-          ISSUER: ${{ secrets.SEMGREP_CI_APP_ID }}
-          PRIVATE_KEY: ${{ secrets.SEMGREP_CI_APP_KEY }}
-        id: jwt
-        name: Get JWT for semgrep-ci GitHub App
-        uses: docker://public.ecr.aws/y9k7q4m1/devops/cicd:latest
-      - env:
-          JWT: ${{ steps.jwt.outputs.jwt }}
-          SEMGREP_CI_APP_INSTALLATION_ID: ${{ secrets.SEMGREP_CI_APP_INSTALLATION_ID }}
-        id: token
+      - id: token
         name: Get token for semgrep-ci GitHub App
-        run: |
-          TOKEN="$(curl -X POST \
-          -H "Authorization: Bearer $JWT" \
-          -H "Accept: application/vnd.github.v3+json" \
-          "https://api.github.com/app/installations/${SEMGREP_CI_APP_INSTALLATION_ID}/access_tokens" | \
-          jq -r .token)"
-          echo "::add-mask::$TOKEN"
-          echo "token=$TOKEN" >> $GITHUB_OUTPUT
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349
+        with:
+          app-id: ${{ secrets.SEMGREP_CI_APP_ID }}
+          owner: semgrep
+          private-key: ${{ secrets.SEMGREP_CI_APP_KEY }}
+          repositories: e2e
       - env:
           GITHUB_TOKEN: ${{ steps.token.outputs.token }}
         name: Wait for checks to register


### PR DESCRIPTION
Replace:
- bespoke JWT mint + token exchange with `actions/create-github-app-token`
- manual git/gh PR plumbing with `peter-evans/create-pull-request`
- Commits to `semgrep/e2e` are now signed via the GitHub API

Behavior is otherwise unchanged: same unique-per-run branch, base, title, body, and downstream consumers of the pr-number output.

Produced [this PR](https://github.com/semgrep/e2e/pull/1498) which lgtm