### PR TITLE
[do not merge] Validate reusable pre-commit-with-opam workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,32 +24,10 @@ jobs:
           make
           git diff --exit-code
   pre-commit:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Configure git safedir properly
-        run: git config --global --add safe.directory $(pwd)
-      - name: Make checkout speedy
-        run: git config --global fetch.parallel 50
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
-        with:
-          submodules: true
-      - name: Configure git safedir properly
-        run: git config --global --add safe.directory $(pwd)
-      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78
-        with:
-          enable-cache: false
-          python-version: "3.11"
-          version: 0.10.9
-      - uses: semgrep/setup-ocaml@a739c5405d73c42ef15a9dc995efc0f87396cc36
-        with:
-          cache-prefix: v5
-          ocaml-compiler: ocaml-variants.5.3.0+options,ocaml-option-flambda
-          opam-pin: false
-          save-opam-post-run: true
-      - run: opam install -y ocamlformat.0.29.0
-      - env:
-          SKIP: check-opam-conflicts
-        uses: pre-commit/action@646c83fcd040023954eafda54b4db0192ce70507
+    uses: semgrep/release-workflows/.github/workflows/pre-commit-with-opam.yaml@ef88cfbc3f18439dab4c6dbc571f40c0369d114e # leif/reusable-pre-commit-with-opam
+    with:
+      submodules: true
+      skip: check-opam-conflicts
 name: lint
 on:
   pull_request:


### PR DESCRIPTION
## Important: do not merge

This PR is a throwaway validation run for semgrep/release-workflows#120. The real migration will go through `lint.jsonnet` once that PR lands — this PR edits `lint.yml` directly so I can prove the reusable workflow works against this repo's CI without waiting on a jsonnet refactor.

I'll close this once #120 lands and the real jsonnet-based migration is in flight.

## What it does

Replaces the inline `pre-commit` job in `lint.yml` (24 lines) with a 4-line `uses:` call to:

```
semgrep/release-workflows/.github/workflows/pre-commit-with-opam.yaml@ef88cfb (leif/reusable-pre-commit-with-opam)
```

Passes `submodules: true` and `skip: check-opam-conflicts` to match the current behavior. Everything else (setup-ocaml, opam install, the SKIP env, the OCaml toolchain) lives in the reusable workflow.

## Expected CI results

| Job | Expected | Why |
|---|---|---|
| `pre-commit` | ✅ green | This is what we're testing |
| `github-actions` (actionlint) | ✅ green | Unchanged |
| `jsonnet-gha` | ❌ red | We edited the rendered yaml but not the jsonnet source. `make && git diff --exit-code` will fail. This is expected — when the real migration lands through jsonnet, this job will pass again. |

If `pre-commit` is green and `jsonnet-gha` fails exactly the way described, the reusable workflow is validated and we can proceed.

## Behavior deltas from the current inline job (covered in #120's body)

- `actions/checkout` v4 → v6.0.2
- `astral-sh/setup-uv` v6 → v8.1.0
- `enable-cache: false` → `enable-cache: true` with `cache-dependency-glob: .pre-commit-config.yaml`
- uv `version: 0.10.9` pin dropped (uses latest)
- The duplicate `safedir` config step is collapsed
- `pre-commit/action` → `uv tool install pre-commit --with pre-commit-uv` + direct `pre-commit run`
- New: `actions/cache@v5.0.5` step for `~/.cache/pre-commit` (this repo has no pre-commit cache today)

## Test plan

- [ ] Confirm `pre-commit` job goes green
- [ ] Confirm cache writes on first run (look for `Cache saved successfully` in `Post Cache pre-commit hook envs`)
- [ ] Push an empty commit and confirm the second run hits the cache (`Cache restored from key: pre-commit-v1|...`)
- [ ] Confirm `jsonnet-gha` fails only on the yaml-vs-jsonnet drift, not anything substantive

🤖 Generated with [Claude Code](https://claude.com/claude-code)