### PR TITLE
fix(text-output): filter nosemgrep-suppressed findings from terminal display

### DIFF
--- a/src/osemgrep/reporting/Text_output.ml
+++ b/src/osemgrep/reporting/Text_output.ml
@@ -449,7 +449,7 @@ let matches_output ~max_chars_per_line ~max_lines_per_finding
 let text_output ~max_chars_per_line ~max_lines_per_finding
     (cli_output : Out.cli_output) : string =
   let groups : (report_group, Out.cli_match list) Assoc.t =
-    cli_output.results |> Semgrep_output_utils.sort_cli_matches
+    cli_output.results |> List.filter (fun (m : Out.cli_match) -> m.extra.is_ignored <> Some true) |> Semgrep_output_utils.sort_cli_matches
     |> Assoc.group_by (fun (m : Out.cli_match) ->
         match Product.of_cli_match m with
         | `SCA -> (


### PR DESCRIPTION
## Summary

Fixes #11715 (variant of #11605)

When `--sarif-output` is used, `Output_format.keep_ignores` returns `true` so the SARIF formatter can include suppressed findings per the SARIF spec. However, findings with `is_ignored = Some true` were flowing through the entire pipeline including the terminal renderer, creating a confusing inconsistency: SARIF file shows 0 findings while the terminal shows N findings.

## Root cause

In `Scan_subcommand.ml`, `keep_ignored = true` for SARIF output prevents `Nosemgrep.filter_ignored` from removing suppressed findings. These findings then reach `text_output` in `Text_output.ml` unfiltered.

## Fix

Filter `is_ignored = Some true` findings before grouping in `text_output`:

```diff
-    cli_output.results |> Semgrep_output_utils.sort_cli_matches
+    cli_output.results
+    |> List.filter (fun (m : Out.cli_match) -> m.extra.is_ignored <> Some true)
+    |> Semgrep_output_utils.sort_cli_matches
```

## Testing

Reproduced locally. OCaml toolchain not available — relying on CI for build validation.

Fixes #11715