### PR TITLE
fix: print usage info on invalid flag combinations (fixes #5684)

### DIFF
--- a/cli/src/semgrep/commands/scan.py
+++ b/cli/src/semgrep/commands/scan.py
@@ -975,11 +975,14 @@ def scan(
             )
 
         if pattern is not None and lang is None:
-            abort("-e/--pattern and -l/--lang must both be specified")
+            ctx = click.get_current_context()
+            raise click.UsageError("-e/--pattern and -l/--lang must both be specified", ctx=ctx)
 
         if config and "auto" in config and metrics == MetricsState.OFF:
-            abort(
-                "Cannot create auto config when metrics are off. Please allow metrics or run with a specific config."
+            ctx = click.get_current_context()
+            raise click.UsageError(
+                "Cannot create auto config when metrics are off. Please allow metrics or run with a specific config.",
+                ctx=ctx,
             )
 
         # People have more flexibility on local scans so --max-memory and --pro-timeout is set to unlimited
@@ -1026,7 +1029,8 @@ def scan(
 
         if test:
             if len(outputs) > 0:
-                abort("The --test option doesn't support additional outputs to files.")
+                ctx = click.get_current_context()
+                raise click.UsageError("The --test option doesn't support additional outputs to files.", ctx=ctx)
             # the test code (which isn't a "test" per se but is actually
             # machinery to evaluate semgrep performance) uses
             # managed_output internally

--- a/cli/src/semgrep/commands/wrapper.py
+++ b/cli/src/semgrep/commands/wrapper.py
@@ -11,12 +11,12 @@
 # LICENSE for more details.
 #
 import sys
+import click
 from functools import wraps
 from typing import Any
 from typing import Callable
 from typing import NoReturn
 from typing import Optional
-
 from semgrep import state
 from semgrep.error import FATAL_EXIT_CODE
 from semgrep.error import is_semgrep_error_already_reported
@@ -53,6 +53,10 @@ def handle_command_errors(func: Callable) -> Callable:
                 logger.error(e.format_for_terminal())
                 mark_semgrep_error_as_reported(e)
             exit_code = e.code
+            exc = e
+        except click.UsageError as e:
+            e.show()
+            exit_code = 2
             exc = e
         except Exception as e:  # noqa: W0718
             logger.exception(e)

--- a/cli/tests/default/e2e/test_misc.py
+++ b/cli/tests/default/e2e/test_misc.py
@@ -576,3 +576,18 @@ def test_critical_severity(run_semgrep_on_copied_files: RunSemgrep, posix_snapsh
         ).stdout,
         "results.json",
     )
+
+def test_pattern_without_lang_shows_usage_error(run_semgrep_on_copied_files: RunSemgrep):
+    """
+    -e/--pattern without -l/--lang should print Click usage info,
+    not a bare error message. See GH issue #5684.
+    """
+    result = run_semgrep_on_copied_files(
+        subcommand="scan",
+        options=["-e", "foo"],
+        target_name="basic",
+        assert_exit_code=2,
+        use_click_runner=True,
+    )
+    assert "Usage: semgrep scan" in result.stderr
+    assert "-e/--pattern and -l/--lang must both be specified" in result.stderr


### PR DESCRIPTION
When users provide invalid or incomplete flag combinations to `semgrep scan`, the CLI previously printed a bare red error message with no guidance on correct usage:
$ semgrep -e foo
-e/--pattern and -l/--lang must both be specified

This PR fixes three cases where `abort()` was called instead of raising `click.UsageError`, so users now see the command's usage block alongside the error:
$ semgrep --legacy scan -e foo .
Usage: semgrep scan [OPTIONS] [SCANNING_ROOTS]...
Error: -e/--pattern and -l/--lang must both be specified

## Changes

- **`scan.py`**: Replace three `abort()` calls with `raise click.UsageError(..., ctx=ctx)` for invalid flag combinations (`-e` without `-l`, `--config auto` with `--metrics off`, `--test` with additional output files)
- **`wrapper.py`**: Add an `except click.UsageError` branch in `handle_command_errors` that calls `e.show()` so Click formats the error correctly instead of falling through to the generic exception handler
- **`test_misc.py`**: Add a test verifying the usage block appears in stderr for the `-e`/`-l` case

## Note

`scan.py` is marked deprecated in favor of `Scan_CLI.ml` as part of the osemgrep migration. This fix applies to the active `pysemgrep` path which is still used via `--legacy` and osemgrep fallback. Happy to discuss if equivalent behavior should be addressed on the osemgrep side as well.

Fixes #5684