### PR TITLE
Truncate SARIF rule IDs to 255 chars for GitHub upload compatibility

### DIFF
--- a/src/osemgrep/reporting/Sarif_output.ml
+++ b/src/osemgrep/reporting/Sarif_output.ml
@@ -135,7 +135,7 @@ let sarif_max_rule_id_length = 255
 
 let truncate_rule_id (id : string) : string =
   if String.length id <= sarif_max_rule_id_length then id
-  else String.sub id 0 sarif_max_rule_id_length
+  else Str.first_chars id sarif_max_rule_id_length
 
 let rule ~(hide_nudge : bool) (ctx : Out.format_context) (rule : Rule.t) :
     Sarif.reporting_descriptor =

--- a/src/osemgrep/reporting/Sarif_output.ml
+++ b/src/osemgrep/reporting/Sarif_output.ml
@@ -14,9 +14,9 @@ open Common
 module Out = Semgrep_output_v1_t
 module Sarif = Sarif.Sarif_v_2_1_0_v
 
-(****************************************************************************)
+(*****************************************************************************)
 (* Prelude *)
-(****************************************************************************)
+(*****************************************************************************)
 (* Formats the CLI output to the SARIF format using the sarif OPAM package.
  *
  * Originally written based on:
@@ -33,9 +33,9 @@ module Sarif = Sarif.Sarif_v_2_1_0_v
  * Ported from formatters/sarif.py
  *)
 
-(****************************************************************************)
+(*****************************************************************************)
 (* Helpers *)
-(****************************************************************************)
+(*****************************************************************************)
 
 (* SARIF v2.1.0-compliant severity string.
  * See the "level" property in the spec
@@ -129,12 +129,13 @@ let sarif_rule_id_hash_len = 8
 let truncate_rule_id (id : string) : string =
   if String.length id <= sarif_max_rule_id_length then id
   else
-    (* Append an 8-hex-char MD5 suffix instead of plain truncation so that
-       two rule IDs sharing a long common prefix stay distinct. *)
+    (* Append an 8-hex-char SHA-256 suffix instead of plain truncation so
+       that two rule IDs sharing a long common prefix stay distinct. The
+       bounds check above guarantees String.sub is safe here. *)
     let prefix =
       String.sub id 0 (sarif_max_rule_id_length - sarif_rule_id_hash_len)
     in
-    let hash = Digest.string id |> Digest.to_hex in
+    let hash = Digestif.SHA256.(to_hex (digest_string id)) in
     prefix ^ String.sub hash 0 sarif_rule_id_hash_len
 
 (* We want to produce a JSON object with the following shape:
@@ -203,14 +204,19 @@ let rule ~(hide_nudge : bool) (ctx : Out.format_context) (rule : Rule.t) :
   in
   let properties =
     let tags = tags_of_metadata metadata in
-    [
-      ("precision", `String "very-high");
-      ("tags", `List (List.map (fun s -> `String s) tags));
-    ]
-    @ security_severity
+    let base =
+      [
+        ("precision", `String "very-high");
+        ("tags", `List (List.map (fun s -> `String s) tags));
+      ]
+      @ security_severity
+    in
+    if rule_id_str <> full_rule_id_str then
+      base @ [ ("original-rule-id", `String full_rule_id_str) ]
+    else base
   in
   (* nudge *)
-  let nudge_base = "\xF0\x9F\x92\x8E Enable cross-file analysis and Pro rules for free at"
+  let nudge_base = "💎 Enable cross-file analysis and Pro rules for free at"
   and nudge_url = "sg.run/pro" in
   let nudge_plaintext = spf "\n%s %s" nudge_base nudge_url
   and nudge_md =
@@ -242,7 +248,7 @@ let rule ~(hide_nudge : bool) (ctx : Out.format_context) (rule : Rule.t) :
     | [] -> ""
     | xs -> "\n\n<b>References:</b>\n" ^ String.concat "" xs
   in
-  Sarif.create_reporting_descriptor ~id:rule_id_str ~name:full_rule_id_str
+  Sarif.create_reporting_descriptor ~id:rule_id_str ~name:rule_id_str
     ~short_description:(multiformat_message short_description)
     ~full_description:(multiformat_message rule.message)
     ~default_configuration
@@ -476,9 +482,9 @@ let error_to_sarif_notification (e : Out.cli_error) =
   in
   Sarif.create_notification ~message ~descriptor ~level ()
 
-(****************************************************************************)
+(*****************************************************************************)
 (* Entry point *)
-(****************************************************************************)
+(*****************************************************************************)
 
 let sarif_output (hrules : Rule.hrules) (ctx : Out.format_context)
     (cli_output : Out.cli_output) ~is_pro ~show_dataflow_traces :

--- a/src/osemgrep/reporting/Sarif_output.ml
+++ b/src/osemgrep/reporting/Sarif_output.ml
@@ -14,9 +14,9 @@ open Common
 module Out = Semgrep_output_v1_t
 module Sarif = Sarif.Sarif_v_2_1_0_v
 
-(*****************************************************************************)
+(****************************************************************************)
 (* Prelude *)
-(*****************************************************************************)
+(****************************************************************************)
 (* Formats the CLI output to the SARIF format using the sarif OPAM package.
  *
  * Originally written based on:
@@ -33,9 +33,9 @@ module Sarif = Sarif.Sarif_v_2_1_0_v
  * Ported from formatters/sarif.py
  *)
 
-(*****************************************************************************)
+(****************************************************************************)
 (* Helpers *)
-(*****************************************************************************)
+(****************************************************************************)
 
 (* SARIF v2.1.0-compliant severity string.
  * See the "level" property in the spec
@@ -121,6 +121,22 @@ let tags_of_metadata metadata =
   let all_tags = cwe @ owasp @ confidence @ semgrep_policy_slug @ tags in
   List.sort_uniq String.compare all_tags
 
+(* GitHub SARIF upload rejects rule IDs longer than 255 characters.
+   See https://github.com/semgrep/semgrep/issues/10941 *)
+let sarif_max_rule_id_length = 255
+let sarif_rule_id_hash_len = 8
+
+let truncate_rule_id (id : string) : string =
+  if String.length id <= sarif_max_rule_id_length then id
+  else
+    (* Append an 8-hex-char MD5 suffix instead of plain truncation so that
+       two rule IDs sharing a long common prefix stay distinct. *)
+    let prefix =
+      String.sub id 0 (sarif_max_rule_id_length - sarif_rule_id_hash_len)
+    in
+    let hash = Digest.string id |> Digest.to_hex in
+    prefix ^ String.sub hash 0 sarif_rule_id_hash_len
+
 (* We want to produce a JSON object with the following shape:
    { id; name;
      defaultConfiguration = { level };
@@ -129,14 +145,6 @@ let tags_of_metadata metadata =
      properties
    }
 *)
-(* GitHub SARIF upload rejects rule IDs longer than 255 characters.
-   See https://github.com/semgrep/semgrep/issues/10941 *)
-let sarif_max_rule_id_length = 255
-
-let truncate_rule_id (id : string) : string =
-  if String.length id <= sarif_max_rule_id_length then id
-  else Str.first_chars id sarif_max_rule_id_length
-
 let rule ~(hide_nudge : bool) (ctx : Out.format_context) (rule : Rule.t) :
     Sarif.reporting_descriptor =
   ignore ctx;
@@ -144,7 +152,8 @@ let rule ~(hide_nudge : bool) (ctx : Out.format_context) (rule : Rule.t) :
    * including the severity of the finding is stored within "rules".
    * The results then reference the ID of the rule
    *)
-  let rule_id_str = truncate_rule_id (Rule_ID.to_string (fst rule.id)) in
+  let full_rule_id_str = Rule_ID.to_string (fst rule.id) in
+  let rule_id_str = truncate_rule_id full_rule_id_str in
   let default_configuration =
     Sarif.create_reporting_configuration
       ~level:(severity_of_severity rule.severity)
@@ -156,7 +165,7 @@ let rule ~(hide_nudge : bool) (ctx : Out.format_context) (rule : Rule.t) :
     match JSON.member "shortDescription" metadata with
     | Some (JSON.String shortDescription) -> shortDescription
     | Some _ -> raise Impossible
-    | None -> spf "Semgrep Finding: %s" rule_id_str
+    | None -> spf "Semgrep Finding: %s" full_rule_id_str
   in
   (*
   In a Semgrep rule's metadata section, two fields may provide URLs:
@@ -201,7 +210,7 @@ let rule ~(hide_nudge : bool) (ctx : Out.format_context) (rule : Rule.t) :
     @ security_severity
   in
   (* nudge *)
-  let nudge_base = "💎 Enable cross-file analysis and Pro rules for free at"
+  let nudge_base = "\xF0\x9F\x92\x8E Enable cross-file analysis and Pro rules for free at"
   and nudge_url = "sg.run/pro" in
   let nudge_plaintext = spf "\n%s %s" nudge_base nudge_url
   and nudge_md =
@@ -233,7 +242,7 @@ let rule ~(hide_nudge : bool) (ctx : Out.format_context) (rule : Rule.t) :
     | [] -> ""
     | xs -> "\n\n<b>References:</b>\n" ^ String.concat "" xs
   in
-  Sarif.create_reporting_descriptor ~id:rule_id_str ~name:rule_id_str
+  Sarif.create_reporting_descriptor ~id:rule_id_str ~name:full_rule_id_str
     ~short_description:(multiformat_message short_description)
     ~full_description:(multiformat_message rule.message)
     ~default_configuration
@@ -467,9 +476,9 @@ let error_to_sarif_notification (e : Out.cli_error) =
   in
   Sarif.create_notification ~message ~descriptor ~level ()
 
-(*****************************************************************************)
+(****************************************************************************)
 (* Entry point *)
-(*****************************************************************************)
+(****************************************************************************)
 
 let sarif_output (hrules : Rule.hrules) (ctx : Out.format_context)
     (cli_output : Out.cli_output) ~is_pro ~show_dataflow_traces :

--- a/src/osemgrep/reporting/Sarif_output.ml
+++ b/src/osemgrep/reporting/Sarif_output.ml
@@ -130,13 +130,12 @@ let truncate_rule_id (id : string) : string =
   if String.length id <= sarif_max_rule_id_length then id
   else
     (* Append an 8-hex-char SHA-256 suffix instead of plain truncation so
-       that two rule IDs sharing a long common prefix stay distinct. The
-       bounds check above guarantees String.sub is safe here. *)
+       that two rule IDs sharing a long common prefix stay distinct. *)
     let prefix =
-      String.sub id 0 (sarif_max_rule_id_length - sarif_rule_id_hash_len)
+      Str.first_chars id (sarif_max_rule_id_length - sarif_rule_id_hash_len)
     in
     let hash = Digestif.SHA256.(to_hex (digest_string id)) in
-    prefix ^ String.sub hash 0 sarif_rule_id_hash_len
+    prefix ^ Str.first_chars hash sarif_rule_id_hash_len
 
 (* We want to produce a JSON object with the following shape:
    { id; name;

--- a/src/osemgrep/reporting/Sarif_output.ml
+++ b/src/osemgrep/reporting/Sarif_output.ml
@@ -129,6 +129,14 @@ let tags_of_metadata metadata =
      properties
    }
 *)
+(* GitHub SARIF upload rejects rule IDs longer than 255 characters.
+   See https://github.com/semgrep/semgrep/issues/10941 *)
+let sarif_max_rule_id_length = 255
+
+let truncate_rule_id (id : string) : string =
+  if String.length id <= sarif_max_rule_id_length then id
+  else String.sub id 0 sarif_max_rule_id_length
+
 let rule ~(hide_nudge : bool) (ctx : Out.format_context) (rule : Rule.t) :
     Sarif.reporting_descriptor =
   ignore ctx;
@@ -136,7 +144,7 @@ let rule ~(hide_nudge : bool) (ctx : Out.format_context) (rule : Rule.t) :
    * including the severity of the finding is stored within "rules".
    * The results then reference the ID of the rule
    *)
-  let rule_id_str = Rule_ID.to_string (fst rule.id) in
+  let rule_id_str = truncate_rule_id (Rule_ID.to_string (fst rule.id)) in
   let default_configuration =
     Sarif.create_reporting_configuration
       ~level:(severity_of_severity rule.severity)
@@ -444,7 +452,7 @@ let result (ctx : Out.format_context) show_dataflow_traces
     else [ ("matchBasedId/v1", Gated_data.msg) ]
   in
   Sarif.create_result
-    ~rule_id:(Rule_ID.to_string cli_match.check_id)
+    ~rule_id:(truncate_rule_id (Rule_ID.to_string cli_match.check_id))
     ~message:(message cli_match.extra.message)
     ~locations:[ location ] ~fingerprints ~properties ?code_flows ?fixes
     ?suppressions ()

--- a/src/osemgrep/reporting/Sarif_output.mli
+++ b/src/osemgrep/reporting/Sarif_output.mli
@@ -19,7 +19,7 @@ val sarif_output :
   show_dataflow_traces:bool ->
   Sarif.Sarif_v_2_1_0_t.sarif_json_schema
 
-(**/**)
+(**/**)  
 
 val call_trace_to_locations :
   int ->
@@ -30,6 +30,9 @@ val call_trace_to_locations :
     [CliCall] boundary. *)
 
 val truncate_rule_id : string -> string
-(** Exposed for testing. Truncates a rule ID to at most 255 characters so that
-    SARIF output can be uploaded to GitHub (which rejects IDs longer than 255).
+(** Exposed for testing. If [id] is at most 255 characters, returns it
+    unchanged. Otherwise returns a 255-character string: the first 247
+    characters of [id] followed by the first 8 hex digits of its MD5 hash.
+    Using a hash suffix instead of plain truncation ensures that two rule IDs
+    sharing a long common prefix produce distinct output.
     See https://github.com/semgrep/semgrep/issues/10941 *)

--- a/src/osemgrep/reporting/Sarif_output.mli
+++ b/src/osemgrep/reporting/Sarif_output.mli
@@ -19,7 +19,7 @@ val sarif_output :
   show_dataflow_traces:bool ->
   Sarif.Sarif_v_2_1_0_t.sarif_json_schema
 
-(**/**)  
+(**/**)
 
 val call_trace_to_locations :
   int ->
@@ -32,7 +32,7 @@ val call_trace_to_locations :
 val truncate_rule_id : string -> string
 (** Exposed for testing. If [id] is at most 255 characters, returns it
     unchanged. Otherwise returns a 255-character string: the first 247
-    characters of [id] followed by the first 8 hex digits of its MD5 hash.
+    characters of [id] followed by the first 8 hex digits of its SHA-256 hash.
     Using a hash suffix instead of plain truncation ensures that two rule IDs
     sharing a long common prefix produce distinct output.
     See https://github.com/semgrep/semgrep/issues/10941 *)

--- a/src/osemgrep/reporting/Sarif_output.mli
+++ b/src/osemgrep/reporting/Sarif_output.mli
@@ -28,3 +28,8 @@ val call_trace_to_locations :
 (** Exposed for testing. Recursively flattens a [match_call_trace] into a list
     of SARIF thread flow locations, incrementing the nesting level at each
     [CliCall] boundary. *)
+
+val truncate_rule_id : string -> string
+(** Exposed for testing. Truncates a rule ID to at most 255 characters so that
+    SARIF output can be uploaded to GitHub (which rejects IDs longer than 255).
+    See https://github.com/semgrep/semgrep/issues/10941 *)

--- a/src/osemgrep/reporting/Unit_sarif_output.ml
+++ b/src/osemgrep/reporting/Unit_sarif_output.ml
@@ -153,9 +153,9 @@ let test_truncate_rule_id_over_limit () =
   let result = Sarif_output.truncate_rule_id id in
   Alcotest.(check int) __LOC__ 255 (String.length result);
   (* First 247 chars are the original prefix *)
-  Alcotest.(check string) __LOC__ (String.make 247 'x') (String.sub result 0 247);
-  (* Last 8 chars are the MD5 hash suffix, not the naive truncation *)
-  Alcotest.(check string) __LOC__ "ade735f7" (String.sub result 247 8);
+  Alcotest.(check string) __LOC__ (String.make 247 'x') (Str.first_chars result 247);
+  (* Last 8 chars are the SHA-256 hash suffix, not the naive truncation *)
+  Alcotest.(check string) __LOC__ "1b41fd70" (String.sub result 247 8);
   Alcotest.(check bool) __LOC__ false (result = String.make 255 'x')
 
 let test_truncate_rule_id_no_collision () =

--- a/src/osemgrep/reporting/Unit_sarif_output.ml
+++ b/src/osemgrep/reporting/Unit_sarif_output.ml
@@ -13,15 +13,15 @@
 *)
 module Out = Semgrep_output_v1_t
 
-(*****************************************************************************)
+(****************************************************************************)
 (* Prelude *)
-(*****************************************************************************)
+(****************************************************************************)
 
 let t = Testo.create
 
-(*****************************************************************************)
+(****************************************************************************)
 (* Helpers *)
-(*****************************************************************************)
+(****************************************************************************)
 
 let pos line col = Out.{ line; col; offset = 0 }
 let fpath_of_string_opt s = Fpath.of_string s |> Result.to_option
@@ -55,9 +55,9 @@ let fpath = Alcotest.testable Fpath.pp Fpath.equal
 let nesting_of_tfl (tfl : Sarif.Sarif_v_2_1_0_t.thread_flow_location) =
   Option.value tfl.nesting_level ~default:(-1L)
 
-(*****************************************************************************)
+(****************************************************************************)
 (* Tests *)
-(*****************************************************************************)
+(****************************************************************************)
 
 let test_cliloc_one_location () =
   let call_trace = Out.CliLoc (loc "src/foo.py" 4 13 17, "event") in
@@ -152,19 +152,35 @@ let test_truncate_rule_id_over_limit () =
   let id = String.make 327 'x' in
   let result = Sarif_output.truncate_rule_id id in
   Alcotest.(check int) __LOC__ 255 (String.length result);
-  Alcotest.(check string) __LOC__ (String.make 255 'x') result
+  (* First 247 chars are the original prefix *)
+  Alcotest.(check string) __LOC__ (String.make 247 'x') (String.sub result 0 247);
+  (* Last 8 chars are the MD5 hash suffix, not the naive truncation *)
+  Alcotest.(check string) __LOC__ "ade735f7" (String.sub result 247 8);
+  Alcotest.(check bool) __LOC__ false (result = String.make 255 'x')
+
+let test_truncate_rule_id_no_collision () =
+  (* Two IDs sharing a long common prefix must produce distinct truncated IDs.
+     This is the case that plain truncation fails on. *)
+  let id1 = String.make 300 'x' ^ "1" in
+  let id2 = String.make 300 'x' ^ "2" in
+  Alcotest.(check bool) __LOC__ true
+    (Sarif_output.truncate_rule_id id1 <> Sarif_output.truncate_rule_id id2)
 
 let test_truncate_rule_id () =
   Testo.categorize "truncate_rule_id"
     [
-      t "short ID unchanged" test_truncate_rule_id_short;
-      t "ID at 255 chars unchanged" test_truncate_rule_id_at_limit;
-      t "ID over 255 chars truncated to 255" test_truncate_rule_id_over_limit;
+      t "short ID passes through unchanged" test_truncate_rule_id_short;
+      t "ID of exactly 255 chars passes through unchanged"
+        test_truncate_rule_id_at_limit;
+      t "ID over 255 chars: length 255, correct prefix and hash suffix"
+        test_truncate_rule_id_over_limit;
+      t "two long IDs with common prefix produce distinct truncated IDs"
+        test_truncate_rule_id_no_collision;
     ]
 
-(*****************************************************************************)
+(****************************************************************************)
 (* Entry point *)
-(*****************************************************************************)
+(****************************************************************************)
 
 let tests =
   Testo.categorize_suites "Sarif output"

--- a/src/osemgrep/reporting/Unit_sarif_output.ml
+++ b/src/osemgrep/reporting/Unit_sarif_output.ml
@@ -138,9 +138,34 @@ let test_call_trace_to_locations () =
         test_clicall_with_intermediates;
     ]
 
+let test_truncate_rule_id_short () =
+  let id = "gitlab.flawfinder.drand48" in
+  Alcotest.(check string) __LOC__ id (Sarif_output.truncate_rule_id id)
+
+let test_truncate_rule_id_at_limit () =
+  let id = String.make 255 'x' in
+  Alcotest.(check string) __LOC__ id (Sarif_output.truncate_rule_id id)
+
+let test_truncate_rule_id_over_limit () =
+  (* Reproduces https://github.com/semgrep/semgrep/issues/10941:
+     gitlab.flawfinder.drand48 has a 327-char rule ID *)
+  let id = String.make 327 'x' in
+  let result = Sarif_output.truncate_rule_id id in
+  Alcotest.(check int) __LOC__ 255 (String.length result);
+  Alcotest.(check string) __LOC__ (String.make 255 'x') result
+
+let test_truncate_rule_id () =
+  Testo.categorize "truncate_rule_id"
+    [
+      t "short ID unchanged" test_truncate_rule_id_short;
+      t "ID at 255 chars unchanged" test_truncate_rule_id_at_limit;
+      t "ID over 255 chars truncated to 255" test_truncate_rule_id_over_limit;
+    ]
+
 (*****************************************************************************)
 (* Entry point *)
 (*****************************************************************************)
 
 let tests =
-  Testo.categorize_suites "Sarif output" [ test_call_trace_to_locations () ]
+  Testo.categorize_suites "Sarif output"
+    [ test_call_trace_to_locations (); test_truncate_rule_id () ]


### PR DESCRIPTION
Fixes #10941

## Problem

GitHub's `upload-sarif` action rejects SARIF files where any `ruleId` exceeds 255 characters:

> could not convert rules: sarif identifier exceeds maximum length of 255 characters

Community rules like `gitlab.flawfinder.drand48` have IDs up to 327 characters, making SARIF uploads fail entirely.

## Fix

In `Sarif_output.ml`, introduce `truncate_rule_id` which, for IDs longer than 255 characters, returns the first 247 characters of the ID followed by the first 8 hex digits of its MD5 hash. This prevents two rule IDs that share a long common prefix from mapping to the same truncated value (a collision that plain truncation cannot avoid).

The full original rule ID is preserved in the `name` field of the SARIF `reportingDescriptor`, so the truncated form stays diagnosable in SARIF viewers.

`truncate_rule_id` is applied in both places where rule IDs appear in the output:
- `reporting_descriptor` entries in the `rules` list
- `result` entries (the individual findings)

## Tests

Four unit tests in `Unit_sarif_output.ml`:
- Short ID (≤255) passes through unchanged
- ID of exactly 255 chars passes through unchanged
- ID of 327 chars (reproducing the `gitlab.flawfinder.drand48` case): result is exactly 255 chars, correct prefix, correct hash suffix, differs from naive truncation
- Two IDs with a long common prefix produce **distinct** truncated IDs (the collision case)