### PR TITLE
docs: fix step numbering and remove duplicate Docker badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,6 @@
   <a href="https://hub.docker.com/r/semgrep/semgrep">
     <img src="https://img.shields.io/docker/pulls/semgrep/semgrep.svg?style=flat-square" alt="Docker Pulls" />
   </a>
-  <a href="https://hub.docker.com/r/semgrep/semgrep">
-    <img src="https://img.shields.io/docker/pulls/semgrep/semgrep.svg?style=flat-square" alt="Docker Pulls (Old)" />
-  </a>
   <a href="https://twitter.com/intent/follow?screen_name=semgrep">
     <img src="https://img.shields.io/twitter/follow/semgrep?label=Follow%20semgrep&style=social&color=blue" alt="Follow @semgrep on Twitter" />
   </a>
@@ -112,15 +109,15 @@ If there are any issues, <a href="https://go.semgrep.dev/slack" target="_blank">
     $ docker run -e SEMGREP_APP_TOKEN=<TOKEN> --rm -v "${PWD}:/src" semgrep/semgrep semgrep ci
     ```
 
-1. Run `semgrep login` to create your account and login to Semgrep. This step is optional, but logging into Semgrep gets you access to:
+2. Run `semgrep login` to create your account and login to Semgrep. This step is optional, but logging into Semgrep gets you access to:
 
     - [Semgrep Supply Chain](https://semgrep.dev/products/semgrep-supply-chain?utm_medium=readme&utm_source=github&utm_content=ssc-product): A dependency scanner that detects reachable vulnerabilities in third party libraries
     - [Semgrep Code's Pro rules](https://semgrep.dev/products/semgrep-code?utm_medium=readme&utm_source=github&utm_content=code-pro-rules): 600+ high confidence rules written by Semgrep's security research team
     - [Semgrep Code's Pro engine](https://semgrep.dev/products/pro-engine?utm_medium=readme&utm_source=github&utm_content=pro-engine): An advanced code analysis engine, designed to detect complex vulnerabilities, and reduce false positives
 
-1. Go to your app's root directory and run `semgrep ci`. This will scan your project to check for vulnerabilities in your source code and its dependencies.
+3. Go to your app's root directory and run `semgrep ci`. This will scan your project to check for vulnerabilities in your source code and its dependencies.
 
-1. Try writing your own query interactively with `-e`. For example, a check for Python == where the left and right hand sides are the same (potentially a bug):
+4. Try writing your own query interactively with `-e`. For example, a check for Python == where the left and right hand sides are the same (potentially a bug):
     `$ semgrep -e '$X == $X' --lang=py path/to/src`
 
 ### Semgrep Ecosystem


### PR DESCRIPTION
## Motivation

The README has two formatting issues that affect readability:

1. **Duplicate Docker badge**: The same Docker Pulls badge appears twice in the header
2. **Incorrect step numbering**: All steps in the "Getting started from the CLI" section use `1.` instead of sequential numbers (1, 2, 3, 4)

## Changes

- Removed duplicate Docker Pulls badge
- Fixed step numbering from all `1.` to `1.`, `2.`, `3.`, `4.`

## Testing

- [x] Markdown renders correctly
- [x] Step numbers display in correct order
- [x] No duplicate badges

## Checklist

- [x] Documentation fix only
- [x] No breaking changes
- [x] Improves readability
