### PR TITLE
Fix #10063: remove incorrect help message about scan default

### DIFF
--- a/cli/tests/default/e2e/snapshots/test_help/test_help_text/--help/help.txt
+++ b/cli/tests/default/e2e/snapshots/test_help/test_help_text/--help/help.txt
@@ -4,8 +4,6 @@
 
   Run [36m`semgrep SUBCOMMAND --help`[39m for more information on each subcommand
 
-  If no subcommand is passed, will show a welcome message with usage info
-
 [4mOptions[24m:
   -h, --help  Show this message and exit.
 

--- a/cli/tests/default/e2e/snapshots/test_help/test_help_text/-h/help.txt
+++ b/cli/tests/default/e2e/snapshots/test_help/test_help_text/-h/help.txt
@@ -4,8 +4,6 @@
 
   Run [36m`semgrep SUBCOMMAND --help`[39m for more information on each subcommand
 
-  If no subcommand is passed, will show a welcome message with usage info
-
 [4mOptions[24m:
   -h, --help  Show this message and exit.
 

--- a/src/osemgrep/cli/Help.ml
+++ b/src/osemgrep/cli/Help.ml
@@ -73,7 +73,6 @@ let print_semgrep_dashdash_help () =
 
   Run @{<cyan>`semgrep SUBCOMMAND --help`@} for more information on each subcommand
 
-  If no subcommand is passed, will show a welcome message with usage info
 
 @{<ul>Options@}:
   -h, --help  Show this message and exit.


### PR DESCRIPTION
Fixes #10063 by updating the help text and fixing the e2e test snapshots.