### PR TITLE
Fix taint findings for typed TypeScript destructured parameters

### DIFF
--- a/changelog.d/10163.fixed
+++ b/changelog.d/10163.fixed
@@ -1,0 +1,1 @@
+Fixed taint analysis for TypeScript arrow functions with typed object-destructured parameters and focused metavariables.

--- a/src/naming/Naming_AST.ml
+++ b/src/naming/Naming_AST.ml
@@ -825,6 +825,22 @@ let resolution_visitor =
       (* do not recurse here, we don't want the PatId case above
        * to overwrite the job done here
        *)
+      | PatTyped
+          ( OtherPat (("ExprToPattern", _), [ E { e = Record (_, _, _); _ } ]),
+            ty )
+        when Lang.is_js env.lang ->
+          (* Keep JS/TS object-destructuring parameters consistent with their
+             untyped representation. Walking the type's record fields here
+             would treat them as value bindings, but the annotation itself
+             still needs normal name resolution. *)
+          Common.save_excursion env.in_type true (fun () ->
+              let visitor =
+                object
+                  inherit [_] AST_generic.iter_no_id_info
+                  method! visit_name env x = self#visit_name env x
+                end
+              in
+              visitor#visit_type_ env ty)
       | OtherPat _
       (* This interacts badly with implicit JS/TS declarations. It causes
          * `foo` in `function f({ foo }) { ... }` to be resolved as a global

--- a/tests/rules/taint_param_source_typed_arrow.ts
+++ b/tests/rules/taint_param_source_typed_arrow.ts
@@ -1,0 +1,18 @@
+const sink = (value: string) => value;
+
+import { Props as LocalProps } from "./types";
+
+const TypedComponent = ({ html }: { html: string }) => {
+  // ruleid:taint-param-source-typed-arrow
+  return sink(html);
+};
+
+const UntypedComponent = ({ html }) => {
+  // ruleid:taint-param-source-typed-arrow
+  return sink(html);
+};
+
+// ruleid:typed-destructured-param-imported-type
+const ImportedTypedComponent = ({ html }: LocalProps) => {
+  return html;
+};

--- a/tests/rules/taint_param_source_typed_arrow.yaml
+++ b/tests/rules/taint_param_source_typed_arrow.yaml
@@ -1,0 +1,27 @@
+rules:
+  - id: taint-param-source-typed-arrow
+    mode: taint
+    languages:
+      - typescript
+    message: |
+      This confirms taint mode works for focused destructured parameters.
+    pattern-sources:
+      - patterns:
+          - pattern-either:
+              - pattern: |
+                  const $FUNC = ({ ..., $X, ... }: $T) => { ... }
+              - pattern: |
+                  const $FUNC = ({ ..., $X, ... }) => { ... }
+          - focus-metavariable: $X
+    pattern-sinks:
+      - patterns:
+          - pattern: $SINK($CONTENT)
+          - focus-metavariable: $CONTENT
+    severity: ERROR
+  - id: typed-destructured-param-imported-type
+    languages:
+      - typescript
+    message: This confirms imported types remain resolvable in typed destructured parameters.
+    pattern: |
+      const $FUNC = ({ ..., $X, ... }: LocalProps) => { ... }
+    severity: ERROR


### PR DESCRIPTION
Fixes #10163.

Typed TypeScript arrow functions with object-destructured parameters and
`focus-metavariable` could miss taint findings.

`Naming_AST` was traversing fields from the type annotation as local value
bindings. This caused the destructured parameter and its use in the function
body to receive different name identities, breaking the taint flow.

This change keeps typed JS/TS object-destructuring patterns consistent with
the existing untyped behavior and adds regression coverage for the typed case.

Tests:
- `taint_param_source_typed_arrow`
- `taint_param_source2`
- `taint_object_destructure`

Additional checks:
- `semgrep-core` release build
- OCaml formatting
- `git diff --check`