### PR TITLE
fix(cli): stop `scan --test` crashing with IndexError on a single rule file

### DIFF
--- a/changelog.d/gh-11391.fixed
+++ b/changelog.d/gh-11391.fixed
@@ -1,0 +1,1 @@
+Fixed an `IndexError` crash in `semgrep scan --test` when a single rule file was passed with `-c` and the test targets lived in a subdirectory.

--- a/cli/src/semgrep/test.py
+++ b/cli/src/semgrep/test.py
@@ -339,6 +339,13 @@ def relatively_eq(
     rel1 = target.relative_to(parent_target).parts
     rel2 = config.relative_to(parent_config).parts
     s = len(rel2)
+    if s == 0:
+        # The config is the parent config itself (a single rule file passed via
+        # -c). There is no relative stem to compare, so every target under the
+        # target tree matches, the same as the directory case. Without this
+        # guard `s -= 1` below would make `s == -1` and the final `rel2[s]`
+        # would index an empty tuple and raise IndexError (see GH issue 11391).
+        return True
     if len(rel1) < s:
         return False
     s -= 1

--- a/cli/tests/default/unit/test_semgrep_test.py
+++ b/cli/tests/default/unit/test_semgrep_test.py
@@ -123,3 +123,8 @@ def test_relatively_eq():
         relatively_eq(p1, p1 / "my-rule-a" / "views.py", p2, p2 / "my-rule-a.yaml")
         is True
     )
+    # A single rule file passed via -c: the config equals its own parent, so the
+    # relative config path is empty. Any target under the tree should match
+    # instead of raising IndexError (GH issue 11391).
+    single_config = Path("semgrep-rules.yaml")
+    assert relatively_eq(p1, p1 / "os_open.go", single_config, single_config) is True


### PR DESCRIPTION
Running `semgrep scan --test` crashes with `IndexError: tuple index out of range` whenever you point `-c` at a single rule file and the test targets live in a subdirectory (#11391). The cause is in `relatively_eq`: when a single rule file is passed it gets called with the config equal to its own parent, so `config.relative_to(parent_config).parts` is empty, `s` becomes 0, then `s -= 1` makes it -1, and the final `rel2[s]` indexes an empty tuple. This adds an early return for that empty case so any target under the tree matches, the same way the directory form already behaves.

I extended the existing `test_relatively_eq` with the single-rule-file case, which reproduced the IndexError before the fix and passes after it; the full `cli/tests/default/unit/test_semgrep_test.py` module stays green (561 passed). There is also a changelog entry under `changelog.d/`.