### PR TITLE
Removed stale Semgrep Pro Engine FIXME

### DIFF
--- a/cli/src/semgrep/commands/install.py
+++ b/cli/src/semgrep/commands/install.py
@@ -91,7 +91,7 @@ def download_semgrep_pro(
             logger.warning(
                 "Logged in deployment does not have access to Semgrep Pro Engine"
             )
-            # FIXME: Needs to be updated before launch Feb 2023
+            
             logger.warning(
                 "Visit https://semgrep.dev/products/pro-engine/ for more information."
             )


### PR DESCRIPTION
Removes a stale FIXME comment referencing a February 2023 launch.

The linked Semgrep Pro Engine page still exists and redirects correctly, and the product name is still current, so the outdated FIXME no longer appears actionable.