### PR TITLE
docs: clarify scan profile help text

### DIFF
--- a/src/osemgrep/core/CLI_common.ml
+++ b/src/osemgrep/core/CLI_common.ml
@@ -180,7 +180,8 @@ let o_profile : bool Term.t =
   let info =
     Arg.info [ "profile" ] ~docs:Cmdliner.Manpage.s_common_options
       ~doc:
-        {|Record profiles via Pyro Caml. By default sends them to localhost:4040|}
+        {|Record scan performance profiles via Pyro Caml. By default, profiles
+are sent to localhost:4040.|}
   in
   Arg.value (Arg.flag info)
 


### PR DESCRIPTION
## Summary
- Clarifies the `--profile` help text to say it records scan performance profiles.
- Adds punctuation and makes the localhost:4040 default phrasing grammatical.

Fixes #10994

## Verification
- `git diff --check`
- `make core` (not completed locally: `dune` is not installed in this environment)