### PR TITLE
Warn when -j > 1 returns 0 findings with no errors (#11606)

### DIFF
--- a/changelog.d/gh-11606.added
+++ b/changelog.d/gh-11606.added
@@ -1,0 +1,1 @@
+Warn when a multi-job scan (`-j > 1`) returns 0 findings with no errors but real rules and targets, since this can indicate workers failing silently under memory pressure.

--- a/cli/src/semgrep/commands/scan.py
+++ b/cli/src/semgrep/commands/scan.py
@@ -75,6 +75,7 @@ from semgrep.types import FilteredMatches
 from semgrep.types import TargetInfoAccumulator
 from semgrep.util import abort
 from semgrep.util import is_truthy
+from semgrep.util import unit_str
 from semgrep.util import with_color
 from semgrep.verbose_logging import getLogger
 
@@ -578,7 +579,13 @@ def scan_options(func: Callable) -> Callable:
 
 
 def log_findings(
-    filtered_matches_by_rule: RuleMatchMap, engine_type: EngineType
+    filtered_matches_by_rule: RuleMatchMap,
+    engine_type: EngineType,
+    *,
+    jobs: Optional[int] = None,
+    num_targets: int = 0,
+    num_rules: int = 0,
+    has_errors: bool = False,
 ) -> None:
     findings_count = sum(len(matches) for matches in filtered_matches_by_rule.values())
     no_findings = findings_count == 0
@@ -590,6 +597,29 @@ def log_findings(
                 logger.info(msg)
         except Exception as e:
             logger.debug(f"Error getting no findings message: {e}")
+
+        # If a high-parallelism scan exercised real work (rules and targets) but
+        # produced no findings *and* no errors, surface a warning. Workers that
+        # die under resource pressure (e.g. OOM) can leave findings missing
+        # without anything in the JSON `errors` array, which has caused silent
+        # correctness regressions in the field. See issue #11606.
+        if (
+            jobs is not None
+            and jobs > 1
+            and num_targets > 0
+            and num_rules > 0
+            and not has_errors
+        ):
+            logger.warning(
+                "Scan with -j %d returned 0 findings across %s and %s and "
+                "produced no errors. If you expected results, re-running with "
+                "-j 1 may help confirm whether high parallelism on a "
+                "memory-constrained host caused workers to fail silently "
+                "(see https://github.com/semgrep/semgrep/issues/11606).",
+                jobs,
+                unit_str(num_rules, "rule"),
+                unit_str(num_targets, "target"),
+            )
 
     if findings_count > TOO_MANY_FINDINGS_THRESHOLD and engine_type is EngineType.OSS:
         try:
@@ -1180,6 +1210,17 @@ def scan(
             # Fetch the latest version and potentially display a banner
             version_check()
             # TODO? this should be guarded by enable_version_check too??
-            log_findings(filtered_matches_by_rule.kept, engine_type)
+            # log_findings depends on the scan path having populated the
+            # match-by-rule map; on the --validate-only path return_data is
+            # still None and there is nothing to log.
+            if return_data is not None:
+                log_findings(
+                    return_data.filtered_matches_by_rule,
+                    engine_type,
+                    jobs=jobs,
+                    num_targets=len(return_data.all_targets.targets),
+                    num_rules=len(return_data.filtered_rules),
+                    has_errors=bool(return_data.semgrep_errors),
+                )
 
         return return_data

--- a/cli/tests/default/unit/test_log_findings.py
+++ b/cli/tests/default/unit/test_log_findings.py
@@ -1,0 +1,108 @@
+#
+# Copyright (c) 2026 Semgrep Inc.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public License
+# version 2.1 as published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the file
+# LICENSE for more details.
+#
+import logging
+
+import pytest
+from semgrep.commands.scan import log_findings
+from semgrep.engine import EngineType
+
+
+@pytest.mark.quick
+def test_log_findings_warns_on_suspicious_zero_with_high_jobs(caplog):
+    """A clean 0-finding scan with -j > 1 should emit a warning pointing at #11606."""
+    with caplog.at_level(logging.WARNING, logger="semgrep"):
+        log_findings(
+            {},
+            EngineType.OSS,
+            jobs=27,
+            num_targets=4400,
+            num_rules=65,
+            has_errors=False,
+        )
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert any("0 findings" in r.getMessage() for r in warnings)
+    assert any("11606" in r.getMessage() for r in warnings)
+    assert any("-j 27" in r.getMessage() for r in warnings)
+
+
+@pytest.mark.quick
+def test_log_findings_silent_when_serial(caplog):
+    """A 0-finding scan with -j=1 should not trigger the multicore warning."""
+    with caplog.at_level(logging.WARNING, logger="semgrep"):
+        log_findings(
+            {},
+            EngineType.OSS,
+            jobs=1,
+            num_targets=4400,
+            num_rules=65,
+            has_errors=False,
+        )
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert not any("11606" in r.getMessage() for r in warnings)
+
+
+@pytest.mark.quick
+def test_log_findings_silent_when_jobs_unspecified(caplog):
+    """When jobs is None (e.g. validate path) we should not warn."""
+    with caplog.at_level(logging.WARNING, logger="semgrep"):
+        log_findings({}, EngineType.OSS)
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert not any("11606" in r.getMessage() for r in warnings)
+
+
+@pytest.mark.quick
+def test_log_findings_silent_when_errors_present(caplog):
+    """If errors were reported we already alerted the user; suppress the heuristic."""
+    with caplog.at_level(logging.WARNING, logger="semgrep"):
+        log_findings(
+            {},
+            EngineType.OSS,
+            jobs=27,
+            num_targets=4400,
+            num_rules=65,
+            has_errors=True,
+        )
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert not any("11606" in r.getMessage() for r in warnings)
+
+
+@pytest.mark.quick
+def test_log_findings_silent_when_no_targets(caplog):
+    """An empty target set legitimately produces 0 findings."""
+    with caplog.at_level(logging.WARNING, logger="semgrep"):
+        log_findings(
+            {},
+            EngineType.OSS,
+            jobs=27,
+            num_targets=0,
+            num_rules=65,
+            has_errors=False,
+        )
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert not any("11606" in r.getMessage() for r in warnings)
+
+
+@pytest.mark.quick
+def test_log_findings_silent_when_no_rules(caplog):
+    """An empty rules set legitimately produces 0 findings."""
+    with caplog.at_level(logging.WARNING, logger="semgrep"):
+        log_findings(
+            {},
+            EngineType.OSS,
+            jobs=27,
+            num_targets=4400,
+            num_rules=0,
+            has_errors=False,
+        )
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert not any("11606" in r.getMessage() for r in warnings)


### PR DESCRIPTION
Refs #11606.

#11606 reports that on a 32-vCPU / 8 GB host, `semgrep -j 27` against a 4,400-file Ruby tree silently returns `"results": []` and an empty `errors` array on roughly half of runs. The same scan with `-j 8` returns thousands of findings every time. Both runs exit 0. There is no warning, no error, no skipped-files entry — nothing in the output schema tells the user something went wrong.

Until the underlying multicore behaviour is fully diagnosed (the issue thread is still gathering info), this is a small defensive change so the CLI does not just go quiet when the result looks suspiciously empty.

## What this PR does

`log_findings` now also accepts `jobs`, `num_targets`, `num_rules`, and `has_errors`. When all of the following hold it prints a warning to stderr:

- `jobs > 1`
- `findings == 0`
- `num_targets > 0`
- `num_rules > 0`
- `has_errors == False`

The warning text:

> Scan with -j 27 returned 0 findings across 65 rules and 4400 targets and produced no errors. If you expected results, re-running with -j 1 may help confirm whether high parallelism on a memory-constrained host caused workers to fail silently (see https://github.com/semgrep/semgrep/issues/11606).

The heuristic is intentionally narrow — there are legitimate 0-finding scans (empty rule pack, no eligible targets, all findings ignored, etc.) and the conditions above filter those out. There is no change to exit codes, JSON schema, or any other consumer-visible format.

## What this PR does not do

It does not fix the root cause. The `Concurrent_map_targets` / `Executor_pool` path can still drop work; that is a deeper problem that needs the maintainer investigation hinted at in the issue thread. This is just a stderr warning so users notice and can fall back to `-j 1` while the real fix lands.

It also does not change the registry-suggestion or too-many-findings hints already in `log_findings`; those still piggyback on `version_check` exactly as before.

## Side effect / drive-by

While moving the call site, I noticed a latent `NameError`: when `--validate` was used with `--enable-version-check` (the default), `log_findings(filtered_matches_by_rule.kept, engine_type)` was reached with `filtered_matches_by_rule` never bound (the `else:` scan branch never ran). The TODO right above the call already hinted at this. The new call is guarded on `return_data is not None`, which silently fixes that case. Happy to split this into its own PR if you would prefer.

## Tests

Added `cli/tests/default/unit/test_log_findings.py` with 6 quick unit tests covering: the warning fires for the issue's exact scenario; stays silent when `-j == 1`, when `jobs is None`, when errors are present, when there are no targets, and when there are no rules. All 6 pass locally. Black + reorder-python-imports clean.