### PR TITLE
fix: close join-rule temp file before nested scan reads it

### DIFF
--- a/changelog.d/gh-11403.fixed
+++ b/changelog.d/gh-11403.fixed
@@ -1,0 +1,1 @@
+Fixed a `PermissionError: [Errno 13] Permission denied` crash on Windows when running join-mode rules (rules using the `join:` key), caused by handing a still-open temporary rule file to a nested scan.

--- a/cli/src/semgrep/join_rule.py
+++ b/cli/src/semgrep/join_rule.py
@@ -11,6 +11,7 @@
 # LICENSE for more details.
 #
 import json
+import os
 import tempfile
 from collections import defaultdict
 from enum import Enum
@@ -407,6 +408,25 @@ def json_to_rule_match(
     )
 
 
+def _write_temp_rule_file(raw_rules: List[Any]) -> Path:
+    """
+    Write the combined join-rule parts to a closed temporary YAML file and
+    return its path. The caller is responsible for deleting the file (e.g.
+    via `os.unlink`) once done with it.
+
+    The file is created with delete=False and is fully closed before its
+    path is returned: a `NamedTemporaryFile`'s path cannot be reopened while
+    the original handle is still open on Windows (POSIX allows this), so a
+    caller that hands this path to a nested scan must not receive it while
+    still open, or that nested scan fails with
+    `PermissionError: [Errno 13] Permission denied` on Windows.
+    """
+    with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False) as rule_file:
+        yaml.dump({"rules": raw_rules}, rule_file)
+        rule_path = Path(rule_file.name)
+    return rule_path
+
+
 def run_join_rule(
     join_rule: Dict[str, Any],
     scanning_roots: List[Path],
@@ -487,25 +507,23 @@ def run_join_rule(
         return [], [e]
 
     # Run Semgrep
-    with tempfile.NamedTemporaryFile() as rule_path:
-        # Combine inline rules and refs
-        raw_rules = [rule.raw for rule in inline_rules]
-        raw_rules.extend([rule.raw for rule in config_map.values()])
-        yaml.dump({"rules": raw_rules}, rule_path)
-        rule_path.flush()
-        rule_path.seek(0)
-
+    raw_rules = [rule.raw for rule in inline_rules]
+    raw_rules.extend([rule.raw for rule in config_map.values()])
+    rule_path = _write_temp_rule_file(raw_rules)
+    try:
         logger.debug(
             f"Running join mode rule {join_rule.get('id')} on {len(scanning_roots)} files."
         )
         output = semgrep.run_scan.run_scan_and_return_json(
-            config=Path(rule_path.name),
+            config=rule_path,
             scanning_roots=scanning_roots,
             no_rewrite_rule_ids=True,
             optimizations="all",
             allow_local_builds=allow_local_builds,
             ptt_enabled=ptt_enabled,
         )
+    finally:
+        os.unlink(rule_path)
 
     assert isinstance(output, dict)  # placate mypy
 

--- a/cli/tests/default/unit/test_join_rule.py
+++ b/cli/tests/default/unit/test_join_rule.py
@@ -10,8 +10,12 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the file
 # LICENSE for more details.
 #
+import os
+import tempfile
+
 import pytest
 
+import semgrep.join_rule as join_rule_module
 from semgrep.join_rule import Condition
 from semgrep.join_rule import create_collection_set_from_conditions
 from semgrep.join_rule import create_model_map
@@ -235,3 +239,44 @@ def test_create_model_map():
         metavars = result.get("extra", {}).get("metavars")  # type: ignore
         for metavar in metavars.keys():
             assert getattr(model_map[check_id], metavar)  # type: ignore
+
+
+@pytest.mark.quick
+def test_write_temp_rule_file_closes_handle_before_returning(monkeypatch):
+    """
+    Regression test for GH-11403.
+
+    `run_join_rule` hands the temp rule file's path to a *nested* Semgrep
+    scan while relying on the OS to let that path be reopened by name. A
+    `NamedTemporaryFile`'s path cannot be reopened while its own handle is
+    still open on Windows (POSIX allows this, which is why this bug only
+    ever reproduced for Windows users). Assert that `_write_temp_rule_file`
+    always closes its handle before handing back the path, by spying on the
+    real `NamedTemporaryFile` object it creates.
+    """
+    created_handles = []
+    real_named_temporary_file = tempfile.NamedTemporaryFile
+
+    def spy_named_temporary_file(*args, **kwargs):
+        handle = real_named_temporary_file(*args, **kwargs)
+        created_handles.append(handle)
+        return handle
+
+    monkeypatch.setattr(
+        join_rule_module.tempfile, "NamedTemporaryFile", spy_named_temporary_file
+    )
+
+    rule_path = join_rule_module._write_temp_rule_file(
+        [{"id": "test-rule", "pattern": "foo", "severity": "INFO"}]
+    )
+    try:
+        assert len(created_handles) == 1
+        assert created_handles[0].closed is True
+
+        # The path must also be independently readable by a brand new
+        # handle -- the actual behavior that fails on Windows when the
+        # original handle is left open.
+        content = rule_path.read_text()
+        assert "test-rule" in content
+    finally:
+        os.unlink(rule_path)


### PR DESCRIPTION
`run_join_rule` wrote combined rule content to a NamedTemporaryFile and passed its path to a nested run_scan_and_return_json() call while the original handle was still open. POSIX allows reopening a path with an open handle, but Windows does not, so the nested scan's config load raised `PermissionError: [Errno 13] Permission denied` for any user running a join-mode rule on Windows.

Extract the temp-file creation into _write_temp_rule_file(), which now closes the handle (via delete=False) before returning the path, and clean the file up afterwards in a finally block.

Fixes GH-11403

