### PR TITLE
fix: propagate Rust taint across self-shadowing let bindings

### DIFF
--- a/changelog.d/gh-11467.fixed
+++ b/changelog.d/gh-11467.fixed
@@ -1,0 +1,1 @@
+Rust taint mode no longer loses taint across a self-shadowing `let x = x;` (or `let x: T = x;`) binding. Previously the naming pass declared the shadowed variable twice, which made the right-hand side `x` resolve to a fresh, never-tainted binding instead of the prior one.

--- a/src/naming/Naming_AST.ml
+++ b/src/naming/Naming_AST.ml
@@ -641,6 +641,15 @@ let resolution_visitor =
        * TODO handle more cases than just the simple identifier pattern. *)
       | ( { name = EPattern (PatId (id, id_info)); _ },
           VarDef { vinit; vtype; vtok = _ } )
+        when is_resolvable_name_ctx env env.lang ->
+          (* Only visit vinit/vtype then declare_var once. Calling
+           * super#visit_definition here recurses into the LHS pattern and
+           * declares the var prematurely, minting an orphan sid that a
+           * self-shadowing `let x = x` binds to, losing taint (gh-11467).
+           *)
+          Option.iter (self#visit_expr env) vinit;
+          Option.iter (self#visit_type_ env) vtype;
+          declare_var env env.lang id id_info ~explicit:true vinit vtype
       | { name = EN (Id (id, id_info)); _ }, VarDef { vinit; vtype; vtok = _ }
       (* note that some languages such as Python do not have VarDef
        * construct

--- a/tests/rules/taint_rust_let_shadow.rs
+++ b/tests/rules/taint_rust_let_shadow.rs
@@ -1,0 +1,29 @@
+fn source() -> String { String::from("tainted") }
+fn sink(x: &str) {}
+
+fn test_with_shadow() {
+    let x = source();
+    let x = x;
+    // ruleid: taint-rust-let-shadow
+    sink(&x);
+}
+
+fn test_without_shadow() {
+    let x = source();
+    // ruleid: taint-rust-let-shadow
+    sink(&x);
+}
+
+fn test_rename_not_shadow() {
+    let x = source();
+    let y = x;
+    // ruleid: taint-rust-let-shadow
+    sink(&y);
+}
+
+fn test_typed_shadow() {
+    let x = source();
+    let x: String = x;
+    // ruleid: taint-rust-let-shadow
+    sink(&x);
+}

--- a/tests/rules/taint_rust_let_shadow.yaml
+++ b/tests/rules/taint_rust_let_shadow.yaml
@@ -1,0 +1,10 @@
+rules:
+  - id: taint-rust-let-shadow
+    message: tainted value reaches sink
+    languages: [rust]
+    severity: ERROR
+    mode: taint
+    pattern-sources:
+      - pattern: source(...)
+    pattern-sinks:
+      - pattern: sink(...)

--- a/tests/snapshots/semgrep-core/76cfd22fb010/stdout
+++ b/tests/snapshots/semgrep-core/76cfd22fb010/stdout
@@ -1690,8 +1690,7 @@
                                                      (TyN
                                                         (Id (("bool", _),
                                                            { id_resolved =
-                                                             ref ((Some (
-                                                             LocalVar, _)));
+                                                             ref (None);
                                                              id_resolved_alternatives =
                                                              ref ([]);
                                                              id_type =
@@ -1717,8 +1716,7 @@
                                    (Some { t =
                                            (TyN
                                               (Id (("bool", _),
-                                                 { id_resolved =
-                                                   ref ((Some (LocalVar, _)));
+                                                 { id_resolved = ref (None);
                                                    id_resolved_alternatives =
                                                    ref ([]);
                                                    id_type = ref (None);


### PR DESCRIPTION
Fixes #11467.

Rust taint mode was losing taint across a self-shadowing let binding: `let x = x;` (and the typed variant `let x: T = x;`). A tainted value that flowed through the shadow into a sink was silently not reported, a false negative across the Rust security rule families that rely on taint mode.

Root cause: the naming pass resolves the left-hand side of a Rust let binding as a pattern (`EPattern (PatId ...)`), in the same code path as the plain identifier case. That path called the generic definition visitor before declaring the variable, which recursed into the left-hand pattern and declared it there first, minting a fresh variable id before the initializer was visited. For `let x = x;` the right-hand `x` then resolved to that new, never-tainted binding instead of the real one from the line above.

Fix: split the Rust pattern case into its own arm. It now visits only `vinit` and `vtype` (the initializer and type annotation) and declares the variable once, after the right-hand side has already been resolved. No recursion into the left-hand pattern, no premature declaration.

This is scoped to the Rust naming pass only. Other languages use the plain identifier arm and are unaffected.

One existing snapshot changed (`tests/snapshots/semgrep-core/76cfd22fb010/stdout`): a type annotation like `bool` in a typed shadow was incorrectly resolving as a reference to a local variable named `bool` before this fix, and now correctly resolves to nothing. That was a second symptom of the same premature-declaration bug and is strictly more correct.

Added `tests/rules/taint_rust_let_shadow.rs` and `.yaml` covering the plain self-shadow, a typed self-shadow, a no-shadow control, and a rename-not-shadow control. All four are annotated as expected true positives and pass. Full test suite passes.

Changelog entry added under `changelog.d/gh-11467.fixed`.
