### PR TITLE
fix: use this installation's own pysemgrep when invoked by absolute path

### DIFF
--- a/changelog.d/gh-11864.fixed
+++ b/changelog.d/gh-11864.fixed
@@ -1,0 +1,1 @@
+An installation invoked by its absolute path now uses its own `pysemgrep`. Previously the installation directory was appended to `PATH`, so a different Semgrep earlier in `PATH` answered the lookup and ran its own `pysemgrep` instead -- a version pinned per project and invoked by explicit path could be overridden by a globally installed one.

--- a/cli/src/semgrep/console_scripts/entrypoint.py
+++ b/cli/src/semgrep/console_scripts/entrypoint.py
@@ -42,19 +42,77 @@ import warnings
 
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
-# Add the directory containing this script in the PATH, so the pysemgrep
-# script will also be in the PATH.
-# Some people don't have semgrep in their PATH and call it instead
-# explicitly as in /path/to/somewhere/bin/semgrep, but this means
-# that calling pysemgrep from osemgrep would be difficult because
-# it would not be in the PATH (we would need to pass its path to osemgrep,
-# which seems more complicated).
+IS_WINDOWS = platform.system() == "Windows"
+
+# The names a console script for pysemgrep can go by. setuptools writes a .exe
+# launcher on Windows; everywhere else the script keeps its bare name.
+PYSEMGREP_SCRIPT_NAMES = (
+    ("pysemgrep.exe", "pysemgrep") if IS_WINDOWS else ("pysemgrep",)
+)
+
+
+def provides_pysemgrep(directory):
+    """Whether a PATH lookup of "pysemgrep" would resolve inside directory."""
+    for name in PYSEMGREP_SCRIPT_NAMES:
+        candidate = os.path.join(directory, name)
+        if os.path.isfile(candidate) and (IS_WINDOWS or os.access(candidate, os.X_OK)):
+            return True
+    return False
+
+
+def is_same_directory(left, right):
+    try:
+        return os.path.samefile(left, right)
+    except OSError:
+        # one of them does not exist, or cannot be stat'd
+        return os.path.normcase(os.path.abspath(left)) == os.path.normcase(
+            os.path.abspath(right)
+        )
+
+
+def path_with_scripts_dir(path, scripts_dir):
+    """PATH with scripts_dir added, placed so that a lookup of "pysemgrep" finds our own.
+
+    osemgrep dispatches back to pysemgrep by name -- execvp in
+    src/osemgrep/core/Pysemgrep.ml -- so the helper has to be reachable through
+    PATH even when semgrep was invoked as /path/to/somewhere/bin/semgrep and is
+    not on PATH at all. Adding this installation's scripts directory is what
+    makes that work.
+
+    Appending it is not enough on its own: an unrelated Semgrep earlier in PATH
+    is found first, so naming one install by absolute path runs another
+    install's pysemgrep, and `semgrep --version` reports the other version.
+
+    Prepending unconditionally would fix that, but the scripts directory is a
+    shared bin directory for a Homebrew, system-Python or Docker install, and
+    moving it to the front reorders lookups for everything else the process
+    shells out to -- semgrep runs `git` by name throughout `semgrep ci`. So the
+    directory only moves ahead of a *conflicting* pysemgrep, and is appended,
+    as before, when there is none.
+    """
+    entries = [entry for entry in path.split(os.pathsep) if entry]
+    appended = os.pathsep.join([*entries, scripts_dir])
+
+    if not provides_pysemgrep(scripts_dir):
+        # nothing of ours to protect, so leave the ordering alone
+        return appended
+
+    for i, entry in enumerate(entries):
+        if not provides_pysemgrep(entry):
+            continue
+        # the first entry that answers the lookup decides it: ours already wins
+        # if that entry is our own directory, otherwise it has to go in front
+        if is_same_directory(entry, scripts_dir):
+            return appended
+        return os.pathsep.join([*entries[:i], scripts_dir, *entries[i:]])
+
+    return appended
+
+
 # nosem: no-env-vars-on-top-level
 PATH = os.environ.get("PATH", "")
 # nosem: no-env-vars-on-top-level
-os.environ["PATH"] = PATH + os.pathsep + sysconfig.get_path("scripts")
-
-IS_WINDOWS = platform.system() == "Windows"
+os.environ["PATH"] = path_with_scripts_dir(PATH, sysconfig.get_path("scripts"))
 
 PRO_FLAGS = ["--pro", "--pro-languages", "--pro-intrafile"]
 

--- a/cli/tests/default/unit/test_entrypoint_path.py
+++ b/cli/tests/default/unit/test_entrypoint_path.py
@@ -1,0 +1,99 @@
+import os
+import stat
+
+import pytest
+
+from semgrep.console_scripts.entrypoint import IS_WINDOWS
+from semgrep.console_scripts.entrypoint import path_with_scripts_dir
+from semgrep.console_scripts.entrypoint import provides_pysemgrep
+
+
+def make_scripts_dir(root, name, with_pysemgrep=True):
+    directory = root / name
+    directory.mkdir()
+    if with_pysemgrep:
+        script = directory / ("pysemgrep.exe" if IS_WINDOWS else "pysemgrep")
+        script.write_text("")
+        script.chmod(script.stat().st_mode | stat.S_IXUSR)
+    return str(directory)
+
+
+def lookup(path, name="pysemgrep"):
+    """The directory a PATH lookup of name would resolve in, as execvp does it."""
+    for entry in path.split(os.pathsep):
+        if entry and provides_pysemgrep(entry):
+            return entry
+    return None
+
+
+@pytest.mark.quick
+def test_own_pysemgrep_wins_over_an_install_earlier_in_path(tmp_path):
+    """An install invoked by absolute path uses its own pysemgrep.
+
+    Regression test: the scripts directory used to be appended, so a different
+    Semgrep sitting earlier in PATH answered the lookup and the install the user
+    named ran the other install's pysemgrep.
+    """
+    ours = make_scripts_dir(tmp_path, "new")
+    theirs = make_scripts_dir(tmp_path, "old")
+
+    path = path_with_scripts_dir(os.pathsep.join([theirs, "/usr/bin"]), ours)
+
+    assert lookup(path) == ours
+
+
+@pytest.mark.quick
+def test_ordering_is_untouched_when_nothing_else_provides_pysemgrep(tmp_path):
+    """The common case must not reorder PATH.
+
+    semgrep shells out to `git` by name, so moving the scripts directory --
+    which is a shared bin directory for Homebrew, a system Python, or the Docker
+    image -- ahead of the rest of PATH would change which one runs.
+    """
+    ours = make_scripts_dir(tmp_path, "scripts")
+    original = os.pathsep.join(["/opt/tools/bin", "/usr/local/bin", "/usr/bin"])
+
+    path = path_with_scripts_dir(original, ours)
+
+    assert path == os.pathsep.join(
+        ["/opt/tools/bin", "/usr/local/bin", "/usr/bin", ours]
+    )
+
+
+@pytest.mark.quick
+def test_scripts_dir_already_on_path_is_not_moved_ahead_of_it(tmp_path):
+    ours = make_scripts_dir(tmp_path, "scripts")
+    original = os.pathsep.join(["/opt/tools/bin", ours, "/usr/bin"])
+
+    path = path_with_scripts_dir(original, ours)
+
+    assert path.split(os.pathsep)[0] == "/opt/tools/bin"
+    assert lookup(path) == ours
+
+
+@pytest.mark.quick
+def test_scripts_dir_without_a_pysemgrep_is_only_appended(tmp_path):
+    """Nothing of ours to protect, so the ordering is left alone."""
+    ours = make_scripts_dir(tmp_path, "scripts", with_pysemgrep=False)
+    theirs = make_scripts_dir(tmp_path, "other")
+
+    path = path_with_scripts_dir(theirs, ours)
+
+    assert path == os.pathsep.join([theirs, ours])
+
+
+@pytest.mark.quick
+def test_empty_path(tmp_path):
+    ours = make_scripts_dir(tmp_path, "scripts")
+
+    assert path_with_scripts_dir("", ours) == ours
+
+
+@pytest.mark.quick
+@pytest.mark.skipif(IS_WINDOWS, reason="POSIX permission bits")
+def test_a_non_executable_file_does_not_answer_the_lookup(tmp_path):
+    directory = tmp_path / "not-a-script"
+    directory.mkdir()
+    (directory / "pysemgrep").write_text("")
+
+    assert not provides_pysemgrep(str(directory))


### PR DESCRIPTION
Fixes #11864.

### The problem

`entrypoint.py` adds this installation's scripts directory to `PATH` so that `osemgrep` can dispatch back to `pysemgrep`, which it does by bare name — `Unix.execvp "pysemgrep" argv` in `src/osemgrep/core/Pysemgrep.ml`. The directory was **appended**, so any other Semgrep install earlier in `PATH` answers the lookup first:

```console
$ env PATH="/tmp/old/bin:/usr/bin" /tmp/new/bin/semgrep --version
1.161.0        # /tmp/new is 1.173.0
```

Naming an install by absolute path runs a *different* install's `pysemgrep`. The reporter's case is version pinning: a project that pins Semgrep into a project-local directory and invokes it by explicit path can be gated by whatever Semgrep happens to be installed globally, without any indication that it happened.

### Why not simply prepend

Prepending fixes the lookup, but the scripts directory is a shared bin directory for a Homebrew, system-Python or Docker install — often `/usr/local/bin` — so moving it to the front reorders lookups for everything the process shells out to afterwards. `semgrep ci` runs `git` by name throughout (`cli/src/semgrep/git.py`), so on some machines this would quietly change which `git` a scan uses. That is a worse failure than the one being fixed, and I suspect it is why the directory was appended in the first place.

Passing `pysemgrep`'s absolute path to `osemgrep` — the alternative the comment in the source already contemplates — is the cleaner fix, but it needs `Pysemgrep.ml` to learn about it too, so it is not contained in the Python wrapper. **Happy to redo it that way if you'd prefer**; I went with the self-contained option first so there is something concrete to compare against.

### What this does instead

Keep appending, but move the directory ahead of a *conflicting* `pysemgrep` when one exists:

- no other directory on `PATH` provides a `pysemgrep` → the resulting value is byte-identical to today;
- our own directory is already the first provider → unchanged;
- our directory has no `pysemgrep` at all → unchanged;
- another install answers first → ours is inserted directly in front of it, and nothing else moves.

So the reordering is scoped to exactly the situation being fixed. The cost is one `isfile` (plus an `access` off Windows) per `PATH` entry, stopping at the first provider — the wrapper's startup budget is unaffected.

### Verification

`cli/tests/default/unit/test_entrypoint_path.py` covers all five cases above, plus an empty `PATH` and a non-executable file that must not answer the lookup. The lookup helper in the test walks `PATH` the way `execvp` does, so the assertions are about which install actually runs, not about string layout.

Against the reporter's exact scenario, with the old and new logic side by side on the same directories:

```
invoking the 'new' install by absolute path, with 'old' earlier on PATH:
  before this change -> runs pysemgrep from: old
  after  this change -> runs pysemgrep from: new
```

`pytest` 5 passed / 1 skipped (the skip is the POSIX permission-bit case; this was run on Windows). `black` and `flake8` clean on both files.

A `changelog.d/gh-11864.fixed` entry is included.

*Note: the branch is based on the `1.172.0` release commit rather than current `develop`, because the token used here lacks the `workflow` scope needed to push newer upstream commits that touch `.github/workflows/`. `entrypoint.py` and `Pysemgrep.ml` are identical on both, so it applies to `develop` unchanged — happy to rebase if that's easier for you.*

**AI disclosure:** this change was prepared with the assistance of Claude Code. I reviewed the change and the verification, and will respond to review personally.
